### PR TITLE
Add verifiers for Codeforces contest 38

### DIFF
--- a/0-999/0-99/30-39/38/verifierA.go
+++ b/0-999/0-99/30-39/38/verifierA.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n int, d []int, a, b int) int {
+	sum := 0
+	for i := a; i < b; i++ {
+		sum += d[i]
+	}
+	return sum
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(99) + 2 // 2..100
+	d := make([]int, n)
+	for i := 1; i < n; i++ {
+		d[i] = rng.Intn(100) + 1
+	}
+	a := rng.Intn(n-1) + 1
+	b := rng.Intn(n-a) + a + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i < n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", d[i]))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	expected := fmt.Sprintf("%d", solveCase(n, d, a, b))
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/38/verifierB.go
+++ b/0-999/0-99/30-39/38/verifierB.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isKnight(x1, y1, x2, y2 int) bool {
+	dx := x1 - x2
+	if dx < 0 {
+		dx = -dx
+	}
+	dy := y1 - y2
+	if dy < 0 {
+		dy = -dy
+	}
+	return (dx == 1 && dy == 2) || (dx == 2 && dy == 1)
+}
+
+func posToStr(x, y int) string {
+	return fmt.Sprintf("%c%d", 'a'+x-1, y)
+}
+
+func solveCase(rX, rY, kX, kY int) int {
+	count := 0
+	for x := 1; x <= 8; x++ {
+		for y := 1; y <= 8; y++ {
+			if x == rX && y == rY {
+				continue
+			}
+			if x == kX && y == kY {
+				continue
+			}
+			if x == rX || y == rY {
+				continue
+			}
+			if isKnight(rX, rY, x, y) {
+				continue
+			}
+			if isKnight(kX, kY, x, y) {
+				continue
+			}
+			count++
+		}
+	}
+	return count
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	for {
+		rX := rng.Intn(8) + 1
+		rY := rng.Intn(8) + 1
+		kX := rng.Intn(8) + 1
+		kY := rng.Intn(8) + 1
+		if rX == kX && rY == kY {
+			continue
+		}
+		if rX == kX || rY == kY {
+			continue
+		}
+		if isKnight(rX, rY, kX, kY) {
+			continue
+		}
+		input := posToStr(rX, rY) + "\n" + posToStr(kX, kY) + "\n"
+		exp := fmt.Sprintf("%d", solveCase(rX, rY, kX, kY))
+		return input, exp
+	}
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/38/verifierC.go
+++ b/0-999/0-99/30-39/38/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n, l int, a []int) int {
+	maxArea := 0
+	maxA := 0
+	for _, v := range a {
+		if v > maxA {
+			maxA = v
+		}
+	}
+	for d := l; d <= maxA; d++ {
+		total := 0
+		for _, v := range a {
+			total += v / d
+		}
+		area := total * d
+		if area > maxArea {
+			maxArea = area
+		}
+	}
+	return maxArea
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	l := rng.Intn(10) + 1
+	a := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, l))
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(50) + 1
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	expected := fmt.Sprintf("%d", solveCase(n, l, a))
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/38/verifierD.go
+++ b/0-999/0-99/30-39/38/verifierD.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n int, x1, y1, x2, y2 []float64) int {
+	minX := make([]float64, n+1)
+	maxX := make([]float64, n+1)
+	minY := make([]float64, n+1)
+	maxY := make([]float64, n+1)
+	cx := make([]float64, n+1)
+	cy := make([]float64, n+1)
+	w := make([]float64, n+1)
+	for i := 1; i <= n; i++ {
+		minX[i] = math.Min(x1[i], x2[i])
+		maxX[i] = math.Max(x1[i], x2[i])
+		minY[i] = math.Min(y1[i], y2[i])
+		maxY[i] = math.Max(y1[i], y2[i])
+		cx[i] = (x1[i] + x2[i]) / 2.0
+		cy[i] = (y1[i] + y2[i]) / 2.0
+		a := maxX[i] - minX[i]
+		w[i] = a * a * a
+	}
+	const eps = 1e-9
+	for k := 2; k <= n; k++ {
+		for i := k; i >= 2; i-- {
+			var sumW, sumX, sumY float64
+			for j := i; j <= k; j++ {
+				sumW += w[j]
+				sumX += w[j] * cx[j]
+				sumY += w[j] * cy[j]
+			}
+			cmX := sumX / sumW
+			cmY := sumY / sumW
+			sx := math.Max(minX[i-1], minX[i])
+			tx := math.Min(maxX[i-1], maxX[i])
+			sy := math.Max(minY[i-1], minY[i])
+			ty := math.Min(maxY[i-1], maxY[i])
+			if cmX < sx-eps || cmX > tx+eps || cmY < sy-eps || cmY > ty+eps {
+				return k - 1
+			}
+		}
+	}
+	return n
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	x1 := make([]float64, n+1)
+	y1 := make([]float64, n+1)
+	x2 := make([]float64, n+1)
+	y2 := make([]float64, n+1)
+	// base brick
+	size := float64(rng.Intn(4) + 2)
+	x1[1] = 0
+	y1[1] = 0
+	x2[1] = size
+	y2[1] = size
+	for i := 2; i <= n; i++ {
+		s := float64(rng.Intn(4) + 1)
+		px := x1[i-1] + rng.Float64()*(x2[i-1]-x1[i-1])
+		py := y1[i-1] + rng.Float64()*(y2[i-1]-y1[i-1])
+		x1[i] = px - rng.Float64()*s
+		y1[i] = py - rng.Float64()*s
+		x2[i] = x1[i] + s
+		y2[i] = y1[i] + s
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", int(x1[i]), int(y1[i]), int(x2[i]), int(y2[i])))
+	}
+	ans := solveCase(n, x1, y1, x2, y2)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/38/verifierE.go
+++ b/0-999/0-99/30-39/38/verifierE.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveCase(xVals, cVals []int64) int64 {
+	n := len(xVals) - 1
+	prefixX := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		prefixX[i] = prefixX[i-1] + xVals[i]
+	}
+	const INF = int64(9e18)
+	dp := make([]int64, n+1)
+	dp[1] = cVals[1]
+	for i := 2; i <= n; i++ {
+		best := INF
+		for p := 1; p <= i-1; p++ {
+			moveCost := (prefixX[i-1] - prefixX[p]) - int64(i-1-p)*xVals[p]
+			if dp[p]+moveCost < best {
+				best = dp[p] + moveCost
+			}
+		}
+		dp[i] = best + cVals[i]
+	}
+	ans := INF
+	for i := 1; i <= n; i++ {
+		tailCost := (prefixX[n] - prefixX[i]) - int64(n-i)*xVals[i]
+		if dp[i]+tailCost < ans {
+			ans = dp[i] + tailCost
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	arr := make([]struct{ x, c int64 }, n)
+	cur := int64(rng.Intn(10))
+	for i := 0; i < n; i++ {
+		cur += int64(rng.Intn(10) + 1)
+		arr[i].x = cur
+		arr[i].c = int64(rng.Intn(20) + 1)
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i].x < arr[j].x })
+	x := make([]int64, n+1)
+	c := make([]int64, n+1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		x[i] = arr[i-1].x
+		c[i] = arr[i-1].c
+		sb.WriteString(fmt.Sprintf("%d %d\n", x[i], c[i]))
+	}
+	ans := solveCase(x, c)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/38/verifierF.go
+++ b/0-999/0-99/30-39/38/verifierF.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type result struct {
+	win      bool
+	own, opp int64
+}
+
+func better(a, b result) bool {
+	if a.win != b.win {
+		return a.win && !b.win
+	}
+	if a.own != b.own {
+		return a.own > b.own
+	}
+	return a.opp < b.opp
+}
+
+func solveCase(words []string) (string, string) {
+	subMap := make(map[string]int)
+	num := make([]int64, 0)
+	for _, w := range words {
+		seen := make(map[string]bool)
+		L := len(w)
+		for l := 0; l < L; l++ {
+			for r := l + 1; r <= L; r++ {
+				s := w[l:r]
+				if !seen[s] {
+					seen[s] = true
+					if id, ok := subMap[s]; ok {
+						num[id]++
+					} else {
+						id = len(num)
+						subMap[s] = id
+						num = append(num, 1)
+					}
+				}
+			}
+		}
+	}
+	m := len(num)
+	subs := make([]string, m)
+	for s, id := range subMap {
+		subs[id] = s
+	}
+	weight := make([]int64, m)
+	maxLen := 0
+	buckets := make(map[int][]int)
+	for id, s := range subs {
+		sum := int64(0)
+		for i := 0; i < len(s); i++ {
+			sum += int64(s[i] - 'a' + 1)
+		}
+		weight[id] = sum * num[id]
+		L := len(s)
+		if L > maxLen {
+			maxLen = L
+		}
+		buckets[L] = append(buckets[L], id)
+	}
+	nexts := make([][]int, m)
+	for id, s := range subs {
+		for c := byte('a'); c <= 'z'; c++ {
+			t1 := string(c) + s
+			if j, ok := subMap[t1]; ok {
+				nexts[id] = append(nexts[id], j)
+			}
+			t2 := s + string(c)
+			if j, ok := subMap[t2]; ok {
+				nexts[id] = append(nexts[id], j)
+			}
+		}
+	}
+	dp := make([]result, m)
+	for L := maxLen; L >= 1; L-- {
+		for _, id := range buckets[L] {
+			bestSet := false
+			var best result
+			for _, j := range nexts[id] {
+				child := dp[j]
+				w := weight[j]
+				res := result{win: !child.win, own: w + child.opp, opp: child.own}
+				if !bestSet || better(res, best) {
+					bestSet = true
+					best = res
+				}
+			}
+			if bestSet {
+				dp[id] = best
+			} else {
+				dp[id] = result{win: false, own: 0, opp: 0}
+			}
+		}
+	}
+	var initSet bool
+	var initRes result
+	for _, id := range buckets[1] {
+		child := dp[id]
+		w := weight[id]
+		res := result{win: !child.win, own: w + child.opp, opp: child.own}
+		if !initSet || better(res, initRes) {
+			initSet = true
+			initRes = res
+		}
+	}
+	if initRes.win {
+		return "First", fmt.Sprintf("%d %d", initRes.own, initRes.opp)
+	}
+	return "Second", fmt.Sprintf("%d %d", initRes.own, initRes.opp)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	words := make([]string, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(3) + 1
+		b := make([]byte, l)
+		for j := range b {
+			b[j] = byte('a' + rng.Intn(3))
+		}
+		words[i] = string(b)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(words[i])
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	if n > 0 {
+		sb.WriteByte('\n')
+	}
+	w, res := solveCase(words)
+	return sb.String(), w + "\n" + res
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/38/verifierG.go
+++ b/0-999/0-99/30-39/38/verifierG.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Node struct {
+	imp, id, prio, sz, maxImp int
+	left, right               *Node
+}
+
+func sz(n *Node) int {
+	if n == nil {
+		return 0
+	}
+	return n.sz
+}
+
+func upd(n *Node) {
+	if n == nil {
+		return
+	}
+	n.sz = 1 + sz(n.left) + sz(n.right)
+	n.maxImp = n.imp
+	if n.left != nil && n.left.maxImp > n.maxImp {
+		n.maxImp = n.left.maxImp
+	}
+	if n.right != nil && n.right.maxImp > n.maxImp {
+		n.maxImp = n.right.maxImp
+	}
+}
+
+func merge(l, r *Node) *Node {
+	if l == nil {
+		return r
+	}
+	if r == nil {
+		return l
+	}
+	if l.prio > r.prio {
+		l.right = merge(l.right, r)
+		upd(l)
+		return l
+	}
+	r.left = merge(l, r.left)
+	upd(r)
+	return r
+}
+
+func split(t *Node, k int) (l, r *Node) {
+	if t == nil {
+		return nil, nil
+	}
+	if sz(t.left) >= k {
+		l0, r0 := split(t.left, k)
+		t.left = r0
+		upd(t)
+		return l0, t
+	}
+	l0, r0 := split(t.right, k-sz(t.left)-1)
+	t.right = l0
+	upd(t)
+	return t, r0
+}
+
+func findLastGE(n *Node, value int) int {
+	if n == nil || n.maxImp < value {
+		return 0
+	}
+	if n.right != nil && n.right.maxImp >= value {
+		idx := findLastGE(n.right, value)
+		if idx > 0 {
+			return sz(n.left) + 1 + idx
+		}
+	}
+	if n.imp >= value {
+		return sz(n.left) + 1
+	}
+	return findLastGE(n.left, value)
+}
+
+func solveCase(a, c []int) string {
+	n := len(a)
+	var root *Node
+	for i := 0; i < n; i++ {
+		imp := a[i]
+		cnt := c[i]
+		cur := sz(root)
+		lo := 1
+		if cur+1-cnt > 1 {
+			lo = cur + 1 - cnt
+		}
+		left, right := split(root, lo-1)
+		posInRight := findLastGE(right, imp)
+		var pos int
+		if posInRight > 0 {
+			pos = (lo - 1) + posInRight
+		} else {
+			pos = 0
+		}
+		p := lo
+		if pos+1 > lo {
+			p = pos + 1
+		}
+		root = merge(left, right)
+		l2, r2 := split(root, p-1)
+		node := &Node{imp: imp, id: i + 1, prio: rand.Int(), sz: 1, maxImp: imp}
+		root = merge(merge(l2, node), r2)
+	}
+	var out strings.Builder
+	var dfs func(n *Node)
+	dfs = func(n *Node) {
+		if n == nil {
+			return
+		}
+		dfs(n.left)
+		out.WriteString(fmt.Sprintf("%d ", n.id))
+		dfs(n.right)
+	}
+	dfs(root)
+	return strings.TrimSpace(out.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	perm := rng.Perm(n)
+	a := make([]int, n)
+	for i, v := range perm {
+		a[i] = v + 1
+	}
+	cVals := make([]int, n)
+	for i := 0; i < n; i++ {
+		cVals[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", a[i], cVals[i]))
+	}
+	exp := solveCase(a, cVals)
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/38/verifierH.go
+++ b/0-999/0-99/30-39/38/verifierH.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func uniqueInt64(a []int64) []int64 {
+	j := 0
+	for i := 0; i < len(a); i++ {
+		if i == 0 || a[i] != a[i-1] {
+			a[j] = a[i]
+			j++
+		}
+	}
+	return a[:j]
+}
+
+func solveCase(n int, dist [][]int64, g1, g2, s1, s2 int) int64 {
+	const INF = int64(1e18)
+	// Floyd-Warshall
+	for k := 0; k < n; k++ {
+		for i := 0; i < n; i++ {
+			if dist[i][k] == INF {
+				continue
+			}
+			for j := 0; j < n; j++ {
+				if dist[k][j] == INF {
+					continue
+				}
+				nd := dist[i][k] + dist[k][j]
+				if nd < dist[i][j] {
+					dist[i][j] = nd
+				}
+			}
+		}
+	}
+	dvals := make([]int64, 0, n*(n-1))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if i != j {
+				dvals = append(dvals, dist[i][j])
+			}
+		}
+	}
+	sort.Slice(dvals, func(i, j int) bool { return dvals[i] < dvals[j] })
+	dvals = uniqueInt64(dvals)
+	D := len(dvals)
+	A := make([][]int, D)
+	for p := 0; p < D; p++ {
+		A[p] = make([]int, n)
+		for i := 0; i < n; i++ {
+			cnt := 0
+			for j := 0; j < n; j++ {
+				if i != j && dist[i][j] <= dvals[p] {
+					cnt++
+				}
+			}
+			A[p][i] = cnt
+		}
+	}
+	ans := int64(0)
+	maxG := g2
+	maxS := s2
+	for p := 0; p < D; p++ {
+		for q := p + 1; q < D; q++ {
+			a := make([]int64, n)
+			b := make([]int64, n)
+			c := make([]int64, n)
+			for i := 0; i < n; i++ {
+				a[i] = int64(A[p][i])
+				b[i] = int64(A[q][i] - A[p][i])
+				c[i] = int64((n - 1) - A[q][i])
+			}
+			dp := make([][]int64, maxG+1)
+			for i := range dp {
+				dp[i] = make([]int64, maxS+1)
+			}
+			dp[0][0] = 1
+			for i := 0; i < n; i++ {
+				ndp := make([][]int64, maxG+1)
+				for ii := range ndp {
+					ndp[ii] = make([]int64, maxS+1)
+				}
+				for gi := 0; gi <= maxG; gi++ {
+					for si := 0; si <= maxS; si++ {
+						v := dp[gi][si]
+						if v == 0 {
+							continue
+						}
+						if gi < maxG && a[i] > 0 {
+							ndp[gi+1][si] += v * a[i]
+						}
+						if si < maxS && b[i] > 0 {
+							ndp[gi][si+1] += v * b[i]
+						}
+						if c[i] > 0 {
+							ndp[gi][si] += v * c[i]
+						}
+					}
+				}
+				dp = ndp
+			}
+			for gi := g1; gi <= g2; gi++ {
+				if gi > maxG {
+					break
+				}
+				for si := s1; si <= s2; si++ {
+					if si > maxS {
+						break
+					}
+					ans += dp[gi][si]
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 3
+	dist := make([][]int64, n)
+	for i := 0; i < n; i++ {
+		dist[i] = make([]int64, n)
+		for j := 0; j < n; j++ {
+			if i == j {
+				dist[i][j] = 0
+			} else {
+				dist[i][j] = int64(rng.Intn(20) + 1)
+			}
+		}
+	}
+	g2 := rng.Intn(n)
+	g1 := rng.Intn(g2 + 1)
+	s2 := rng.Intn(n - g2)
+	s1 := rng.Intn(s2 + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, n*(n-1)/2))
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			w := dist[i][j]
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", i+1, j+1, w))
+			dist[j][i] = w
+		}
+	}
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", g1, g2, s1, s2))
+	ans := solveCase(n, dist, g1, g2, s1, s2)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 38 problems A through H
- each verifier generates at least 100 random test cases and checks a provided binary

## Testing
- `go build 0-999/0-99/30-39/38/verifierA.go`
- `go build 0-999/0-99/30-39/38/verifierB.go`
- `go build 0-999/0-99/30-39/38/verifierC.go`
- `go build 0-999/0-99/30-39/38/verifierD.go`
- `go build 0-999/0-99/30-39/38/verifierE.go`
- `go build 0-999/0-99/30-39/38/verifierF.go`
- `go build 0-999/0-99/30-39/38/verifierG.go`
- `go build 0-999/0-99/30-39/38/verifierH.go`

------
https://chatgpt.com/codex/tasks/task_e_687e60deb7208324a70103cf6b157084