### PR TITLE
Add Go translations for Codeforces 1985 contest

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1985/1985A.go
+++ b/1000-1999/1900-1999/1980-1989/1985/1985A.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	in.ReadString('\n')
+	for ; t > 0; t-- {
+		line, _ := in.ReadString('\n')
+		line = strings.TrimRight(line, "\r\n")
+		b := []byte(line)
+		if len(b) >= 5 {
+			b[0], b[4] = b[4], b[0]
+		}
+		fmt.Fprintln(out, string(b))
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1985/1985B.go
+++ b/1000-1999/1900-1999/1980-1989/1985/1985B.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		if n == 3 {
+			fmt.Fprintln(out, 3)
+		} else {
+			fmt.Fprintln(out, 2)
+		}
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1985/1985C.go
+++ b/1000-1999/1900-1999/1980-1989/1985/1985C.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		var sum, maxVal int64
+		count := 0
+		for i := 0; i < n; i++ {
+			var v int64
+			fmt.Fscan(in, &v)
+			sum += v
+			if v > maxVal {
+				maxVal = v
+			}
+			if sum == maxVal*2 {
+				count++
+			}
+		}
+		fmt.Fprintln(out, count)
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1985/1985D.go
+++ b/1000-1999/1900-1999/1980-1989/1985/1985D.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(in, &n, &m)
+		var sumX, sumY, cnt int
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				var ch byte
+				fmt.Fscan(in, &ch)
+				if ch == '#' {
+					sumX += i + 1
+					sumY += j + 1
+					cnt++
+				}
+			}
+		}
+		if cnt > 0 {
+			fmt.Fprintf(out, "%d %d\n", sumX/cnt, sumY/cnt)
+		} else {
+			fmt.Fprintln(out)
+		}
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1985/1985E.go
+++ b/1000-1999/1900-1999/1980-1989/1985/1985E.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var x, y, z, k int64
+		fmt.Fscan(in, &x, &y, &z, &k)
+		var maxWays int64
+		for i := int64(1); i <= x; i++ {
+			for j := int64(1); j <= y; j++ {
+				if k%(i*j) != 0 {
+					continue
+				}
+				p := k / (i * j)
+				if p <= z {
+					ways := (x - i + 1) * (y - j + 1) * (z - p + 1)
+					if ways > maxWays {
+						maxWays = ways
+					}
+				}
+			}
+		}
+		fmt.Fprintln(out, maxWays)
+	}
+}


### PR DESCRIPTION
## Summary
- translate contest 1985 solutions from C++ to Go
- add solutions `1985A.go` through `1985E.go`

## Testing
- `go build 1000-1999/1900-1999/1980-1989/1985/1985A.go`
- `go build 1000-1999/1900-1999/1980-1989/1985/1985B.go`
- `go build 1000-1999/1900-1999/1980-1989/1985/1985C.go`
- `go build 1000-1999/1900-1999/1980-1989/1985/1985D.go`
- `go build 1000-1999/1900-1999/1980-1989/1985/1985E.go`


------
https://chatgpt.com/codex/tasks/task_e_687dea74fe4c8324b1281f2c7d43237d