### PR TITLE
Add Go verifiers for contest 19

### DIFF
--- a/0-999/0-99/10-19/19/verifierA.go
+++ b/0-999/0-99/10-19/19/verifierA.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type team struct {
+	name           string
+	points, gd, gs int
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int, names []string, matches []match) string {
+	teams := make([]*team, n)
+	idx := make(map[string]int, n)
+	for i, name := range names {
+		teams[i] = &team{name: name}
+		idx[name] = i
+	}
+	for _, m := range matches {
+		t1 := teams[idx[m.name1]]
+		t2 := teams[idx[m.name2]]
+		t1.gs += m.s1
+		t1.gd += m.s1 - m.s2
+		t2.gs += m.s2
+		t2.gd += m.s2 - m.s1
+		if m.s1 > m.s2 {
+			t1.points += 3
+		} else if m.s1 < m.s2 {
+			t2.points += 3
+		} else {
+			t1.points++
+			t2.points++
+		}
+	}
+	sort.Slice(teams, func(i, j int) bool {
+		a, b := teams[i], teams[j]
+		if a.points != b.points {
+			return a.points > b.points
+		}
+		if a.gd != b.gd {
+			return a.gd > b.gd
+		}
+		if a.gs != b.gs {
+			return a.gs > b.gs
+		}
+		return false
+	})
+	m := n / 2
+	selected := make([]string, m)
+	for i := 0; i < m; i++ {
+		selected[i] = teams[i].name
+	}
+	sort.Strings(selected)
+	return strings.Join(selected, "\n")
+}
+
+type match struct {
+	name1, name2 string
+	s1, s2       int
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6)*2 + 2 // even between 2 and 12
+	names := make([]string, n)
+	for i := 0; i < n; i++ {
+		names[i] = fmt.Sprintf("team%d", i+1)
+	}
+	total := n * (n - 1) / 2
+	matches := make([]match, 0, total)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			s1 := rng.Intn(6)
+			s2 := rng.Intn(6)
+			matches = append(matches, match{names[i], names[j], s1, s2})
+		}
+	}
+	// Build input
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, name := range names {
+		fmt.Fprintln(&sb, name)
+	}
+	for _, m := range matches {
+		fmt.Fprintf(&sb, "%s-%s %d:%d\n", m.name1, m.name2, m.s1, m.s2)
+	}
+	expect := solveCase(n, names, matches)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/19/verifierB.go
+++ b/0-999/0-99/10-19/19/verifierB.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type item struct {
+	t int
+	c int64
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(items []item) int64 {
+	n := len(items)
+	const inf int64 = 1 << 60
+	dp := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		dp[i] = inf
+	}
+	for _, it := range items {
+		w := it.t + 1
+		for j := n; j >= 0; j-- {
+			if dp[j] == inf {
+				continue
+			}
+			nj := j + w
+			if nj > n {
+				nj = n
+			}
+			if dp[j]+it.c < dp[nj] {
+				dp[nj] = dp[j] + it.c
+			}
+		}
+	}
+	return dp[n]
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	items := make([]item, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		items[i] = item{t: rng.Intn(6), c: int64(rng.Intn(50) + 1)}
+		fmt.Fprintf(&sb, "%d %d\n", items[i].t, items[i].c)
+	}
+	expect := fmt.Sprintf("%d", solveCase(items))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/19/verifierC.go
+++ b/0-999/0-99/10-19/19/verifierC.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(arr []int) []int {
+	for {
+		n := len(arr)
+		found := false
+		var bestX, bestB int
+		for x := 1; x*2 <= n && !found; x++ {
+			for b := 0; b+2*x <= n; b++ {
+				ok := true
+				for i := 0; i < x; i++ {
+					if arr[b+i] != arr[b+x+i] {
+						ok = false
+						break
+					}
+				}
+				if ok {
+					bestX = x
+					bestB = b
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			break
+		}
+		arr = arr[bestB+bestX:]
+	}
+	return arr
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	counts := make(map[int]int)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		for {
+			v := rng.Intn(5)
+			if counts[v] < 10 {
+				arr[i] = v
+				counts[v]++
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	res := solveCase(append([]int(nil), arr...))
+	var out strings.Builder
+	fmt.Fprintf(&out, "%d\n", len(res))
+	for i := 0; i < len(res); i++ {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprintf(&out, "%d", res[i])
+	}
+	out.WriteByte('\n')
+	return sb.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/19/verifierD.go
+++ b/0-999/0-99/10-19/19/verifierD.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type point struct{ x, y int }
+
+type op struct {
+	kind string
+	x, y int
+}
+
+func solveCase(ops []op) []string {
+	pts := make(map[point]struct{})
+	var res []string
+	for _, o := range ops {
+		switch o.kind {
+		case "add":
+			pts[point{o.x, o.y}] = struct{}{}
+		case "remove":
+			delete(pts, point{o.x, o.y})
+		case "find":
+			found := false
+			best := point{0, 0}
+			for p := range pts {
+				if p.x > o.x && p.y > o.y {
+					if !found || p.x < best.x || (p.x == best.x && p.y < best.y) {
+						found = true
+						best = p
+					}
+				}
+			}
+			if found {
+				res = append(res, fmt.Sprintf("%d %d", best.x, best.y))
+			} else {
+				res = append(res, "-1")
+			}
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 1
+	var ops []op
+	pts := make([]point, 0)
+	inUse := make(map[point]bool)
+	for i := 0; i < n; i++ {
+		t := rng.Intn(3)
+		switch t {
+		case 0:
+			// add
+			var p point
+			for {
+				p = point{rng.Intn(10), rng.Intn(10)}
+				if !inUse[p] {
+					break
+				}
+			}
+			inUse[p] = true
+			pts = append(pts, p)
+			ops = append(ops, op{"add", p.x, p.y})
+		case 1:
+			if len(pts) == 0 {
+				i--
+				continue
+			}
+			idx := rng.Intn(len(pts))
+			p := pts[idx]
+			pts = append(pts[:idx], pts[idx+1:]...)
+			delete(inUse, p)
+			ops = append(ops, op{"remove", p.x, p.y})
+		case 2:
+			ops = append(ops, op{"find", rng.Intn(10), rng.Intn(10)})
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(ops))
+	for _, o := range ops {
+		fmt.Fprintf(&sb, "%s %d %d\n", o.kind, o.x, o.y)
+	}
+	outVals := solveCase(ops)
+	var out strings.Builder
+	for i, v := range outVals {
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		out.WriteString(v)
+	}
+	if len(outVals) > 0 {
+		out.WriteByte('\n')
+	}
+	return sb.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/10-19/19/verifierE.go
+++ b/0-999/0-99/10-19/19/verifierE.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type edge struct{ u, v int }
+
+func isBipartite(n int, edges []edge, skip int) bool {
+	adj := make([][]int, n+1)
+	for i, e := range edges {
+		if i == skip {
+			continue
+		}
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	color := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		if color[i] != 0 {
+			continue
+		}
+		color[i] = 1
+		q := []int{i}
+		for len(q) > 0 {
+			v := q[0]
+			q = q[1:]
+			for _, to := range adj[v] {
+				if color[to] == 0 {
+					color[to] = -color[v]
+					q = append(q, to)
+				} else if color[to] == color[v] {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func solveCase(n int, edges []edge) []int {
+	m := len(edges)
+	if isBipartite(n, edges, -1) {
+		res := make([]int, m)
+		for i := range res {
+			res[i] = i + 1
+		}
+		return res
+	}
+	var ans []int
+	for i := 0; i < m; i++ {
+		if isBipartite(n, edges, i) {
+			ans = append(ans, i+1)
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	used := make(map[[2]int]bool)
+	edges := make([]edge, m)
+	for i := 0; i < m; i++ {
+		var u, v int
+		for {
+			u = rng.Intn(n) + 1
+			v = rng.Intn(n) + 1
+			if u != v {
+				if u > v {
+					u, v = v, u
+				}
+				if !used[[2]int{u, v}] {
+					break
+				}
+			}
+		}
+		used[[2]int{u, v}] = true
+		edges[i] = edge{u, v}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+	}
+	ans := solveCase(n, edges)
+	sort.Ints(ans)
+	var out strings.Builder
+	fmt.Fprintf(&out, "%d\n", len(ans))
+	for i, id := range ans {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprintf(&out, "%d", id)
+	}
+	out.WriteByte('\n')
+	return sb.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verification programs for contest 19 problems A–E
- each verifier generates at least 100 random tests and checks a user binary

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e17b782d88324a187bfb9bf97b5a3