### PR TITLE
Add verifiers for contest 73

### DIFF
--- a/0-999/0-99/70-79/73/verifierA.go
+++ b/0-999/0-99/70-79/73/verifierA.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	x, y, z, k int64
+}
+
+func pieces(x, y, z, k int64) int64 {
+	caps := []int64{x - 1, y - 1, z - 1}
+	sort.Slice(caps, func(i, j int) bool { return caps[i] < caps[j] })
+	sumcaps := caps[0] + caps[1] + caps[2]
+	if k >= sumcaps {
+		return x * y * z
+	}
+	T := k
+	low, high := int64(0), caps[2]
+	for low < high {
+		mid := (low + high) / 2
+		var s int64
+		for i := 0; i < 3; i++ {
+			if caps[i] < mid {
+				s += caps[i]
+			} else {
+				s += mid
+			}
+		}
+		if s >= T {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+	L := low
+	xcuts := make([]int64, 3)
+	var sumX int64
+	for i := 0; i < 3; i++ {
+		if caps[i] < L {
+			xcuts[i] = caps[i]
+		} else {
+			xcuts[i] = L
+		}
+		sumX += xcuts[i]
+	}
+	E := sumX - T
+	for i := 2; i >= 0 && E > 0; i-- {
+		if xcuts[i] == L {
+			xcuts[i]--
+			E--
+		}
+	}
+	res := int64(1)
+	for i := 0; i < 3; i++ {
+		res *= (xcuts[i] + 1)
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		x := rng.Int63n(10) + 1
+		y := rng.Int63n(10) + 1
+		z := rng.Int63n(10) + 1
+		k := rng.Int63n(30)
+		input := fmt.Sprintf("%d %d %d %d\n", x, y, z, k)
+		expected := fmt.Sprintf("%d", pieces(x, y, z, k))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/73/verifierB.go
+++ b/0-999/0-99/70-79/73/verifierB.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Racer struct {
+	name string
+	a    int
+}
+
+func rankRange(racers []Racer, b []int, vasyaName string) (int, int) {
+	n := len(racers)
+	var vasyaA int
+	others := make([]Racer, 0, n-1)
+	for _, r := range racers {
+		if r.name == vasyaName {
+			vasyaA = r.a
+		} else {
+			others = append(others, r)
+		}
+	}
+	total := n
+	B := make([]int, 0, total)
+	for i := 0; i < len(b); i++ {
+		B = append(B, b[i])
+	}
+	for i := 0; i < total-len(b); i++ {
+		B = append(B, 0)
+	}
+	sort.Slice(B, func(i, j int) bool { return B[i] > B[j] })
+	bestB := append([]int(nil), B[1:]...)
+	threshBest := vasyaA + B[0]
+	worstB := append([]int(nil), B[:len(B)-1]...)
+	threshWorst := vasyaA + B[len(B)-1]
+	sort.Slice(others, func(i, j int) bool {
+		if others[i].a != others[j].a {
+			return others[i].a < others[j].a
+		}
+		return others[i].name < others[j].name
+	})
+	threatsBest := 0
+	for i, r := range others {
+		sum := r.a + bestB[i]
+		if sum > threshBest || (sum == threshBest && r.name < vasyaName) {
+			threatsBest++
+		}
+	}
+	sort.Slice(others, func(i, j int) bool {
+		if others[i].a != others[j].a {
+			return others[i].a > others[j].a
+		}
+		return others[i].name > others[j].name
+	})
+	threatsWorst := 0
+	for i, r := range others {
+		sum := r.a + worstB[i]
+		if sum > threshWorst || (sum == threshWorst && r.name < vasyaName) {
+			threatsWorst++
+		}
+	}
+	return 1 + threatsBest, 1 + threatsWorst
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 2
+		racers := make([]Racer, n)
+		for j := 0; j < n; j++ {
+			racers[j] = Racer{
+				name: fmt.Sprintf("p%d", j),
+				a:    rng.Intn(30),
+			}
+		}
+		m := rng.Intn(n) + 1
+		b := make([]int, m)
+		for j := 0; j < m; j++ {
+			b[j] = rng.Intn(20)
+		}
+		vasyaIndex := rng.Intn(n)
+		vasyaName := racers[vasyaIndex].name
+		best, worst := rankRange(racers, b, vasyaName)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for _, r := range racers {
+			sb.WriteString(fmt.Sprintf("%s %d\n", r.name, r.a))
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+		for j, v := range b {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(vasyaName)
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := fmt.Sprintf("%d %d", best, worst)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/73/verifierC.go
+++ b/0-999/0-99/70-79/73/verifierC.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const NEG_INF = -1000000000
+
+func euphony(s string, k int, c [26][26]int) int {
+	m := len(s)
+	dpPrev := make([][]int, k+1)
+	dpCurr := make([][]int, k+1)
+	for j := 0; j <= k; j++ {
+		dpPrev[j] = make([]int, 26)
+		dpCurr[j] = make([]int, 26)
+		for l := 0; l < 26; l++ {
+			dpPrev[j][l] = NEG_INF
+			dpCurr[j][l] = NEG_INF
+		}
+	}
+	orig0 := int(s[0] - 'a')
+	for l := 0; l < 26; l++ {
+		chg := 0
+		if l != orig0 {
+			chg = 1
+		}
+		if chg <= k {
+			dpPrev[chg][l] = 0
+		}
+	}
+	for pos := 1; pos < m; pos++ {
+		for j := 0; j <= k; j++ {
+			for l := 0; l < 26; l++ {
+				dpCurr[j][l] = NEG_INF
+			}
+		}
+		curOrig := int(s[pos] - 'a')
+		for used := 0; used <= k; used++ {
+			for prevL := 0; prevL < 26; prevL++ {
+				prevVal := dpPrev[used][prevL]
+				if prevVal <= NEG_INF {
+					continue
+				}
+				for l := 0; l < 26; l++ {
+					nj := used
+					if l != curOrig {
+						nj++
+					}
+					if nj > k {
+						continue
+					}
+					val := prevVal + c[prevL][l]
+					if val > dpCurr[nj][l] {
+						dpCurr[nj][l] = val
+					}
+				}
+			}
+		}
+		dpPrev, dpCurr = dpCurr, dpPrev
+	}
+	ans := NEG_INF
+	for used := 0; used <= k; used++ {
+		for l := 0; l < 26; l++ {
+			if dpPrev[used][l] > ans {
+				ans = dpPrev[used][l]
+			}
+		}
+	}
+	if m <= 1 {
+		ans = 0
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(4))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := randString(rng, rng.Intn(5)+1)
+		k := rng.Intn(len(s) + 1)
+		n := rng.Intn(5)
+		var c [26][26]int
+		for j := 0; j < n; j++ {
+			x := rng.Intn(4)
+			y := rng.Intn(4)
+			val := rng.Intn(11) - 5
+			c[x][y] = val
+		}
+		expected := fmt.Sprintf("%d", euphony(s, k, c))
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%s %d\n", s, k))
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for x := 0; x < 26; x++ {
+			for y := 0; y < 26; y++ {
+				if c[x][y] != 0 {
+					sb.WriteString(fmt.Sprintf("%c %c %d\n", 'a'+x, 'a'+y, c[x][y]))
+				}
+			}
+		}
+		input := sb.String()
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/73/verifierD.go
+++ b/0-999/0-99/70-79/73/verifierD.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	p, sz []int
+}
+
+func NewDSU(n int) *DSU {
+	p := make([]int, n+1)
+	sz := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		p[i] = i
+		sz[i] = 1
+	}
+	return &DSU{p: p, sz: sz}
+}
+
+func (d *DSU) Find(x int) int {
+	for d.p[x] != x {
+		d.p[x] = d.p[d.p[x]]
+		x = d.p[x]
+	}
+	return x
+}
+
+func (d *DSU) Union(a, b int) {
+	ra := d.Find(a)
+	rb := d.Find(b)
+	if ra == rb {
+		return
+	}
+	if d.sz[ra] < d.sz[rb] {
+		ra, rb = rb, ra
+	}
+	d.p[rb] = ra
+	d.sz[ra] += d.sz[rb]
+}
+
+type IntHeap []int
+
+func (h IntHeap) Len() int            { return len(h) }
+func (h IntHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h IntHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *IntHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *IntHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+func solve(n, m, k int, edges [][2]int) int {
+	dsu := NewDSU(n)
+	for _, e := range edges {
+		dsu.Union(e[0], e[1])
+	}
+	compCap := make(map[int]int)
+	for i := 1; i <= n; i++ {
+		r := dsu.Find(i)
+		compCap[r]++
+	}
+	h := &IntHeap{}
+	heap.Init(h)
+	sumCaps := 0
+	D := 0
+	for _, sz := range compCap {
+		cap := sz
+		if cap > k {
+			cap = k
+		}
+		heap.Push(h, cap)
+		sumCaps += cap
+		D++
+	}
+	if D <= 1 {
+		return 0
+	}
+	roads := 0
+	for sumCaps < 2*(D-1) {
+		c1 := heap.Pop(h).(int)
+		c2 := heap.Pop(h).(int)
+		newC := c1 + c2
+		loss := 0
+		if newC > k {
+			loss = newC - k
+			newC = k
+		}
+		sumCaps -= loss
+		D--
+		roads++
+		heap.Push(h, newC)
+	}
+	return roads
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		maxEdges := n * (n - 1) / 2
+		m := rng.Intn(maxEdges + 1)
+		edges := make([][2]int, 0, m)
+		used := make(map[[2]int]bool)
+		for len(edges) < m {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			e := [2]int{u, v}
+			if u > v {
+				e = [2]int{v, u}
+			}
+			if used[e] {
+				continue
+			}
+			used[e] = true
+			edges = append(edges, e)
+		}
+		k := rng.Intn(5) + 1
+		expected := fmt.Sprintf("%d", solve(n, m, k, edges))
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		input := sb.String()
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/73/verifierE.go
+++ b/0-999/0-99/70-79/73/verifierE.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solve(n int, x int, a []int) int {
+	if x <= 2 {
+		return 0
+	}
+	hasOne := false
+	for _, v := range a {
+		if v == 1 {
+			hasOne = true
+			break
+		}
+	}
+	if hasOne {
+		return 1
+	}
+	L := x - 1
+	const maxL = 2000000
+	if L > maxL {
+		return -1
+	}
+	uniq := make([]bool, L+1)
+	for _, v := range a {
+		if v <= L {
+			uniq[v] = true
+		}
+	}
+	vals := make([]int, 0)
+	for v, ok := range uniq {
+		if ok && v >= 2 {
+			vals = append(vals, v)
+		}
+	}
+	if len(vals) == 0 {
+		return -1
+	}
+	sort.Ints(vals)
+	spf := make([]int, L+1)
+	for i := 2; i <= L; i++ {
+		if spf[i] == 0 {
+			for j := i; j <= L; j += i {
+				if spf[j] == 0 {
+					spf[j] = i
+				}
+			}
+		}
+	}
+	hasB := make([]bool, L+1)
+	B := make([]int, 0)
+	for _, v := range vals {
+		ok := true
+		divs := []int{1}
+		vv := v
+		for vv > 1 {
+			p := spf[vv]
+			cnt := 0
+			for vv%p == 0 {
+				vv /= p
+				cnt++
+			}
+			base := len(divs)
+			mul := 1
+			for e := 1; e <= cnt; e++ {
+				mul *= p
+				for i := 0; i < base; i++ {
+					divs = append(divs, divs[i]*mul)
+				}
+			}
+		}
+		for _, d := range divs {
+			if d == v {
+				continue
+			}
+			if hasB[d] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			hasB[v] = true
+			B = append(B, v)
+		}
+	}
+	covered := make([]bool, L+1)
+	for _, b := range B {
+		for m := b; m <= L; m += b {
+			covered[m] = true
+		}
+	}
+	for k := 2; k <= L; k++ {
+		if !covered[k] {
+			return -1
+		}
+	}
+	return len(B)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		x := rng.Intn(15) + 3
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rng.Intn(x) + 1
+		}
+		expected := fmt.Sprintf("%d", solve(n, x, a))
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+		for j, v := range a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/73/verifierF.go
+++ b/0-999/0-99/70-79/73/verifierF.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Pnt struct{ x, y float64 }
+
+func get(a, b Pnt, s, w float64) float64 {
+	dir := Pnt{b.x - a.x, b.y - a.y}
+	length := math.Hypot(dir.x, dir.y)
+	best := 0.0
+	twoPi := 2 * math.Pi
+	for i := 0; i <= 100; i++ {
+		t := float64(i) / 100.0
+		x := a.x + dir.x*t
+		y := a.y + dir.y*t
+		r := math.Atan2(y, x) - s
+		for r < 0 {
+			r += twoPi
+		}
+		for r > twoPi {
+			r -= twoPi
+		}
+		minr := math.Min(r, twoPi-r)
+		val := length * t * w / minr
+		if val > best {
+			best = val
+		}
+	}
+	return best
+}
+
+func solve(ax, ay, bx, by float64, tanks []struct{ x, y, s, w float64 }, k int) float64 {
+	a := Pnt{ax, ay}
+	b := Pnt{bx, by}
+	v := make([]float64, 0, len(tanks)+1)
+	v = append(v, 0.0)
+	for _, t := range tanks {
+		p := Pnt{t.x, t.y}
+		ap := Pnt{a.x - p.x, a.y - p.y}
+		bp := Pnt{b.x - p.x, b.y - p.y}
+		v = append(v, get(ap, bp, t.s, t.w))
+	}
+	sort.Float64s(v)
+	for i, j := 0, len(v)-1; i < j; i, j = i+1, j-1 {
+		v[i], v[j] = v[j], v[i]
+	}
+	return v[k]
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		ax := float64(rng.Intn(11) - 5)
+		ay := float64(rng.Intn(11) - 5)
+		bx := float64(rng.Intn(11) - 5)
+		by := float64(rng.Intn(11) - 5)
+		if ax == bx && ay == by {
+			bx++
+		}
+		n := rng.Intn(3) + 1
+		tanks := make([]struct{ x, y, s, w float64 }, n)
+		for j := 0; j < n; j++ {
+			tanks[j].x = float64(rng.Intn(11) - 5)
+			tanks[j].y = float64(rng.Intn(11) - 5)
+			tanks[j].s = rng.Float64() * 2 * math.Pi
+			tanks[j].w = rng.Float64()*2 + 0.1
+		}
+		k := rng.Intn(n + 1)
+		expected := solve(ax, ay, bx, by, tanks, k)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%.0f %.0f %.0f %.0f\n", ax, ay, bx, by))
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for _, t := range tanks {
+			sb.WriteString(fmt.Sprintf("%.0f %.0f %.5f %.5f\n", t.x, t.y, t.s, t.w))
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", k))
+		input := sb.String()
+		gotStr, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseFloat(strings.TrimSpace(gotStr), 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output\n", i+1)
+			os.Exit(1)
+		}
+		if math.Abs(got-expected) > 1e-4*math.Max(1.0, math.Abs(expected)) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.6f got %.6f\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems in contest 73
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go build verifierA.go` etc
- `./verifierA ./73A_bin`

------
https://chatgpt.com/codex/tasks/task_e_687e618e89f083248d6b402b50329046