### PR TITLE
Add Go verifiers for CF 1988

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1988/verifierA.go
+++ b/1000-1999/1900-1999/1980-1989/1988/verifierA.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generate() (string, string) {
+	const T = 100
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", T)
+	rand.Seed(1)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(1000) + 1
+		k := rand.Intn(999) + 2
+		fmt.Fprintf(&in, "%d %d\n", n, k)
+		res := (n + k - 3) / (k - 1)
+		fmt.Fprintf(&out, "%d\n", res)
+	}
+	return in.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	in, exp := generate()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("error running binary:", err)
+		os.Exit(1)
+	}
+	got := buf.String()
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		fmt.Println("wrong answer")
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1900-1999/1980-1989/1988/verifierB.go
+++ b/1000-1999/1900-1999/1980-1989/1988/verifierB.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func generate() (string, string) {
+	const T = 100
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", T)
+	rand.Seed(2)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(20) + 1
+		sb := make([]byte, n)
+		ones, groups := 0, 0
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				sb[j] = '0'
+				if j == 0 || sb[j-1] != '0' {
+					groups++
+				}
+			} else {
+				sb[j] = '1'
+				ones++
+			}
+		}
+		s := string(sb)
+		fmt.Fprintf(&in, "%d %s\n", n, s)
+		if ones > groups {
+			fmt.Fprintln(&out, "YES")
+		} else {
+			fmt.Fprintln(&out, "NO")
+		}
+	}
+	return in.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	in, exp := generate()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("error running binary:", err)
+		os.Exit(1)
+	}
+	got := buf.String()
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		fmt.Println("wrong answer")
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1900-1999/1980-1989/1988/verifierC.go
+++ b/1000-1999/1900-1999/1980-1989/1988/verifierC.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solve(n uint64) (res []uint64) {
+	if bits.OnesCount64(n) == 1 {
+		return []uint64{n}
+	}
+	for i := uint(0); i < 64; i++ {
+		if n&(1<<i) != 0 {
+			res = append(res, n^(1<<i))
+		}
+	}
+	res = append(res, n)
+	return
+}
+
+func generate() (string, string) {
+	const T = 100
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", T)
+	rand.Seed(3)
+	for i := 0; i < T; i++ {
+		n := rand.Uint64()
+		fmt.Fprintf(&in, "%d\n", n)
+		ans := solve(n)
+		fmt.Fprintf(&out, "%d\n", len(ans))
+		for j, v := range ans {
+			if j+1 == len(ans) {
+				fmt.Fprintf(&out, "%d\n", v)
+			} else {
+				fmt.Fprintf(&out, "%d ", v)
+			}
+		}
+	}
+	return in.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	in, exp := generate()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("error running binary:", err)
+		os.Exit(1)
+	}
+	got := buf.String()
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		fmt.Println("wrong answer")
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1900-1999/1980-1989/1988/verifierD.go
+++ b/1000-1999/1900-1999/1980-1989/1988/verifierD.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const maxN = 300005
+
+var (
+	g  [maxN][]int
+	a  [maxN]int64
+	dp [maxN][20]int64
+)
+
+func dfs(x, p int) {
+	for i := 1; i < 20; i++ {
+		dp[x][i] = int64(i) * a[x]
+	}
+	for _, u := range g[x] {
+		if u == p {
+			continue
+		}
+		dfs(u, x)
+		for j := 1; j < 20; j++ {
+			sum := int64(1<<63 - 1)
+			for k := 1; k < 20; k++ {
+				if j != k && dp[u][k] < sum {
+					sum = dp[u][k]
+				}
+			}
+			dp[x][j] += sum
+		}
+	}
+}
+
+func solve(n int) int64 {
+	dfs(1, 0)
+	ans := dp[1][1]
+	for i := 2; i < 20; i++ {
+		if dp[1][i] < ans {
+			ans = dp[1][i]
+		}
+	}
+	return ans
+}
+
+func generate() (string, string) {
+	const T = 100
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", T)
+	rand.Seed(4)
+	for t := 0; t < T; t++ {
+		n := rand.Intn(6) + 1
+		fmt.Fprintf(&in, "%d\n", n)
+		for i := 1; i <= n; i++ {
+			a[i] = int64(rand.Intn(10) + 1)
+			fmt.Fprintf(&in, "%d ", a[i])
+			g[i] = g[i][:0]
+		}
+		fmt.Fprintf(&in, "\n")
+		for i := 2; i <= n; i++ {
+			p := rand.Intn(i-1) + 1
+			g[p] = append(g[p], i)
+			g[i] = append(g[i], p)
+			fmt.Fprintf(&in, "%d %d\n", p, i)
+		}
+		res := solve(n)
+		fmt.Fprintf(&out, "%d\n", res)
+	}
+	return in.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	in, exp := generate()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("error running binary:", err)
+		os.Exit(1)
+	}
+	got := buf.String()
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		fmt.Println("wrong answer")
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1900-1999/1980-1989/1988/verifierE.go
+++ b/1000-1999/1900-1999/1980-1989/1988/verifierE.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func add(S []int64, l, r int, x int64) {
+	if l > r {
+		return
+	}
+	S[l] += x
+	if r+1 < len(S) {
+		S[r+1] -= x
+	}
+}
+
+type orderedSet struct{ arr []int }
+
+func (s *orderedSet) Insert(x int) int {
+	i := sort.SearchInts(s.arr, x)
+	if i == len(s.arr) || s.arr[i] != x {
+		s.arr = append(s.arr, 0)
+		copy(s.arr[i+1:], s.arr[i:])
+		s.arr[i] = x
+	}
+	return i
+}
+
+func (s *orderedSet) At(i int) int { return s.arr[i] }
+func (s *orderedSet) Size() int    { return len(s.arr) }
+
+func solve(n int, a []int) []int64 {
+	g := make([][]int, n+2)
+	S := make([]int64, n+2)
+	for i := 1; i <= n; i++ {
+		g[a[i-1]] = append(g[a[i-1]], i)
+	}
+	se := orderedSet{}
+	se.Insert(0)
+	se.Insert(n + 1)
+	for i := 1; i <= n; i++ {
+		for _, x := range g[i] {
+			idx := se.Insert(x)
+			t1, t2 := idx-1, idx+1
+			L := se.At(t1)
+			R := se.At(t2)
+			add(S, 0, L-1, int64(x-L)*int64(R-x)*int64(a[x-1]))
+			add(S, R+1, n, int64(x-L)*int64(R-x)*int64(a[x-1]))
+			add(S, L+1, x-1, int64(x-L-1)*int64(R-x)*int64(a[x-1]))
+			add(S, x+1, R-1, int64(x-L)*int64(R-x-1)*int64(a[x-1]))
+			if L != 0 && t1-1 >= 0 {
+				LL := se.At(t1 - 1)
+				add(S, L, L, int64(x-LL-1)*int64(R-x)*int64(a[x-1]))
+			}
+			if R != n+1 && t2+1 < se.Size() {
+				RR := se.At(t2 + 1)
+				add(S, R, R, int64(x-L)*int64(RR-x-1)*int64(a[x-1]))
+			}
+		}
+	}
+	ans := make([]int64, n)
+	for i := 1; i <= n; i++ {
+		S[i] += S[i-1]
+		ans[i-1] = S[i]
+	}
+	return ans
+}
+
+func generate() (string, string) {
+	const T = 100
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", T)
+	rand.Seed(5)
+	for t := 0; t < T; t++ {
+		n := rand.Intn(10) + 1
+		fmt.Fprintf(&in, "%d\n", n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rand.Intn(n) + 1
+			fmt.Fprintf(&in, "%d ", arr[i])
+		}
+		fmt.Fprintf(&in, "\n")
+		res := solve(n, arr)
+		for i, v := range res {
+			if i+1 == len(res) {
+				fmt.Fprintf(&out, "%d\n", v)
+			} else {
+				fmt.Fprintf(&out, "%d ", v)
+			}
+		}
+	}
+	return in.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	in, exp := generate()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("error running binary:", err)
+		os.Exit(1)
+	}
+	got := buf.String()
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		fmt.Println("wrong answer")
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + got)
+		os.Exit(1)
+	}
+	fmt.Println("ok")
+}

