### PR TITLE
Add verifiers for contest 15

### DIFF
--- a/0-999/0-99/10-19/15/verifierA.go
+++ b/0-999/0-99/10-19/15/verifierA.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+    "time"
+)
+
+func run(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, t int, arr [][2]int) string {
+    type interval struct{ l, r int }
+    ints := make([]interval, n)
+    for i := 0; i < n; i++ {
+        x := arr[i][0]
+        a := arr[i][1]
+        ints[i].l = 2*x - a
+        ints[i].r = 2*x + a
+    }
+    sort.Slice(ints, func(i, j int) bool {
+        if ints[i].l != ints[j].l {
+            return ints[i].l < ints[j].l
+        }
+        return ints[i].r < ints[j].r
+    })
+    ans := 2
+    t2 := 2 * t
+    for i := 0; i+1 < n; i++ {
+        gap := ints[i+1].l - ints[i].r
+        if gap == t2 {
+            ans++
+        } else if gap > t2 {
+            ans += 2
+        }
+    }
+    return fmt.Sprintf("%d", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+    n := rng.Intn(10) + 1
+    t := rng.Intn(20) + 1
+    arr := make([][2]int, n)
+    // generate non-overlapping intervals by sorting centers
+    xs := make([]int, n)
+    for i := 0; i < n; i++ {
+        xs[i] = rng.Intn(200) - 100
+    }
+    sort.Ints(xs)
+    for i := 0; i < n; i++ {
+        a := rng.Intn(10) + 1
+        arr[i][0] = xs[i]
+        arr[i][1] = a
+        if i > 0 {
+            prevR := 2*arr[i-1][0] + arr[i-1][1]
+            curL := 2*arr[i][0] - arr[i][1]
+            if curL < prevR {
+                diff := prevR - curL
+                arr[i][0] += (diff+1)/2
+            }
+        }
+    }
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d\n", n, t))
+    for i := 0; i < n; i++ {
+        sb.WriteString(fmt.Sprintf("%d %d\n", arr[i][0], arr[i][1]))
+    }
+    exp := expected(n, t, arr)
+    return sb.String(), exp
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    for i := 0; i < 100; i++ {
+        in, exp := genCase(rng)
+        out, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if out != exp {
+            fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/0-99/10-19/15/verifierB.go
+++ b/0-999/0-99/10-19/15/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func run(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m, x1, y1, x2, y2 int64) string {
+    dx := x1 - x2
+    if dx < 0 {
+        dx = -dx
+    }
+    dy := y1 - y2
+    if dy < 0 {
+        dy = -dy
+    }
+    W := n - dx
+    H := m - dy
+    overlapW := n - 2*dx
+    if overlapW < 0 {
+        overlapW = 0
+    }
+    overlapH := m - 2*dy
+    if overlapH < 0 {
+        overlapH = 0
+    }
+    melted := 2*W*H - overlapW*overlapH
+    total := n * m
+    unmelted := total - melted
+    return fmt.Sprintf("%d", unmelted)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+    n := int64(rng.Intn(100) + 2)
+    m := int64(rng.Intn(100) + 2)
+    x1 := int64(rng.Intn(int(n))) + 1
+    y1 := int64(rng.Intn(int(m))) + 1
+    for {
+        x2 := int64(rng.Intn(int(n))) + 1
+        y2 := int64(rng.Intn(int(m))) + 1
+        if x2 != x1 || y2 != y1 {
+            exp := expected(n, m, x1, y1, x2, y2)
+            input := fmt.Sprintf("1\n%d %d %d %d %d %d\n", n, m, x1, y1, x2, y2)
+            return input, exp
+        }
+    }
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    for i := 0; i < 100; i++ {
+        in, exp := genCase(rng)
+        out, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if out != exp {
+            fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/0-99/10-19/15/verifierC.go
+++ b/0-999/0-99/10-19/15/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func run(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func xorTo(n uint64) uint64 {
+    switch n & 3 {
+    case 0:
+        return n
+    case 1:
+        return 1
+    case 2:
+        return n + 1
+    }
+    return 0
+}
+
+func expected(n int, arr [][2]uint64) string {
+    var total uint64
+    for _, v := range arr {
+        x := v[0]
+        m := v[1]
+        start := x
+        end := x + m - 1
+        total ^= xorTo(end) ^ xorTo(start-1)
+    }
+    if total != 0 {
+        return "tolik"
+    }
+    return "bolik"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+    n := rng.Intn(5) + 1
+    arr := make([][2]uint64, n)
+    for i := 0; i < n; i++ {
+        arr[i][0] = uint64(rng.Intn(100) + 1)
+        arr[i][1] = uint64(rng.Intn(5) + 1)
+    }
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d\n", n))
+    for i := 0; i < n; i++ {
+        sb.WriteString(fmt.Sprintf("%d %d\n", arr[i][0], arr[i][1]))
+    }
+    exp := expected(n, arr)
+    return sb.String(), exp
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    for i := 0; i < 100; i++ {
+        in, exp := genCase(rng)
+        out, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if out != exp {
+            fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/0-99/10-19/15/verifierD.go
+++ b/0-999/0-99/10-19/15/verifierD.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func run(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func compute(n, m, a, b int, h [][]int64) [][3]int64 {
+    occ := make([][]bool, n)
+    for i := range occ {
+        occ[i] = make([]bool, m)
+    }
+    res := make([][3]int64, 0)
+    area := int64(a * b)
+    for {
+        bestCost := int64(math.MaxInt64)
+        bi, bj := -1, -1
+        for i := 0; i+a <= n; i++ {
+            for j := 0; j+b <= m; j++ {
+                overl := false
+                for x := i; x < i+a && !overl; x++ {
+                    for y := j; y < j+b; y++ {
+                        if occ[x][y] {
+                            overl = true
+                            break
+                        }
+                    }
+                }
+                if overl {
+                    continue
+                }
+                minv := h[i][j]
+                sum := int64(0)
+                for x := i; x < i+a; x++ {
+                    for y := j; y < j+b; y++ {
+                        v := h[x][y]
+                        if v < minv {
+                            minv = v
+                        }
+                        sum += v
+                    }
+                }
+                cost := sum - int64(minv)*area
+                if cost < bestCost || (cost == bestCost && (i < bi || (i == bi && j < bj))) {
+                    bestCost = cost
+                    bi, bj = i, j
+                }
+            }
+        }
+        if bi == -1 {
+            break
+        }
+        res = append(res, [3]int64{int64(bi + 1), int64(bj + 1), bestCost})
+        for x := bi; x < bi+a; x++ {
+            for y := bj; y < bj+b; y++ {
+                occ[x][y] = true
+            }
+        }
+    }
+    return res
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+    n := rng.Intn(4) + 2  // 2..5
+    m := rng.Intn(4) + 2
+    a := rng.Intn(n) + 1
+    b := rng.Intn(m) + 1
+    h := make([][]int64, n)
+    for i := range h {
+        h[i] = make([]int64, m)
+        for j := range h[i] {
+            h[i][j] = int64(rng.Intn(20))
+        }
+    }
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, a, b))
+    for i := 0; i < n; i++ {
+        for j := 0; j < m; j++ {
+            if j > 0 {
+                sb.WriteByte(' ')
+            }
+            sb.WriteString(fmt.Sprintf("%d", h[i][j]))
+        }
+        sb.WriteByte('\n')
+    }
+    res := compute(n, m, a, b, h)
+    var exp strings.Builder
+    exp.WriteString(fmt.Sprintf("%d\n", len(res)))
+    for _, v := range res {
+        exp.WriteString(fmt.Sprintf("%d %d %d\n", v[0], v[1], v[2]))
+    }
+    return sb.String(), strings.TrimSpace(exp.String())
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    for i := 0; i < 100; i++ {
+        in, exp := genCase(rng)
+        out, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(out) != exp {
+            fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/0-99/10-19/15/verifierE.go
+++ b/0-999/0-99/10-19/15/verifierE.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func run(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+const mod = 1000000009
+
+func expected(n int64) string {
+    n %= mod
+    return fmt.Sprintf("%d", (n*n)%mod)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+    n := int64(rng.Intn(1000000) + 2)
+    input := fmt.Sprintf("%d\n", n)
+    return input, expected(n)
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    for i := 0; i < 100; i++ {
+        in, exp := genCase(rng)
+        out, err := run(bin, in)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+        if out != exp {
+            fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 15 problems A–E
- each verifier runs a user binary or Go source and checks 100 generated tests

## Testing
- `go run verifierA.go ./solutionA`

------
https://chatgpt.com/codex/tasks/task_e_687e17a1c85c8324851dc88c93e722c5