### PR TITLE
Add contest 1974 Go verifiers

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1974/1974A.go
+++ b/1000-1999/1900-1999/1970-1979/1974/1974A.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func screens(x, y int) int {
+	n := (x + 4*y + 14) / 15
+	if n < (y+1)/2 {
+		n = (y + 1) / 2
+	}
+	return n
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var x, y int
+		fmt.Fscan(in, &x, &y)
+		fmt.Fprintln(out, screens(x, y))
+	}
+}

--- a/1000-1999/1900-1999/1970-1979/1974/1974B.go
+++ b/1000-1999/1900-1999/1970-1979/1974/1974B.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func decode(b string) string {
+	set := make(map[rune]struct{})
+	for _, ch := range b {
+		set[ch] = struct{}{}
+	}
+	letters := make([]rune, 0, len(set))
+	for ch := range set {
+		letters = append(letters, ch)
+	}
+	sort.Slice(letters, func(i, j int) bool { return letters[i] < letters[j] })
+	m := make(map[rune]rune)
+	n := len(letters)
+	for i, ch := range letters {
+		m[ch] = letters[n-1-i]
+	}
+	res := make([]rune, len(b))
+	for i, ch := range b {
+		res[i] = m[ch]
+	}
+	return string(res)
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		var b string
+		fmt.Fscan(in, &n)
+		fmt.Fscan(in, &b)
+		fmt.Fprintln(out, decode(b))
+	}
+}

--- a/1000-1999/1900-1999/1970-1979/1974/1974C.go
+++ b/1000-1999/1900-1999/1970-1979/1974/1974C.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func countPairs(a []int) int64 {
+	n := len(a)
+	triples := make([][3]int, n-2)
+	for i := 0; i < n-2; i++ {
+		triples[i] = [3]int{a[i], a[i+1], a[i+2]}
+	}
+	var ans int64
+	type key struct{ x, y int }
+	ab := make(map[key]int)
+	bc := make(map[key]int)
+	ac := make(map[key]int)
+	abc := make(map[[3]int]int)
+	for _, t := range triples {
+		k1 := key{t[0], t[1]}
+		k2 := key{t[1], t[2]}
+		k3 := key{t[0], t[2]}
+		ans += int64(ab[k1] - abc[t])
+		ans += int64(bc[k2] - abc[t])
+		ans += int64(ac[k3] - abc[t])
+		ab[k1]++
+		bc[k2]++
+		ac[k3]++
+		abc[t]++
+	}
+	return ans
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+		}
+		fmt.Fprintln(out, countPairs(arr))
+	}
+}

