### PR TITLE
Add verifiers for contest 35

### DIFF
--- a/0-999/0-99/30-39/35/verifierA.go
+++ b/0-999/0-99/30-39/35/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(start int, shuffles [][2]int) int {
+	pos := start
+	for _, s := range shuffles {
+		a, b := s[0], s[1]
+		if pos == a {
+			pos = b
+		} else if pos == b {
+			pos = a
+		}
+	}
+	return pos
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	pairs := [][2]int{{1, 2}, {2, 1}, {1, 3}, {3, 1}, {2, 3}, {3, 2}}
+	caseNum := 1
+	for start := 1; start <= 3; start++ {
+		for _, p1 := range pairs {
+			for _, p2 := range pairs {
+				for _, p3 := range pairs {
+					sh := [][2]int{p1, p2, p3}
+					input := fmt.Sprintf("%d\n%d %d\n%d %d\n%d %d\n", start, p1[0], p1[1], p2[0], p2[1], p3[0], p3[1])
+					exp := fmt.Sprintf("%d", expected(start, sh))
+					out, err := run(bin, input)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum, err, input)
+						os.Exit(1)
+					}
+					fields := strings.Fields(out)
+					if len(fields) == 0 {
+						fmt.Fprintf(os.Stderr, "case %d: empty output\ninput:\n%s", caseNum, input)
+						os.Exit(1)
+					}
+					if fields[0] != exp {
+						fmt.Fprintf(os.Stderr, "case %d: expected %s got %s\ninput:\n%s", caseNum, exp, fields[0], input)
+						os.Exit(1)
+					}
+					caseNum++
+				}
+			}
+		}
+	}
+	fmt.Printf("All %d tests passed\n", caseNum-1)
+}

