### PR TITLE
Add Go translations for contest 1988 solutions

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1988/1988A.go
+++ b/1000-1999/1900-1999/1980-1989/1988/1988A.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		res := (n + k - 3) / (k - 1)
+		fmt.Fprintln(writer, res)
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1988/1988B.go
+++ b/1000-1999/1900-1999/1980-1989/1988/1988B.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(reader, &n, &s)
+		a, b := 0, 0
+		for i := 0; i < n; i++ {
+			if s[i] == '1' {
+				b++
+			} else if s[i] == '0' && (i == 0 || s[i-1] != '0') {
+				a++
+			}
+		}
+		if b > a {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1988/1988C.go
+++ b/1000-1999/1900-1999/1980-1989/1988/1988C.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/bits"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n uint64
+		fmt.Fscan(reader, &n)
+		if bits.OnesCount64(n) == 1 {
+			fmt.Fprintln(writer, 1)
+			fmt.Fprintln(writer, n)
+		} else {
+			cnt := bits.OnesCount64(n)
+			fmt.Fprintln(writer, cnt+1)
+			for i := uint(0); i < 64; i++ {
+				if n&(1<<i) != 0 {
+					fmt.Fprint(writer, n^(1<<i), " ")
+				}
+			}
+			fmt.Fprintln(writer, n)
+		}
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1988/1988D.go
+++ b/1000-1999/1900-1999/1980-1989/1988/1988D.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const maxN = 300005
+
+var (
+	g   [maxN][]int
+	a   [maxN]int64
+	dp  [maxN][20]int64
+	rdr = bufio.NewReader(os.Stdin)
+	wtr = bufio.NewWriter(os.Stdout)
+)
+
+func dfs(x, p int) {
+	for i := 1; i < 20; i++ {
+		dp[x][i] = int64(i) * a[x]
+	}
+	for _, u := range g[x] {
+		if u == p {
+			continue
+		}
+		dfs(u, x)
+		for j := 1; j < 20; j++ {
+			sum := int64(1<<63 - 1)
+			for k := 1; k < 20; k++ {
+				if j != k && dp[u][k] < sum {
+					sum = dp[u][k]
+				}
+			}
+			dp[x][j] += sum
+		}
+	}
+}
+
+func main() {
+	defer wtr.Flush()
+	var T int
+	fmt.Fscan(rdr, &T)
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(rdr, &n)
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(rdr, &a[i])
+			g[i] = g[i][:0]
+		}
+		for i := 1; i < n; i++ {
+			var x, y int
+			fmt.Fscan(rdr, &x, &y)
+			g[x] = append(g[x], y)
+			g[y] = append(g[y], x)
+		}
+		dfs(1, 0)
+		ans := dp[1][1]
+		for i := 2; i < 20; i++ {
+			if dp[1][i] < ans {
+				ans = dp[1][i]
+			}
+		}
+		fmt.Fprintln(wtr, ans)
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1988/1988E.go
+++ b/1000-1999/1900-1999/1980-1989/1988/1988E.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+const maxE = 500005
+
+var (
+	a   [maxE]int
+	g   [maxE][]int
+	S   [maxE]int64
+	rdr = bufio.NewReader(os.Stdin)
+	wtr = bufio.NewWriter(os.Stdout)
+)
+
+func add(l, r int, x int64) {
+	if l > r {
+		return
+	}
+	S[l] += x
+	if r+1 < maxE {
+		S[r+1] -= x
+	}
+}
+
+type orderedSet struct{ arr []int }
+
+func (s *orderedSet) Insert(x int) int {
+	i := sort.SearchInts(s.arr, x)
+	if i == len(s.arr) || s.arr[i] != x {
+		s.arr = append(s.arr, 0)
+		copy(s.arr[i+1:], s.arr[i:])
+		s.arr[i] = x
+	}
+	return i
+}
+
+func (s *orderedSet) At(i int) int { return s.arr[i] }
+func (s *orderedSet) Size() int    { return len(s.arr) }
+
+func main() {
+	defer wtr.Flush()
+	var T int
+	fmt.Fscan(rdr, &T)
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(rdr, &n)
+		S[0] = 0
+		for i := 1; i <= n; i++ {
+			g[i] = g[i][:0]
+			S[i] = 0
+		}
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(rdr, &a[i])
+			g[a[i]] = append(g[a[i]], i)
+		}
+		se := orderedSet{}
+		se.Insert(0)
+		se.Insert(n + 1)
+		for i := 1; i <= n; i++ {
+			for _, x := range g[i] {
+				idx := se.Insert(x)
+				t1, t2 := idx-1, idx+1
+				L := se.At(t1)
+				R := se.At(t2)
+				add(0, L-1, int64(x-L)*int64(R-x)*int64(a[x]))
+				add(R+1, n, int64(x-L)*int64(R-x)*int64(a[x]))
+				add(L+1, x-1, int64(x-L-1)*int64(R-x)*int64(a[x]))
+				add(x+1, R-1, int64(x-L)*int64(R-x-1)*int64(a[x]))
+				if L != 0 && t1-1 >= 0 {
+					LL := se.At(t1 - 1)
+					add(L, L, int64(x-LL-1)*int64(R-x)*int64(a[x]))
+				}
+				if R != n+1 && t2+1 < se.Size() {
+					RR := se.At(t2 + 1)
+					add(R, R, int64(x-L)*int64(RR-x-1)*int64(a[x]))
+				}
+			}
+		}
+		for i := 1; i <= n; i++ {
+			S[i] += S[i-1]
+			fmt.Fprint(wtr, S[i], " ")
+		}
+		fmt.Fprintln(wtr)
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1988/1988F.go
+++ b/1000-1999/1900-1999/1980-1989/1988/1988F.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const (
+	N   = 710
+	mod = 998244353
+)
+
+var (
+	a   [N]int
+	b   [N]int
+	c   [N]int
+	C   [N][N]int
+	f   [2][N][N]int64
+	pre [N][N]int64
+	suf [N][N]int64
+	g   [N][N]int64
+	rdr = bufio.NewReader(os.Stdin)
+	wtr = bufio.NewWriter(os.Stdout)
+)
+
+func upd(x *int64, y int64) {
+	*x = (*x + y) % mod
+}
+
+func main() {
+	defer wtr.Flush()
+	var n int
+	fmt.Fscan(rdr, &n)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(rdr, &a[i])
+	}
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(rdr, &b[i])
+	}
+	for i := 0; i <= n-1; i++ {
+		fmt.Fscan(rdr, &c[i])
+	}
+	C[0][0] = 1
+	for i := 1; i <= n; i++ {
+		C[i][0] = 1
+		for j := 1; j <= i; j++ {
+			C[i][j] = (C[i-1][j] + C[i-1][j-1]) % mod
+		}
+	}
+	f[1][1][0] = 1
+	pre[0][0] = int64(a[1])
+	suf[0][0] = int64(b[1])
+	for i := 1; i <= n; i++ {
+		nw := i & 1
+		nx := nw ^ 1
+		for j := range f[nx] {
+			for k := range f[nx][j] {
+				f[nx][j][k] = 0
+			}
+		}
+		for j := 1; j <= i; j++ {
+			for k := 0; k <= i-1; k++ {
+				if f[nw][j][k] != 0 {
+					val := f[nw][j][k]
+					upd(&pre[i][k], val*int64(a[j+1]))
+					upd(&suf[i][i-1-k], val*int64(b[j+1]))
+					upd(&f[nx][j+1][k+1], val)
+					upd(&f[nx][j][k], val*int64(k+1))
+					upd(&f[nx][j][k+1], val*int64(i-k-1))
+				}
+			}
+		}
+	}
+	for i := 0; i <= n; i++ {
+		for x := 0; x <= i; x++ {
+			for y := 0; y <= n-x-1; y++ {
+				upd(&g[i][y], pre[i][x]*int64(c[x+y+func() int {
+					if i > 0 {
+						return 1
+					} else {
+						return 0
+					}
+				}()]))
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		ans := int64(0)
+		for p := 1; p <= i; p++ {
+			for y := 0; y <= i-p; y++ {
+				upd(&ans, g[p-1][y]*suf[i-p][y]%mod*int64(C[i-1][p-1])%mod)
+			}
+		}
+		fmt.Fprint(wtr, ans, " ")
+	}
+}


### PR DESCRIPTION
## Summary
- convert solutions for Codeforces contest 1988 from C++ to Go
- add `1988A.go` through `1988F.go`

## Testing
- `go build 1000-1999/1900-1999/1980-1989/1988/1988A.go`
- `go build 1000-1999/1900-1999/1980-1989/1988/1988B.go`
- `go build 1000-1999/1900-1999/1980-1989/1988/1988C.go`
- `go build 1000-1999/1900-1999/1980-1989/1988/1988D.go`
- `go build 1000-1999/1900-1999/1980-1989/1988/1988E.go`
- `go build 1000-1999/1900-1999/1980-1989/1988/1988F.go`


------
https://chatgpt.com/codex/tasks/task_e_687de69e790c8324bcbb7a3a05a9e128