### PR TITLE
Add verifiers for contest 10 problems

### DIFF
--- a/0-999/0-99/10-19/10/verifierB.go
+++ b/0-999/0-99/10-19/10/verifierB.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+type stateB struct {
+	n, k int
+	req  []int
+}
+
+func solveB(n, k int, req []int) []string {
+	p := make([][2]int, k+1)
+	for i := 1; i <= k; i++ {
+		p[i][0] = 0
+		p[i][1] = -1
+	}
+	xc := (k + 1) / 2
+	res := make([]string, n)
+	for i := 0; i < n; i++ {
+		m := req[i]
+		if m > k {
+			res[i] = "-1"
+			continue
+		}
+		best := math.MaxInt32
+		bx, bl, br := 0, 0, 0
+		for x := 1; x <= k; x++ {
+			if p[x][0] > p[x][1] {
+				d := abs(x-xc)*m + (m/2)*((m+1)/2)
+				if d < best {
+					best = d
+					bx = x
+					bl = (k-m)/2 + 1
+					br = bl + m - 1
+				}
+			} else {
+				if p[x][0] > m {
+					d := abs(x-xc)*m + (xc-p[x][0])*m + m*(m+1)/2
+					if d < best {
+						best = d
+						bx = x
+						bl = p[x][0] - m
+						br = p[x][0] - 1
+					}
+				}
+				if p[x][1] <= k-m {
+					d := abs(x-xc)*m + (p[x][1]-xc)*m + m*(m+1)/2
+					if d < best {
+						best = d
+						bx = x
+						bl = p[x][1] + 1
+						br = p[x][1] + m
+					}
+				}
+			}
+		}
+		if bx == 0 {
+			res[i] = "-1"
+			continue
+		}
+		res[i] = fmt.Sprintf("%d %d %d", bx, bl, br)
+		if p[bx][0] > p[bx][1] {
+			p[bx][0] = bl
+			p[bx][1] = br
+		} else if p[bx][0] == br+1 {
+			p[bx][0] = bl
+		} else if p[bx][1] == bl-1 {
+			p[bx][1] = br
+		}
+	}
+	return res
+}
+
+func generateCaseB(rng *rand.Rand) (string, []string) {
+	k := rng.Intn(5)*2 + 3 // odd between 3..11
+	n := rng.Intn(5) + 1
+	req := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		req[i] = rng.Intn(k*2) + 1
+		sb.WriteString(strconv.Itoa(req[i]))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveB(n, k, req)
+}
+
+func runCaseB(bin, input string, expected []string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	for i := 0; i < len(expected); i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("not enough output for case, expected %d lines", len(expected))
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line != expected[i] {
+			return fmt.Errorf("line %d: expected '%s' got '%s'", i+1, expected[i], line)
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output: %s", scanner.Text())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseB(rng)
+		if err := runCaseB(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/10/verifierC.go
+++ b/0-999/0-99/10-19/10/verifierC.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(n int64) int64 {
+	tot := int64(0)
+	for i := int64(1); i <= n; i++ {
+		tot -= n / i
+	}
+	var c [9]int64
+	for i := int64(0); i < 9; i++ {
+		c[i] = n / 9
+		if n%9 >= i {
+			c[i]++
+		}
+	}
+	c[0]--
+	for i := int64(0); i < 9; i++ {
+		for j := int64(0); j < 9; j++ {
+			for k := int64(0); k < 9; k++ {
+				if (i*j)%9 == k {
+					tot += c[i] * c[j] * c[k]
+				}
+			}
+		}
+	}
+	return tot
+}
+
+func generateCaseC(rng *rand.Rand) (string, int64) {
+	n := rng.Int63n(1_000_000) + 1
+	return fmt.Sprintf("%d\n", n), solveC(n)
+}
+
+func runCaseC(bin, input string, expected int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseC(rng)
+		if err := runCaseC(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/10/verifierD.go
+++ b/0-999/0-99/10-19/10/verifierD.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(a, b []int) (int, []int) {
+	n := len(a)
+	m := len(b)
+	dp := make([]int, m)
+	prev := make([]int, m)
+	for j := range prev {
+		prev[j] = -1
+	}
+	for i := 0; i < n; i++ {
+		current := 0
+		last := -1
+		for j := 0; j < m; j++ {
+			if a[i] == b[j] {
+				if current+1 > dp[j] {
+					dp[j] = current + 1
+					prev[j] = last
+				}
+			} else if a[i] > b[j] {
+				if dp[j] > current {
+					current = dp[j]
+					last = j
+				}
+			}
+		}
+	}
+	length := 0
+	endIdx := -1
+	for j := 0; j < m; j++ {
+		if dp[j] > length {
+			length = dp[j]
+			endIdx = j
+		}
+	}
+	seq := make([]int, 0, length)
+	for idx := endIdx; idx != -1; idx = prev[idx] {
+		seq = append(seq, b[idx])
+	}
+	for i, j := 0, len(seq)-1; i < j; i, j = i+1, j-1 {
+		seq[i], seq[j] = seq[j], seq[i]
+	}
+	return length, seq
+}
+
+func generateCaseD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	a := make([]int, n)
+	b := make([]int, m)
+	for i := range a {
+		a[i] = rng.Intn(20)
+	}
+	for i := range b {
+		b[i] = rng.Intn(20)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		sb.WriteString(fmt.Sprintf("%d", v))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i, v := range b {
+		sb.WriteString(fmt.Sprintf("%d", v))
+		if i+1 < m {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	length, seq := solveD(a, b)
+	var exp strings.Builder
+	exp.WriteString(fmt.Sprintf("%d\n", length))
+	for i, v := range seq {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(fmt.Sprintf("%d", v))
+	}
+	if len(seq) > 0 {
+		exp.WriteByte('\n')
+	} else {
+		exp.WriteString("\n")
+	}
+	return sb.String(), exp.String()
+}
+
+func runCaseD(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.ReplaceAll(out.String(), "\r", "")
+	if strings.TrimSpace(outStr) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseD(rng)
+		if err := runCaseD(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/10/verifierE.go
+++ b/0-999/0-99/10-19/10/verifierE.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(a []int) int {
+	const INF = int(^uint(0) >> 1)
+	n := len(a)
+	ans := INF
+	for i := n - 1; i >= 0; i-- {
+		u := a[i] - 1
+		x := 1
+		if a[i] >= ans {
+			break
+		}
+		for j := i + 1; j < n; j++ {
+			v1 := u / a[j]
+			x += v1
+			u -= v1 * a[j]
+			v2 := a[i] + a[j] - u - 1
+			if v2 >= ans {
+				continue
+			}
+			y := 0
+			vv := v2
+			k := 0
+			for vv != 0 && y <= x {
+				y += vv / a[k]
+				vv %= a[k]
+				k++
+			}
+			if y > x {
+				ans = v2
+			}
+		}
+	}
+	if ans == INF {
+		return -1
+	}
+	return ans
+}
+
+func generateCaseE(rng *rand.Rand) (string, int) {
+	n := rng.Intn(5) + 2
+	a := make([]int, n)
+	a[0] = 1
+	for i := 1; i < n; i++ {
+		a[i] = a[i-1] + rng.Intn(5) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		sb.WriteString(fmt.Sprintf("%d", v))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveE(a)
+}
+
+func runCaseE(bin, input string, expected int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseE(rng)
+		if err := runCaseE(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems B–E of contest 10
- each verifier randomly generates 100 tests and checks a provided binary

## Testing
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e017c1d9c832493a6715ca3e84caf