### PR TITLE
Add Go verifiers for Codeforces contest 78

### DIFF
--- a/0-999/0-99/70-79/78/verifierA.go
+++ b/0-999/0-99/70-79/78/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func countVowels(s string) int {
+	cnt := 0
+	for _, ch := range s {
+		switch ch {
+		case 'a', 'e', 'i', 'o', 'u':
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	lines := make([]string, 3)
+	counts := make([]int, 3)
+	for i := 0; i < 3; i++ {
+		l := rng.Intn(20) + 1
+		var sb strings.Builder
+		for j := 0; j < l; j++ {
+			if rng.Intn(5) == 0 {
+				sb.WriteByte(' ')
+				continue
+			}
+			ch := byte('a' + rng.Intn(26))
+			sb.WriteByte(ch)
+			switch ch {
+			case 'a', 'e', 'i', 'o', 'u':
+				counts[i]++
+			}
+		}
+		if strings.TrimSpace(sb.String()) == "" {
+			sb.WriteByte('a')
+			counts[i]++
+		}
+		lines[i] = sb.String()
+	}
+	input := strings.Join(lines, "\n") + "\n"
+	exp := "NO"
+	if counts[0] == 5 && counts[1] == 7 && counts[2] == 5 {
+		exp = "YES"
+	}
+	return input, exp
+}
+
+func runCase(bin string, input string, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/78/verifierB.go
+++ b/0-999/0-99/70-79/78/verifierB.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(94) + 7 // 7..100
+	input := fmt.Sprintf("%d\n", n)
+	return input, n
+}
+
+func validate(output string, n int) error {
+	out := strings.TrimSpace(output)
+	if len(out) != n {
+		return fmt.Errorf("length mismatch: expected %d got %d", n, len(out))
+	}
+	colors := "ROYGBIV"
+	freq := make(map[rune]int)
+	for _, ch := range out {
+		if !strings.ContainsRune(colors, ch) {
+			return fmt.Errorf("invalid character %q", ch)
+		}
+		freq[ch]++
+	}
+	for _, ch := range colors {
+		if freq[ch] == 0 {
+			return fmt.Errorf("color %c missing", ch)
+		}
+	}
+	for i := 0; i < n; i++ {
+		set := make(map[byte]struct{})
+		for j := 0; j < 4; j++ {
+			set[out[(i+j)%n]] = struct{}{}
+		}
+		if len(set) != 4 {
+			return fmt.Errorf("repeated colors in segment starting %d", i)
+		}
+	}
+	return nil
+}
+
+func runCase(bin string, input string, n int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if err := validate(out.String(), n); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n := generateCase(rng)
+		if err := runCase(bin, in, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/78/verifierC.go
+++ b/0-999/0-99/70-79/78/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var kVal int64
+var memo map[int64]int
+
+func grundy(x int64) int {
+	if x < 2*kVal {
+		return 0
+	}
+	if v, ok := memo[x]; ok {
+		return v
+	}
+	lim := x / kVal
+	for i := int64(1); i*i <= x; i++ {
+		if x%i != 0 {
+			continue
+		}
+		d1 := i
+		if d1 >= 2 && d1 <= lim {
+			if d1%2 == 0 || grundy(x/d1) == 0 {
+				memo[x] = 1
+				return 1
+			}
+		}
+		d2 := x / i
+		if d2 != d1 && d2 >= 2 && d2 <= lim {
+			if d2%2 == 0 || grundy(x/d2) == 0 {
+				memo[x] = 1
+				return 1
+			}
+		}
+	}
+	memo[x] = 0
+	return 0
+}
+
+func solve(n, m, k int64) string {
+	if n%2 == 0 {
+		return "Marsel"
+	}
+	kVal = k
+	memo = make(map[int64]int)
+	if grundy(m) != 0 {
+		return "Timur"
+	}
+	return "Marsel"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(5) + 1)
+	m := int64(rng.Intn(200) + 1)
+	k := int64(rng.Intn(int(m)) + 1)
+	input := fmt.Sprintf("%d %d %d\n", n, m, k)
+	return input, solve(n, m, k)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/78/verifierD.go
+++ b/0-999/0-99/70-79/78/verifierD.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isqrt(n int64) int64 {
+	if n <= 0 {
+		return 0
+	}
+	x := int64(math.Sqrt(float64(n)))
+	for (x+1)*(x+1) <= n {
+		x++
+	}
+	for x*x > n {
+		x--
+	}
+	return x
+}
+
+func solve(k int64) int64 {
+	R := k - 1
+	T := 4 * R * R
+	Ymax := isqrt(T / 3)
+	var ans int64
+	for y := int64(0); y <= Ymax; y++ {
+		t := T - 3*y*y
+		if t < 0 {
+			continue
+		}
+		xmax := isqrt(t)
+		var cnt int64
+		if y%2 == 0 {
+			cnt = 2*(xmax/2) + 1
+		} else {
+			cnt = 2 * ((xmax + 1) / 2)
+		}
+		if y == 0 {
+			ans += cnt
+		} else {
+			ans += 2 * cnt
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	k := int64(rng.Intn(50) + 1)
+	input := fmt.Sprintf("%d\n", k)
+	return input, solve(k)
+}
+
+func runCase(bin, input string, expected int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/78/verifierE.go
+++ b/0-999/0-99/70-79/78/verifierE.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to, rev, cap int
+}
+
+type Dinic struct {
+	n     int
+	adj   [][]Edge
+	level []int
+	prog  []int
+}
+
+func NewDinic(n int) *Dinic {
+	d := &Dinic{n: n, adj: make([][]Edge, n), level: make([]int, n), prog: make([]int, n)}
+	return d
+}
+
+func (d *Dinic) AddEdge(u, v, c int) {
+	d.adj[u] = append(d.adj[u], Edge{to: v, rev: len(d.adj[v]), cap: c})
+	d.adj[v] = append(d.adj[v], Edge{to: u, rev: len(d.adj[u]) - 1, cap: 0})
+}
+
+func (d *Dinic) bfs(s, t int) bool {
+	for i := range d.level {
+		d.level[i] = -1
+	}
+	queue := make([]int, 0, d.n)
+	d.level[s] = 0
+	queue = append(queue, s)
+	for qi := 0; qi < len(queue); qi++ {
+		u := queue[qi]
+		for _, e := range d.adj[u] {
+			if e.cap > 0 && d.level[e.to] < 0 {
+				d.level[e.to] = d.level[u] + 1
+				queue = append(queue, e.to)
+				if e.to == t {
+					return true
+				}
+			}
+		}
+	}
+	return d.level[t] >= 0
+}
+
+func (d *Dinic) dfs(u, t, f int) int {
+	if u == t {
+		return f
+	}
+	for i := d.prog[u]; i < len(d.adj[u]); i++ {
+		e := &d.adj[u][i]
+		if e.cap > 0 && d.level[e.to] == d.level[u]+1 {
+			minf := d.dfs(e.to, t, min(f, e.cap))
+			if minf > 0 {
+				e.cap -= minf
+				d.adj[e.to][e.rev].cap += minf
+				return minf
+			}
+		}
+		d.prog[u]++
+	}
+	return 0
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func (d *Dinic) MaxFlow(s, t int) int {
+	flow := 0
+	for d.bfs(s, t) {
+		for i := range d.prog {
+			d.prog[i] = 0
+		}
+		for {
+			f := d.dfs(s, t, 1<<30)
+			if f == 0 {
+				break
+			}
+			flow += f
+		}
+	}
+	return flow
+}
+
+func solve(n, t int, gridS, gridC []string) int {
+	const INF = int(1e9)
+	dist := make([][]int, n)
+	for i := range dist {
+		dist[i] = make([]int, n)
+		for j := range dist[i] {
+			dist[i][j] = INF
+		}
+	}
+	var zi, zj int
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if gridS[i][j] == 'Z' {
+				zi, zj = i, j
+			}
+		}
+	}
+	type P struct{ i, j int }
+	q := make([]P, 0, n*n)
+	dist[zi][zj] = 0
+	q = append(q, P{zi, zj})
+	dirs := []P{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
+	for qi := 0; qi < len(q); qi++ {
+		u := q[qi]
+		for _, ddir := range dirs {
+			ni, nj := u.i+ddir.i, u.j+ddir.j
+			if ni >= 0 && ni < n && nj >= 0 && nj < n && dist[ni][nj] == INF {
+				if gridS[ni][nj] >= '0' && gridS[ni][nj] <= '9' {
+					dist[ni][nj] = dist[u.i][u.j] + 1
+					q = append(q, P{ni, nj})
+				}
+			}
+		}
+	}
+	timeLayers := t + 1
+	totalLabs := n * n
+	baseTime := 0
+	baseCap := baseTime + totalLabs*timeLayers
+	source := baseCap + totalLabs
+	sink := source + 1
+	V := sink + 1
+	dinic := NewDinic(V)
+	infCap := totalLabs*10 + 5
+	timeNode := func(i, j, k int) int {
+		return baseTime + (i*n+j)*timeLayers + k
+	}
+	capNode := func(i, j int) int {
+		return baseCap + (i*n + j)
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if gridS[i][j] >= '0' && gridS[i][j] <= '9' {
+				sCnt := int(gridS[i][j] - '0')
+				if sCnt > 0 && dist[i][j] > 0 {
+					dinic.AddEdge(source, timeNode(i, j, 0), sCnt)
+				}
+			}
+		}
+	}
+	dirs = []P{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if gridS[i][j] >= '0' && gridS[i][j] <= '9' {
+				capCnt := 0
+				if gridC[i][j] >= '0' && gridC[i][j] <= '9' {
+					capCnt = int(gridC[i][j] - '0')
+				}
+				if capCnt > 0 {
+					dinic.AddEdge(capNode(i, j), sink, capCnt)
+				}
+				for k := 0; k <= t; k++ {
+					if dist[i][j] > k {
+						if capCnt > 0 {
+							dinic.AddEdge(timeNode(i, j, k), capNode(i, j), infCap)
+						}
+						if k < t {
+							for _, ddir := range dirs {
+								ni, nj := i+ddir.i, j+ddir.j
+								if ni >= 0 && ni < n && nj >= 0 && nj < n && dist[ni][nj] > k+1 && gridS[ni][nj] >= '0' && gridS[ni][nj] <= '9' {
+									dinic.AddEdge(timeNode(i, j, k), timeNode(ni, nj, k+1), infCap)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	result := dinic.MaxFlow(source, sink)
+	return result
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(3) + 2
+	tVal := rng.Intn(4) + 1
+	gridS := make([]string, n)
+	gridC := make([]string, n)
+	zi := rng.Intn(n)
+	zj := rng.Intn(n)
+	for i := 0; i < n; i++ {
+		var sbS, sbC strings.Builder
+		for j := 0; j < n; j++ {
+			if i == zi && j == zj {
+				sbS.WriteByte('Z')
+				sbC.WriteByte('Z')
+				continue
+			}
+			if rng.Intn(5) == 0 {
+				sbS.WriteByte('Y')
+				sbC.WriteByte('Y')
+			} else {
+				sbS.WriteByte(byte('0' + rng.Intn(3)))
+				sbC.WriteByte(byte('0' + rng.Intn(3)))
+			}
+		}
+		gridS[i] = sbS.String()
+		gridC[i] = sbC.String()
+	}
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d %d\n", n, tVal))
+	for i := 0; i < n; i++ {
+		input.WriteString(gridS[i])
+		input.WriteByte('\n')
+	}
+	input.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		input.WriteString(gridC[i])
+		input.WriteByte('\n')
+	}
+	expect := solve(n, tVal, gridS, gridC)
+	return input.String(), expect
+}
+
+func runCase(bin, input string, expected int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for all problems of contest 78
- each verifier runs 100 randomized test cases against an arbitrary binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go run verifierA.go ./binA`
- `go run verifierB.go ./binB`
- `go run verifierC.go ./binC`
- `go run verifierD.go ./binD`
- `go run verifierE.go ./binE` *(fails: runtime error from solver)*

------
https://chatgpt.com/codex/tasks/task_e_687e61a8362c83249d2fc9783b65889b