### PR TITLE
Add Go verifiers and tests for CF 1992

### DIFF
--- a/1000-1999/1900-1999/1990-1999/1992/problemA.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemA.txt
@@ -1,22 +1,101 @@
-Description:
-Kmes has written three integers $$$a$$$, $$$b$$$ and $$$c$$$ in order to remember that he has to give Noobish_Monk $$$a \times b \times c$$$ bananas.
-
-Noobish_Monk has found these integers and decided to do the following at most $$$5$$$ times:
-
-- pick one of these integers;
-- increase it by $$$1$$$.
-
-For example, if $$$a = 2$$$, $$$b = 3$$$ and $$$c = 4$$$, then one can increase $$$a$$$ three times by one and increase $$$b$$$ two times. After that $$$a = 5$$$, $$$b = 5$$$, $$$c = 4$$$. Then the total number of bananas will be $$$5 \times 5 \times 4 = 100$$$.
-
-What is the maximum value of $$$a \times b \times c$$$ Noobish_Monk can achieve with these operations?
-
-Input Format:
-Each test contains multiple test cases. The first line of input contains a single integer $$$t$$$ ($$$1 \le t \le 1000$$$) — the number of test cases. The description of the test cases follows.
-
-The first and only line of each test case contains three integers $$$a$$$, $$$b$$$ and $$$c$$$ ($$$1 \le a, b, c \le 10$$$) — Kmes's integers.
-
-Output Format:
-For each test case, output a single integer — the maximum amount of bananas Noobish_Monk can get.
-
-Note:
-None
+100
+7 7 1
+5 9 8
+7 5 8
+6 10 4
+9 3 5
+3 2 10
+5 9 10
+3 5 2
+2 6 8
+9 2 6
+7 6 10
+4 9 8
+8 9 5
+1 9 1
+2 7 1
+10 8 6
+4 6 2
+4 10 4
+4 3 9
+8 2 2
+6 9 8
+2 5 9
+5 2 9
+6 9 4
+10 9 10
+5 8 2
+10 7 6
+10 4 5
+3 4 3
+1 10 5
+8 2 2
+3 3 1
+2 9 7
+9 5 9
+4 4 10
+7 10 5
+8 8 6
+2 6 10
+2 8 10
+6 4 4
+1 5 2
+4 6 3
+6 7 1
+2 3 4
+1 10 9
+10 2 1
+2 4 10
+10 2 7
+2 6 2
+1 10 1
+4 3 2
+8 4 1
+1 9 7
+10 2 5
+2 4 2
+5 6 7
+3 1 9
+8 1 10
+2 7 4
+5 6 8
+10 3 4
+1 3 3
+6 9 5
+2 10 8
+3 1 8
+7 10 9
+5 6 7
+5 3 9
+1 8 2
+6 1 9
+5 3 4
+8 6 10
+5 6 10
+10 3 5
+7 7 2
+1 10 4
+6 3 4
+4 8 7
+10 7 1
+7 10 7
+1 3 8
+2 5 3
+8 9 8
+9 10 1
+1 8 6
+5 8 1
+7 4 9
+2 3 1
+7 7 6
+1 4 1
+1 9 10
+2 4 2
+10 4 5
+5 3 2
+8 7 2
+1 5 8
+2 5 3
+9 6 2
+3 5 1
+1 1 4

--- a/1000-1999/1900-1999/1990-1999/1992/problemA_statement.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemA_statement.txt
@@ -1,0 +1,22 @@
+Description:
+Kmes has written three integers $$$a$$$, $$$b$$$ and $$$c$$$ in order to remember that he has to give Noobish_Monk $$$a \times b \times c$$$ bananas.
+
+Noobish_Monk has found these integers and decided to do the following at most $$$5$$$ times:
+
+- pick one of these integers;
+- increase it by $$$1$$$.
+
+For example, if $$$a = 2$$$, $$$b = 3$$$ and $$$c = 4$$$, then one can increase $$$a$$$ three times by one and increase $$$b$$$ two times. After that $$$a = 5$$$, $$$b = 5$$$, $$$c = 4$$$. Then the total number of bananas will be $$$5 \times 5 \times 4 = 100$$$.
+
+What is the maximum value of $$$a \times b \times c$$$ Noobish_Monk can achieve with these operations?
+
+Input Format:
+Each test contains multiple test cases. The first line of input contains a single integer $$$t$$$ ($$$1 \le t \le 1000$$$) — the number of test cases. The description of the test cases follows.
+
+The first and only line of each test case contains three integers $$$a$$$, $$$b$$$ and $$$c$$$ ($$$1 \le a, b, c \le 10$$$) — Kmes's integers.
+
+Output Format:
+For each test case, output a single integer — the maximum amount of bananas Noobish_Monk can get.
+
+Note:
+None

--- a/1000-1999/1900-1999/1990-1999/1992/problemB.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemB.txt
@@ -1,32 +1,201 @@
-Description:
-To celebrate his recovery, k1o0n has baked an enormous $$$n$$$ metres long potato casserole.
-
-Turns out, Noobish_Monk just can't stand potatoes, so he decided to ruin k1o0n's meal. He has cut it into $$$k$$$ pieces, of lengths $$$a_1, a_2, \dots, a_k$$$ meters.
-
-k1o0n wasn't keen on that. Luckily, everything can be fixed. In order to do that, k1o0n can do one of the following operations:
-
-- Pick a piece with length $$$a_i \ge 2$$$ and divide it into two pieces with lengths $$$1$$$ and $$$a_i - 1$$$. As a result, the number of pieces will increase by $$$1$$$;
-- Pick a slice $$$a_i$$$ and another slice with length $$$a_j=1$$$ ($$$i \ne j$$$) and merge them into one piece with length $$$a_i+1$$$. As a result, the number of pieces will decrease by $$$1$$$.
-
-Help k1o0n to find the minimum number of operations he needs to do in order to merge the casserole into one piece with length $$$n$$$.
-
-For example, if $$$n=5$$$, $$$k=2$$$ and $$$a = [3, 2]$$$, it is optimal to do the following:
-
-1. Divide the piece with length $$$2$$$ into two pieces with lengths $$$2-1=1$$$ and $$$1$$$, as a result $$$a = [3, 1, 1]$$$.
-2. Merge the piece with length $$$3$$$ and the piece with length $$$1$$$, as a result $$$a = [4, 1]$$$.
-3. Merge the piece with length $$$4$$$ and the piece with length $$$1$$$, as a result $$$a = [5]$$$.
-
-Input Format:
-Each test contains multiple test cases. The first line contains the number of test cases $$$t$$$ ($$$1 \le t \le 10^4$$$).
-
-Description of each test case consists of two lines. The first line contains two integers $$$n$$$ and $$$k$$$ ($$$2 \le n \le 10^9$$$, $$$2 \le k \le 10^5$$$) — length of casserole and the number of pieces.
-
-The second line contains $$$k$$$ integers $$$a_1, a_2, \ldots, a_k$$$ ($$$1 \le a_i \le n - 1$$$, $$$\sum a_i = n$$$) — lengths of pieces of casserole, which Noobish_Monk has cut.
-
-It is guaranteed that the sum of $$$k$$$ over all $$$t$$$ test cases doesn't exceed $$$2 \cdot 10^5$$$.
-
-Output Format:
-For each test case, output the minimum number of operations K1o0n needs to restore his pie after the terror of Noobish_Monk.
-
-Note:
-None
+100
+36 4
+20 1 3 12
+16 3
+11 2 3
+18 10
+1 1 1 1 1 3 1 5 3 1
+27 5
+3 4 8 11 1
+43 6
+9 5 6 13 1 9
+11 3
+1 5 5
+27 2
+19 8
+33 7
+5 5 6 6 7 1 3
+39 7
+6 1 5 7 13 1 6
+37 5
+19 12 2 1 3
+8 6
+1 3 1 1 1 1
+31 6
+2 7 9 8 1 4
+15 3
+7 2 6
+15 8
+3 1 1 1 1 1 1 6
+32 8
+11 2 3 6 1 5 1 3
+20 6
+6 1 3 6 1 3
+36 2
+23 13
+9 9
+1 1 1 1 1 1 1 1 1
+32 7
+1 6 6 1 1 2 15
+35 8
+2 1 8 5 1 11 1 6
+20 10
+1 1 1 1 3 5 1 1 1 5
+30 4
+15 8 5 2
+13 10
+1 1 1 1 1 1 1 4 1 1
+3 3
+1 1 1
+6 6
+1 1 1 1 1 1
+3 2
+1 2
+13 2
+10 3
+36 4
+9 6 15 6
+18 8
+1 4 1 1 3 1 2 5
+10 6
+1 1 3 1 3 1
+22 5
+13 1 3 4 1
+11 2
+7 4
+19 5
+8 1 5 3 2
+22 3
+8 3 11
+31 4
+8 7 10 6
+33 9
+2 1 9 1 1 6 9 3 1
+12 4
+1 1 4 6
+11 8
+1 3 1 1 1 1 1 2
+30 4
+2 8 13 7
+41 10
+1 2 3 1 9 5 1 6 3 10
+29 6
+1 11 1 10 1 5
+27 2
+20 7
+20 9
+1 8 1 1 1 1 1 1 5
+17 6
+3 1 1 6 5 1
+2 2
+1 1
+14 5
+1 3 6 1 3
+34 6
+9 4 1 7 11 2
+9 4
+1 1 6 1
+24 6
+2 1 4 5 11 1
+42 7
+5 5 6 6 11 8 1
+44 9
+9 5 5 4 1 11 5 1 3
+14 6
+9 1 1 1 1 1
+26 6
+4 1 3 11 1 6
+14 10
+1 1 1 1 1 1 1 1 1 5
+15 3
+7 4 4
+12 6
+1 4 2 1 3 1
+30 3
+4 14 12
+13 8
+1 1 1 1 1 3 1 4
+29 6
+1 5 5 1 11 6
+24 6
+3 3 4 3 3 8
+7 3
+5 1 1
+28 7
+6 1 1 6 1 2 11
+23 9
+1 1 2 9 2 1 1 5 1
+14 4
+1 4 1 8
+17 9
+2 4 1 1 1 5 1 1 1
+23 9
+5 1 2 1 3 1 8 1 1
+26 4
+12 4 2 8
+45 9
+9 1 7 7 4 1 9 1 6
+24 10
+1 6 1 1 3 1 1 1 7 2
+9 2
+2 7
+8 7
+1 1 2 1 1 1 1
+27 4
+15 5 5 2
+12 7
+1 1 5 1 1 1 2
+8 6
+1 1 1 3 1 1
+39 10
+1 1 5 4 1 6 6 2 7 6
+14 6
+1 4 1 6 1 1
+10 7
+1 1 1 4 1 1 1
+35 4
+9 1 24 1
+32 7
+5 2 5 4 9 5 2
+34 5
+1 11 12 1 9
+17 4
+8 6 2 1
+32 10
+6 1 1 6 3 5 5 3 1 1
+34 7
+10 5 1 3 5 2 8
+40 10
+9 4 1 4 1 1 1 2 12 5
+36 10
+1 1 6 1 1 1 6 9 6 4
+28 4
+13 4 6 5
+22 6
+1 5 5 5 1 5
+4 4
+1 1 1 1
+19 4
+1 1 16 1
+23 6
+2 9 5 5 1 1
+4 2
+1 3
+11 9
+1 1 1 1 1 1 3 1 1
+7 2
+1 6
+25 2
+17 8
+41 3
+15 13 13
+32 6
+7 6 5 1 1 12
+18 9
+1 3 1 1 3 1 3 1 4
+20 4
+6 9 4 1
+24 9
+1 1 1 5 5 6 1 3 1
+14 7
+1 1 1 1 3 6 1

