### PR TITLE
Add solution verifiers for contest 33

### DIFF
--- a/0-999/0-99/30-39/33/verifierA.go
+++ b/0-999/0-99/30-39/33/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n, m int
+	var k int64
+	if _, err := fmt.Fscan(reader, &n, &m, &k); err != nil {
+		return ""
+	}
+	caps := make([]int64, m+1)
+	const inf = int64(1) << 60
+	for i := 1; i <= m; i++ {
+		caps[i] = inf
+	}
+	for i := 0; i < n; i++ {
+		var r int
+		var c int64
+		fmt.Fscan(reader, &r, &c)
+		if c < caps[r] {
+			caps[r] = c
+		}
+	}
+	var total int64
+	for i := 1; i <= m; i++ {
+		total += caps[i]
+	}
+	if total > k {
+		total = k
+	}
+	return fmt.Sprintf("%d\n", total)
+}
+
+func genTestA() (string, string) {
+	m := rand.Intn(5) + 1
+	n := m + rand.Intn(5)
+	k := rand.Int63n(100)
+	type tooth struct {
+		r int
+		c int64
+	}
+	teeth := make([]tooth, n)
+	for i := 0; i < m; i++ {
+		teeth[i].r = i + 1
+		teeth[i].c = rand.Int63n(20)
+	}
+	for i := m; i < n; i++ {
+		teeth[i].r = rand.Intn(m) + 1
+		teeth[i].c = rand.Int63n(20)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", teeth[i].r, teeth[i].c)
+	}
+	input := sb.String()
+	out := solveA(input)
+	return input, out
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genTestA()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%s\nOutput:\n%s\n", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/33/verifierB.go
+++ b/0-999/0-99/30-39/33/verifierB.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const infB = 1000000000
+
+func solveB(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	sLine, _ := reader.ReadString('\n')
+	tLine, _ := reader.ReadString('\n')
+	s := strings.TrimSpace(sLine)
+	t := strings.TrimSpace(tLine)
+	if len(s) != len(t) {
+		return "-1\n"
+	}
+	var n int
+	fmt.Fscan(reader, &n)
+	d := make([][]int, 26)
+	for i := 0; i < 26; i++ {
+		d[i] = make([]int, 26)
+		for j := 0; j < 26; j++ {
+			if i == j {
+				d[i][j] = 0
+			} else {
+				d[i][j] = infB
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		var uStr, vStr string
+		var l int
+		fmt.Fscan(reader, &uStr, &vStr, &l)
+		u := int(uStr[0] - 'a')
+		v := int(vStr[0] - 'a')
+		if l < d[u][v] {
+			d[u][v] = l
+		}
+	}
+	for k := 0; k < 26; k++ {
+		for i := 0; i < 26; i++ {
+			for j := 0; j < 26; j++ {
+				if d[i][k] < infB && d[k][j] < infB {
+					if d[i][j] > d[i][k]+d[k][j] {
+						d[i][j] = d[i][k] + d[k][j]
+					}
+				}
+			}
+		}
+	}
+	m := len(s)
+	result := make([]byte, m)
+	ans := 0
+	for i := 0; i < m; i++ {
+		si := int(s[i] - 'a')
+		ti := int(t[i] - 'a')
+		if d[si][ti] > d[ti][si] {
+			si, ti = ti, si
+		}
+		best := d[si][ti]
+		for j := 0; j < 26; j++ {
+			if d[si][j] < infB && d[ti][j] < infB {
+				if d[si][j]+d[ti][j] < best {
+					best = d[si][j] + d[ti][j]
+				}
+			}
+		}
+		if best >= infB {
+			return "-1\n"
+		}
+		c := ti
+		if best != d[si][ti] {
+			for j := 0; j < 26; j++ {
+				if d[si][j] < infB && d[ti][j] < infB && d[si][j]+d[ti][j] == best {
+					c = j
+					break
+				}
+			}
+		}
+		result[i] = byte('a' + c)
+		ans += best
+	}
+	return fmt.Sprintf("%d\n%s\n", ans, string(result))
+}
+
+func genTestB() (string, string) {
+	l := rand.Intn(5) + 1
+	letters := []rune("abcdef")
+	var s, t strings.Builder
+	for i := 0; i < l; i++ {
+		s.WriteRune(letters[rand.Intn(len(letters))])
+		t.WriteRune(letters[rand.Intn(len(letters))])
+	}
+	n := rand.Intn(5)
+	var sb strings.Builder
+	sb.WriteString(s.String() + "\n")
+	sb.WriteString(t.String() + "\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		a := letters[rand.Intn(len(letters))]
+		b := letters[rand.Intn(len(letters))]
+		w := rand.Intn(5) + 1
+		fmt.Fprintf(&sb, "%c %c %d\n", a, b, w)
+	}
+	input := sb.String()
+	out := solveB(input)
+	return input, out
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genTestB()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:\n%s\nOutput:\n%s\n", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/33/verifierC.go
+++ b/0-999/0-99/30-39/33/verifierC.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	P := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		P[i] = P[i-1] + a[i]
+	}
+	minP := make([]int64, n+1)
+	minP[0] = P[0]
+	for i := 1; i <= n; i++ {
+		if P[i] < minP[i-1] {
+			minP[i] = P[i]
+		} else {
+			minP[i] = minP[i-1]
+		}
+	}
+	Suf := make([]int64, n+2)
+	for i := n; i >= 1; i-- {
+		Suf[i] = Suf[i+1] + a[i]
+	}
+	total := P[n]
+	const INF int64 = 1<<63 - 1
+	tcost := INF
+	for j := 1; j <= n+1; j++ {
+		cost := minP[j-1] + Suf[j]
+		if cost < tcost {
+			tcost = cost
+		}
+	}
+	for i := 1; i <= n; i++ {
+		cost := minP[i-1] + Suf[i+1]
+		if cost < tcost {
+			tcost = cost
+		}
+	}
+	ans := total - 2*tcost
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func genTestC() (string, string) {
+	n := rand.Intn(8) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		v := rand.Intn(21) - 10
+		fmt.Fprintf(&sb, "%d ", v)
+	}
+	sb.WriteString("\n")
+	in := sb.String()
+	out := solveC(in)
+	return in, out
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genTestC()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:\n%s\nOutput:\n%s\n", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/33/verifierD.go
+++ b/0-999/0-99/30-39/33/verifierD.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n, m, k int
+	fmt.Fscan(reader, &n, &m, &k)
+	xs := make([]int64, n)
+	ys := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &xs[i], &ys[i])
+	}
+	rs := make([]int64, m)
+	cx := make([]int64, m)
+	cy := make([]int64, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(reader, &rs[i], &cx[i], &cy[i])
+	}
+	wlen := (m + 63) / 64
+	bs := make([][]uint64, n)
+	for i := 0; i < n; i++ {
+		b := make([]uint64, wlen)
+		xi, yi := xs[i], ys[i]
+		for j := 0; j < m; j++ {
+			dx := xi - cx[j]
+			dy := yi - cy[j]
+			if dx*dx+dy*dy < rs[j]*rs[j] {
+				idx := j >> 6
+				off := uint(j & 63)
+				b[idx] |= 1 << off
+			}
+		}
+		bs[i] = b
+	}
+	var sb strings.Builder
+	for qi := 0; qi < k; qi++ {
+		var a, b int
+		fmt.Fscan(reader, &a, &b)
+		a--
+		b--
+		cnt := 0
+		ba, bb := bs[a], bs[b]
+		for i := 0; i < wlen; i++ {
+			cnt += bits.OnesCount64(ba[i] ^ bb[i])
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", cnt))
+	}
+	return sb.String()
+}
+
+func genTestD() (string, string) {
+	n := rand.Intn(3) + 1
+	m := rand.Intn(3) + 1
+	k := rand.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < n; i++ {
+		x := rand.Intn(11) - 5
+		y := rand.Intn(11) - 5
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	for i := 0; i < m; i++ {
+		r := rand.Intn(5) + 1
+		x := rand.Intn(11) - 5
+		y := rand.Intn(11) - 5
+		fmt.Fprintf(&sb, "%d %d %d\n", r, x, y)
+	}
+	for i := 0; i < k; i++ {
+		a := rand.Intn(n) + 1
+		b := rand.Intn(n) + 1
+		fmt.Fprintf(&sb, "%d %d\n", a, b)
+	}
+	in := sb.String()
+	out := solveD(in)
+	return in, out
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genTestD()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:\n%s\nOutput:\n%s\n", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/33/verifierE.go
+++ b/0-999/0-99/30-39/33/verifierE.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func parseHM(s string) int {
+	parts := strings.Split(s, ":")
+	h, _ := strconv.Atoi(parts[0])
+	m, _ := strconv.Atoi(parts[1])
+	return h*60 + m
+}
+
+func solveE(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var m, n, k int
+	fmt.Fscan(reader, &m, &n, &k)
+	subj := make([]string, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(reader, &subj[i])
+	}
+	tsolve := make(map[string]int)
+	times := make([]int, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(reader, &times[i])
+		tsolve[subj[i]] = times[i]
+	}
+	type seg struct{ start, end, idx int }
+	breaks := make([]seg, 4)
+	for i := 0; i < 4; i++ {
+		var s string
+		fmt.Fscan(reader, &s)
+		parts := strings.Split(s, "-")
+		st := parseHM(parts[0])
+		en := parseHM(parts[1])
+		breaks[i] = seg{st, en, i + 1}
+	}
+	totalMin := k * 1440
+	workTimes := make([]int, 0, totalMin)
+	fb := make([]bool, 1440)
+	for _, b := range breaks {
+		for t := b.start; t <= b.end; t++ {
+			fb[t] = true
+		}
+	}
+	for d := 0; d < k; d++ {
+		base := d * 1440
+		for t := 0; t < 1440; t++ {
+			if !fb[t] {
+				workTimes = append(workTimes, base+t)
+			}
+		}
+	}
+	capMax := len(workTimes)
+	type job struct{ p, c, cap, idx int }
+	jobs := make([]job, 0, n)
+	for i := 0; i < n; i++ {
+		var ssub, tstr string
+		var di, ci int
+		fmt.Fscan(reader, &ssub, &di, &tstr, &ci)
+		p, ok := tsolve[ssub]
+		if !ok {
+			continue
+		}
+		dd := parseHM(tstr)
+		deadline := (di-1)*1440 + dd
+		lo, hi := 0, len(workTimes)
+		for lo < hi {
+			mid := (lo + hi) / 2
+			if workTimes[mid] < deadline {
+				lo = mid + 1
+			} else {
+				hi = mid
+			}
+		}
+		cap := lo
+		jobs = append(jobs, job{p: p, c: ci, cap: cap, idx: i + 1})
+	}
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].cap < jobs[j].cap })
+	negInf := -1 << 60
+	dp := make([]int, capMax+1)
+	for i := 1; i <= capMax; i++ {
+		dp[i] = negInf
+	}
+	picks := make([][]bool, len(jobs))
+	for i := range picks {
+		picks[i] = make([]bool, capMax+1)
+	}
+	curCap := capMax
+	for i, jb := range jobs {
+		for t := jb.cap + 1; t <= curCap; t++ {
+			dp[t] = negInf
+		}
+		for t := jb.cap; t >= jb.p; t-- {
+			if dp[t-jb.p]+jb.c > dp[t] {
+				dp[t] = dp[t-jb.p] + jb.c
+				picks[i][t] = true
+			}
+		}
+		curCap = jb.cap
+	}
+	bestProfit := 0
+	bestT := 0
+	for t := 0; t <= curCap; t++ {
+		if dp[t] > bestProfit {
+			bestProfit = dp[t]
+			bestT = t
+		}
+	}
+	sel := make([]job, 0)
+	t := bestT
+	for i := len(jobs) - 1; i >= 0; i-- {
+		if t >= 0 && picks[i][t] {
+			sel = append(sel, jobs[i])
+			t -= jobs[i].p
+		}
+	}
+	for i, j := 0, len(sel)-1; i < j; i, j = i+1, j-1 {
+		sel[i], sel[j] = sel[j], sel[i]
+	}
+	sort.Slice(breaks, func(i, j int) bool { return breaks[i].end < breaks[j].end })
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", bestProfit))
+	sb.WriteString(fmt.Sprintf("%d\n", len(sel)))
+	offset := 0
+	for _, jb := range sel {
+		startG := workTimes[offset]
+		finishG := workTimes[offset+jb.p-1]
+		offset += jb.p
+		minuteInDay := startG % 1440
+		ti := 4
+		prev := -1
+		for _, b := range breaks {
+			if b.end < minuteInDay && b.end > prev {
+				ti = b.idx
+				prev = b.end
+			}
+		}
+		h0 := minuteInDay / 60
+		m0 := minuteInDay % 60
+		finDay := finishG/1440 + 1
+		finMin := finishG % 1440
+		h1 := finMin / 60
+		m1 := finMin % 60
+		sb.WriteString(fmt.Sprintf("%d %d %02d:%02d %d %02d:%02d\n", jb.idx, ti, h0, m0, finDay, h1, m1))
+	}
+	return sb.String()
+}
+
+func genTestE() (string, string) {
+	m := 2
+	n := 2 + rand.Intn(2)
+	k := 1
+	subjects := []string{"math", "prog"}
+	times := []int{rand.Intn(3) + 1, rand.Intn(3) + 1}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", m, n, k)
+	fmt.Fprintf(&sb, "%s\n%s\n", subjects[0], subjects[1])
+	fmt.Fprintf(&sb, "%d %d\n", times[0], times[1])
+	sb.WriteString("00:00-00:10\n01:00-01:10\n02:00-02:10\n03:00-03:10\n")
+	for i := 0; i < n; i++ {
+		subj := subjects[rand.Intn(len(subjects))]
+		day := 1
+		exTime := fmt.Sprintf("0%d:30", 4+i)
+		cost := rand.Intn(10) + 1
+		fmt.Fprintf(&sb, "%s %d %s %d\n", subj, day, exTime, cost)
+	}
+	in := sb.String()
+	out := solveE(in)
+	return in, out
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genTestE()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:\n%s\nOutput:\n%s\n", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–E of contest 33
- each verifier randomly generates 100 test cases and checks a user provided binary
- includes reference implementations of the correct logic for comparison

## Testing
- `go build 0-999/0-99/30-39/33/verifierA.go`
- `go build 0-999/0-99/30-39/33/verifierB.go`
- `go build 0-999/0-99/30-39/33/verifierC.go`
- `go build 0-999/0-99/30-39/33/verifierD.go`
- `go build 0-999/0-99/30-39/33/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e60c57e7c8324bed4cc4d363c4ba2