### PR TITLE
Add Go solution verifiers for contest 14

### DIFF
--- a/0-999/0-99/10-19/14/verifierA.go
+++ b/0-999/0-99/10-19/14/verifierA.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type gridCase struct {
+	n, m   int
+	lines  []string
+	expect []string
+}
+
+func generateCase(rng *rand.Rand) gridCase {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	// create grid with '.'
+	grid := make([][]byte, n)
+	for i := range grid {
+		grid[i] = make([]byte, m)
+		for j := 0; j < m; j++ {
+			grid[i][j] = '.'
+		}
+	}
+	// ensure at least one star
+	starCount := rng.Intn(n*m) + 1
+	for k := 0; k < starCount; k++ {
+		i := rng.Intn(n)
+		j := rng.Intn(m)
+		grid[i][j] = '*'
+	}
+	// convert grid to lines
+	lines := make([]string, n)
+	for i := range grid {
+		lines[i] = string(grid[i])
+	}
+	// compute bounding rectangle
+	minR, maxR := n-1, 0
+	minC, maxC := m-1, 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '*' {
+				if i < minR {
+					minR = i
+				}
+				if i > maxR {
+					maxR = i
+				}
+				if j < minC {
+					minC = j
+				}
+				if j > maxC {
+					maxC = j
+				}
+			}
+		}
+	}
+	expect := make([]string, maxR-minR+1)
+	for i := minR; i <= maxR; i++ {
+		expect[i-minR] = string(grid[i][minC : maxC+1])
+	}
+	return gridCase{n, m, lines, expect}
+}
+
+func runCase(bin string, c gridCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", c.n, c.m))
+	for _, line := range c.lines {
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(outLines) != len(c.expect) {
+		return fmt.Errorf("expected %d lines got %d", len(c.expect), len(outLines))
+	}
+	for i, exp := range c.expect {
+		if strings.TrimSpace(outLines[i]) != exp {
+			return fmt.Errorf("line %d: expected %s got %s", i+1, exp, outLines[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		c := generateCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%v\n", i+1, err, c)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/14/verifierB.go
+++ b/0-999/0-99/10-19/14/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type interval struct {
+	a, b int
+}
+
+func expected(x0 int, ivs []interval) int {
+	left := 0
+	right := 1000000000
+	for _, iv := range ivs {
+		a, b := iv.a, iv.b
+		if a > b {
+			a, b = b, a
+		}
+		if a > left {
+			left = a
+		}
+		if b < right {
+			right = b
+		}
+	}
+	if left > right {
+		return -1
+	}
+	if x0 < left {
+		return left - x0
+	}
+	if x0 > right {
+		return x0 - right
+	}
+	return 0
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10) + 1
+	x0 := rng.Intn(1001)
+	ivs := make([]interval, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, x0))
+	for i := 0; i < n; i++ {
+		a := rng.Intn(1001)
+		b := rng.Intn(1001)
+		for b == a {
+			b = rng.Intn(1001)
+		}
+		ivs[i] = interval{a, b}
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	return sb.String(), expected(x0, ivs)
+}
+
+func runCase(bin, input string, expect int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/14/verifierC.go
+++ b/0-999/0-99/10-19/14/verifierC.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type seg struct{ x1, y1, x2, y2 int }
+
+func check(segs []seg) string {
+	var hor, ver []seg
+	for _, s := range segs {
+		if s.y1 == s.y2 {
+			hor = append(hor, s)
+		} else if s.x1 == s.x2 {
+			ver = append(ver, s)
+		} else {
+			return "NO"
+		}
+	}
+	if len(hor) != 2 || len(ver) != 2 {
+		return "NO"
+	}
+	y0, y1 := hor[0].y1, hor[1].y1
+	if y0 == y1 {
+		return "NO"
+	}
+	var yMin, yMax int
+	if y0 < y1 {
+		yMin, yMax = y0, y1
+	} else {
+		yMin, yMax = y1, y0
+	}
+	h0l, h0r := min(hor[0].x1, hor[0].x2), max(hor[0].x1, hor[0].x2)
+	h1l, h1r := min(hor[1].x1, hor[1].x2), max(hor[1].x1, hor[1].x2)
+	if h0l != h1l || h0r != h1r || h0l >= h0r {
+		return "NO"
+	}
+	xMin, xMax := h0l, h0r
+	xv0, xv1 := ver[0].x1, ver[1].x1
+	if xv0 == xv1 {
+		return "NO"
+	}
+	var vMin, vMax int
+	if xv0 < xv1 {
+		vMin, vMax = xv0, xv1
+	} else {
+		vMin, vMax = xv1, xv0
+	}
+	if vMin != xMin || vMax != xMax {
+		return "NO"
+	}
+	v0l, v0r := min(ver[0].y1, ver[0].y2), max(ver[0].y1, ver[0].y2)
+	v1l, v1r := min(ver[1].y1, ver[1].y2), max(ver[1].y1, ver[1].y2)
+	if v0l != v1l || v0r != v1r {
+		return "NO"
+	}
+	if v0l != yMin || v0r != yMax {
+		return "NO"
+	}
+	return "YES"
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	segs := make([]seg, 4)
+	var sb strings.Builder
+	for i := range segs {
+		if rng.Intn(2) == 0 {
+			x := rng.Intn(11) - 5
+			y1 := rng.Intn(11) - 5
+			y2 := rng.Intn(11) - 5
+			segs[i] = seg{x, y1, x, y2}
+		} else {
+			y := rng.Intn(11) - 5
+			x1 := rng.Intn(11) - 5
+			x2 := rng.Intn(11) - 5
+			segs[i] = seg{x1, y, x2, y}
+		}
+	}
+	for _, s := range segs {
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", s.x1, s.y1, s.x2, s.y2))
+	}
+	exp := check(segs)
+	return sb.String(), exp
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/14/verifierD.go
+++ b/0-999/0-99/10-19/14/verifierD.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ a, b int }
+
+type graphCase struct {
+	n      int
+	edges  []edge
+	expect int
+}
+
+func compute(n int, edges []edge) int {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		a, b := e.a-1, e.b-1
+		adj[a] = append(adj[a], b)
+		adj[b] = append(adj[b], a)
+	}
+	maxProfit := 0
+	dist := make([]int, n)
+	parent := make([]int, n)
+	skip := make([]bool, n)
+	visited := make([]bool, n)
+	queue := make([]int, 0, n)
+	for u := 0; u < n; u++ {
+		for i := 0; i < n; i++ {
+			dist[i] = -1
+			parent[i] = -1
+		}
+		queue = queue[:0]
+		dist[u] = 0
+		queue = append(queue, u)
+		for qi := 0; qi < len(queue); qi++ {
+			v := queue[qi]
+			for _, w := range adj[v] {
+				if dist[w] == -1 {
+					dist[w] = dist[v] + 1
+					parent[w] = v
+					queue = append(queue, w)
+				}
+			}
+		}
+		for v := u + 1; v < n; v++ {
+			pathLen := dist[v]
+			for i := 0; i < n; i++ {
+				skip[i] = false
+				visited[i] = false
+			}
+			x := v
+			for x != -1 {
+				skip[x] = true
+				x = parent[x]
+			}
+			best2 := 0
+			for i := 0; i < n; i++ {
+				if skip[i] || visited[i] {
+					continue
+				}
+				q1 := []int{i}
+				visited[i] = true
+				dmap := map[int]int{i: 0}
+				far := i
+				for qi := 0; qi < len(q1); qi++ {
+					v1 := q1[qi]
+					for _, w1 := range adj[v1] {
+						if skip[w1] || visited[w1] {
+							continue
+						}
+						visited[w1] = true
+						dmap[w1] = dmap[v1] + 1
+						q1 = append(q1, w1)
+						if dmap[w1] > dmap[far] {
+							far = w1
+						}
+					}
+				}
+				q2 := []int{far}
+				seen2 := map[int]bool{far: true}
+				d2 := map[int]int{far: 0}
+				d2max := 0
+				for qi := 0; qi < len(q2); qi++ {
+					v2 := q2[qi]
+					for _, w2 := range adj[v2] {
+						if skip[w2] || seen2[w2] {
+							continue
+						}
+						seen2[w2] = true
+						d2[w2] = d2[v2] + 1
+						q2 = append(q2, w2)
+						if d2[w2] > d2max {
+							d2max = d2[w2]
+						}
+					}
+				}
+				if d2max > best2 {
+					best2 = d2max
+				}
+			}
+			profit := pathLen * best2
+			if profit > maxProfit {
+				maxProfit = profit
+			}
+		}
+	}
+	return maxProfit
+}
+
+func generateCase(rng *rand.Rand) graphCase {
+	n := rng.Intn(5) + 2
+	edges := make([]edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, edge{i, p})
+	}
+	expect := compute(n, edges)
+	return graphCase{n, edges, expect}
+}
+
+func runCase(bin string, c graphCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", c.n))
+	for _, e := range c.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.a, e.b))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != c.expect {
+		return fmt.Errorf("expected %d got %d", c.expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		c := generateCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/14/verifierE.go
+++ b/0-999/0-99/10-19/14/verifierE.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compute(n, t int) int64 {
+	valleyTarget := t - 1
+	dp := make([][][][][]int64, n+1)
+	for i := range dp {
+		dp[i] = make([][][][]int64, 5)
+		for y := 0; y < 5; y++ {
+			dp[i][y] = make([][][]int64, t+1)
+			for p := 0; p <= t; p++ {
+				dp[i][y][p] = make([][]int64, t+1)
+				for v := 0; v <= t; v++ {
+					dp[i][y][p][v] = make([]int64, 3)
+				}
+			}
+		}
+	}
+	for y := 1; y <= 4; y++ {
+		dp[1][y][0][0][0] = 1
+	}
+	for pos := 1; pos < n; pos++ {
+		for lastY := 1; lastY <= 4; lastY++ {
+			for p := 0; p <= t; p++ {
+				for v := 0; v <= valleyTarget; v++ {
+					for lastDir := 0; lastDir < 3; lastDir++ {
+						cnt := dp[pos][lastY][p][v][lastDir]
+						if cnt == 0 {
+							continue
+						}
+						for y2 := 1; y2 <= 4; y2++ {
+							if y2 == lastY {
+								continue
+							}
+							var dir int
+							if y2 > lastY {
+								dir = 1
+							} else {
+								dir = 2
+							}
+							np, nv := p, v
+							if lastDir == 1 && dir == 2 {
+								np++
+							} else if lastDir == 2 && dir == 1 {
+								nv++
+							}
+							if np > t || nv > valleyTarget {
+								continue
+							}
+							dp[pos+1][y2][np][nv][dir] += cnt
+						}
+					}
+				}
+			}
+		}
+	}
+	var res int64
+	for y := 1; y <= 4; y++ {
+		for lastDir := 1; lastDir <= 2; lastDir++ {
+			res += dp[n][y][t][valleyTarget][lastDir]
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(7) + 3
+	t := rng.Intn(4) + 1
+	if t > n {
+		t = n
+	}
+	input := fmt.Sprintf("%d %d\n", n, t)
+	return input, compute(n, t)
+}
+
+func runCase(bin, input string, expected int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add automatic verifiers for contest 14 problems A–E
- each verifier generates 100 random tests and checks a solution binary

## Testing
- `go run 0-999/0-99/10-19/14/verifierA.go /tmp/14A_bin`
- `go run 0-999/0-99/10-19/14/verifierB.go /tmp/14B_bin`
- `go run 0-999/0-99/10-19/14/verifierC.go /tmp/14C_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e1798852083248b9e08c11a3394c6