### PR TITLE
Add contest 70 solution verifiers

### DIFF
--- a/0-999/0-99/70-79/70/verifierA.go
+++ b/0-999/0-99/70-79/70/verifierA.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"time"
+)
+
+const mod = 1000003
+
+func powmod(base, exp int) int {
+	res := 1
+	for exp > 0 {
+		if exp&1 == 1 {
+			res = res * base % mod
+		}
+		base = base * base % mod
+		exp >>= 1
+	}
+	return res
+}
+
+func solve(n int) int {
+	if n <= 0 {
+		return 1
+	}
+	return powmod(3, n-1)
+}
+
+func runCase(bin string, n int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("%d\n", n))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(bytes.NewReader(out.Bytes()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	exp := solve(n)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(1001) // 0..1000
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/70/verifierB.go
+++ b/0-999/0-99/70-79/70/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(input string) string {
+	lines := strings.Split(strings.TrimRight(input, "\n"), "\n")
+	var n int
+	fmt.Sscan(lines[0], &n)
+	text := lines[1]
+	var sentences []string
+	start := 0
+	for i := 0; i < len(text); i++ {
+		c := text[i]
+		if (c == '.' || c == '!' || c == '?') && i+1 < len(text) && text[i+1] == ' ' {
+			sentences = append(sentences, text[start:i+1])
+			start = i + 2
+			i++
+		}
+	}
+	if start < len(text) {
+		sentences = append(sentences, text[start:])
+	}
+	msgs := 0
+	curr := 0
+	for _, s := range sentences {
+		L := len(s)
+		if L > n {
+			return "Impossible"
+		}
+		if curr == 0 {
+			curr = L
+		} else if curr+1+L <= n {
+			curr += 1 + L
+		} else {
+			msgs++
+			curr = L
+		}
+	}
+	if curr > 0 {
+		msgs++
+	}
+	return fmt.Sprintf("%d", msgs)
+}
+
+var punct = []byte{'.', '!', '?'}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(254) + 2 // 2..255
+	sentences := rng.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < sentences; i++ {
+		L := rng.Intn(n*2) + 1
+		for j := 0; j < L; j++ {
+			sb.WriteByte(byte('a' + rng.Intn(3)))
+		}
+		sb.WriteByte(punct[rng.Intn(len(punct))])
+		if i+1 != sentences {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin string, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expected := solve(input)
+		if err := runCase(bin, input, expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/70/verifierC.go
+++ b/0-999/0-99/70-79/70/verifierC.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type rat struct {
+	en, de int
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func newRat(en, de int) rat {
+	g := gcd(en, de)
+	return rat{en / g, de / g}
+}
+
+func ratLess(a, b rat) bool {
+	if a.de != b.de {
+		return a.de < b.de
+	}
+	if a.en != b.en {
+		return a.en < b.en
+	}
+	return false
+}
+
+func rev(x int) int {
+	r := 0
+	for x > 0 {
+		r = r*10 + x%10
+		x /= 10
+	}
+	return r
+}
+
+type pair struct {
+	r rat
+	x int
+}
+
+var S []pair
+
+func initPairs() {
+	const N = 100500
+	S = make([]pair, N)
+	for i := 1; i <= N; i++ {
+		S[i-1] = pair{newRat(i, rev(i)), i}
+	}
+	sort.Slice(S, func(i, j int) bool {
+		if S[i].r.de != S[j].r.de {
+			return S[i].r.de < S[j].r.de
+		}
+		if S[i].r.en != S[j].r.en {
+			return S[i].r.en < S[j].r.en
+		}
+		return S[i].x < S[j].x
+	})
+}
+
+func col(x, mx int) int {
+	if x == 0 {
+		return 0
+	}
+	r := newRat(rev(x), x)
+	n := len(S)
+	lo := sort.Search(n, func(i int) bool {
+		return !ratLess(S[i].r, r)
+	})
+	hi := sort.Search(n, func(i int) bool {
+		if ratLess(r, S[i].r) {
+			return true
+		}
+		if ratLess(S[i].r, r) {
+			return false
+		}
+		return S[i].x > mx
+	})
+	return hi - lo
+}
+
+const INF int64 = 1 << 60
+
+func solve(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	var mxx, mxy, w int
+	if !in.Scan() {
+		return ""
+	}
+	fmt.Sscan(in.Text(), &mxx)
+	in.Scan()
+	fmt.Sscan(in.Text(), &mxy)
+	in.Scan()
+	fmt.Sscan(in.Text(), &w)
+	x := mxx + 1
+	y := 0
+	cur := int64(0)
+	bestArea := INF
+	bestX, bestY := -1, -1
+	for x > 0 {
+		cur -= int64(col(x, y))
+		x--
+		for cur < int64(w) && y <= mxy {
+			y++
+			cur += int64(col(y, x))
+		}
+		if y > mxy {
+			break
+		}
+		area := int64(x) * int64(y)
+		if area < bestArea {
+			bestArea = area
+			bestX = x
+			bestY = y
+		}
+	}
+	if bestArea >= INF {
+		return "-1"
+	}
+	return fmt.Sprintf("%d %d", bestX, bestY)
+}
+
+func genCase(rng *rand.Rand) string {
+	maxx := rng.Intn(500) + 1
+	maxy := rng.Intn(500) + 1
+	w := rng.Intn(100000) + 1
+	return fmt.Sprintf("%d %d %d\n", maxx, maxy, w)
+}
+
+func runCase(bin string, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	initPairs()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expected := solve(input)
+		if err := runCase(bin, input, expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/70/verifierD.go
+++ b/0-999/0-99/70-79/70/verifierD.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Point struct{ x, y int64 }
+
+func cross(a, b, c Point) int64 {
+	return (b.x-a.x)*(c.y-a.y) - (b.y-a.y)*(c.x-a.x)
+}
+
+func convexHull(a []Point) []Point {
+	n := len(a)
+	if n <= 1 {
+		return append([]Point{}, a...)
+	}
+	sort.Slice(a, func(i, j int) bool {
+		if a[i].x != a[j].x {
+			return a[i].x < a[j].x
+		}
+		return a[i].y < a[j].y
+	})
+	lo := []Point{}
+	up := []Point{}
+	for _, p := range a {
+		for len(lo) >= 2 && cross(lo[len(lo)-2], lo[len(lo)-1], p) <= 0 {
+			lo = lo[:len(lo)-1]
+		}
+		lo = append(lo, p)
+	}
+	for i := n - 1; i >= 0; i-- {
+		p := a[i]
+		for len(up) >= 2 && cross(up[len(up)-2], up[len(up)-1], p) <= 0 {
+			up = up[:len(up)-1]
+		}
+		up = append(up, p)
+	}
+	lo = lo[:len(lo)-1]
+	up = up[:len(up)-1]
+	return append(lo, up...)
+}
+
+func pointInConvex(P []Point, q Point) bool {
+	n := len(P)
+	if n == 0 {
+		return false
+	}
+	if cross(P[0], P[1], q) < 0 || cross(P[0], P[n-1], q) > 0 {
+		return false
+	}
+	low, high := 1, n-1
+	for high-low > 1 {
+		mid := (low + high) / 2
+		if cross(P[0], P[mid], q) >= 0 {
+			low = mid
+		} else {
+			high = mid
+		}
+	}
+	return cross(P[low], P[(low+1)%n], q) >= 0
+}
+
+func solve(input string) string {
+	lines := strings.Fields(input)
+	idx := 0
+	q := toInt(lines[idx])
+	idx++
+	pts := make([]Point, 0)
+	var outputs []string
+	for i := 0; i < 3; i++ {
+		t := toInt(lines[idx])
+		idx++
+		x := toInt64(lines[idx])
+		idx++
+		y := toInt64(lines[idx])
+		idx++
+		_ = t
+		pts = append(pts, Point{x, y})
+	}
+	hull := convexHull(pts)
+	for i := 3; i < q; i++ {
+		t := toInt(lines[idx])
+		idx++
+		x := toInt64(lines[idx])
+		idx++
+		y := toInt64(lines[idx])
+		idx++
+		p := Point{x, y}
+		if t == 1 {
+			if pointInConvex(hull, p) {
+				continue
+			}
+			n := len(hull)
+			var L, R int
+			if cross(hull[0], hull[1], p) < 0 {
+				L, R = 0, 1
+			} else if cross(hull[0], hull[n-1], p) > 0 {
+				L, R = n-1, 0
+			} else {
+				low, high := 1, n-1
+				for high-low > 1 {
+					mid := (low + high) / 2
+					if cross(hull[0], hull[mid], p) > 0 {
+						low = mid
+					} else {
+						high = mid
+					}
+				}
+				L, R = low, low+1
+			}
+			for cross(hull[R%len(hull)], hull[(R+1)%len(hull)], p) < 0 {
+				R++
+			}
+			for cross(hull[(L-1+len(hull))%len(hull)], hull[L%len(hull)], p) < 0 {
+				L--
+			}
+			newHull := []Point{p}
+			n0 := len(hull)
+			idx2 := R % n0
+			end := L % n0
+			for {
+				newHull = append(newHull, hull[idx2])
+				if idx2 == end {
+					break
+				}
+				idx2 = (idx2 + 1) % n0
+			}
+			m := len(newHull)
+			minI := 0
+			for i := 1; i < m; i++ {
+				if newHull[i].x < newHull[minI].x || (newHull[i].x == newHull[minI].x && newHull[i].y < newHull[minI].y) {
+					minI = i
+				}
+			}
+			hull = append(newHull[minI:], newHull[:minI]...)
+		} else {
+			if pointInConvex(hull, p) {
+				outputs = append(outputs, "YES")
+			} else {
+				outputs = append(outputs, "NO")
+			}
+		}
+	}
+	return strings.Join(outputs, "\n")
+}
+
+func toInt(s string) int     { var x int; fmt.Sscan(s, &x); return x }
+func toInt64(s string) int64 { var x int64; fmt.Sscan(s, &x); return x }
+
+func genCase(rng *rand.Rand) string {
+	q := rng.Intn(20) + 4
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	pts := make([]Point, 0)
+	for len(pts) < 3 {
+		x := int64(rng.Intn(21) - 10)
+		y := int64(rng.Intn(21) - 10)
+		p := Point{x, y}
+		unique := true
+		for _, t := range pts {
+			if t.x == x && t.y == y {
+				unique = false
+				break
+			}
+		}
+		if unique {
+			pts = append(pts, p)
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", x, y))
+		}
+	}
+	// ensure non-degenerate
+	for cross(pts[0], pts[1], pts[2]) == 0 {
+		pts[2].x = int64(rng.Intn(21) - 10)
+		pts[2].y = int64(rng.Intn(21) - 10)
+	}
+	for i := 3; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			// add unique point
+			for {
+				x := int64(rng.Intn(21) - 10)
+				y := int64(rng.Intn(21) - 10)
+				ok := true
+				for _, t := range pts {
+					if t.x == x && t.y == y {
+						ok = false
+						break
+					}
+				}
+				if ok {
+					pts = append(pts, Point{x, y})
+					sb.WriteString(fmt.Sprintf("1 %d %d\n", x, y))
+					break
+				}
+			}
+		} else {
+			x := int64(rng.Intn(21) - 10)
+			y := int64(rng.Intn(21) - 10)
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", x, y))
+		}
+	}
+	return sb.String()
+}
+
+func runCase(bin string, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(expected) != got {
+		return fmt.Errorf("expected\n%s\nbut got\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expected := solve(strings.TrimRight(input, "\n"))
+		if err := runCase(bin, input, expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/70-79/70/verifierE.go
+++ b/0-999/0-99/70-79/70/verifierE.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var (
+	n, k int
+	w    []int
+	adj  [][]int
+	d    [][]int
+	f    [][]int
+	b    []int
+	c    []int
+)
+
+func dfs(u, parent int) {
+	for j := 1; j <= n; j++ {
+		f[u][j] = w[d[u][j]] + k
+	}
+	for _, v := range adj[u] {
+		if v == parent {
+			continue
+		}
+		dfs(v, u)
+		for j := 1; j <= n; j++ {
+			a := f[v][j] - k
+			bch := f[v][b[v]]
+			if a < bch {
+				f[u][j] += a
+			} else {
+				f[u][j] += bch
+			}
+		}
+	}
+	best := 1
+	for j := 2; j <= n; j++ {
+		if f[u][j] < f[u][best] {
+			best = j
+		}
+	}
+	b[u] = best
+}
+
+func prt(u, parent, z int) {
+	c[u] = z
+	for _, v := range adj[u] {
+		if v == parent {
+			continue
+		}
+		if f[v][z]-k < f[v][b[v]] {
+			prt(v, u, z)
+		} else {
+			prt(v, u, b[v])
+		}
+	}
+}
+
+func solve(input string) string {
+	parts := strings.Fields(input)
+	idx := 0
+	n = toInt(parts[idx])
+	idx++
+	k = toInt(parts[idx])
+	idx++
+	w = make([]int, n+1)
+	for i := 1; i < n; i++ {
+		w[i] = toInt(parts[idx])
+		idx++
+	}
+	adj = make([][]int, n+1)
+	for i := 0; i < n-1; i++ {
+		x := toInt(parts[idx])
+		idx++
+		y := toInt(parts[idx])
+		idx++
+		adj[x] = append(adj[x], y)
+		adj[y] = append(adj[y], x)
+	}
+	// compute distances by BFS
+	d = make([][]int, n+1)
+	for u := 1; u <= n; u++ {
+		dist := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			dist[i] = -1
+		}
+		queue := []int{u}
+		dist[u] = 0
+		for qi := 0; qi < len(queue); qi++ {
+			v := queue[qi]
+			for _, to := range adj[v] {
+				if dist[to] < 0 {
+					dist[to] = dist[v] + 1
+					queue = append(queue, to)
+				}
+			}
+		}
+		row := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			row[i] = dist[i]
+		}
+		d[u] = row
+	}
+	f = make([][]int, n+1)
+	for i := 1; i <= n; i++ {
+		f[i] = make([]int, n+1)
+	}
+	b = make([]int, n+1)
+	c = make([]int, n+1)
+	dfs(1, 0)
+	rootBest := b[1]
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", f[1][rootBest]))
+	prt(1, 0, rootBest)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c[i]))
+	}
+	return sb.String()
+}
+
+func toInt(s string) int { var x int; fmt.Sscan(s, &x); return x }
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(10) + 1
+	weights := make([]int, n-1)
+	for i := range weights {
+		if i == 0 {
+			weights[i] = rng.Intn(5)
+		} else {
+			weights[i] = weights[i-1] + rng.Intn(5)
+		}
+	}
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range weights {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	if n > 1 {
+		sb.WriteByte('\n')
+	}
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func runCase(bin string, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected\n%s\nbut got\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expected := solve(strings.TrimRight(input, "\n"))
+		if err := runCase(bin, input, expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verification harnesses for contest 70 problems A–E

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e617f70fc8324afc68f29edeb9b0b