### PR TITLE
Add verifiers for contest 23

### DIFF
--- a/0-999/0-99/20-29/23/verifierA.go
+++ b/0-999/0-99/20-29/23/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(s string) string {
+	n := len(s)
+	for L := n - 1; L >= 1; L-- {
+		seen := make(map[string]bool)
+		for i := 0; i+L <= n; i++ {
+			sub := s[i : i+L]
+			if seen[sub] {
+				return fmt.Sprintf("%d", L)
+			}
+			seen[sub] = true
+		}
+	}
+	return "0"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	l := rng.Intn(30) + 1
+	b := make([]byte, l)
+	for i := 0; i < l; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	s := string(b)
+	return s + "\n", solveA(s)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/23/verifierB.go
+++ b/0-999/0-99/20-29/23/verifierB.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(ns []int) string {
+	var sb strings.Builder
+	for i, n := range ns {
+		ans := 0
+		if n > 2 {
+			ans = n - 2
+		}
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		fmt.Fprintf(&sb, "%d", ans)
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(5) + 1
+	ns := make([]int, t)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		ns[i] = rng.Intn(1000) + 1
+		fmt.Fprintf(&sb, "%d\n", ns[i])
+	}
+	return sb.String(), solveB(ns)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/23/verifierC.go
+++ b/0-999/0-99/20-29/23/verifierC.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type item struct {
+	a   int
+	s   int
+	pos int
+}
+
+func solveC(q int, arr []item) string {
+	items := make([]item, len(arr))
+	copy(items, arr)
+	sort.Slice(items, func(i, j int) bool { return items[i].a < items[j].a })
+	var sum0, sum1 int64
+	for i := 0; i < len(items); i++ {
+		if i%2 == 0 {
+			sum0 += int64(items[i].s)
+		} else {
+			sum1 += int64(items[i].s)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	if sum0 >= sum1 {
+		for i := 0; i < len(items); i += 2 {
+			fmt.Fprintf(&sb, "%d ", items[i].pos)
+		}
+	} else {
+		for i := 1; i < len(items); i += 2 {
+			fmt.Fprintf(&sb, "%d ", items[i].pos)
+		}
+		fmt.Fprintf(&sb, "%d ", items[len(items)-1].pos)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	q := rng.Intn(5) + 1
+	cnt := 2*q - 1
+	arr := make([]item, cnt)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", q)
+	for i := 0; i < cnt; i++ {
+		arr[i].a = rng.Intn(20)
+		arr[i].s = rng.Intn(20)
+		arr[i].pos = i + 1
+		fmt.Fprintf(&sb, "%d %d\n", arr[i].a, arr[i].s)
+	}
+	return sb.String(), solveC(q, arr)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expStr := strings.TrimSpace(expected)
+	if outStr != expStr {
+		return fmt.Errorf("expected %q got %q", expStr, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/23/verifierD.go
+++ b/0-999/0-99/20-29/23/verifierD.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func cp(x0, y0, x1, y1, x2, y2 float64) float64 {
+	return (x1-x0)*(y2-y0) - (x2-x0)*(y1-y0)
+}
+
+func check(x1, y1, x2, y2, x3, y3 float64) (bool, [8]float64) {
+	sqr := func(x float64) float64 { return x * x }
+	a1 := (x2 - x1) * 2.0
+	b1 := (y2 - y1) * 2.0
+	c1 := sqr(2*x1-x2) + sqr(2*y1-y2) - sqr(x1) - sqr(y1)
+	a2 := (x3 - 2*x2 + x1) * 2.0
+	b2 := (y3 - 2*y2 + y1) * 2.0
+	c2 := sqr(x1) + sqr(y1) - sqr(x3-2*x2+2*x1) - sqr(y3-2*y2+2*y1)
+	if a1*b2 == a2*b1 {
+		return false, [8]float64{}
+	}
+	Y1 := (c2*a1 - c1*a2) / (b1*a2 - b2*a1)
+	X1 := (c2*b1 - c1*b2) / (a1*b2 - a2*b1)
+	X2 := 2*x1 - X1
+	Y2 := 2*y1 - Y1
+	X3 := 2*x2 - 2*x1 + X1
+	Y3 := 2*y2 - 2*y1 + Y1
+	X4 := 2*x3 - 2*x2 + 2*x1 - X1
+	Y4 := 2*y3 - 2*y2 + 2*y1 - Y1
+	v1 := cp(X1, Y1, X2, Y2, X3, Y3)
+	v2 := cp(X2, Y2, X3, Y3, X4, Y4)
+	v3 := cp(X3, Y3, X4, Y4, X1, Y1)
+	v4 := cp(X4, Y4, X1, Y1, X2, Y2)
+	if (v1 < 0 && v2 < 0 && v3 < 0 && v4 < 0) || (v1 > 0 && v2 > 0 && v3 > 0 && v4 > 0) {
+		return true, [8]float64{X1, Y1, X2, Y2, X3, Y3, X4, Y4}
+	}
+	return false, [8]float64{}
+}
+
+func solveOne(x1, y1, x2, y2, x3, y3 float64) (bool, [8]float64) {
+	if ok, p := check(x1, y1, x2, y2, x3, y3); ok {
+		return true, p
+	}
+	if ok, p := check(x1, y1, x3, y3, x2, y2); ok {
+		return true, p
+	}
+	if ok, p := check(x2, y2, x1, y1, x3, y3); ok {
+		return true, p
+	}
+	return false, [8]float64{}
+}
+
+func solveD(points [][6]float64) string {
+	var sb strings.Builder
+	for idx, pt := range points {
+		if idx > 0 {
+			sb.WriteByte('\n')
+		}
+		found, res := solveOne(pt[0], pt[1], pt[2], pt[3], pt[4], pt[5])
+		if found {
+			sb.WriteString("YES\n")
+			fmt.Fprintf(&sb, "%.9f %.9f %.9f %.9f %.9f %.9f %.9f %.9f", res[0], res[1], res[2], res[3], res[4], res[5], res[6], res[7])
+		} else {
+			sb.WriteString("NO\n\n")
+			continue
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(3) + 1
+	pts := make([][6]float64, t)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		for j := 0; j < 6; j++ {
+			pts[i][j] = float64(rng.Intn(11))
+		}
+		fmt.Fprintf(&sb, "%d %d %d %d %d %d\n", int(pts[i][0]), int(pts[i][1]), int(pts[i][2]), int(pts[i][3]), int(pts[i][4]), int(pts[i][5]))
+	}
+	return sb.String(), solveD(pts)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expStr := strings.TrimSpace(expected)
+	if outStr != expStr {
+		return fmt.Errorf("expected %q got %q", expStr, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/20-29/23/verifierE.go
+++ b/0-999/0-99/20-29/23/verifierE.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func dfs(u, p int, adj [][]int) ([]*big.Int, int) {
+	dp := make([]*big.Int, 2)
+	dp[1] = big.NewInt(1)
+	sz := 1
+	for _, v := range adj[u] {
+		if v == p {
+			continue
+		}
+		dpv, sv := dfs(v, u, adj)
+		newDp := make([]*big.Int, sz+sv+1)
+		for su := 1; su <= sz; su++ {
+			if dp[su] == nil {
+				continue
+			}
+			for svv := 1; svv < len(dpv); svv++ {
+				if dpv[svv] == nil {
+					continue
+				}
+				nk := su + svv
+				prod1 := new(big.Int).Mul(dp[su], dpv[svv])
+				if newDp[nk] == nil || prod1.Cmp(newDp[nk]) > 0 {
+					newDp[nk] = prod1
+				}
+				prod2 := new(big.Int).Mul(dp[su], dpv[svv])
+				prod2.Mul(prod2, big.NewInt(int64(svv)))
+				if newDp[su] == nil || prod2.Cmp(newDp[su]) > 0 {
+					newDp[su] = prod2
+				}
+			}
+		}
+		sz += sv
+		dp = newDp
+	}
+	return dp, sz
+}
+
+func solveE(n int, edges [][2]int) string {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	dp, _ := dfs(1, 0, adj)
+	ans := big.NewInt(0)
+	for k, prod := range dp {
+		if prod == nil {
+			continue
+		}
+		total := new(big.Int).Mul(prod, big.NewInt(int64(k)))
+		if total.Cmp(ans) > 0 {
+			ans = total
+		}
+	}
+	return ans.String()
+}
+
+func genTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(7) + 1
+	edges := genTree(rng, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	return sb.String(), solveE(n, edges)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expStr := strings.TrimSpace(expected)
+	if outStr != expStr {
+		return fmt.Errorf("expected %q got %q", expStr, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems of contest 23
- each verifier generates 100 random tests and runs a candidate binary

## Testing
- `go build 0-999/0-99/20-29/23/verifierA.go`
- `go build 0-999/0-99/20-29/23/verifierB.go`
- `go build 0-999/0-99/20-29/23/verifierC.go`
- `go build 0-999/0-99/20-29/23/verifierD.go`
- `go build 0-999/0-99/20-29/23/verifierE.go`
- `go build -o candidateA 0-999/0-99/20-29/23/23A.go`
- `go run 0-999/0-99/20-29/23/verifierA.go ./candidateA`

------
https://chatgpt.com/codex/tasks/task_e_687e2affcfbc8324a87b9464b33c63f3