### PR TITLE
Add contest 82 solution verifiers

### DIFF
--- a/0-999/0-99/80-89/82/verifierA.go
+++ b/0-999/0-99/80-89/82/verifierA.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(n int64) string {
+	names := []string{"Sheldon", "Leonard", "Penny", "Rajesh", "Howard"}
+	group := int64(1)
+	count := group * int64(len(names))
+	for n > count {
+		n -= count
+		group *= 2
+		count = group * int64(len(names))
+	}
+	idx := (n - 1) / group
+	return names[idx]
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 20; i++ {
+		n := rand.Int63n(1_000_000_000) + 1
+		expected := solveA(n)
+		input := fmt.Sprintf("%d\n", n)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("case %d failed: n=%d expected %s got %s\n", i+1, n, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/82/verifierB.go
+++ b/0-999/0-99/80-89/82/verifierB.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	input    string
+	expected [][]int
+}
+
+func generateCase(rng *rand.Rand) testCaseB {
+	n := rng.Intn(3) + 2 // 2..4
+	sets := make([][]int, n)
+	next := 1
+	for i := 0; i < n; i++ {
+		sz := rng.Intn(3) + 1 // 1..3
+		sets[i] = make([]int, sz)
+		for j := 0; j < sz; j++ {
+			sets[i][j] = next
+			next++
+		}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			union := append(append([]int{}, sets[i]...), sets[j]...)
+			sort.Ints(union)
+			fmt.Fprintf(&b, "%d", len(union))
+			for _, v := range union {
+				fmt.Fprintf(&b, " %d", v)
+			}
+			fmt.Fprintln(&b)
+		}
+	}
+	return testCaseB{input: b.String(), expected: sets}
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseOutput(out string) ([][]int, error) {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	sets := make([][]int, 0, len(lines))
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		k := 0
+		fmt.Sscan(fields[0], &k)
+		if len(fields)-1 != k {
+			return nil, fmt.Errorf("invalid line %q", line)
+		}
+		arr := make([]int, k)
+		for i := 0; i < k; i++ {
+			fmt.Sscan(fields[i+1], &arr[i])
+		}
+		sort.Ints(arr)
+		sets = append(sets, arr)
+	}
+	// sort sets lexicographically
+	sort.Slice(sets, func(i, j int) bool {
+		a, b := sets[i], sets[j]
+		for x := 0; x < len(a) && x < len(b); x++ {
+			if a[x] != b[x] {
+				return a[x] < b[x]
+			}
+		}
+		return len(a) < len(b)
+	})
+	return sets, nil
+}
+
+func equalSets(a, b [][]int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if len(a[i]) != len(b[i]) {
+			return false
+		}
+		for j := range a[i] {
+			if a[i][j] != b[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 20; i++ {
+		tc := generateCase(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := parseOutput(out)
+		if err != nil {
+			fmt.Printf("case %d invalid output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		// sort expected sets as well
+		exp := make([][]int, len(tc.expected))
+		for j := range tc.expected {
+			exp[j] = append([]int{}, tc.expected[j]...)
+			sort.Ints(exp[j])
+		}
+		sort.Slice(exp, func(i, j int) bool {
+			a, b := exp[i], exp[j]
+			for x := 0; x < len(a) && x < len(b); x++ {
+				if a[x] != b[x] {
+					return a[x] < b[x]
+				}
+			}
+			return len(a) < len(b)
+		})
+		if !equalSets(exp, got) {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:%v\ngot:%v\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/82/verifierC.go
+++ b/0-999/0-99/80-89/82/verifierC.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Div struct {
+	ai int
+	t  int
+	id int
+}
+
+type DivHeap []Div
+
+func (h DivHeap) Len() int            { return len(h) }
+func (h DivHeap) Less(i, j int) bool  { return h[i].ai < h[j].ai }
+func (h DivHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *DivHeap) Push(x interface{}) { *h = append(*h, x.(Div)) }
+func (h *DivHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func schedule(divs []Div, cap int) []Div {
+	sort.Slice(divs, func(i, j int) bool { return divs[i].t < divs[j].t })
+	var pq DivHeap
+	heap.Init(&pq)
+	res := make([]Div, 0, len(divs))
+	idx := 0
+	day := 0
+	for len(res) < len(divs) {
+		if pq.Len() == 0 && idx < len(divs) && divs[idx].t > day {
+			day = divs[idx].t
+		}
+		for idx < len(divs) && divs[idx].t <= day {
+			heap.Push(&pq, divs[idx])
+			idx++
+		}
+		for k := 0; k < cap && pq.Len() > 0; k++ {
+			d := heap.Pop(&pq).(Div)
+			d.t = day + 1
+			res = append(res, d)
+		}
+		day++
+	}
+	return res
+}
+
+func solveCaseC(n int, a []int, edges [][3]int) []int {
+	adj := make([][]struct{ to, cap int }, n+1)
+	for _, e := range edges {
+		u, v, c := e[0], e[1], e[2]
+		adj[u] = append(adj[u], struct{ to, cap int }{v, c})
+		adj[v] = append(adj[v], struct{ to, cap int }{u, c})
+	}
+	children := make([][]int, n+1)
+	capToParent := make([]int, n+1)
+	parent := make([]int, n+1)
+	q := []int{1}
+	for len(q) > 0 {
+		u := q[0]
+		q = q[1:]
+		for _, e := range adj[u] {
+			if e.to == parent[u] {
+				continue
+			}
+			parent[e.to] = u
+			capToParent[e.to] = e.cap
+			children[u] = append(children[u], e.to)
+			q = append(q, e.to)
+		}
+	}
+	var dfs func(int) []Div
+	dfs = func(u int) []Div {
+		divs := []Div{{ai: a[u], t: 0, id: u}}
+		for _, v := range children[u] {
+			sub := dfs(v)
+			sched := schedule(sub, capToParent[v])
+			divs = append(divs, sched...)
+		}
+		return divs
+	}
+	rootDivs := dfs(1)
+	ans := make([]int, n+1)
+	for _, d := range rootDivs {
+		ans[d.id] = d.t
+	}
+	return ans[1:]
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(5) + 1 // 1..5
+	a := rng.Perm(n)
+	for i := range a {
+		a[i] = a[i] + 1 + rng.Intn(5)
+	}
+	edges := make([][3]int, 0, n-1)
+	for v := 2; v <= n; v++ {
+		u := rng.Intn(v-1) + 1
+		c := rng.Intn(n) + 1
+		edges = append(edges, [3]int{u, v, c})
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i, val := range a {
+		if i > 0 {
+			fmt.Fprint(&b, " ")
+		}
+		fmt.Fprint(&b, val)
+	}
+	fmt.Fprintln(&b)
+	for _, e := range edges {
+		fmt.Fprintf(&b, "%d %d %d\n", e[0], e[1], e[2])
+	}
+	exp := solveCaseC(n, append([]int{0}, a...), edges)
+	return b.String(), exp
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseOutput(out string, n int) ([]int, error) {
+	fields := strings.Fields(out)
+	if len(fields) != n {
+		return nil, fmt.Errorf("expected %d numbers", n)
+	}
+	res := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Sscan(fields[i], &res[i])
+	}
+	return res, nil
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 20; i++ {
+		input, expected := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := parseOutput(out, len(expected))
+		if err != nil {
+			fmt.Printf("case %d invalid output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !equalInts(expected, got) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%v\ngot:%v\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/82/verifierD.go
+++ b/0-999/0-99/80-89/82/verifierD.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveTime(a []int) int {
+	n := len(a)
+	d := make([]int, n+3)
+	p := make([]int, n+3)
+	var even func(int) int
+	var odd func(int) int
+	max := func(x, y int) int {
+		if x > y {
+			return x
+		}
+		return y
+	}
+	even = func(m int) int {
+		if m <= 0 {
+			return 0
+		}
+		if d[m] != 0 {
+			return d[m]
+		}
+		if m == 2 {
+			d[m] = max(a[0], a[1])
+			p[m] = 0
+			return d[m]
+		}
+		smallest := even(m-2) + max(a[m-2], a[m-1])
+		k := m - 2
+		sum := 0
+		for i := m - 2; i >= 0; i -= 2 {
+			cur := even(i) + sum + max(a[i], a[m-1])
+			sum += max(a[i], a[i-1])
+			if cur < smallest {
+				smallest = cur
+				k = i
+			}
+		}
+		sum = 0
+		for i := m - 3; i >= 0; i -= 2 {
+			cur := odd(i) + sum + max(a[i], a[m-1])
+			sum += max(a[i], a[i+1])
+			if cur < smallest {
+				smallest = cur
+				k = i
+			}
+		}
+		d[m] = smallest
+		p[m] = k
+		return smallest
+	}
+	odd = func(m int) int {
+		if m == 1 {
+			return max(a[0], a[2])
+		}
+		if d[m] != 0 {
+			return d[m]
+		}
+		smallest := even(m-1) + max(a[m-1], a[m+1])
+		k := m - 1
+		sum := 0
+		for i := m - 1; i >= 0; i -= 2 {
+			cur := even(i) + sum + max(a[i], a[m+1])
+			sum += max(a[i], a[i-1])
+			if cur < smallest {
+				smallest = cur
+				k = i
+			}
+		}
+		sum = 0
+		for i := m - 2; i >= 0; i -= 2 {
+			cur := odd(i) + sum + max(a[i], a[m+1])
+			sum += max(a[i], a[i+1])
+			if cur < smallest {
+				smallest = cur
+				k = i
+			}
+		}
+		d[m] = smallest
+		p[m] = k
+		return smallest
+	}
+	if n%2 == 0 {
+		return even(n)
+	}
+	return odd(n)
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(6) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(20) + 1
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			fmt.Fprint(&b, " ")
+		}
+		fmt.Fprint(&b, v)
+	}
+	fmt.Fprintln(&b)
+	expected := solveTime(append([]int{}, a...))
+	return b.String(), expected
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 20; i++ {
+		input, expected := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) == 0 {
+			fmt.Printf("case %d: no output\n", i+1)
+			os.Exit(1)
+		}
+		var got int
+		fmt.Sscan(fields[0], &got)
+		if got != expected {
+			fmt.Printf("case %d failed expected %d got %d\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/82/verifierE.go
+++ b/0-999/0-99/80-89/82/verifierE.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type pd struct{ X, Y float64 }
+
+type line struct{ A, B, C float64 }
+
+const eps = 1e-7
+
+func getLine(a, b pd) line {
+	A := b.Y - a.Y
+	B := a.X - b.X
+	C := -A*a.X - B*a.Y
+	return line{A, B, C}
+}
+
+func cp(a, b pd) float64 { return a.X*b.Y - a.Y*b.X }
+
+func intersect(a, b line) (pd, bool) {
+	d := cp(pd{a.A, a.B}, pd{b.A, b.B})
+	if math.Abs(d) < eps {
+		return pd{}, false
+	}
+	x := -cp(pd{a.C, a.B}, pd{b.C, b.B}) / d
+	y := -cp(pd{a.A, a.C}, pd{b.A, b.C}) / d
+	return pd{x, y}, true
+}
+
+func equals(a, b pd) bool { return math.Hypot(a.X-b.X, a.Y-b.Y) < eps }
+
+func getArea(p []pd) float64 {
+	if len(p) < 3 {
+		return 0
+	}
+	pts := append([]pd(nil), p...)
+	var c pd
+	n := float64(len(pts))
+	for _, v := range pts {
+		c.X += v.X / n
+		c.Y += v.Y / n
+	}
+	for i := range pts {
+		pts[i].X -= c.X
+		pts[i].Y -= c.Y
+	}
+	type ap struct {
+		ang float64
+		pt  pd
+	}
+	arr := make([]ap, len(pts))
+	for i, v := range pts {
+		arr[i] = ap{math.Atan2(v.Y, v.X), v}
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i].ang < arr[j].ang })
+	pts = pts[:0]
+	for _, v := range arr {
+		pts = append(pts, v.pt)
+	}
+	uniq := make([]pd, 0, len(pts))
+	for _, v := range pts {
+		if len(uniq) == 0 || !equals(uniq[len(uniq)-1], v) {
+			uniq = append(uniq, v)
+		}
+	}
+	pts = uniq
+	res := 0.0
+	for i := range pts {
+		j := (i + 1) % len(pts)
+		ax := pts[i].X - c.X
+		ay := pts[i].Y - c.Y
+		bx := pts[j].X - c.X
+		by := pts[j].Y - c.Y
+		res += ax*by - ay*bx
+	}
+	return math.Abs(res) / 2
+}
+
+func solveE(n int, h, f float64, segs [][2]float64) float64 {
+	s := make([]pd, 0, n*2)
+	for i := 0; i < n; i++ {
+		l, r := segs[i][0], segs[i][1]
+		if l < 0 && r > 0 {
+			s = append(s, pd{l, 0}, pd{0, r})
+		} else {
+			s = append(s, pd{l, r})
+		}
+	}
+	cu := pd{0, f}
+	cd := pd{0, -f}
+	ul := getLine(pd{0, h}, pd{1, h})
+	dl := getLine(pd{0, -h}, pd{1, -h})
+	ans := 0.0
+	for i := range s {
+		lp := pd{s[i].X, -h}
+		rp := pd{s[i].Y, -h}
+		lLine := getLine(cd, lp)
+		rLine := getLine(cd, rp)
+		ulp, _ := intersect(lLine, ul)
+		urp, _ := intersect(rLine, ul)
+		ans += h * (s[i].Y - s[i].X + urp.X - ulp.X)
+	}
+	ans *= 2
+	for i := range s {
+		for j := 0; j <= i; j++ {
+			pts := make([]pd, 0, 16)
+			lp1 := pd{s[i].X, -h}
+			rp1 := pd{s[i].Y, -h}
+			l1 := getLine(cd, lp1)
+			r1 := getLine(cd, rp1)
+			ulp1, _ := intersect(l1, ul)
+			urp1, _ := intersect(r1, ul)
+			lp2 := pd{s[j].X, h}
+			rp2 := pd{s[j].Y, h}
+			l2 := getLine(cu, lp2)
+			r2 := getLine(cu, rp2)
+			dlp2, _ := intersect(l2, dl)
+			drp2, _ := intersect(r2, dl)
+			if ulp1.X >= lp2.X && ulp1.X <= rp2.X {
+				pts = append(pts, ulp1)
+			}
+			if urp1.X >= lp2.X && urp1.X <= rp2.X {
+				pts = append(pts, urp1)
+			}
+			if dlp2.X >= lp1.X && dlp2.X <= rp1.X {
+				pts = append(pts, dlp2)
+			}
+			if drp2.X >= lp1.X && drp2.X <= rp1.X {
+				pts = append(pts, drp2)
+			}
+			if lp2.X >= ulp1.X && lp2.X <= urp1.X {
+				pts = append(pts, lp2)
+			}
+			if rp2.X >= ulp1.X && rp2.X <= urp1.X {
+				pts = append(pts, rp2)
+			}
+			if lp1.X >= dlp2.X && lp1.X <= drp2.X {
+				pts = append(pts, lp1)
+			}
+			if rp1.X >= dlp2.X && rp1.X <= drp2.X {
+				pts = append(pts, rp1)
+			}
+			if cll, ok := intersect(l1, l2); ok && cll.Y >= -h && cll.Y <= h {
+				pts = append(pts, cll)
+			}
+			if clr, ok := intersect(l1, r2); ok && clr.Y >= -h && clr.Y <= h {
+				pts = append(pts, clr)
+			}
+			if crl, ok := intersect(r1, l2); ok && crl.Y >= -h && crl.Y <= h {
+				pts = append(pts, crl)
+			}
+			if crr, ok := intersect(r1, r2); ok && crr.Y >= -h && crr.Y <= h {
+				pts = append(pts, crr)
+			}
+			if i == j {
+				ans -= getArea(pts)
+			} else {
+				ans -= 2 * getArea(pts)
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	n := rng.Intn(3) + 1
+	h := float64(rng.Intn(9) + 1)
+	f := h + float64(rng.Intn(20)+1)
+	segs := make([][2]float64, n)
+	used := [][2]float64{}
+	for i := 0; i < n; i++ {
+		for {
+			l := float64(rng.Intn(10) - 5)
+			r := l + float64(rng.Intn(3)+1)
+			overlap := false
+			for _, u := range used {
+				if !(r <= u[0] || l >= u[1]) {
+					overlap = true
+					break
+				}
+			}
+			if !overlap {
+				segs[i] = [2]float64{l, r}
+				used = append(used, segs[i])
+				break
+			}
+		}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %d %d\n", n, int(h), int(f))
+	for _, s := range segs {
+		fmt.Fprintf(&b, "%d %d\n", int(s[0]), int(s[1]))
+	}
+	expected := solveE(n, h, f, segs)
+	return b.String(), expected
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 20; i++ {
+		input, expected := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var got float64
+		fmt.Sscan(strings.TrimSpace(out), &got)
+		if math.Abs(got-expected) > 1e-4 {
+			fmt.Printf("case %d failed\ninput:\n%sexpected %.6f got %.6f\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 82 problems A–E
- each verifier generates 20 random tests and runs a candidate binary
- expected outputs are computed with reference solutions from this repo

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e61bbd2f48324bb0095e6429d893f