### PR TITLE
Add solution verifiers for contest 1997

### DIFF
--- a/1000-1999/1900-1999/1990-1999/1997/verifierA.go
+++ b/1000-1999/1900-1999/1990-1999/1997/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswer(s string) string {
+	i := 1
+	for i < len(s) && s[i-1] != s[i] {
+		i++
+	}
+	ch := byte('a')
+	if s[i-1] == 'a' {
+		ch = 'b'
+	}
+	if i == len(s) {
+		return s + string(ch)
+	}
+	return s[:i] + string(ch) + s[i:]
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func runCase(bin string, s string) error {
+	input := fmt.Sprintf("1\n%s\n", s)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedAnswer(s)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := generateCase(rng)
+		if err := runCase(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1990-1999/1997/verifierB.go
+++ b/1000-1999/1900-1999/1990-1999/1997/verifierB.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswerB(n int, a, b string) int {
+	ans := 0
+	for i := 0; i < n-2; i++ {
+		if a[i] != b[i] && a[i] == a[i+2] && b[i] == b[i+2] && a[i+1] == '.' && b[i+1] == '.' {
+			ans++
+		}
+	}
+	return ans
+}
+
+func generateCaseB(rng *rand.Rand) (int, string, string) {
+	n := rng.Intn(8) + 3 // at least 3
+	row1 := make([]byte, n)
+	row2 := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			row1[i] = '.'
+		} else {
+			row1[i] = 'x'
+		}
+		if rng.Intn(2) == 0 {
+			row2[i] = '.'
+		} else {
+			row2[i] = 'x'
+		}
+	}
+	return n, string(row1), string(row2)
+}
+
+func runCaseB(bin string, n int, a, b string) error {
+	input := fmt.Sprintf("1\n%d\n%s\n%s\n", n, a, b)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := fmt.Sprint(expectedAnswerB(n, a, b))
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, r1, r2 := generateCaseB(rng)
+		if err := runCaseB(bin, n, r1, r2); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d\n%s\n%s\n", i+1, err, n, r1, r2)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1990-1999/1997/verifierC.go
+++ b/1000-1999/1900-1999/1990-1999/1997/verifierC.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswerC(n int, s string) int {
+	x := n / 2
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '(' {
+			x += 2
+		}
+	}
+	return x
+}
+
+func generateCaseC(rng *rand.Rand) (int, string) {
+	n := rng.Intn(10) + 1
+	b := make([]byte, n)
+	for i := range b {
+		if rng.Intn(2) == 0 {
+			b[i] = '('
+		} else {
+			b[i] = ')'
+		}
+	}
+	return n, string(b)
+}
+
+func runCaseC(bin string, n int, s string) error {
+	input := fmt.Sprintf("1\n%d %s\n", n, s)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := fmt.Sprint(expectedAnswerC(n, s))
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, s := generateCaseC(rng)
+		if err := runCaseC(bin, n, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %s\n", i+1, err, n, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1990-1999/1997/verifierD.go
+++ b/1000-1999/1900-1999/1990-1999/1997/verifierD.go
@@ -90,7 +90,7 @@ func main() {
 	}
 	bin := os.Args[1]
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for i := 0; i < 50; i++ {
+	for i := 0; i < 100; i++ {
 		n, vals, parents := generateCaseD(rng)
 		if err := runCaseD(bin, n, vals, parents); err != nil {
 			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)

--- a/1000-1999/1900-1999/1990-1999/1997/verifierD.go
+++ b/1000-1999/1900-1999/1990-1999/1997/verifierD.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswerD(n int, vals []int, parents []int) int {
+	e := make([][]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := parents[i-2]
+		e[p] = append(e[p], i)
+	}
+	var S func(u int) int
+	S = func(u int) int {
+		if len(e[u]) == 0 {
+			return vals[u-1]
+		}
+		r := 1000000000
+		for _, v := range e[u] {
+			val := S(v)
+			if val < r {
+				r = val
+			}
+		}
+		if vals[u-1] < r && u != 1 {
+			return (r + vals[u-1]) / 2
+		}
+		return r
+	}
+	return vals[0] + S(1)
+}
+
+func generateCaseD(rng *rand.Rand) (int, []int, []int) {
+	n := rng.Intn(6) + 2 // at least 2
+	vals := make([]int, n)
+	for i := range vals {
+		vals[i] = rng.Intn(10) + 1
+	}
+	parents := make([]int, n-1)
+	for i := 2; i <= n; i++ {
+		parents[i-2] = rng.Intn(i-1) + 1
+	}
+	return n, vals, parents
+}
+
+func runCaseD(bin string, n int, vals []int, parents []int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	for i, p := range parents {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(p))
+	}
+	sb.WriteString("\n")
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := fmt.Sprint(expectedAnswerD(n, vals, parents))
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 50; i++ {
+		n, vals, parents := generateCaseD(rng)
+		if err := runCaseD(bin, n, vals, parents); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1990-1999/1997/verifierE.go
+++ b/1000-1999/1900-1999/1990-1999/1997/verifierE.go
@@ -104,7 +104,7 @@ func main() {
 	}
 	bin := os.Args[1]
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for i := 0; i < 50; i++ {
+	for i := 0; i < 100; i++ {
 		n, arr, queries := generateCaseE(rng)
 		if err := runCaseE(bin, n, arr, queries); err != nil {
 			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)

--- a/1000-1999/1900-1999/1990-1999/1997/verifierE.go
+++ b/1000-1999/1900-1999/1990-1999/1997/verifierE.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const N_E = 200001
+
+func expectedAnswerE(n int, arr []int, queries [][2]int) []string {
+	a := make([]int, n+1)
+	copy(a[1:], arr)
+	t := make([]int, N_E)
+	req := make([]int, n+1)
+	add := func(x int) {
+		for x < N_E {
+			t[x]++
+			x += x & -x
+		}
+	}
+	for i := 1; i <= n; i++ {
+		x, y := 0, 0
+		for j := 17; j >= 0; j-- {
+			nxt := x | (1 << j)
+			if nxt < N_E && int64(a[i])*int64(nxt) <= int64(y+t[nxt]) {
+				x = nxt
+				y += t[nxt]
+			}
+		}
+		x++
+		add(x)
+		req[i] = x
+	}
+	res := make([]string, len(queries))
+	for i, q := range queries {
+		x, y := q[0], q[1]
+		if y < req[x] {
+			res[i] = "NO"
+		} else {
+			res[i] = "YES"
+		}
+	}
+	return res
+}
+
+func generateCaseE(rng *rand.Rand) (int, []int, [][2]int) {
+	n := rng.Intn(5) + 1
+	q := rng.Intn(5) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(5) + 1
+	}
+	queries := make([][2]int, q)
+	for i := range queries {
+		queries[i][0] = rng.Intn(n) + 1
+		queries[i][1] = rng.Intn(10) + 1
+	}
+	return n, arr, queries
+}
+
+func runCaseE(bin string, n int, arr []int, queries [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(queries)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	for _, q := range queries {
+		sb.WriteString(fmt.Sprintf("%d %d\n", q[0], q[1]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	expected := expectedAnswerE(n, arr, queries)
+	if len(gotLines) != len(expected) {
+		return fmt.Errorf("expected %d lines got %d", len(expected), len(gotLines))
+	}
+	for i := range expected {
+		if strings.TrimSpace(gotLines[i]) != expected[i] {
+			return fmt.Errorf("line %d expected %s got %s", i+1, expected[i], gotLines[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 50; i++ {
+		n, arr, queries := generateCaseE(rng)
+		if err := runCaseE(bin, n, arr, queries); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1990-1999/1997/verifierF.go
+++ b/1000-1999/1900-1999/1990-1999/1997/verifierF.go
@@ -80,7 +80,7 @@ func main() {
 	}
 	bin := os.Args[1]
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 100; i++ {
 		n, x, m := generateCaseF(rng)
 		if err := runCaseF(bin, n, x, m); err != nil {
 			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)

--- a/1000-1999/1900-1999/1990-1999/1997/verifierF.go
+++ b/1000-1999/1900-1999/1990-1999/1997/verifierF.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modF int64 = 998244353
+
+func expectedAnswerF(n, x, m int) int64 {
+	fib := make([]int64, 31)
+	fib[1], fib[2] = 1, 1
+	for i := 3; i <= 30; i++ {
+		fib[i] = fib[i-1] + fib[i-2]
+	}
+	limit := int(fib[x] * int64(n))
+	dp := make([][]int64, n+1)
+	for i := range dp {
+		dp[i] = make([]int64, limit+1)
+	}
+	dp[0][0] = 1
+	for i := 1; i <= x; i++ {
+		fi := int(fib[i])
+		for j := 1; j <= n; j++ {
+			for l := fi; l <= fi*j; l++ {
+				dp[j][l] = (dp[j][l] + dp[j-1][l-fi]) % modF
+			}
+		}
+	}
+	ans := int64(0)
+	for i := 0; i <= limit; i++ {
+		t := i
+		c := 0
+		for j := 30; j >= 1; j-- {
+			fj := int(fib[j])
+			c += t / fj
+			t %= fj
+		}
+		if c == m {
+			ans = (ans + dp[n][i]) % modF
+		}
+	}
+	return ans
+}
+
+func generateCaseF(rng *rand.Rand) (int, int, int) {
+	n := rng.Intn(4) + 1
+	x := rng.Intn(5) + 1
+	m := rng.Intn(5)
+	return n, x, m
+}
+
+func runCaseF(bin string, n, x, m int) error {
+	input := fmt.Sprintf("%d %d %d\n", n, x, m)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := fmt.Sprint(expectedAnswerF(n, x, m))
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 20; i++ {
+		n, x, m := generateCaseF(rng)
+		if err := runCaseF(bin, n, x, m); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new Go verifiers for Codeforces contest 1997 problems A–F
- each verifier generates random test cases and checks the given binary against expected output
- fix fibonacci logic in verifierF

## Testing
- `go run 1000-1999/1900-1999/1990-1999/1997/verifierA.go ./a1997_bin`
- `go run 1000-1999/1900-1999/1990-1999/1997/verifierB.go ./b1997_bin`
- `go run 1000-1999/1900-1999/1990-1999/1997/verifierC.go ./c1997_bin`
- `go run 1000-1999/1900-1999/1990-1999/1997/verifierD.go ./d1997_bin`
- `go run 1000-1999/1900-1999/1990-1999/1997/verifierE.go ./e1997_bin`
- `go run 1000-1999/1900-1999/1990-1999/1997/verifierF.go ./f1997_bin`


------
https://chatgpt.com/codex/tasks/task_e_687ba559be4483248c3e77b534f165e5