### PR TITLE
Add verifiers for CF 1986

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1986/verifierA.go
+++ b/1000-1999/1900-1999/1980-1989/1986/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	x1, x2, x3 int
+}
+
+func expected(t Test) int {
+	minv := t.x1
+	if t.x2 < minv {
+		minv = t.x2
+	}
+	if t.x3 < minv {
+		minv = t.x3
+	}
+	maxv := t.x1
+	if t.x2 > maxv {
+		maxv = t.x2
+	}
+	if t.x3 > maxv {
+		maxv = t.x3
+	}
+	return maxv - minv
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	c := Test{rng.Intn(10) + 1, rng.Intn(10) + 1, rng.Intn(10) + 1}
+	input := fmt.Sprintf("1\n%d %d %d\n", c.x1, c.x2, c.x3)
+	return input, expected(c)
+}
+
+func runCase(bin, input string, exp int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1986/verifierB.go
+++ b/1000-1999/1900-1999/1980-1989/1986/verifierB.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type cell struct{ r, c int }
+
+func stabilize(a [][]int) [][]int {
+	n := len(a)
+	m := len(a[0])
+	q := make([]cell, 0, n*m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			q = append(q, cell{i, j})
+		}
+	}
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		r, c := cur.r, cur.c
+		mx := math.MinInt64
+		for _, d := range dirs {
+			nr, nc := r+d[0], c+d[1]
+			if nr >= 0 && nr < n && nc >= 0 && nc < m {
+				if a[nr][nc] > mx {
+					mx = a[nr][nc]
+				}
+			}
+		}
+		if mx == math.MinInt64 {
+			continue
+		}
+		if a[r][c] > mx {
+			a[r][c] = mx
+			q = append(q, cell{r, c})
+			for _, d := range dirs {
+				nr, nc := r+d[0], c+d[1]
+				if nr >= 0 && nr < n && nc >= 0 && nc < m {
+					q = append(q, cell{nr, nc})
+				}
+			}
+		}
+	}
+	return a
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	if n*m == 1 {
+		m++
+	}
+	a := make([][]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			a[i][j] = rng.Intn(20) + 1
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", a[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	res := stabilize(cloneMatrix(a))
+	var out strings.Builder
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				out.WriteByte(' ')
+			}
+			fmt.Fprintf(&out, "%d", res[i][j])
+		}
+		if i+1 < n {
+			out.WriteByte('\n')
+		}
+	}
+	out.WriteByte('\n')
+	return sb.String(), out.String()
+}
+
+func cloneMatrix(a [][]int) [][]int {
+	n := len(a)
+	m := len(a[0])
+	b := make([][]int, n)
+	for i := 0; i < n; i++ {
+		b[i] = make([]int, m)
+		copy(b[i], a[i])
+	}
+	return b
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1986/verifierC.go
+++ b/1000-1999/1900-1999/1980-1989/1986/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveCase(n, m int, s string, inds []int, c string) string {
+	letters := []byte(c)
+	sort.Ints(inds)
+	sort.Slice(letters, func(i, j int) bool { return letters[i] < letters[j] })
+	bs := []byte(s)
+	uniq := make([]int, 0, len(inds))
+	for _, v := range inds {
+		if len(uniq) == 0 || uniq[len(uniq)-1] != v {
+			uniq = append(uniq, v)
+		}
+	}
+	for i := 0; i < len(uniq); i++ {
+		idx := uniq[i] - 1
+		if i < len(letters) {
+			bs[idx] = letters[i]
+		}
+	}
+	return string(bs)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	letters := make([]byte, n)
+	for i := 0; i < n; i++ {
+		letters[i] = byte('a' + rng.Intn(5))
+	}
+	inds := make([]int, m)
+	for i := 0; i < m; i++ {
+		inds[i] = rng.Intn(n) + 1
+	}
+	cs := make([]byte, m)
+	for i := 0; i < m; i++ {
+		cs[i] = byte('a' + rng.Intn(5))
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n%s\n", n, m, string(letters))
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", inds[i])
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(string(cs))
+	sb.WriteByte('\n')
+	expected := solveCase(n, m, string(letters), inds, string(cs)) + "\n"
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1986/verifierD.go
+++ b/1000-1999/1900-1999/1980-1989/1986/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const INF int64 = 1e18
+
+func minResult(arr []int) int64 {
+	m := len(arr)
+	dp := make([]int64, m+1)
+	for i := 0; i <= m; i++ {
+		dp[i] = INF
+	}
+	dp[m] = 0
+	for i := m - 1; i >= 0; i-- {
+		prod := int64(1)
+		for j := i; j < m; j++ {
+			prod *= int64(arr[j])
+			if prod > INF {
+				prod = INF
+			}
+			if val := prod + dp[j+1]; val < dp[i] {
+				dp[i] = val
+			}
+		}
+	}
+	return dp[0]
+}
+
+func solveCase(n int, s string) int64 {
+	digits := make([]int, n)
+	for i := 0; i < n; i++ {
+		digits[i] = int(s[i] - '0')
+	}
+	ans := INF
+	for merge := 0; merge < n-1; merge++ {
+		arr := make([]int, 0, n-1)
+		for i := 0; i < n; i++ {
+			if i == merge {
+				val := digits[i]*10 + digits[i+1]
+				arr = append(arr, val)
+				i++
+				continue
+			}
+			arr = append(arr, digits[i])
+		}
+		if val := minResult(arr); val < ans {
+			ans = val
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	digits := make([]byte, n)
+	for i := 0; i < n; i++ {
+		digits[i] = byte('0' + rng.Intn(10))
+	}
+	s := string(digits)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n%s\n", n, s)
+	expected := fmt.Sprintf("%d\n", solveCase(n, s))
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1986/verifierE.go
+++ b/1000-1999/1900-1999/1980-1989/1986/verifierE.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveCase(n, k int, arr []int) int64 {
+	groups := make(map[int][]int)
+	for _, v := range arr {
+		r := v % k
+		groups[r] = append(groups[r], v)
+	}
+	oddGroups := 0
+	for _, g := range groups {
+		if len(g)%2 == 1 {
+			oddGroups++
+		}
+	}
+	if (n%2 == 0 && oddGroups > 0) || (n%2 == 1 && oddGroups > 1) {
+		return -1
+	}
+	ops := int64(0)
+	for _, g := range groups {
+		sort.Ints(g)
+		for i := 0; i+1 < len(g); i += 2 {
+			ops += int64((g[i+1] - g[i]) / k)
+		}
+	}
+	return ops
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(9) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(20) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	expected := fmt.Sprintf("%d\n", solveCase(n, k, arr))
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1986/verifierF.go
+++ b/1000-1999/1900-1999/1980-1989/1986/verifierF.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ to, id int }
+
+var (
+	adj   [][]edge
+	disc  []int
+	low   []int
+	sz    []int
+	timer int
+	n     int
+	ans   int64
+)
+
+func dfs(v, pe int) {
+	timer++
+	disc[v] = timer
+	low[v] = timer
+	sz[v] = 1
+	for _, e := range adj[v] {
+		if e.id == pe {
+			continue
+		}
+		to := e.to
+		if disc[to] == 0 {
+			dfs(to, e.id)
+			sz[v] += sz[to]
+			if low[to] > disc[v] {
+				s := sz[to]
+				val := int64(s*(s-1)/2 + (n-s)*(n-s-1)/2)
+				if val < ans {
+					ans = val
+				}
+			}
+			if low[to] < low[v] {
+				low[v] = low[to]
+			}
+		} else {
+			if disc[to] < low[v] {
+				low[v] = disc[to]
+			}
+		}
+	}
+}
+
+func solveCase(nv int, edges [][2]int) int64 {
+	n = nv
+	adj = make([][]edge, n)
+	id := 0
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], edge{v, id})
+		adj[v] = append(adj[v], edge{u, id})
+		id++
+	}
+	disc = make([]int, n)
+	low = make([]int, n)
+	sz = make([]int, n)
+	timer = 0
+	ans = int64(n * (n - 1) / 2)
+	dfs(0, -1)
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 2
+	m := n - 1 + rng.Intn(n) // up to around 2n-1
+	edges := make([][2]int, 0, m)
+	// build tree first
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges = append(edges, [2]int{p, i})
+	}
+	for len(edges) < m {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		if u == v {
+			continue
+		}
+		// avoid duplicates simple
+		edges = append(edges, [2]int{u, v})
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, len(edges))
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0]+1, e[1]+1)
+	}
+	expected := fmt.Sprintf("%d\n", solveCase(n, edges))
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1986/verifierG1.go
+++ b/1000-1999/1900-1999/1980-1989/1986/verifierG1.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(p []int) int {
+	n := len(p) - 1
+	cnt := 0
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			if (p[i]*p[j])%(i*j) == 0 {
+				cnt++
+			}
+		}
+	}
+	return cnt
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	perm := rand.Perm(n)
+	p := make([]int, n+1)
+	for i, v := range perm {
+		p[i+1] = v + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", p[i])
+	}
+	sb.WriteByte('\n')
+	expected := fmt.Sprintf("%d\n", solveCase(p))
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1980-1989/1986/verifierG2.go
+++ b/1000-1999/1900-1999/1980-1989/1986/verifierG2.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(p []int) int {
+	n := len(p) - 1
+	cnt := 0
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			if (p[i]*p[j])%(i*j) == 0 {
+				cnt++
+			}
+		}
+	}
+	return cnt
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	perm := rand.Perm(n)
+	p := make([]int, n+1)
+	for i, v := range perm {
+		p[i+1] = v + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d\n", n)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", p[i])
+	}
+	sb.WriteByte('\n')
+	expected := fmt.Sprintf("%d\n", solveCase(p))
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers in Go for contest 1986 (problems A–G2)
- each verifier generates at least 100 random test cases and checks a candidate binary

## Testing
- `go fmt` on new files


------
https://chatgpt.com/codex/tasks/task_e_687dee357f4c83249818b7d518b9af20