### PR TITLE
Add verifiers for contest 71

### DIFF
--- a/0-999/0-99/70-79/71/verifierA.go
+++ b/0-999/0-99/70-79/71/verifierA.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func randomWord(rng *rand.Rand, length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(20) + 1
+		if rng.Float64() < 0.3 {
+			l = rng.Intn(100) + 1
+		}
+		w := randomWord(rng, l)
+		fmt.Fprintln(&in, w)
+		if len(w) > 10 {
+			fmt.Fprintf(&out, "%c%d%c\n", w[0], len(w)-2, w[len(w)-1])
+		} else {
+			fmt.Fprintf(&out, "%s\n", w)
+		}
+	}
+	return in.String(), out.String()
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	if strings.TrimSpace(buf.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected\n%s\ngot\n%s", expected, buf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/71/verifierB.go
+++ b/0-999/0-99/70-79/71/verifierB.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compute(n, k, t int) []int {
+	S := t * n * k / 100
+	full := S / k
+	rem := S % k
+	res := make([]int, n)
+	for i := 0; i < n; i++ {
+		switch {
+		case i < full:
+			res[i] = k
+		case i == full:
+			res[i] = rem
+		default:
+			res[i] = 0
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(10) + 1
+	t := rng.Intn(101)
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d %d %d\n", n, k, t)
+	res := compute(n, k, t)
+	var out strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		out.WriteString(fmt.Sprintf("%d", v))
+	}
+	out.WriteByte('\n')
+	return in.String(), out.String()
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	if strings.TrimSpace(buf.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, buf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/71/verifierC.go
+++ b/0-999/0-99/70-79/71/verifierC.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compute(n int, a []int) string {
+	for step := 1; step <= n; step++ {
+		if n%step != 0 {
+			continue
+		}
+		if n/step < 3 {
+			continue
+		}
+		for offset := 0; offset < step; offset++ {
+			ok := true
+			for i := offset; i < n; i += step {
+				if a[i] == 0 {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				return "YES\n"
+			}
+		}
+	}
+	return "NO\n"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 3
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(2)
+	}
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			in.WriteByte(' ')
+		}
+		in.WriteString(fmt.Sprintf("%d", v))
+	}
+	in.WriteByte('\n')
+	return in.String(), compute(n, a)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	if strings.TrimSpace(buf.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, buf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/71/verifierD.go
+++ b/0-999/0-99/70-79/71/verifierD.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ r, s int }
+
+func cardData(card string, crank, suit string) (int, int) {
+	if card[0] == 'J' && card[1] >= '1' && card[1] <= '2' {
+		return -1, int(card[1] - '1')
+	}
+	r := strings.IndexByte(crank, card[0])
+	s := strings.IndexByte(suit, card[1])
+	return r, s
+}
+
+func solveD(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var out bytes.Buffer
+
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return ""
+	}
+	crank := "A23456789TJQK"
+	suit := "CDHS"
+	inDeck := make([][]bool, 13)
+	for i := range inDeck {
+		inDeck[i] = make([]bool, 4)
+		for j := 0; j < 4; j++ {
+			inDeck[i][j] = true
+		}
+	}
+	card := make([][]string, n)
+	var jokers []int
+	for i := 0; i < n; i++ {
+		card[i] = make([]string, m)
+		for j := 0; j < m; j++ {
+			fmt.Fscan(in, &card[i][j])
+			r, s := cardData(card[i][j], crank, suit)
+			if r >= 0 {
+				inDeck[r][s] = false
+			} else {
+				jokers = append(jokers, s)
+			}
+		}
+	}
+	var placeJokers []int
+	jreplace := [2][]pair{}
+	place := func(y, x int) bool {
+		used := make([]bool, 13)
+		var localJokers []int
+		for dy := 0; dy < 3; dy++ {
+			for dx := 0; dx < 3; dx++ {
+				cy, cx := y+dy, x+dx
+				r, s := cardData(card[cy][cx], crank, suit)
+				if r < 0 {
+					localJokers = append(localJokers, s)
+				} else {
+					if used[r] {
+						return false
+					}
+					used[r] = true
+				}
+			}
+		}
+		for _, v := range localJokers {
+			placeJokers = append(placeJokers, v)
+		}
+		for i := 0; i < 13; i++ {
+			if !used[i] {
+				for j := 0; j < 4; j++ {
+					if inDeck[i][j] && len(localJokers) > 0 {
+						t := localJokers[len(localJokers)-1]
+						jreplace[t] = append(jreplace[t], pair{i, j})
+						if len(localJokers) > 1 {
+							localJokers = localJokers[:len(localJokers)-1]
+							break
+						}
+					}
+				}
+			}
+		}
+		return true
+	}
+	for y1 := 0; y1+3 <= n; y1++ {
+		for x1 := 0; x1+3 <= m; x1++ {
+			for y2 := 0; y2+3 <= n; y2++ {
+				for x2 := 0; x2+3 <= m; x2++ {
+					if y2+3 <= y1 || y1+3 <= y2 || x1+3 <= x2 || x2+3 <= x1 {
+						placeJokers = placeJokers[:0]
+						jreplace = [2][]pair{{}, {}}
+						if !place(y1, x1) {
+							continue
+						}
+						if !place(y2, x2) {
+							continue
+						}
+						var rep [2]pair
+						if len(placeJokers) == 1 {
+							t := placeJokers[0]
+							if len(jreplace[t]) == 0 {
+								continue
+							}
+							rep[t] = jreplace[t][0]
+						} else if len(placeJokers) == 2 {
+							if len(jreplace[0]) == 0 || len(jreplace[1]) == 0 {
+								continue
+							}
+							rep[0] = jreplace[0][0]
+							rep[1] = jreplace[1][0]
+							if rep[0] == rep[1] && len(jreplace[0]) > 1 {
+								rep[0] = jreplace[0][1]
+							}
+							if rep[0] == rep[1] && len(jreplace[1]) > 1 {
+								rep[1] = jreplace[1][1]
+							}
+						}
+						if len(jokers) > len(placeJokers) {
+							if len(placeJokers) == 1 {
+								other := 1 - placeJokers[0]
+								for i := 0; i < 13; i++ {
+									for j := 0; j < 4; j++ {
+										if inDeck[i][j] && (i != rep[placeJokers[0]].r || j != rep[placeJokers[0]].s) {
+											rep[other] = pair{i, j}
+										}
+									}
+								}
+							} else {
+								cnt := 0
+								for i := 0; i < 13; i++ {
+									for j := 0; j < 4; j++ {
+										if inDeck[i][j] {
+											rep[cnt] = pair{i, j}
+											cnt = (cnt + 1) % 2
+										}
+									}
+								}
+							}
+						}
+						fmt.Fprintln(&out, "Solution exists.")
+						if len(jokers) == 1 {
+							t := jokers[0]
+							p := rep[t]
+							fmt.Fprintf(&out, "Replace J%d with %c%c.\n", t+1, crank[p.r], suit[p.s])
+						} else if len(jokers) == 2 {
+							fmt.Fprintf(&out, "Replace J1 with %c%c and J2 with %c%c.\n", crank[rep[0].r], suit[rep[0].s], crank[rep[1].r], suit[rep[1].s])
+						} else {
+							fmt.Fprintln(&out, "There are no jokers.")
+						}
+						fmt.Fprintf(&out, "Put the first square to (%d, %d).\n", y1+1, x1+1)
+						fmt.Fprintf(&out, "Put the second square to (%d, %d).\n", y2+1, x2+1)
+						return out.String()
+					}
+				}
+			}
+		}
+	}
+	fmt.Fprintln(&out, "No solution.")
+	return out.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 3
+	m := rng.Intn(3) + 3
+	ranks := "A23456789TJQK"
+	suits := "CDHS"
+	deck := make([]string, 0, 54)
+	for i := 0; i < len(ranks); i++ {
+		for j := 0; j < len(suits); j++ {
+			deck = append(deck, string(ranks[i])+string(suits[j]))
+		}
+	}
+	deck = append(deck, "J1", "J2")
+	for i := len(deck) - 1; i > 0; i-- {
+		j := rng.Intn(i + 1)
+		deck[i], deck[j] = deck[j], deck[i]
+	}
+	total := n * m
+	cards := deck[:total]
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d %d\n", n, m)
+	idx := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				in.WriteByte(' ')
+			}
+			in.WriteString(cards[idx])
+			idx++
+		}
+		in.WriteByte('\n')
+	}
+	expect := solveD(in.String())
+	return in.String(), expect
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	if strings.TrimSpace(buf.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected\n%s\ngot\n%s", expected, buf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/71/verifierE.go
+++ b/0-999/0-99/70-79/71/verifierE.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var elements = []string{
+	"H", "He", "Li", "Be", "B", "C", "N", "O", "F", "Ne",
+	"Na", "Mg", "Al", "Si", "P", "S", "Cl", "Ar", "K", "Ca",
+	"Sc", "Ti", "V", "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn",
+	"Ga", "Ge", "As", "Se", "Br", "Kr", "Rb", "Sr", "Y", "Zr",
+	"Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ag", "Cd", "In", "Sn",
+	"Sb", "Te", "I", "Xe", "Cs", "Ba", "La", "Ce", "Pr", "Nd",
+	"Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb",
+	"Lu", "Hf", "Ta", "W", "Re", "Os", "Ir", "Pt", "Au", "Hg",
+	"Tl", "Pb", "Bi", "Po", "At", "Rn", "Fr", "Ra", "Ac", "Th",
+	"Pa", "U", "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm",
+}
+
+func solveE(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var out bytes.Buffer
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return ""
+	}
+	seq := make([]int, n)
+	tar := make([]int, m)
+	elementMap := make(map[string]int, len(elements))
+	for i, s := range elements {
+		elementMap[s] = i + 1
+	}
+	var s string
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &s)
+		seq[i] = elementMap[s]
+	}
+	for i := 0; i < m; i++ {
+		fmt.Fscan(in, &s)
+		tar[i] = elementMap[s]
+	}
+	lim := (1 << n) - 1
+	type data struct{ id, val int }
+	f := make([]data, lim+1)
+	link := make([]int, lim+1)
+	for i := range link {
+		link[i] = -1
+	}
+	for mask := 0; mask <= lim; mask++ {
+		cur := f[mask]
+		for j := 0; j < n; j++ {
+			bit := 1 << j
+			if mask&bit != 0 {
+				continue
+			}
+			p := seq[j]
+			id0, val0 := cur.id, cur.val
+			rem := tar[id0] - val0
+			if rem < p {
+				continue
+			}
+			var nd data
+			if rem == p {
+				nd = data{id: id0 + 1, val: 0}
+			} else {
+				nd = data{id: id0, val: val0 + p}
+			}
+			nxt := mask | bit
+			prev := f[nxt]
+			if prev.id < nd.id || (prev.id == nd.id && prev.val < nd.val) {
+				f[nxt] = nd
+				link[nxt] = mask
+			}
+		}
+	}
+	end := f[lim]
+	if end.id == m && end.val == 0 {
+		fmt.Fprintln(&out, "YES")
+		now := lim
+		v := 0
+		for now > 0 {
+			prev := link[now]
+			diff := now ^ prev
+			for j := 0; j < n; j++ {
+				if diff&(1<<j) != 0 {
+					if v > 0 {
+						fmt.Fprintf(&out, "+%s", elements[seq[j]-1])
+					} else {
+						fmt.Fprintf(&out, "%s", elements[seq[j]-1])
+					}
+					v++
+				}
+			}
+			if f[prev].val == 0 {
+				v = 0
+				fmt.Fprintf(&out, "->%s\n", elements[tar[f[prev].id]-1])
+			}
+			now = prev
+		}
+	} else {
+		fmt.Fprintln(&out, "NO")
+	}
+	return out.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(n) + 1
+	start := make([]int, n)
+	for i := range start {
+		start[i] = rng.Intn(30) + 1
+	}
+	sum := 0
+	for _, v := range start {
+		sum += v
+	}
+	var target []int
+	for {
+		target = make([]int, k)
+		rem := sum
+		ok := true
+		for i := 0; i < k-1; i++ {
+			lo := 1
+			hi := rem - (k - 1 - i)
+			if hi > 100 {
+				hi = 100
+			}
+			if lo > hi {
+				ok = false
+				break
+			}
+			target[i] = rng.Intn(hi-lo+1) + lo
+			rem -= target[i]
+		}
+		if !ok {
+			continue
+		}
+		target[k-1] = rem
+		if target[k-1] >= 1 && target[k-1] <= 100 {
+			break
+		}
+	}
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d %d\n", n, k)
+	for i, v := range start {
+		if i > 0 {
+			in.WriteByte(' ')
+		}
+		in.WriteString(elements[v-1])
+	}
+	in.WriteByte('\n')
+	for i, v := range target {
+		if i > 0 {
+			in.WriteByte(' ')
+		}
+		in.WriteString(elements[v-1])
+	}
+	in.WriteByte('\n')
+	expect := solveE(in.String())
+	return in.String(), expect
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	if strings.TrimSpace(buf.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected\n%s\ngot\n%s", expected, buf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go-based verifiers for contest 71 problems A–E
- random case generation with 100 test cases per verifier
- internal solution code included for expected outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e61847768832490361dcc56c6033c