### PR TITLE
Add Go translations for contest 1989

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1989/1989A.go
+++ b/1000-1999/1900-1999/1980-1989/1989/1989A.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var x, y int
+		fmt.Fscan(in, &x, &y)
+		if y >= -1 {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1989/1989B.go
+++ b/1000-1999/1900-1999/1980-1989/1989/1989B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var a, b string
+		fmt.Fscan(in, &a, &b)
+		as := []byte(a)
+		bs := []byte(b)
+		n := len(as)
+		m := len(bs)
+		ans := n + m
+		for i := 0; i < m; i++ {
+			j := i
+			for _, ch := range as {
+				if j < m && ch == bs[j] {
+					j++
+				}
+			}
+			val := n + m - (j - i)
+			if val < ans {
+				ans = val
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1989/1989C.go
+++ b/1000-1999/1900-1999/1980-1989/1989/1989C.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		c, d, e := int64(0), int64(0), int64(0)
+		for i := 0; i < n; i++ {
+			var b int64
+			fmt.Fscan(in, &b)
+			if a[i] > b {
+				c += a[i]
+			} else if a[i] < b {
+				d += b
+			} else if a[i] == 1 {
+				e += a[i]
+			} else if a[i] == -1 {
+				e++
+				c--
+				d--
+			}
+		}
+		x1 := c + e
+		x2 := d + e
+		x3 := (c + e + d) >> 1
+		ans := x1
+		if x2 < ans {
+			ans = x2
+		}
+		if x3 < ans {
+			ans = x3
+		}
+		fmt.Fprintln(out, ans)
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1989/1989D.go
+++ b/1000-1999/1900-1999/1980-1989/1989/1989D.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const N = 1000005
+const INF int64 = 1 << 60
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	d := make([]int64, N)
+	dp := make([]int64, N)
+	for i := range d {
+		d[i] = INF
+	}
+
+	var n, m int
+	fmt.Fscan(in, &n, &m)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	for i := 0; i < n; i++ {
+		var b int
+		fmt.Fscan(in, &b)
+		diff := int64(a[i] - b)
+		if diff < d[a[i]] {
+			d[a[i]] = diff
+		}
+	}
+	for i := 1; i < N; i++ {
+		if d[i-1] < d[i] {
+			d[i] = d[i-1]
+		}
+		if d[i] <= int64(i) {
+			dp[i] = 2 + dp[i-int(d[i])]
+		} else {
+			dp[i] = 0
+		}
+	}
+	var ans int64
+	for ; m > 0; m-- {
+		var c int64
+		fmt.Fscan(in, &c)
+		if c >= N {
+			x := (c-N)/d[N-1] + 1
+			c -= x * d[N-1]
+			ans += 2 * x
+		}
+		ans += dp[int(c)]
+	}
+	fmt.Fprint(out, ans)
+}

--- a/1000-1999/1900-1999/1980-1989/1989/1989E.go
+++ b/1000-1999/1900-1999/1980-1989/1989/1989E.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const MOD int64 = 998244353
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		f := make([]int64, n+2)
+		s := make([]int64, n+2)
+		for i := 1; i <= n; i++ {
+			var x int64
+			fmt.Fscan(in, &x)
+			f[i] = (s[i-1] + x*int64(n-i+1)) % MOD
+			s[i] = (s[i-1] + f[i]) % MOD
+		}
+		fmt.Fprintln(out, f[n])
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1989/1989F.go
+++ b/1000-1999/1900-1999/1980-1989/1989/1989F.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const N = 400000 + 5
+
+type edge struct {
+	x, y, t int
+}
+
+var (
+	n, m, q int
+	fa      [N]int
+	sz      [N]int
+	ans     int64
+
+	e   [N][]int
+	dfn [N]int
+	low [N]int
+	st  [N]int
+	tp  int
+	co  [N]int
+	tot int
+	vis [N]bool
+)
+
+func gf(x int) int {
+	if fa[x] == x {
+		return x
+	}
+	fa[x] = gf(fa[x])
+	return fa[x]
+}
+
+func merge(x, y int) {
+	x = gf(x)
+	y = gf(y)
+	if x == y {
+		return
+	}
+	if sz[x] > 1 {
+		ans -= int64(sz[x]) * int64(sz[x])
+	}
+	if sz[y] > 1 {
+		ans -= int64(sz[y]) * int64(sz[y])
+	}
+	fa[y] = x
+	sz[x] += sz[y]
+	ans += int64(sz[x]) * int64(sz[x])
+}
+
+func tarjan(x int) {
+	tot++
+	dfn[x] = tot
+	low[x] = tot
+	tp++
+	st[tp] = x
+	vis[x] = true
+	for _, v := range e[x] {
+		if dfn[v] == 0 {
+			tarjan(v)
+			if low[v] < low[x] {
+				low[x] = low[v]
+			}
+		} else if vis[v] {
+			if dfn[v] < low[x] {
+				low[x] = dfn[v]
+			}
+		}
+	}
+	if low[x] == dfn[x] {
+		co[x] = x
+		for st[tp] != x {
+			co[st[tp]] = x
+			vis[st[tp]] = false
+			tp--
+		}
+		tp--
+		vis[x] = false
+	}
+}
+
+func solve(l, r int, ed []edge) {
+	if l == r {
+		if l > q {
+			return
+		}
+		for _, v := range ed {
+			merge(v.x, v.y)
+		}
+		fmt.Println(ans)
+		return
+	}
+	mid := (l + r) >> 1
+	tot = 0
+	var el, er []edge
+	for i := range ed {
+		v := &ed[i]
+		v.x = gf(v.x)
+		v.y = gf(v.y)
+		e[v.x] = nil
+		e[v.y] = nil
+		dfn[v.x] = 0
+		dfn[v.y] = 0
+	}
+	for _, v := range ed {
+		if v.t <= mid {
+			e[v.x] = append(e[v.x], v.y)
+		}
+	}
+	for _, v := range ed {
+		if v.t <= mid {
+			if dfn[v.x] == 0 {
+				tarjan(v.x)
+			}
+			if dfn[v.y] == 0 {
+				tarjan(v.y)
+			}
+			if co[v.x] == co[v.y] {
+				el = append(el, v)
+				continue
+			}
+		}
+		er = append(er, v)
+	}
+	solve(l, mid, el)
+	solve(mid+1, r, er)
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	fmt.Fscan(in, &n, &m, &q)
+	for i := 1; i <= n+m; i++ {
+		fa[i] = i
+		sz[i] = 1
+	}
+	edges := make([]edge, q)
+	for i := 0; i < q; i++ {
+		var x, y int
+		fmt.Fscan(in, &x, &y)
+		var c string
+		fmt.Fscan(in, &c)
+		if c == "R" {
+			edges[i] = edge{y + n, x, i + 1}
+		} else {
+			edges[i] = edge{x, y + n, i + 1}
+		}
+	}
+	solve(1, q+1, edges)
+}


### PR DESCRIPTION
## Summary
- add Go versions of each solution for contest 1989

## Testing
- `go build 1000-1999/1900-1999/1980-1989/1989/1989A.go`
- `go build 1000-1999/1900-1999/1980-1989/1989/1989B.go`
- `go build 1000-1999/1900-1999/1980-1989/1989/1989C.go`
- `go build 1000-1999/1900-1999/1980-1989/1989/1989D.go`
- `go build 1000-1999/1900-1999/1980-1989/1989/1989E.go`
- `go build 1000-1999/1900-1999/1980-1989/1989/1989F.go`


------
https://chatgpt.com/codex/tasks/task_e_687de689a0788324a6ed6143546e3d36