### PR TITLE
Add solution verifiers for contest 69

### DIFF
--- a/0-999/0-99/60-69/69/verifierA.go
+++ b/0-999/0-99/60-69/69/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseA struct {
+	n        int
+	vecs     [][3]int
+	expected string
+}
+
+func generateTests() []testCaseA {
+	rng := rand.New(rand.NewSource(1))
+	cases := make([]testCaseA, 100)
+	for i := range cases {
+		n := rng.Intn(100) + 1
+		vecs := make([][3]int, n)
+		sx, sy, sz := 0, 0, 0
+		for j := 0; j < n; j++ {
+			x := rng.Intn(201) - 100
+			y := rng.Intn(201) - 100
+			z := rng.Intn(201) - 100
+			vecs[j] = [3]int{x, y, z}
+			sx += x
+			sy += y
+			sz += z
+		}
+		exp := "NO"
+		if sx == 0 && sy == 0 && sz == 0 {
+			exp = "YES"
+		}
+		cases[i] = testCaseA{n: n, vecs: vecs, expected: exp}
+	}
+	return cases
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", tc.n)
+		for _, v := range tc.vecs {
+			fmt.Fprintf(&sb, "%d %d %d\n", v[0], v[1], v[2])
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, tc.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/69/verifierB.go
+++ b/0-999/0-99/60-69/69/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseB struct {
+	n, m       int
+	l, r, t, c []int
+	expected   int
+}
+
+func solveCase(n, m int, l, r, t, c []int) int {
+	total := 0
+	for j := 1; j <= n; j++ {
+		bestTime := 1<<31 - 1
+		bestIdx := -1
+		for i := 0; i < m; i++ {
+			if l[i] <= j && j <= r[i] {
+				if t[i] < bestTime || (t[i] == bestTime && i < bestIdx) {
+					bestTime = t[i]
+					bestIdx = i
+				}
+			}
+		}
+		if bestIdx != -1 {
+			total += c[bestIdx]
+		}
+	}
+	return total
+}
+
+func generateTests() []testCaseB {
+	rng := rand.New(rand.NewSource(2))
+	cases := make([]testCaseB, 100)
+	for idx := range cases {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		l := make([]int, m)
+		r := make([]int, m)
+		tVals := make([]int, m)
+		cVals := make([]int, m)
+		for i := 0; i < m; i++ {
+			l[i] = rng.Intn(n) + 1
+			r[i] = l[i] + rng.Intn(n-l[i]+1)
+			tVals[i] = rng.Intn(1000) + 1
+			cVals[i] = rng.Intn(1000) + 1
+		}
+		exp := solveCase(n, m, l, r, tVals, cVals)
+		cases[idx] = testCaseB{n: n, m: m, l: l, r: r, t: tVals, c: cVals, expected: exp}
+	}
+	return cases
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+		for j := 0; j < tc.m; j++ {
+			fmt.Fprintf(&sb, "%d %d %d %d\n", tc.l[j], tc.r[j], tc.t[j], tc.c[j])
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != fmt.Sprint(tc.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, tc.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/69/verifierC.go
+++ b/0-999/0-99/60-69/69/verifierC.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type comp struct {
+	name string
+	req  []int
+}
+
+type purchase struct {
+	hero int
+	item int
+}
+
+type testCaseC struct {
+	k, n, m, q int
+	basic      []string
+	comps      []comp
+	ops        []purchase
+	expected   string
+}
+
+func solveCase(tc testCaseC) string {
+	k, n, m := tc.k, tc.n, tc.m
+	basicNames := tc.basic
+	compNames := make([]string, m)
+	compReq := make([][]int, m)
+	for i, c := range tc.comps {
+		compNames[i] = c.name
+		compReq[i] = c.req
+	}
+	basicCnt := make([][]int, k)
+	compCnt := make([][]int, k)
+	for i := 0; i < k; i++ {
+		basicCnt[i] = make([]int, n)
+		compCnt[i] = make([]int, m)
+	}
+	for _, op := range tc.ops {
+		h := op.hero
+		bi := op.item
+		basicCnt[h][bi]++
+		for j := 0; j < m; j++ {
+			can := true
+			for idx, need := range compReq[j] {
+				if need > 0 && basicCnt[h][idx] < need {
+					can = false
+					break
+				}
+			}
+			if can {
+				for idx, need := range compReq[j] {
+					if need > 0 {
+						basicCnt[h][idx] -= need
+					}
+				}
+				compCnt[h][j]++
+				break
+			}
+		}
+	}
+	var out strings.Builder
+	type pair struct {
+		name string
+		cnt  int
+	}
+	for i := 0; i < k; i++ {
+		var lst []pair
+		for bi := 0; bi < n; bi++ {
+			if basicCnt[i][bi] > 0 {
+				lst = append(lst, pair{basicNames[bi], basicCnt[i][bi]})
+			}
+		}
+		for cj := 0; cj < m; cj++ {
+			if compCnt[i][cj] > 0 {
+				lst = append(lst, pair{compNames[cj], compCnt[i][cj]})
+			}
+		}
+		sort.Slice(lst, func(a, b int) bool { return lst[a].name < lst[b].name })
+		fmt.Fprintln(&out, len(lst))
+		for _, p := range lst {
+			fmt.Fprintf(&out, "%s %d\n", p.name, p.cnt)
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateCase(rng *rand.Rand) testCaseC {
+	for {
+		k := rng.Intn(3) + 1
+		n := rng.Intn(3) + 1
+		m := rng.Intn(3)
+		q := rng.Intn(10) + 1
+		basic := make([]string, n)
+		for i := 0; i < n; i++ {
+			basic[i] = fmt.Sprintf("b%d", i)
+		}
+		comps := make([]comp, m)
+		for i := 0; i < m; i++ {
+			req := make([]int, n)
+			cnt := rng.Intn(n) + 1
+			used := make(map[int]bool)
+			for j := 0; j < cnt; j++ {
+				idx := rng.Intn(n)
+				for used[idx] {
+					idx = rng.Intn(n)
+				}
+				used[idx] = true
+				req[idx] = rng.Intn(2) + 1
+			}
+			comps[i] = comp{name: fmt.Sprintf("c%d", i), req: req}
+		}
+		ops := make([]purchase, q)
+		valid := true
+		basicCnt := make([][]int, k)
+		for i := 0; i < k; i++ {
+			basicCnt[i] = make([]int, n)
+		}
+		for step := 0; step < q && valid; step++ {
+			hero := rng.Intn(k)
+			item := rng.Intn(n)
+			ops[step] = purchase{hero, item}
+			basicCnt[hero][item]++
+			craftable := 0
+			for j := 0; j < m; j++ {
+				can := true
+				for idx, need := range comps[j].req {
+					if need > 0 && basicCnt[hero][idx] < need {
+						can = false
+						break
+					}
+				}
+				if can {
+					craftable++
+				}
+			}
+			if craftable > 1 {
+				valid = false
+				break
+			}
+			if craftable == 1 {
+				for j := 0; j < m; j++ {
+					can := true
+					for idx, need := range comps[j].req {
+						if need > 0 && basicCnt[hero][idx] < need {
+							can = false
+							break
+						}
+					}
+					if can {
+						for idx, need := range comps[j].req {
+							if need > 0 {
+								basicCnt[hero][idx] -= need
+							}
+						}
+						break
+					}
+				}
+			}
+		}
+		if !valid {
+			continue
+		}
+		exp := solveCase(testCaseC{k: k, n: n, m: m, q: q, basic: basic, comps: comps, ops: ops})
+		return testCaseC{k: k, n: n, m: m, q: q, basic: basic, comps: comps, ops: ops, expected: exp}
+	}
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(3))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d\n", tc.k, tc.n, tc.m, tc.q)
+		for _, name := range tc.basic {
+			fmt.Fprintf(&sb, "%s\n", name)
+		}
+		for _, cp := range tc.comps {
+			var parts []string
+			for idx, need := range cp.req {
+				if need > 0 {
+					parts = append(parts, fmt.Sprintf("%s %d", tc.basic[idx], need))
+				}
+			}
+			fmt.Fprintf(&sb, "%s: %s\n", cp.name, strings.Join(parts, ", "))
+		}
+		for _, op := range tc.ops {
+			fmt.Fprintf(&sb, "%d %s\n", op.hero+1, tc.basic[op.item])
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\ngot:\n%s\n", i+1, tc.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/69/verifierD.go
+++ b/0-999/0-99/60-69/69/verifierD.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseD struct {
+	x, y     int
+	n, d     int
+	dx, dy   []int
+	expected string
+}
+
+var (
+	d2     int
+	offset int
+	memo   map[int]bool
+	vis    map[int]bool
+)
+
+func encode(x, y, rA, rB, turn int) int {
+	xi := x + offset
+	yi := y + offset
+	return (((xi << 9) | yi) << 3) | (rA << 2) | (rB << 1) | turn
+}
+
+func dfs(x, y, rA, rB, turn int, moves [][2]int) bool {
+	key := encode(x, y, rA, rB, turn)
+	if vis[key] {
+		return memo[key]
+	}
+	vis[key] = true
+	win := false
+	for _, mv := range moves {
+		nx := x + mv[0]
+		ny := y + mv[1]
+		if nx*nx+ny*ny > d2 {
+			continue
+		}
+		if !dfs(nx, ny, rA, rB, 1-turn, moves) {
+			win = true
+			break
+		}
+	}
+	if !win {
+		if turn == 0 && rA == 1 {
+			if !dfs(y, x, 0, rB, 1-turn, moves) {
+				win = true
+			}
+		} else if turn == 1 && rB == 1 {
+			if !dfs(y, x, rA, 0, 1-turn, moves) {
+				win = true
+			}
+		}
+	}
+	memo[key] = win
+	return win
+}
+
+func solveCase(tc testCaseD) string {
+	offset = tc.d
+	d2 = tc.d * tc.d
+	memo = make(map[int]bool)
+	vis = make(map[int]bool)
+	moves := make([][2]int, tc.n)
+	for i := 0; i < tc.n; i++ {
+		moves[i] = [2]int{tc.dx[i], tc.dy[i]}
+	}
+	if dfs(tc.x, tc.y, 1, 1, 0, moves) {
+		return "Anton"
+	}
+	return "Dasha"
+}
+
+func generateTests() []testCaseD {
+	rng := rand.New(rand.NewSource(4))
+	cases := make([]testCaseD, 100)
+	for i := range cases {
+		d := rng.Intn(5) + 2
+		x := rng.Intn(2*d) - d
+		y := rng.Intn(2*d) - d
+		n := rng.Intn(3) + 1
+		dx := make([]int, n)
+		dy := make([]int, n)
+		for j := 0; j < n; j++ {
+			dx[j] = rng.Intn(d)
+			dy[j] = rng.Intn(d)
+			if dx[j] == 0 && dy[j] == 0 {
+				dx[j] = 1
+			}
+		}
+		tc := testCaseD{x: x, y: y, n: n, d: d, dx: dx, dy: dy}
+		tc.expected = solveCase(tc)
+		cases[i] = tc
+	}
+	return cases
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d\n", tc.x, tc.y, tc.n, tc.d)
+		for j := 0; j < tc.n; j++ {
+			fmt.Fprintf(&sb, "%d %d\n", tc.dx[j], tc.dy[j])
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, tc.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/69/verifierE.go
+++ b/0-999/0-99/60-69/69/verifierE.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseE struct {
+	n, k     int
+	arr      []int
+	expected []string
+}
+
+func solveCase(tc testCaseE) []string {
+	n, k := tc.n, tc.k
+	arr := tc.arr
+	res := make([]string, n-k+1)
+	cnt := make(map[int]int)
+	for i := 0; i < k; i++ {
+		cnt[arr[i]]++
+	}
+	for i := 0; i <= n-k; i++ {
+		max := math.MinInt64
+		found := false
+		for v, c := range cnt {
+			if c == 1 {
+				if !found || v > max {
+					max = v
+					found = true
+				}
+			}
+		}
+		if found {
+			res[i] = fmt.Sprint(max)
+		} else {
+			res[i] = "Nothing"
+		}
+		if i == n-k {
+			break
+		}
+		cnt[arr[i]]--
+		if cnt[arr[i]] == 0 {
+			delete(cnt, arr[i])
+		}
+		cnt[arr[i+k]]++
+	}
+	return res
+}
+
+func generateTests() []testCaseE {
+	rng := rand.New(rand.NewSource(5))
+	cases := make([]testCaseE, 100)
+	for i := range cases {
+		n := rng.Intn(30) + 1
+		k := rng.Intn(n) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(11) - 5
+		}
+		tc := testCaseE{n: n, k: k, arr: arr}
+		tc.expected = solveCase(tc)
+		cases[i] = tc
+	}
+	return cases
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.k)
+		for _, v := range tc.arr {
+			fmt.Fprintf(&sb, "%d\n", v)
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(got), "\n")
+		if len(lines) != len(tc.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\n", i+1, len(tc.expected), len(lines))
+			os.Exit(1)
+		}
+		for j, exp := range tc.expected {
+			if strings.TrimSpace(lines[j]) != exp {
+				fmt.Fprintf(os.Stderr, "case %d line %d expected %s got %s\n", i+1, j+1, exp, lines[j])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to check equilibrium vectors
- add verifierB.go to check betting profit problem
- add verifierC.go for artifact inventory problem
- add verifierD.go for Anton vs Dasha game
- add verifierE.go for unique maximum in windows

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e617a81f08324977787de316ba5d8