--- a/1000-1999/1900-1999/1990-1999/1992/problemB_statement.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemB_statement.txt
@@ -1,0 +1,32 @@
+Description:
+To celebrate his recovery, k1o0n has baked an enormous $$$n$$$ metres long potato casserole.
+
+Turns out, Noobish_Monk just can't stand potatoes, so he decided to ruin k1o0n's meal. He has cut it into $$$k$$$ pieces, of lengths $$$a_1, a_2, \dots, a_k$$$ meters.
+
+k1o0n wasn't keen on that. Luckily, everything can be fixed. In order to do that, k1o0n can do one of the following operations:
+
+- Pick a piece with length $$$a_i \ge 2$$$ and divide it into two pieces with lengths $$$1$$$ and $$$a_i - 1$$$. As a result, the number of pieces will increase by $$$1$$$;
+- Pick a slice $$$a_i$$$ and another slice with length $$$a_j=1$$$ ($$$i \ne j$$$) and merge them into one piece with length $$$a_i+1$$$. As a result, the number of pieces will decrease by $$$1$$$.
+
+Help k1o0n to find the minimum number of operations he needs to do in order to merge the casserole into one piece with length $$$n$$$.
+
+For example, if $$$n=5$$$, $$$k=2$$$ and $$$a = [3, 2]$$$, it is optimal to do the following:
+
+1. Divide the piece with length $$$2$$$ into two pieces with lengths $$$2-1=1$$$ and $$$1$$$, as a result $$$a = [3, 1, 1]$$$.
+2. Merge the piece with length $$$3$$$ and the piece with length $$$1$$$, as a result $$$a = [4, 1]$$$.
+3. Merge the piece with length $$$4$$$ and the piece with length $$$1$$$, as a result $$$a = [5]$$$.
+
+Input Format:
+Each test contains multiple test cases. The first line contains the number of test cases $$$t$$$ ($$$1 \le t \le 10^4$$$).
+
+Description of each test case consists of two lines. The first line contains two integers $$$n$$$ and $$$k$$$ ($$$2 \le n \le 10^9$$$, $$$2 \le k \le 10^5$$$) — length of casserole and the number of pieces.
+
+The second line contains $$$k$$$ integers $$$a_1, a_2, \ldots, a_k$$$ ($$$1 \le a_i \le n - 1$$$, $$$\sum a_i = n$$$) — lengths of pieces of casserole, which Noobish_Monk has cut.
+
+It is guaranteed that the sum of $$$k$$$ over all $$$t$$$ test cases doesn't exceed $$$2 \cdot 10^5$$$.
+
+Output Format:
+For each test case, output the minimum number of operations K1o0n needs to restore his pie after the terror of Noobish_Monk.
+
+Note:
+None

--- a/1000-1999/1900-1999/1990-1999/1992/problemC.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemC.txt
@@ -1,29 +1,101 @@
-Description:
-Gorilla and Noobish_Monk found three numbers $$$n$$$, $$$m$$$, and $$$k$$$ ($$$m < k$$$). They decided to construct a permutation$$$^{\dagger}$$$ of length $$$n$$$.
-
-For the permutation, Noobish_Monk came up with the following function: $$$g(i)$$$ is the sum of all the numbers in the permutation on a prefix of length $$$i$$$ that are not greater than $$$m$$$. Similarly, Gorilla came up with the function $$$f$$$, where $$$f(i)$$$ is the sum of all the numbers in the permutation on a prefix of length $$$i$$$ that are not less than $$$k$$$. A prefix of length $$$i$$$ is a subarray consisting of the first $$$i$$$ elements of the original array.
-
-For example, if $$$n = 5$$$, $$$m = 2$$$, $$$k = 5$$$, and the permutation is $$$[5, 3, 4, 1, 2]$$$, then:
-
-- $$$f(1) = 5$$$, because $$$5 \ge 5$$$; $$$g(1) = 0$$$, because $$$5 > 2$$$;
-- $$$f(2) = 5$$$, because $$$3 < 5$$$; $$$g(2) = 0$$$, because $$$3 > 2$$$;
-- $$$f(3) = 5$$$, because $$$4 < 5$$$; $$$g(3) = 0$$$, because $$$4 > 2$$$;
-- $$$f(4) = 5$$$, because $$$1 < 5$$$; $$$g(4) = 1$$$, because $$$1 \le 2$$$;
-- $$$f(5) = 5$$$, because $$$2 < 5$$$; $$$g(5) = 1 + 2 = 3$$$, because $$$2 \le 2$$$.
-
-Help them find a permutation for which the value of $$$\left(\sum_{i=1}^n f(i) - \sum_{i=1}^n g(i)\right)$$$ is maximized.
-
-$$$^{\dagger}$$$A permutation of length $$$n$$$ is an array consisting of $$$n$$$ distinct integers from $$$1$$$ to $$$n$$$ in any order. For example, $$$[2,3,1,5,4]$$$ is a permutation, but $$$[1,2,2]$$$ is not a permutation (as $$$2$$$ appears twice in the array) and $$$[1,3,4]$$$ is also not a permutation (as $$$n=3$$$, but $$$4$$$ appears in the array).
-
-Input Format:
-The first line contains a single integer $$$t$$$ ($$$1 \le t \le 10^4$$$)  — the number of test cases.
-
-The only line of each case contains three integers $$$n$$$, $$$m$$$, $$$k$$$ ($$$2\le n \le 10^5$$$; $$$1 \le m < k \le n$$$) — the size of the permutation to be constructed and two integers.
-
-It is guaranteed that the sum of $$$n$$$ over all test cases does not exceed $$$2 \cdot 10^5$$$.
-
-Output Format:
-For each test case, output the permutation  — a set of numbers that satisfies the conditions of the problem. If there are multiple solutions, output any of them.
-
-Note:
-In the first example, $$$\left(\sum_{i=1}^n f(i) - \sum_{i=1}^n g(i)\right) = 5 \cdot 5 - (0 \cdot 3 + 1 + 3) = 25 - 4 = 21$$$
+100
+4 1 2
+14 3 14
+12 5 10
+9 5 6
+8 4 8
+19 12 17
+17 9 14
+4 1 3
+17 15 17
+15 7 10
+20 6 10
+10 1 4
+13 3 6
+19 17 19
+19 6 14
+16 12 15
+14 6 14
+8 4 8
+19 8 16
+11 8 11
+19 12 18
+17 15 17
+14 10 14
+18 8 14
+8 5 7
+18 10 15
+19 17 19
+12 4 12
+19 12 18
+5 2 5
+3 1 2
+4 1 3
+10 2 5
+11 4 11
+9 1 8
+4 1 3
+14 3 7
+3 1 2
+5 1 2
+3 1 3
+7 2 4
+19 1 14
+4 1 2
+4 1 3
+6 3 5
+18 1 11
+17 9 10
+11 7 9
+18 8 10
+13 2 3
+17 13 15
+19 13 17
+19 11 14
+13 5 10
+16 11 12
+20 5 16
+4 2 3
+7 2 4
+6 4 5
+19 2 10
+10 8 9
+11 2 6
+14 5 12
+11 9 10
+7 1 5
+16 3 5
+19 3 11
+6 1 2
+8 2 3
+9 1 9
+17 5 14
+15 4 15
+9 6 8
+16 9 10
+4 2 3
+6 4 6
+3 1 3
+12 6 9
+3 1 2
+6 3 4
+3 1 2
+16 11 15
+17 4 14
+5 1 4
+3 1 3
+5 1 5
+9 1 7
+15 12 14
+7 3 7
+6 3 4
+6 1 6
+13 11 13
+9 6 7
+3 1 2
+18 10 16
+17 3 16
+14 5 13
+19 16 19
+16 8 13
+15 4 7