--- a/1000-1999/1900-1999/1970-1979/1974/1974D.go
+++ b/1000-1999/1900-1999/1970-1979/1974/1974D.go
@@ -1,78 +1,78 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   writer := bufio.NewWriter(os.Stdout)
-   defer writer.Flush()
-   var T int
-   fmt.Fscan(reader, &T)
-   for T > 0 {
-       T--
-       solve(reader, writer)
-   }
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var T int
+	fmt.Fscan(reader, &T)
+	for T > 0 {
+		T--
+		solve(reader, writer)
+	}
 }
 
 func solve(r *bufio.Reader, w *bufio.Writer) {
-   var n int
-   fmt.Fscan(r, &n)
-   var str string
-   fmt.Fscan(r, &str)
-   s := []byte(str)
-   // Map directions to their indices
-   mp := make(map[byte][]int)
-   for i, c := range s {
-       mp[c] = append(mp[c], i)
-   }
-   x := len(mp['E']) - len(mp['W'])
-   y := len(mp['N']) - len(mp['S'])
-   // If differences are odd, impossible
-   if x%2 != 0 || y%2 != 0 {
-       fmt.Fprintln(w, "NO")
-       return
-   }
-   // Initialize all as 'R'
-   ans := make([]byte, n)
-   for i := range ans {
-       ans[i] = 'R'
-   }
-   if x != 0 || y != 0 {
-       if x > 0 {
-           for i := 0; i < x/2; i++ {
-               ans[mp['E'][i]] = 'H'
-           }
-       } else {
-           for i := 0; i < (-x)/2; i++ {
-               ans[mp['W'][i]] = 'H'
-           }
-       }
-       if y > 0 {
-           for i := 0; i < y/2; i++ {
-               ans[mp['N'][i]] = 'H'
-           }
-       } else {
-           for i := 0; i < (-y)/2; i++ {
-               ans[mp['S'][i]] = 'H'
-           }
-       }
-   } else {
-       // Balanced but no excess; need at least one H-pair
-       if n == 2 {
-           fmt.Fprintln(w, "NO")
-           return
-       }
-       if len(mp['E']) > 0 {
-           ans[mp['E'][0]] = 'H'
-           ans[mp['W'][0]] = 'H'
-       } else {
-           ans[mp['N'][0]] = 'H'
-           ans[mp['S'][0]] = 'H'
-       }
-   }
-   fmt.Fprintln(w, string(ans))
+	var n int
+	fmt.Fscan(r, &n)
+	var str string
+	fmt.Fscan(r, &str)
+	s := []byte(str)
+	// Map directions to their indices
+	mp := make(map[byte][]int)
+	for i, c := range s {
+		mp[c] = append(mp[c], i)
+	}
+	x := len(mp['E']) - len(mp['W'])
+	y := len(mp['N']) - len(mp['S'])
+	// If differences are odd, impossible
+	if x%2 != 0 || y%2 != 0 {
+		fmt.Fprintln(w, "NO")
+		return
+	}
+	// Initialize all as 'R'
+	ans := make([]byte, n)
+	for i := range ans {
+		ans[i] = 'R'
+	}
+	if x != 0 || y != 0 {
+		if x > 0 {
+			for i := 0; i < x/2; i++ {
+				ans[mp['E'][i]] = 'H'
+			}
+		} else {
+			for i := 0; i < (-x)/2; i++ {
+				ans[mp['W'][i]] = 'H'
+			}
+		}
+		if y > 0 {
+			for i := 0; i < y/2; i++ {
+				ans[mp['N'][i]] = 'H'
+			}
+		} else {
+			for i := 0; i < (-y)/2; i++ {
+				ans[mp['S'][i]] = 'H'
+			}
+		}
+	} else {
+		// Balanced but no excess; need at least one H-pair
+		if n == 2 {
+			fmt.Fprintln(w, "NO")
+			return
+		}
+		if len(mp['E']) > 0 {
+			ans[mp['E'][0]] = 'H'
+			ans[mp['W'][0]] = 'H'
+		} else {
+			ans[mp['N'][0]] = 'H'
+			ans[mp['S'][0]] = 'H'
+		}
+	}
+	fmt.Fprintln(w, string(ans))
 }

--- a/1000-1999/1900-1999/1970-1979/1974/1974E.go
+++ b/1000-1999/1900-1999/1970-1979/1974/1974E.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func solve(m int, x int64, c, h []int) int {
+	maxH := 0
+	for _, v := range h {
+		maxH += v
+	}
+	const inf int64 = math.MaxInt64 / 4
+	dp := make([]int64, maxH+1)
+	for i := range dp {
+		dp[i] = inf
+	}
+	dp[0] = 0
+	for i := 1; i <= m; i++ {
+		for j := maxH; j >= 0; j-- {
+			if dp[j] == inf {
+				continue
+			}
+			if int64(j) > int64(maxH) {
+				continue
+			}
+			if dp[j]+int64(c[i-1]) <= int64(i-1)*x {
+				if nj := j + h[i-1]; nj <= maxH {
+					if val := dp[j] + int64(c[i-1]); val < dp[nj] {
+						dp[nj] = val
+					}
+				}
+			}
+		}
+	}
+	res := 0
+	for i := maxH; i >= 0; i-- {
+		if dp[i] != inf {
+			res = i
+			break
+		}
+	}
+	return res
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var m int
+		var x int64
+		fmt.Fscan(in, &m, &x)
+		c := make([]int, m)
+		h := make([]int, m)
+		for i := 0; i < m; i++ {
+			fmt.Fscan(in, &c[i], &h[i])
+		}
+		fmt.Fprintln(out, solve(m, x, c, h))
+	}
+}

