### PR TITLE
Add Go verifiers for Codeforces contest 1978

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1978/1978A.go
+++ b/1000-1999/1900-1999/1970-1979/1978/1978A.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	panic("runtime error")
+}

--- a/1000-1999/1900-1999/1970-1979/1978/verifierA.go
+++ b/1000-1999/1900-1999/1970-1979/1978/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseA struct {
+	n   int
+	arr []int
+}
+
+func genTestsA() []testCaseA {
+	rand.Seed(42)
+	tests := make([]testCaseA, 20)
+	for i := range tests {
+		n := rand.Intn(9) + 2 // 2..10
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(100) + 1
+		}
+		tests[i] = testCaseA{n, arr}
+	}
+	return tests
+}
+
+func solveA(tc testCaseA) int {
+	maxPrev := 0
+	for i := 0; i < tc.n-1; i++ {
+		if tc.arr[i] > maxPrev {
+			maxPrev = tc.arr[i]
+		}
+	}
+	return tc.arr[tc.n-1] + maxPrev
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for i, v := range tc.arr {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expected := make([]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveA(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		valStr := scanner.Text()
+		val, err := strconv.Atoi(valStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d: %s\n", i+1, valStr)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", i+1, exp, val)
+			os.Exit(1)
+		}
+	}
+
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1900-1999/1970-1979/1978/verifierB.go
+++ b/1000-1999/1900-1999/1970-1979/1978/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseB struct {
+	n int64
+	a int64
+	b int64
+}
+
+func genTestsB() []testCaseB {
+	rand.Seed(43)
+	tests := make([]testCaseB, 20)
+	for i := range tests {
+		tests[i] = testCaseB{
+			n: int64(rand.Intn(50) + 1),
+			a: int64(rand.Intn(50) + 1),
+			b: int64(rand.Intn(50) + 1),
+		}
+	}
+	return tests
+}
+
+func profit(n, a, b, k int64) int64 {
+	return k*b - k*(k-1)/2 + (n-k)*a
+}
+
+func solveB(tc testCaseB) int64 {
+	maxk := tc.n
+	if tc.b < maxk {
+		maxk = tc.b
+	}
+	if tc.b <= tc.a {
+		return tc.n * tc.a
+	}
+	k := tc.b - tc.a
+	if k > maxk {
+		k = maxk
+	}
+	best := profit(tc.n, tc.a, tc.b, k)
+	last := profit(tc.n, tc.a, tc.b, maxk)
+	if last > best {
+		best = last
+	}
+	return best
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d %d\n", tc.n, tc.a, tc.b)
+	}
+	expected := make([]int64, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveB(tc)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		valStr := scanner.Text()
+		val, err := strconv.ParseInt(valStr, 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d: %s\n", i+1, valStr)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", i+1, exp, val)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1900-1999/1970-1979/1978/verifierC.go
+++ b/1000-1999/1900-1999/1970-1979/1978/verifierC.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCaseC struct {
+	n int
+	k int64
+}
+
+func genTestsC() []testCaseC {
+	rand.Seed(44)
+	tests := make([]testCaseC, 20)
+	for i := range tests {
+		n := rand.Intn(7) + 2
+		var k int64 = int64(rand.Intn(n*n + 1))
+		tests[i] = testCaseC{n: n, k: k}
+	}
+	return tests
+}
+
+func possible(n int, k int64) bool {
+	if k%2 != 0 {
+		return false
+	}
+	rem := k
+	for i := 0; i < n-i-1; i++ {
+		j := n - i - 1
+		d := int64(j - i)
+		if d*2 < rem {
+			rem -= d * 2
+		} else {
+			rem = 0
+			break
+		}
+	}
+	return rem == 0
+}
+
+func manhattan(p []int) int64 {
+	var sum int64
+	for i, v := range p {
+		sum += int64(math.Abs(float64(v - (i + 1))))
+	}
+	return sum
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+	}
+
+	poss := make([]bool, len(tests))
+	for i, tc := range tests {
+		poss[i] = possible(tc.n, tc.k)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, tc := range tests {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		word := strings.ToLower(scanner.Text())
+		if word == "no" {
+			if poss[i] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected Yes got No\n", i+1)
+				os.Exit(1)
+			}
+			continue
+		}
+		if word != "yes" {
+			fmt.Fprintf(os.Stderr, "invalid output on test %d: %s\n", i+1, word)
+			os.Exit(1)
+		}
+		if !poss[i] {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected No got Yes\n", i+1)
+			os.Exit(1)
+		}
+		perm := make([]int, tc.n)
+		for j := 0; j < tc.n; j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "not enough numbers for permutation on test %d\n", i+1)
+				os.Exit(1)
+			}
+			val, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "invalid number on test %d\n", i+1)
+				os.Exit(1)
+			}
+			perm[j] = val
+		}
+		used := make([]bool, tc.n+1)
+		for _, v := range perm {
+			if v < 1 || v > tc.n || used[v] {
+				fmt.Fprintf(os.Stderr, "invalid permutation on test %d\n", i+1)
+				os.Exit(1)
+			}
+			used[v] = true
+		}
+		if manhattan(perm) != tc.k {
+			fmt.Fprintf(os.Stderr, "wrong permutation value on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1900-1999/1970-1979/1978/verifierD.go
+++ b/1000-1999/1900-1999/1970-1979/1978/verifierD.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseD struct {
+	n int
+	c int
+	a []int
+}
+
+type subset struct {
+	mask int
+}
+
+func genTestsD() []testCaseD {
+	rand.Seed(45)
+	tests := make([]testCaseD, 20)
+	for i := range tests {
+		n := rand.Intn(5) + 2 // 2..6
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rand.Intn(5)
+		}
+		tests[i] = testCaseD{n: n, c: rand.Intn(5), a: a}
+	}
+	return tests
+}
+
+func winner(n int, c int, a []int, mask int) int {
+	undecided := c
+	remaining := make([]int, n)
+	minIdx := -1
+	for i := 0; i < n; i++ {
+		if mask&(1<<i) != 0 {
+			undecided += a[i]
+		} else {
+			remaining[i] = a[i]
+			if minIdx == -1 {
+				minIdx = i
+			}
+		}
+	}
+	if minIdx != -1 {
+		remaining[minIdx] += undecided
+	}
+	winner := -1
+	best := -1
+	for i := 0; i < n; i++ {
+		if mask&(1<<i) != 0 {
+			continue
+		}
+		v := remaining[i]
+		if v > best || (v == best && i < winner) {
+			best = v
+			winner = i
+		}
+	}
+	return winner
+}
+
+func solveD(tc testCaseD) []int {
+	res := make([]int, tc.n)
+	for target := 0; target < tc.n; target++ {
+		best := tc.n + 1
+		for mask := 0; mask < 1<<tc.n; mask++ {
+			if mask&(1<<target) != 0 {
+				continue
+			}
+			if winner(tc.n, tc.c, tc.a, mask) == target {
+				removed := bits.OnesCount(uint(mask))
+				if removed < best {
+					best = removed
+				}
+			}
+		}
+		res[target] = best
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.c)
+		for i, v := range tc.a {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+	expected := make([][]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveD(tc)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, tc := range tests {
+		for j := 0; j < tc.n; j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			val, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if val != expected[i][j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1900-1999/1970-1979/1978/verifierE.go
+++ b/1000-1999/1900-1999/1970-1979/1978/verifierE.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type query struct{ l, r int }
+type testCaseE struct {
+	n int
+	s string
+	t string
+	q []query
+}
+
+func genTestsE() []testCaseE {
+	rand.Seed(46)
+	tests := make([]testCaseE, 20)
+	for i := range tests {
+		n := rand.Intn(3) + 3 // 3..5
+		s := randomBinary(n)
+		t := randomBinary(n)
+		qn := rand.Intn(3) + 1
+		qs := make([]query, qn)
+		for j := 0; j < qn; j++ {
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			qs[j] = query{l, r}
+		}
+		tests[i] = testCaseE{n, s, t, qs}
+	}
+	return tests
+}
+
+func randomBinary(n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rand.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return string(b)
+}
+
+func bitsFromString(s string) int {
+	x := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '1' {
+			x |= 1 << i
+		}
+	}
+	return x
+}
+
+type state struct{ a, b int }
+
+func maxOnes(aStart, bStart int, k int) int {
+	vis := make(map[state]bool)
+	q := []state{{aStart, bStart}}
+	vis[state{aStart, bStart}] = true
+	best := bits.OnesCount(uint(aStart))
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		if c := bits.OnesCount(uint(cur.a)); c > best {
+			best = c
+		}
+		for i := 0; i < k-2; i++ {
+			if (cur.a>>i)&1 == 0 && (cur.a>>(i+2))&1 == 0 {
+				nb := cur.b | (1 << (i + 1))
+				st := state{cur.a, nb}
+				if !vis[st] {
+					vis[st] = true
+					q = append(q, st)
+				}
+			}
+			if (cur.b>>i)&1 == 1 && (cur.b>>(i+2))&1 == 1 {
+				na := cur.a | (1 << (i + 1))
+				st := state{na, cur.b}
+				if !vis[st] {
+					vis[st] = true
+					q = append(q, st)
+				}
+			}
+		}
+	}
+	return best
+}
+
+func solveE(tc testCaseE) []int {
+	ans := make([]int, len(tc.q))
+	for idx, qq := range tc.q {
+		a := tc.s[qq.l-1 : qq.r]
+		b := tc.t[qq.l-1 : qq.r]
+		maskA := bitsFromString(a)
+		maskB := bitsFromString(b)
+		ans[idx] = maxOnes(maskA, maskB, len(a))
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		fmt.Fprintln(&input, tc.s)
+		fmt.Fprintln(&input, tc.t)
+		fmt.Fprintln(&input, len(tc.q))
+		for _, qv := range tc.q {
+			fmt.Fprintf(&input, "%d %d\n", qv.l, qv.r)
+		}
+	}
+	expected := make([][]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveE(tc)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, tc := range tests {
+		for j := 0; j < len(tc.q); j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			val, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if val != expected[i][j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1900-1999/1970-1979/1978/verifierF.go
+++ b/1000-1999/1900-1999/1970-1979/1978/verifierF.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseF struct {
+	n int
+	k int
+	a []int
+}
+
+func genTestsF() []testCaseF {
+	rand.Seed(47)
+	tests := make([]testCaseF, 20)
+	for i := range tests {
+		n := rand.Intn(3) + 2 // 2..4
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rand.Intn(10) + 1
+		}
+		tests[i] = testCaseF{n: n, k: rand.Intn(3) + 1, a: a}
+	}
+	return tests
+}
+
+func gcd(x, y int) int {
+	for y != 0 {
+		x, y = y, x%y
+	}
+	return x
+}
+
+func solveF(tc testCaseF) int {
+	n := tc.n
+	k := tc.k
+	b := make([][]int, n)
+	for i := range b {
+		b[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			idx := (j - i + n) % n
+			b[i][j] = tc.a[idx]
+		}
+	}
+	total := n * n
+	visited := make([]bool, total)
+	comp := 0
+	for idx := 0; idx < total; idx++ {
+		if visited[idx] {
+			continue
+		}
+		comp++
+		queue := []int{idx}
+		visited[idx] = true
+		for len(queue) > 0 {
+			v := queue[0]
+			queue = queue[1:]
+			x1 := v / n
+			y1 := v % n
+			for w := 0; w < total; w++ {
+				if visited[w] {
+					continue
+				}
+				x2 := w / n
+				y2 := w % n
+				if abs(x1-x2)+abs(y1-y2) <= k && gcd(b[x1][y1], b[x2][y2]) > 1 {
+					visited[w] = true
+					queue = append(queue, w)
+				}
+			}
+		}
+	}
+	return comp
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsF()
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		for i, v := range tc.a {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+	expected := make([]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveF(tc)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i := range tests {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if val != expected[i] {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}


### PR DESCRIPTION
## Summary
- provide example runtime-error solution `1978A.go`
- add Go verifiers for problems A–F in contest 1978
- each verifier generates 20 deterministic tests and checks user binaries

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build 1978A.go`


------
https://chatgpt.com/codex/tasks/task_e_687deededbd083248a3f9cb9f02a8f83