### PR TITLE
Fix incorrect DP state in 1992F.go

### DIFF
--- a/1000-1999/1900-1999/1990-1999/1992/1992F.go
+++ b/1000-1999/1900-1999/1990-1999/1992/1992F.go
@@ -76,9 +76,6 @@ func main() {
 					tmp /= f.p
 					c++
 				}
-				if c > f.e {
-					c = f.e
-				}
 				vec[j] = c
 			}
 			if tmp != 1 {
@@ -90,14 +87,16 @@ func main() {
 				for s := 0; s < states; s++ {
 					if dp[s] {
 						idx := 0
+						ok := true
 						for j := 0; j < m; j++ {
 							v := decode[s][j] + vec[j]
 							if v > exps[j] {
-								v = exps[j]
+								ok = false
+								break
 							}
 							idx += v * base[j]
 						}
-						if !newdp[idx] {
+						if ok && !newdp[idx] {
 							newdp[idx] = true
 						}
 					}
@@ -111,14 +110,16 @@ func main() {
 					for s := 0; s < states; s++ {
 						if dp[s] {
 							idx := 0
+							ok := true
 							for j := 0; j < m; j++ {
 								v := decode[s][j] + vec[j]
 								if v > exps[j] {
-									v = exps[j]
+									ok = false
+									break
 								}
 								idx += v * base[j]
 							}
-							if !dp[idx] {
+							if ok && !dp[idx] {
 								dp[idx] = true
 							}
 						}


### PR DESCRIPTION
## Summary
- fix exponent handling in 1992F.go
- avoid saturating prime exponents when factoring values
- ignore transitions that overshoot target exponents

## Testing
- `go run 1000-1999/1900-1999/1990-1999/1992/1992F.go < /tmp/test.in`


------
https://chatgpt.com/codex/tasks/task_e_687ca10d42288324be9413e766b7c4e5