### PR TITLE
Add solution verifiers for contest 18

### DIFF
--- a/0-999/0-99/10-19/18/verifierA.go
+++ b/0-999/0-99/10-19/18/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Point struct{ x, y int }
+
+func isRight(p1, p2, p3 Point) bool {
+	dx := p2.x - p1.x
+	dy := p2.y - p1.y
+	a := dx*dx + dy*dy
+	dx = p3.x - p2.x
+	dy = p3.y - p2.y
+	b := dx*dx + dy*dy
+	dx = p1.x - p3.x
+	dy = p1.y - p3.y
+	c := dx*dx + dy*dy
+	if a == 0 || b == 0 || c == 0 {
+		return false
+	}
+	return a+b == c || a+c == b || b+c == a
+}
+
+func expected(p [3]Point) string {
+	if isRight(p[0], p[1], p[2]) {
+		return "RIGHT"
+	}
+	dirs := []Point{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for i := 0; i < 3; i++ {
+		orig := p[i]
+		for _, d := range dirs {
+			p[i] = Point{orig.x + d.x, orig.y + d.y}
+			if isRight(p[0], p[1], p[2]) {
+				return "ALMOST"
+			}
+		}
+		p[i] = orig
+	}
+	return "NEITHER"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	for {
+		var p [3]Point
+		for i := 0; i < 3; i++ {
+			p[i].x = rng.Intn(21) - 10
+			p[i].y = rng.Intn(21) - 10
+		}
+		area := (p[1].x-p[0].x)*(p[2].y-p[0].y) - (p[1].y-p[0].y)*(p[2].x-p[0].x)
+		if area != 0 {
+			input := fmt.Sprintf("%d %d %d %d %d %d\n", p[0].x, p[0].y, p[1].x, p[1].y, p[2].x, p[2].y)
+			exp := expected(p)
+			return input, exp
+		}
+	}
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	res := strings.TrimSpace(out.String())
+	if res != exp {
+		return fmt.Errorf("expected %s got %s", exp, res)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/18/verifierB.go
+++ b/0-999/0-99/10-19/18/verifierB.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, d, m, l int64) int64 {
+	limit := n * m
+	x := d
+	for {
+		if x >= limit || x%m > l {
+			return x
+		}
+		x += d
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := int64(rng.Intn(20) + 1)
+	d := int64(rng.Intn(20) + 1)
+	m := int64(rng.Intn(20) + 1)
+	l := int64(rng.Intn(int(m)))
+	input := fmt.Sprintf("%d %d %d %d\n", n, d, m, l)
+	return input, expected(n, d, m, l)
+}
+
+func runCase(bin, input string, exp int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/18/verifierC.go
+++ b/0-999/0-99/10-19/18/verifierC.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(arr []int64) int64 {
+	var total int64
+	for _, v := range arr {
+		total += v
+	}
+	var prefix, count int64
+	for i := 0; i < len(arr)-1; i++ {
+		prefix += arr[i]
+		if prefix*2 == total {
+			count++
+		}
+	}
+	return count
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(20) + 2
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(200) - 100)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(arr)
+}
+
+func runCase(bin, input string, exp int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/18/verifierD.go
+++ b/0-999/0-99/10-19/18/verifierD.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type event struct {
+	typ string
+	x   int
+}
+
+type interval struct {
+	start, end int
+	x          int
+	weight     *big.Int
+}
+
+func solve(events []event) *big.Int {
+	winsList := make(map[int][]int)
+	intervals := make([]interval, 0)
+	for i, e := range events {
+		if e.typ == "win" {
+			winsList[e.x] = append(winsList[e.x], i)
+		} else {
+			list := winsList[e.x]
+			if len(list) > 0 {
+				start := list[len(list)-1]
+				intervals = append(intervals, interval{start: start, end: i, x: e.x})
+			}
+		}
+	}
+	if len(intervals) == 0 {
+		return big.NewInt(0)
+	}
+	sort.Slice(intervals, func(i, j int) bool { return intervals[i].end < intervals[j].end })
+	m := len(intervals)
+	ends := make([]int, m)
+	maxX := 0
+	for i, iv := range intervals {
+		ends[i] = iv.end
+		if iv.x > maxX {
+			maxX = iv.x
+		}
+	}
+	pow2 := make([]*big.Int, maxX+1)
+	pow2[0] = big.NewInt(1)
+	for i := 1; i <= maxX; i++ {
+		pow2[i] = new(big.Int).Lsh(pow2[i-1], 1)
+	}
+	for i := range intervals {
+		intervals[i].weight = pow2[intervals[i].x]
+	}
+	dp := make([]*big.Int, m+1)
+	dp[0] = big.NewInt(0)
+	for j := 1; j <= m; j++ {
+		best := new(big.Int).Set(dp[j-1])
+		iv := intervals[j-1]
+		k := sort.Search(m, func(i int) bool { return ends[i] >= iv.start })
+		with := new(big.Int).Set(iv.weight)
+		if k > 0 {
+			with.Add(with, dp[k])
+		}
+		if with.Cmp(best) > 0 {
+			dp[j] = with
+		} else {
+			dp[j] = best
+		}
+	}
+	return dp[m]
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	events := make([]event, n)
+	usedSell := make(map[int]bool)
+	for i := 0; i < n; i++ {
+		typ := "win"
+		if rng.Intn(2) == 0 {
+			typ = "sell"
+		}
+		x := rng.Intn(6)
+		if typ == "sell" {
+			if usedSell[x] {
+				typ = "win"
+			} else {
+				usedSell[x] = true
+			}
+		}
+		events[i] = event{typ: typ, x: x}
+	}
+	if solve(events).Cmp(big.NewInt(0)) == 0 {
+		events = append(events, event{typ: "win", x: 1}, event{typ: "sell", x: 1})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(events)))
+	for _, e := range events {
+		sb.WriteString(fmt.Sprintf("%s %d\n", e.typ, e.x))
+	}
+	ans := solve(events)
+	return sb.String(), ans.String()
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/18/verifierE.go
+++ b/0-999/0-99/10-19/18/verifierE.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const ALPHA = 26
+const INF = 1000000000
+
+func solve(str []string) (int, []string) {
+	n := len(str)
+	m := len(str[0])
+	cost := make([][ALPHA][ALPHA]int, n)
+	for i := 0; i < n; i++ {
+		var even [ALPHA]int
+		var odd [ALPHA]int
+		row := str[i]
+		for j := 0; j < m; j++ {
+			c := int(row[j] - 'a')
+			if j%2 == 0 {
+				for x := 0; x < ALPHA; x++ {
+					if x != c {
+						even[x]++
+					}
+				}
+			} else {
+				for x := 0; x < ALPHA; x++ {
+					if x != c {
+						odd[x]++
+					}
+				}
+			}
+		}
+		for x := 0; x < ALPHA; x++ {
+			for y := 0; y < ALPHA; y++ {
+				cost[i][x][y] = even[x] + odd[y]
+			}
+		}
+	}
+	var dpPrev [ALPHA][ALPHA]int
+	var dpCurr [ALPHA][ALPHA]int
+	pre := make([][ALPHA][ALPHA][2]int, n+1)
+	for x := 0; x < ALPHA; x++ {
+		for y := 0; y < ALPHA; y++ {
+			if x != y {
+				dpPrev[x][y] = 0
+			} else {
+				dpPrev[x][y] = INF
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		best := INF
+		ba, bb := 0, 0
+		for x := 0; x < ALPHA; x++ {
+			for y := 0; y < ALPHA; y++ {
+				if dpPrev[x][y] < best {
+					best = dpPrev[x][y]
+					ba, bb = x, y
+				}
+			}
+		}
+		for x := 0; x < ALPHA; x++ {
+			for y := 0; y < ALPHA; y++ {
+				dpCurr[x][y] = INF
+				if x == y {
+					continue
+				}
+				if x != ba && y != bb {
+					dpCurr[x][y] = best + cost[i][x][y]
+					pre[i+1][x][y][0] = ba
+					pre[i+1][x][y][1] = bb
+				} else {
+					curBest := INF
+					pa, pb := 0, 0
+					for u := 0; u < ALPHA; u++ {
+						if u == x {
+							continue
+						}
+						for v := 0; v < ALPHA; v++ {
+							if v == y {
+								continue
+							}
+							if dpPrev[u][v] < curBest {
+								curBest = dpPrev[u][v]
+								pa, pb = u, v
+							}
+						}
+					}
+					dpCurr[x][y] = curBest + cost[i][x][y]
+					pre[i+1][x][y][0] = pa
+					pre[i+1][x][y][1] = pb
+				}
+			}
+		}
+		for x := 0; x < ALPHA; x++ {
+			for y := 0; y < ALPHA; y++ {
+				dpPrev[x][y] = dpCurr[x][y]
+			}
+		}
+	}
+	ansCost := INF
+	a, b := 0, 0
+	for x := 0; x < ALPHA; x++ {
+		for y := 0; y < ALPHA; y++ {
+			if dpPrev[x][y] < ansCost {
+				ansCost = dpPrev[x][y]
+				a, b = x, y
+			}
+		}
+	}
+	ans := make([]string, n)
+	for i := n - 1; i >= 0; i-- {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if j%2 == 0 {
+				row[j] = byte('a' + a)
+			} else {
+				row[j] = byte('a' + b)
+			}
+		}
+		ans[i] = string(row)
+		pa := pre[i+1][a][b][0]
+		pb := pre[i+1][a][b][1]
+		a, b = pa, pb
+	}
+	return ansCost, ans
+}
+
+func valid(output []string) bool {
+	n := len(output)
+	m := len(output[0])
+	for i := 0; i < n; i++ {
+		colors := make(map[byte]struct{})
+		for j := 0; j < m; j++ {
+			c := output[i][j]
+			colors[c] = struct{}{}
+			if j > 0 && output[i][j-1] == c {
+				return false
+			}
+			if i > 0 && output[i-1][j] == c {
+				return false
+			}
+		}
+		if len(colors) > 2 {
+			return false
+		}
+	}
+	return true
+}
+
+func generateCase(rng *rand.Rand) (string, int, []string) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	strs := make([]string, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			b[j] = byte('a' + rng.Intn(ALPHA))
+		}
+		strs[i] = string(b)
+		sb.WriteString(strs[i] + "\n")
+	}
+	cost, _ := solve(strs)
+	input := sb.String()
+	return input, cost, strs
+}
+
+func runCase(bin, input string, expCost int, orig []string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) < 1+len(orig) {
+		return fmt.Errorf("expected %d lines, got %d", 1+len(orig), len(lines))
+	}
+	var gotCost int
+	if _, err := fmt.Sscan(lines[0], &gotCost); err != nil {
+		return fmt.Errorf("failed to parse cost: %v", err)
+	}
+	grid := lines[1 : 1+len(orig)]
+	if gotCost != expCost {
+		return fmt.Errorf("expected cost %d got %d", expCost, gotCost)
+	}
+	if !valid(grid) {
+		return fmt.Errorf("output grid invalid")
+	}
+	diff := 0
+	for i := 0; i < len(orig); i++ {
+		if len(grid[i]) != len(orig[0]) {
+			return fmt.Errorf("row %d length mismatch", i)
+		}
+		for j := 0; j < len(orig[0]); j++ {
+			if grid[i][j] != orig[i][j] {
+				diff++
+			}
+		}
+	}
+	if diff != gotCost {
+		return fmt.Errorf("reported cost %d but actual %d", gotCost, diff)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, cost, orig := generateCase(rng)
+		if err := runCase(bin, input, cost, orig); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 18 problems A–E
- each verifier runs 100 random test cases against a binary

## Testing
- `go run verifierA.go ./18A`
- `go run verifierB.go ./18B`
- `go run verifierC.go ./18C`
- `go run verifierD.go ./18D`
- `go run verifierE.go ./18E`


------
https://chatgpt.com/codex/tasks/task_e_687e17b295888324803ff664bf5dca10