--- a/1000-1999/1900-1999/1970-1979/1974/1974F.go
+++ b/1000-1999/1900-1999/1970-1979/1974/1974F.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type move struct {
+	c byte
+	k int
+}
+
+func solve(a, b, n, m int, chips [][2]int, moves []move) (int, int) {
+	chipSet := make(map[[2]int]struct{})
+	for _, p := range chips {
+		chipSet[p] = struct{}{}
+	}
+	r1, r2 := 1, a
+	c1, c2 := 1, b
+	alice, bob := 0, 0
+	turn := 0
+	for _, mv := range moves {
+		var removed [][2]int
+		switch mv.c {
+		case 'U':
+			for i := r1; i < r1+mv.k; i++ {
+				for j := c1; j <= c2; j++ {
+					p := [2]int{i, j}
+					if _, ok := chipSet[p]; ok {
+						removed = append(removed, p)
+					}
+				}
+			}
+			r1 += mv.k
+		case 'D':
+			for i := r2 - mv.k + 1; i <= r2; i++ {
+				for j := c1; j <= c2; j++ {
+					p := [2]int{i, j}
+					if _, ok := chipSet[p]; ok {
+						removed = append(removed, p)
+					}
+				}
+			}
+			r2 -= mv.k
+		case 'L':
+			for j := c1; j < c1+mv.k; j++ {
+				for i := r1; i <= r2; i++ {
+					p := [2]int{i, j}
+					if _, ok := chipSet[p]; ok {
+						removed = append(removed, p)
+					}
+				}
+			}
+			c1 += mv.k
+		case 'R':
+			for j := c2 - mv.k + 1; j <= c2; j++ {
+				for i := r1; i <= r2; i++ {
+					p := [2]int{i, j}
+					if _, ok := chipSet[p]; ok {
+						removed = append(removed, p)
+					}
+				}
+			}
+			c2 -= mv.k
+		}
+		if turn%2 == 0 {
+			alice += len(removed)
+		} else {
+			bob += len(removed)
+		}
+		for _, p := range removed {
+			delete(chipSet, p)
+		}
+		turn++
+	}
+	return alice, bob
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var a, b, n, m int
+		fmt.Fscan(in, &a, &b, &n, &m)
+		chips := make([][2]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &chips[i][0], &chips[i][1])
+		}
+		moves := make([]move, m)
+		for i := 0; i < m; i++ {
+			var c string
+			fmt.Fscan(in, &c, &moves[i].k)
+			moves[i].c = c[0]
+		}
+		x, y := solve(a, b, n, m, chips, moves)
+		fmt.Fprintf(out, "%d %d\n", x, y)
+	}
+}

--- a/1000-1999/1900-1999/1970-1979/1974/1974G.go
+++ b/1000-1999/1900-1999/1970-1979/1974/1974G.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"container/heap"
+	"fmt"
+	"os"
+)
+
+// maxHeap for removing largest cost when over budget
+
+type intHeap []int
+
+func (h intHeap) Len() int            { return len(h) }
+func (h intHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h intHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *intHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *intHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func solve(m int, x int, costs []int) int {
+	h := &intHeap{}
+	heap.Init(h)
+	total := 0
+	for i := 1; i <= m; i++ {
+		heap.Push(h, costs[i-1])
+		total += costs[i-1]
+		limit := x * (i - 1)
+		for total > limit {
+			removed := heap.Pop(h).(int)
+			total -= removed
+		}
+	}
+	return h.Len()
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var m, x int
+		fmt.Fscan(in, &m, &x)
+		costs := make([]int, m)
+		for i := 0; i < m; i++ {
+			fmt.Fscan(in, &costs[i])
+		}
+		fmt.Fprintln(out, solve(m, x, costs))
+	}
+}

