### PR TITLE
Add Go verifiers for contest 20

### DIFF
--- a/0-999/0-99/20-29/20/verifierA.go
+++ b/0-999/0-99/20-29/20/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func normalize(s string) string {
+	var b strings.Builder
+	prevSlash := false
+	for _, ch := range s {
+		if ch == '/' {
+			if !prevSlash {
+				b.WriteByte('/')
+				prevSlash = true
+			}
+		} else {
+			b.WriteRune(ch)
+			prevSlash = false
+		}
+	}
+	res := b.String()
+	if len(res) > 1 && res[len(res)-1] == '/' {
+		res = res[:len(res)-1]
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	l := rng.Intn(50) + 1
+	var sb strings.Builder
+	sb.WriteByte('/')
+	for i := 1; i < l; i++ {
+		if rng.Intn(3) == 0 {
+			sb.WriteByte('/')
+		} else {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		}
+	}
+	for i := 0; i < rng.Intn(3); i++ {
+		sb.WriteByte('/')
+	}
+	input := sb.String()
+	return input + "\n", normalize(input)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected '%s' got '%s'", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/20/verifierB.go
+++ b/0-999/0-99/20-29/20/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveEquation(a, b, c float64) (int, []float64) {
+	if a == 0 && b == 0 && c != 0 {
+		return 0, nil
+	}
+	if a == 0 && b == 0 && c == 0 {
+		return -1, nil
+	}
+	if a == 0 {
+		return 1, []float64{-c / b}
+	}
+	disc := b*b - 4*a*c
+	if disc < 0 {
+		return 0, nil
+	}
+	if disc == 0 {
+		return 1, []float64{-b / (2 * a)}
+	}
+	d := math.Sqrt(disc)
+	r1 := (-b - d) / (2 * a)
+	r2 := (-b + d) / (2 * a)
+	if r1 > r2 {
+		r1, r2 = r2, r1
+	}
+	return 2, []float64{r1, r2}
+}
+
+func generateCase(rng *rand.Rand) (string, int, []float64) {
+	a := float64(rng.Intn(200001) - 100000)
+	b := float64(rng.Intn(200001) - 100000)
+	c := float64(rng.Intn(200001) - 100000)
+	input := fmt.Sprintf("%d %d %d\n", int(a), int(b), int(c))
+	cnt, roots := solveEquation(a, b, c)
+	return input, cnt, roots
+}
+
+func runCase(bin, input string, expCnt int, expRoots []float64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	tokens := strings.Fields(strings.TrimSpace(out.String()))
+	if expCnt == -1 {
+		if len(tokens) != 1 || tokens[0] != "-1" {
+			return fmt.Errorf("expected -1 got %q", strings.Join(tokens, " "))
+		}
+		return nil
+	}
+	if expCnt == 0 {
+		if len(tokens) != 1 || tokens[0] != "0" {
+			return fmt.Errorf("expected 0 got %q", strings.Join(tokens, " "))
+		}
+		return nil
+	}
+	if len(tokens) != expCnt+1 {
+		return fmt.Errorf("expected %d values got %d", expCnt+1, len(tokens))
+	}
+	if tokens[0] != strconv.Itoa(expCnt) {
+		return fmt.Errorf("expected count %d got %s", expCnt, tokens[0])
+	}
+	const eps = 1e-4
+	for i := 0; i < expCnt; i++ {
+		got, err := strconv.ParseFloat(tokens[i+1], 64)
+		if err != nil {
+			return fmt.Errorf("failed to parse float '%s'", tokens[i+1])
+		}
+		if math.Abs(got-expRoots[i]) > eps {
+			return fmt.Errorf("root %d: expected %.5f got %.5f", i+1, expRoots[i], got)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, cnt, roots := generateCase(rng)
+		if err := runCase(bin, in, cnt, roots); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/20/verifierC.go
+++ b/0-999/0-99/20-29/20/verifierC.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to int
+	w  int64
+}
+
+func shortestPath(n int, edges [][3]int) []int {
+	adj := make([][]Edge, n+1)
+	for _, e := range edges {
+		u, v, w := e[0], e[1], int64(e[2])
+		adj[u] = append(adj[u], Edge{v, w})
+		adj[v] = append(adj[v], Edge{u, w})
+	}
+	const inf = int64(1<<63 - 1)
+	dist := make([]int64, n+1)
+	prev := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = inf
+	}
+	dist[1] = 0
+	pq := &itemPQ{}
+	heap.Push(pq, &item{1, 0})
+	for pq.Len() > 0 {
+		it := heap.Pop(pq).(*item)
+		if it.d != dist[it.v] {
+			continue
+		}
+		if it.v == n {
+			break
+		}
+		for _, e := range adj[it.v] {
+			nd := it.d + e.w
+			if nd < dist[e.to] {
+				dist[e.to] = nd
+				prev[e.to] = it.v
+				heap.Push(pq, &item{e.to, nd})
+			}
+		}
+	}
+	if dist[n] == inf {
+		return nil
+	}
+	var path []int
+	for v := n; v != 0; v = prev[v] {
+		path = append(path, v)
+	}
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+	return path
+}
+
+type item struct {
+	v   int
+	d   int64
+	idx int
+}
+
+type itemPQ []*item
+
+func (pq itemPQ) Len() int           { return len(pq) }
+func (pq itemPQ) Less(i, j int) bool { return pq[i].d < pq[j].d }
+func (pq itemPQ) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].idx = i
+	pq[j].idx = j
+}
+func (pq *itemPQ) Push(x interface{}) {
+	it := x.(*item)
+	it.idx = len(*pq)
+	*pq = append(*pq, it)
+}
+func (pq *itemPQ) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	it := old[n-1]
+	*pq = old[:n-1]
+	return it
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(7) + 2 // 2..8
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	edges := make([][3]int, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		w := rng.Intn(100) + 1
+		edges[i] = [3]int{u, v, w}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", u, v, w))
+	}
+	path := shortestPath(n, edges)
+	return sb.String(), path
+}
+
+func runCase(bin, input string, expected []int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if expected == nil {
+		if outStr != "-1" {
+			return fmt.Errorf("expected -1 got %s", outStr)
+		}
+		return nil
+	}
+	tokens := strings.Fields(outStr)
+	if len(tokens) != len(expected) {
+		return fmt.Errorf("expected %d nodes got %d", len(expected), len(tokens))
+	}
+	for i, exp := range expected {
+		val, err := strconv.Atoi(tokens[i])
+		if err != nil {
+			return fmt.Errorf("failed to parse int '%s'", tokens[i])
+		}
+		if val != exp {
+			return fmt.Errorf("position %d: expected %d got %d", i+1, exp, val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- each verifier generates 100 random tests

## Testing
- `go run 0-999/0-99/20-29/20/verifierA.go ./20A`

------
https://chatgpt.com/codex/tasks/task_e_687e17bc11508324bd43b63d4c1d6af2