### PR TITLE
Add Go verifiers for contest 21

### DIFF
--- a/0-999/0-99/20-29/21/verifierA.go
+++ b/0-999/0-99/20-29/21/verifierA.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isValidToken(s string, minLen, maxLen int) bool {
+	n := len(s)
+	if n < minLen || n > maxLen {
+		return false
+	}
+	for i := 0; i < n; i++ {
+		c := s[i]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func isValidJabberID(s string) bool {
+	if strings.Count(s, "@") != 1 {
+		return false
+	}
+	parts := strings.SplitN(s, "@", 2)
+	user := parts[0]
+	rest := parts[1]
+	if !isValidToken(user, 1, 16) {
+		return false
+	}
+	if strings.Count(rest, "/") > 1 {
+		return false
+	}
+	var host, res string
+	if idx := strings.Index(rest, "/"); idx >= 0 {
+		host = rest[:idx]
+		res = rest[idx+1:]
+		if !isValidToken(res, 1, 16) {
+			return false
+		}
+	} else {
+		host = rest
+	}
+	if len(host) < 1 || len(host) > 32 {
+		return false
+	}
+	labels := strings.Split(host, ".")
+	for _, lbl := range labels {
+		if !isValidToken(lbl, 1, 16) {
+			return false
+		}
+	}
+	return true
+}
+
+func randomToken(rng *rand.Rand, minLen, maxLen int) string {
+	l := rng.Intn(maxLen-minLen+1) + minLen
+	b := make([]byte, l)
+	for i := 0; i < l; i++ {
+		typ := rng.Intn(3)
+		switch typ {
+		case 0:
+			b[i] = byte('a' + rng.Intn(26))
+		case 1:
+			b[i] = byte('A' + rng.Intn(26))
+		default:
+			b[i] = byte('0' + rng.Intn(10))
+		}
+	}
+	return string(b)
+}
+
+func generateValid(rng *rand.Rand) string {
+	user := randomToken(rng, 1, 16)
+	// host labels
+	var hostParts []string
+	for {
+		part := randomToken(rng, 1, 16)
+		if len(strings.Join(append(hostParts, part), ".")) > 32 {
+			continue
+		}
+		hostParts = append(hostParts, part)
+		if len(strings.Join(hostParts, ".")) >= rng.Intn(32-1)+1 || rng.Float64() < 0.3 {
+			break
+		}
+	}
+	host := strings.Join(hostParts, ".")
+	res := ""
+	if rng.Float64() < 0.5 {
+		res = randomToken(rng, 1, 16)
+	}
+	if res != "" {
+		return user + "@" + host + "/" + res
+	}
+	return user + "@" + host
+}
+
+func mutateInvalid(rng *rand.Rand, s string) string {
+	choice := rng.Intn(6)
+	switch choice {
+	case 0:
+		// remove @
+		return strings.ReplaceAll(s, "@", "")
+	case 1:
+		// add extra @
+		return s + "@" + randomToken(rng, 1, 5)
+	case 2:
+		// invalid char in username
+		return "#" + s
+	case 3:
+		// host too long
+		return strings.Split(s, "@")[0] + "@" + strings.Repeat("a", 33)
+	case 4:
+		// invalid resource char
+		return s + "/" + "!" + randomToken(rng, 1, 3)
+	default:
+		return s + "//" + randomToken(rng, 1, 3)
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	valid := rng.Float64() < 0.5
+	id := generateValid(rng)
+	if !valid {
+		id = mutateInvalid(rng, id)
+	}
+	expected := "NO"
+	if isValidJabberID(id) {
+		expected = "YES"
+	}
+	return id + "\n", expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/21/verifierB.go
+++ b/0-999/0-99/20-29/21/verifierB.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func intersectionSize(A1, B1, C1, A2, B2, C2 int) int {
+	state := func(A, B, C int) int {
+		if A == 0 && B == 0 {
+			if C == 0 {
+				return 1
+			}
+			return 0
+		}
+		return 2
+	}
+	s1 := state(A1, B1, C1)
+	s2 := state(A2, B2, C2)
+	if s1 == 0 || s2 == 0 {
+		return 0
+	}
+	if s1 != 2 || s2 != 2 {
+		return -1
+	}
+	det := A1*B2 - A2*B1
+	if det != 0 {
+		return 1
+	}
+	if A1*C2 == A2*C1 && B1*C2 == B2*C1 {
+		return -1
+	}
+	return 0
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	A1 := rng.Intn(201) - 100
+	B1 := rng.Intn(201) - 100
+	C1 := rng.Intn(201) - 100
+	A2 := rng.Intn(201) - 100
+	B2 := rng.Intn(201) - 100
+	C2 := rng.Intn(201) - 100
+	expected := fmt.Sprintf("%d", intersectionSize(A1, B1, C1, A2, B2, C2))
+	input := fmt.Sprintf("%d %d %d\n%d %d %d\n", A1, B1, C1, A2, B2, C2)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/21/verifierC.go
+++ b/0-999/0-99/20-29/21/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func countWays(arr []int64) int64 {
+	var total int64
+	for _, v := range arr {
+		total += v
+	}
+	if total%3 != 0 {
+		return 0
+	}
+	target := total / 3
+	var prefix int64
+	var countFirst int64
+	var ways int64
+	for i := 0; i < len(arr)-1; i++ {
+		prefix += arr[i]
+		if prefix == 2*target {
+			ways += countFirst
+		}
+		if prefix == target {
+			countFirst++
+		}
+	}
+	return ways
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(30) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(21) - 10)
+	}
+	expected := fmt.Sprintf("%d", countWays(arr))
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/21/verifierD.go
+++ b/0-999/0-99/20-29/21/verifierD.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	x, y int
+	w    int64
+}
+
+func bitsCount(x int) int {
+	cnt := 0
+	for x != 0 {
+		x &= x - 1
+		cnt++
+	}
+	return cnt
+}
+
+func shortestCycle(n int, edges []edge) int64 {
+	deg := make([]int, n+1)
+	var sumW int64
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		sumW += e.w
+		if e.x == e.y {
+			deg[e.x] += 2
+			if len(adj[e.x]) == 0 {
+				adj[e.x] = append(adj[e.x], e.y)
+			}
+		} else {
+			deg[e.x]++
+			deg[e.y]++
+			adj[e.x] = append(adj[e.x], e.y)
+			adj[e.y] = append(adj[e.y], e.x)
+		}
+	}
+	vis := make([]bool, n+1)
+	q := []int{1}
+	vis[1] = true
+	for qi := 0; qi < len(q); qi++ {
+		u := q[qi]
+		for _, v := range adj[u] {
+			if !vis[v] {
+				vis[v] = true
+				q = append(q, v)
+			}
+		}
+	}
+	for v := 1; v <= n; v++ {
+		if deg[v] > 0 && !vis[v] {
+			return -1
+		}
+	}
+	const INF = int64(4e18)
+	dist := make([][]int64, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = make([]int64, n+1)
+		for j := 1; j <= n; j++ {
+			if i == j {
+				dist[i][j] = 0
+			} else {
+				dist[i][j] = INF
+			}
+		}
+	}
+	for _, e := range edges {
+		if e.w < dist[e.x][e.y] {
+			dist[e.x][e.y] = e.w
+			dist[e.y][e.x] = e.w
+		}
+	}
+	for k := 1; k <= n; k++ {
+		for i := 1; i <= n; i++ {
+			if dist[i][k] == INF {
+				continue
+			}
+			for j := 1; j <= n; j++ {
+				nd := dist[i][k] + dist[k][j]
+				if nd < dist[i][j] {
+					dist[i][j] = nd
+				}
+			}
+		}
+	}
+	odds := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		if deg[i]%2 != 0 {
+			odds = append(odds, i)
+		}
+	}
+	k := len(odds)
+	if k == 0 {
+		return sumW
+	}
+	full := 1 << k
+	dp := make([]int64, full)
+	for mask := 1; mask < full; mask++ {
+		dp[mask] = INF
+	}
+	dp[0] = 0
+	for mask := 1; mask < full; mask++ {
+		if bitsCount(mask)%2 != 0 {
+			continue
+		}
+		var i int
+		for i = 0; i < k; i++ {
+			if mask&(1<<i) != 0 {
+				break
+			}
+		}
+		for j := i + 1; j < k; j++ {
+			if mask&(1<<j) != 0 {
+				m2 := mask ^ (1 << i) ^ (1 << j)
+				cost := dp[m2] + dist[odds[i]][odds[j]]
+				if cost < dp[mask] {
+					dp[mask] = cost
+				}
+			}
+		}
+	}
+	return sumW + dp[full-1]
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(10)
+	edges := make([]edge, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(n) + 1
+		w := int64(rng.Intn(20) + 1)
+		edges[i] = edge{x, y, w}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", x, y, w))
+	}
+	expected := fmt.Sprintf("%d", shortestCycle(n, edges))
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for problems A–D of contest 21
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go run verifierA.go ./21A_bin`
- `go run verifierB.go ./21B_bin`
- `go run verifierC.go ./21C_bin`
- `go run verifierD.go ./21D_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e1d41c6bc8324a87fd858a061fb4f