--- a/1000-1999/1900-1999/1970-1979/1974/verifierA.go
+++ b/1000-1999/1900-1999/1970-1979/1974/verifierA.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func screens(x, y int) int {
+	n := (x + 4*y + 14) / 15
+	if n < (y+1)/2 {
+		n = (y + 1) / 2
+	}
+	return n
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		x := rng.Intn(100)
+		y := rng.Intn(100)
+		input := fmt.Sprintf("1\n%d %d\n", x, y)
+		expected := fmt.Sprintf("%d", screens(x, y))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1974/verifierB.go
+++ b/1000-1999/1900-1999/1970-1979/1974/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func encode(s string) string {
+	set := make(map[rune]struct{})
+	for _, ch := range s {
+		set[ch] = struct{}{}
+	}
+	letters := make([]rune, 0, len(set))
+	for ch := range set {
+		letters = append(letters, ch)
+	}
+	sort.Slice(letters, func(i, j int) bool { return letters[i] < letters[j] })
+	m := make(map[rune]rune)
+	n := len(letters)
+	for i, ch := range letters {
+		m[ch] = letters[n-1-i]
+	}
+	res := make([]rune, len(s))
+	for i, ch := range s {
+		res[i] = m[ch]
+	}
+	return string(res)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		sb := make([]rune, n)
+		for j := 0; j < n; j++ {
+			sb[j] = letters[rng.Intn(len(letters))]
+		}
+		s := string(sb)
+		b := encode(s)
+		input := fmt.Sprintf("1\n%d\n%s\n", n, b)
+		expected := s
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1974/verifierC.go
+++ b/1000-1999/1900-1999/1970-1979/1974/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type key struct{ x, y int }
+
+func expected(arr []int) int64 {
+	n := len(arr)
+	if n < 3 {
+		return 0
+	}
+	triples := make([][3]int, n-2)
+	for i := 0; i < n-2; i++ {
+		triples[i] = [3]int{arr[i], arr[i+1], arr[i+2]}
+	}
+	var ans int64
+	ab := make(map[key]int)
+	bc := make(map[key]int)
+	ac := make(map[key]int)
+	abc := make(map[[3]int]int)
+	for _, t := range triples {
+		k1 := key{t[0], t[1]}
+		k2 := key{t[1], t[2]}
+		k3 := key{t[0], t[2]}
+		ans += int64(ab[k1] - abc[t])
+		ans += int64(bc[k2] - abc[t])
+		ans += int64(ac[k3] - abc[t])
+		ab[k1]++
+		bc[k2]++
+		ac[k3]++
+		abc[t]++
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 3
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(6)
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expectedVal := fmt.Sprintf("%d", expected(arr))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedVal {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expectedVal, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1974/verifierD.go
+++ b/1000-1999/1900-1999/1970-1979/1974/verifierD.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n int, s string) string {
+	mp := map[byte][]int{'N': {}, 'S': {}, 'E': {}, 'W': {}}
+	for i := 0; i < n; i++ {
+		mp[s[i]] = append(mp[s[i]], i)
+	}
+	x := len(mp['E']) - len(mp['W'])
+	y := len(mp['N']) - len(mp['S'])
+	if x%2 != 0 || y%2 != 0 {
+		return "NO"
+	}
+	ans := make([]byte, n)
+	for i := range ans {
+		ans[i] = 'R'
+	}
+	if x != 0 || y != 0 {
+		if x > 0 {
+			for i := 0; i < x/2; i++ {
+				ans[mp['E'][i]] = 'H'
+			}
+		} else {
+			for i := 0; i < (-x)/2; i++ {
+				ans[mp['W'][i]] = 'H'
+			}
+		}
+		if y > 0 {
+			for i := 0; i < y/2; i++ {
+				ans[mp['N'][i]] = 'H'
+			}
+		} else {
+			for i := 0; i < (-y)/2; i++ {
+				ans[mp['S'][i]] = 'H'
+			}
+		}
+	} else {
+		if n == 2 {
+			return "NO"
+		}
+		if len(mp['E']) > 0 {
+			ans[mp['E'][0]] = 'H'
+			ans[mp['W'][0]] = 'H'
+		} else {
+			ans[mp['N'][0]] = 'H'
+			ans[mp['S'][0]] = 'H'
+		}
+	}
+	return string(ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	dirs := []byte{'N', 'S', 'E', 'W'}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		b := make([]byte, n)
+		for j := 0; j < n; j++ {
+			b[j] = dirs[rng.Intn(len(dirs))]
+		}
+		s := string(b)
+		input := fmt.Sprintf("1\n%d\n%s\n", n, s)
+		expected := solve(n, s)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1974/verifierE.go
+++ b/1000-1999/1900-1999/1970-1979/1974/verifierE.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(m int, x int64, c, h []int) int {
+	maxH := 0
+	for _, v := range h {
+		maxH += v
+	}
+	const inf int64 = math.MaxInt64 / 4
+	dp := make([]int64, maxH+1)
+	for i := range dp {
+		dp[i] = inf
+	}
+	dp[0] = 0
+	for i := 1; i <= m; i++ {
+		for j := maxH; j >= 0; j-- {
+			if dp[j] == inf {
+				continue
+			}
+			if dp[j]+int64(c[i-1]) <= int64(i-1)*x {
+				nj := j + h[i-1]
+				if nj <= maxH {
+					val := dp[j] + int64(c[i-1])
+					if val < dp[nj] {
+						dp[nj] = val
+					}
+				}
+			}
+		}
+	}
+	res := 0
+	for i := maxH; i >= 0; i-- {
+		if dp[i] != inf {
+			res = i
+			break
+		}
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		m := rng.Intn(5) + 1
+		x := int64(rng.Intn(20) + 1)
+		c := make([]int, m)
+		h := make([]int, m)
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", m, x))
+		for j := 0; j < m; j++ {
+			c[j] = rng.Intn(20)
+			h[j] = rng.Intn(10) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", c[j], h[j]))
+		}
+		input := sb.String()
+		exp := fmt.Sprintf("%d", expected(m, x, c, h))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1974/verifierF.go
+++ b/1000-1999/1900-1999/1970-1979/1974/verifierF.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type move struct {
+	c byte
+	k int
+}
+
+func expected(a, b, n, m int, chips [][2]int, moves []move) (int, int) {
+	chipSet := make(map[[2]int]struct{})
+	for _, p := range chips {
+		chipSet[p] = struct{}{}
+	}
+	r1, r2 := 1, a
+	c1, c2 := 1, b
+	alice, bob := 0, 0
+	turn := 0
+	for _, mv := range moves {
+		var removed [][2]int
+		switch mv.c {
+		case 'U':
+			for i := r1; i < r1+mv.k; i++ {
+				for j := c1; j <= c2; j++ {
+					p := [2]int{i, j}
+					if _, ok := chipSet[p]; ok {
+						removed = append(removed, p)
+					}
+				}
+			}
+			r1 += mv.k
+		case 'D':
+			for i := r2 - mv.k + 1; i <= r2; i++ {
+				for j := c1; j <= c2; j++ {
+					p := [2]int{i, j}
+					if _, ok := chipSet[p]; ok {
+						removed = append(removed, p)
+					}
+				}
+			}
+			r2 -= mv.k
+		case 'L':
+			for j := c1; j < c1+mv.k; j++ {
+				for i := r1; i <= r2; i++ {
+					p := [2]int{i, j}
+					if _, ok := chipSet[p]; ok {
+						removed = append(removed, p)
+					}
+				}
+			}
+			c1 += mv.k
+		case 'R':
+			for j := c2 - mv.k + 1; j <= c2; j++ {
+				for i := r1; i <= r2; i++ {
+					p := [2]int{i, j}
+					if _, ok := chipSet[p]; ok {
+						removed = append(removed, p)
+					}
+				}
+			}
+			c2 -= mv.k
+		}
+		if turn%2 == 0 {
+			alice += len(removed)
+		} else {
+			bob += len(removed)
+		}
+		for _, p := range removed {
+			delete(chipSet, p)
+		}
+		turn++
+	}
+	return alice, bob
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	dirs := []byte{'U', 'D', 'L', 'R'}
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		a := rng.Intn(4) + 3
+		b := rng.Intn(4) + 3
+		n := rng.Intn(4) + 1
+		m := rng.Intn(4) + 1
+		chipMap := make(map[[2]int]struct{})
+		chips := make([][2]int, 0, n)
+		for len(chips) < n {
+			x := rng.Intn(a) + 1
+			y := rng.Intn(b) + 1
+			p := [2]int{x, y}
+			if _, ok := chipMap[p]; ok {
+				continue
+			}
+			chipMap[p] = struct{}{}
+			chips = append(chips, p)
+		}
+		moves := make([]move, m)
+		r1, r2 := 1, a
+		c1, c2 := 1, b
+		for i := 0; i < m; i++ {
+			dir := dirs[rng.Intn(4)]
+			var limit int
+			if dir == 'U' || dir == 'D' {
+				limit = r2 - r1 + 1
+			} else {
+				limit = c2 - c1 + 1
+			}
+			if limit <= 1 {
+				moves[i] = move{dir, 0}
+				continue
+			}
+			k := rng.Intn(limit-1) + 1
+			moves[i] = move{dir, k}
+			switch dir {
+			case 'U':
+				r1 += k
+			case 'D':
+				r2 -= k
+			case 'L':
+				c1 += k
+			case 'R':
+				c2 -= k
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", a, b, n, m))
+		for _, p := range chips {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+		}
+		for _, mv := range moves {
+			sb.WriteString(fmt.Sprintf("%c %d\n", mv.c, mv.k))
+		}
+		input := sb.String()
+		exa, exb := expected(a, b, n, m, chips, moves)
+		expectedStr := fmt.Sprintf("%d %d", exa, exb)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedStr {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, expectedStr, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1974/verifierG.go
+++ b/1000-1999/1900-1999/1970-1979/1974/verifierG.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type intHeap []int
+
+func (h intHeap) Len() int            { return len(h) }
+func (h intHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h intHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *intHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *intHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func expected(m, x int, costs []int) int {
+	h := &intHeap{}
+	heap.Init(h)
+	total := 0
+	for i := 1; i <= m; i++ {
+		heap.Push(h, costs[i-1])
+		total += costs[i-1]
+		limit := x * (i - 1)
+		for total > limit {
+			removed := heap.Pop(h).(int)
+			total -= removed
+		}
+	}
+	return h.Len()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		m := rng.Intn(10) + 1
+		x := rng.Intn(10) + 1
+		costs := make([]int, m)
+		for j := 0; j < m; j++ {
+			costs[j] = rng.Intn(10) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(fmt.Sprintf("%d %d\n", m, x))
+		for j, c := range costs {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", c))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := fmt.Sprintf("%d", expected(m, x, costs))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go reference solutions for contest 1974 problems A–G
- add verifier programs for the same problems using random tests
- each verifier runs 100 generated cases and checks output

## Testing
- `gofmt -w 1974A.go 1974B.go 1974C.go 1974E.go 1974F.go 1974G.go verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go 1974D.go`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687def671bf883249aa78f77c748d3d8