### PR TITLE
Add Go verifiers for 1970 B problems

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1970/verifierB1.go
+++ b/1000-1999/1900-1999/1970-1979/1970/verifierB1.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB1(a []int) string {
+	n := len(a)
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", i+1, i+1))
+	}
+	for i := 0; i < n; i++ {
+		sel := a[i] / 2
+		if i >= sel {
+			sb.WriteString(fmt.Sprintf("%d ", i-sel+1))
+		} else if i+sel < n {
+			sb.WriteString(fmt.Sprintf("%d ", i+sel+1))
+		} else {
+			// invalid case
+			return "NO\n"
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(n/2+1) * 2
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), arr
+}
+
+func runCase(bin string, input string, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, arr := generateCase(rng)
+		expect := solveB1(arr)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1970/verifierB2.go
+++ b/1000-1999/1900-1999/1970-1979/1970/verifierB2.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type pair struct{ a, idx int }
+
+func solveB2(a []int) string {
+	n := len(a)
+	v := make([]pair, n)
+	for i := 0; i < n; i++ {
+		v[i] = pair{a[i], i}
+	}
+	sort.Slice(v, func(i, j int) bool { return v[i].a < v[j].a })
+	ansx := make([]int, n)
+	ansy := make([]int, n)
+	dir := make([]int, n)
+	taken := make([]int, n+1)
+	takenID := make([]int, n+1)
+	if v[0].a == 0 {
+		id0 := v[0].idx
+		ansx[id0] = 1
+		ansy[id0] = 1
+		dir[id0] = id0 + 1
+		taken[1] = 1
+		takenID[1] = id0
+	} else {
+		i := 0
+		for i+1 < n && v[i].a != v[i+1].a {
+			i++
+		}
+		dis := v[i].a
+		id1 := v[i].idx
+		id2 := v[i+1].idx
+		ansx[id1] = 1
+		ansy[id1] = 1
+		dir[id1] = id2 + 1
+		taken[1] = 1
+		takenID[1] = id1
+		x := 1 + dis
+		y := 1
+		if x > n {
+			y += x - n
+			x = n
+		}
+		ansx[id2] = x
+		ansy[id2] = y
+		dir[id2] = id1 + 1
+		taken[x] = y
+		takenID[x] = id2
+	}
+	curX := 1
+	for _, p := range v {
+		aVal := p.a
+		id := p.idx
+		if dir[id] != 0 {
+			continue
+		}
+		for curX <= n && taken[curX] != 0 {
+			curX++
+		}
+		var y int
+		if aVal == 0 {
+			y = 1
+			dir[id] = id + 1
+		} else {
+			if curX-aVal >= 1 {
+				y = taken[curX-aVal]
+				dir[id] = takenID[curX-aVal] + 1
+			} else {
+				y = aVal - curX + 2
+				dir[id] = takenID[1] + 1
+			}
+		}
+		ansx[id] = curX
+		ansy[id] = y
+		taken[curX] = y
+		takenID[curX] = id
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", ansx[i], ansy[i]))
+	}
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d\n", dir[i]))
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(10) + 2
+	arr := make([]int, n)
+	arr[0] = 0
+	for i := 1; i < n; i++ {
+		arr[i] = rng.Intn(n + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), arr
+}
+
+func runCase(bin string, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, arr := generateCase(rng)
+		expect := solveB2(arr)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1900-1999/1970-1979/1970/verifierB3.go
+++ b/1000-1999/1900-1999/1970-1979/1970/verifierB3.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveB3(a []int) string {
+	n := len(a)
+	type node struct{ fs, sn int }
+	arr := make([]node, n+1)
+	for i := 1; i <= n; i++ {
+		arr[i] = node{a[i-1], i}
+	}
+	sort.Slice(arr[1:], func(i, j int) bool { return arr[i+1].fs < arr[j+1].fs })
+	x := 0
+	for i := 1; i < n; i++ {
+		if arr[i].fs == arr[i+1].fs {
+			x = i
+			break
+		}
+	}
+	ansX := make([]int, n+1)
+	ansY := make([]int, n+1)
+	anss := make([]int, n+1)
+	v := make([]int, n+1)
+	if x > 0 || arr[1].fs == 0 {
+		if x > 0 {
+			arr[1], arr[x] = arr[x], arr[1]
+			arr[2], arr[x+1] = arr[x+1], arr[2]
+		}
+		ansX[arr[1].sn] = 1
+		ansY[arr[1].sn] = 1
+		v[1] = 1
+		if arr[1].fs == 0 {
+			anss[arr[1].sn] = arr[1].sn
+		} else {
+			anss[arr[1].sn] = arr[2].sn
+		}
+		for i := 2; i <= n; i++ {
+			idx := arr[i].sn
+			if arr[i].fs == 0 {
+				ansX[idx] = i
+				ansY[idx] = 1
+				v[i] = 1
+				anss[idx] = arr[i].sn
+			} else if arr[i].fs < i {
+				ansX[idx] = i
+				y := v[i-arr[i].fs]
+				ansY[idx] = y
+				v[i] = y
+				anss[idx] = arr[i-arr[i].fs].sn
+			} else {
+				ansX[idx] = i
+				y := arr[i].fs - i + 2
+				ansY[idx] = y
+				v[i] = y
+				anss[idx] = arr[1].sn
+			}
+		}
+	} else {
+		if n == 2 {
+			return "NO\n"
+		}
+		ansX[arr[n].sn] = 1
+		ansY[arr[n].sn] = 1
+		anss[arr[n].sn] = arr[n-1].sn
+		ansX[arr[n-1].sn] = n
+		ansY[arr[n-1].sn] = 2
+		anss[arr[n-1].sn] = arr[1].sn
+		for i := 1; i <= n-2; i++ {
+			idx := arr[i].sn
+			ansX[idx] = i + 1
+			ansY[idx] = 1
+			anss[idx] = arr[n].sn
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	for i := 1; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", ansX[i], ansY[i]))
+	}
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", anss[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(10) + 2
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(n + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), arr
+}
+
+func runCase(bin string, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB3.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, arr := generateCase(rng)
+		expect := solveB3(arr)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add three Go verifier programs for contest 1970 (problems B1, B2, B3)
- verifiers generate random test cases, compute expected output using solution logic, and compare against a candidate binary

## Testing
- `go build verifierB1.go`
- `go build verifierB2.go`
- `go build verifierB3.go`
- `go run verifierB1.go ./b1`
- `go run verifierB2.go ./b2`
- `go run verifierB3.go ./b3`

------
https://chatgpt.com/codex/tasks/task_e_687defa80c1c832484274d851498b861