--- a/1000-1999/1900-1999/1990-1999/1992/problemC_statement.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemC_statement.txt
@@ -1,0 +1,29 @@
+Description:
+Gorilla and Noobish_Monk found three numbers $$$n$$$, $$$m$$$, and $$$k$$$ ($$$m < k$$$). They decided to construct a permutation$$$^{\dagger}$$$ of length $$$n$$$.
+
+For the permutation, Noobish_Monk came up with the following function: $$$g(i)$$$ is the sum of all the numbers in the permutation on a prefix of length $$$i$$$ that are not greater than $$$m$$$. Similarly, Gorilla came up with the function $$$f$$$, where $$$f(i)$$$ is the sum of all the numbers in the permutation on a prefix of length $$$i$$$ that are not less than $$$k$$$. A prefix of length $$$i$$$ is a subarray consisting of the first $$$i$$$ elements of the original array.
+
+For example, if $$$n = 5$$$, $$$m = 2$$$, $$$k = 5$$$, and the permutation is $$$[5, 3, 4, 1, 2]$$$, then:
+
+- $$$f(1) = 5$$$, because $$$5 \ge 5$$$; $$$g(1) = 0$$$, because $$$5 > 2$$$;
+- $$$f(2) = 5$$$, because $$$3 < 5$$$; $$$g(2) = 0$$$, because $$$3 > 2$$$;
+- $$$f(3) = 5$$$, because $$$4 < 5$$$; $$$g(3) = 0$$$, because $$$4 > 2$$$;
+- $$$f(4) = 5$$$, because $$$1 < 5$$$; $$$g(4) = 1$$$, because $$$1 \le 2$$$;
+- $$$f(5) = 5$$$, because $$$2 < 5$$$; $$$g(5) = 1 + 2 = 3$$$, because $$$2 \le 2$$$.
+
+Help them find a permutation for which the value of $$$\left(\sum_{i=1}^n f(i) - \sum_{i=1}^n g(i)\right)$$$ is maximized.
+
+$$$^{\dagger}$$$A permutation of length $$$n$$$ is an array consisting of $$$n$$$ distinct integers from $$$1$$$ to $$$n$$$ in any order. For example, $$$[2,3,1,5,4]$$$ is a permutation, but $$$[1,2,2]$$$ is not a permutation (as $$$2$$$ appears twice in the array) and $$$[1,3,4]$$$ is also not a permutation (as $$$n=3$$$, but $$$4$$$ appears in the array).
+
+Input Format:
+The first line contains a single integer $$$t$$$ ($$$1 \le t \le 10^4$$$)  — the number of test cases.
+
+The only line of each case contains three integers $$$n$$$, $$$m$$$, $$$k$$$ ($$$2\le n \le 10^5$$$; $$$1 \le m < k \le n$$$) — the size of the permutation to be constructed and two integers.
+
+It is guaranteed that the sum of $$$n$$$ over all test cases does not exceed $$$2 \cdot 10^5$$$.
+
+Output Format:
+For each test case, output the permutation  — a set of numbers that satisfies the conditions of the problem. If there are multiple solutions, output any of them.
+
+Note:
+In the first example, $$$\left(\sum_{i=1}^n f(i) - \sum_{i=1}^n g(i)\right) = 5 \cdot 5 - (0 \cdot 3 + 1 + 3) = 25 - 4 = 21$$$

--- a/1000-1999/1900-1999/1990-1999/1992/problemD.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemD.txt
@@ -1,34 +1,201 @@
-Description:
-ErnKor is ready to do anything for Julen, even to swim through crocodile-infested swamps. We decided to test this love. ErnKor will have to swim across a river with a width of $$$1$$$ meter and a length of $$$n$$$ meters.
-
-The river is very cold. Therefore, in total (that is, throughout the entire swim from $$$0$$$ to $$$n+1$$$) ErnKor can swim in the water for no more than $$$k$$$ meters. For the sake of humanity, we have added not only crocodiles to the river, but also logs on which he can jump. Our test is as follows:
-
-Initially, ErnKor is on the left bank and needs to reach the right bank. They are located at the $$$0$$$ and $$$n+1$$$ meters respectively. The river can be represented as $$$n$$$ segments, each with a length of $$$1$$$ meter. Each segment contains either a log 'L', a crocodile 'C', or just water 'W'. ErnKor can move as follows:
-
-- If he is on the surface (i.e., on the bank or on a log), he can jump forward for no more than $$$m$$$ ($$$1 \le m \le 10$$$) meters (he can jump on the bank, on a log, or in the water).
-- If he is in the water, he can only swim to the next river segment (or to the bank if he is at the $$$n$$$-th meter).
-- ErnKor cannot land in a segment with a crocodile in any way.
-
-Determine if ErnKor can reach the right bank.
-
-Input Format:
-The first line contains a single integer $$$t$$$ ($$$1 \le t \le 10^4$$$)  — the number of test cases.
-
-The first line of each test case contains three numbers $$$n, m, k$$$ ($$$0 \le k \le 2 \cdot 10^5$$$, $$$1 \le n \le 2 \cdot 10^5$$$, $$$1 \le m \le 10$$$) — the length of the river, the distance ErnKor can jump, and the number of meters ErnKor can swim without freezing.
-
-The second line of each test case contains a string $$$a$$$ of length $$$n$$$. $$$a_i$$$ denotes the object located at the $$$i$$$-th meter. ($$$a_i \in \{$$$'W','C','L'$$$\}$$$)
-
-It is guaranteed that the sum of $$$n$$$ over all test cases does not exceed $$$2 \cdot 10^5$$$.
-
-Output Format:
-For each test case, output "YES" if ErnKor can pass the test, and output "NO" otherwise.
-
-You can output the answer in any case (upper or lower). For example, the strings "yEs", "yes", "Yes", and "YES" will be recognized as positive responses.
-
-Note:
-Let's consider examples:
-
-- First example: We jump from the shore to the first log ($$$0 \rightarrow 1$$$), from the first log to the second ($$$1 \rightarrow 3$$$), from the second to the fourth ($$$3 \rightarrow 5$$$), and from the last log to the shore ($$$5 \rightarrow 7$$$). So, we have $$$0 \rightarrow 1 \rightarrow 3 \rightarrow 5 \rightarrow 7$$$. Since we did not encounter a crocodile and swam no more than k meters, the answer is «YES».
-- Second example: $$$0 \rightarrow 1$$$, we jump into the water from the first log ($$$1 \rightarrow 2$$$), swim a cell to the log ($$$2 \leadsto 3$$$), $$$3 \rightarrow 4 \rightarrow 5 \rightarrow 6 \rightarrow 7$$$. Since we did not encounter a crocodile and swam no more than k meters, the answer is «YES».
-- In the third example, ErnKor needs to swim two cells 'W', but can only swim one. Therefore, the answer is «NO».
-- Sixth example: We jump from the shore into the water ($$$0 \rightarrow 6$$$) and swim one cell in the water ($$$6 \leadsto 7$$$). Since we did not encounter a crocodile and swam no more than k meters, the answer is «YES».
+100
+9 9 2
+WCWCCLCLW
+10 9 3
+LCWCCWWCLL
+6 5 3
+CLCLLC
+3 2 0
+WWC
+14 7 6
+CCWLWLLLWLWCWC
+11 7 8
+WCWCCWCLWCL
+10 10 10
+CLCWCCCLCC
+8 5 4
+LLWCWLWL
+15 3 0
+WWWLLCCLWCCWCWC
+9 1 4
+LLLCCLLWW
+10 3 0
+WWWLWWWCWC
+19 2 19
+CWWCCCLWWWCWCWLWCWL
+14 10 9
+CLLCCWWWCWCCWC
+17 1 1
+CLWWCWWCCWLWLWWCW
+11 7 1
+LCCCLWCLCWL
+12 3 10
+WCCLLCWWCLWL
+4 3 1
+CWWL
+5 1 4
+LWCLW
+12 2 12
+CWCLWWCWWWCW
+11 7 9
+WLWLLLWCCWC
+9 1 7
+CCCWCWLLC
+11 2 3
+LLCCLWCLLWC
+5 2 4
+WLCLC
+19 7 1
+CLWLWCWLWLLLCLLLWLL
+17 10 12
+LWLWCCCWLWWLLLLLL
+4 4 0
+CLCC
+17 6 5
+WLWWCWCWWWLWWLLCL
+14 2 9
+LLWWCCCWCLCWLW
+17 6 13
+CWWLLLCWCCLWLWLLW
+13 9 12
+WLWCLCCCWCLCW
+20 9 3
+CCLWLLWLCLCLCWLLWLLL
+17 5 9
+LLCCCCLLCCLCLCWCL
+4 2 1
+CLWC
+14 5 5
+CWWCWLWCLWCLWC
+20 10 16
+CWLCWLLLWCWCCWCCLLWL
+6 5 4
+WLCCWC
+15 10 8
+LWLWWWLLCWLWWLW
+17 10 6
+WCCCLWCLWCLWLLCCC
+4 2 2
+LLWL
+7 5 0
+WLLWLWL
+4 1 0
+WWLW
+16 10 10
+LLWWWWWLLCCCWWLC
+12 2 4
+LCWLWCWLCCWC
+13 8 4
+CCCCWLWCCCCLC
+17 9 11
+LCWCCCCLCCCCLLWCW
+5 1 4
+LWCCC
+15 9 9
+CLWWWLCLLCLCCCC
+14 6 1
+WWWLLLWCWLCCWW
+14 8 8
+LWWLLWCLCLCCLL
+8 7 6
+CLCCLWLC
+18 3 18
+LLWWWLWWWWCCWCWCCC
+11 8 0
+CLCCLLCLWLC
+16 4 6
+CLLCCWLCWCLLWLCL
+2 2 2
+LC
+4 4 4
+LWWW
+13 3 1
+CLCLCWLLLWCLW
+12 2 12
+LWLLCLWWWCLC
+15 4 15
+WLWWCWWLWLCWWWW
+18 6 12
+LLLWWLWCLLLLLCWCLC
+2 1 0
+CL
+16 8 5
+LLWWWWLCCLLWLWWL
+9 4 1
+WWLLWCLWL
+3 3 2
+WWW
+17 4 17
+WLWCWWLLCWLCCLLLC
+4 1 1
+CLWL
+8 6 3
+WWWWCLWW
+14 2 4
+LWLCWCWCCWLCCW
+19 6 5
+WWWLWCWWWLCCCCCWWLL
+7 6 0
+WLCCCLW
+9 1 9
+LWWCCWWLL
+8 7 1
+WCWLWLCL
+9 1 2
+CLCLLLWLL
+19 9 13
+CCWCLWLCLLLCLLLWLLW
+14 4 13
+CCLCWCCWWCCWLW
+16 7 6
+LCLWWCCLWWLWLCCC
+13 7 12
+CLCCLLWLWLWWL
+10 4 5
+LCLCLCCWCC
+15 6 6
+CWWWWCLWLLLLCLW
+18 9 1
+CWLLCLWWWLWWCLCWLL
+16 5 13
+WLLLWCWWCWLWWWWC
+19 4 11
+WWLWWWWCLCLLLCCLCLL
+3 1 1
+WWW
+19 1 15
+LLLWWWLCCLWWWLCWWCW
+12 1 0
+WLCCLCLLCWCW
+19 3 8
+LLLLWCLWWCCCCWWCCLW
+7 1 2
+CLWWWWW
+10 8 4
+CLCWLCLWWL
+16 10 8
+LWCCCLWLWCWLWCLW
+3 3 3
+CWL
+11 6 2
+CWWWLWLLWWC
+14 9 4
+LLWWWLWLLCLCCL
+5 1 2
+CLWWW
+16 5 9
+CCLLLWLLLCLCWCWC
+2 1 1
+LL
+7 3 3
+CLLLCLC
+8 7 1
+WWLLWLLL
+6 3 1
+WWCLLL
+13 3 7
+LLWCWLCWWLCWC
+16 10 13
+WCCWWLCWWLCWCCLW
+7 3 4
+LLLCLWC

