### PR TITLE
Add Go solutions for contest 1987

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1987/1987A.go
+++ b/1000-1999/1900-1999/1980-1989/1987/1987A.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a, b int
+		fmt.Fscan(reader, &a, &b)
+		fmt.Fprintln(writer, a*b-b+1)
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1987/1987B.go
+++ b/1000-1999/1900-1999/1980-1989/1987/1987B.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		mx := int64(0)
+		x := int64(0)
+		ans := int64(0)
+		for i := 0; i < n; i++ {
+			var v int64
+			fmt.Fscan(reader, &v)
+			if diff := mx - v; diff > 0 {
+				ans += diff
+				if diff > x {
+					x = diff
+				}
+			}
+			if v > mx {
+				mx = v
+			}
+		}
+		fmt.Fprintln(writer, ans+x)
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1987/1987C.go
+++ b/1000-1999/1900-1999/1980-1989/1987/1987C.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		ans := 0
+		for i := 0; i < n; i++ {
+			var d int
+			fmt.Fscan(reader, &d)
+			if val := i + d; val > ans {
+				ans = val
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- convert C++ solutions for contest 1987 (A–C) to Go

## Testing
- `go build 1000-1999/1900-1999/1980-1989/1987/1987A.go`
- `go build 1000-1999/1900-1999/1980-1989/1987/1987B.go`
- `go build 1000-1999/1900-1999/1980-1989/1987/1987C.go`


------
https://chatgpt.com/codex/tasks/task_e_687de6b2dee0832495bcd778918720d3