### PR TITLE
Improve stderr output from early verifiers

### DIFF
--- a/0-999/0-99/0-9/1/verifierA.go
+++ b/0-999/0-99/0-9/1/verifierA.go
@@ -1,52 +1,55 @@
 package main
 
 import (
-    "bufio"
-    "bytes"
-    "fmt"
-    "math"
-    "os"
-    "os/exec"
-    "strings"
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"strings"
 )
 
 func main() {
-    if len(os.Args) < 2 {
-        fmt.Println("usage: go run verifierA.go /path/to/binary")
-        os.Exit(1)
-    }
-    binary := os.Args[1]
-    file, err := os.Open("testcasesA.txt")
-    if err != nil {
-        panic(err)
-    }
-    defer file.Close()
-    scanner := bufio.NewScanner(file)
-    idx := 0
-    for scanner.Scan() {
-        line := strings.TrimSpace(scanner.Text())
-        if line == "" {
-            continue
-        }
-        idx++
-        var n, m, a int64
-        fmt.Sscan(line, &n, &m, &a)
-        expected := int64(math.Ceil(float64(n)/float64(a))) * int64(math.Ceil(float64(m)/float64(a)))
-        cmd := exec.Command(binary)
-        cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("%d %d %d\n", n, m, a))
-        out, err := cmd.CombinedOutput()
-        if err != nil {
-            fmt.Printf("Test %d: runtime error: %v\n", idx, err)
-            os.Exit(1)
-        }
-        var got int64
-        outStr := strings.TrimSpace(string(out))
-        fmt.Sscan(outStr, &got)
-        if got != expected {
-            fmt.Printf("Test %d failed: expected %d got %s\n", idx, expected, outStr)
-            os.Exit(1)
-        }
-    }
-    fmt.Printf("All %d tests passed\n", idx)
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	file, err := os.Open("testcasesA.txt")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	idx := 0
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		idx++
+		var n, m, a int64
+		fmt.Sscan(line, &n, &m, &a)
+		expected := int64(math.Ceil(float64(n)/float64(a))) * int64(math.Ceil(float64(m)/float64(a)))
+		cmd := exec.Command(binary)
+		cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("%d %d %d\n", n, m, a))
+		var outBuf bytes.Buffer
+		var errBuf bytes.Buffer
+		cmd.Stdout = &outBuf
+		cmd.Stderr = &errBuf
+		err = cmd.Run()
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nstderr: %s\n", idx, err, errBuf.String())
+			os.Exit(1)
+		}
+		var got int64
+		outStr := strings.TrimSpace(outBuf.String())
+		fmt.Sscan(outStr, &got)
+		if got != expected {
+			fmt.Printf("Test %d failed: expected %d got %s\n", idx, expected, outStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
 }
-

--- a/0-999/0-99/0-9/1/verifierB.go
+++ b/0-999/0-99/0-9/1/verifierB.go
@@ -1,114 +1,117 @@
 package main
 
 import (
-    "bufio"
-    "bytes"
-    "fmt"
-    "os"
-    "os/exec"
-    "strings"
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 )
 
 func colToLetters(c int) string {
-    s := ""
-    for c > 0 {
-        c--
-        s = string(rune('A'+(c%26))) + s
-        c /= 26
-    }
-    return s
+	s := ""
+	for c > 0 {
+		c--
+		s = string(rune('A'+(c%26))) + s
+		c /= 26
+	}
+	return s
 }
 
 func lettersToCol(s string) int {
-    c := 0
-    for _, ch := range s {
-        c = c*26 + int(ch-'A'+1)
-    }
-    return c
+	c := 0
+	for _, ch := range s {
+		c = c*26 + int(ch-'A'+1)
+	}
+	return c
 }
 
 func isRXCY(s string) bool {
-    if len(s) < 4 || s[0] != 'R' {
-        return false
-    }
-    idx := strings.IndexRune(s, 'C')
-    if idx == -1 {
-        return false
-    }
-    for i := 1; i < idx; i++ {
-        if s[i] < '0' || s[i] > '9' {
-            return false
-        }
-    }
-    for i := idx + 1; i < len(s); i++ {
-        if s[i] < '0' || s[i] > '9' {
-            return false
-        }
-    }
-    return idx > 1
+	if len(s) < 4 || s[0] != 'R' {
+		return false
+	}
+	idx := strings.IndexRune(s, 'C')
+	if idx == -1 {
+		return false
+	}
+	for i := 1; i < idx; i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	for i := idx + 1; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return idx > 1
 }
 
 func convert(s string) string {
-    if isRXCY(s) {
-        idx := strings.IndexRune(s, 'C')
-        row := s[1:idx]
-        col := s[idx+1:]
-        c := 0
-        fmt.Sscan(col, &c)
-        return colToLetters(c) + row
-    }
-    // letters+row
-    i := 0
-    for i < len(s) && s[i] >= 'A' && s[i] <= 'Z' {
-        i++
-    }
-    col := lettersToCol(s[:i])
-    row := s[i:]
-    return fmt.Sprintf("R%vC%v", row, col)
+	if isRXCY(s) {
+		idx := strings.IndexRune(s, 'C')
+		row := s[1:idx]
+		col := s[idx+1:]
+		c := 0
+		fmt.Sscan(col, &c)
+		return colToLetters(c) + row
+	}
+	// letters+row
+	i := 0
+	for i < len(s) && s[i] >= 'A' && s[i] <= 'Z' {
+		i++
+	}
+	col := lettersToCol(s[:i])
+	row := s[i:]
+	return fmt.Sprintf("R%vC%v", row, col)
 }
 
 func main() {
-    if len(os.Args) < 2 {
-        fmt.Println("usage: go run verifierB.go /path/to/binary")
-        os.Exit(1)
-    }
-    binary := os.Args[1]
-    file, err := os.Open("testcasesB.txt")
-    if err != nil {
-        panic(err)
-    }
-    defer file.Close()
-    var inputs []string
-    scanner := bufio.NewScanner(file)
-    for scanner.Scan() {
-        line := strings.TrimSpace(scanner.Text())
-        if line != "" {
-            inputs = append(inputs, line)
-        }
-    }
-    expected := make([]string, len(inputs))
-    for i, in := range inputs {
-        expected[i] = convert(in)
-    }
-    inputStr := fmt.Sprintf("%d\n%s\n", len(inputs), strings.Join(inputs, "\n"))
-    cmd := exec.Command(binary)
-    cmd.Stdin = bytes.NewBufferString(inputStr)
-    out, err := cmd.CombinedOutput()
-    if err != nil {
-        fmt.Printf("runtime error: %v\n", err)
-        os.Exit(1)
-    }
-    outLines := strings.Split(strings.TrimSpace(string(out)), "\n")
-    if len(outLines) != len(expected) {
-        fmt.Printf("expected %d lines, got %d\n", len(expected), len(outLines))
-        os.Exit(1)
-    }
-    for i, exp := range expected {
-        if strings.TrimSpace(outLines[i]) != exp {
-            fmt.Printf("test %d failed: expected %s got %s\n", i+1, exp, outLines[i])
-            os.Exit(1)
-        }
-    }
-    fmt.Printf("All %d tests passed\n", len(expected))
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	file, err := os.Open("testcasesB.txt")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+	var inputs []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			inputs = append(inputs, line)
+		}
+	}
+	expected := make([]string, len(inputs))
+	for i, in := range inputs {
+		expected[i] = convert(in)
+	}
+	inputStr := fmt.Sprintf("%d\n%s\n", len(inputs), strings.Join(inputs, "\n"))
+	cmd := exec.Command(binary)
+	cmd.Stdin = bytes.NewBufferString(inputStr)
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	if err != nil {
+		fmt.Printf("runtime error: %v\nstderr: %s\n", err, errBuf.String())
+		os.Exit(1)
+	}
+	outLines := strings.Split(strings.TrimSpace(outBuf.String()), "\n")
+	if len(outLines) != len(expected) {
+		fmt.Printf("expected %d lines, got %d\n", len(expected), len(outLines))
+		os.Exit(1)
+	}
+	for i, exp := range expected {
+		if strings.TrimSpace(outLines[i]) != exp {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, exp, outLines[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(expected))
 }
-

--- a/0-999/0-99/0-9/1/verifierC.go
+++ b/0-999/0-99/0-9/1/verifierC.go
@@ -1,73 +1,76 @@
 package main
 
 import (
-    "bufio"
-    "bytes"
-    "fmt"
-    "math"
-    "os"
-    "os/exec"
-    "strings"
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"strings"
 )
 
 func gcd(x, y float64) float64 {
-    for y > 1e-7 {
-        x, y = y, math.Mod(x, y)
-    }
-    return x
+	for y > 1e-7 {
+		x, y = y, math.Mod(x, y)
+	}
+	return x
 }
 
 func expectedArea(ax, ay, bx, by, cx, cy float64) float64 {
-    a := math.Hypot(ax-bx, ay-by)
-    b := math.Hypot(ax-cx, ay-cy)
-    c := math.Hypot(bx-cx, by-cy)
-    p := (a + b + c) / 2.0
-    s := math.Sqrt(p * (p - a) * (p - b) * (p - c))
-    R := a * b * c / (4.0 * s)
-    A := math.Acos((b*b + c*c - a*a) / (2 * b * c))
-    B := math.Acos((a*a + c*c - b*b) / (2 * a * c))
-    C := math.Acos((a*a + b*b - c*c) / (2 * a * b))
-    n := math.Pi / gcd(A, gcd(B, C))
-    return R * R * math.Sin(2*math.Pi/n) * n / 2
+	a := math.Hypot(ax-bx, ay-by)
+	b := math.Hypot(ax-cx, ay-cy)
+	c := math.Hypot(bx-cx, by-cy)
+	p := (a + b + c) / 2.0
+	s := math.Sqrt(p * (p - a) * (p - b) * (p - c))
+	R := a * b * c / (4.0 * s)
+	A := math.Acos((b*b + c*c - a*a) / (2 * b * c))
+	B := math.Acos((a*a + c*c - b*b) / (2 * a * c))
+	C := math.Acos((a*a + b*b - c*c) / (2 * a * b))
+	n := math.Pi / gcd(A, gcd(B, C))
+	return R * R * math.Sin(2*math.Pi/n) * n / 2
 }
 
 func main() {
-    if len(os.Args) < 2 {
-        fmt.Println("usage: go run verifierC.go /path/to/binary")
-        os.Exit(1)
-    }
-    binary := os.Args[1]
-    file, err := os.Open("testcasesC.txt")
-    if err != nil {
-        panic(err)
-    }
-    defer file.Close()
-    scanner := bufio.NewScanner(file)
-    idx := 0
-    for scanner.Scan() {
-        line := strings.TrimSpace(scanner.Text())
-        if line == "" {
-            continue
-        }
-        idx++
-        var ax, ay, bx, by, cx, cy float64
-        fmt.Sscan(line, &ax, &ay, &bx, &by, &cx, &cy)
-        exp := expectedArea(ax, ay, bx, by, cx, cy)
-        cmd := exec.Command(binary)
-        cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("%f %f %f %f %f %f\n", ax, ay, bx, by, cx, cy))
-        out, err := cmd.CombinedOutput()
-        if err != nil {
-            fmt.Printf("Test %d: runtime error: %v\n", idx, err)
-            os.Exit(1)
-        }
-        var got float64
-        outStr := strings.TrimSpace(string(out))
-        fmt.Sscan(outStr, &got)
-        if math.Abs(got-exp) > 1e-4*math.Max(1.0, math.Abs(exp)) {
-            fmt.Printf("Test %d failed: expected %f got %s\n", idx, exp, outStr)
-            os.Exit(1)
-        }
-    }
-    fmt.Printf("All %d tests passed\n", idx)
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	file, err := os.Open("testcasesC.txt")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	idx := 0
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		idx++
+		var ax, ay, bx, by, cx, cy float64
+		fmt.Sscan(line, &ax, &ay, &bx, &by, &cx, &cy)
+		exp := expectedArea(ax, ay, bx, by, cx, cy)
+		cmd := exec.Command(binary)
+		cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("%f %f %f %f %f %f\n", ax, ay, bx, by, cx, cy))
+		var outBuf bytes.Buffer
+		var errBuf bytes.Buffer
+		cmd.Stdout = &outBuf
+		cmd.Stderr = &errBuf
+		err = cmd.Run()
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nstderr: %s\n", idx, err, errBuf.String())
+			os.Exit(1)
+		}
+		var got float64
+		outStr := strings.TrimSpace(outBuf.String())
+		fmt.Sscan(outStr, &got)
+		if math.Abs(got-exp) > 1e-4*math.Max(1.0, math.Abs(exp)) {
+			fmt.Printf("Test %d failed: expected %f got %s\n", idx, exp, outStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
 }
-


### PR DESCRIPTION
## Summary
- show stderr from user programs in the contest 1 verifiers

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`


------
https://chatgpt.com/codex/tasks/task_e_687e2aa3cbd88324bf8fdc8b74a55ecc