### PR TITLE
Add Go verifiers for problem set 5

### DIFF
--- a/0-999/0-99/0-9/5/verifierA.go
+++ b/0-999/0-99/0-9/5/verifierA.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type command struct {
+	line         string
+	participants int
+	add          bool
+	remove       bool
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	names := []string{"alice", "bob", "carol", "dave", "eve"}
+	used := make(map[string]bool)
+	var cmds []string
+	participants := 0
+	total := 0
+	n := rng.Intn(20) + 1
+	for i := 0; i < n; i++ {
+		choice := rng.Intn(3)
+		if participants == 0 {
+			choice = 0 // must add
+		}
+		switch choice {
+		case 0: // add
+			var name string
+			for {
+				name = names[rng.Intn(len(names))]
+				if !used[name] {
+					break
+				}
+			}
+			used[name] = true
+			participants++
+			cmds = append(cmds, "+"+name)
+		case 1: // message
+			// pick any participant
+			idx := rng.Intn(participants)
+			var name string
+			cnt := 0
+			for n := range used {
+				if cnt == idx {
+					name = n
+					break
+				}
+				cnt++
+			}
+			msgLen := rng.Intn(10)
+			msg := make([]byte, msgLen)
+			for j := 0; j < msgLen; j++ {
+				msg[j] = byte('a' + rng.Intn(26))
+			}
+			cmds = append(cmds, fmt.Sprintf("%s:%s", name, string(msg)))
+			total += participants * msgLen
+		case 2: // remove
+			idx := rng.Intn(participants)
+			var name string
+			cnt := 0
+			for n := range used {
+				if cnt == idx {
+					name = n
+					break
+				}
+				cnt++
+			}
+			delete(used, name)
+			participants--
+			cmds = append(cmds, "-"+name)
+		}
+	}
+	input := strings.Join(cmds, "\n") + "\n"
+	return input, total
+}
+
+func runCase(bin string, input string, expected int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/0-9/5/verifierB.go
+++ b/0-999/0-99/0-9/5/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	lines := rng.Intn(5) + 1
+	var inputLines []string
+	maxLen := 0
+	for i := 0; i < lines; i++ {
+		length := rng.Intn(20) + 1
+		// generate string of letters/digits/spaces not starting or ending with space
+		b := make([]byte, length)
+		for {
+			for j := 0; j < length; j++ {
+				t := rng.Intn(36 + 1) // letters+digits+space
+				if t < 26 {
+					b[j] = byte('a' + t)
+				} else if t < 36 {
+					b[j] = byte('0' + t - 26)
+				} else {
+					b[j] = ' '
+				}
+			}
+			if b[0] != ' ' && b[length-1] != ' ' {
+				break
+			}
+		}
+		s := string(b)
+		inputLines = append(inputLines, s)
+		if len(s) > maxLen {
+			maxLen = len(s)
+		}
+	}
+	// compute expected output
+	border := strings.Repeat("*", maxLen+2)
+	var out []string
+	out = append(out, border)
+	leftFlag := true
+	for _, line := range inputLines {
+		spaces := maxLen - len(line)
+		l := spaces / 2
+		r := spaces - l
+		if spaces%2 == 1 {
+			if leftFlag {
+				l++
+			} else {
+				r++
+			}
+			leftFlag = !leftFlag
+		}
+		out = append(out, "*"+strings.Repeat(" ", l)+line+strings.Repeat(" ", r)+"*")
+	}
+	out = append(out, border)
+	input := strings.Join(inputLines, "\n") + "\n"
+	expected := strings.Join(out, "\n")
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/0-9/5/verifierC.go
+++ b/0-999/0-99/0-9/5/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, int, int) {
+	n := rng.Intn(100) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '('
+		} else {
+			b[i] = ')'
+		}
+	}
+	s := string(b)
+	l, c := longestRegular(s)
+	return s + "\n", l, c
+}
+
+func longestRegular(s string) (int, int) {
+	stack := []int{-1}
+	best := 0
+	count := 1
+	for i, ch := range s {
+		if ch == '(' {
+			stack = append(stack, i)
+		} else {
+			stack = stack[:len(stack)-1]
+			if len(stack) == 0 {
+				stack = append(stack, i)
+			} else {
+				length := i - stack[len(stack)-1]
+				if length == best {
+					count++
+				} else if length > best {
+					best = length
+					count = 1
+				}
+			}
+		}
+	}
+	if best == 0 {
+		return 0, 1
+	}
+	return best, count
+}
+
+func runCase(bin, input string, expLen, expCnt int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var gotL, gotC int
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &gotL, &gotC); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if gotL != expLen || gotC != expCnt {
+		return fmt.Errorf("expected %d %d got %d %d", expLen, expCnt, gotL, gotC)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, l, c := generateCase(rng)
+		if err := runCase(bin, in, l, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/0-9/5/verifierD.go
+++ b/0-999/0-99/0-9/5/verifierD.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	a := float64(rng.Intn(5) + 1)
+	v := float64(rng.Intn(10) + 1)
+	l := float64(rng.Intn(9) + 2)
+	d := float64(rng.Intn(int(l-1)) + 1)
+	w := float64(rng.Intn(10) + 1)
+	input := fmt.Sprintf("%d %d %d %d %d\n", int(a), int(v), int(l), int(d), int(w))
+	expected := solve(a, v, l, d, w)
+	return input, expected
+}
+
+func solve(a, v, l, d, w float64) float64 {
+	t := 0.0
+	if w > v {
+		w = v
+	}
+	l3 := w * w / (2 * a)
+	var v1 float64
+	if l3 <= d {
+		t += w / a
+		l1 := d - l3
+		l3 = math.Sqrt(a*l1 + w*w)
+		if l3 > v {
+			l3 = v
+		}
+		t += 2 * (l3 - w) / a
+		t += (l1 - (l3*l3-w*w)/a) / l3
+		v1 = w
+	} else {
+		t += math.Sqrt(2 * d / a)
+		v1 = a * t
+	}
+	l = l - d
+	l2 := (v*v - v1*v1) / (2 * a)
+	if l2 <= l {
+		t += (v - v1) / a
+		t += (l - l2) / v
+	} else {
+		t += (math.Sqrt(2*a*l+v1*v1) - v1) / a
+	}
+	return t
+}
+
+func runCase(bin, input string, expected float64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if math.Abs(got-expected) > 1e-4 {
+		return fmt.Errorf("expected %.5f got %.5f", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/0-9/5/verifierE.go
+++ b/0-999/0-99/0-9/5/verifierE.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func visible(h []int, i, j int) bool {
+	n := len(h)
+	minH := h[i]
+	if h[j] < minH {
+		minH = h[j]
+	}
+	// clockwise i->j
+	k := (i + 1) % n
+	ok := true
+	for k != j {
+		if h[k] > minH {
+			ok = false
+			break
+		}
+		k = (k + 1) % n
+	}
+	if ok {
+		return true
+	}
+	// counter-clockwise
+	k = (i - 1 + n) % n
+	ok = true
+	for k != j {
+		if h[k] > minH {
+			ok = false
+			break
+		}
+		k = (k - 1 + n) % n
+	}
+	return ok
+}
+
+func countPairs(h []int) int {
+	n := len(h)
+	res := 0
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if visible(h, i, j) {
+				res++
+			}
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(6) + 3
+	h := make([]int, n)
+	for i := range h {
+		h[i] = rng.Intn(10) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range h {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), countPairs(h)
+}
+
+func runCase(bin, input string, expected int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go–verifierE.go for problems 5A–5E
- each verifier runs 100 generated test cases against any solution binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687a2ada09f48324a19afba6a5a6324f