### PR TITLE
Add sample go verifiers

### DIFF
--- a/0-999/0-99/0-9/2/verifierA.go
+++ b/0-999/0-99/0-9/2/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+    "fmt"
+    "math/rand"
+    "bytes"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type event struct {
+    name  string
+    score int
+}
+
+func winner(events []event) string {
+    totals := make(map[string]int)
+    for _, e := range events {
+        totals[e.name] += e.score
+    }
+    maxScore := -1 << 60
+    for _, v := range totals {
+        if v > maxScore {
+            maxScore = v
+        }
+    }
+    cumulative := make(map[string]int)
+    for _, e := range events {
+        cumulative[e.name] += e.score
+        if cumulative[e.name] >= maxScore && totals[e.name] == maxScore {
+            return e.name
+        }
+    }
+    return ""
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+    players := []string{"alice", "bob", "carol", "dave", "eve"}
+    n := rng.Intn(10) + 1
+    events := make([]event, n)
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d\n", n))
+    for i := 0; i < n; i++ {
+        name := players[rng.Intn(len(players))]
+        score := rng.Intn(21) - 10
+        events[i] = event{name, score}
+        sb.WriteString(fmt.Sprintf("%s %d\n", name, score))
+    }
+    // ensure at least one positive final score
+    totals := make(map[string]int)
+    for _, e := range events {
+        totals[e.name] += e.score
+    }
+    positive := false
+    for _, v := range totals {
+        if v > 0 {
+            positive = true
+            break
+        }
+    }
+    if !positive {
+        events[0].score = rng.Intn(10) + 1
+        sb.Reset()
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for _, e := range events {
+            sb.WriteString(fmt.Sprintf("%s %d\n", e.name, e.score))
+        }
+    }
+    return sb.String(), winner(events)
+}
+
+func runCase(exe string, input, expected string) error {
+    cmd := exec.Command(exe)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    got := strings.TrimSpace(out.String())
+    if got != expected {
+        return fmt.Errorf("expected %s got %s", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    exe := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    for i := 0; i < 100; i++ {
+        in, exp := generateCase(rng)
+        if err := runCase(exe, in, exp); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/0-99/0-9/2/verifierB.go
+++ b/0-999/0-99/0-9/2/verifierB.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func countFactor(x, p int) int {
+    if x == 0 {
+        return 1
+    }
+    c := 0
+    for x%p == 0 {
+        c++
+        x /= p
+    }
+    return c
+}
+
+func min(a, b int) int {
+    if a < b {
+        return a
+    }
+    return b
+}
+
+func solve(mat [][]int) int {
+    n := len(mat)
+    dp2 := make([][]int, n)
+    dp5 := make([][]int, n)
+    for i := range dp2 {
+        dp2[i] = make([]int, n)
+        dp5[i] = make([]int, n)
+    }
+    for i := 0; i < n; i++ {
+        for j := 0; j < n; j++ {
+            c2 := countFactor(mat[i][j], 2)
+            c5 := countFactor(mat[i][j], 5)
+            if i == 0 && j == 0 {
+                dp2[i][j] = c2
+                dp5[i][j] = c5
+            } else if i == 0 {
+                dp2[i][j] = dp2[i][j-1] + c2
+                dp5[i][j] = dp5[i][j-1] + c5
+            } else if j == 0 {
+                dp2[i][j] = dp2[i-1][j] + c2
+                dp5[i][j] = dp5[i-1][j] + c5
+            } else {
+                dp2[i][j] = min(dp2[i-1][j], dp2[i][j-1]) + c2
+                dp5[i][j] = min(dp5[i-1][j], dp5[i][j-1]) + c5
+            }
+        }
+    }
+    best := min(dp2[n-1][n-1], dp5[n-1][n-1])
+    // check path through zero
+    start := make([][]bool, n)
+    end := make([][]bool, n)
+    for i := range start {
+        start[i] = make([]bool, n)
+        end[i] = make([]bool, n)
+    }
+    start[0][0] = true
+    for i := 0; i < n; i++ {
+        for j := 0; j < n; j++ {
+            if i > 0 && start[i-1][j] {
+                start[i][j] = true
+            }
+            if j > 0 && start[i][j-1] {
+                start[i][j] = true
+            }
+        }
+    }
+    end[n-1][n-1] = true
+    for i := n - 1; i >= 0; i-- {
+        for j := n - 1; j >= 0; j-- {
+            if i+1 < n && end[i+1][j] {
+                end[i][j] = true
+            }
+            if j+1 < n && end[i][j+1] {
+                end[i][j] = true
+            }
+        }
+    }
+    for i := 0; i < n; i++ {
+        for j := 0; j < n; j++ {
+            if mat[i][j] == 0 && start[i][j] && end[i][j] {
+                if best > 1 {
+                    best = 1
+                }
+            }
+        }
+    }
+    return best
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+    n := rng.Intn(6) + 2 // 2..7
+    mat := make([][]int, n)
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d\n", n))
+    for i := 0; i < n; i++ {
+        mat[i] = make([]int, n)
+        for j := 0; j < n; j++ {
+            val := rng.Intn(1000)
+            mat[i][j] = val
+            sb.WriteString(fmt.Sprintf("%d ", val))
+        }
+        sb.WriteString("\n")
+    }
+    return sb.String(), solve(mat)
+}
+
+func runCase(exe string, input string, expected int) error {
+    cmd := exec.Command(exe)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    var got int
+    if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+        return fmt.Errorf("bad output: %v", err)
+    }
+    if got != expected {
+        return fmt.Errorf("expected %d got %d", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    exe := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    for i := 0; i < 100; i++ {
+        in, exp := generateCase(rng)
+        if err := runCase(exe, in, exp); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/0-99/0-9/3/verifierA.go
+++ b/0-999/0-99/0-9/3/verifierA.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func dist(s, t string) int {
+    dx := int(s[0]) - int(t[0])
+    if dx < 0 {
+        dx = -dx
+    }
+    dy := int(s[1]) - int(t[1])
+    if dy < 0 {
+        dy = -dy
+    }
+    if dx > dy {
+        return dx
+    }
+    return dy
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+    letters := "abcdefgh"
+    nums := "12345678"
+    s := []byte{letters[rng.Intn(8)], nums[rng.Intn(8)]}
+    t := []byte{letters[rng.Intn(8)], nums[rng.Intn(8)]}
+    input := fmt.Sprintf("%s\n%s\n", s, t)
+    return input, dist(string(s), string(t))
+}
+
+func runCase(exe string, input string, expected int) error {
+    cmd := exec.Command(exe)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    var got int
+    if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+        return fmt.Errorf("bad output: %v", err)
+    }
+    if got != expected {
+        return fmt.Errorf("expected %d got %d", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    exe := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    for i := 0; i < 100; i++ {
+        in, exp := generateCase(rng)
+        if err := runCase(exe, in, exp); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/0-99/0-9/3/verifierB.go
+++ b/0-999/0-99/0-9/3/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+    "time"
+)
+
+type boat struct {
+    typ int
+    cap int
+}
+
+func solve(n, v int, bs []boat) int {
+    var one, two []int
+    for _, b := range bs {
+        if b.typ == 1 {
+            one = append(one, b.cap)
+        } else {
+            two = append(two, b.cap)
+        }
+    }
+    sort.Slice(one, func(i, j int) bool { return one[i] > one[j] })
+    sort.Slice(two, func(i, j int) bool { return two[i] > two[j] })
+    pref1 := make([]int, len(one)+1)
+    for i, v := range one {
+        pref1[i+1] = pref1[i] + v
+    }
+    pref2 := make([]int, len(two)+1)
+    for i, v := range two {
+        pref2[i+1] = pref2[i] + v
+    }
+    best := 0
+    for k := 0; k <= len(two) && 2*k <= v; k++ {
+        rem := v - 2*k
+        if rem > len(one) {
+            rem = len(one)
+        }
+        val := pref2[k] + pref1[rem]
+        if val > best {
+            best = val
+        }
+    }
+    return best
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+    n := rng.Intn(6) + 1
+    v := rng.Intn(10) + 1
+    boats := make([]boat, n)
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d\n", n, v))
+    for i := 0; i < n; i++ {
+        typ := rng.Intn(2) + 1
+        cap := rng.Intn(20) + 1
+        boats[i] = boat{typ, cap}
+        sb.WriteString(fmt.Sprintf("%d %d\n", typ, cap))
+    }
+    return sb.String(), solve(n, v, boats)
+}
+
+func runCase(exe, input string, expected int) error {
+    cmd := exec.Command(exe)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    var got int
+    if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+        return fmt.Errorf("bad output: %v", err)
+    }
+    if got != expected {
+        return fmt.Errorf("expected %d got %d", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    exe := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    for i := 0; i < 100; i++ {
+        in, exp := generateCase(rng)
+        if err := runCase(exe, in, exp); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+


### PR DESCRIPTION
## Summary
- add verifiers for missing problems in `0-999/0-99/0-9/2` and `0-999/0-99/0-9/3`
- each verifier generates 100 random tests and checks a supplied binary

## Testing
- `go run 0-999/0-99/0-9/3/verifierA.go ./sol3A`
- `go run 0-999/0-99/0-9/3/verifierB.go ./sol3B`
- `go run 0-999/0-99/0-9/2/verifierB.go ../../../../solB2`

------
https://chatgpt.com/codex/tasks/task_e_687a2299e91c8324a625e3e689f5b03f