### PR TITLE
Add Go verifiers for contest 22

### DIFF
--- a/0-999/0-99/20-29/22/verifierA.go
+++ b/0-999/0-99/20-29/22/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(nums []int) string {
+	uniq := make(map[int]struct{})
+	for _, v := range nums {
+		uniq[v] = struct{}{}
+	}
+	if len(uniq) < 2 {
+		return "NO"
+	}
+	vals := make([]int, 0, len(uniq))
+	for v := range uniq {
+		vals = append(vals, v)
+	}
+	sort.Ints(vals)
+	return strconv.Itoa(vals[1])
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(100) + 1
+		nums := make([]int, n)
+		for j := 0; j < n; j++ {
+			nums[j] = rng.Intn(201) - 100
+		}
+		input := fmt.Sprintf("%d\n", n)
+		for j, v := range nums {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		expectedOut := expected(nums)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedOut {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expectedOut, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/22/verifierB.go
+++ b/0-999/0-99/20-29/22/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func maxPerimeter(grid [][]int) int {
+	n := len(grid)
+	m := len(grid[0])
+	maxP := 0
+	for r1 := 0; r1 < n; r1++ {
+		for r2 := r1; r2 < n; r2++ {
+			curr := 0
+			for c := 0; c < m; c++ {
+				zero := true
+				for r := r1; r <= r2; r++ {
+					if grid[r][c] != 0 {
+						zero = false
+						break
+					}
+				}
+				if zero {
+					curr++
+					p := 2 * (curr + r2 - r1 + 1)
+					if p > maxP {
+						maxP = p
+					}
+				} else {
+					curr = 0
+				}
+			}
+		}
+	}
+	return maxP
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		grid := make([][]int, n)
+		for i := 0; i < n; i++ {
+			grid[i] = make([]int, m)
+			for j := 0; j < m; j++ {
+				grid[i][j] = rng.Intn(2)
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				if grid[i][j] == 0 {
+					sb.WriteByte('0')
+				} else {
+					sb.WriteByte('1')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expected := fmt.Sprintf("%d", maxPerimeter(grid))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/22/verifierC.go
+++ b/0-999/0-99/20-29/22/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n, m, v int) string {
+	maxExtra := (n-1)*(n-2)/2 + 1
+	if m < n-1 || m > maxExtra {
+		return "-1"
+	}
+	edges := 0
+	var a, b int
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		if i == v {
+			continue
+		}
+		a, b = i, v
+		edges++
+		if edges == n-1 {
+			a, b = b, a
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	for i := 1; i <= n && edges < m; i++ {
+		if i == v || i == b {
+			continue
+		}
+		for j := i + 1; j <= n && edges < m; j++ {
+			if j == v || j == b {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("%d %d\n", i, j))
+			edges++
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(6) + 3
+		maxM := n * (n - 1) / 2
+		m := rng.Intn(maxM + 1)
+		v := rng.Intn(n) + 1
+		input := fmt.Sprintf("%d %d %d\n", n, m, v)
+		expected := solveCase(n, m, v)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\ngot:\n%s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/22/verifierD.go
+++ b/0-999/0-99/20-29/22/verifierD.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type segment struct{ l, r int }
+
+func solveCase(segs []segment) string {
+	sort.Slice(segs, func(i, j int) bool { return segs[i].r < segs[j].r })
+	nails := make([]int, 0, len(segs))
+	hasLast := false
+	last := 0
+	for _, s := range segs {
+		if !hasLast || last < s.l {
+			last = s.r
+			nails = append(nails, last)
+			hasLast = true
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(nails)))
+	for i, v := range nails {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(6) + 1
+		segs := make([]segment, n)
+		for i := 0; i < n; i++ {
+			x := rng.Intn(21) - 10
+			y := rng.Intn(21) - 10
+			if x <= y {
+				segs[i] = segment{x, y}
+			} else {
+				segs[i] = segment{y, x}
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for _, s := range segs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", s.l, s.r))
+		}
+		input := sb.String()
+		expected := solveCase(segs)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/22/verifierE.go
+++ b/0-999/0-99/20-29/22/verifierE.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(a []int) string {
+	n := len(a) - 1
+	d := make([]int, n+1)
+	vis := make([]int, n+1)
+	f := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		d[a[i]]++
+	}
+	var dfs func(int) int
+	dfs = func(x int) int {
+		if f[x] != 0 {
+			return f[x]
+		}
+		if vis[x] != 0 {
+			return 0
+		}
+		vis[x] = 1
+		res := dfs(a[x])
+		f[x] = res
+		if f[x] != 0 {
+			return f[x]
+		}
+		f[x] = x
+		return x
+	}
+	for i := 1; i <= n; i++ {
+		if d[i] == 0 || vis[i] == 0 {
+			dfs(i)
+		}
+	}
+	ans1 := make([]int, 0)
+	ans2 := make([]int, 0)
+	for i := 1; i <= n; i++ {
+		if d[i] == 0 {
+			ans1 = append(ans1, i)
+			ans2 = append(ans2, f[i])
+			vis[f[i]] = 2
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if f[i] == i && vis[i] < 2 {
+			ans1 = append(ans1, i)
+			ans2 = append(ans2, i)
+		}
+	}
+	m := len(ans1)
+	if m == 1 && ans1[0] == ans2[0] {
+		m = 0
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		j := (i + 1) % m
+		sb.WriteString(fmt.Sprintf("%d %d\n", ans2[i], ans1[j]))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(8) + 2
+		a := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			v := rng.Intn(n) + 1
+			if v == i {
+				if v < n {
+					v++
+				} else {
+					v--
+				}
+			}
+			a[i] = v
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 1; i <= n; i++ {
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveCase(a)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\ngot:\n%s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifiers for contest 22 problems A–E
- each verifier generates random tests and compares results to reference implementation

## Testing
- `go run verifierA.go ./22A.go`
- `go run verifierB.go ./22B.go`
- `go run verifierC.go ./22C.go`
- `go run verifierD.go ./22D.go`
- `go run verifierE.go ./22E.go`

------
https://chatgpt.com/codex/tasks/task_e_687e2af0b2608324a25b5b53ead4f498