### PR TITLE
Clarify Python version for submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A few utility programs exist in the repository root:
 - `create.go` – helper for creating new contest folders and boilerplate files.
 - `auto.go` – simple concurrent build runner for multiple solutions.
 - `webserver.go` – demo HTTP server used for uploading solutions locally.
+- Python submissions run with `python3`.
 
 To build or run any of the Go utilities, use the standard Go tooling. For example:
 

--- a/webserver.go
+++ b/webserver.go
@@ -64,7 +64,7 @@ textarea { width: 100%; }
 <option value="c">C</option>
 <option value="cpp">C++</option>
 <option value="java">Java</option>
-<option value="python">Python</option>
+<option value="python">Python 3</option>
 <option value="go">Go</option>
 <option value="rust">Rust</option>
 </select><br>


### PR DESCRIPTION
## Summary
- label the Python option as Python 3 in the webserver
- document that Python submissions use python3

## Testing
- `go build webserver.go`

------
https://chatgpt.com/codex/tasks/task_e_687e270420608324b05a2ba435d82860