### PR TITLE
Add Go verifiers for contest 31

### DIFF
--- a/0-999/0-99/30-39/31/verifierA.go
+++ b/0-999/0-99/30-39/31/verifierA.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n   int
+	arr []int
+}
+
+func generateCaseA(rng *rand.Rand) testCaseA {
+	n := rng.Intn(20) + 3
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(1000) + 1
+	}
+	// occasionally enforce a valid triple
+	if rng.Intn(2) == 0 {
+		i := rng.Intn(n)
+		j := rng.Intn(n)
+		for j == i {
+			j = rng.Intn(n)
+		}
+		k := rng.Intn(n)
+		for k == i || k == j {
+			k = rng.Intn(n)
+		}
+		arr[i] = arr[j] + arr[k]
+	}
+	return testCaseA{n: n, arr: arr}
+}
+
+func runCaseA(bin string, tc testCaseA) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) == 1 && fields[0] == "-1" {
+		if hasSolutionA(tc.arr) {
+			return fmt.Errorf("expected a solution but got -1")
+		}
+		return nil
+	}
+	if len(fields) != 3 {
+		return fmt.Errorf("expected three integers or -1, got %q", out.String())
+	}
+	var i, j, k int
+	if _, err := fmt.Sscan(strings.Join(fields, " "), &i, &j, &k); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	if i < 1 || i > tc.n || j < 1 || j > tc.n || k < 1 || k > tc.n {
+		return fmt.Errorf("indices out of range")
+	}
+	if i == j || i == k || j == k {
+		return fmt.Errorf("indices must be distinct")
+	}
+	arr := tc.arr
+	if arr[i-1] != arr[j-1]+arr[k-1] {
+		return fmt.Errorf("invalid triple")
+	}
+	return nil
+}
+
+func hasSolutionA(a []int) bool {
+	n := len(a)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j == i {
+				continue
+			}
+			for k := 0; k < n; k++ {
+				if k == i || k == j {
+					continue
+				}
+				if a[i] == a[j]+a[k] {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		tc := generateCaseA(rng)
+		if err := runCaseA(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%v\n", t+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/31/verifierB.go
+++ b/0-999/0-99/30-39/31/verifierB.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	s     string
+	valid bool
+}
+
+func generateValidEmail(rng *rand.Rand) string {
+	m := rng.Intn(5) + 1
+	parts := make([]string, m)
+	for i := 0; i < m; i++ {
+		aLen := rng.Intn(3) + 1
+		bLen := rng.Intn(3) + 1
+		a := randomLetters(rng, aLen)
+		b := randomLetters(rng, bLen)
+		parts[i] = a + "@" + b
+	}
+	return strings.Join(parts, "")
+}
+
+func generateInvalidString(rng *rand.Rand) string {
+	// random letters and '@'
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	atUsed := false
+	for i := 0; i < n; i++ {
+		if rng.Intn(5) == 0 {
+			sb.WriteByte('@')
+			atUsed = true
+		} else {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		}
+	}
+	if !atUsed {
+		sb.WriteByte('@')
+	}
+	return sb.String()
+}
+
+func randomLetters(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCaseB(rng *rand.Rand) testCaseB {
+	if rng.Intn(2) == 0 {
+		return testCaseB{s: generateValidEmail(rng), valid: true}
+	}
+	return testCaseB{s: generateInvalidString(rng), valid: false}
+}
+
+func solveB(s string) (string, bool) {
+	n := len(s)
+	var pos []int
+	for i, c := range s {
+		if c == '@' {
+			pos = append(pos, i)
+		}
+	}
+	m := len(pos)
+	if m == 0 {
+		return "No solution", false
+	}
+	if pos[0] < 1 || pos[m-1] > n-2 {
+		return "No solution", false
+	}
+	for i := 0; i < m-1; i++ {
+		if pos[i+1]-pos[i] < 3 {
+			return "No solution", false
+		}
+	}
+	var parts []string
+	start := 0
+	for i := 0; i < m-1; i++ {
+		end := pos[i+1] - 2
+		if end < start {
+			return "No solution", false
+		}
+		parts = append(parts, s[start:end+1])
+		start = end + 1
+	}
+	parts = append(parts, s[start:])
+	for _, p := range parts {
+		idx := strings.Index(p, "@")
+		if idx <= 0 || idx >= len(p)-1 || strings.Count(p, "@") != 1 {
+			return "No solution", false
+		}
+	}
+	return strings.Join(parts, ","), true
+}
+
+func checkOutputB(input, out string) error {
+	_, ok := solveB(input)
+	out = strings.TrimSpace(out)
+	if !ok {
+		if out != "No solution" {
+			return fmt.Errorf("expected 'No solution', got %q", out)
+		}
+		return nil
+	}
+	// verify candidate solution is valid
+	if strings.ReplaceAll(out, ",", "") != input {
+		return fmt.Errorf("output does not reconstruct original string")
+	}
+	segments := strings.Split(out, ",")
+	for _, p := range segments {
+		idx := strings.Index(p, "@")
+		if idx <= 0 || idx >= len(p)-1 || strings.Count(p, "@") != 1 {
+			return fmt.Errorf("segment %q is invalid", p)
+		}
+	}
+	return nil
+}
+
+func runCaseB(bin string, tc testCaseB) error {
+	input := tc.s + "\n"
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return checkOutputB(tc.s, out.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseB(rng)
+		if err := runCaseB(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s\n", i+1, err, tc.s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/31/verifierC.go
+++ b/0-999/0-99/30-39/31/verifierC.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type interval struct {
+	l, r int
+}
+
+type testCaseC struct {
+	intervals []interval
+}
+
+func generateCaseC(rng *rand.Rand) testCaseC {
+	n := rng.Intn(8) + 1
+	intervals := make([]interval, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(90) + 1
+		r := l + rng.Intn(10) + 1
+		intervals[i] = interval{l: l, r: r}
+	}
+	return testCaseC{intervals: intervals}
+}
+
+func expectedC(iv []interval) []int {
+	n := len(iv)
+	res := []int{}
+	for i := 0; i < n; i++ {
+		list := make([]interval, 0, n-1)
+		for j := 0; j < n; j++ {
+			if i == j {
+				continue
+			}
+			list = append(list, iv[j])
+		}
+		sort.Slice(list, func(a, b int) bool {
+			if list[a].l == list[b].l {
+				return list[a].r < list[b].r
+			}
+			return list[a].l < list[b].l
+		})
+		ok := true
+		for j := 1; j < len(list); j++ {
+			if list[j].l < list[j-1].r {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			res = append(res, i+1)
+		}
+	}
+	return res
+}
+
+func runCaseC(bin string, tc testCaseC) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.intervals)))
+	for _, iv := range tc.intervals {
+		sb.WriteString(fmt.Sprintf("%d %d\n", iv.l, iv.r))
+	}
+	input := sb.String()
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := expectedC(tc.intervals)
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	var k int
+	if _, err := fmt.Sscan(fields[0], &k); err != nil {
+		return fmt.Errorf("failed to parse k: %v", err)
+	}
+	if k != len(expected) {
+		return fmt.Errorf("expected k=%d got %d", len(expected), k)
+	}
+	if k == 0 {
+		return nil
+	}
+	if len(fields[1:]) != k {
+		return fmt.Errorf("expected %d indices got %d", k, len(fields[1:]))
+	}
+	got := make([]int, k)
+	for i := 0; i < k; i++ {
+		if _, err := fmt.Sscan(fields[i+1], &got[i]); err != nil {
+			return fmt.Errorf("bad index: %v", err)
+		}
+	}
+	sort.Ints(got)
+	sort.Ints(expected)
+	for i := range got {
+		if got[i] != expected[i] {
+			return fmt.Errorf("expected %v got %v", expected, got)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseC(rng)
+		if err := runCaseC(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/31/verifierD.go
+++ b/0-999/0-99/30-39/31/verifierD.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type seg struct {
+	x1, y1, x2, y2 int
+}
+
+type rect struct {
+	x1, y1, x2, y2 int
+}
+
+type testCaseD struct {
+	W, H  int
+	segs  []seg
+	areas []int
+}
+
+func generateCaseD(rng *rand.Rand) testCaseD {
+	W := rng.Intn(9) + 2
+	H := rng.Intn(9) + 2
+	n := rng.Intn(4) + 1
+	rects := []rect{{0, 0, W, H}}
+	segs := make([]seg, 0, n)
+	for i := 0; i < n; i++ {
+		idx := rng.Intn(len(rects))
+		r := rects[idx]
+		var s seg
+		if (r.x2-r.x1 > 1 && rng.Intn(2) == 0) || r.y2-r.y1 <= 1 {
+			// vertical
+			x := rng.Intn(r.x2-r.x1-1) + r.x1 + 1
+			s = seg{x, r.y1, x, r.y2}
+			rect1 := rect{r.x1, r.y1, x, r.y2}
+			rect2 := rect{x, r.y1, r.x2, r.y2}
+			rects[idx] = rect1
+			rects = append(rects, rect2)
+		} else {
+			// horizontal
+			y := rng.Intn(r.y2-r.y1-1) + r.y1 + 1
+			s = seg{r.x1, y, r.x2, y}
+			rect1 := rect{r.x1, r.y1, r.x2, y}
+			rect2 := rect{r.x1, y, r.x2, r.y2}
+			rects[idx] = rect1
+			rects = append(rects, rect2)
+		}
+		segs = append(segs, s)
+	}
+	areas := make([]int, len(rects))
+	for i, r := range rects {
+		areas[i] = (r.x2 - r.x1) * (r.y2 - r.y1)
+	}
+	sort.Ints(areas)
+	// shuffle segs
+	perm := rng.Perm(len(segs))
+	shuffled := make([]seg, len(segs))
+	for i, p := range perm {
+		shuffled[i] = segs[p]
+	}
+	segs = shuffled
+	return testCaseD{W: W, H: H, segs: segs, areas: areas}
+}
+
+func runCaseD(bin string, tc testCaseD) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.W, tc.H, len(tc.segs)))
+	for _, s := range tc.segs {
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", s.x1, s.y1, s.x2, s.y2))
+	}
+	input := sb.String()
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != len(tc.areas) {
+		return fmt.Errorf("expected %d numbers got %d", len(tc.areas), len(fields))
+	}
+	got := make([]int, len(fields))
+	for i, f := range fields {
+		if _, err := fmt.Sscan(f, &got[i]); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+	}
+	sort.Ints(got)
+	for i := range got {
+		if got[i] != tc.areas[i] {
+			return fmt.Errorf("expected %v got %v", tc.areas, got)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseD(rng)
+		if err := runCaseD(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/31/verifierE.go
+++ b/0-999/0-99/30-39/31/verifierE.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseE struct {
+	n      int
+	digits []int
+}
+
+func generateCaseE(rng *rand.Rand) testCaseE {
+	n := rng.Intn(6) + 1
+	digits := make([]int, 2*n)
+	for i := range digits {
+		digits[i] = rng.Intn(10)
+	}
+	return testCaseE{n: n, digits: digits}
+}
+
+func maxTotal(digits []int, n int) int64 {
+	p10 := make([]int64, n+1)
+	p10[0] = 1
+	for i := 1; i <= n; i++ {
+		p10[i] = p10[i-1] * 10
+	}
+	f := make([][]int64, n+1)
+	for i := range f {
+		f[i] = make([]int64, n+1)
+	}
+	for i := 0; i <= n; i++ {
+		for j := 0; j <= n; j++ {
+			if i < n {
+				idx := i + j
+				w := int64(digits[idx]) * p10[n-i-1]
+				if v := f[i][j] + w; v > f[i+1][j] {
+					f[i+1][j] = v
+				}
+			}
+			if j < n {
+				idx := i + j
+				w := int64(digits[idx]) * p10[n-j-1]
+				if v := f[i][j] + w; v > f[i][j+1] {
+					f[i][j+1] = v
+				}
+			}
+		}
+	}
+	return f[n][n]
+}
+
+func totalForOrder(order string, digits []int, n int) (int64, bool) {
+	if len(order) != 2*n {
+		return 0, false
+	}
+	hCnt := 0
+	mCnt := 0
+	var s1, s2 int64
+	for idx, c := range order {
+		d := int64(digits[idx])
+		if c == 'H' {
+			if hCnt >= n {
+				return 0, false
+			}
+			s1 = s1*10 + d
+			hCnt++
+		} else if c == 'M' {
+			if mCnt >= n {
+				return 0, false
+			}
+			s2 = s2*10 + d
+			mCnt++
+		} else {
+			return 0, false
+		}
+	}
+	if hCnt != n || mCnt != n {
+		return 0, false
+	}
+	return s1 + s2, true
+}
+
+func runCaseE(bin string, tc testCaseE) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for _, d := range tc.digits {
+		sb.WriteByte(byte('0' + d))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	order := strings.TrimSpace(out.String())
+	got, ok := totalForOrder(order, tc.digits, tc.n)
+	if !ok {
+		return fmt.Errorf("invalid output format")
+	}
+	if got != maxTotal(tc.digits, tc.n) {
+		return fmt.Errorf("output does not achieve maximum")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseE(rng)
+		if err := runCaseE(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifier programs for contest 31 problems A–E
- verifiers generate 100 random tests each and check a binary's output

## Testing
- `go build 0-999/0-99/30-39/31/verifierA.go`
- `go build 0-999/0-99/30-39/31/verifierB.go`
- `go build 0-999/0-99/30-39/31/verifierC.go`
- `go build 0-999/0-99/30-39/31/verifierD.go`
- `go build 0-999/0-99/30-39/31/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e60bb68f8832497c49300dba00b21