### PR TITLE
Add Go solutions for contest 1975

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1975/1975A.go
+++ b/1000-1999/1900-1999/1970-1979/1975/1975A.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		solveA(in, out)
+	}
+}
+
+func solveA(in *bufio.Reader, out *bufio.Writer) {
+	var n int
+	fmt.Fscan(in, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	cnt := 0
+	for i := 0; i < n-1; i++ {
+		if a[i] > a[i+1] {
+			cnt++
+		}
+	}
+	if a[n-1] > a[0] {
+		cnt++
+	}
+	if cnt <= 1 {
+		fmt.Fprintln(out, "Yes")
+	} else {
+		fmt.Fprintln(out, "No")
+	}
+}

--- a/1000-1999/1900-1999/1970-1979/1975/1975B.go
+++ b/1000-1999/1900-1999/1970-1979/1975/1975B.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		solveB(in, out)
+	}
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func primeFactors(x int) []int {
+	factors := make([]int, 0)
+	for i := 2; i*i <= x; i++ {
+		if x%i == 0 {
+			factors = append(factors, i)
+			for x%i == 0 {
+				x /= i
+			}
+		}
+	}
+	if x > 1 {
+		factors = append(factors, x)
+	}
+	return factors
+}
+
+func solveB(in *bufio.Reader, out *bufio.Writer) {
+	var n int
+	fmt.Fscan(in, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	pf := primeFactors(a[0])
+	for _, p := range pf {
+		g := 0
+		for _, v := range a {
+			if v%p != 0 {
+				g = gcd(g, v)
+			}
+		}
+		if g == 0 {
+			fmt.Fprintln(out, "Yes")
+			return
+		}
+		if g > 1 {
+			fmt.Fprintln(out, "Yes")
+			return
+		}
+	}
+	fmt.Fprintln(out, "No")
+}

--- a/1000-1999/1900-1999/1970-1979/1975/1975C.go
+++ b/1000-1999/1900-1999/1970-1979/1975/1975C.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		solveC(in, out)
+	}
+}
+
+func solveC(in *bufio.Reader, out *bufio.Writer) {
+	var n int
+	fmt.Fscan(in, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	sort.Ints(a)
+	if n == 1 {
+		fmt.Fprintln(out, a[0])
+		return
+	}
+	if a[n-1] == a[n-2] {
+		fmt.Fprintln(out, a[n-1])
+	} else {
+		fmt.Fprintln(out, a[n-2])
+	}
+}

--- a/1000-1999/1900-1999/1970-1979/1975/1975D.go
+++ b/1000-1999/1900-1999/1970-1979/1975/1975D.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/1000-1999/1900-1999/1970-1979/1975/1975E.go
+++ b/1000-1999/1900-1999/1970-1979/1975/1975E.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/1000-1999/1900-1999/1970-1979/1975/1975F.go
+++ b/1000-1999/1900-1999/1970-1979/1975/1975F.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/1000-1999/1900-1999/1970-1979/1975/1975G.go
+++ b/1000-1999/1900-1999/1970-1979/1975/1975G.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/1000-1999/1900-1999/1970-1979/1975/1975H.go
+++ b/1000-1999/1900-1999/1970-1979/1975/1975H.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/1000-1999/1900-1999/1970-1979/1975/1975I.go
+++ b/1000-1999/1900-1999/1970-1979/1975/1975I.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
## Summary
- implement Go solutions for problems A-C of contest 1975
- add placeholder files for later problems

## Testing
- `gofmt -w 1000-1999/1900-1999/1970-1979/1975/1975A.go 1000-1999/1900-1999/1970-1979/1975/1975B.go 1000-1999/1900-1999/1970-1979/1975/1975C.go`
- `gofmt -w 1000-1999/1900-1999/1970-1979/1975/1975D.go 1000-1999/1900-1999/1970-1979/1975/1975E.go 1000-1999/1900-1999/1970-1979/1975/1975F.go 1000-1999/1900-1999/1970-1979/1975/1975G.go 1000-1999/1900-1999/1970-1979/1975/1975H.go 1000-1999/1900-1999/1970-1979/1975/1975I.go`


------
https://chatgpt.com/codex/tasks/task_e_687def3ef84483248e197764b3e57a90