### PR TITLE
Add contest 85 Go verifiers

### DIFF
--- a/0-999/0-99/80-89/85/verifierA.go
+++ b/0-999/0-99/80-89/85/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleA"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/85/85A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\n got:\n%s\ninput:%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/85/verifierB.go
+++ b/0-999/0-99/80-89/85/verifierB.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleB"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/85/85B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	k1 := rng.Intn(3) + 1
+	k2 := rng.Intn(3) + 1
+	k3 := rng.Intn(3) + 1
+	t1 := rng.Intn(10) + 1
+	t2 := rng.Intn(10) + 1
+	t3 := rng.Intn(10) + 1
+	n := rng.Intn(8) + 1
+	arr := make([]int, n)
+	cur := rng.Intn(3) + 1
+	arr[0] = cur
+	for i := 1; i < n; i++ {
+		cur += rng.Intn(3)
+		arr[i] = cur
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", k1, k2, k3)
+	fmt.Fprintf(&sb, "%d %d %d\n", t1, t2, t3)
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/85/verifierC.go
+++ b/0-999/0-99/80-89/85/verifierC.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type node struct {
+	val         int
+	parent      int
+	left, right *node
+	idx         int
+}
+
+func buildBST(vals []int) (*node, []*node) {
+	sort.Ints(vals)
+	var nodes []*node
+	var build func(l, r int) *node
+	build = func(l, r int) *node {
+		if l > r {
+			return nil
+		}
+		m := (l + r) / 2
+		nd := &node{val: vals[m]}
+		nodes = append(nodes, nd)
+		nd.left = build(l, m-1)
+		nd.right = build(m+1, r)
+		if nd.left != nil {
+			nd.left.parent = len(nodes) // placeholder
+		}
+		if nd.right != nil {
+			nd.right.parent = len(nodes)
+		}
+		return nd
+	}
+	root := build(0, len(vals)-1)
+	// assign indices BFS
+	queue := []*node{root}
+	idx := 1
+	for len(queue) > 0 {
+		n := queue[0]
+		queue = queue[1:]
+		n.idx = idx
+		idx++
+		if n.left != nil {
+			queue = append(queue, n.left)
+		}
+		if n.right != nil {
+			queue = append(queue, n.right)
+		}
+	}
+	// fix parent indices
+	queue = []*node{root}
+	for len(queue) > 0 {
+		n := queue[0]
+		queue = queue[1:]
+		if n.left != nil {
+			n.left.parent = n.idx
+			queue = append(queue, n.left)
+		}
+		if n.right != nil {
+			n.right.parent = n.idx
+			queue = append(queue, n.right)
+		}
+	}
+	// collect nodes in index order
+	ordered := make([]*node, idx-1)
+	queue = []*node{root}
+	for len(queue) > 0 {
+		n := queue[0]
+		queue = queue[1:]
+		ordered[n.idx-1] = n
+		if n.left != nil {
+			queue = append(queue, n.left)
+		}
+		if n.right != nil {
+			queue = append(queue, n.right)
+		}
+	}
+	return root, ordered
+}
+
+func generateCase(rng *rand.Rand) string {
+	h := rng.Intn(3) + 1 // height 1..3 => 3,7,15 nodes
+	n := (1 << (h + 1)) - 1
+	vals := make([]int, n)
+	used := map[int]bool{}
+	for i := 0; i < n; {
+		v := rng.Intn(1000) + 1
+		if !used[v] {
+			used[v] = true
+			vals[i] = v
+			i++
+		}
+	}
+	_, nodes := buildBST(vals)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, nd := range nodes {
+		p := nd.parent
+		if p == 0 {
+			p = -1
+		}
+		fmt.Fprintf(&sb, "%d %d\n", p, nd.val)
+	}
+	q := rng.Intn(5) + 1
+	fmt.Fprintf(&sb, "%d\n", q)
+	for i := 0; i < q; i++ {
+		for {
+			v := rng.Intn(1000) + 1001
+			if !used[v] {
+				fmt.Fprintf(&sb, "%d\n", v)
+				break
+			}
+		}
+	}
+	return sb.String()
+}
+
+func buildOracle() (string, error) {
+	exe := "oracleC"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/85/85C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/85/verifierD.go
+++ b/0-999/0-99/80-89/85/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleD"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/85/85D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	ops := rng.Intn(50) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", ops)
+	present := map[int]bool{}
+	keys := []int{}
+	for i := 0; i < ops; i++ {
+		typ := rng.Intn(3)
+		switch typ {
+		case 0:
+			// add
+			var x int
+			for {
+				x = rng.Intn(1000) + 1
+				if !present[x] {
+					break
+				}
+			}
+			present[x] = true
+			keys = append(keys, x)
+			fmt.Fprintf(&sb, "add %d\n", x)
+		case 1:
+			// del if any else add
+			if len(keys) == 0 {
+				i--
+				continue
+			}
+			idx := rng.Intn(len(keys))
+			x := keys[idx]
+			keys = append(keys[:idx], keys[idx+1:]...)
+			delete(present, x)
+			fmt.Fprintf(&sb, "del %d\n", x)
+		default:
+			fmt.Fprintf(&sb, "sum\n")
+		}
+	}
+	return sb.String()
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/85/verifierE.go
+++ b/0-999/0-99/80-89/85/verifierE.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleE"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/85/85E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	coords := make(map[[2]int]bool)
+	xs := make([]int, n)
+	ys := make([]int, n)
+	for i := 0; i < n; {
+		x := rng.Intn(20)
+		y := rng.Intn(20)
+		key := [2]int{x, y}
+		if !coords[key] {
+			coords[key] = true
+			xs[i] = x
+			ys[i] = y
+			i++
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", xs[i], ys[i])
+	}
+	return sb.String()
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 85 problems A–E
- each verifier builds an oracle from the original Go solution
- generates 100 random test cases and compares program output
- fix oracle path handling

## Testing
- `go build 0-999/0-99/80-89/85/verifierA.go`
- `go build 0-999/0-99/80-89/85/verifierB.go`
- `go build 0-999/0-99/80-89/85/verifierC.go`
- `go build 0-999/0-99/80-89/85/verifierD.go`
- `go build 0-999/0-99/80-89/85/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e61cb1fb88324b0b2901fc2a0e5e0