### PR TITLE
Add Go solutions for contest 1982

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1982/1982A.go
+++ b/1000-1999/1900-1999/1980-1989/1982/1982A.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var x1, y1, x2, y2 int64
+		fmt.Fscan(in, &x1, &y1)
+		fmt.Fscan(in, &x2, &y2)
+		diff1 := x1 - y1
+		diff2 := x2 - y2
+		if diff1*diff2 > 0 {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1982/1982B.go
+++ b/1000-1999/1900-1999/1980-1989/1982/1982B.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var x, y, k int64
+		fmt.Fscan(in, &x, &y, &k)
+		for k > 0 && x >= y {
+			rem := int64(y-1) - x%y
+			if rem >= k {
+				x += k
+				k = 0
+				break
+			}
+			x += rem
+			k -= rem
+			x++
+			k--
+			for x%y == 0 {
+				x /= y
+			}
+		}
+		if k > 0 {
+			period := int64(y - 1)
+			if period > 0 {
+				k %= period
+				x = ((x - 1 + k) % period) + 1
+			}
+		}
+		fmt.Fprintln(out, x)
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1982/1982C.go
+++ b/1000-1999/1900-1999/1980-1989/1982/1982C.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var l, r int64
+		fmt.Fscan(in, &n, &l, &r)
+		sum := int64(0)
+		wins := 0
+		for i := 0; i < n; i++ {
+			var v int64
+			fmt.Fscan(in, &v)
+			sum += v
+			if sum > r {
+				sum = 0
+			} else if sum >= l {
+				wins++
+				sum = 0
+			}
+		}
+		fmt.Fprintln(out, wins)
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1982/1982D.go
+++ b/1000-1999/1900-1999/1980-1989/1982/1982D.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m, k int
+		fmt.Fscan(in, &n, &m, &k)
+		heights := make([][]int64, n)
+		for i := 0; i < n; i++ {
+			heights[i] = make([]int64, m)
+			for j := 0; j < m; j++ {
+				fmt.Fscan(in, &heights[i][j])
+			}
+		}
+		types := make([]string, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &types[i])
+		}
+		ones := make([][]int, n)
+		var sum0, sum1 int64
+		for i := 0; i < n; i++ {
+			ones[i] = make([]int, m)
+			for j := 0; j < m; j++ {
+				if types[i][j] == '1' {
+					ones[i][j] = 1
+					sum1 += heights[i][j]
+				} else {
+					sum0 += heights[i][j]
+				}
+			}
+		}
+		pref := make([][]int, n+1)
+		for i := 0; i <= n; i++ {
+			pref[i] = make([]int, m+1)
+		}
+		for i := 0; i < n; i++ {
+			rowSum := 0
+			for j := 0; j < m; j++ {
+				rowSum += ones[i][j]
+				pref[i+1][j+1] = pref[i][j+1] + rowSum
+			}
+		}
+		var g int64
+		for i := 0; i+k <= n; i++ {
+			for j := 0; j+k <= m; j++ {
+				onesCount := pref[i+k][j+k] - pref[i][j+k] - pref[i+k][j] + pref[i][j]
+				diff := int64(k*k - 2*onesCount)
+				if diff < 0 {
+					diff = -diff
+				}
+				g = gcd(g, diff)
+			}
+		}
+		diffTotal := sum1 - sum0
+		if g == 0 {
+			if diffTotal == 0 {
+				fmt.Fprintln(out, "YES")
+			} else {
+				fmt.Fprintln(out, "NO")
+			}
+		} else {
+			if diffTotal%g == 0 {
+				fmt.Fprintln(out, "YES")
+			} else {
+				fmt.Fprintln(out, "NO")
+			}
+		}
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1982/1982E.go
+++ b/1000-1999/1900-1999/1980-1989/1982/1982E.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/bits"
+	"os"
+)
+
+const mod = 1000000007
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int64
+		var k int
+		fmt.Fscan(in, &n, &k)
+		ans := int64(0)
+		i := int64(0)
+		for i < n {
+			if bits.OnesCount64(uint64(i)) > k {
+				i++
+				continue
+			}
+			j := i
+			for j < n && bits.OnesCount64(uint64(j)) <= k {
+				j++
+			}
+			length := j - i
+			ans = (ans + (length*(length+1)/2)%mod) % mod
+			i = j
+		}
+		fmt.Fprintln(out, ans%mod)
+	}
+}

--- a/1000-1999/1900-1999/1980-1989/1982/1982F.go
+++ b/1000-1999/1900-1999/1980-1989/1982/1982F.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func findSegment(a []int) (int, int) {
+	n := len(a)
+	l := 0
+	for l+1 < n && a[l] <= a[l+1] {
+		l++
+	}
+	if l == n-1 {
+		return -1, -1
+	}
+	r := n - 1
+	for r > 0 && a[r-1] <= a[r] {
+		r--
+	}
+	minV, maxV := a[l], a[l]
+	for i := l; i <= r; i++ {
+		if a[i] < minV {
+			minV = a[i]
+		}
+		if a[i] > maxV {
+			maxV = a[i]
+		}
+	}
+	for l > 0 && a[l-1] > minV {
+		l--
+	}
+	for r < n-1 && a[r+1] < maxV {
+		r++
+	}
+	return l + 1, r + 1
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	if _, err := fmt.Fscan(in, &T); err != nil {
+		return
+	}
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		var q int
+		fmt.Fscan(in, &q)
+		l, r := findSegment(a)
+		fmt.Fprintln(out, l, r)
+		for ; q > 0; q-- {
+			var pos, val int
+			fmt.Fscan(in, &pos, &val)
+			a[pos-1] = val
+			l, r = findSegment(a)
+			fmt.Fprintln(out, l, r)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solutions for contest 1982 problems A-F

## Testing
- `go build 1000-1999/1900-1999/1980-1989/1982/1982A.go`
- `go build 1000-1999/1900-1999/1980-1989/1982/1982B.go`
- `go build 1000-1999/1900-1999/1980-1989/1982/1982C.go`
- `go build 1000-1999/1900-1999/1980-1989/1982/1982D.go`
- `go build 1000-1999/1900-1999/1980-1989/1982/1982E.go`
- `go build 1000-1999/1900-1999/1980-1989/1982/1982F.go`


------
https://chatgpt.com/codex/tasks/task_e_687deb2d8bac8324a6c55fcbfca5cf91