### PR TITLE
Add solution verifiers for contest 72

### DIFF
--- a/0-999/0-99/70-79/72/verifierA.go
+++ b/0-999/0-99/70-79/72/verifierA.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(n int) string {
+	// generate primes up to n
+	isPrime := make([]bool, n+1)
+	for i := 2; i <= n; i++ {
+		isPrime[i] = true
+	}
+	for i := 2; i*i <= n; i++ {
+		if isPrime[i] {
+			for j := i * i; j <= n; j += i {
+				isPrime[j] = false
+			}
+		}
+	}
+	primes := make([]int, 0)
+	for i := 2; i <= n; i++ {
+		if isPrime[i] {
+			primes = append(primes, i)
+		}
+	}
+	vals := make([]int, 0, len(primes)+1)
+	for i := len(primes) - 1; i >= 0; i-- {
+		vals = append(vals, primes[i])
+	}
+	if n >= 1 {
+		vals = append(vals, 1)
+	}
+	m := len(vals)
+	dp := make([][]bool, m+1)
+	for i := range dp {
+		dp[i] = make([]bool, n+1)
+	}
+	dp[m][0] = true
+	for i := m - 1; i >= 0; i-- {
+		vi := vals[i]
+		for s := 0; s <= n; s++ {
+			if dp[i+1][s] {
+				dp[i][s] = true
+			} else if s >= vi && dp[i+1][s-vi] {
+				dp[i][s] = true
+			}
+		}
+	}
+	if !dp[0][n] {
+		return "0"
+	}
+	res := make([]int, 0)
+	sum := n
+	idx := 0
+	for sum > 0 {
+		picked := false
+		for i := idx; i < m; i++ {
+			v := vals[i]
+			if v > sum {
+				continue
+			}
+			if dp[i+1][sum-v] {
+				res = append(res, v)
+				sum -= v
+				idx = i + 1
+				picked = true
+				break
+			}
+		}
+		if !picked {
+			return "0"
+		}
+	}
+	var sb strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	return input, expected(n)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected '%s' got '%s'", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/72/verifierB.go
+++ b/0-999/0-99/70-79/72/verifierB.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func randomID(rng *rand.Rand) string {
+	l := rng.Intn(3) + 1
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func randomSpaces(rng *rand.Rand) string {
+	return strings.Repeat(" ", rng.Intn(3))
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	sections := rng.Intn(3) + 1
+	var lines []string
+	// some global key-values
+	gCount := rng.Intn(3)
+	for i := 0; i < gCount; i++ {
+		key := randomID(rng)
+		val := randomID(rng)
+		line := randomSpaces(rng) + key + randomSpaces(rng) + "=" + randomSpaces(rng) + val + randomSpaces(rng)
+		lines = append(lines, line)
+	}
+	for s := 0; s < sections; s++ {
+		name := fmt.Sprintf("sec%d", s+1)
+		secLine := randomSpaces(rng) + "[" + name + "]" + randomSpaces(rng)
+		lines = append(lines, secLine)
+		kvCount := rng.Intn(5) + 1
+		for i := 0; i < kvCount; i++ {
+			key := randomID(rng)
+			val := randomID(rng)
+			line := randomSpaces(rng) + key + randomSpaces(rng) + "=" + randomSpaces(rng) + val + randomSpaces(rng)
+			lines = append(lines, line)
+		}
+	}
+	// add some comments
+	for i := 0; i < rng.Intn(3); i++ {
+		lines = append(lines, randomSpaces(rng)+";comment")
+	}
+	n := len(lines)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, l := range lines {
+		sb.WriteString(l)
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	expected := computeExpected(lines)
+	return input, expected
+}
+
+func computeExpected(lines []string) string {
+	global := make(map[string]string)
+	sections := make(map[string]map[string]string)
+	var sectionNames []string
+	current := ""
+	for _, line := range lines {
+		trimmedLeft := strings.TrimLeft(line, " \t")
+		if len(trimmedLeft) > 0 && trimmedLeft[0] == ';' {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) >= 2 && trimmed[0] == '[' && trimmed[len(trimmed)-1] == ']' {
+			name := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+			current = name
+			if _, ok := sections[current]; !ok {
+				sections[current] = make(map[string]string)
+				sectionNames = append(sectionNames, current)
+			}
+		} else {
+			if idx := strings.Index(line, "="); idx != -1 {
+				key := strings.TrimSpace(line[:idx])
+				value := strings.TrimSpace(line[idx+1:])
+				if current == "" {
+					global[key] = value
+				} else {
+					sections[current][key] = value
+				}
+			}
+		}
+	}
+	var gKeys []string
+	for k := range global {
+		gKeys = append(gKeys, k)
+	}
+	sort.Strings(gKeys)
+	var out strings.Builder
+	for _, k := range gKeys {
+		out.WriteString(fmt.Sprintf("%s=%s\n", k, global[k]))
+	}
+	sort.Strings(sectionNames)
+	for _, sec := range sectionNames {
+		out.WriteString(fmt.Sprintf("[%s]\n", sec))
+		var keys []string
+		for k := range sections[sec] {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			out.WriteString(fmt.Sprintf("%s=%s\n", k, sections[sec][k]))
+		}
+	}
+	res := strings.TrimRight(out.String(), "\n")
+	return res
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected '%s' got '%s'", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/72/verifierC.go
+++ b/0-999/0-99/70-79/72/verifierC.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(x int) string {
+	if x%2 == 0 && x%4 != 0 {
+		return "yes"
+	}
+	return "no"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	x := rng.Intn(10000) + 1
+	input := fmt.Sprintf("%d\n", x)
+	return input, expected(x)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected '%s' got '%s'", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/72/verifierD.go
+++ b/0-999/0-99/70-79/72/verifierD.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func reverseString(s string) string {
+	r := []rune(s)
+	for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+	return string(r)
+}
+
+func substrVal(s string, a, b, step int) string {
+	if a < 1 {
+		a = 1
+	}
+	if b > len(s) {
+		b = len(s)
+	}
+	if step <= 1 {
+		if a > b {
+			return ""
+		}
+		return s[a-1 : b]
+	}
+	var sb strings.Builder
+	for i := a; i <= b && i <= len(s); i += step {
+		sb.WriteByte(s[i-1])
+	}
+	return sb.String()
+}
+
+func genExpr(rng *rand.Rand, depth int) (string, string) {
+	if depth <= 0 || rng.Intn(4) == 0 {
+		l := rng.Intn(5) + 1
+		b := make([]byte, l)
+		for i := range b {
+			b[i] = byte('a' + rng.Intn(3))
+		}
+		str := string(b)
+		return fmt.Sprintf("\"%s\"", str), str
+	}
+	switch rng.Intn(3) {
+	case 0:
+		e1, v1 := genExpr(rng, depth-1)
+		e2, v2 := genExpr(rng, depth-1)
+		return fmt.Sprintf("concat(%s,%s)", e1, e2), v1 + v2
+	case 1:
+		e, v := genExpr(rng, depth-1)
+		return fmt.Sprintf("reverse(%s)", e), reverseString(v)
+	default:
+		e, v := genExpr(rng, depth-1)
+		n := len(v)
+		if n == 0 {
+			return fmt.Sprintf("substr(%s,1,0)", e), ""
+		}
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a > b {
+			a, b = b, a
+		}
+		if rng.Intn(2) == 0 {
+			return fmt.Sprintf("substr(%s,%d,%d)", e, a, b), substrVal(v, a, b, 1)
+		}
+		step := rng.Intn(n) + 1
+		return fmt.Sprintf("substr(%s,%d,%d,%d)", e, a, b, step), substrVal(v, a, b, step)
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	expr, val := genExpr(rng, 3)
+	return expr + "\n", val
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected '%s' got '%s'", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/72/verifierE.go
+++ b/0-999/0-99/70-79/72/verifierE.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) string {
+	bestCount := 0
+	bestLen := 0
+	bestS := ""
+	n := len(s)
+	for i := 0; i < n; i++ {
+		for l := 1; i+l <= n; l++ {
+			sub := s[i : i+l]
+			cnt := 0
+			for j := 0; j+l <= n; j++ {
+				if s[j:j+l] == sub {
+					cnt++
+				}
+			}
+			if cnt > bestCount || (cnt == bestCount && (l > bestLen || (l == bestLen && sub > bestS))) {
+				bestCount = cnt
+				bestLen = l
+				bestS = sub
+			}
+		}
+	}
+	return bestS
+}
+
+func randomString(rng *rand.Rand) string {
+	l := rng.Intn(8) + 2
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	s := randomString(rng)
+	return fmt.Sprintf("%s\n", s), expected(s)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected '%s' got '%s'", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/72/verifierF.go
+++ b/0-999/0-99/70-79/72/verifierF.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func pickUnique(rng *rand.Rand, max, count int) []int {
+	m := make(map[int]struct{})
+	for len(m) < count {
+		v := rng.Intn(max) + 1
+		m[v] = struct{}{}
+	}
+	res := make([]int, 0, count)
+	for v := range m {
+		res = append(res, v)
+	}
+	sort.Ints(res)
+	return res
+}
+
+func expected(n, m int, rows, cols []int) string {
+	emptyRow := make([]bool, n+2)
+	for _, r := range rows {
+		if r >= 1 && r <= n {
+			emptyRow[r] = true
+		}
+	}
+	rowSeg := 0
+	for i := 1; i <= n; i++ {
+		if !emptyRow[i] && (i == 1 || emptyRow[i-1]) {
+			rowSeg++
+		}
+	}
+	emptyCol := make([]bool, m+2)
+	for _, c := range cols {
+		if c >= 1 && c <= m {
+			emptyCol[c] = true
+		}
+	}
+	colSeg := 0
+	for j := 1; j <= m; j++ {
+		if !emptyCol[j] && (j == 1 || emptyCol[j-1]) {
+			colSeg++
+		}
+	}
+	return fmt.Sprintf("%d", rowSeg*colSeg)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	t := rng.Intn(n + 1)
+	rows := pickUnique(rng, n, t)
+	s := rng.Intn(m + 1)
+	cols := pickUnique(rng, m, s)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	sb.WriteString(fmt.Sprintf("%d", t))
+	for _, r := range rows {
+		sb.WriteString(fmt.Sprintf(" %d", r))
+	}
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("%d", s))
+	for _, c := range cols {
+		sb.WriteString(fmt.Sprintf(" %d", c))
+	}
+	sb.WriteString("\n")
+	input := sb.String()
+	return input, expected(n, m, rows, cols)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected '%s' got '%s'", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/72/verifierG.go
+++ b/0-999/0-99/70-79/72/verifierG.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) string {
+	a, b := 1, 1
+	for i := 2; i <= n; i++ {
+		a, b = b, a+b
+	}
+	return fmt.Sprintf("%d", b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	return fmt.Sprintf("%d\n", n), expected(n)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected '%s' got '%s'", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/72/verifierH.go
+++ b/0-999/0-99/70-79/72/verifierH.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) string {
+	sign := ""
+	if strings.HasPrefix(s, "-") {
+		sign = "-"
+		s = s[1:]
+	}
+	i := 0
+	for i < len(s) && s[i] == '0' {
+		i++
+	}
+	s = s[i:]
+	if len(s) == 0 {
+		return "0"
+	}
+	bs := []byte(s)
+	for i, j := 0, len(bs)-1; i < j; i, j = i+1, j-1 {
+		bs[i], bs[j] = bs[j], bs[i]
+	}
+	j := 0
+	for j < len(bs) && bs[j] == '0' {
+		j++
+	}
+	bs = bs[j:]
+	if len(bs) == 0 {
+		return "0"
+	}
+	if sign != "" {
+		return sign + string(bs)
+	}
+	return string(bs)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	sign := ""
+	if rng.Intn(2) == 0 {
+		sign = "-"
+	}
+	l := rng.Intn(8) + 1
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('0' + rng.Intn(10))
+	}
+	s := sign + string(b)
+	return fmt.Sprintf("%s\n", s), expected(s)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected '%s' got '%s'", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/72/verifierI.go
+++ b/0-999/0-99/70-79/72/verifierI.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) string {
+	s := fmt.Sprint(n)
+	total := len(s)
+	divCount := 0
+	for i := 0; i < len(s); i++ {
+		d := int(s[i] - '0')
+		if d != 0 && n%d == 0 {
+			divCount++
+		}
+	}
+	switch {
+	case divCount == 0:
+		return "upset"
+	case divCount == total:
+		return "happier"
+	default:
+		return "happy"
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100000) + 1
+	return fmt.Sprintf("%d\n", n), expected(n)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected '%s' got '%s'", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems in contest 72
- verifiers generate 100 random test cases and execute a provided binary
- support running compiled binaries or Go source via `go run`

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build verifierI.go`
- `go run verifierA.go ./72A_bin` (after building example binary)

------
https://chatgpt.com/codex/tasks/task_e_687e618982b4832497cc3d497d409af1