### PR TITLE
Add Go verifiers for contest 8 problems

### DIFF
--- a/0-999/0-99/0-9/8/solC.cpp
+++ b/0-999/0-99/0-9/8/solC.cpp
@@ -1,3 +1,4 @@
+//go:build ignore
 #include <cstdio>
 using namespace std;
 

--- a/0-999/0-99/0-9/8/solD.cpp
+++ b/0-999/0-99/0-9/8/solD.cpp
@@ -1,3 +1,4 @@
+//go:build ignore
 #include <cstdio>
 #include <cstring>
 #include <algorithm>

--- a/0-999/0-99/0-9/8/verifierA.go
+++ b/0-999/0-99/0-9/8/verifierA.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// can checks if pattern a occurs in s and pattern b occurs after it
+func can(s, a, b string) bool {
+	i := strings.Index(s, a)
+	if i == -1 {
+		return false
+	}
+	j := strings.Index(s[i+len(a):], b)
+	return j != -1
+}
+
+// reverse returns the reversed string
+func reverse(s string) string {
+	r := []rune(s)
+	for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+	return string(r)
+}
+
+// solve computes the expected answer for a single test case
+func solve(input string) string {
+	lines := strings.Split(strings.TrimSpace(input), "\n")
+	s := strings.TrimSpace(lines[0])
+	a := strings.TrimSpace(lines[1])
+	b := strings.TrimSpace(lines[2])
+	forward := can(s, a, b)
+	backward := can(reverse(s), a, b)
+	switch {
+	case forward && backward:
+		return "both"
+	case forward:
+		return "forward"
+	case backward:
+		return "backward"
+	default:
+		return "fantasy"
+	}
+}
+
+type test struct {
+	input    string
+	expected string
+}
+
+// generateTests creates at least 100 deterministic test cases
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	// some fixed edge cases
+	fixed := []string{
+		"aaaaa\na\na",
+		"abcde\nab\ncd",
+		"ababa\naba\nba",
+		"xyz\nxy\nz",
+		"abcdef\nabc\ndef",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f + "\n", solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(20) + 5
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteByte(byte('a' + rand.Intn(3)))
+		}
+		la := rand.Intn(3) + 1
+		var sa strings.Builder
+		for i := 0; i < la; i++ {
+			sa.WriteByte(byte('a' + rand.Intn(3)))
+		}
+		lb := rand.Intn(3) + 1
+		var sb2 strings.Builder
+		for i := 0; i < lb; i++ {
+			sb2.WriteByte(byte('a' + rand.Intn(3)))
+		}
+		inp := fmt.Sprintf("%s\n%s\n%s\n", sb.String(), sa.String(), sb2.String())
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected: %s\nGot: %s\n", i+1, t.input, strings.TrimSpace(t.expected), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/0-99/0-9/8/verifierB.go
+++ b/0-999/0-99/0-9/8/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type pt struct{ x, y int }
+
+func solve(input string) string {
+	s := strings.TrimSpace(input)
+	positions := make([]pt, 0, len(s)+1)
+	positions = append(positions, pt{0, 0})
+	visited := map[pt]int{positions[0]: 0}
+	x, y := 0, 0
+	for i, ch := range s {
+		switch ch {
+		case 'L':
+			x--
+		case 'R':
+			x++
+		case 'U':
+			y++
+		case 'D':
+			y--
+		}
+		cur := pt{x, y}
+		if _, ok := visited[cur]; ok {
+			return "BUG"
+		}
+		positions = append(positions, cur)
+		visited[cur] = i + 1
+	}
+	dirs := []pt{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for i, p := range positions {
+		for _, d := range dirs {
+			np := pt{p.x + d.x, p.y + d.y}
+			if j, ok := visited[np]; ok {
+				if j != i-1 && j != i+1 {
+					return "BUG"
+				}
+			}
+		}
+	}
+	return "OK"
+}
+
+type test struct {
+	input    string
+	expected string
+}
+
+func generateTests() []test {
+	rand.Seed(99)
+	var tests []test
+	fixed := []string{"LR", "UD", "LLRR", "URDL"}
+	for _, f := range fixed {
+		tests = append(tests, test{f + "\n", solve(f)})
+	}
+	moves := []byte{'L', 'R', 'U', 'D'}
+	for len(tests) < 100 {
+		n := rand.Intn(20) + 1
+		var b strings.Builder
+		for i := 0; i < n; i++ {
+			b.WriteByte(moves[rand.Intn(4)])
+		}
+		inp := b.String() + "\n"
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, strings.TrimSpace(t.expected), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/0-99/0-9/8/verifierC.go
+++ b/0-999/0-99/0-9/8/verifierC.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solve(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var xs, ys, n int
+	fmt.Fscan(reader, &xs, &ys)
+	fmt.Fscan(reader, &n)
+	x := make([]int, n)
+	y := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &x[i], &y[i])
+	}
+	d := make([]int, n)
+	for i := 0; i < n; i++ {
+		dx := x[i] - xs
+		dy := y[i] - ys
+		d[i] = dx*dx + dy*dy
+	}
+	a := make([][]int, n)
+	for i := range a {
+		a[i] = make([]int, n)
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < i; j++ {
+			dx := x[i] - x[j]
+			dy := y[i] - y[j]
+			a[i][j] = dx*dx + dy*dy
+			a[j][i] = a[i][j]
+		}
+	}
+	size := 1 << n
+	const INF = 1 << 60
+	f := make([]int, size)
+	g := make([]int, size)
+	for i := range f {
+		f[i] = INF
+	}
+	f[0] = 0
+	for mask := 0; mask < size; mask++ {
+		if f[mask] == INF {
+			continue
+		}
+		for i := 0; i < n; i++ {
+			bit := 1 << i
+			if mask&bit == 0 {
+				m1 := mask | bit
+				cost1 := f[mask] + 2*d[i]
+				if cost1 < f[m1] {
+					f[m1] = cost1
+					g[m1] = mask
+				}
+				for j := i + 1; j < n; j++ {
+					bitj := 1 << j
+					if mask&bitj == 0 {
+						m2 := mask | bit | bitj
+						cost2 := f[mask] + d[i] + d[j] + a[i][j]
+						if cost2 < f[m2] {
+							f[m2] = cost2
+							g[m2] = mask
+						}
+					}
+				}
+				break
+			}
+		}
+	}
+	full := (1 << n) - 1
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, f[full])
+	mask := full
+	var path []int
+	for mask > 0 {
+		path = append(path, 0)
+		prev := g[mask]
+		diff := mask ^ prev
+		for i := 0; i < n; i++ {
+			if diff&(1<<i) != 0 {
+				path = append(path, i+1)
+			}
+		}
+		mask = prev
+	}
+	path = append(path, 0)
+	for _, v := range path {
+		fmt.Fprint(&buf, v, " ")
+	}
+	fmt.Fprintln(&buf)
+	return buf.String()
+}
+
+type test struct{ input, expected string }
+
+func generateTests() []test {
+	rand.Seed(7)
+	var tests []test
+	for len(tests) < 100 {
+		xs := rand.Intn(11) - 5
+		ys := rand.Intn(11) - 5
+		n := rand.Intn(4) + 1
+		used := map[[2]int]bool{}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n%d\n", xs, ys, n)
+		for i := 0; i < n; i++ {
+			for {
+				x := rand.Intn(11) - 5
+				y := rand.Intn(11) - 5
+				if !used[[2]int{x, y}] && !(x == xs && y == ys) {
+					used[[2]int{x, y}] = true
+					fmt.Fprintf(&sb, "%d %d\n", x, y)
+					break
+				}
+			}
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, t.input, strings.TrimSpace(t.expected), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/0-99/0-9/8/verifierD.go
+++ b/0-999/0-99/0-9/8/verifierD.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Point struct{ x, y float64 }
+
+func (p Point) add(q Point) Point   { return Point{p.x + q.x, p.y + q.y} }
+func (p Point) mul(s float64) Point { return Point{p.x * s, p.y * s} }
+
+func dist(p, q Point) float64 { return math.Hypot(p.x-q.x, p.y-q.y) }
+
+func solve(input string) string {
+	rdr := strings.NewReader(input)
+	var t1, t2 float64
+	fmt.Fscan(rdr, &t1, &t2)
+	var a, b, c Point
+	fmt.Fscan(rdr, &a.x, &a.y, &c.x, &c.y, &b.x, &b.y)
+	ab := dist(a, b)
+	bc := dist(b, c)
+	ac := dist(a, c)
+	t1 += ab + bc + 1e-12
+	t2 += ac + 1e-12
+	if ab+bc < t2 {
+		return fmt.Sprintf("%.10f", math.Min(t1, t2))
+	}
+	cal := func(k float64) float64 {
+		p := b.mul(1 - k).add(c.mul(k))
+		ap := dist(a, p)
+		if ap+(k+1)*bc < t1 && ap+(1-k)*bc < t2 {
+			if t1-(k+1)*bc < t2-(1-k)*bc {
+				return t1 - (k+1)*bc
+			}
+			return t2 - (1-k)*bc
+		}
+		l, r := 0.0, 1.0
+		for r-l > 1e-15 {
+			m := (l + r) / 2
+			p1 := a.mul(1 - m).add(p.mul(m))
+			if ap*m+dist(p1, b)+bc < t1 && ap*m+dist(p1, c) < t2 {
+				l = m
+			} else {
+				r = m
+			}
+		}
+		return ((l + r) / 2) * ap
+	}
+	l, r := 0.0, 1.0
+	for r-l > 1e-15 {
+		m1 := (2*l + r) / 3
+		m2 := (l + 2*r) / 3
+		if cal(m1)-cal(m2) < 1e-12 {
+			l = m1
+		} else {
+			r = m2
+		}
+	}
+	ans := cal((l + r) / 2)
+	return fmt.Sprintf("%.10f", ans)
+}
+
+type test struct{ input, expected string }
+
+func generateTests() []test {
+	rand.Seed(123)
+	var tests []test
+	for len(tests) < 100 {
+		t1 := rand.Float64() * 50
+		t2 := rand.Float64() * 50
+		ax := rand.Float64()*20 - 10
+		ay := rand.Float64()*20 - 10
+		bx := rand.Float64()*20 - 10
+		by := rand.Float64()*20 - 10
+		cx := rand.Float64()*20 - 10
+		cy := rand.Float64()*20 - 10
+		inp := fmt.Sprintf("%.2f %.2f\n%.2f %.2f %.2f %.2f %.2f %.2f\n", t1, t2, ax, ay, cx, cy, bx, by)
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != t.expected {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/0-99/0-9/8/verifierE.go
+++ b/0-999/0-99/0-9/8/verifierE.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solve(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	var k uint64
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return ""
+	}
+	prefix := make([]int8, n)
+	for i := range prefix {
+		prefix[i] = -1
+	}
+	numPairs := n / 2
+	var dpMemo [51][2][2]uint64
+	var dpVis [51][2][2]bool
+	var countDP func(i int, revState, crState int) uint64
+	countDP = func(i int, revState, crState int) uint64 {
+		if prefix[0] == 1 {
+			return 0
+		}
+		if i == numPairs {
+			if n%2 == 1 {
+				mid := numPairs
+				bit := prefix[mid]
+				if bit >= 0 {
+					if crState == 0 && bit == 1 {
+						return 0
+					}
+					return 1
+				}
+				if crState == 0 {
+					return 1
+				}
+				return 2
+			}
+			return 1
+		}
+		if dpVis[i][revState][crState] {
+			return dpMemo[i][revState][crState]
+		}
+		var res uint64
+		j := n - 1 - i
+		ai := prefix[i]
+		bj := prefix[j]
+		if ai >= 0 && bj >= 0 {
+			a := ai
+			b := bj
+			ns := revState
+			if ns == 0 {
+				if a < b {
+					ns = 1
+				} else if a > b {
+					dpVis[i][revState][crState] = true
+					return 0
+				}
+			}
+			nc := crState
+			if nc == 0 {
+				if a < 1-b {
+					nc = 1
+				} else if a > 1-b {
+					dpVis[i][revState][crState] = true
+					return 0
+				}
+			}
+			res = countDP(i+1, ns, nc)
+		} else if ai >= 0 {
+			a := ai
+			for b := int8(0); b <= 1; b++ {
+				ns := revState
+				if ns == 0 {
+					if a < b {
+						ns = 1
+					} else if a > b {
+						continue
+					}
+				}
+				nc := crState
+				if nc == 0 {
+					if a < 1-b {
+						nc = 1
+					} else if a > 1-b {
+						continue
+					}
+				}
+				prefix[j] = b
+				res += countDP(i+1, ns, nc)
+				prefix[j] = -1
+			}
+		} else {
+			for a := int8(0); a <= 1; a++ {
+				if i == 0 && a != 0 {
+					continue
+				}
+				for b := int8(0); b <= 1; b++ {
+					ns := revState
+					if ns == 0 {
+						if a < b {
+							ns = 1
+						} else if a > b {
+							continue
+						}
+					}
+					nc := crState
+					if nc == 0 {
+						if a < 1-b {
+							nc = 1
+						} else if a > 1-b {
+							continue
+						}
+					}
+					prefix[i], prefix[j] = a, b
+					res += countDP(i+1, ns, nc)
+					prefix[i], prefix[j] = -1, -1
+				}
+			}
+		}
+		dpVis[i][revState][crState] = true
+		dpMemo[i][revState][crState] = res
+		return res
+	}
+
+	total := countDP(0, 0, 0)
+	if k+1 > total {
+		return "-1"
+	}
+	K := k + 1
+	prefix[0] = 0
+	for pos := 1; pos < n; pos++ {
+		prefix[pos] = 0
+		for i := 0; i <= numPairs; i++ {
+			for rv := 0; rv < 2; rv++ {
+				for cr := 0; cr < 2; cr++ {
+					dpVis[i][rv][cr] = false
+				}
+			}
+		}
+		cnt0 := countDP(0, 0, 0)
+		if K <= cnt0 {
+			continue
+		}
+		K -= cnt0
+		prefix[pos] = 1
+	}
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if prefix[i] == 0 {
+			out[i] = '0'
+		} else {
+			out[i] = '1'
+		}
+	}
+	return string(out)
+}
+
+type test struct{ input, expected string }
+
+func generateTests() []test {
+	rand.Seed(555)
+	var tests []test
+	for len(tests) < 100 {
+		n := rand.Intn(8) + 2
+		var limit uint64 = 1
+		if n < 20 {
+			limit = 1 << n
+		} else {
+			limit = 1000
+		}
+		k := rand.Uint64()%limit + 1
+		inp := fmt.Sprintf("%d %d\n", n, k)
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != t.expected {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add build-ignore tags so C++ code doesn't interfere with `go run`
- implement Go verifiers for contest 8 problems A–E with deterministic test generation

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e00c6daf88324bd669d39eb1c66c0