--- a/1000-1999/1900-1999/1990-1999/1992/problemD_statement.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemD_statement.txt
@@ -1,0 +1,34 @@
+Description:
+ErnKor is ready to do anything for Julen, even to swim through crocodile-infested swamps. We decided to test this love. ErnKor will have to swim across a river with a width of $$$1$$$ meter and a length of $$$n$$$ meters.
+
+The river is very cold. Therefore, in total (that is, throughout the entire swim from $$$0$$$ to $$$n+1$$$) ErnKor can swim in the water for no more than $$$k$$$ meters. For the sake of humanity, we have added not only crocodiles to the river, but also logs on which he can jump. Our test is as follows:
+
+Initially, ErnKor is on the left bank and needs to reach the right bank. They are located at the $$$0$$$ and $$$n+1$$$ meters respectively. The river can be represented as $$$n$$$ segments, each with a length of $$$1$$$ meter. Each segment contains either a log 'L', a crocodile 'C', or just water 'W'. ErnKor can move as follows:
+
+- If he is on the surface (i.e., on the bank or on a log), he can jump forward for no more than $$$m$$$ ($$$1 \le m \le 10$$$) meters (he can jump on the bank, on a log, or in the water).
+- If he is in the water, he can only swim to the next river segment (or to the bank if he is at the $$$n$$$-th meter).
+- ErnKor cannot land in a segment with a crocodile in any way.
+
+Determine if ErnKor can reach the right bank.
+
+Input Format:
+The first line contains a single integer $$$t$$$ ($$$1 \le t \le 10^4$$$)  — the number of test cases.
+
+The first line of each test case contains three numbers $$$n, m, k$$$ ($$$0 \le k \le 2 \cdot 10^5$$$, $$$1 \le n \le 2 \cdot 10^5$$$, $$$1 \le m \le 10$$$) — the length of the river, the distance ErnKor can jump, and the number of meters ErnKor can swim without freezing.
+
+The second line of each test case contains a string $$$a$$$ of length $$$n$$$. $$$a_i$$$ denotes the object located at the $$$i$$$-th meter. ($$$a_i \in \{$$$'W','C','L'$$$\}$$$)
+
+It is guaranteed that the sum of $$$n$$$ over all test cases does not exceed $$$2 \cdot 10^5$$$.
+
+Output Format:
+For each test case, output "YES" if ErnKor can pass the test, and output "NO" otherwise.
+
+You can output the answer in any case (upper or lower). For example, the strings "yEs", "yes", "Yes", and "YES" will be recognized as positive responses.
+
+Note:
+Let's consider examples:
+
+- First example: We jump from the shore to the first log ($$$0 \rightarrow 1$$$), from the first log to the second ($$$1 \rightarrow 3$$$), from the second to the fourth ($$$3 \rightarrow 5$$$), and from the last log to the shore ($$$5 \rightarrow 7$$$). So, we have $$$0 \rightarrow 1 \rightarrow 3 \rightarrow 5 \rightarrow 7$$$. Since we did not encounter a crocodile and swam no more than k meters, the answer is «YES».
+- Second example: $$$0 \rightarrow 1$$$, we jump into the water from the first log ($$$1 \rightarrow 2$$$), swim a cell to the log ($$$2 \leadsto 3$$$), $$$3 \rightarrow 4 \rightarrow 5 \rightarrow 6 \rightarrow 7$$$. Since we did not encounter a crocodile and swam no more than k meters, the answer is «YES».
+- In the third example, ErnKor needs to swim two cells 'W', but can only swim one. Therefore, the answer is «NO».
+- Sixth example: We jump from the shore into the water ($$$0 \rightarrow 6$$$) and swim one cell in the water ($$$6 \leadsto 7$$$). Since we did not encounter a crocodile and swam no more than k meters, the answer is «YES».