--- a/0-999/0-99/30-39/35/verifierB.go
+++ b/0-999/0-99/30-39/35/verifierB.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type op struct {
+	add  bool
+	x, y int
+	id   string
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func simulate(n, m int, ops []op) string {
+	grid := make([][]bool, n+1)
+	for i := range grid {
+		grid[i] = make([]bool, m+1)
+	}
+	pos := make(map[string][2]int)
+	var out strings.Builder
+	for _, op := range ops {
+		if op.add {
+			placed := false
+			for sx := op.x; sx <= n && !placed; sx++ {
+				start := 1
+				if sx == op.x {
+					start = op.y
+				}
+				for sy := start; sy <= m; sy++ {
+					if !grid[sx][sy] {
+						grid[sx][sy] = true
+						pos[op.id] = [2]int{sx, sy}
+						placed = true
+						break
+					}
+				}
+			}
+		} else {
+			if p, ok := pos[op.id]; ok {
+				fmt.Fprintf(&out, "%d %d\n", p[0], p[1])
+				grid[p[0]][p[1]] = false
+				delete(pos, op.id)
+			} else {
+				out.WriteString("-1 -1\n")
+			}
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	k := rng.Intn(8) + 1
+	var ops []op
+	nextID := 1
+	for i := 0; i < k; i++ {
+		if rng.Intn(2) == 0 || nextID == 1 {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(m) + 1
+			id := fmt.Sprintf("id%d", nextID)
+			nextID++
+			ops = append(ops, op{add: true, x: x, y: y, id: id})
+		} else {
+			idn := rng.Intn(nextID-1) + 1
+			id := fmt.Sprintf("id%d", idn)
+			ops = append(ops, op{add: false, id: id})
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for _, op := range ops {
+		if op.add {
+			fmt.Fprintf(&sb, "+1 %d %d %s\n", op.x, op.y, op.id)
+		} else {
+			fmt.Fprintf(&sb, "-1 %s\n", op.id)
+		}
+	}
+	input := sb.String()
+	expected := simulate(n, m, ops)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases [][2]string
+	// simple fixed case
+	cases = append(cases, [2]string{"1 1 2\n+1 1 1 a\n-1 a\n", "1 1"})
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		cases = append(cases, [2]string{in, exp})
+	}
+
+	for i, tc := range cases {
+		out, err := run(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc[0])
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc[1] {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/0-99/30-39/35/verifierC.go
+++ b/0-999/0-99/30-39/35/verifierC.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func bfs(n, m int, starts [][2]int) (int, int) {
+	total := n * m
+	visited := make([]bool, total)
+	q := make([]int, 0, total)
+	var last int
+	for _, st := range starts {
+		x, y := st[0]-1, st[1]-1
+		idx := x*m + y
+		if !visited[idx] {
+			visited[idx] = true
+			q = append(q, idx)
+		}
+	}
+	for head := 0; head < len(q); head++ {
+		idx := q[head]
+		last = idx
+		r := idx / m
+		c := idx % m
+		if r > 0 {
+			ni := (r-1)*m + c
+			if !visited[ni] {
+				visited[ni] = true
+				q = append(q, ni)
+			}
+		}
+		if r+1 < n {
+			ni := (r+1)*m + c
+			if !visited[ni] {
+				visited[ni] = true
+				q = append(q, ni)
+			}
+		}
+		if c > 0 {
+			ni := r*m + c - 1
+			if !visited[ni] {
+				visited[ni] = true
+				q = append(q, ni)
+			}
+		}
+		if c+1 < m {
+			ni := r*m + c + 1
+			if !visited[ni] {
+				visited[ni] = true
+				q = append(q, ni)
+			}
+		}
+	}
+	return last/m + 1, last%m + 1
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	k := rng.Intn(min(3, n*m)) + 1
+	starts := make([][2]int, k)
+	used := make(map[[2]int]bool)
+	for i := 0; i < k; i++ {
+		for {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(m) + 1
+			if !used[[2]int{x, y}] {
+				used[[2]int{x, y}] = true
+				starts[i] = [2]int{x, y}
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	fmt.Fprintf(&sb, "%d\n", k)
+	for i, st := range starts {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d %d", st[0], st[1])
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	x, y := bfs(n, m, starts)
+	expected := fmt.Sprintf("%d %d", x, y)
+	return input, expected
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases [][2]string
+	cases = append(cases, [2]string{"1 1\n1\n1 1\n", "1 1"})
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		cases = append(cases, [2]string{in, exp})
+	}
+	for i, tc := range cases {
+		out, err := run(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc[0])
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc[1] {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/0-99/30-39/35/verifierD.go
+++ b/0-999/0-99/30-39/35/verifierD.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(c []int, X int) int {
+	n := len(c)
+	w := make([]int, n)
+	for i := 0; i < n; i++ {
+		w[i] = c[i] * (n - i)
+	}
+	sort.Ints(w)
+	cnt, sum := 0, 0
+	for _, wi := range w {
+		if sum+wi <= X {
+			sum += wi
+			cnt++
+		} else {
+			break
+		}
+	}
+	return cnt
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	X := rng.Intn(20) + 1
+	c := make([]int, n)
+	for i := 0; i < n; i++ {
+		c[i] = rng.Intn(10) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, X)
+	for i, v := range c {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	ans := expected(c, X)
+	return input, fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases [][2]string
+	cases = append(cases, [2]string{"1 1\n1\n", "1"})
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		cases = append(cases, [2]string{in, exp})
+	}
+	for i, tc := range cases {
+		out, err := run(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc[0])
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc[1] {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/0-99/30-39/35/verifierE.go
+++ b/0-999/0-99/30-39/35/verifierE.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type event struct {
+	x   int64
+	h   int64
+	typ int // 1 start, 0 end
+}
+
+type maxHeap []int64
+
+func (h maxHeap) Len() int            { return len(h) }
+func (h maxHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h maxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *maxHeap) Push(x interface{}) { *h = append(*h, x.(int64)) }
+func (h *maxHeap) Pop() interface{} {
+	a := *h
+	v := a[len(a)-1]
+	*h = a[:len(a)-1]
+	return v
+}
+
+func envelope(blds [][3]int64) [][2]int64 {
+	events := make([]event, 0, len(blds)*2)
+	for _, b := range blds {
+		h, l, r := b[0], b[1], b[2]
+		events = append(events, event{x: l, h: h, typ: 1})
+		events = append(events, event{x: r, h: h, typ: 0})
+	}
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].x != events[j].x {
+			return events[i].x < events[j].x
+		}
+		if events[i].typ != events[j].typ {
+			return events[i].typ > events[j].typ
+		}
+		if events[i].typ == 1 {
+			return events[i].h > events[j].h
+		}
+		return events[i].h < events[j].h
+	})
+	hq := &maxHeap{}
+	heap.Init(hq)
+	heap.Push(hq, 0)
+	rem := make(map[int64]int)
+	prev := int64(0)
+	var keys []event
+	for i := 0; i < len(events); {
+		x := events[i].x
+		j := i
+		for j < len(events) && events[j].x == x {
+			e := events[j]
+			if e.typ == 1 {
+				heap.Push(hq, e.h)
+			} else {
+				rem[e.h]++
+			}
+			j++
+		}
+		for hq.Len() > 0 {
+			top := (*hq)[0]
+			if c, ok := rem[top]; ok && c > 0 {
+				heap.Pop(hq)
+				rem[top]--
+			} else {
+				break
+			}
+		}
+		cur := (*hq)[0]
+		if cur != prev {
+			keys = append(keys, event{x: x, h: cur})
+			prev = cur
+		}
+		i = j
+	}
+	var verts [][2]int64
+	if len(keys) > 0 {
+		prevX := keys[0].x
+		prevH := int64(0)
+		verts = append(verts, [2]int64{prevX, 0})
+		for _, k := range keys {
+			if k.h != prevH {
+				if k.x != prevX {
+					verts = append(verts, [2]int64{k.x, prevH})
+				}
+				verts = append(verts, [2]int64{k.x, k.h})
+				prevX, prevH = k.x, k.h
+			}
+		}
+	}
+	return verts
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	blds := make([][3]int64, n)
+	for i := 0; i < n; i++ {
+		h := int64(rng.Intn(10) + 1)
+		l := int64(rng.Intn(10))
+		r := l + int64(rng.Intn(5)+1)
+		blds[i] = [3]int64{h, l, r}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, b := range blds {
+		fmt.Fprintf(&sb, "%d %d %d\n", b[0], b[1], b[2])
+	}
+	input := sb.String()
+	verts := envelope(blds)
+	var exp strings.Builder
+	fmt.Fprintf(&exp, "%d\n", len(verts))
+	for _, v := range verts {
+		fmt.Fprintf(&exp, "%d %d\n", v[0], v[1])
+	}
+	return input, strings.TrimSpace(exp.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases [][2]string
+	cases = append(cases, [2]string{"1\n1 0 1\n", "2\n0 0\n1 1"})
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		cases = append(cases, [2]string{in, exp})
+	}
+	for i, tc := range cases {
+		out, err := run(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc[0])
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc[1] {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 35 problems A–E

## Testing
- `go run 0-999/0-99/30-39/35/verifierA.go ./a.out`

------
https://chatgpt.com/codex/tasks/task_e_687e60cf91fc8324b64eeee56cfe3a31