### PR TITLE
Add Go translations for contest 1997

### DIFF
--- a/1000-1999/1900-1999/1990-1999/1997/1997A.go
+++ b/1000-1999/1900-1999/1990-1999/1997/1997A.go
@@ -1,52 +1,34 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
-// helper computes the score of string s: starts with 2, adds 1 if current and previous chars match, else adds 2
-func helper(s string) int {
-   ans := 2
-   for i := 1; i < len(s); i++ {
-       if s[i] == s[i-1] {
-           ans++
-       } else {
-           ans += 2
-       }
-   }
-   return ans
-}
-
-// solve processes one test case: reads string s, inserts one lowercase letter to maximize helper score
-func solve(reader *bufio.Reader, writer *bufio.Writer) {
-   var s string
-   fmt.Fscan(reader, &s)
-   var ans string
-   curr := 0
-   n := len(s)
-   for i := 0; i <= n; i++ {
-       for ch := byte('a'); ch <= 'z'; ch++ {
-           modified := s[:i] + string(ch) + s[i:]
-           score := helper(modified)
-           if score > curr {
-               curr = score
-               ans = modified
-           }
-       }
-   }
-   fmt.Fprintln(writer, ans)
-}
-
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   writer := bufio.NewWriter(os.Stdout)
-   defer writer.Flush()
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
 
-   var t int
-   fmt.Fscan(reader, &t)
-   for i := 0; i < t; i++ {
-       solve(reader, writer)
-   }
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		i := 1
+		for i < len(s) && s[i-1] != s[i] {
+			i++
+		}
+		ch := byte('a')
+		if s[i-1] == 'a' {
+			ch = 'b'
+		}
+		if i == len(s) {
+			s += string(ch)
+		} else {
+			s = s[:i] + string(ch) + s[i:]
+		}
+		fmt.Fprintln(writer, s)
+	}
 }

--- a/1000-1999/1900-1999/1990-1999/1997/1997B.go
+++ b/1000-1999/1900-1999/1990-1999/1997/1997B.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var a, b string
+		fmt.Fscan(reader, &a, &b)
+		ans := 0
+		for i := 0; i < n-2; i++ {
+			if a[i] != b[i] && a[i] == a[i+2] && b[i] == b[i+2] && a[i+1] == '.' && b[i+1] == '.' {
+				ans++
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1997/1997C.go
+++ b/1000-1999/1900-1999/1990-1999/1997/1997C.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		if _, err := fmt.Fscan(reader, &n, &s); err != nil {
+			return
+		}
+		x := n / 2
+		for i := len(s) - 1; i >= 0; i-- {
+			if s[i] == '(' {
+				x += 2
+			}
+		}
+		fmt.Fprintln(writer, x)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1997/1997D.go
+++ b/1000-1999/1900-1999/1990-1999/1997/1997D.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const N = 200005
+
+var a [N]int
+var e [N][]int
+
+func S(u int) int {
+	if len(e[u]) == 0 {
+		return a[u]
+	}
+	r := 1_000_000_000
+	for _, v := range e[u] {
+		val := S(v)
+		if val < r {
+			r = val
+		}
+	}
+	if a[u] < r && u != 1 {
+		return (r + a[u]) / 2
+	}
+	return r
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t, n int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		fmt.Fscan(reader, &n)
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(reader, &a[i])
+			e[i] = e[i][:0]
+		}
+		for i := 2; i <= n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			e[x] = append(e[x], i)
+		}
+		res := a[1] + S(1)
+		fmt.Fprintln(writer, res)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1997/1997E.go
+++ b/1000-1999/1900-1999/1990-1999/1997/1997E.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const N = 200001
+
+var a [N]int
+var req [N]int
+var t [N]int
+
+func add(x int) {
+	for x < N {
+		t[x]++
+		x += x & -x
+	}
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, q int
+	fmt.Fscan(reader, &n, &q)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	for i := 1; i <= n; i++ {
+		x, y := 0, 0
+		for j := 17; j >= 0; j-- {
+			nxt := x | (1 << j)
+			if nxt < N && int64(a[i])*int64(nxt) <= int64(y+t[nxt]) {
+				x = nxt
+				y += t[nxt]
+			}
+		}
+		x++
+		add(x)
+		req[i] = x
+	}
+	for ; q > 0; q-- {
+		var x, y int
+		fmt.Fscan(reader, &x, &y)
+		if y < req[x] {
+			fmt.Fprintln(writer, "NO")
+		} else {
+			fmt.Fprintln(writer, "YES")
+		}
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1997/1997F.go
+++ b/1000-1999/1900-1999/1990-1999/1997/1997F.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 998244353
+
+var fib [55]int64
+var dp [1005][55005]int64
+
+func main() {
+	fib[1], fib[2] = 1, 1
+	for i := 3; i <= 30; i++ {
+		fib[i] = fib[i-1] + fib[i-2]
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, x, m int
+	fmt.Fscan(reader, &n, &x, &m)
+
+	dp[0][0] = 1
+	for i := 1; i <= x; i++ {
+		for j := 1; j <= n; j++ {
+			for l := fib[i]; l <= fib[i]*int64(j); l++ {
+				dp[j][l] = (dp[j][l] + dp[j-1][l-fib[i]]) % mod
+			}
+		}
+	}
+
+	var ans int64
+	limit := int(fib[x] * int64(n))
+	for i := 0; i <= limit; i++ {
+		t := i
+		c := 0
+		for j := 30; j >= 1; j-- {
+			c += t / int(fib[j])
+			t %= int(fib[j])
+		}
+		if c == m {
+			ans = (ans + dp[n][i]) % mod
+		}
+	}
+
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- translate all C++ solutions for contest 1997 into Go
- solutions are named `1997A.go` through `1997F.go`

## Testing
- `go build 1000-1999/1900-1999/1990-1999/1997/1997A.go`
- `go build 1000-1999/1900-1999/1990-1999/1997/1997B.go`
- `go build 1000-1999/1900-1999/1990-1999/1997/1997C.go`
- `go build 1000-1999/1900-1999/1990-1999/1997/1997D.go`
- `go build 1000-1999/1900-1999/1990-1999/1997/1997E.go`
- `go build 1000-1999/1900-1999/1990-1999/1997/1997F.go`


------
https://chatgpt.com/codex/tasks/task_e_687b9e59e7b8832489bb24b95f61ad67