### PR TITLE
Add Go verifiers for contest 12

### DIFF
--- a/0-999/0-99/10-19/12/verifierA.go
+++ b/0-999/0-99/10-19/12/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(grid [3]string) string {
+	for i := 0; i < 3; i++ {
+		for j := 0; j < 3; j++ {
+			if grid[i][j] != grid[2-i][2-j] {
+				return "NO"
+			}
+		}
+	}
+	return "YES"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	total := 0
+	for mask := 0; mask < 512; mask++ {
+		var g [3]string
+		for i := 0; i < 3; i++ {
+			var b strings.Builder
+			for j := 0; j < 3; j++ {
+				idx := i*3 + j
+				if mask&(1<<idx) != 0 {
+					b.WriteByte('X')
+				} else {
+					b.WriteByte('.')
+				}
+			}
+			g[i] = b.String()
+		}
+		input := g[0] + "\n" + g[1] + "\n" + g[2] + "\n"
+		exp := expected(g)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", total+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", total+1, exp, out, input)
+			os.Exit(1)
+		}
+		total++
+	}
+	fmt.Printf("All %d tests passed\n", total)
+}

--- a/0-999/0-99/10-19/12/verifierB.go
+++ b/0-999/0-99/10-19/12/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func computeMinimal(s string) string {
+	if s == "0" {
+		return "0"
+	}
+	digits := []byte(s)
+	for i := 0; i < len(digits); i++ {
+		for j := i + 1; j < len(digits); j++ {
+			if digits[j] < digits[i] {
+				digits[i], digits[j] = digits[j], digits[i]
+			}
+		}
+	}
+	// count leading zeros
+	z := 0
+	for z < len(digits) && digits[z] == '0' {
+		z++
+	}
+	if z == 0 {
+		return string(digits)
+	}
+	first := digits[z]
+	res := []byte{first}
+	for i := 0; i < z; i++ {
+		res = append(res, '0')
+	}
+	for i := z + 1; i < len(digits); i++ {
+		res = append(res, digits[i])
+	}
+	return string(res)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(1_000_000_000 + 1)
+		nStr := strconv.Itoa(n)
+		minimal := computeMinimal(nStr)
+		var mStr string
+		if rng.Intn(2) == 0 {
+			mStr = minimal
+		} else {
+			for {
+				m := rng.Intn(1_000_000_000 + 1)
+				mStr = strconv.Itoa(m)
+				if mStr != minimal {
+					break
+				}
+			}
+		}
+		input := fmt.Sprintf("%s\n%s\n", nStr, mStr)
+		expected := "WRONG_ANSWER"
+		if mStr == minimal {
+			expected = "OK"
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/12/verifierC.go
+++ b/0-999/0-99/10-19/12/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n, m int, prices []int, fruits []string) (int, int) {
+	count := map[string]int{}
+	for _, f := range fruits {
+		count[f]++
+	}
+	counts := make([]int, 0, len(count))
+	for _, c := range count {
+		counts = append(counts, c)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(counts)))
+	sort.Ints(prices)
+	k := len(counts)
+	minSum := 0
+	for i := 0; i < k; i++ {
+		minSum += counts[i] * prices[i]
+	}
+	maxSum := 0
+	for i := 0; i < k; i++ {
+		maxSum += counts[i] * prices[n-1-i]
+	}
+	return minSum, maxSum
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	names := []string{"apple", "banana", "orange", "kiwi", "grape", "lemon", "melon", "pear", "plum", "mango"}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 2 // 2..9
+		m := rng.Intn(8) + 2
+		prices := make([]int, n)
+		for j := range prices {
+			prices[j] = rng.Intn(100) + 1
+		}
+		fruits := make([]string, m)
+		for j := range fruits {
+			fruits[j] = names[rng.Intn(n)]
+		}
+		input := fmt.Sprintf("%d %d\n", n, m)
+		for j, p := range prices {
+			if j > 0 {
+				input += " "
+			}
+			input += strconv.Itoa(p)
+		}
+		input += "\n"
+		for _, f := range fruits {
+			input += f + "\n"
+		}
+		minSum, maxSum := solve(n, m, prices, fruits)
+		expected := fmt.Sprintf("%d %d", minSum, maxSum)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/12/verifierD.go
+++ b/0-999/0-99/10-19/12/verifierD.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveNaive(B, I, R []int) int {
+	n := len(B)
+	cnt := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if B[j] > B[i] && I[j] > I[i] && R[j] > R[i] {
+				cnt++
+				break
+			}
+		}
+	}
+	return cnt
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(20) + 1
+		B := make([]int, n)
+		I := make([]int, n)
+		Rr := make([]int, n)
+		for i := 0; i < n; i++ {
+			B[i] = rng.Intn(100)
+			I[i] = rng.Intn(100)
+			Rr[i] = rng.Intn(100)
+		}
+		var input strings.Builder
+		fmt.Fprintf(&input, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(strconv.Itoa(B[i]))
+		}
+		input.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(strconv.Itoa(I[i]))
+		}
+		input.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(strconv.Itoa(Rr[i]))
+		}
+		input.WriteByte('\n')
+		expected := strconv.Itoa(solveNaive(B, I, Rr))
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input.String())
+			os.Exit(1)
+		}
+		if out != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t+1, expected, out, input.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/12/verifierE.go
+++ b/0-999/0-99/10-19/12/verifierE.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func checkMatrix(n int, output string) error {
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(output)))
+	matrix := make([][]int, 0, n)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 0 {
+			continue
+		}
+		if len(fields) != n {
+			return fmt.Errorf("expected %d numbers per line", n)
+		}
+		row := make([]int, n)
+		for i, f := range fields {
+			v, err := strconv.Atoi(f)
+			if err != nil || v < 0 || v >= n {
+				return fmt.Errorf("invalid value %q", f)
+			}
+			row[i] = v
+		}
+		matrix = append(matrix, row)
+	}
+	if len(matrix) != n {
+		return fmt.Errorf("expected %d lines, got %d", n, len(matrix))
+	}
+	for i := 0; i < n; i++ {
+		if matrix[i][i] != 0 {
+			return fmt.Errorf("diagonal element at %d,%d not zero", i, i)
+		}
+		seen := make(map[int]bool)
+		for j := 0; j < n; j++ {
+			if seen[matrix[i][j]] {
+				return fmt.Errorf("row %d has duplicates", i)
+			}
+			seen[matrix[i][j]] = true
+			if matrix[i][j] != matrix[j][i] {
+				return fmt.Errorf("matrix not symmetric at %d,%d", i, j)
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := (rng.Intn(10) + 1) * 2 // even between 2 and 20
+		input := fmt.Sprintf("%d\n", n)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if err := checkMatrix(n, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", t+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go solution verifiers for contest 12
- verifiers include 100+ test cases and work for any binary

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go /tmp/solB`
- `go run verifierC.go /tmp/solC`
- `go run verifierD.go /tmp/solD`
- `go run verifierE.go /tmp/solE`


------
https://chatgpt.com/codex/tasks/task_e_687e01a641e0832495446fe9ba49e6f5