--- a/1000-1999/1900-1999/1980-1989/1988/verifierF.go
+++ b/1000-1999/1900-1999/1980-1989/1988/verifierF.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod = 998244353
+
+func upd(x *int64, y int64) { *x = (*x + y) % mod }
+
+func solve(n int, a, b, c []int) []int64 {
+	C := make([][]int, n+1)
+	for i := range C {
+		C[i] = make([]int, n+1)
+	}
+	C[0][0] = 1
+	for i := 1; i <= n; i++ {
+		C[i][0] = 1
+		for j := 1; j <= i; j++ {
+			C[i][j] = (C[i-1][j] + C[i-1][j-1]) % mod
+		}
+	}
+	f := make([][][]int64, 2)
+	for i := range f {
+		f[i] = make([][]int64, n+2)
+		for j := range f[i] {
+			f[i][j] = make([]int64, n+2)
+		}
+	}
+	pre := make([][]int64, n+1)
+	suf := make([][]int64, n+1)
+	g := make([][]int64, n+1)
+	for i := 0; i <= n; i++ {
+		pre[i] = make([]int64, n+1)
+		suf[i] = make([]int64, n+1)
+		g[i] = make([]int64, n+1)
+	}
+	f[1][1][0] = 1
+	pre[0][0] = int64(a[0])
+	suf[0][0] = int64(b[0])
+	for i := 1; i <= n; i++ {
+		nw := i & 1
+		nx := nw ^ 1
+		for j := range f[nx] {
+			for k := range f[nx][j] {
+				f[nx][j][k] = 0
+			}
+		}
+		for j := 1; j <= i; j++ {
+			for k := 0; k <= i-1; k++ {
+				if f[nw][j][k] != 0 {
+					val := f[nw][j][k]
+					upd(&pre[i][k], val*int64(a[j]))
+					upd(&suf[i][i-1-k], val*int64(b[j]))
+					upd(&f[nx][j+1][k+1], val)
+					upd(&f[nx][j][k], val*int64(k+1))
+					upd(&f[nx][j][k+1], val*int64(i-k-1))
+				}
+			}
+		}
+	}
+	for i := 0; i <= n; i++ {
+		for x := 0; x <= i; x++ {
+			for y := 0; y <= n-x-1; y++ {
+				t := 0
+				if i > 0 {
+					t = 1
+				}
+				upd(&g[i][y], pre[i][x]*int64(c[x+y+t]))
+			}
+		}
+	}
+	ans := make([]int64, n)
+	for i := 1; i <= n; i++ {
+		var cur int64
+		for p := 1; p <= i; p++ {
+			for y := 0; y <= i-p; y++ {
+				upd(&cur, g[p-1][y]*suf[i-p][y]%mod*int64(C[i-1][p-1])%mod)
+			}
+		}
+		ans[i-1] = cur
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(6)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(6) + 1
+		a := make([]int, n)
+		b := make([]int, n)
+		c := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rand.Intn(5) + 1
+		}
+		for i := 0; i < n; i++ {
+			b[i] = rand.Intn(5) + 1
+		}
+		for i := 0; i < n; i++ {
+			c[i] = rand.Intn(5) + 1
+		}
+		input := &bytes.Buffer{}
+		fmt.Fprintf(input, "%d\n", n)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(input, "%d ", a[i])
+		}
+		fmt.Fprintln(input)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(input, "%d ", b[i])
+		}
+		fmt.Fprintln(input)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(input, "%d ", c[i])
+		}
+		fmt.Fprintln(input)
+		expected := solve(n, a, b, c)
+		var expBuf bytes.Buffer
+		for i, v := range expected {
+			if i+1 == len(expected) {
+				fmt.Fprintf(&expBuf, "%d ", v%mod)
+			} else {
+				fmt.Fprintf(&expBuf, "%d ", v%mod)
+			}
+		}
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Println("error running binary:", err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out.String()) != strings.TrimSpace(expBuf.String()) {
+			fmt.Println("wrong answer on test", t+1)
+			fmt.Println("expected:", expBuf.String())
+			fmt.Println("got:", out.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1988 problems A-F
- each verifier generates 100 random tests and checks a supplied binary

## Testing
- `go build 1000-1999/1900-1999/1980-1989/1988/verifierA.go`
- `go build 1000-1999/1900-1999/1980-1989/1988/verifierB.go`
- `go build 1000-1999/1900-1999/1980-1989/1988/verifierC.go`
- `go build 1000-1999/1900-1999/1980-1989/1988/verifierD.go`
- `go build 1000-1999/1900-1999/1980-1989/1988/verifierE.go`
- `go build 1000-1999/1900-1999/1980-1989/1988/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_687de9b58aa88324bce7cab2ddc54899