### PR TITLE
Add Go verifiers for contest 83

### DIFF
--- a/0-999/0-99/80-89/83/verifierA.go
+++ b/0-999/0-99/80-89/83/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierA.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refA")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "83A.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 1
+		arr := make([]int64, n)
+		for i := range arr {
+			arr[i] = int64(rand.Intn(7) - 3)
+		}
+		var b bytes.Buffer
+		fmt.Fprintln(&b, n)
+		for i, v := range arr {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprint(&b, v)
+		}
+		b.WriteByte('\n')
+		input := b.String()
+
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}

--- a/0-999/0-99/80-89/83/verifierB.go
+++ b/0-999/0-99/80-89/83/verifierB.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierB.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refB")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "83B.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(2)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		k := int64(rand.Intn(50))
+		a := make([]int64, n)
+		for i := range a {
+			a[i] = int64(rand.Intn(20) + 1)
+		}
+		var b bytes.Buffer
+		fmt.Fprintf(&b, "%d %d\n", n, k)
+		for i, v := range a {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprint(&b, v)
+		}
+		b.WriteByte('\n')
+		input := b.String()
+
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}

--- a/0-999/0-99/80-89/83/verifierC.go
+++ b/0-999/0-99/80-89/83/verifierC.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierC.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refC")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "83C.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(3)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(4) + 2
+		m := rand.Intn(4) + 2
+		k := rand.Intn(4) + 1
+		grid := make([][]byte, n)
+		for i := range grid {
+			grid[i] = make([]byte, m)
+			for j := range grid[i] {
+				grid[i][j] = byte('a' + rand.Intn(4))
+			}
+		}
+		sr, sc := rand.Intn(n), rand.Intn(m)
+		tr, tc := rand.Intn(n), rand.Intn(m)
+		for tr == sr && tc == sc {
+			tr, tc = rand.Intn(n), rand.Intn(m)
+		}
+		grid[sr][sc] = 'S'
+		grid[tr][tc] = 'T'
+
+		var b bytes.Buffer
+		fmt.Fprintf(&b, "%d %d %d\n", n, m, k)
+		for i := 0; i < n; i++ {
+			b.Write(grid[i])
+			b.WriteByte('\n')
+		}
+		input := b.String()
+
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}

--- a/0-999/0-99/80-89/83/verifierD.go
+++ b/0-999/0-99/80-89/83/verifierD.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierD.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refD")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "83D.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(4)
+	for t := 0; t < 100; t++ {
+		a := rand.Int63n(1000) + 1
+		b := a + rand.Int63n(1000)
+		k := rand.Int63n(20) + 2
+		var bldr bytes.Buffer
+		fmt.Fprintf(&bldr, "%d %d %d\n", a, b, k)
+		input := bldr.String()
+
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}

--- a/0-999/0-99/80-89/83/verifierE.go
+++ b/0-999/0-99/80-89/83/verifierE.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierE.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refE")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "83E.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(5)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 1
+		L := rand.Intn(5) + 1
+		seq := make([]string, n)
+		for i := range seq {
+			b := make([]byte, L)
+			for j := range b {
+				if rand.Intn(2) == 0 {
+					b[j] = '0'
+				} else {
+					b[j] = '1'
+				}
+			}
+			seq[i] = string(b)
+		}
+		var bldr bytes.Buffer
+		fmt.Fprintf(&bldr, "%d\n", n)
+		for _, s := range seq {
+			bldr.WriteString(s)
+			bldr.WriteByte('\n')
+		}
+		input := bldr.String()
+
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E

Each verifier builds the official solution to compare against and runs 100 randomised tests.

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go run verifierA.go ./83A_binary`

------
https://chatgpt.com/codex/tasks/task_e_687e61c10a08832493491ee33fef8af0