### PR TITLE
Add Go verifiers for contest 9

### DIFF
--- a/0-999/0-99/0-9/9/verifierA.go
+++ b/0-999/0-99/0-9/9/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveCase(y, w int) string {
+	m := y
+	if w > m {
+		m = w
+	}
+	num := 7 - m
+	den := 6
+	g := gcd(num, den)
+	num /= g
+	den /= g
+	return fmt.Sprintf("%d/%d", num, den)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	y := rng.Intn(6) + 1
+	w := rng.Intn(6) + 1
+	input := fmt.Sprintf("%d %d\n", y, w)
+	expect := solveCase(y, w)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/0-9/9/verifierB.go
+++ b/0-999/0-99/0-9/9/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, vb, vs int, xs []int, xu, yu int) int {
+	eps := 1e-9
+	bestIdx := 2
+	x := xs[1]
+	bestTime := float64(x)/float64(vb) + math.Hypot(float64(xu-x), float64(yu))/float64(vs)
+	bestDist := math.Hypot(float64(xu-x), float64(yu))
+	for i := 2; i < n; i++ {
+		xi := xs[i]
+		tBus := float64(xi) / float64(vb)
+		dRun := math.Hypot(float64(xu-xi), float64(yu))
+		tTotal := tBus + dRun/float64(vs)
+		if tTotal+eps < bestTime {
+			bestTime = tTotal
+			bestDist = dRun
+			bestIdx = i + 1
+		} else if math.Abs(tTotal-bestTime) <= eps && dRun < bestDist {
+			bestDist = dRun
+			bestIdx = i + 1
+		}
+	}
+	return bestIdx
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(9) + 2 // 2..10 stops
+	vb := rng.Intn(100) + 1
+	vs := rng.Intn(100) + 1
+	xs := make([]int, n)
+	cur := 0
+	for i := 0; i < n; i++ {
+		if i == 0 {
+			cur = 0
+		} else {
+			cur += rng.Intn(20) + 1
+		}
+		xs[i] = cur
+	}
+	xu := rng.Intn(200) + 1
+	yu := rng.Intn(200) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, vb, vs))
+	for i, v := range xs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d %d\n", xu, yu))
+	expect := fmt.Sprintf("%d", solveCase(n, vb, vs, xs, xu, yu))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/0-9/9/verifierC.go
+++ b/0-999/0-99/0-9/9/verifierC.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int64) int64 {
+	count := int64(0)
+	queue := []int64{1}
+	for len(queue) > 0 {
+		x := queue[0]
+		queue = queue[1:]
+		if x > n {
+			continue
+		}
+		count++
+		x10 := x * 10
+		if x10 <= n {
+			queue = append(queue, x10)
+		}
+		if x10+1 <= n {
+			queue = append(queue, x10+1)
+		}
+	}
+	return count
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	expect := fmt.Sprintf("%d", solveCase(n))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/0-9/9/verifierD.go
+++ b/0-999/0-99/0-9/9/verifierD.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, h int) uint64 {
+	dp := make([][]uint64, n+1)
+	for i := range dp {
+		dp[i] = make([]uint64, n+1)
+	}
+	for j := 0; j <= n; j++ {
+		dp[0][j] = 1
+	}
+	for j := 1; j <= n; j++ {
+		for i := 1; i <= n; i++ {
+			var cnt uint64
+			for left := 0; left < i; left++ {
+				right := i - 1 - left
+				cnt += dp[left][j-1] * dp[right][j-1]
+			}
+			dp[i][j] = cnt
+		}
+	}
+	total := dp[n][n]
+	less := uint64(0)
+	if h > 0 {
+		less = dp[n][h-1]
+	}
+	return total - less
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	h := rng.Intn(n) + 1
+	input := fmt.Sprintf("%d %d\n", n, h)
+	expect := fmt.Sprintf("%d", solveCase(n, h))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/0-9/9/verifierE.go
+++ b/0-999/0-99/0-9/9/verifierE.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ u, v int }
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, m int, u, v []int) string {
+	dsuP := make([]int, n)
+	for i := range dsuP {
+		dsuP[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if dsuP[x] != x {
+			dsuP[x] = find(dsuP[x])
+		}
+		return dsuP[x]
+	}
+	unite := func(a, b int) {
+		ra, rb := find(a), find(b)
+		if ra != rb {
+			dsuP[rb] = ra
+		}
+	}
+	for i := 0; i < m; i++ {
+		unite(u[i], v[i])
+	}
+	compVerts := make([][]int, n)
+	compEdges := make([]int, n)
+	for i := 0; i < n; i++ {
+		compVerts[find(i)] = append(compVerts[find(i)], i)
+	}
+	for i := 0; i < m; i++ {
+		compEdges[find(u[i])]++
+	}
+	for r, verts := range compVerts {
+		if len(verts) == 0 {
+			continue
+		}
+		if compEdges[r]-len(verts)+1 > 1 {
+			return "NO"
+		}
+	}
+	deg := make([]int, n)
+	inCycle := make([]bool, n)
+	adj := make([][]int, n)
+	for i := 0; i < m; i++ {
+		a, b := u[i], v[i]
+		if a == b {
+			inCycle[a] = true
+		} else {
+			deg[a]++
+			deg[b]++
+			adj[a] = append(adj[a], b)
+			adj[b] = append(adj[b], a)
+		}
+	}
+	queue := []int{}
+	for i := 0; i < n; i++ {
+		if deg[i] == 1 {
+			queue = append(queue, i)
+		}
+	}
+	for len(queue) > 0 {
+		x := queue[0]
+		queue = queue[1:]
+		for _, y := range adj[x] {
+			if deg[y] > 0 {
+				deg[y]--
+				if deg[y] == 1 {
+					queue = append(queue, y)
+				}
+			}
+		}
+		deg[x] = 0
+	}
+	for i := 0; i < n; i++ {
+		if deg[i] > 0 {
+			inCycle[i] = true
+		}
+	}
+	var add []pair
+	for i := 0; i < n; i++ {
+		if !inCycle[i] {
+			add = append(add, pair{i, i})
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(add)))
+	for _, p := range add {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.u+1, p.v+1))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	maxEdges := n + rng.Intn(4)
+	m := rng.Intn(maxEdges + 1)
+	u := make([]int, m)
+	v := make([]int, m)
+	for i := 0; i < m; i++ {
+		u[i] = rng.Intn(n)
+		v[i] = rng.Intn(n)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", u[i]+1, v[i]+1))
+	}
+	expect := solveCase(n, m, u, v)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifiers for problems 9A–9E
- each verifier runs 100 random test cases against a provided binary

## Testing
- `go build 0-999/0-99/0-9/9/verifierA.go`
- `go build 0-999/0-99/0-9/9/verifierB.go`
- `go build 0-999/0-99/0-9/9/verifierC.go`
- `go build 0-999/0-99/0-9/9/verifierD.go`
- `go build 0-999/0-99/0-9/9/verifierE.go`
- `go build -o 0-999/0-99/0-9/9/9A_bin 0-999/0-99/0-9/9/9A.go`
- `go run 0-999/0-99/0-9/9/verifierA.go 0-999/0-99/0-9/9/9A_bin`

------
https://chatgpt.com/codex/tasks/task_e_687e00da4d708324a103d751cf67797e