--- a/1000-1999/1900-1999/1990-1999/1992/problemE.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemE.txt
@@ -1,28 +1,101 @@
-Description:
-One of the first programming problems by K1o0n looked like this: "Noobish_Monk has $$$n$$$ $$$(1 \le n \le 100)$$$ friends. Each of them gave him $$$a$$$ $$$(1 \le a \le 10000)$$$ apples for his birthday. Delighted with such a gift, Noobish_Monk returned $$$b$$$ $$$(1 \le b \le \min(10000, a \cdot n))$$$ apples to his friends. How many apples are left with Noobish_Monk?"
-
-K1o0n wrote a solution, but accidentally considered the value of $$$n$$$ as a string, so the value of $$$n \cdot a - b$$$ was calculated differently. Specifically:
-
-- when multiplying the string $$$n$$$ by the integer $$$a$$$, he will get the string $$$s=\underbrace{n + n + \dots + n + n}_{a\ \text{times}}$$$
-- when subtracting the integer $$$b$$$ from the string $$$s$$$, the last $$$b$$$ characters will be removed from it. If $$$b$$$ is greater than or equal to the length of the string $$$s$$$, it will become empty.
-
-Learning about this, ErnKor became interested in how many pairs $$$(a, b)$$$ exist for a given $$$n$$$, satisfying the constraints of the problem, on which K1o0n's solution gives the correct answer.
-
-"The solution gives the correct answer" means that it outputs a non-empty string, and this string, when converted to an integer, equals the correct answer, i.e., the value of $$$n \cdot a - b$$$.
-
-Input Format:
-The first line contains a single integer $$$t$$$ ($$$1 \le t \le 100$$$)  — the number of test cases.
-
-For each test case, a single line of input contains an integer $$$n$$$ ($$$1 \le n \le 100$$$).
-
-It is guaranteed that in all test cases, $$$n$$$ is distinct.
-
-Output Format:
-For each test case, output the answer in the following format:
-
-In the first line, output the integer $$$x$$$ — the number of bad tests for the given $$$n$$$.
-
-In the next $$$x$$$ lines, output two integers $$$a_i$$$ and $$$b_i$$$ — such integers that K1o0n's solution on the test "$$$n$$$ $$$a_i$$$ $$$b_i$$$" gives the correct answer.
-
-Note:
-In the first example, $$$a = 20$$$, $$$b = 18$$$ are suitable, as "$$$\text{2}$$$" $$$\cdot 20 - 18 =$$$ "$$$\text{22222222222222222222}$$$"$$$- 18 = 22 = 2 \cdot 20 - 18$$$
+100
+3868
+4970
+1691
+6490
+7846
+2540
+1477
+1090
+325
+6580
+9002
+4742
+965
+3637
+8526
+8793
+5903
+4534
+2829
+1740
+4289
+3513
+421
+4265
+4453
+3170
+2701
+5077
+4746
+6102
+1421
+9927
+5529
+6356
+8290
+4078
+2913
+4053
+7760
+4588
+1464
+8973
+4920
+119
+4784
+9378
+5108
+8330
+3197
+6783
+6943
+9813
+4722
+7063
+7396
+2644
+3822
+4999
+4255
+709
+1329
+759
+7581
+4595
+8502
+8760
+7721
+5618
+2377
+3205
+1089
+6764
+3321
+7228
+4527
+3010
+5830
+7143
+9647
+5254
+9151
+3256
+5301
+1655
+1010
+3750
+4547
+9539
+3890
+2002
+5425
+2909
+4767
+7521
+421
+702
+5851
+1354
+4681
+5360

--- a/1000-1999/1900-1999/1990-1999/1992/problemE_statement.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemE_statement.txt
@@ -1,0 +1,28 @@
+Description:
+One of the first programming problems by K1o0n looked like this: "Noobish_Monk has $$$n$$$ $$$(1 \le n \le 100)$$$ friends. Each of them gave him $$$a$$$ $$$(1 \le a \le 10000)$$$ apples for his birthday. Delighted with such a gift, Noobish_Monk returned $$$b$$$ $$$(1 \le b \le \min(10000, a \cdot n))$$$ apples to his friends. How many apples are left with Noobish_Monk?"
+
+K1o0n wrote a solution, but accidentally considered the value of $$$n$$$ as a string, so the value of $$$n \cdot a - b$$$ was calculated differently. Specifically:
+
+- when multiplying the string $$$n$$$ by the integer $$$a$$$, he will get the string $$$s=\underbrace{n + n + \dots + n + n}_{a\ \text{times}}$$$
+- when subtracting the integer $$$b$$$ from the string $$$s$$$, the last $$$b$$$ characters will be removed from it. If $$$b$$$ is greater than or equal to the length of the string $$$s$$$, it will become empty.
+
+Learning about this, ErnKor became interested in how many pairs $$$(a, b)$$$ exist for a given $$$n$$$, satisfying the constraints of the problem, on which K1o0n's solution gives the correct answer.
+
+"The solution gives the correct answer" means that it outputs a non-empty string, and this string, when converted to an integer, equals the correct answer, i.e., the value of $$$n \cdot a - b$$$.
+
+Input Format:
+The first line contains a single integer $$$t$$$ ($$$1 \le t \le 100$$$)  — the number of test cases.
+
+For each test case, a single line of input contains an integer $$$n$$$ ($$$1 \le n \le 100$$$).
+
+It is guaranteed that in all test cases, $$$n$$$ is distinct.
+
+Output Format:
+For each test case, output the answer in the following format:
+
+In the first line, output the integer $$$x$$$ — the number of bad tests for the given $$$n$$$.
+
+In the next $$$x$$$ lines, output two integers $$$a_i$$$ and $$$b_i$$$ — such integers that K1o0n's solution on the test "$$$n$$$ $$$a_i$$$ $$$b_i$$$" gives the correct answer.
+
+Note:
+In the first example, $$$a = 20$$$, $$$b = 18$$$ are suitable, as "$$$\text{2}$$$" $$$\cdot 20 - 18 =$$$ "$$$\text{22222222222222222222}$$$"$$$- 18 = 22 = 2 \cdot 20 - 18$$$

--- a/1000-1999/1900-1999/1990-1999/1992/problemF.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemF.txt
@@ -1,25 +1,201 @@
-Description:
-In his favorite cafe Kmes once again wanted to try the herring under a fur coat. Previously, it would not have been difficult for him to do this, but the cafe recently introduced a new purchasing policy.
-
-Now, in order to make a purchase, Kmes needs to solve the following problem: $$$n$$$ cards with prices for different positions are laid out in front of him, on the $$$i$$$-th card there is an integer $$$a_i$$$, among these prices there is no whole positive integer $$$x$$$.
-
-Kmes is asked to divide these cards into the minimum number of bad segments (so that each card belongs to exactly one segment). A segment is considered bad if it is impossible to select a subset of cards with a product equal to $$$x$$$. All segments, in which Kmes will divide the cards, must be bad.
-
-Formally, the segment $$$(l, r)$$$ is bad if there are no indices $$$i_1 < i_2 < \ldots < i_k$$$ such that $$$l \le i_1, i_k \le r$$$, and $$$a_{i_1} \cdot a_{i_2} \ldots \cdot a_{i_k} = x$$$.
-
-Help Kmes determine the minimum number of bad segments in order to enjoy his favorite dish.
-
-Input Format:
-The first line contains a single integer $$$t$$$ ($$$1 \le t \le 10^3$$$) — the number of test cases.
-
-The first line of each set of input data gives you $$$2$$$ integers $$$n$$$ and $$$x$$$ ($$$1 \le n \le 10^5, 2 \le x \le 10^5$$$) — the number of cards and the integer, respectively.
-
-The second line of each set of input data contains $$$n$$$ integers $$$a_i$$$ ($$$1 \le a_i \le 2 \cdot 10^5, a_i \neq x$$$) — the prices on the cards.
-
-It is guaranteed that the sum of $$$n$$$ over all sets of test data does not exceed $$$10^5$$$.
-
-Output Format:
-For each set of input data, output the minimum number of bad segments.
-
-Note:
-None
+100
+10 10
+6 9 1 8 4 1 3 2 6 8
+4 14
+9 2 10 4
+1 8
+7
+5 7
+7 3 2 3 10
+10 16
+3 3 1 1 4 4 3 3 5 6
+4 19
+4 3 4 7
+5 2
+6 7 3 3 5
+2 12
+5 10
+10 2
+10 6 2 5 6 5 8 6 3 8
+8 7
+1 5 1 6 7 1 9 7
+6 14
+10 1 8 1 3 10
+4 5
+4 8 6 9
+6 18
+5 8 2 10 6 5
+1 15
+2
+4 12
+9 10 6 3
+6 10
+9 2 5 6 5 3
+2 6
+5 8
+3 3
+2 10 9
+7 3
+4 10 6 5 8 7 3
+1 3
+8
+6 8
+3 10 3 7 2 3
+7 13
+3 1 7 5 3 8 10
+3 18
+8 8 6
+8 10
+5 8 7 3 2 7 9 3
+8 12
+3 2 8 5 9 9 9 6
+2 13
+10 1
+5 13
+9 5 8 5 5
+6 7
+10 1 8 9 5 6
+5 16
+5 9 6 6 5
+6 15
+6 3 8 6 6 9
+3 18
+3 4 6
+8 11
+2 7 3 10 10 9 7 5
+10 19
+5 1 4 3 10 8 10 3 4 3
+1 17
+4
+3 3
+3 2 6
+3 17
+4 9 1
+7 16
+6 7 10 2 10 4 4
+6 2
+6 7 5 7 2 9
+6 3
+9 10 5 2 5 9
+9 12
+10 5 6 3 7 7 10 9 6
+8 6
+3 10 7 10 8 4 3 10
+2 13
+1 7
+2 12
+10 10
+9 6
+6 10 7 7 7 4 8 5 8
+7 14
+3 10 10 5 5 8 5
+7 2
+6 5 8 5 3 8 1
+2 16
+4 5
+1 6
+7
+1 17
+9
+9 10
+4 8 1 4 8 5 3 5 5
+8 17
+9 10 2 1 3 5 5 9
+6 11
+9 1 8 6 6 10
+3 3
+1 5 9
+8 5
+9 4 1 7 7 10 10 8
+7 17
+7 4 5 8 2 5 1
+7 20
+5 8 5 3 3 8 9
+8 12
+9 3 7 10 9 1 2 4
+5 4
+2 1 6 7 2
+7 17
+1 2 2 4 10 2 3
+5 16
+3 3 10 3 7
+3 4
+10 4 1
+9 5
+7 2 5 1 10 10 2 7 10
+3 2
+7 2 6
+10 17
+8 6 6 1 3 5 3 10 9 5
+9 19
+10 4 5 2 9 4 5 5 9
+3 9
+6 8 7
+3 6
+1 6 2
+10 3
+2 2 9 10 8 4 7 8 8 6
+2 18
+1 9
+7 3
+3 7 4 2 2 8 4
+3 14
+6 4 5
+6 13
+7 7 3 6 5 7
+6 18
+1 10 10 4 3 7
+2 5
+1 1
+3 8
+4 1 8
+8 13
+1 7 8 5 10 7 6 8
+8 5
+4 3 3 2 6 7 8 3
+9 10
+2 5 3 5 4 1 8 1 6
+6 12
+1 1 8 8 3 2
+6 11
+8 4 3 1 4 1
+10 9
+2 10 7 6 5 3 8 6 5 2
+8 7
+4 3 4 1 10 7 5 1
+8 3
+8 7 3 1 1 9 9 10
+6 5
+2 4 8 2 8 1
+4 3
+8 7 1 1
+5 15
+8 5 1 1 4
+3 18
+7 4 9
+4 4
+6 2 2 9
+3 4
+4 10 1
+8 19
+6 8 7 10 7 9 3 1
+5 16
+4 9 2 3 5
+8 4
+5 7 6 3 3 9 2 8
+4 4
+7 10 4 5
+1 17
+4
+1 8
+5
+6 5
+2 7 6 7 9 1
+5 6
+10 1 8 3 1
+1 15
+5
+2 14
+9 3
+6 4
+5 3 3 5 8 6

