### PR TITLE
Add Go verifiers for contest 13

### DIFF
--- a/0-999/0-99/10-19/13/verifierA.go
+++ b/0-999/0-99/10-19/13/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func expectedA(A int) string {
+	sum := 0
+	for base := 2; base < A; base++ {
+		t := A
+		for t > 0 {
+			sum += t % base
+			t /= base
+		}
+	}
+	num := sum
+	den := A - 2
+	g := gcd(num, den)
+	num /= g
+	den /= g
+	return fmt.Sprintf("%d/%d", num, den)
+}
+
+func generateCaseA(rng *rand.Rand) (string, string) {
+	A := rng.Intn(998) + 3
+	return fmt.Sprintf("%d\n", A), expectedA(A)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseA(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/13/verifierB.go
+++ b/0-999/0-99/10-19/13/verifierB.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Point struct{ x, y int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func onSegment(a, b, c Point) bool {
+	cross := int64(b.x-a.x)*int64(c.y-a.y) - int64(b.y-a.y)*int64(c.x-a.x)
+	if cross != 0 {
+		return false
+	}
+	dot := int64(c.x-a.x)*int64(c.x-b.x) + int64(c.y-a.y)*int64(c.y-b.y)
+	return dot <= 0
+}
+
+func ratioOK(p, e, q Point) bool {
+	if !onSegment(p, e, q) {
+		return false
+	}
+	ex, ey := int64(e.x-p.x), int64(e.y-p.y)
+	dx, dy := int64(q.x-p.x), int64(q.y-p.y)
+	dot := dx*ex + dy*ey
+	lenSq := ex*ex + ey*ey
+	if dot*5 < lenSq || dot*5 > 4*lenSq {
+		return false
+	}
+	return true
+}
+
+func isLetterA(seg [3][2]Point) bool {
+	for i := 0; i < 3; i++ {
+		for j := i + 1; j < 3; j++ {
+			a1, a2 := seg[i][0], seg[i][1]
+			b1, b2 := seg[j][0], seg[j][1]
+			var p, e1, e2 Point
+			found := false
+			switch {
+			case a1 == b1:
+				p, e1, e2 = a1, a2, b2
+				found = true
+			case a1 == b2:
+				p, e1, e2 = a1, a2, b1
+				found = true
+			case a2 == b1:
+				p, e1, e2 = a2, a1, b2
+				found = true
+			case a2 == b2:
+				p, e1, e2 = a2, a1, b1
+				found = true
+			}
+			if !found {
+				continue
+			}
+			v1x, v1y := float64(e1.x-p.x), float64(e1.y-p.y)
+			v2x, v2y := float64(e2.x-p.x), float64(e2.y-p.y)
+			dot := v1x*v2x + v1y*v2y
+			l1 := math.Hypot(v1x, v1y)
+			l2 := math.Hypot(v2x, v2y)
+			cross := v1x*v2y - v1y*v2x
+			if cross == 0 || dot < 0 || dot > l1*l2 {
+				continue
+			}
+			k := 3 - i - j
+			c1, c2 := seg[k][0], seg[k][1]
+			if (ratioOK(p, e1, c1) && ratioOK(p, e2, c2)) || (ratioOK(p, e1, c2) && ratioOK(p, e2, c1)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func generateCaseB(rng *rand.Rand) (string, []string) {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	expect := make([]string, t)
+	for i := 0; i < t; i++ {
+		var seg [3][2]Point
+		for j := 0; j < 3; j++ {
+			seg[j][0] = Point{rng.Intn(11) - 5, rng.Intn(11) - 5}
+			for {
+				seg[j][1] = Point{rng.Intn(11) - 5, rng.Intn(11) - 5}
+				if seg[j][1] != seg[j][0] {
+					break
+				}
+			}
+			sb.WriteString(fmt.Sprintf("%d %d %d %d\n", seg[j][0].x, seg[j][0].y, seg[j][1].x, seg[j][1].y))
+		}
+		if isLetterA(seg) {
+			expect[i] = "YES"
+		} else {
+			expect[i] = "NO"
+		}
+	}
+	return sb.String(), expect
+}
+
+func runCase(bin, input string, expected []string) error {
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for i := 0; i < len(expected); i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("not enough output for case, expected %d lines", len(expected))
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line != expected[i] {
+			return fmt.Errorf("line %d: expected '%s' got '%s'", i+1, expected[i], line)
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output: %s", scanner.Text())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseB(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/13/verifierC.go
+++ b/0-999/0-99/10-19/13/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func expectedC(arr []int) int {
+	n := len(arr)
+	const V = 20
+	offset := V
+	const INF = int(1e9)
+	dp := make([]int, 2*V+1)
+	for i := range dp {
+		dp[i] = abs(arr[0] - (i - offset))
+	}
+	for i := 1; i < n; i++ {
+		ndp := make([]int, 2*V+1)
+		for j := range ndp {
+			ndp[j] = INF
+		}
+		best := INF
+		for v := -V; v <= V; v++ {
+			idx := v + offset
+			if dp[idx] < best {
+				best = dp[idx]
+			}
+			cost := best + abs(arr[i]-v)
+			ndp[idx] = cost
+		}
+		copy(dp, ndp)
+	}
+	ans := INF
+	for _, v := range dp {
+		if v < ans {
+			ans = v
+		}
+	}
+	return ans
+}
+
+func generateCaseC(rng *rand.Rand) (string, int) {
+	n := rng.Intn(6) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(21) - 10
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expectedC(arr)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseC(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d bad output: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/13/verifierD.go
+++ b/0-999/0-99/10-19/13/verifierD.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Point struct{ x, y int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func cross(ax, ay, bx, by int) int {
+	return ax*by - ay*bx
+}
+
+func inside(a, b, c, p Point) bool {
+	s1 := cross(b.x-a.x, b.y-a.y, p.x-a.x, p.y-a.y)
+	s2 := cross(c.x-b.x, c.y-b.y, p.x-b.x, p.y-b.y)
+	s3 := cross(a.x-c.x, a.y-c.y, p.x-c.x, p.y-c.y)
+	if (s1 > 0 && s2 > 0 && s3 > 0) || (s1 < 0 && s2 < 0 && s3 < 0) {
+		return true
+	}
+	return false
+}
+
+func countTriangles(reds []Point, blues []Point) int {
+	n := len(reds)
+	cnt := 0
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			for k := j + 1; k < n; k++ {
+				if cross(reds[j].x-reds[i].x, reds[j].y-reds[i].y, reds[k].x-reds[i].x, reds[k].y-reds[i].y) == 0 {
+					continue
+				}
+				ok := true
+				for _, b := range blues {
+					if inside(reds[i], reds[j], reds[k], b) {
+						ok = false
+						break
+					}
+				}
+				if ok {
+					cnt++
+				}
+			}
+		}
+	}
+	return cnt
+}
+
+func generateCaseD(rng *rand.Rand) (string, int) {
+	n := rng.Intn(4) + 3
+	m := rng.Intn(4)
+	reds := make([]Point, n)
+	blues := make([]Point, m)
+	for i := range reds {
+		reds[i] = Point{rng.Intn(11) - 5, rng.Intn(11) - 5}
+	}
+	for i := range blues {
+		blues[i] = Point{rng.Intn(11) - 5, rng.Intn(11) - 5}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, p := range reds {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.x, p.y))
+	}
+	for _, p := range blues {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.x, p.y))
+	}
+	return sb.String(), countTriangles(reds, blues)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseD(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d bad output: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/13/verifierE.go
+++ b/0-999/0-99/10-19/13/verifierE.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Query struct {
+	typ int
+	a   int
+	b   int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func simulate(n int, a []int, qs []Query) []string {
+	res := []string{}
+	for _, q := range qs {
+		if q.typ == 0 {
+			a[q.a-1] = q.b
+		} else {
+			pos := q.a
+			steps := 0
+			last := pos
+			for pos <= n {
+				last = pos
+				pos += a[pos-1]
+				steps++
+			}
+			res = append(res, fmt.Sprintf("%d %d", last, steps))
+		}
+	}
+	return res
+}
+
+func generateCaseE(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(15) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(n) + 1
+	}
+	qs := make([]Query, m)
+	for i := range qs {
+		if rng.Intn(2) == 0 {
+			qs[i].typ = 0
+			qs[i].a = rng.Intn(n) + 1
+			qs[i].b = rng.Intn(n) + 1
+		} else {
+			qs[i].typ = 1
+			qs[i].a = rng.Intn(n) + 1
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for _, q := range qs {
+		if q.typ == 0 {
+			sb.WriteString(fmt.Sprintf("0 %d %d\n", q.a, q.b))
+		} else {
+			sb.WriteString(fmt.Sprintf("1 %d\n", q.a))
+		}
+	}
+	return sb.String(), simulate(n, arr, qs)
+}
+
+func runCase(bin, input string, expected []string) error {
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for i := 0; i < len(expected); i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("not enough output, expected %d lines", len(expected))
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line != expected[i] {
+			return fmt.Errorf("line %d: expected '%s' got '%s'", i+1, expected[i], line)
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output: %s", scanner.Text())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseE(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers in Go for problems A–E of contest 13
- verifiers generate at least 100 random tests each and run a candidate program
- support verifying `.go` files or binaries

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`
- `go build verifierA.go` *(and others)*

------
https://chatgpt.com/codex/tasks/task_e_687e1787936c83249991c79fb7452337