### PR TITLE
Add Go verifiers for contest 34

### DIFF
--- a/0-999/0-99/30-39/34/verifierA.go
+++ b/0-999/0-99/30-39/34/verifierA.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func generateCase() string {
+	n := rand.Intn(99) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(1000)+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func expected(in string) string {
+	scanner := bufio.NewScanner(strings.NewReader(in))
+	scanner.Split(bufio.ScanWords)
+	var n int
+	scanner.Scan()
+	fmt.Sscan(scanner.Text(), &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		scanner.Scan()
+		fmt.Sscan(scanner.Text(), &a[i])
+	}
+	minDiff := abs(a[n-1] - a[0])
+	ans1, ans2 := n, 1
+	for i := 1; i < n; i++ {
+		d := abs(a[i] - a[i-1])
+		if d < minDiff {
+			minDiff = d
+			ans1 = i
+			ans2 = i + 1
+		}
+	}
+	return fmt.Sprintf("%d %d", ans1, ans2)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := generateCase()
+		exp := expected(tc)
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: error executing binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/34/verifierB.go
+++ b/0-999/0-99/30-39/34/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func generateCase() string {
+	n := rand.Intn(100) + 1
+	m := rand.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(2001)-1000))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func expected(in string) string {
+	scanner := bufio.NewScanner(strings.NewReader(in))
+	scanner.Split(bufio.ScanWords)
+	var n, m int
+	scanner.Scan()
+	fmt.Sscan(scanner.Text(), &n)
+	scanner.Scan()
+	fmt.Sscan(scanner.Text(), &m)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		scanner.Scan()
+		fmt.Sscan(scanner.Text(), &a[i])
+	}
+	sort.Ints(a)
+	res := 0
+	for i := 0; i < n && i < m; i++ {
+		if a[i] < 0 {
+			res += -a[i]
+		} else {
+			break
+		}
+	}
+	return fmt.Sprintf("%d", res)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := generateCase()
+		exp := expected(tc)
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: error executing binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/34/verifierC.go
+++ b/0-999/0-99/30-39/34/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase() string {
+	length := rand.Intn(100) + 1
+	var nums []string
+	for i := 0; i < length; i++ {
+		nums = append(nums, fmt.Sprintf("%d", rand.Intn(1000)+1))
+		if rand.Intn(3) == 0 { // duplicate sometimes
+			nums = append(nums, nums[len(nums)-1])
+		}
+	}
+	return strings.Join(nums, ",")
+}
+
+func expected(in string) string {
+	parts := strings.Split(in, ",")
+	seen := make(map[int]bool)
+	var nums []int
+	for _, p := range parts {
+		v, _ := strconv.Atoi(p)
+		if !seen[v] {
+			seen[v] = true
+			nums = append(nums, v)
+		}
+	}
+	if len(nums) == 0 {
+		return ""
+	}
+	var ranges []string
+	start := nums[0]
+	prev := nums[0]
+	for i := 1; i < len(nums); i++ {
+		v := nums[i]
+		if v == prev+1 {
+			prev = v
+			continue
+		}
+		if start == prev {
+			ranges = append(ranges, fmt.Sprintf("%d", start))
+		} else {
+			ranges = append(ranges, fmt.Sprintf("%d-%d", start, prev))
+		}
+		start = v
+		prev = v
+	}
+	if start == prev {
+		ranges = append(ranges, fmt.Sprintf("%d", start))
+	} else {
+		ranges = append(ranges, fmt.Sprintf("%d-%d", start, prev))
+	}
+	return strings.Join(ranges, ",")
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := generateCase()
+		exp := expected(tc)
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: error executing binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("case %d failed\ninput:%s\nexpected:%s\ngot:%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/34/verifierD.go
+++ b/0-999/0-99/30-39/34/verifierD.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type queue []int
+
+func (q *queue) push(x int)  { *q = append(*q, x) }
+func (q *queue) pop() int    { v := (*q)[0]; *q = (*q)[1:]; return v }
+func (q *queue) empty() bool { return len(*q) == 0 }
+
+func generateCase() string {
+	n := rand.Intn(50) + 2
+	r1 := rand.Intn(n) + 1
+	r2 := rand.Intn(n-1) + 1
+	if r2 >= r1 {
+		r2++
+	}
+	parent := make([]int, n+1)
+	processed := []int{r1}
+	for i := 1; i <= n; i++ {
+		if i == r1 {
+			continue
+		}
+		p := processed[rand.Intn(len(processed))]
+		parent[i] = p
+		processed = append(processed, i)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, r1, r2))
+	first := true
+	for i := 1; i <= n; i++ {
+		if i == r1 {
+			continue
+		}
+		if !first {
+			sb.WriteByte(' ')
+		} else {
+			first = false
+		}
+		sb.WriteString(fmt.Sprintf("%d", parent[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func expected(in string) string {
+	scanner := bufio.NewScanner(strings.NewReader(in))
+	scanner.Split(bufio.ScanWords)
+	var n, r1, r2 int
+	scanner.Scan()
+	fmt.Sscan(scanner.Text(), &n)
+	scanner.Scan()
+	fmt.Sscan(scanner.Text(), &r1)
+	scanner.Scan()
+	fmt.Sscan(scanner.Text(), &r2)
+	parent := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		if i == r1 {
+			continue
+		}
+		scanner.Scan()
+		fmt.Sscan(scanner.Text(), &parent[i])
+	}
+	adj := make([][]int, n+1)
+	for i := 1; i <= n; i++ {
+		if i == r1 {
+			continue
+		}
+		p := parent[i]
+		adj[i] = append(adj[i], p)
+		adj[p] = append(adj[p], i)
+	}
+	resParent := make([]int, n+1)
+	visited := make([]bool, n+1)
+	q := queue{r2}
+	visited[r2] = true
+	for !q.empty() {
+		u := q.pop()
+		for _, v := range adj[u] {
+			if !visited[v] {
+				visited[v] = true
+				resParent[v] = u
+				q.push(v)
+			}
+		}
+	}
+	var sb strings.Builder
+	first := true
+	for i := 1; i <= n; i++ {
+		if i == r2 {
+			continue
+		}
+		if !first {
+			sb.WriteByte(' ')
+		} else {
+			first = false
+		}
+		sb.WriteString(fmt.Sprintf("%d", resParent[i]))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := generateCase()
+		exp := expected(tc)
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: error executing binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/34/verifierE.go
+++ b/0-999/0-99/30-39/34/verifierE.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	errorTol = 1e-4
+	infinite = 1e9
+)
+
+func calTime(x, v []float64, i, j int) float64 {
+	if math.Abs(v[i]-v[j]) > errorTol && math.Abs(x[j]-x[i]) > errorTol && (v[i]-v[j])*(x[j]-x[i]) > 0 {
+		return (x[j] - x[i]) / (v[i] - v[j])
+	}
+	return infinite
+}
+
+func collide(v []float64, m []int, i, j int) {
+	v1, v2 := v[i], v[j]
+	m1, m2 := float64(m[i]), float64(m[j])
+	v[i] = ((m1-m2)*v1 + 2*m2*v2) / (m1 + m2)
+	v[j] = ((m2-m1)*v2 + 2*m1*v1) / (m1 + m2)
+}
+
+func passTime(x, v []float64, t float64) {
+	for i := range x {
+		x[i] += v[i] * t
+	}
+}
+
+func solve(in string) string {
+	scanner := bufio.NewScanner(strings.NewReader(in))
+	scanner.Split(bufio.ScanWords)
+	var n int
+	var T float64
+	scanner.Scan()
+	fmt.Sscan(scanner.Text(), &n)
+	scanner.Scan()
+	fmt.Sscan(scanner.Text(), &T)
+	x := make([]float64, n)
+	v := make([]float64, n)
+	m := make([]int, n)
+	for i := 0; i < n; i++ {
+		scanner.Scan()
+		fmt.Sscan(scanner.Text(), &x[i])
+		scanner.Scan()
+		fmt.Sscan(scanner.Text(), &v[i])
+		scanner.Scan()
+		fmt.Sscan(scanner.Text(), &m[i])
+	}
+	for T > 0 {
+		colTime := infinite
+		for i := 0; i < n; i++ {
+			for j := i + 1; j < n; j++ {
+				t := calTime(x, v, i, j)
+				if t < colTime && t < T {
+					colTime = t
+				}
+			}
+		}
+		if colTime == infinite {
+			passTime(x, v, T)
+			break
+		}
+		passTime(x, v, colTime)
+		for i := 0; i < n; i++ {
+			for j := i + 1; j < n; j++ {
+				if math.Abs(x[i]-x[j]) < errorTol {
+					collide(v, m, i, j)
+				}
+			}
+		}
+		T -= colTime
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%.6f\n", x[i]))
+	}
+	sb.WriteByte('\n')
+	return strings.TrimSpace(sb.String())
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase() string {
+	n := rand.Intn(5) + 1
+	T := rand.Float64() * 100
+	coords := map[int]bool{}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %.6f\n", n, T))
+	for i := 0; i < n; i++ {
+		var x int
+		for {
+			x = rand.Intn(201) - 100
+			if !coords[x] {
+				coords[x] = true
+				break
+			}
+		}
+		v := rand.Intn(200) + 1
+		if rand.Intn(2) == 0 {
+			v = -v
+		}
+		m := rand.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", x, v, m))
+	}
+	return sb.String()
+}
+
+func compareFloats(a, b string) bool {
+	sa := strings.Fields(a)
+	sb := strings.Fields(b)
+	if len(sa) != len(sb) {
+		return false
+	}
+	for i := 0; i < len(sa); i++ {
+		fa, _ := strconv.ParseFloat(sa[i], 64)
+		fb, _ := strconv.ParseFloat(sb[i], 64)
+		if math.Abs(fa-fb) > 1e-3 {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := generateCase()
+		exp := solve(tc)
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: error executing binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !compareFloats(got, exp) {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verification tools for contest 34 problems A–E
- verifiers generate 100 random test cases and compare outputs against reference implementations

## Testing
- `go run verifierA.go ./34A_bin` *(fails as solution incorrect)*
- `go run verifierB.go ./34B_bin`
- `go run verifierC.go ./34C_bin`
- `go run verifierD.go ./34D_bin`
- `go run verifierE.go ./34E_bin`

------
https://chatgpt.com/codex/tasks/task_e_687e60ca3aa883249f96d2fc3f610038