### PR TITLE
Add Go verifiers for contest 101

### DIFF
--- a/0-999/100-199/100-109/101/verifierA.go
+++ b/0-999/100-199/100-109/101/verifierA.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// testCase represents a single verifier test
+type testCase struct {
+	s string
+	k int
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := []testCase{
+		{s: "aaaaa", k: 4},
+		{s: "abacaba", k: 3},
+		{s: "abc", k: 0},
+		{s: "abcdefgh", k: 10},
+		{s: "ababcd", k: 2},
+	}
+	for i, t := range tests {
+		input := fmt.Sprintf("%s\n%d\n", t.s, t.k)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\nstderr: %s\n", i+1, err, stderr.String())
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+		if len(lines) < 2 {
+			fmt.Printf("test %d: expected two output lines, got %d\n", i+1, len(lines))
+			os.Exit(1)
+		}
+		reportedAns := strings.TrimSpace(lines[0])
+		reportedStr := strings.TrimSpace(lines[1])
+
+		expectedAns, errExp := expectedAnswer(t.s, t.k)
+		if errExp != nil {
+			fmt.Printf("test %d: internal error: %v\n", i+1, errExp)
+			os.Exit(1)
+		}
+		if reportedAns != fmt.Sprint(expectedAns) {
+			fmt.Printf("test %d: expected answer %d, got %s\n", i+1, expectedAns, reportedAns)
+			os.Exit(1)
+		}
+		if !isSubsequence(t.s, reportedStr) {
+			fmt.Printf("test %d: output string is not a subsequence\n", i+1)
+			os.Exit(1)
+		}
+		if len(t.s)-len(reportedStr) > t.k {
+			fmt.Printf("test %d: removed more than k characters\n", i+1)
+			os.Exit(1)
+		}
+		if distinctCount(reportedStr) != expectedAns {
+			fmt.Printf("test %d: output string has wrong number of distinct characters\n", i+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+// expectedAnswer computes the minimal number of distinct characters
+func expectedAnswer(s string, k int) (int, error) {
+	n := len(s)
+	if k >= n {
+		return 0, nil
+	}
+	freq := make([]int, 256)
+	for i := 0; i < n; i++ {
+		freq[s[i]]++
+	}
+	// sort frequencies descending
+	counts := make([]int, 0, 256)
+	for _, f := range freq {
+		if f > 0 {
+			counts = append(counts, f)
+		}
+	}
+	for i := 0; i < len(counts); i++ {
+		for j := i + 1; j < len(counts); j++ {
+			if counts[j] > counts[i] {
+				counts[i], counts[j] = counts[j], counts[i]
+			}
+		}
+	}
+	remain := n - k
+	ans := 0
+	for i := 0; i < len(counts) && remain > 0; i++ {
+		remain -= counts[i]
+		ans++
+	}
+	if remain > 0 {
+		return 0, fmt.Errorf("invalid k")
+	}
+	if ans < 0 {
+		ans = 0
+	}
+	return ans, nil
+}
+
+func isSubsequence(s, sub string) bool {
+	j := 0
+	for i := 0; i < len(s) && j < len(sub); i++ {
+		if s[i] == sub[j] {
+			j++
+		}
+	}
+	return j == len(sub)
+}
+
+func distinctCount(s string) int {
+	seen := make(map[byte]struct{})
+	for i := 0; i < len(s); i++ {
+		seen[s[i]] = struct{}{}
+	}
+	return len(seen)
+}

--- a/0-999/100-199/100-109/101/verifierB.go
+++ b/0-999/100-199/100-109/101/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCaseB struct {
+	input string
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := []testCaseB{
+		{input: "2 1\n0 2\n"},
+		{input: "3 3\n0 2\n2 3\n0 3\n"},
+	}
+	for i, t := range tests {
+		expect := solveB(strings.NewReader(t.input))
+		gotOut, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(gotOut) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(gotOut))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+const mod = 1000000007
+
+type seg struct{ r, l int }
+
+func solveB(r io.Reader) string {
+	in := bufio.NewReader(r)
+	var n, m int
+	fmt.Fscan(in, &n, &m)
+	segs := make([]seg, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(in, &segs[i].l, &segs[i].r)
+	}
+	sort.Slice(segs, func(i, j int) bool { return segs[i].r < segs[j].r })
+	b := []int{0}
+	c := make([]int, m)
+	last := -1
+	for i, s := range segs {
+		if s.r != last {
+			last = s.r
+			b = append(b, s.r)
+		}
+		c[i] = len(b) - 1
+	}
+	E := len(b) - 1
+	if b[E] != n {
+		return "0\n"
+	}
+	f := make([]int, E+1)
+	ssum := make([]int, E+1)
+	f[0], ssum[0] = 1, 1
+	for i, seg := range segs {
+		ci := c[i]
+		lo, hi := 0, ci
+		for lo < hi {
+			mid := (lo + hi) / 2
+			if b[mid] < seg.l {
+				lo = mid + 1
+			} else {
+				hi = mid
+			}
+		}
+		if lo < ci {
+			add := ssum[ci-1]
+			if lo > 0 {
+				add = (add - ssum[lo-1] + mod) % mod
+			}
+			f[ci] = (f[ci] + add) % mod
+		}
+		if i+1 == m || c[i+1] != ci {
+			ssum[ci] = (ssum[ci-1] + f[ci]) % mod
+		}
+	}
+	return fmt.Sprintf("%d\n", f[E])
+}

--- a/0-999/100-199/100-109/101/verifierC.go
+++ b/0-999/100-199/100-109/101/verifierC.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseC struct {
+	ax, ay, bx, by, cx, cy int64
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := []testCaseC{
+		{1, 0, 2, 0, 1, 0},
+		{1, 1, 0, 0, 1, 0},
+	}
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d %d %d %d %d\n", t.ax, t.ay, t.bx, t.by, t.cx, t.cy)
+		expect := solveC(t.ax, t.ay, t.bx, t.by, t.cx, t.cy)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveC(ax, ay, bx, by, cx, cy int64) string {
+	t := cx*cx + cy*cy
+	check := func(x, y int64) bool {
+		if t == 0 {
+			return x == bx && y == by
+		}
+		expr1 := cx*bx + cy*by - x*cx - y*cy
+		expr2 := bx*cy - by*cx - x*cy + y*cx
+		return expr1%t == 0 && expr2%t == 0
+	}
+	if check(ax, ay) || check(ay, -ax) || check(-ax, -ay) || check(-ay, ax) {
+		return "YES\n"
+	}
+	return "NO\n"
+}

--- a/0-999/100-199/100-109/101/verifierD.go
+++ b/0-999/100-199/100-109/101/verifierD.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCaseD struct {
+	input string
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := []testCaseD{
+		{input: "2\n1 2 1\n"},
+		{input: "3\n1 2 1\n1 3 1\n"},
+	}
+	for i, t := range tests {
+		expect := solveD(strings.NewReader(t.input))
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type Edge struct{ to, v int }
+
+type Arr struct {
+	size int
+	sum  int64
+}
+
+func solveD(r io.Reader) string {
+	in := bufio.NewReader(r)
+	var n int
+	fmt.Fscan(in, &n)
+	adj := make([][]Edge, n+1)
+	for i := 1; i < n; i++ {
+		var x, y, v int
+		fmt.Fscan(in, &x, &y, &v)
+		adj[x] = append(adj[x], Edge{to: y, v: v})
+		adj[y] = append(adj[y], Edge{to: x, v: v})
+	}
+	sizeArr := make([]int, n+1)
+	sumArr := make([]int64, n+1)
+	timeArr := make([]int64, n+1)
+	var dfs func(int, int)
+	dfs = func(x, fa int) {
+		sizeArr[x] = 1
+		for _, e := range adj[x] {
+			y, v := e.to, e.v
+			if y == fa {
+				continue
+			}
+			sumArr[y] = int64(v) * 2
+			dfs(y, x)
+			sumArr[x] += sumArr[y]
+			sizeArr[x] += sizeArr[y]
+		}
+		var q []Arr
+		for _, e := range adj[x] {
+			y, v := e.to, e.v
+			if y == fa {
+				continue
+			}
+			timeArr[x] += timeArr[y] + int64(v)*int64(sizeArr[y])
+			q = append(q, Arr{sizeArr[y], sumArr[y]})
+		}
+		sort.Slice(q, func(i, j int) bool { return q[i].sum*int64(q[j].size) < q[j].sum*int64(q[i].size) })
+		var s int64
+		for _, a := range q {
+			timeArr[x] += int64(a.size) * s
+			s += a.sum
+		}
+	}
+	dfs(1, 0)
+	res := float64(timeArr[1]) / float64(n-1)
+	return fmt.Sprintf("%.10f\n", res)
+}

--- a/0-999/100-199/100-109/101/verifierE.go
+++ b/0-999/100-199/100-109/101/verifierE.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseE struct {
+	input string
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := []testCaseE{
+		{input: "1 1 10\n3\n4\n"},
+		{input: "2 2 5\n1 2\n3 4\n"},
+	}
+	for i, t := range tests {
+		expect := solveE(strings.NewReader(t.input))
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+var (
+	n, m, p int
+	X, Y    []int
+	F, G    []int
+	ans     []byte
+	sum     int64
+)
+
+func f(a, b int) int { return (X[a] + Y[b]) % p }
+
+func solve(x0, y0, x1, y1 int) {
+	if x0 == x1 {
+		sum += int64(f(x0, y0))
+		for j := y0 + 1; j <= y1; j++ {
+			sum += int64(f(x0, j))
+			ans = append(ans, 'S')
+		}
+		return
+	}
+	for j := y0; j <= y1; j++ {
+		F[j] = 0
+		G[j] = 0
+	}
+	mid := (x0 + x1) >> 1
+	for i := x0; i <= mid; i++ {
+		F[y0] += f(i, y0)
+		for j := y0 + 1; j <= y1; j++ {
+			if F[j-1] > F[j] {
+				F[j] = F[j-1]
+			}
+			F[j] += f(i, j)
+		}
+	}
+	for i := x1; i >= mid+1; i-- {
+		G[y1] += f(i, y1)
+		for j := y1 - 1; j >= y0; j-- {
+			if G[j+1] > G[j] {
+				G[j] = G[j+1]
+			}
+			G[j] += f(i, j)
+		}
+	}
+	bst := y1
+	for j := y0; j < y1; j++ {
+		if F[j]+G[j] > F[bst]+G[bst] {
+			bst = j
+		}
+	}
+	solve(x0, y0, mid, bst)
+	ans = append(ans, 'C')
+	solve(mid+1, bst, x1, y1)
+}
+
+func solveE(r io.Reader) string {
+	in := bufio.NewReader(r)
+	fmt.Fscan(in, &n, &m, &p)
+	X = make([]int, n)
+	Y = make([]int, m)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &X[i])
+	}
+	for j := 0; j < m; j++ {
+		fmt.Fscan(in, &Y[j])
+	}
+	F = make([]int, m)
+	G = make([]int, m)
+	ans = make([]byte, 0, n+m)
+	sum = 0
+	solve(0, 0, n-1, m-1)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d\n", sum)
+	if len(ans) > 0 {
+		buf.Write(ans)
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 101 problems A–E
- verifiers execute a provided binary on simple test cases and check output

## Testing
- `go run verifierA.go ./101A` *(passes)*
- `go run verifierB.go ./101B` *(passes)*
- `go run verifierC.go ./101C` *(passes)*
- `go run verifierD.go ./101D` *(passes)*
- `go run verifierE.go ./101E` *(passes)*

------
https://chatgpt.com/codex/tasks/task_e_687b73a824ec832486479dd3ba35ca20