### PR TITLE
Add verifiers for contest 76

### DIFF
--- a/0-999/0-99/70-79/76/verifierA.go
+++ b/0-999/0-99/70-79/76/verifierA.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	u, v int
+	g, s int64
+	idxG int
+}
+
+type DSU struct {
+	p, r []int
+}
+
+func NewDSU(n int) *DSU {
+	p := make([]int, n)
+	r := make([]int, n)
+	for i := range p {
+		p[i] = i
+	}
+	return &DSU{p: p, r: r}
+}
+
+func (d *DSU) Find(x int) int {
+	for d.p[x] != x {
+		d.p[x] = d.p[d.p[x]]
+		x = d.p[x]
+	}
+	return x
+}
+
+func (d *DSU) Union(x, y int) bool {
+	rx := d.Find(x)
+	ry := d.Find(y)
+	if rx == ry {
+		return false
+	}
+	if d.r[rx] < d.r[ry] {
+		d.p[rx] = ry
+	} else if d.r[rx] > d.r[ry] {
+		d.p[ry] = rx
+	} else {
+		d.p[ry] = rx
+		d.r[rx]++
+	}
+	return true
+}
+
+func solve(data string) string {
+	in := bufio.NewReader(strings.NewReader(data))
+	var N, M int
+	var G, S int64
+	if _, err := fmt.Fscan(in, &N, &M); err != nil {
+		return ""
+	}
+	fmt.Fscan(in, &G, &S)
+	edges := make([]Edge, M)
+	for i := 0; i < M; i++ {
+		var x, y int
+		var gi, si int64
+		fmt.Fscan(in, &x, &y, &gi, &si)
+		edges[i] = Edge{u: x - 1, v: y - 1, g: gi, s: si}
+	}
+	sort.Slice(edges, func(i, j int) bool { return edges[i].g < edges[j].g })
+	for i := range edges {
+		edges[i].idxG = i
+	}
+	d0 := NewDSU(N)
+	comps := N
+	i0 := -1
+	for i, e := range edges {
+		if d0.Union(e.u, e.v) {
+			comps--
+			if comps == 1 {
+				i0 = i
+				break
+			}
+		}
+	}
+	if i0 < 0 {
+		return "-1\n"
+	}
+	edgesS := make([]Edge, M)
+	copy(edgesS, edges)
+	sort.Slice(edgesS, func(i, j int) bool { return edgesS[i].s < edgesS[j].s })
+	const INF = int64(4e18)
+	ans := INF
+	for i := i0; i < M; i++ {
+		a := edges[i].g
+		if a*G >= ans {
+			break
+		}
+		dsu := NewDSU(N)
+		used := 0
+		var b int64
+		for _, e := range edgesS {
+			if e.idxG > i {
+				continue
+			}
+			if dsu.Union(e.u, e.v) {
+				used++
+				if e.s > b {
+					b = e.s
+				}
+				if used == N-1 {
+					break
+				}
+			}
+		}
+		if used == N-1 {
+			cost := a*G + b*S
+			if cost < ans {
+				ans = cost
+			}
+		}
+	}
+	if ans == INF {
+		return "-1\n"
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	N := rng.Intn(5) + 2
+	maxM := N * N
+	M := rng.Intn(maxM) + 1
+	if M > 15 {
+		M = 15
+	}
+	G := rng.Int63n(5) + 1
+	S := rng.Int63n(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", N, M))
+	sb.WriteString(fmt.Sprintf("%d %d\n", G, S))
+	for i := 0; i < M; i++ {
+		u := rng.Intn(N) + 1
+		v := rng.Intn(N) + 1
+		g := rng.Int63n(10) + 1
+		s := rng.Int63n(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", u, v, g, s))
+	}
+	input := sb.String()
+	expected := solve(input)
+	return input, expected
+}
+
+func runCase(exe string, in, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/76/verifierB.go
+++ b/0-999/0-99/70-79/76/verifierB.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solve(data string) string {
+	in := bufio.NewReader(strings.NewReader(data))
+	var n, m int
+	var y0, y1 int
+	if _, err := fmt.Fscan(in, &n, &m, &y0, &y1); err != nil {
+		return ""
+	}
+	mice := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &mice[i])
+	}
+	cheese := make([]int, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(in, &cheese[i])
+	}
+	if m == 0 {
+		return fmt.Sprintf("%d\n", n)
+	}
+	t := make([]int, m)
+	inf := int64(1) << 60
+	d2 := make([]int64, m)
+	c := make([]int, m)
+	for j := 0; j < m; j++ {
+		d2[j] = inf
+	}
+	for _, x := range mice {
+		k := sort.SearchInts(cheese, x)
+		if k > 0 && k < m {
+			dl := absInt(x - cheese[k-1])
+			dr := cheese[k] - x
+			if dr < 0 {
+				dr = -dr
+			}
+			if dl == dr {
+				t[k-1]++
+				continue
+			}
+		}
+		var j int
+		if k == 0 {
+			j = 0
+		} else if k == m {
+			j = m - 1
+		} else {
+			dl := absInt(x - cheese[k-1])
+			dr := cheese[k] - x
+			if dr < 0 {
+				dr = -dr
+			}
+			if dl < dr {
+				j = k - 1
+			} else {
+				j = k
+			}
+		}
+		dist2 := int64(absInt(x-cheese[j])) * 2
+		if c[j] == 0 || dist2 < d2[j] {
+			d2[j] = dist2
+			c[j] = 1
+		} else if dist2 == d2[j] {
+			c[j]++
+		}
+	}
+	dpPrev := [2]int64{0, -inf}
+	dpCur := [2]int64{0, 0}
+	for j := 0; j < m-1; j++ {
+		dpCur[0], dpCur[1] = -inf, -inf
+		for s := 0; s < 2; s++ {
+			base := dpPrev[s]
+			if base < 0 {
+				continue
+			}
+			for ns := 0; ns < 2; ns++ {
+				var Lcnt, Rcnt int
+				if s == 1 && j > 0 {
+					Lcnt = t[j-1]
+				}
+				if ns == 1 {
+					Rcnt = t[j]
+				}
+				minDist := inf
+				if c[j] > 0 {
+					minDist = d2[j]
+				}
+				if Lcnt > 0 {
+					dl := int64(cheese[j] - cheese[j-1])
+					if dl < minDist {
+						minDist = dl
+					}
+				}
+				if Rcnt > 0 {
+					dr := int64(cheese[j+1] - cheese[j])
+					if dr < minDist {
+						minDist = dr
+					}
+				}
+				fed := int64(0)
+				if c[j] > 0 && d2[j] == minDist {
+					fed += int64(c[j])
+				}
+				if Lcnt > 0 && int64(cheese[j]-cheese[j-1]) == minDist {
+					fed += int64(Lcnt)
+				}
+				if Rcnt > 0 && int64(cheese[j+1]-cheese[j]) == minDist {
+					fed += int64(Rcnt)
+				}
+				val := base + fed
+				if val > dpCur[ns] {
+					dpCur[ns] = val
+				}
+			}
+		}
+		dpPrev = dpCur
+	}
+	best := int64(0)
+	for s := 0; s < 2; s++ {
+		base := dpPrev[s]
+		if base < 0 {
+			continue
+		}
+		j := m - 1
+		var Lcnt int
+		if s == 1 && j > 0 {
+			Lcnt = t[j-1]
+		}
+		minDist := inf
+		if c[j] > 0 {
+			minDist = d2[j]
+		}
+		if Lcnt > 0 {
+			dl := int64(cheese[j] - cheese[j-1])
+			if dl < minDist {
+				minDist = dl
+			}
+		}
+		fed := int64(0)
+		if c[j] > 0 && d2[j] == minDist {
+			fed += int64(c[j])
+		}
+		if Lcnt > 0 && int64(cheese[j]-cheese[j-1]) == minDist {
+			fed += int64(Lcnt)
+		}
+		total := base + fed
+		if total > best {
+			best = total
+		}
+	}
+	hungry := int64(n) - best
+	if hungry < 0 {
+		hungry = 0
+	}
+	return fmt.Sprintf("%d\n", hungry)
+}
+
+func absInt(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(9) + 1
+	m := rng.Intn(9)
+	y0 := rng.Intn(20)
+	y1 := rng.Intn(20)
+	if y1 == y0 {
+		y1++
+	}
+	mice := make([]int, n)
+	for i := range mice {
+		mice[i] = rng.Intn(50)
+	}
+	sort.Ints(mice)
+	cheese := make([]int, m)
+	for i := range cheese {
+		cheese[i] = rng.Intn(50)
+	}
+	sort.Ints(cheese)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, y0, y1))
+	for i, v := range mice {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range cheese {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expected := solve(input)
+	return input, expected
+}
+
+func runCase(exe string, in, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/76/verifierC.go
+++ b/0-999/0-99/70-79/76/verifierC.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func bitsTrailing(x uint) int {
+	return bitsTrailingDeBruijn(x)
+}
+
+var deBruijn = uint(0x077CB531)
+var idx32 = [32]int{
+	0, 1, 28, 2, 29, 14, 24, 3,
+	30, 22, 20, 15, 25, 17, 4, 8,
+	31, 27, 13, 23, 21, 19, 16, 7,
+	26, 12, 18, 6, 11, 5, 10, 9,
+}
+
+func bitsTrailingDeBruijn(v uint) int {
+	return idx32[((v&-v)*deBruijn)>>27]
+}
+
+func solve(data string) string {
+	in := bufio.NewReader(strings.NewReader(data))
+	var N, K int
+	var Tlimit int64
+	fmt.Fscan(in, &N, &K, &Tlimit)
+	var s string
+	fmt.Fscan(in, &s)
+	tAll := make([]int64, K)
+	for i := 0; i < K; i++ {
+		fmt.Fscan(in, &tAll[i])
+	}
+	aAll := make([][]int64, K)
+	for i := 0; i < K; i++ {
+		aAll[i] = make([]int64, K)
+		for j := 0; j < K; j++ {
+			fmt.Fscan(in, &aAll[i][j])
+		}
+	}
+	present := make([]bool, K)
+	for i := 0; i < N; i++ {
+		present[s[i]-'A'] = true
+	}
+	typeMap := make([]int, K)
+	revMap := make([]int, 0, K)
+	for i := 0; i < K; i++ {
+		if present[i] {
+			typeMap[i] = len(revMap)
+			revMap = append(revMap, i)
+		}
+	}
+	m := len(revMap)
+	if m == 0 {
+		return "0\n"
+	}
+	A := make([]int, N)
+	for i := 0; i < N; i++ {
+		A[i] = typeMap[s[i]-'A']
+	}
+	nextpos := make([][]int, m)
+	for x := 0; x < m; x++ {
+		nextpos[x] = make([]int, N+1)
+		next := N
+		for i := N - 1; i >= 0; i-- {
+			if A[i] == x {
+				next = i
+			}
+			nextpos[x][i] = next
+		}
+		nextpos[x][N] = N
+	}
+	size := 1 << m
+	totalOut := make([]int64, size)
+	updates := make([][]struct {
+		mask uint32
+		val  int64
+	}, m)
+	type pair struct{ pos, idx int }
+	ord := make([]pair, 0, m)
+	for p := 0; p < N; p++ {
+		i := A[p]
+		ord = ord[:0]
+		for x := 0; x < m; x++ {
+			np := nextpos[x][p]
+			if np < N {
+				ord = append(ord, pair{np, x})
+			}
+		}
+		sort.Slice(ord, func(i, j int) bool { return ord[i].pos < ord[j].pos })
+		var mask uint32
+		for _, pr := range ord {
+			j := pr.idx
+			cost := aAll[revMap[i]][revMap[j]]
+			totalOut[mask] += cost
+			updates[j] = append(updates[j], struct {
+				mask uint32
+				val  int64
+			}{mask, cost})
+			mask |= 1 << j
+		}
+	}
+	for b := 0; b < m; b++ {
+		for mask := 0; mask < size; mask++ {
+			if mask&(1<<b) != 0 {
+				totalOut[mask] += totalOut[mask^(1<<b)]
+			}
+		}
+	}
+	h := make([]int64, size)
+	for j := 0; j < m; j++ {
+		W := make([]int64, size)
+		for _, u := range updates[j] {
+			W[u.mask] += u.val
+		}
+		updates[j] = nil
+		for b := 0; b < m; b++ {
+			for mask := 0; mask < size; mask++ {
+				if mask&(1<<b) != 0 {
+					W[mask] += W[mask^(1<<b)]
+				}
+			}
+		}
+		bit := 1 << j
+		for mask := bit; mask < size; mask++ {
+			if mask&bit != 0 {
+				h[mask] += W[mask]
+			}
+		}
+	}
+	tMap := make([]int64, m)
+	for idx, orig := range revMap {
+		tMap[idx] = tAll[orig]
+	}
+	tMask := make([]int64, size)
+	for mask := 1; mask < size; mask++ {
+		lsb := mask & -mask
+		b := bitsTrailing(uint(lsb))
+		tMask[mask] = tMask[mask^lsb] + tMap[b]
+	}
+	full := size - 1
+	var ans int64
+	for mask := 0; mask < size; mask++ {
+		if mask == full {
+			continue
+		}
+		riskAdj := totalOut[mask] - h[mask]
+		if riskAdj+tMask[mask] <= Tlimit {
+			ans++
+		}
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	N := rng.Intn(8) + 1
+	K := rng.Intn(3) + 1
+	Tlimit := int64(rng.Intn(50) + 10)
+	letters := make([]byte, N)
+	for i := 0; i < N; i++ {
+		letters[i] = byte('A' + rng.Intn(K))
+	}
+	tVals := make([]int64, K)
+	for i := range tVals {
+		tVals[i] = int64(rng.Intn(10) + 1)
+	}
+	a := make([][]int64, K)
+	for i := 0; i < K; i++ {
+		a[i] = make([]int64, K)
+		for j := 0; j < K; j++ {
+			a[i][j] = int64(rng.Intn(5))
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", N, K, Tlimit))
+	sb.WriteString(string(letters) + "\n")
+	for i, v := range tVals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < K; i++ {
+		for j := 0; j < K; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(a[i][j], 10))
+		}
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	expected := solve(input)
+	return input, expected
+}
+
+func runCase(exe string, in, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/76/verifierD.go
+++ b/0-999/0-99/70-79/76/verifierD.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solve(input string) string {
+	in := strings.Fields(input)
+	if len(in) < 2 {
+		return "-1\n"
+	}
+	A, _ := strconv.ParseUint(in[0], 10, 64)
+	B, _ := strconv.ParseUint(in[1], 10, 64)
+	if A < B {
+		return "-1\n"
+	}
+	diff := A - B
+	if diff%2 == 1 {
+		return "-1\n"
+	}
+	d := diff / 2
+	if d&B != 0 {
+		return "-1\n"
+	}
+	x := d
+	y := d + B
+	return fmt.Sprintf("%d %d\n", x, y)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	A := rng.Uint64() % 1000
+	B := rng.Uint64() % 1000
+	input := fmt.Sprintf("%d\n%d\n", A, B)
+	expected := solve(fmt.Sprintf("%d %d", A, B))
+	return input, expected
+}
+
+func runCase(exe string, in, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/76/verifierE.go
+++ b/0-999/0-99/70-79/76/verifierE.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solve(input string) string {
+	fields := strings.Fields(input)
+	if len(fields) == 0 {
+		return ""
+	}
+	n, _ := strconv.Atoi(fields[0])
+	idx := 1
+	var sx, sy, sx2, sy2 int64
+	for i := 0; i < n; i++ {
+		x, _ := strconv.ParseInt(fields[idx], 10, 64)
+		y, _ := strconv.ParseInt(fields[idx+1], 10, 64)
+		idx += 2
+		sx += x
+		sy += y
+		sx2 += x * x
+		sy2 += y * y
+	}
+	N := int64(n)
+	ansX := N*sx2 - sx*sx
+	ansY := N*sy2 - sy*sy
+	ans := ansX + ansY
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(9) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := rng.Intn(21) - 10
+		y := rng.Intn(21) - 10
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	input := sb.String()
+	expected := solve(strings.TrimSpace(input))
+	return input, expected
+}
+
+func runCase(exe string, in, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/76/verifierF.go
+++ b/0-999/0-99/70-79/76/verifierF.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Event struct {
+	x int64
+	t int64
+}
+
+func maxEventsStartZero(events []Event, V int64) int {
+	n := len(events)
+	sortEvents(events)
+	size := 1 << n
+	dp := make([][]bool, size)
+	for i := range dp {
+		dp[i] = make([]bool, n)
+	}
+	for i := 0; i < n; i++ {
+		if abs64(events[i].x) <= V*events[i].t {
+			dp[1<<i][i] = true
+		}
+	}
+	best := 0
+	for mask := 1; mask < size; mask++ {
+		for last := 0; last < n; last++ {
+			if !dp[mask][last] {
+				continue
+			}
+			cnt := bitsCount(mask)
+			if cnt > best {
+				best = cnt
+			}
+			for nxt := last + 1; nxt < n; nxt++ {
+				if mask&(1<<nxt) != 0 {
+					continue
+				}
+				dt := events[nxt].t - events[last].t
+				dist := abs64(events[nxt].x - events[last].x)
+				if dist <= V*dt {
+					dp[mask|1<<nxt][nxt] = true
+				}
+			}
+		}
+	}
+	return best
+}
+
+func maxEventsFreeStart(events []Event, V int64) int {
+	n := len(events)
+	sortEvents(events)
+	size := 1 << n
+	dp := make([][]bool, size)
+	for i := range dp {
+		dp[i] = make([]bool, n)
+	}
+	for i := 0; i < n; i++ {
+		dp[1<<i][i] = true
+	}
+	best := 0
+	for mask := 1; mask < size; mask++ {
+		for last := 0; last < n; last++ {
+			if !dp[mask][last] {
+				continue
+			}
+			cnt := bitsCount(mask)
+			if cnt > best {
+				best = cnt
+			}
+			for nxt := last + 1; nxt < n; nxt++ {
+				if mask&(1<<nxt) != 0 {
+					continue
+				}
+				dt := events[nxt].t - events[last].t
+				dist := abs64(events[nxt].x - events[last].x)
+				if dist <= V*dt {
+					dp[mask|1<<nxt][nxt] = true
+				}
+			}
+		}
+	}
+	return best
+}
+
+func bitsCount(x int) int {
+	c := 0
+	for x > 0 {
+		x &= x - 1
+		c++
+	}
+	return c
+}
+
+func sortEvents(ev []Event) {
+	for i := 0; i < len(ev); i++ {
+		for j := i + 1; j < len(ev); j++ {
+			if ev[j].t < ev[i].t {
+				ev[i], ev[j] = ev[j], ev[i]
+			}
+		}
+	}
+}
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func solve(data string) string {
+	fields := strings.Fields(data)
+	if len(fields) == 0 {
+		return ""
+	}
+	idx := 0
+	n, _ := strconv.Atoi(fields[idx])
+	idx++
+	events := make([]Event, n)
+	for i := 0; i < n; i++ {
+		x, _ := strconv.ParseInt(fields[idx], 10, 64)
+		idx++
+		t, _ := strconv.ParseInt(fields[idx], 10, 64)
+		idx++
+		events[i] = Event{x: x, t: t}
+	}
+	V, _ := strconv.ParseInt(fields[idx], 10, 64)
+	a1 := maxEventsStartZero(append([]Event(nil), events...), V)
+	a2 := maxEventsFreeStart(events, V)
+	return fmt.Sprintf("%d %d\n", a1, a2)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	events := make([]Event, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := int64(rng.Intn(41) - 20)
+		t := int64(rng.Intn(10) + i + 1)
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, t))
+		events[i] = Event{x: x, t: t}
+	}
+	V := int64(rng.Intn(5) + 1)
+	sb.WriteString(fmt.Sprintf("%d\n", V))
+	input := sb.String()
+	expected := solve(input)
+	return input, expected
+}
+
+func runCase(exe string, in, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 76 problems A–F
- randomize 100 tests per run and check candidate binaries

## Testing
- `go run verifierA.go ./solverA`
- `go run verifierD.go ./solverD`


------
https://chatgpt.com/codex/tasks/task_e_687e619dc314832487d434d0e7b76166