### PR TITLE
Add verifiers for contest 86

### DIFF
--- a/0-999/0-99/80-89/86/verifierA.go
+++ b/0-999/0-99/80-89/86/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(l, r int64) int64 {
+	pow10 := [...]int64{1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000}
+	ans := int64(0)
+	for L := 1; L < len(pow10); L++ {
+		lo := l
+		if lo < pow10[L-1] {
+			lo = pow10[L-1]
+		}
+		hi := r
+		if hi > pow10[L]-1 {
+			hi = pow10[L] - 1
+		}
+		if lo > hi {
+			continue
+		}
+		M := pow10[L] - 1
+		c1 := M / 2
+		c2 := c1 + 1
+		candidates := []int64{lo, hi, c1, c2}
+		for _, n := range candidates {
+			if n < lo || n > hi {
+				continue
+			}
+			prod := n * (M - n)
+			if prod > ans {
+				ans = prod
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	l := rng.Int63n(1000000000) + 1
+	r := l + rng.Int63n(1000000000-l+1)
+	input := fmt.Sprintf("%d %d\n", l, r)
+	return input, expected(l, r)
+}
+
+func runCase(bin, input string, exp int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []struct{ l, r int64 }{
+		{1, 1}, {1, 1000000000}, {123456789, 987654321},
+	}
+	for _, c := range cases {
+		input := fmt.Sprintf("%d %d\n", c.l, c.r)
+		if err := runCase(bin, input, expected(c.l, c.r)); err != nil {
+			fmt.Fprintf(os.Stderr, "special case failed: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/86/verifierB.go
+++ b/0-999/0-99/80-89/86/verifierB.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type cell struct{ x, y int }
+
+type shape []cell
+
+var dirs = []cell{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+var validShapes map[string]struct{}
+
+func canonical(s shape) string {
+	best := ""
+	trans := func(c cell, rot int, flip bool) cell {
+		x, y := c.x, c.y
+		// rotate
+		for i := 0; i < rot; i++ {
+			x, y = y, -x
+		}
+		if flip {
+			x = -x
+		}
+		return cell{x, y}
+	}
+	for rot := 0; rot < 4; rot++ {
+		for _, flip := range []bool{false, true} {
+			tmp := make([]cell, len(s))
+			for i, c := range s {
+				tmp[i] = trans(c, rot, flip)
+			}
+			minX, minY := tmp[0].x, tmp[0].y
+			for _, c := range tmp {
+				if c.x < minX {
+					minX = c.x
+				}
+				if c.y < minY {
+					minY = c.y
+				}
+			}
+			for i := range tmp {
+				tmp[i].x -= minX
+				tmp[i].y -= minY
+			}
+			sort.Slice(tmp, func(i, j int) bool {
+				if tmp[i].x == tmp[j].x {
+					return tmp[i].y < tmp[j].y
+				}
+				return tmp[i].x < tmp[j].x
+			})
+			var b strings.Builder
+			for _, c := range tmp {
+				b.WriteString(fmt.Sprintf("%d:%d,", c.x, c.y))
+			}
+			str := b.String()
+			if best == "" || str < best {
+				best = str
+			}
+		}
+	}
+	return best
+}
+
+func contains(s shape, c cell) bool {
+	for _, x := range s {
+		if x == c {
+			return true
+		}
+	}
+	return false
+}
+
+func generateShapes() {
+	shapes := map[int]map[string]shape{}
+	shapes[1] = map[string]shape{canonical(shape{{0, 0}}): {{0, 0}}}
+	validShapes = make(map[string]struct{})
+	for size := 1; size < 5; size++ {
+		next := map[string]shape{}
+		for _, sh := range shapes[size] {
+			for _, c := range sh {
+				for _, d := range dirs {
+					nc := cell{c.x + d.x, c.y + d.y}
+					if contains(sh, nc) {
+						continue
+					}
+					ns := append([]cell(nil), sh...)
+					ns = append(ns, nc)
+					key := canonical(ns)
+					if _, ok := next[key]; !ok {
+						cp := append(shape(nil), ns...)
+						next[key] = cp
+						if len(cp) >= 2 {
+							validShapes[key] = struct{}{}
+						}
+					}
+				}
+			}
+		}
+		shapes[size+1] = next
+	}
+}
+
+func checkSolution(n, m int, orig []string, out []string) error {
+	if len(out) != n {
+		return fmt.Errorf("wrong number of lines")
+	}
+	for i := 0; i < n; i++ {
+		if len(out[i]) != m {
+			return fmt.Errorf("wrong line length")
+		}
+	}
+	visited := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		visited[i] = make([]bool, m)
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if orig[i][j] == '#' {
+				if out[i][j] != '#' {
+					return fmt.Errorf("cell %d %d should be #", i, j)
+				}
+				visited[i][j] = true
+				continue
+			}
+			if out[i][j] < '0' || out[i][j] > '9' {
+				return fmt.Errorf("invalid char at %d %d", i, j)
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if visited[i][j] {
+				continue
+			}
+			digit := out[i][j]
+			q := []cell{{i, j}}
+			visited[i][j] = true
+			var cells shape
+			for len(q) > 0 {
+				c := q[0]
+				q = q[1:]
+				cells = append(cells, c)
+				for _, d := range dirs {
+					ni, nj := c.x+d.x, c.y+d.y
+					if ni < 0 || ni >= n || nj < 0 || nj >= m {
+						continue
+					}
+					if visited[ni][nj] {
+						continue
+					}
+					if orig[ni][nj] == '#' {
+						continue
+					}
+					if out[ni][nj] == digit {
+						visited[ni][nj] = true
+						q = append(q, cell{ni, nj})
+					}
+				}
+			}
+			if len(cells) < 2 || len(cells) > 5 {
+				return fmt.Errorf("component size %d invalid", len(cells))
+			}
+			// convert to relative coords
+			base := cells[0]
+			rel := make(shape, len(cells))
+			for idx, c := range cells {
+				rel[idx] = cell{c.x - base.x, c.y - base.y}
+			}
+			if _, ok := validShapes[canonical(rel)]; !ok {
+				return fmt.Errorf("invalid shape of size %d", len(cells))
+			}
+		}
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, bool) {
+	if rng.Float64() < 0.1 {
+		// unsolvable 1x1 board
+		return "1 1\n.\n", false
+	}
+	n := rng.Intn(6) + 2
+	m := rng.Intn(6) + 2
+	board := make([]string, n)
+	for i := 0; i < n; i++ {
+		board[i] = strings.Repeat(".", m)
+	}
+	solvable := (n*m)%2 == 0
+	return fmt.Sprintf("%d %d\n%s\n", n, m, strings.Join(board, "\n")), solvable
+}
+
+func runCase(bin, input string, solvable bool) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	output := strings.TrimSpace(out.String())
+	if output == "-1" {
+		if solvable {
+			return fmt.Errorf("returned -1 on solvable case")
+		}
+		return nil
+	}
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	inputR := bufio.NewScanner(strings.NewReader(input))
+	inputR.Scan() // first line n m
+	n, m := 0, 0
+	fmt.Sscan(inputR.Text(), &n, &m)
+	orig := make([]string, n)
+	for i := 0; i < n; i++ {
+		inputR.Scan()
+		orig[i] = inputR.Text()
+	}
+	return checkSolution(n, m, orig, lines)
+}
+
+func main() {
+	generateShapes()
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, solv := generateCase(rng)
+		if err := runCase(bin, in, solv); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/86/verifierC.go
+++ b/0-999/0-99/80-89/86/verifierC.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000009
+
+type automaton struct {
+	next   [][4]int
+	out    [][]int
+	link   []int
+	maxLen int
+}
+
+func buildAutomaton(patterns []string) *automaton {
+	toIndex := func(c byte) int {
+		switch c {
+		case 'A':
+			return 0
+		case 'C':
+			return 1
+		case 'G':
+			return 2
+		case 'T':
+			return 3
+		}
+		return 0
+	}
+	next := make([][4]int, 1)
+	out := make([][]int, 1)
+	link := []int{0}
+	maxLen := 0
+	for _, p := range patterns {
+		if len(p) > maxLen {
+			maxLen = len(p)
+		}
+		v := 0
+		for i := 0; i < len(p); i++ {
+			ci := toIndex(p[i])
+			if next[v][ci] == 0 {
+				next = append(next, [4]int{})
+				out = append(out, nil)
+				link = append(link, 0)
+				next[v][ci] = len(next) - 1
+			}
+			v = next[v][ci]
+		}
+		out[v] = append(out[v], len(p))
+	}
+	queue := make([]int, 0, len(next))
+	for c := 0; c < 4; c++ {
+		if next[0][c] != 0 {
+			queue = append(queue, next[0][c])
+			link[next[0][c]] = 0
+		}
+	}
+	for qi := 0; qi < len(queue); qi++ {
+		v := queue[qi]
+		lv := link[v]
+		if len(out[lv]) > 0 {
+			out[v] = append(out[v], out[lv]...)
+		}
+		for c := 0; c < 4; c++ {
+			u := next[v][c]
+			if u != 0 {
+				link[u] = next[link[v]][c]
+				queue = append(queue, u)
+			} else {
+				next[v][c] = next[link[v]][c]
+			}
+		}
+	}
+	return &automaton{next: next, out: out, link: link, maxLen: maxLen}
+}
+
+func countStrings(n int, patterns []string) int {
+	auto := buildAutomaton(patterns)
+	numStates := len(auto.next)
+	M := auto.maxLen
+	dpCur := make([][]int, M)
+	dpNext := make([][]int, M)
+	for k := 0; k < M; k++ {
+		dpCur[k] = make([]int, numStates)
+		dpNext[k] = make([]int, numStates)
+	}
+	dpCur[0][0] = 1
+	for pos := 0; pos < n; pos++ {
+		for k := 0; k < M; k++ {
+			for s := 0; s < numStates; s++ {
+				dpNext[k][s] = 0
+			}
+		}
+		for k := 0; k < M; k++ {
+			for s := 0; s < numStates; s++ {
+				ways := dpCur[k][s]
+				if ways == 0 {
+					continue
+				}
+				for c := 0; c < 4; c++ {
+					ns := auto.next[s][c]
+					maxP := 0
+					for _, L := range auto.out[ns] {
+						if L > maxP {
+							maxP = L
+						}
+					}
+					t := k + 1
+					if maxP > t {
+						maxP = t
+					}
+					k2 := t - maxP
+					if k2 < M {
+						dpNext[k2][ns] = (dpNext[k2][ns] + ways) % MOD
+					}
+				}
+			}
+		}
+		dpCur, dpNext = dpNext, dpCur
+	}
+	ans := 0
+	for s := 0; s < numStates; s++ {
+		ans = (ans + dpCur[0][s]) % MOD
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(5) + 1
+	patterns := make([]string, m)
+	for i := 0; i < m; i++ {
+		l := rng.Intn(5) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = "ACGT"[rng.Intn(4)]
+		}
+		patterns[i] = string(b)
+	}
+	input := fmt.Sprintf("%d %d\n%s\n", n, m, strings.Join(patterns, "\n"))
+	return input, countStrings(n, patterns)
+}
+
+func runCase(bin, input string, exp int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got%MOD != exp%MOD {
+		return fmt.Errorf("expected %d got %d", exp%MOD, got%MOD)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/86/verifierD.go
+++ b/0-999/0-99/80-89/86/verifierD.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type query struct{ l, r int }
+
+func expected(a []int, qs []query) []int64 {
+	res := make([]int64, len(qs))
+	for i, q := range qs {
+		cnt := make(map[int]int)
+		var ans int64
+		for j := q.l; j <= q.r; j++ {
+			v := a[j]
+			cnt[v]++
+		}
+		for v, c := range cnt {
+			ans += int64(c*c) * int64(v)
+		}
+		res[i] = ans
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(30) + 1
+	t := rng.Intn(20) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(20) + 1
+	}
+	qs := make([]query, t)
+	for i := 0; i < t; i++ {
+		l := rng.Intn(n)
+		r := rng.Intn(n-l) + l
+		qs[i] = query{l: r}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, t))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for _, q := range qs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", q.l+1, q.r+1))
+	}
+	return sb.String(), expected(a, qs)
+}
+
+func runCase(bin, input string, exp []int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Fields(out.String())
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, txt := range lines {
+		var val int64
+		if _, err := fmt.Sscan(txt, &val); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if val != exp[i] {
+			return fmt.Errorf("ans %d expected %d got %d", i+1, exp[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/86/verifierE.go
+++ b/0-999/0-99/80-89/86/verifierE.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var answer = [][]int{
+	{}, {},
+	{2, 1}, {3, 2}, {4, 3}, {5, 3}, {6, 5}, {7, 6}, {8, 6, 5, 4}, {9, 5},
+	{10, 7}, {11, 9}, {12, 11, 10, 4}, {13, 12, 11, 8}, {14, 13, 12, 2},
+	{15, 14}, {16, 14, 13, 11}, {17, 14}, {18, 11}, {19, 6, 2, 1},
+	{20, 17}, {21, 19}, {22, 21}, {23, 18}, {24, 23, 22, 17},
+	{25, 22}, {26, 6, 2, 1}, {27, 5, 2, 1}, {28, 25}, {29, 27},
+	{30, 6, 4, 1}, {31, 28}, {32, 22, 2, 1}, {33, 20}, {34, 27, 2, 1},
+	{35, 33}, {36, 25}, {37, 5, 4, 3, 2, 1}, {38, 6, 5, 1}, {39, 35},
+	{40, 38, 21, 19}, {41, 38}, {42, 41, 20, 19}, {43, 42, 38, 37},
+	{44, 43, 18, 17}, {45, 44, 42, 41}, {46, 45, 26, 25}, {47, 42},
+	{48, 47, 21, 20}, {49, 40}, {50, 49, 24, 23}, {},
+}
+
+func expected(k int) string {
+	arr := make([]int, k)
+	for _, x := range answer[k] {
+		if x > 0 && x <= k {
+			arr[x-1] = 1
+		}
+	}
+	parts := make([]string, k)
+	for i, v := range arr {
+		parts[i] = fmt.Sprint(v)
+	}
+	line := strings.Join(parts, " ")
+	return line + "\n" + line + "\n"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	k := rng.Intn(49) + 2
+	return fmt.Sprintf("%d\n", k), expected(k)
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if out.String() != exp {
+		return fmt.Errorf("expected %q got %q", exp, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go based verifiers for problems A through E of contest 86
- each verifier generates at least 100 random test cases and checks a submission

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e61d005cc83249df7eecb322cc200