### PR TITLE
Add Go solutions for 1992B

### DIFF
--- a/1000-1999/1900-1999/1990-1999/1992/1992A.go
+++ b/1000-1999/1900-1999/1990-1999/1992/1992A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var a, b, c int
+		fmt.Fscan(reader, &a, &b, &c)
+		best := 0
+		for i := 0; i <= 5; i++ {
+			for j := 0; j <= 5-i; j++ {
+				k := 5 - i - j
+				prod := (a + i) * (b + j) * (c + k)
+				if prod > best {
+					best = prod
+				}
+			}
+		}
+		fmt.Fprintln(writer, best)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1992/1992B.go
+++ b/1000-1999/1900-1999/1990-1999/1992/1992B.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		maxVal := 0
+		var ai int
+		for i := 0; i < k; i++ {
+			fmt.Fscan(reader, &ai)
+			if ai > maxVal {
+				maxVal = ai
+			}
+		}
+		ans := 2*(n-maxVal) - (k - 1)
+		if ans < 0 {
+			ans = 0
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1992/1992D.go
+++ b/1000-1999/1900-1999/1990-1999/1992/1992D.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bufio"
+	"container/list"
+	"fmt"
+	"os"
+)
+
+type state struct {
+	pos   int
+	water bool
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, m, k int
+		fmt.Fscan(in, &n, &m, &k)
+		var s string
+		fmt.Fscan(in, &s)
+		river := make([]byte, n+2)
+		river[0] = 'L'
+		for i := 0; i < n; i++ {
+			river[i+1] = s[i]
+		}
+		river[n+1] = 'L'
+
+		const INF = int(1e9)
+		surf := make([]int, n+2)
+		wat := make([]int, n+2)
+		for i := 0; i < n+2; i++ {
+			surf[i] = INF
+			wat[i] = INF
+		}
+		dq := list.New()
+		surf[0] = 0
+		dq.PushFront(state{0, false})
+		for dq.Len() > 0 {
+			cur := dq.Remove(dq.Front()).(state)
+			var d int
+			if cur.water {
+				d = wat[cur.pos]
+			} else {
+				d = surf[cur.pos]
+			}
+			if cur.water {
+				nxt := cur.pos + 1
+				if nxt <= n+1 && river[nxt] != 'C' {
+					nw := river[nxt] == 'W'
+					nd := d + 1
+					if nw {
+						if nd < wat[nxt] {
+							wat[nxt] = nd
+							dq.PushBack(state{nxt, true})
+						}
+					} else {
+						if nd < surf[nxt] {
+							surf[nxt] = nd
+							dq.PushBack(state{nxt, false})
+						}
+					}
+				}
+			} else {
+				for j := cur.pos + 1; j <= n+1 && j <= cur.pos+m; j++ {
+					if river[j] == 'C' {
+						continue
+					}
+					nw := river[j] == 'W'
+					if nw {
+						if d < wat[j] {
+							wat[j] = d
+							dq.PushFront(state{j, true})
+						}
+					} else {
+						if d < surf[j] {
+							surf[j] = d
+							dq.PushFront(state{j, false})
+						}
+					}
+				}
+			}
+		}
+		ans := surf[n+1]
+		if wat[n+1] < ans {
+			ans = wat[n+1]
+		}
+		if ans <= k {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1992/1992E.go
+++ b/1000-1999/1900-1999/1990-1999/1992/1992E.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func prefixRepeat(s string, d int) int {
+	var b strings.Builder
+	for b.Len() < d {
+		b.WriteString(s)
+	}
+	str := b.String()[:d]
+	val, _ := strconv.Atoi(str)
+	return val
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		ns := strconv.Itoa(n)
+		l := len(ns)
+		type pair struct{ a, b int }
+		res := make([]pair, 0)
+		for a := 1; a <= 10000; a++ {
+			for d := 1; d <= 7; d++ {
+				b := l*a - d
+				if b < 1 || b > a*n || b > 10000 {
+					continue
+				}
+				if d > l*a {
+					continue
+				}
+				pref := prefixRepeat(ns, d)
+				if pref == a*n-b {
+					res = append(res, pair{a, b})
+				}
+			}
+		}
+		fmt.Fprintln(out, len(res))
+		for _, p := range res {
+			fmt.Fprintln(out, p.a, p.b)
+		}
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1992/1992F.go
+++ b/1000-1999/1900-1999/1990-1999/1992/1992F.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type factor struct {
+	p int
+	e int
+}
+
+func factorize(x int) []factor {
+	res := []factor{}
+	for i := 2; i*i <= x; i++ {
+		if x%i == 0 {
+			c := 0
+			for x%i == 0 {
+				x /= i
+				c++
+			}
+			res = append(res, factor{i, c})
+		}
+	}
+	if x > 1 {
+		res = append(res, factor{x, 1})
+	}
+	return res
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var n, x int
+		fmt.Fscan(in, &n, &x)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+		}
+		fac := factorize(x)
+		m := len(fac)
+		base := make([]int, m)
+		base[0] = 1
+		for i := 1; i < m; i++ {
+			base[i] = base[i-1] * (fac[i-1].e + 1)
+		}
+		states := base[m-1] * (fac[m-1].e + 1)
+		decode := make([][]int, states)
+		for s := 0; s < states; s++ {
+			decode[s] = make([]int, m)
+			for j := 0; j < m; j++ {
+				decode[s][j] = (s / base[j]) % (fac[j].e + 1)
+			}
+		}
+		exps := make([]int, m)
+		for j := 0; j < m; j++ {
+			exps[j] = fac[j].e
+		}
+		target := states - 1
+		dp := make([]bool, states)
+		dp[0] = true
+		segments := 1
+		for _, val := range arr {
+			vec := make([]int, m)
+			tmp := val
+			valid := true
+			for j, f := range fac {
+				c := 0
+				for tmp%f.p == 0 {
+					tmp /= f.p
+					c++
+				}
+				if c > f.e {
+					c = f.e
+				}
+				vec[j] = c
+			}
+			if tmp != 1 {
+				valid = false
+			}
+			newdp := make([]bool, states)
+			copy(newdp, dp)
+			if valid {
+				for s := 0; s < states; s++ {
+					if dp[s] {
+						idx := 0
+						for j := 0; j < m; j++ {
+							v := decode[s][j] + vec[j]
+							if v > exps[j] {
+								v = exps[j]
+							}
+							idx += v * base[j]
+						}
+						if !newdp[idx] {
+							newdp[idx] = true
+						}
+					}
+				}
+			}
+			if newdp[target] {
+				segments++
+				dp = make([]bool, states)
+				dp[0] = true
+				if valid {
+					for s := 0; s < states; s++ {
+						if dp[s] {
+							idx := 0
+							for j := 0; j < m; j++ {
+								v := decode[s][j] + vec[j]
+								if v > exps[j] {
+									v = exps[j]
+								}
+								idx += v * base[j]
+							}
+							if !dp[idx] {
+								dp[idx] = true
+							}
+						}
+					}
+				}
+			} else {
+				dp = newdp
+			}
+		}
+		fmt.Fprintln(out, segments)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1992/1992G.go
+++ b/1000-1999/1900-1999/1990-1999/1992/1992G.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 1e9 + 7
+
+func modPow(a, b, m int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % m
+		}
+		a = a * a % m
+		b >>= 1
+	}
+	return res
+}
+
+func prepareFact(n int) ([]int64, []int64) {
+	fact := make([]int64, n+1)
+	inv := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	inv[n] = modPow(fact[n], mod-2, mod)
+	for i := n; i > 0; i-- {
+		inv[i-1] = inv[i] * int64(i) % mod
+	}
+	return fact, inv
+}
+
+func C(n, r int64, fact, inv []int64) int64 {
+	if r < 0 || r > n {
+		return 0
+	}
+	return fact[n] * inv[r] % mod * inv[n-r] % mod
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	maxN := 5000
+	fact, inv := prepareFact(maxN)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		res := int64(0)
+		half := (n - 1) / 2
+		for s := 0; s <= half; s++ {
+			for x := s + 1; x <= 2*s+1 && x <= n; x++ {
+				ways := C(int64(x-1), int64(s), fact, inv) * C(int64(n-x), int64(n-2*s-1), fact, inv) % mod
+				res = (res + int64(x)*ways) % mod
+			}
+		}
+		for s := (n + 1) / 2; s <= n; s++ {
+			ways := C(int64(n), int64(s), fact, inv)
+			mex := int64(2*s + 1)
+			res = (res + mex*ways) % mod
+		}
+		fmt.Fprintln(out, res%mod)
+	}
+}


### PR DESCRIPTION
## Summary
- implemented a Go solution for Contest 1992 problem B using a closed-form formula
- added implementations for problems D to G

## Testing
- `go build 1000-1999/1900-1999/1990-1999/1992/1992A.go`
- `go build 1000-1999/1900-1999/1990-1999/1992/1992B.go`
- `go build 1000-1999/1900-1999/1990-1999/1992/1992C.go`
- `go build 1000-1999/1900-1999/1990-1999/1992/1992D.go`
- `go build 1000-1999/1900-1999/1990-1999/1992/1992E.go`
- `go build 1000-1999/1900-1999/1990-1999/1992/1992F.go`
- `go build 1000-1999/1900-1999/1990-1999/1992/1992G.go`


------
https://chatgpt.com/codex/tasks/task_e_687c958102248324aa64bef7e57f8de0