--- a/1000-1999/1900-1999/1990-1999/1992/problemF_statement.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemF_statement.txt
@@ -1,0 +1,25 @@
+Description:
+In his favorite cafe Kmes once again wanted to try the herring under a fur coat. Previously, it would not have been difficult for him to do this, but the cafe recently introduced a new purchasing policy.
+
+Now, in order to make a purchase, Kmes needs to solve the following problem: $$$n$$$ cards with prices for different positions are laid out in front of him, on the $$$i$$$-th card there is an integer $$$a_i$$$, among these prices there is no whole positive integer $$$x$$$.
+
+Kmes is asked to divide these cards into the minimum number of bad segments (so that each card belongs to exactly one segment). A segment is considered bad if it is impossible to select a subset of cards with a product equal to $$$x$$$. All segments, in which Kmes will divide the cards, must be bad.
+
+Formally, the segment $$$(l, r)$$$ is bad if there are no indices $$$i_1 < i_2 < \ldots < i_k$$$ such that $$$l \le i_1, i_k \le r$$$, and $$$a_{i_1} \cdot a_{i_2} \ldots \cdot a_{i_k} = x$$$.
+
+Help Kmes determine the minimum number of bad segments in order to enjoy his favorite dish.
+
+Input Format:
+The first line contains a single integer $$$t$$$ ($$$1 \le t \le 10^3$$$) — the number of test cases.
+
+The first line of each set of input data gives you $$$2$$$ integers $$$n$$$ and $$$x$$$ ($$$1 \le n \le 10^5, 2 \le x \le 10^5$$$) — the number of cards and the integer, respectively.
+
+The second line of each set of input data contains $$$n$$$ integers $$$a_i$$$ ($$$1 \le a_i \le 2 \cdot 10^5, a_i \neq x$$$) — the prices on the cards.
+
+It is guaranteed that the sum of $$$n$$$ over all sets of test data does not exceed $$$10^5$$$.
+
+Output Format:
+For each set of input data, output the minimum number of bad segments.
+
+Note:
+None

--- a/1000-1999/1900-1999/1990-1999/1992/problemG.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemG.txt
@@ -1,23 +1,101 @@
-Description:
-K1o0n gave you an array $$$a$$$ of length $$$n$$$, consisting of numbers $$$1, 2, \ldots, n$$$. Accept it? Of course! But what to do with it? Of course, calculate $$$\text{MEOW}(a)$$$.
-
-Let $$$\text{MEX}(S, k)$$$ be the $$$k$$$-th positive (strictly greater than zero) integer in ascending order that is not present in the set $$$S$$$. Denote $$$\text{MEOW}(a)$$$ as the sum of $$$\text{MEX}(b, |b| + 1)$$$, over all distinct subsets $$$b$$$ of the array $$$a$$$.
-
-Examples of $$$\text{MEX}(S, k)$$$ values for sets:
-
-- $$$\text{MEX}(\{3,2\}, 1) = 1$$$, because $$$1$$$ is the first positive integer not present in the set;
-- $$$\text{MEX}(\{4,2,1\}, 2) = 5$$$, because the first two positive integers not present in the set are $$$3$$$ and $$$5$$$;
-- $$$\text{MEX}(\{\}, 4) = 4$$$, because there are no numbers in the empty set, so the first $$$4$$$ positive integers not present in it are $$$1, 2, 3, 4$$$.
-
-Input Format:
-The first line contains a single integer $$$t$$$ ($$$1 \le t \le 10^4$$$) — the number of test cases.
-
-In a single line of each test case, an integer $$$n$$$ ($$$1 \le n \le 5000$$$) is entered, the size of the array of gifted numbers.
-
-It is guaranteed that the sum of $$$n^2$$$ over all test cases does not exceed $$$25 \cdot 10^6$$$.
-
-Output Format:
-For each test case, output a single number — $$$\text{MEOW}(a)$$$. Since it may be very large, output it modulo $$$10^9 + 7$$$.
-
-Note:
-None
+100
+19
+3
+16
+9
+2
+1
+5
+19
+16
+12
+11
+1
+9
+16
+7
+14
+18
+18
+4
+7
+19
+18
+9
+20
+3
+14
+11
+3
+12
+14
+9
+15
+4
+7
+10
+4
+2
+19
+7
+12
+16
+7
+17
+19
+17
+1
+12
+8
+20
+14
+10
+12
+19
+4
+3
+17
+17
+7
+4
+20
+9
+10
+7
+13
+16
+8
+5
+20
+7
+17
+1
+7
+6
+1
+11
+18
+20
+20
+10
+12
+13
+17
+13
+10
+5
+16
+2
+6
+14
+20
+13
+4
+15
+8
+3
+20
+15
+15
+13
+3

--- a/1000-1999/1900-1999/1990-1999/1992/problemG_statement.txt
+++ b/1000-1999/1900-1999/1990-1999/1992/problemG_statement.txt
@@ -1,0 +1,23 @@
+Description:
+K1o0n gave you an array $$$a$$$ of length $$$n$$$, consisting of numbers $$$1, 2, \ldots, n$$$. Accept it? Of course! But what to do with it? Of course, calculate $$$\text{MEOW}(a)$$$.
+
+Let $$$\text{MEX}(S, k)$$$ be the $$$k$$$-th positive (strictly greater than zero) integer in ascending order that is not present in the set $$$S$$$. Denote $$$\text{MEOW}(a)$$$ as the sum of $$$\text{MEX}(b, |b| + 1)$$$, over all distinct subsets $$$b$$$ of the array $$$a$$$.
+
+Examples of $$$\text{MEX}(S, k)$$$ values for sets:
+
+- $$$\text{MEX}(\{3,2\}, 1) = 1$$$, because $$$1$$$ is the first positive integer not present in the set;
+- $$$\text{MEX}(\{4,2,1\}, 2) = 5$$$, because the first two positive integers not present in the set are $$$3$$$ and $$$5$$$;
+- $$$\text{MEX}(\{\}, 4) = 4$$$, because there are no numbers in the empty set, so the first $$$4$$$ positive integers not present in it are $$$1, 2, 3, 4$$$.
+
+Input Format:
+The first line contains a single integer $$$t$$$ ($$$1 \le t \le 10^4$$$) — the number of test cases.
+
+In a single line of each test case, an integer $$$n$$$ ($$$1 \le n \le 5000$$$) is entered, the size of the array of gifted numbers.
+
+It is guaranteed that the sum of $$$n^2$$$ over all test cases does not exceed $$$25 \cdot 10^6$$$.
+
+Output Format:
+For each test case, output a single number — $$$\text{MEOW}(a)$$$. Since it may be very large, output it modulo $$$10^9 + 7$$$.
+
+Note:
+None

