### PR TITLE
Add Go versions for contest 1995 solutions

### DIFF
--- a/1000-1999/1900-1999/1990-1999/1995/1995A.go
+++ b/1000-1999/1900-1999/1990-1999/1995/1995A.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var n, k int
+		fmt.Fscan(in, &n, &k)
+		ans := 0
+		if k >= n {
+			k -= n
+			ans++
+		}
+		for i := n - 1; i >= 1; i-- {
+			if k >= i {
+				k -= i
+				ans++
+			}
+			if k >= i {
+				k -= i
+				ans++
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1995/1995B.go
+++ b/1000-1999/1900-1999/1990-1999/1995/1995B.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var n int
+		var m int64
+		fmt.Fscan(in, &n, &m)
+		v := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &v[i])
+		}
+		sort.Slice(v, func(i, j int) bool { return v[i] < v[j] })
+		l, r := 0, 1
+		sum := v[0]
+		var ans int64
+		if v[0] > m {
+			fmt.Fprintln(out, 0)
+			continue
+		}
+		for l < n {
+			if r < n && v[r]-v[l] <= 1 && sum+v[r] <= m {
+				sum += v[r]
+				r++
+			} else {
+				sum -= v[l]
+				l++
+			}
+			if sum > ans {
+				ans = sum
+			}
+		}
+		if v[0] > ans {
+			ans = v[0]
+		}
+		fmt.Fprintln(out, ans)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1995/1995C.go
+++ b/1000-1999/1900-1999/1990-1999/1995/1995C.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func solve(in *bufio.Reader, out *bufio.Writer) {
+	var n int64
+	var x int64
+	fmt.Fscan(in, &n, &x)
+	n--
+	ans := int64(0)
+	temp := int64(0)
+	for ; n > 0; n-- {
+		var y int64
+		fmt.Fscan(in, &y)
+		if y == 1 && x != 1 {
+			ans = -1
+		}
+		if ans == -1 {
+			x = y
+			continue
+		}
+		val := math.Log(float64(x)) / math.Log(float64(y))
+		val = math.Log2(val)
+		inc := int64(math.Ceil(val))
+		if inc+temp < 0 {
+			temp = 0
+		} else {
+			temp += inc
+			if temp < 0 {
+				temp = 0
+			}
+		}
+		ans += temp
+		x = y
+	}
+	fmt.Fprintln(out, ans)
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		solve(in, out)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1995/1995D.go
+++ b/1000-1999/1900-1999/1990-1999/1995/1995D.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/bits"
+	"os"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var n, c, k int
+		var s string
+		fmt.Fscan(in, &n, &c, &k, &s)
+
+		tag := make([]bool, 1<<uint(c))
+		sum := make([][]int, c)
+		for j := 0; j < c; j++ {
+			sum[j] = make([]int, n+1)
+			for i := 1; i <= n; i++ {
+				val := 0
+				if int(s[i-1]-'A') == j {
+					val = 1
+				}
+				sum[j][i] = sum[j][i-1] + val
+			}
+		}
+		for i := 1; i <= n-k+1; i++ {
+			t := 0
+			for j := 0; j < c; j++ {
+				if sum[j][i+k-1]-sum[j][i-1] == 0 {
+					t |= 1 << uint(j)
+				}
+			}
+			tag[t] = true
+		}
+		for i := (1 << uint(c)) - 1; i > 0; i-- {
+			if tag[i] {
+				for j := 0; j < c; j++ {
+					if (i>>uint(j))&1 != 0 {
+						tag[i^(1<<uint(j))] = true
+					}
+				}
+			}
+		}
+		ans := int(1e9)
+		last := int(s[len(s)-1] - 'A')
+		for i := 0; i < (1 << uint(c)); i++ {
+			if !tag[i] && ((i>>uint(last))&1) != 0 {
+				cnt := bits.OnesCount(uint(i))
+				ans = min(ans, cnt)
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1995/1995E.go
+++ b/1000-1999/1900-1999/1990-1999/1995/1995E.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+const INF int = 2000000001
+
+func M(x, n int) int {
+	return (x + 2*n) % (2 * n)
+}
+
+func solve(in *bufio.Reader, out *bufio.Writer) {
+	var n int
+	fmt.Fscan(in, &n)
+	v := make([]int, 2*n)
+	for i := 0; i < 2*n; i++ {
+		fmt.Fscan(in, &v[i])
+	}
+	if n%2 == 0 {
+		maxx := 0
+		minn := INF
+		for i := 0; i < n/2; i++ {
+			s := []int{v[2*i] + v[2*i+1], v[2*i] + v[2*i+n+1], v[2*i+n] + v[2*i+n+1], v[2*i+n] + v[2*i+1]}
+			sort.Ints(s)
+			if s[2] > maxx {
+				maxx = s[2]
+			}
+			if s[1] < minn {
+				minn = s[1]
+			}
+		}
+		fmt.Fprintln(out, maxx-minn)
+		return
+	}
+	if n == 1 {
+		fmt.Fprintln(out, 0)
+		return
+	}
+	r := make([]int, 0, 2*n)
+	cnt := 0
+	for i := 0; i < n; i++ {
+		r = append(r, v[cnt])
+		cnt ^= 1
+		r = append(r, v[cnt])
+		cnt = M(cnt+n, n)
+	}
+	ans := INF
+	for id := 0; id < n; id++ {
+		for m1 := 0; m1 < 2; m1++ {
+			for m2 := 0; m2 < 2; m2++ {
+				minn := r[M(2*id-m1, n)] + r[M(2*id+m2+1, n)]
+				dp := [2][]int{make([]int, n), make([]int, n)}
+				for t := 0; t < 2; t++ {
+					for j := 0; j < n; j++ {
+						dp[t][j] = INF
+					}
+				}
+				dp[m2][id] = minn
+				for j := 1; j < n; j++ {
+					d2 := (id + j) % n
+					d1 := (id + j - 1) % n
+					for c1 := 0; c1 < 2; c1++ {
+						for c2 := 0; c2 < 2; c2++ {
+							if dp[c1][d1] != INF {
+								val := r[M(2*d2-c1, n)] + r[M(2*d2+c2+1, n)]
+								if val >= minn {
+									cur := dp[c1][d1]
+									if val > cur {
+										cur = val
+									}
+									if cur < dp[c2][d2] {
+										dp[c2][d2] = cur
+									}
+								}
+							}
+						}
+					}
+				}
+				p := (id + n - 1) % n
+				if dp[m1][p] != INF {
+					diff := dp[m1][p] - minn
+					if diff < ans {
+						ans = diff
+					}
+				}
+			}
+		}
+	}
+	fmt.Fprintln(out, ans)
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		solve(in, out)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go ports of solutions for contest 1995

## Testing
- `go build 1000-1999/1900-1999/1990-1999/1995/1995A.go`
- `go build 1000-1999/1900-1999/1990-1999/1995/1995B.go`
- `go build 1000-1999/1900-1999/1990-1999/1995/1995C.go`
- `go build 1000-1999/1900-1999/1990-1999/1995/1995D.go`
- `go build 1000-1999/1900-1999/1990-1999/1995/1995E.go`


------
https://chatgpt.com/codex/tasks/task_e_687bb22c2ee88324b5af7ba5209fd910