### PR TITLE
Add Go verifiers for contest 1971

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1971/1971A.go
+++ b/1000-1999/1900-1999/1970-1979/1971/1971A.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var x, y int
+		fmt.Fscan(in, &x, &y)
+		if x < y {
+			fmt.Printf("%d %d\n", x, y)
+		} else {
+			fmt.Printf("%d %d\n", y, x)
+		}
+	}
+}

--- a/1000-1999/1900-1999/1970-1979/1971/1971B.go
+++ b/1000-1999/1900-1999/1970-1979/1971/1971B.go
@@ -1,49 +1,49 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
-   "sort"
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
 )
 
 func sortString(s string) string {
-   b := []byte(s)
-   sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
-   return string(b)
+	b := []byte(s)
+	sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
+	return string(b)
 }
 
 func reverseString(s string) string {
-   b := []byte(s)
-   for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
-       b[i], b[j] = b[j], b[i]
-   }
-   return string(b)
+	b := []byte(s)
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
 }
 
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   writer := bufio.NewWriter(os.Stdout)
-   defer writer.Flush()
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
 
-   var t int
-   if _, err := fmt.Fscan(reader, &t); err != nil {
-       return
-   }
-   for ; t > 0; t-- {
-       var s string
-       fmt.Fscan(reader, &s)
-       a := sortString(s)
-       b := reverseString(a)
-       if a == s && b == s {
-           fmt.Fprintln(writer, "NO")
-       } else {
-           fmt.Fprintln(writer, "YES")
-           if a == s {
-               fmt.Fprintln(writer, b)
-           } else {
-               fmt.Fprintln(writer, a)
-           }
-       }
-   }
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		a := sortString(s)
+		b := reverseString(a)
+		if a == s && b == s {
+			fmt.Fprintln(writer, "NO")
+		} else {
+			fmt.Fprintln(writer, "YES")
+			if a == s {
+				fmt.Fprintln(writer, b)
+			} else {
+				fmt.Fprintln(writer, a)
+			}
+		}
+	}
 }

