### PR TITLE
Add Go verifiers for contest 6

### DIFF
--- a/0-999/0-99/0-9/6/verifierA.go
+++ b/0-999/0-99/0-9/6/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(sticks [4]int) string {
+	triangle := false
+	segment := false
+	for i := 0; i < 4; i++ {
+		for j := i + 1; j < 4; j++ {
+			for k := j + 1; k < 4; k++ {
+				a, b, c := sticks[i], sticks[j], sticks[k]
+				if a > b {
+					a, b = b, a
+				}
+				if b > c {
+					b, c = c, b
+				}
+				if a > b {
+					a, b = b, a
+				}
+				if a+b > c {
+					triangle = true
+				} else if a+b == c {
+					segment = true
+				}
+			}
+		}
+	}
+	if triangle {
+		return "TRIANGLE"
+	}
+	if segment {
+		return "SEGMENT"
+	}
+	return "IMPOSSIBLE"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	var sticks [4]int
+	for i := 0; i < 4; i++ {
+		sticks[i] = rng.Intn(100) + 1
+	}
+	input := fmt.Sprintf("%d %d %d %d\n", sticks[0], sticks[1], sticks[2], sticks[3])
+	return input, solve(sticks)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := generateCase(rng)
+		if err := runCase(exe, input, expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/0-9/6/verifierB.go
+++ b/0-999/0-99/0-9/6/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ x, y int }
+
+func solve(n, m int, pres byte, grid []string) int {
+	seen := make(map[byte]bool)
+	dirs := []pair{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] != pres {
+				continue
+			}
+			for _, d := range dirs {
+				ni, nj := i+d.x, j+d.y
+				if ni >= 0 && ni < n && nj >= 0 && nj < m {
+					c := grid[ni][nj]
+					if c != '.' && c != pres {
+						seen[c] = true
+					}
+				}
+			}
+		}
+	}
+	return len(seen)
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	pres := byte('A' + rng.Intn(26))
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %c\n", n, m, pres))
+	grid := make([]string, n)
+	letters := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(5) == 0 {
+				row[j] = '.'
+			} else {
+				row[j] = letters[rng.Intn(len(letters))]
+			}
+		}
+		grid[i] = string(row)
+		sb.WriteString(grid[i])
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solve(n, m, pres, grid)
+}
+
+func runCase(exe, input string, expected int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/0-9/6/verifierC.go
+++ b/0-999/0-99/0-9/6/verifierC.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(times []int) (int, int) {
+	left, right := 0, len(times)-1
+	var timeA, timeB int
+	var countA, countB int
+	for left <= right {
+		if timeA <= timeB {
+			timeA += times[left]
+			left++
+			countA++
+		} else {
+			timeB += times[right]
+			right--
+			countB++
+		}
+	}
+	return countA, countB
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	times := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		times[i] = rng.Intn(1000) + 1
+		sb.WriteString(fmt.Sprintf("%d", times[i]))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	a, b := solve(times)
+	return sb.String(), fmt.Sprintf("%d %d", a, b)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/0-9/6/verifierD.go
+++ b/0-999/0-99/0-9/6/verifierD.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var (
+	nGlobal int
+	aGlobal int
+	bGlobal int
+	hGlobal []int
+	shoot   []int
+)
+
+func dfs(l, balls, last int) bool {
+	if balls == 0 {
+		for i := 1; i <= nGlobal; i++ {
+			if hGlobal[i] >= 0 {
+				return false
+			}
+		}
+		return true
+	}
+	if l <= nGlobal && hGlobal[l] < 0 {
+		return dfs(l+1, balls, last)
+	}
+	lb := last
+	if l > 2 && l > lb {
+		lb = l
+	}
+	if lb < 2 {
+		lb = 2
+	}
+	ub := nGlobal - 1
+	if l+1 < ub {
+		ub = l + 1
+	}
+	for i := lb; i <= ub; i++ {
+		shoot[balls] = i
+		hGlobal[i] -= aGlobal
+		hGlobal[i-1] -= bGlobal
+		hGlobal[i+1] -= bGlobal
+		if dfs(l, balls-1, i) {
+			return true
+		}
+		hGlobal[i] += aGlobal
+		hGlobal[i-1] += bGlobal
+		hGlobal[i+1] += bGlobal
+	}
+	return false
+}
+
+// solve uses BFS to find the optimal sequence of shots
+func solve(n, a, b int, h []int) (int, []int) {
+	type node struct {
+		h   []int
+		seq []int
+	}
+	serialize := func(arr []int) string {
+		var sb strings.Builder
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		return sb.String()
+	}
+	start := make([]int, n)
+	copy(start, h)
+	vis := map[string]bool{serialize(start): true}
+	q := []node{{h: start}}
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		allDead := true
+		for _, v := range cur.h {
+			if v >= 0 {
+				allDead = false
+				break
+			}
+		}
+		if allDead {
+			return len(cur.seq), cur.seq
+		}
+		for i := 1; i < n-1; i++ {
+			nxt := make([]int, n)
+			copy(nxt, cur.h)
+			nxt[i] -= a
+			nxt[i-1] -= b
+			nxt[i+1] -= b
+			key := serialize(nxt)
+			if !vis[key] {
+				vis[key] = true
+				seq := append(append([]int(nil), cur.seq...), i+1)
+				q = append(q, node{h: nxt, seq: seq})
+			}
+		}
+	}
+	return -1, nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 3 // 3..5
+	a := rng.Intn(5) + 2
+	b := rng.Intn(a-1) + 1
+	heights := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, a, b))
+	for i := 0; i < n; i++ {
+		heights[i] = rng.Intn(4) + 1
+		sb.WriteString(fmt.Sprintf("%d", heights[i]))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	ans, seq := solve(n, a, b, heights)
+	var exp strings.Builder
+	exp.WriteString(fmt.Sprintf("%d\n", ans))
+	for i, v := range seq {
+		exp.WriteString(fmt.Sprintf("%d", v))
+		if i+1 < len(seq) {
+			exp.WriteByte(' ')
+		}
+	}
+	return sb.String(), exp.String()
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/0-9/6/verifierE.go
+++ b/0-999/0-99/0-9/6/verifierE.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type interval struct{ l, r int }
+
+func solve(n, k int, h []int) (int, []interval) {
+	maxDeque := make([]int, 0, n)
+	minDeque := make([]int, 0, n)
+	l := 0
+	best := 0
+	res := make([]interval, 0)
+	for r := 0; r < n; r++ {
+		for len(maxDeque) > 0 && h[maxDeque[len(maxDeque)-1]] <= h[r] {
+			maxDeque = maxDeque[:len(maxDeque)-1]
+		}
+		maxDeque = append(maxDeque, r)
+		for len(minDeque) > 0 && h[minDeque[len(minDeque)-1]] >= h[r] {
+			minDeque = minDeque[:len(minDeque)-1]
+		}
+		minDeque = append(minDeque, r)
+		for l <= r && h[maxDeque[0]]-h[minDeque[0]] > k {
+			if maxDeque[0] == l {
+				maxDeque = maxDeque[1:]
+			}
+			if minDeque[0] == l {
+				minDeque = minDeque[1:]
+			}
+			l++
+		}
+		length := r - l + 1
+		if length > best {
+			best = length
+			res = res[:0]
+			res = append(res, interval{l, r})
+		} else if length == best {
+			res = append(res, interval{l, r})
+		}
+	}
+	return best, res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	k := rng.Intn(1000)
+	h := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		h[i] = rng.Intn(1000) + 1
+		sb.WriteString(fmt.Sprintf("%d", h[i]))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	best, res := solve(n, k, h)
+	var exp strings.Builder
+	exp.WriteString(fmt.Sprintf("%d %d\n", best, len(res)))
+	for _, iv := range res {
+		exp.WriteString(fmt.Sprintf("%d %d\n", iv.l+1, iv.r+1))
+	}
+	return sb.String(), strings.TrimSpace(exp.String())
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new Go verifiers for problems A–E of contest 6
- each verifier generates random test cases (100 by default) and checks any binary
- problem D verifier uses BFS-based solver

## Testing
- `go run verifierA.go ./6A`
- `go run verifierB.go ./6B`
- `go run verifierE.go ./6E`


------
https://chatgpt.com/codex/tasks/task_e_687e00776a3083249db0912cc9cd1df6