--- a/1000-1999/1900-1999/1990-1999/1992/verifierA.go
+++ b/1000-1999/1900-1999/1990-1999/1992/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func solve(a, b, c int) int {
+	best := 0
+	for i := 0; i <= 5; i++ {
+		for j := 0; j <= 5-i; j++ {
+			k := 5 - i - j
+			prod := (a + i) * (b + j) * (c + k)
+			if prod > best {
+				best = prod
+			}
+		}
+	}
+	return best
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	data, err := os.ReadFile("problemA.txt")
+	if err != nil {
+		fmt.Println("could not read problemA.txt:", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		fmt.Println("invalid test file")
+		os.Exit(1)
+	}
+	t, _ := strconv.Atoi(scanner.Text())
+	expected := make([]string, t)
+	for i := 0; i < t; i++ {
+		if !scanner.Scan() {
+			fmt.Println("not enough values in test file")
+			os.Exit(1)
+		}
+		a, _ := strconv.Atoi(scanner.Text())
+		scanner.Scan()
+		b, _ := strconv.Atoi(scanner.Text())
+		scanner.Scan()
+		c, _ := strconv.Atoi(scanner.Text())
+		expected[i] = fmt.Sprintf("%d", solve(a, b, c))
+	}
+	cmd := exec.Command(os.Args[1])
+	cmd.Stdin = bytes.NewReader(data)
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("execution failed:", err)
+		os.Exit(1)
+	}
+	outScan := bufio.NewScanner(bytes.NewReader(out))
+	outScan.Split(bufio.ScanWords)
+	for i := 0; i < t; i++ {
+		if !outScan.Scan() {
+			fmt.Printf("missing output for test %d\n", i+1)
+			os.Exit(1)
+		}
+		got := outScan.Text()
+		if got != expected[i] {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	if outScan.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1900-1999/1990-1999/1992/verifierB.go
+++ b/1000-1999/1900-1999/1990-1999/1992/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func solveCase(n int, arr []int) int {
+	maxVal := 0
+	for _, v := range arr {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	ans := 2*(n-maxVal) - (len(arr) - 1)
+	if ans < 0 {
+		ans = 0
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	data, err := os.ReadFile("problemB.txt")
+	if err != nil {
+		fmt.Println("could not read problemB.txt:", err)
+		os.Exit(1)
+	}
+	scan := bufio.NewScanner(bytes.NewReader(data))
+	scan.Split(bufio.ScanWords)
+	if !scan.Scan() {
+		fmt.Println("invalid test file")
+		os.Exit(1)
+	}
+	t, _ := strconv.Atoi(scan.Text())
+	expected := make([]string, t)
+	for i := 0; i < t; i++ {
+		if !scan.Scan() {
+			fmt.Println("bad test file")
+			os.Exit(1)
+		}
+		n, _ := strconv.Atoi(scan.Text())
+		scan.Scan()
+		k, _ := strconv.Atoi(scan.Text())
+		arr := make([]int, k)
+		for j := 0; j < k; j++ {
+			scan.Scan()
+			v, _ := strconv.Atoi(scan.Text())
+			arr[j] = v
+		}
+		expected[i] = fmt.Sprintf("%d", solveCase(n, arr))
+	}
+	cmd := exec.Command(os.Args[1])
+	cmd.Stdin = bytes.NewReader(data)
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("execution failed:", err)
+		os.Exit(1)
+	}
+	outScan := bufio.NewScanner(bytes.NewReader(out))
+	outScan.Split(bufio.ScanWords)
+	for i := 0; i < t; i++ {
+		if !outScan.Scan() {
+			fmt.Printf("missing output for test %d\n", i+1)
+			os.Exit(1)
+		}
+		got := outScan.Text()
+		if got != expected[i] {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	if outScan.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1900-1999/1990-1999/1992/verifierC.go
+++ b/1000-1999/1900-1999/1990-1999/1992/verifierC.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func solveCase(n, m, k int) string {
+	var parts []string
+	for i := n; i >= k; i-- {
+		parts = append(parts, strconv.Itoa(i))
+	}
+	for i := m + 1; i < k; i++ {
+		parts = append(parts, strconv.Itoa(i))
+	}
+	for i := 1; i <= m; i++ {
+		parts = append(parts, strconv.Itoa(i))
+	}
+	return strings.Join(parts, " ")
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	data, err := os.ReadFile("problemC.txt")
+	if err != nil {
+		fmt.Println("could not read problemC.txt:", err)
+		os.Exit(1)
+	}
+	scan := bufio.NewScanner(bytes.NewReader(data))
+	scan.Split(bufio.ScanWords)
+	if !scan.Scan() {
+		fmt.Println("invalid test file")
+		os.Exit(1)
+	}
+	t, _ := strconv.Atoi(scan.Text())
+	cases := make([]string, t)
+	for i := 0; i < t; i++ {
+		if !scan.Scan() {
+			fmt.Println("bad test file")
+			os.Exit(1)
+		}
+		n, _ := strconv.Atoi(scan.Text())
+		scan.Scan()
+		m, _ := strconv.Atoi(scan.Text())
+		scan.Scan()
+		k, _ := strconv.Atoi(scan.Text())
+		cases[i] = solveCase(n, m, k)
+	}
+	cmd := exec.Command(os.Args[1])
+	cmd.Stdin = bytes.NewReader(data)
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("execution failed:", err)
+		os.Exit(1)
+	}
+	outScan := bufio.NewScanner(bytes.NewReader(out))
+	for i := 0; i < t; i++ {
+		if !outScan.Scan() {
+			fmt.Printf("missing output for test %d\n", i+1)
+			os.Exit(1)
+		}
+		line := strings.TrimSpace(outScan.Text())
+		if line != cases[i] {
+			fmt.Printf("test %d failed:\nexpected: %s\n got: %s\n", i+1, cases[i], line)
+			os.Exit(1)
+		}
+	}
+	if outScan.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1900-1999/1990-1999/1992/verifierD.go
+++ b/1000-1999/1900-1999/1990-1999/1992/verifierD.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"container/list"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type state struct {
+	pos   int
+	water bool
+}
+
+func solve(n, m, k int, s string) string {
+	river := make([]byte, n+2)
+	river[0] = 'L'
+	for i := 0; i < n; i++ {
+		river[i+1] = s[i]
+	}
+	river[n+1] = 'L'
+	const INF = int(1e9)
+	surf := make([]int, n+2)
+	wat := make([]int, n+2)
+	for i := 0; i < n+2; i++ {
+		surf[i] = INF
+		wat[i] = INF
+	}
+	dq := list.New()
+	surf[0] = 0
+	dq.PushFront(state{0, false})
+	for dq.Len() > 0 {
+		cur := dq.Remove(dq.Front()).(state)
+		var d int
+		if cur.water {
+			d = wat[cur.pos]
+		} else {
+			d = surf[cur.pos]
+		}
+		if cur.water {
+			nxt := cur.pos + 1
+			if nxt <= n+1 && river[nxt] != 'C' {
+				nw := river[nxt] == 'W'
+				nd := d + 1
+				if nw {
+					if nd < wat[nxt] {
+						wat[nxt] = nd
+						dq.PushBack(state{nxt, true})
+					}
+				} else {
+					if nd < surf[nxt] {
+						surf[nxt] = nd
+						dq.PushBack(state{nxt, false})
+					}
+				}
+			}
+		} else {
+			for j := cur.pos + 1; j <= n+1 && j <= cur.pos+m; j++ {
+				if river[j] == 'C' {
+					continue
+				}
+				nw := river[j] == 'W'
+				if nw {
+					if d < wat[j] {
+						wat[j] = d
+						dq.PushFront(state{j, true})
+					}
+				} else {
+					if d < surf[j] {
+						surf[j] = d
+						dq.PushFront(state{j, false})
+					}
+				}
+			}
+		}
+	}
+	ans := surf[n+1]
+	if wat[n+1] < ans {
+		ans = wat[n+1]
+	}
+	if ans <= k {
+		return "YES"
+	}
+	return "NO"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	data, err := os.ReadFile("problemD.txt")
+	if err != nil {
+		fmt.Println("could not read problemD.txt:", err)
+		os.Exit(1)
+	}
+	scan := bufio.NewScanner(bytes.NewReader(data))
+	scan.Split(bufio.ScanWords)
+	if !scan.Scan() {
+		fmt.Println("invalid test file")
+		os.Exit(1)
+	}
+	t, _ := strconv.Atoi(scan.Text())
+	expected := make([]string, t)
+	for i := 0; i < t; i++ {
+		if !scan.Scan() {
+			fmt.Println("bad test file")
+			os.Exit(1)
+		}
+		n, _ := strconv.Atoi(scan.Text())
+		scan.Scan()
+		m, _ := strconv.Atoi(scan.Text())
+		scan.Scan()
+		k, _ := strconv.Atoi(scan.Text())
+		if !scan.Scan() {
+			fmt.Println("missing string")
+			os.Exit(1)
+		}
+		s := scan.Text()
+		expected[i] = solve(n, m, k, s)
+	}
+	cmd := exec.Command(os.Args[1])
+	cmd.Stdin = bytes.NewReader(data)
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("execution failed:", err)
+		os.Exit(1)
+	}
+	outScan := bufio.NewScanner(bytes.NewReader(out))
+	outScan.Split(bufio.ScanWords)
+	for i := 0; i < t; i++ {
+		if !outScan.Scan() {
+			fmt.Printf("missing output for test %d\n", i+1)
+			os.Exit(1)
+		}
+		got := outScan.Text()
+		if got != expected[i] {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	if outScan.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1900-1999/1990-1999/1992/verifierE.go
+++ b/1000-1999/1900-1999/1990-1999/1992/verifierE.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type pair struct{ a, b int }
+
+func prefixRepeat(s string, d int) int {
+	var b strings.Builder
+	for b.Len() < d {
+		b.WriteString(s)
+	}
+	str := b.String()[:d]
+	val, _ := strconv.Atoi(str)
+	return val
+}
+
+func solve(n int) []pair {
+	ns := strconv.Itoa(n)
+	l := len(ns)
+	res := make([]pair, 0)
+	for a := 1; a <= 10000; a++ {
+		for d := 1; d <= 7; d++ {
+			b := l*a - d
+			if b < 1 || b > a*n || b > 10000 {
+				continue
+			}
+			if d > l*a {
+				continue
+			}
+			pref := prefixRepeat(ns, d)
+			if pref == a*n-b {
+				res = append(res, pair{a, b})
+			}
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	data, err := os.ReadFile("problemE.txt")
+	if err != nil {
+		fmt.Println("could not read problemE.txt:", err)
+		os.Exit(1)
+	}
+	scan := bufio.NewScanner(bytes.NewReader(data))
+	scan.Split(bufio.ScanWords)
+	if !scan.Scan() {
+		fmt.Println("invalid test file")
+		os.Exit(1)
+	}
+	t, _ := strconv.Atoi(scan.Text())
+	expected := make([][]pair, t)
+	for i := 0; i < t; i++ {
+		if !scan.Scan() {
+			fmt.Println("bad test file")
+			os.Exit(1)
+		}
+		n, _ := strconv.Atoi(scan.Text())
+		expected[i] = solve(n)
+	}
+	cmd := exec.Command(os.Args[1])
+	cmd.Stdin = bytes.NewReader(data)
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("execution failed:", err)
+		os.Exit(1)
+	}
+	outScan := bufio.NewScanner(bytes.NewReader(out))
+	outScan.Split(bufio.ScanWords)
+	for i := 0; i < t; i++ {
+		if !outScan.Scan() {
+			fmt.Printf("missing count for test %d\n", i+1)
+			os.Exit(1)
+		}
+		cnt, _ := strconv.Atoi(outScan.Text())
+		if cnt != len(expected[i]) {
+			fmt.Printf("test %d failed: expected count %d got %d\n", i+1, len(expected[i]), cnt)
+			os.Exit(1)
+		}
+		for j := 0; j < cnt; j++ {
+			if !outScan.Scan() {
+				fmt.Printf("missing output for test %d pair %d\n", i+1, j+1)
+				os.Exit(1)
+			}
+			a, _ := strconv.Atoi(outScan.Text())
+			outScan.Scan()
+			b, _ := strconv.Atoi(outScan.Text())
+			if j >= len(expected[i]) || a != expected[i][j].a || b != expected[i][j].b {
+				fmt.Printf("test %d pair %d mismatch\n", i+1, j+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if outScan.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1900-1999/1990-1999/1992/verifierF.go
+++ b/1000-1999/1900-1999/1990-1999/1992/verifierF.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func solve(n, x int, arr []int) int {
+	ans := 1
+	s := map[int]struct{}{1: {}}
+	for _, v := range arr {
+		s2 := make(map[int]struct{})
+		for val := range s {
+			if x%(val*v) == 0 {
+				s2[val*v] = struct{}{}
+			}
+		}
+		for k := range s2 {
+			s[k] = struct{}{}
+		}
+		if _, ok := s[x]; ok {
+			ans++
+			s = map[int]struct{}{1: {}, v: {}}
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	data, err := os.ReadFile("problemF.txt")
+	if err != nil {
+		fmt.Println("could not read problemF.txt:", err)
+		os.Exit(1)
+	}
+	scan := bufio.NewScanner(bytes.NewReader(data))
+	scan.Split(bufio.ScanWords)
+	if !scan.Scan() {
+		fmt.Println("invalid test file")
+		os.Exit(1)
+	}
+	t, _ := strconv.Atoi(scan.Text())
+	expected := make([]int, t)
+	for i := 0; i < t; i++ {
+		if !scan.Scan() {
+			fmt.Println("bad file")
+			os.Exit(1)
+		}
+		n, _ := strconv.Atoi(scan.Text())
+		scan.Scan()
+		x, _ := strconv.Atoi(scan.Text())
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			scan.Scan()
+			v, _ := strconv.Atoi(scan.Text())
+			arr[j] = v
+		}
+		expected[i] = solve(n, x, arr)
+	}
+	cmd := exec.Command(os.Args[1])
+	cmd.Stdin = bytes.NewReader(data)
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("execution failed:", err)
+		os.Exit(1)
+	}
+	outScan := bufio.NewScanner(bytes.NewReader(out))
+	outScan.Split(bufio.ScanWords)
+	for i := 0; i < t; i++ {
+		if !outScan.Scan() {
+			fmt.Printf("missing output for test %d\n", i+1)
+			os.Exit(1)
+		}
+		got, _ := strconv.Atoi(outScan.Text())
+		if got != expected[i] {
+			fmt.Printf("test %d failed: expected %d got %d\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	if outScan.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1900-1999/1990-1999/1992/verifierG.go
+++ b/1000-1999/1900-1999/1990-1999/1992/verifierG.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+const mod int64 = 1e9 + 7
+
+func modPow(a, b, m int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % m
+		}
+		a = a * a % m
+		b >>= 1
+	}
+	return res
+}
+
+func prepareFact(n int) ([]int64, []int64) {
+	fact := make([]int64, n+1)
+	inv := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	inv[n] = modPow(fact[n], mod-2, mod)
+	for i := n; i > 0; i-- {
+		inv[i-1] = inv[i] * int64(i) % mod
+	}
+	return fact, inv
+}
+
+func C(n, r int64, fact, inv []int64) int64 {
+	if r < 0 || r > n {
+		return 0
+	}
+	return fact[n] * inv[r] % mod * inv[n-r] % mod
+}
+
+func solve(n int, fact, inv []int64) int64 {
+	res := int64(0)
+	half := (n - 1) / 2
+	for s := 0; s <= half; s++ {
+		for x := s + 1; x <= 2*s+1 && x <= n; x++ {
+			ways := C(int64(x-1), int64(s), fact, inv) * C(int64(n-x), int64(n-2*s-1), fact, inv) % mod
+			res = (res + int64(x)*ways) % mod
+		}
+	}
+	for s := (n + 1) / 2; s <= n; s++ {
+		ways := C(int64(n), int64(s), fact, inv)
+		mex := int64(2*s + 1)
+		res = (res + mex*ways) % mod
+	}
+	return res % mod
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	data, err := os.ReadFile("problemG.txt")
+	if err != nil {
+		fmt.Println("could not read problemG.txt:", err)
+		os.Exit(1)
+	}
+	scan := bufio.NewScanner(bytes.NewReader(data))
+	scan.Split(bufio.ScanWords)
+	if !scan.Scan() {
+		fmt.Println("invalid test file")
+		os.Exit(1)
+	}
+	t, _ := strconv.Atoi(scan.Text())
+	maxN := 5000
+	fact, inv := prepareFact(maxN)
+	expected := make([]int64, t)
+	for i := 0; i < t; i++ {
+		if !scan.Scan() {
+			fmt.Println("bad test file")
+			os.Exit(1)
+		}
+		n, _ := strconv.Atoi(scan.Text())
+		expected[i] = solve(n, fact, inv)
+	}
+	cmd := exec.Command(os.Args[1])
+	cmd.Stdin = bytes.NewReader(data)
+	out, err := cmd.Output()
+	if err != nil {
+		fmt.Println("execution failed:", err)
+		os.Exit(1)
+	}
+	outScan := bufio.NewScanner(bytes.NewReader(out))
+	outScan.Split(bufio.ScanWords)
+	for i := 0; i < t; i++ {
+		if !outScan.Scan() {
+			fmt.Printf("missing output for test %d\n", i+1)
+			os.Exit(1)
+		}
+		got, _ := strconv.ParseInt(outScan.Text(), 10, 64)
+		if got != expected[i] {
+			fmt.Printf("test %d failed: expected %d got %d\n", i+1, expected[i], got)
+			os.Exit(1)
+		}
+	}
+	if outScan.Scan() {
+		fmt.Println("extra output detected")
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- create new test suites for contest 1992 problems A–G
- add Go verifiers (`verifierA.go` … `verifierG.go`) that run a binary on the tests
- keep original statements as `problem*_statement.txt`
- generate 100+ randomized cases for each problem

## Testing
- `go run verifierA.go ./1992A`
- `go run verifierB.go ./1992B`
- `go run verifierC.go ./1992C`
- `go run verifierD.go ./1992D`
- `go run verifierE.go ./1992E`
- `go run verifierF.go ./1992F`
- `go run verifierG.go ./1992G`

------
https://chatgpt.com/codex/tasks/task_e_687cdd0fd4508324b84578e506e05143