### PR TITLE
Add Go translations for contest 1996

### DIFF
--- a/1000-1999/1900-1999/1990-1999/1996/1996A.go
+++ b/1000-1999/1900-1999/1990-1999/1996/1996A.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		fmt.Fprintln(writer, n/4+n%4/2)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1996/1996B.go
+++ b/1000-1999/1900-1999/1990-1999/1996/1996B.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		grid := make([]string, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &grid[i])
+		}
+		for i := 0; i < n; i += k {
+			for j := 0; j < n; j += k {
+				fmt.Fprintf(writer, "%c", grid[i][j])
+			}
+			fmt.Fprintln(writer)
+		}
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1996/1996C.go
+++ b/1000-1999/1900-1999/1990-1999/1996/1996C.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var T int
+	fmt.Fscan(reader, &T)
+	for ; T > 0; T-- {
+		var n, q int
+		fmt.Fscan(reader, &n, &q)
+		var aStr, bStr string
+		fmt.Fscan(reader, &aStr, &bStr)
+		s := make([][26]int, n+1)
+		for i := 0; i < n; i++ {
+			s[i+1] = s[i]
+			s[i+1][aStr[i]-'a']++
+			s[i+1][bStr[i]-'a']--
+		}
+		for ; q > 0; q-- {
+			var l, r int
+			fmt.Fscan(reader, &l, &r)
+			l--
+			ans := 0
+			for i := 0; i < 26; i++ {
+				diff := s[r][i] - s[l][i]
+				if diff > 0 {
+					ans += diff
+				}
+			}
+			fmt.Fprintln(writer, ans)
+		}
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1996/1996D.go
+++ b/1000-1999/1900-1999/1990-1999/1996/1996D.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var T int
+	fmt.Fscan(reader, &T)
+	for ; T > 0; T-- {
+		var n, m int
+		fmt.Fscan(reader, &n, &m)
+		ans := 0
+		for i := 1; i <= n && i <= m; i++ {
+			for j := 1; i+j < m && i*j < n; j++ {
+				a := (n - i*j) / (i + j)
+				b := m - i - j
+				if a < b {
+					ans += a
+				} else {
+					ans += b
+				}
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1996/1996E.go
+++ b/1000-1999/1900-1999/1990-1999/1996/1996E.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const MOD int64 = 1_000_000_007
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var s string
+		if _, err := fmt.Fscan(reader, &s); err != nil {
+			return
+		}
+		m := map[int64]int64{0: 1}
+		var b, a int64
+		for i := int64(0); i < int64(len(s)); i++ {
+			if s[i] == '1' {
+				b++
+			} else {
+				b--
+			}
+			a = (a + (int64(len(s))-i)*m[b]) % MOD
+			m[b] = (m[b] + i + 2) % MOD
+		}
+		fmt.Fprintln(writer, a%MOD)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1996/1996F.go
+++ b/1000-1999/1900-1999/1990-1999/1996/1996F.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func calc(x int64, n int, a, b []int64) (int64, int64) {
+	var cnt, ans int64
+	for i := 1; i <= n; i++ {
+		if a[i] < x {
+			continue
+		}
+		now := (a[i]-x)/b[i] + 1
+		cnt += now
+		ans += (a[i] + a[i] - b[i]*(now-1)) * now / 2
+	}
+	return cnt, ans
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var T int
+	fmt.Fscan(reader, &T)
+	for ; T > 0; T-- {
+		var n int
+		var k int64
+		fmt.Fscan(reader, &n, &k)
+		a := make([]int64, n+1)
+		b := make([]int64, n+1)
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(reader, &b[i])
+		}
+		l, r := int64(0), int64(1e9)
+		for l < r {
+			mid := (l + r + 1) / 2
+			cnt, _ := calc(mid, n, a, b)
+			if cnt >= k {
+				l = mid
+			} else {
+				r = mid - 1
+			}
+		}
+		cnt, ans := calc(l, n, a, b)
+		fmt.Fprintln(writer, ans-(cnt-k)*l)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1996/1996G.go
+++ b/1000-1999/1900-1999/1990-1999/1996/1996G.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(reader, &n, &m)
+		v := make([]uint64, n)
+		for i := 0; i < m; i++ {
+			var a, b int
+			fmt.Fscan(reader, &a, &b)
+			k := rnd.Uint64()
+			v[a-1] ^= k
+			v[b-1] ^= k
+		}
+		count := make(map[uint64]int)
+		var prefix uint64
+		best := 0
+		for _, r := range v {
+			prefix ^= r
+			count[prefix]++
+			if count[prefix] > best {
+				best = count[prefix]
+			}
+		}
+		fmt.Fprintln(writer, n-best)
+	}
+}


### PR DESCRIPTION
## Summary
- convert C++ solutions for contest 1996 into Go
- new files `1996A.go` through `1996G.go`

## Testing
- `go build ./1000-1999/1900-1999/1990-1999/1996/1996A.go`
- `go build ./1000-1999/1900-1999/1990-1999/1996/1996B.go`
- `go build ./1000-1999/1900-1999/1990-1999/1996/1996C.go`
- `go build ./1000-1999/1900-1999/1990-1999/1996/1996D.go`
- `go build ./1000-1999/1900-1999/1990-1999/1996/1996E.go`
- `go build ./1000-1999/1900-1999/1990-1999/1996/1996F.go`
- `go build ./1000-1999/1900-1999/1990-1999/1996/1996G.go`


------
https://chatgpt.com/codex/tasks/task_e_687baa5a4b308324967b09e1d83b966c