### PR TITLE
Add verifier programs for contest 75

### DIFF
--- a/0-999/0-99/70-79/75/verifierA.go
+++ b/0-999/0-99/70-79/75/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "75A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(1))
+	const cases = 100
+	for i := 1; i <= cases; i++ {
+		a := rng.Intn(1_000_000_000) + 1
+		b := rng.Intn(1_000_000_000) + 1
+		input := fmt.Sprintf("%d\n%d\n", a, b)
+		expected, err := runCase(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runCase(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("case %d failed: expected %s got %s (a=%d b=%d)\n", i, expected, got, a, b)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/0-99/70-79/75/verifierB.go
+++ b/0-999/0-99/70-79/75/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "75B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+var names = []string{"alice", "bob", "carol", "dave", "erin", "frank", "grace", "heidi", "ivan", "judy"}
+
+func generateCase(rng *rand.Rand) string {
+	you := "user"
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(you + "\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		x := names[rng.Intn(len(names))]
+		y := names[rng.Intn(len(names))]
+		for y == x {
+			y = names[rng.Intn(len(names))]
+		}
+		switch rng.Intn(3) {
+		case 0:
+			fmt.Fprintf(&sb, "%s posted on %s's wall\n", x, y)
+		case 1:
+			fmt.Fprintf(&sb, "%s commented on %s's post\n", x, y)
+		default:
+			fmt.Fprintf(&sb, "%s likes %s's post\n", x, y)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(2))
+	const cases = 100
+	for i := 1; i <= cases; i++ {
+		input := generateCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/0-99/70-79/75/verifierC.go
+++ b/0-999/0-99/70-79/75/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "75C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	a := rng.Int63n(1_000_000_000) + 1
+	b := rng.Int63n(1_000_000_000) + 1
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", a, b)
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		low := rng.Int63n(1_000_000_000) + 1
+		high := rng.Int63n(1_000_000_000) + 1
+		if low > high {
+			low, high = high, low
+		}
+		fmt.Fprintf(&sb, "%d %d\n", low, high)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(3))
+	const cases = 100
+	for i := 1; i <= cases; i++ {
+		input := generateCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/0-99/70-79/75/verifierD.go
+++ b/0-999/0-99/70-79/75/verifierD.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "75D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(4) + 1
+		fmt.Fprintf(&sb, "%d", l)
+		for j := 0; j < l; j++ {
+			v := rng.Intn(21) - 10
+			fmt.Fprintf(&sb, " %d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		idx := rng.Intn(n) + 1
+		fmt.Fprintf(&sb, "%d", idx)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(4))
+	const cases = 100
+	for i := 1; i <= cases; i++ {
+		input := generateCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/0-99/70-79/75/verifierE.go
+++ b/0-999/0-99/70-79/75/verifierE.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "75E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	x1 := rng.Intn(41) - 20
+	y1 := rng.Intn(41) - 20
+	x2 := rng.Intn(41) - 20
+	y2 := rng.Intn(41) - 20
+	n := rng.Intn(5) + 3
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", x1, y1, x2, y2)
+	fmt.Fprintf(&sb, "%d\n", n)
+	r := 10.0
+	for i := 0; i < n; i++ {
+		ang := 2 * math.Pi * float64(i) / float64(n)
+		px := int(math.Round(r * math.Cos(ang)))
+		py := int(math.Round(r * math.Sin(ang)))
+		fmt.Fprintf(&sb, "%d %d\n", px, py)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(5))
+	const cases = 100
+	for i := 1; i <= cases; i++ {
+		input := generateCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for all problems in contest 75
- each verifier compiles reference solution, generates 100 random test cases and checks candidate output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go run verifierA.go ./candidateA` *(all 100 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_687e6198eee88324b8b7b3fd57167bec