### PR TITLE
Convert contest 1990 solutions to Go

### DIFF
--- a/1000-1999/1900-1999/1990-1999/1990/1990A.go
+++ b/1000-1999/1900-1999/1990-1999/1990/1990A.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		cnt := make([]int, 101)
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			if x >= 0 && x < len(cnt) {
+				cnt[x]++
+			}
+		}
+		odd := false
+		for i := 1; i <= 50; i++ {
+			if cnt[i]%2 == 1 {
+				odd = true
+				break
+			}
+		}
+		if odd {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1990/1990B.go
+++ b/1000-1999/1900-1999/1990-1999/1990/1990B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, x, y int
+		fmt.Fscan(reader, &n, &x, &y)
+		for i := 1; i < y; i++ {
+			if (y-i)%2 == 1 {
+				fmt.Fprint(writer, "-1 ")
+			} else {
+				fmt.Fprint(writer, "1 ")
+			}
+		}
+		for i := y; i <= x; i++ {
+			fmt.Fprint(writer, "1 ")
+		}
+		for i := x + 1; i <= n; i++ {
+			if (i-x)%2 == 1 {
+				fmt.Fprint(writer, "-1 ")
+			} else {
+				fmt.Fprint(writer, "1 ")
+			}
+		}
+		fmt.Fprintln(writer)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1990/1990C.go
+++ b/1000-1999/1900-1999/1990-1999/1990/1990C.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	const maxN = 200005
+
+	var T int
+	fmt.Fscan(reader, &T)
+	for ; T > 0; T-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		var b, c int64
+		sum := int64(0)
+		p1 := make([]bool, maxN)
+		p2 := make([]bool, maxN)
+		for n > 0 {
+			n--
+			var x int64
+			fmt.Fscan(reader, &x)
+			if p1[x] {
+				if x > b {
+					b = x
+				}
+			} else {
+				p1[x] = true
+			}
+			if p2[b] {
+				if b > c {
+					c = b
+				}
+			} else if b != 0 {
+				p2[b] = true
+			}
+			sum += x + b + (n+1)*c
+		}
+		fmt.Fprintln(writer, sum)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1990/1990D.go
+++ b/1000-1999/1900-1999/1990-1999/1990/1990D.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	const maxN = 200005
+
+	var T int
+	fmt.Fscan(reader, &T)
+	for ; T > 0; T-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		var b, c int64
+		sum := int64(0)
+		p1 := make([]bool, maxN)
+		p2 := make([]bool, maxN)
+		for n > 0 {
+			n--
+			var x int64
+			fmt.Fscan(reader, &x)
+			if p1[x] {
+				if x > b {
+					b = x
+				}
+			} else {
+				p1[x] = true
+			}
+			if p2[b] {
+				if b > c {
+					c = b
+				}
+			} else if b != 0 {
+				p2[b] = true
+			}
+			sum += x + b + (n+1)*c
+		}
+		fmt.Fprintln(writer, sum)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1990/1990E1.go
+++ b/1000-1999/1900-1999/1990-1999/1990/1990E1.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type pair struct {
+	first  int
+	second int
+}
+
+func ask(w *bufio.Writer, r *bufio.Reader, x int) int {
+	fmt.Fprintf(w, "? %d\n", x+1)
+	w.Flush()
+	var b int
+	fmt.Fscan(r, &b)
+	return b
+}
+
+func solve(g []map[int]struct{}, r *bufio.Reader, w *bufio.Writer) int {
+	n := len(g)
+	f := make([]int, n)
+	d := make([]int, n)
+	m := make([]int, n)
+	var dfs func(int, int)
+	dfs = func(u, p int) {
+		f[u] = p
+		m[u] = d[u]
+		for v := range g[u] {
+			if v != p {
+				d[v] = d[u] + 1
+				dfs(v, u)
+				if m[v] > m[u] {
+					m[u] = m[v]
+				}
+			}
+		}
+	}
+	dfs(0, 0)
+	b := make([]bool, n)
+	l := 0
+	for i := 1; i < n; i++ {
+		if d[i] > d[l] {
+			l = i
+		}
+	}
+	if ask(w, r, l) != 0 {
+		return l
+	}
+	for i := 0; i < n; i++ {
+		if m[i]-d[i] == 51 && !b[i] {
+			b[i] = true
+			if ask(w, r, i) != 0 {
+				if i != 0 {
+					for {
+						ask(w, r, l)
+						if ask(w, r, i) == 0 {
+							break
+						}
+					}
+					if ask(w, r, f[i]) != 0 {
+						return f[i]
+					}
+					return f[f[f[i]]]
+				}
+				break
+			} else {
+				delete(g[f[i]], i)
+				delete(g[i], f[i])
+				dfs(0, 0)
+				i = -1
+			}
+		}
+	}
+	for i := 0; i < 100; i++ {
+		ask(w, r, l)
+	}
+	return 0
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		g := make([]map[int]struct{}, n)
+		for i := 0; i < n; i++ {
+			g[i] = make(map[int]struct{})
+		}
+		for i := 1; i < n; i++ {
+			var u, v int
+			fmt.Fscan(reader, &u, &v)
+			u--
+			v--
+			g[u][v] = struct{}{}
+			g[v][u] = struct{}{}
+		}
+		x := solve(g, reader, writer)
+		fmt.Fprintf(writer, "! %d\n", x+1)
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1990/1990E2.go
+++ b/1000-1999/1900-1999/1990-1999/1990/1990E2.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const N = 5005
+
+var (
+	g   [N][]int
+	ord []int
+	d   [N]int
+	s   = 73
+	c   int
+)
+
+func check(w *bufio.Writer, r *bufio.Reader, x int) bool {
+	fmt.Fprintf(w, "? %d\n", x)
+	w.Flush()
+	var y int
+	fmt.Fscan(r, &y)
+	return y != 0
+}
+
+func dfs(v, p int, w *bufio.Writer, r *bufio.Reader) {
+	ord = append(ord, v)
+	for _, u := range g[v] {
+		if u != p && d[u] >= s {
+			c = u
+		}
+	}
+	for _, u := range g[v] {
+		if u != p && d[u] >= s {
+			if u == c || check(w, r, u) {
+				dfs(u, v, w, r)
+				return
+			}
+		}
+	}
+}
+
+func cfs(v, p int) {
+	for _, u := range g[v] {
+		if u != p {
+			cfs(u, v)
+			if d[u]+1 > d[v] {
+				d[v] = d[u] + 1
+			}
+		}
+	}
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		for v := 1; v <= n; v++ {
+			d[v] = 0
+			g[v] = g[v][:0]
+		}
+		for i := 1; i < n; i++ {
+			var x, y int
+			fmt.Fscan(reader, &x, &y)
+			g[x] = append(g[x], y)
+			g[y] = append(g[y], x)
+		}
+		q := 0
+		for i := 2; i <= n; i++ {
+			if len(g[i]) == 1 {
+				q = i
+			}
+		}
+		fl := false
+		for i := 0; i < s; i++ {
+			if check(writer, reader, q) {
+				fl = true
+			}
+		}
+		if fl {
+			fmt.Fprintf(writer, "! %d\n", q)
+			continue
+		}
+		ord = ord[:0]
+		cfs(1, -1)
+		dfs(1, -1, writer, reader)
+		l := 0
+		r := len(ord) - 1
+		for l != r {
+			mid := (l + r + 1) >> 1
+			if check(writer, reader, ord[mid]) {
+				l = mid
+			} else {
+				r = mid - 2
+				l--
+				if l < 0 {
+					l = 0
+				}
+				if r < 0 {
+					r = 0
+				}
+			}
+		}
+		fmt.Fprintf(writer, "! %d\n", ord[l])
+	}
+}

--- a/1000-1999/1900-1999/1990-1999/1990/1990F.go
+++ b/1000-1999/1900-1999/1990-1999/1990/1990F.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const MAXN = 200005
+
+var a [MAXN]int64
+
+type STree struct {
+	n  int
+	ty int
+	t  []int64
+}
+
+func oper(i, j int64, ty int) int64 {
+	if ty == 1 {
+		return i + j
+	}
+	if ty == 0 {
+		if i == -1 {
+			return j
+		}
+		if j == -1 {
+			return i
+		}
+		if a[i] >= a[j] {
+			return i
+		}
+		return j
+	}
+	if i > j {
+		return i
+	}
+	return j
+}
+
+func newSTree(n int, ty int) *STree {
+	neut := int64(0)
+	if ty != 1 {
+		neut = -1
+	}
+	t := make([]int64, 2*n+5)
+	for i := range t {
+		t[i] = neut
+	}
+	return &STree{n: n, ty: ty, t: t}
+}
+
+func (st *STree) upd(p int, v int64) {
+	p += st.n
+	st.t[p] = v
+	for p > 1 {
+		p >>= 1
+		st.t[p] = oper(st.t[p<<1], st.t[p<<1|1], st.ty)
+	}
+}
+
+func (st *STree) query(l, r int) int64 {
+	var res int64
+	if st.ty == 1 {
+		res = 0
+	} else {
+		res = -1
+	}
+	l += st.n
+	r += st.n
+	for l < r {
+		if l&1 == 1 {
+			res = oper(res, st.t[l], st.ty)
+			l++
+		}
+		if r&1 == 1 {
+			r--
+			res = oper(res, st.t[r], st.ty)
+		}
+		l >>= 1
+		r >>= 1
+	}
+	return res
+}
+
+type pair struct {
+	first  int64
+	second int64
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var T int
+	fmt.Fscan(reader, &T)
+	for ; T > 0; T-- {
+		var n, q int
+		fmt.Fscan(reader, &n, &q)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		stm := newSTree(n, 0)
+		sts := newSTree(n, 1)
+		tim := newSTree(n, 2)
+		for i := 0; i < n; i++ {
+			sts.upd(i, a[i])
+			stm.upd(i, int64(i))
+		}
+		cnt := int64(0)
+		dp := make([]map[int]pair, n)
+		for i := 0; i < n; i++ {
+			dp[i] = make(map[int]pair)
+		}
+		var f func(int, int) int64
+		f = func(l, r int) int64 {
+			if r-l <= 0 {
+				return -1
+			}
+			res, ok := dp[l][r]
+			if ok && tim.query(l, r) <= res.second {
+				return res.first
+			}
+			res.second = cnt
+			p := int(stm.query(l, r))
+			s := sts.query(l, r)
+			if s-a[p] > a[p] {
+				res.first = int64(r - l)
+			} else {
+				left := f(l, p)
+				right := f(p+1, r)
+				if left > right {
+					res.first = left
+				} else {
+					res.first = right
+				}
+			}
+			dp[l][r] = res
+			return res.first
+		}
+		for ; q > 0; q-- {
+			var ty int
+			var l, r int
+			fmt.Fscan(reader, &ty, &l, &r)
+			l--
+			if ty == 1 {
+				ans := f(l, r)
+				fmt.Fprintln(writer, ans)
+			} else {
+				a[l] = int64(r)
+				sts.upd(l, int64(r))
+				stm.upd(l, int64(l))
+				tim.upd(l, cnt)
+			}
+			cnt++
+		}
+		for i := 0; i < n; i++ {
+			dp[i] = nil
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go ports for all problems in contest 1990
- each new file is named `1990A.go` through `1990F.go`

## Testing
- `go build 1990A.go`
- `go build 1990B.go`
- `go build 1990C.go`
- `go build 1990D.go`
- `go build 1990E1.go`
- `go build 1990E2.go`
- `go build 1990F.go`


------
https://chatgpt.com/codex/tasks/task_e_687de650beec8324832fc4a6c252ebf7