--- a/1000-1999/1900-1999/1970-1979/1971/verifierA.go
+++ b/1000-1999/1900-1999/1970-1979/1971/verifierA.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type pair struct{ x, y int }
+
+func runCase(bin string, p pair) error {
+	input := fmt.Sprintf("1\n%d %d\n", p.x, p.y)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var a, b int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &a, &b); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expA, expB := p.x, p.y
+	if expA > expB {
+		expA, expB = expB, expA
+	}
+	if a != expA || b != expB {
+		return fmt.Errorf("expected %d %d got %d %d", expA, expB, a, b)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := make([]pair, 0, 100)
+	for x := 0; x < 10; x++ {
+		for y := 0; y < 10; y++ {
+			cases = append(cases, pair{x, y})
+		}
+	}
+	for i, c := range cases {
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1971/verifierB.go
+++ b/1000-1999/1900-1999/1970-1979/1971/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct{ s string }
+
+func generateCase(rng *rand.Rand) testCaseB {
+	n := rng.Intn(10) + 1
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return testCaseB{string(b)}
+}
+
+func checkOutput(tc testCaseB, out string) error {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) == 0 {
+		return fmt.Errorf("no output")
+	}
+	ans := strings.ToLower(strings.TrimSpace(lines[0]))
+	if ans == "no" {
+		// should be impossible
+		for i := 1; i < len(tc.s); i++ {
+			if tc.s[i] != tc.s[0] {
+				return fmt.Errorf("expected YES, got NO")
+			}
+		}
+		return nil
+	}
+	if ans != "yes" {
+		return fmt.Errorf("first line should be YES or NO")
+	}
+	if len(lines) < 2 {
+		return fmt.Errorf("missing permutation line")
+	}
+	r := strings.TrimSpace(lines[1])
+	if len(r) != len(tc.s) {
+		return fmt.Errorf("permutation wrong length")
+	}
+	if r == tc.s {
+		return fmt.Errorf("permutation equal to original")
+	}
+	// check multiset equality
+	cnt := make(map[rune]int)
+	for _, ch := range tc.s {
+		cnt[ch]++
+	}
+	for _, ch := range r {
+		cnt[ch]--
+	}
+	for _, v := range cnt {
+		if v != 0 {
+			return fmt.Errorf("permutation mismatch")
+		}
+	}
+	return nil
+}
+
+func runCase(bin string, tc testCaseB) error {
+	input := fmt.Sprintf("1\n%s\n", tc.s)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return checkOutput(tc, out.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, tc.s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1971/verifierC.go
+++ b/1000-1999/1900-1999/1970-1979/1971/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func coord(p int) (float64, float64) {
+	if p == 12 {
+		p = 0
+	}
+	angle := 2 * math.Pi * float64(p) / 12
+	return math.Cos(angle), math.Sin(angle)
+}
+
+func orientation(ax, ay, bx, by, cx, cy float64) float64 {
+	return (bx-ax)*(cy-ay) - (by-ay)*(cx-ax)
+}
+
+func intersect(a, b, c, d int) bool {
+	ax, ay := coord(a)
+	bx, by := coord(b)
+	cx, cy := coord(c)
+	dx, dy := coord(d)
+	o1 := orientation(ax, ay, bx, by, cx, cy)
+	o2 := orientation(ax, ay, bx, by, dx, dy)
+	o3 := orientation(cx, cy, dx, dy, ax, ay)
+	o4 := orientation(cx, cy, dx, dy, bx, by)
+	return o1*o2 < 0 && o3*o4 < 0
+}
+
+type caseC struct{ a, b, c, d int }
+
+func generateCase(rng *rand.Rand) caseC {
+	vals := rng.Perm(12)[:4]
+	for i := range vals {
+		vals[i]++
+	}
+	return caseC{vals[0], vals[1], vals[2], vals[3]}
+}
+
+func runCase(bin string, tc caseC) error {
+	input := fmt.Sprintf("1\n%d %d %d %d\n", tc.a, tc.b, tc.c, tc.d)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.ToLower(strings.TrimSpace(out.String()))
+	exp := "no"
+	if intersect(tc.a, tc.b, tc.c, tc.d) {
+		exp = "yes"
+	}
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%d %d %d %d\n", i+1, err, tc.a, tc.b, tc.c, tc.d)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1971/verifierD.go
+++ b/1000-1999/1900-1999/1970-1979/1971/verifierD.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedPieces(s string) int {
+	cnt := 1
+	for i := 0; i+1 < len(s); i++ {
+		if s[i] == '1' && s[i+1] == '0' {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+type caseD struct{ s string }
+
+func genCase(rng *rand.Rand) caseD {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := range b {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return caseD{string(b)}
+}
+
+func runCase(bin string, tc caseD) error {
+	input := fmt.Sprintf("1\n%s\n", tc.s)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := expectedPieces(tc.s)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s\n", i+1, err, tc.s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1971/verifierE.go
+++ b/1000-1999/1900-1999/1970-1979/1971/verifierE.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func timeAt(n int, a, b []int, d int) int {
+	if d == 0 {
+		return 0
+	}
+	prevA, prevB := 0, 0
+	for i := 0; i < len(a); i++ {
+		if d <= a[i] {
+			num := (d - prevA) * (b[i] - prevB)
+			den := a[i] - prevA
+			return prevB + num/den
+		}
+		prevA, prevB = a[i], b[i]
+	}
+	return b[len(b)-1]
+}
+
+type caseE struct {
+	n, k, q int
+	a, b    []int
+	queries []int
+}
+
+func genCase(rng *rand.Rand) caseE {
+	n := rng.Intn(100) + 1
+	k := rng.Intn(5) + 1
+	if k > n {
+		k = n
+	}
+	q := rng.Intn(5) + 1
+	a := make([]int, k)
+	b := make([]int, k)
+	lastA := 0
+	lastB := 0
+	for i := 0; i < k; i++ {
+		lastA += rng.Intn(10) + 1
+		if i == k-1 && lastA < n {
+			lastA = n
+		}
+		if lastA > n {
+			lastA = n
+		}
+		a[i] = lastA
+		lastB += rng.Intn(10) + 1
+		b[i] = lastB
+	}
+	qs := make([]int, q)
+	for i := 0; i < q; i++ {
+		qs[i] = rng.Intn(n + 1)
+	}
+	return caseE{n, k, q, a, b, qs}
+}
+
+func runCase(bin string, tc caseE) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d %d %d\n", tc.n, tc.k, tc.q))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for _, v := range tc.queries {
+		sb.WriteString(fmt.Sprintf("%d\n", v))
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	expected := make([]int, len(tc.queries))
+	for i, d := range tc.queries {
+		expected[i] = timeAt(tc.n, tc.a, tc.b, d)
+	}
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			return fmt.Errorf("missing output line %d", i+1)
+		}
+		var got int
+		if _, err := fmt.Sscan(scanner.Text(), &got); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if got != exp {
+			return fmt.Errorf("query %d expected %d got %d", i+1, exp, got)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1971/verifierF.go
+++ b/1000-1999/1900-1999/1970-1979/1971/verifierF.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func countPoints(r int) int {
+	limit := r + 1
+	count := 0
+	r2 := r * r
+	r2n := (r + 1) * (r + 1)
+	for x := -limit; x <= limit; x++ {
+		for y := -limit; y <= limit; y++ {
+			d2 := x*x + y*y
+			if d2 >= r2 && d2 < r2n {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+type caseF struct{ r int }
+
+func genCase(rng *rand.Rand) caseF {
+	return caseF{rng.Intn(50) + 1}
+}
+
+func runCase(bin string, tc caseF) error {
+	input := fmt.Sprintf("1\n%d\n", tc.r)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := countPoints(tc.r)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1971/verifierG.go
+++ b/1000-1999/1900-1999/1970-1979/1971/verifierG.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func serialize(arr []int) string {
+	var sb strings.Builder
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String()
+}
+
+func lexLess(a, b []int) bool {
+	for i := range a {
+		if a[i] < b[i] {
+			return true
+		}
+		if a[i] > b[i] {
+			return false
+		}
+	}
+	return false
+}
+
+func bfs(a []int) []int {
+	start := append([]int{}, a...)
+	best := append([]int{}, a...)
+	type node struct{ arr []int }
+	q := []node{{start}}
+	seen := map[string]bool{serialize(start): true}
+	for len(q) > 0 {
+		cur := q[0].arr
+		q = q[1:]
+		if lexLess(cur, best) {
+			best = append([]int{}, cur...)
+		}
+		n := len(cur)
+		for i := 0; i < n; i++ {
+			for j := i + 1; j < n; j++ {
+				if cur[i]^cur[j] < 4 {
+					next := append([]int{}, cur...)
+					next[i], next[j] = next[j], next[i]
+					key := serialize(next)
+					if !seen[key] {
+						seen[key] = true
+						q = append(q, node{next})
+					}
+				}
+			}
+		}
+	}
+	return best
+}
+
+type caseG struct{ arr []int }
+
+func genCase(rng *rand.Rand) caseG {
+	n := rng.Intn(5) + 2
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(20)
+	}
+	return caseG{arr}
+}
+
+func runCase(bin string, tc caseG) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d\n", len(tc.arr)))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != len(tc.arr) {
+		return fmt.Errorf("expected %d numbers got %d", len(tc.arr), len(fields))
+	}
+	got := make([]int, len(fields))
+	for i, f := range fields {
+		fmt.Sscan(f, &got[i])
+	}
+	exp := bfs(tc.arr)
+	for i := range exp {
+		if got[i] != exp[i] {
+			return fmt.Errorf("mismatch at %d exp %d got %d", i, exp[i], got[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1971/verifierH.go
+++ b/1000-1999/1900-1999/1970-1979/1971/verifierH.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type caseH struct {
+	n    int
+	grid [3][]int
+}
+
+func genCase(rng *rand.Rand) caseH {
+	n := rng.Intn(4) + 2
+	g := [3][]int{}
+	for i := 0; i < 3; i++ {
+		g[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			idx := rng.Intn(n) + 1
+			if rng.Intn(2) == 0 {
+				g[i][j] = idx
+			} else {
+				g[i][j] = -idx
+			}
+		}
+	}
+	return caseH{n, g}
+}
+
+func canWin(tc caseH) bool {
+	n := tc.n
+	for mask := 0; mask < (1 << n); mask++ {
+		assign := make([]int, n)
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) != 0 {
+				assign[i] = 1
+			} else {
+				assign[i] = -1
+			}
+		}
+		ok := true
+		for j := 0; j < n && ok; j++ {
+			col := []int{
+				val(tc.grid[0][j], assign),
+				val(tc.grid[1][j], assign),
+				val(tc.grid[2][j], assign),
+			}
+			sort.Ints(col)
+			if col[1] != 1 {
+				ok = false
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+func val(x int, a []int) int {
+	if x > 0 {
+		return a[x-1]
+	}
+	return -a[-x-1]
+}
+
+func runCase(bin string, tc caseH) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d\n", tc.n))
+	for i := 0; i < 3; i++ {
+		for j := 0; j < tc.n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", tc.grid[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.ToLower(strings.TrimSpace(out.String()))
+	exp := "no"
+	if canWin(tc) {
+		exp = "yes"
+	}
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- provide solution `1971A.go` as example implementation
- add verifiers `verifierA.go`–`verifierH.go` for contest 1971 problems
- each verifier runs at least 100 random test cases and checks a binary's output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build 1971A.go`

------
https://chatgpt.com/codex/tasks/task_e_687def916d4083249bd5338b7258bf73