### PR TITLE
Add solution verifiers for CF contest 74

### DIFF
--- a/0-999/0-99/70-79/74/verifierA.go
+++ b/0-999/0-99/70-79/74/verifierA.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func randScore(minVal, maxVal int) int {
+	if rand.Intn(2) == 0 {
+		return 0
+	}
+	return minVal + rand.Intn(maxVal-minVal+1)
+}
+
+func generateTest() (string, string) {
+	n := rand.Intn(10) + 1 // 1..10
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d\n", n)
+	bestScore := -1 << 60
+	bestHandle := ""
+	for i := 0; i < n; i++ {
+		handle := fmt.Sprintf("h%d_%d", i, rand.Intn(1000))
+		plus := rand.Intn(51)
+		minus := rand.Intn(51)
+		a := randScore(150, 500)
+		b := randScore(300, 1000)
+		c := randScore(450, 1500)
+		d := randScore(600, 2000)
+		e := randScore(750, 2500)
+		fmt.Fprintf(&buf, "%s %d %d %d %d %d %d %d\n", handle, plus, minus, a, b, c, d, e)
+		score := a + b + c + d + e + 100*plus - 50*minus
+		if score > bestScore {
+			bestScore = score
+			bestHandle = handle
+		}
+	}
+	return buf.String(), bestHandle
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	const tests = 100
+	for t := 1; t <= tests; t++ {
+		inp, want := generateTest()
+		cmd := exec.Command(binary)
+		cmd.Stdin = bytes.NewBufferString(inp)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(string(out))
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", t, inp, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/74/verifierB.go
+++ b/0-999/0-99/70-79/74/verifierB.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expectedOutcome(n, m, k int, dirStr, st string) string {
+	dir := 0
+	if strings.Contains(dirStr, "tail") {
+		dir = 1
+	} else {
+		dir = -1
+	}
+	S := make([]bool, n+1)
+	S[m] = true
+	cpos := k
+	for i := 1; i <= len(st); i++ {
+		ch := st[i-1]
+		if ch == '0' {
+			U := make([]bool, n+1)
+			for p := 1; p <= n; p++ {
+				if !S[p] {
+					continue
+				}
+				for _, dp := range []int{-1, 0, 1} {
+					q := p + dp
+					if q < 1 || q > n {
+						continue
+					}
+					if q == cpos {
+						continue
+					}
+					U[q] = true
+				}
+			}
+			newpos := cpos + dir
+			newdir := dir
+			if newpos == 1 || newpos == n {
+				newdir = -dir
+			}
+			if newpos >= 1 && newpos <= n {
+				U[newpos] = false
+			}
+			ok := false
+			for p := 1; p <= n; p++ {
+				if U[p] {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				return fmt.Sprintf("Controller %d", i)
+			}
+			S = U
+			cpos = newpos
+			dir = newdir
+		} else {
+			newpos := cpos + dir
+			newdir := dir
+			if newpos == 1 || newpos == n {
+				newdir = -dir
+			}
+			if i == len(st) {
+				return "Stowaway"
+			}
+			U := make([]bool, n+1)
+			for p := 1; p <= n; p++ {
+				if p != newpos {
+					U[p] = true
+				}
+			}
+			S = U
+			cpos = newpos
+			dir = newdir
+		}
+	}
+	return "Stowaway"
+}
+
+func generateTest() (string, string) {
+	n := rand.Intn(8) + 2 // 2..9
+	m := rand.Intn(n) + 1
+	k := rand.Intn(n) + 1
+	for k == m {
+		k = rand.Intn(n) + 1
+	}
+	dirStr := "to tail"
+	if k > 1 && k < n {
+		if rand.Intn(2) == 0 {
+			dirStr = "to head"
+		}
+	} else if k == n {
+		dirStr = "to head"
+	}
+	if k == 1 {
+		dirStr = "to tail"
+	}
+	tlen := rand.Intn(9) + 1
+	stBytes := make([]byte, tlen)
+	for i := 0; i < tlen-1; i++ {
+		if rand.Intn(2) == 0 {
+			stBytes[i] = '0'
+		} else {
+			stBytes[i] = '1'
+		}
+	}
+	stBytes[tlen-1] = '1'
+	st := string(stBytes)
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d %d %d\n", n, m, k)
+	fmt.Fprintln(&buf, dirStr)
+	fmt.Fprintln(&buf, st)
+	want := expectedOutcome(n, m, k, dirStr, st)
+	return buf.String(), want
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	const tests = 100
+	for t := 1; t <= tests; t++ {
+		inp, want := generateTest()
+		cmd := exec.Command(binary)
+		cmd.Stdin = bytes.NewBufferString(inp)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(string(out))
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", t, inp, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/74/verifierC.go
+++ b/0-999/0-99/70-79/74/verifierC.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func generateTest() (string, string) {
+	n := int64(rand.Intn(100) + 2)
+	m := int64(rand.Intn(100) + 2)
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d %d\n", n, m)
+	result := gcd(n-1, m-1) + 1
+	return buf.String(), fmt.Sprintf("%d", result)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	const tests = 100
+	for t := 1; t <= tests; t++ {
+		inp, want := generateTest()
+		cmd := exec.Command(binary)
+		cmd.Stdin = bytes.NewBufferString(inp)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(string(out))
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", t, inp, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/74/verifierD.go
+++ b/0-999/0-99/70-79/74/verifierD.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n       int
+	queries []string
+	answers []string
+}
+
+func generateTest() (string, string) {
+	n := rand.Intn(20) + 1
+	q := rand.Intn(20) + 1
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "%d %d\n", n, q)
+	occupied := make([]bool, n+1)
+	empPos := make(map[int]int)
+	answers := []string{}
+	existingIDs := []int{}
+	nextID := 1
+	ensureQuery := false
+	for i := 0; i < q; i++ {
+		typ := rand.Intn(3)
+		if !ensureQuery && i == q-1 {
+			typ = 0 // ensure at least one query
+		}
+		switch typ {
+		case 0: // query
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n) + 1
+			if l > r {
+				l, r = r, l
+			}
+			count := 0
+			for p := l; p <= r; p++ {
+				if occupied[p] {
+					count++
+				}
+			}
+			fmt.Fprintf(&buf, "0 %d %d\n", l, r)
+			answers = append(answers, fmt.Sprintf("%d", count))
+			ensureQuery = true
+		case 1: // arrival
+			id := nextID
+			nextID++
+			// find longest free segment
+			bestLen := -1
+			bestStart := -1
+			bestEnd := -1
+			start := -1
+			for p := 1; p <= n; p++ {
+				if !occupied[p] {
+					if start == -1 {
+						start = p
+					}
+				} else {
+					if start != -1 {
+						length := p - start
+						if length > bestLen || (length == bestLen && start > bestStart) {
+							bestLen = length
+							bestStart = start
+							bestEnd = p - 1
+						}
+						start = -1
+					}
+				}
+			}
+			if start != -1 {
+				length := n - start + 1
+				if length > bestLen || (length == bestLen && start > bestStart) {
+					bestLen = length
+					bestStart = start
+					bestEnd = n
+				}
+			}
+			length := bestEnd - bestStart + 1
+			pos := bestStart + (length-1)/2
+			if length%2 == 0 {
+				pos = bestStart + length/2
+			}
+			occupied[pos] = true
+			empPos[id] = pos
+			existingIDs = append(existingIDs, id)
+			fmt.Fprintf(&buf, "%d\n", id)
+		default: // departure
+			if len(existingIDs) == 0 {
+				id := nextID
+				nextID++
+				fmt.Fprintf(&buf, "%d\n", id)
+				continue
+			}
+			idx := rand.Intn(len(existingIDs))
+			id := existingIDs[idx]
+			existingIDs = append(existingIDs[:idx], existingIDs[idx+1:]...)
+			pos := empPos[id]
+			occupied[pos] = false
+			delete(empPos, id)
+			fmt.Fprintf(&buf, "%d\n", id)
+		}
+	}
+	return buf.String(), strings.Join(answers, "\n")
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	const tests = 100
+	for t := 1; t <= tests; t++ {
+		inp, want := generateTest()
+		cmd := exec.Command(binary)
+		cmd.Stdin = bytes.NewBufferString(inp)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(string(out))
+		want = strings.TrimSpace(want)
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", t, inp, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/74/verifierE.go
+++ b/0-999/0-99/70-79/74/verifierE.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func generateBoard() []string {
+	perm := rand.Perm(len(chars))
+	board := make([]string, 6)
+	for i := 0; i < 6; i++ {
+		row := make([]byte, 6)
+		for j := 0; j < 6; j++ {
+			row[j] = chars[perm[i*6+j]]
+		}
+		board[i] = string(row)
+	}
+	return board
+}
+
+func boardToString(b []string) string {
+	return strings.Join(b, "\n") + "\n"
+}
+
+func applyMove(board [][]byte, op string) bool {
+	if len(op) != 2 {
+		return false
+	}
+	dir := op[0]
+	idx := int(op[1] - '1')
+	if idx < 0 || idx >= 6 {
+		return false
+	}
+	switch dir {
+	case 'L':
+		row := board[idx]
+		first := row[0]
+		copy(row, row[1:])
+		row[5] = first
+	case 'R':
+		row := board[idx]
+		last := row[5]
+		copy(row[1:], row[:5])
+		row[0] = last
+	case 'U':
+		first := board[0][idx]
+		for i := 0; i < 5; i++ {
+			board[i][idx] = board[i+1][idx]
+		}
+		board[5][idx] = first
+	case 'D':
+		last := board[5][idx]
+		for i := 5; i > 0; i-- {
+			board[i][idx] = board[i-1][idx]
+		}
+		board[0][idx] = last
+	default:
+		return false
+	}
+	return true
+}
+
+func checkSolution(initial []string, output string) bool {
+	rdr := strings.NewReader(output)
+	scanner := bufio.NewScanner(rdr)
+	if !scanner.Scan() {
+		return false
+	}
+	var steps int
+	if _, err := fmt.Sscan(scanner.Text(), &steps); err != nil {
+		return false
+	}
+	if steps > 10000 || steps < 0 {
+		return false
+	}
+	board := make([][]byte, 6)
+	for i := 0; i < 6; i++ {
+		board[i] = []byte(initial[i])
+	}
+	for i := 0; i < steps; i++ {
+		if !scanner.Scan() {
+			return false
+		}
+		op := strings.TrimSpace(scanner.Text())
+		if !applyMove(board, op) {
+			return false
+		}
+	}
+	target := make([][]byte, 6)
+	for i := 0; i < 6; i++ {
+		target[i] = []byte(chars[i*6 : i*6+6])
+	}
+	for i := 0; i < 6; i++ {
+		for j := 0; j < 6; j++ {
+			if board[i][j] != target[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func generateTest() string {
+	board := generateBoard()
+	return boardToString(board)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	const tests = 100
+	for t := 1; t <= tests; t++ {
+		inp := generateTest()
+		cmd := exec.Command(binary)
+		cmd.Stdin = bytes.NewBufferString(inp)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if !checkSolution(strings.Split(strings.TrimSpace(inp), "\n"), string(out)) {
+			fmt.Printf("Test %d failed. Invalid solution.\nInput:\n%s\nOutput:\n%s\n", t, inp, string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go based verifiers for contest 74 problems A–E
- each verifier generates 100 deterministic test cases
- verifiers execute a provided binary and compare its output
- puzzle verifier checks correctness of the produced moves

## Testing
- `gofmt -w 0-999/0-99/70-79/74/verifierA.go 0-999/0-99/70-79/74/verifierB.go 0-999/0-99/70-79/74/verifierC.go 0-999/0-99/70-79/74/verifierD.go 0-999/0-99/70-79/74/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e6193e6e8832483a3e58e3910306a