### PR TITLE
Add Go verifiers for Codeforces Round 68

### DIFF
--- a/0-999/0-99/60-69/68/verifierA.go
+++ b/0-999/0-99/60-69/68/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(p1, p2, p3, p4, a, b int) int {
+	m := p1
+	if p2 < m {
+		m = p2
+	}
+	if p3 < m {
+		m = p3
+	}
+	if p4 < m {
+		m = p4
+	}
+	r := b
+	if r > m-1 {
+		r = m - 1
+	}
+	if r >= a {
+		return r - a + 1
+	}
+	return 0
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	// distinct p1..p4 in [1,1000]
+	vals := make([]int, 0, 4)
+	for len(vals) < 4 {
+		v := rng.Intn(1000) + 1
+		ok := true
+		for _, x := range vals {
+			if x == v {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			vals = append(vals, v)
+		}
+	}
+	a := rng.Intn(31416)
+	b := rng.Intn(31416)
+	if a > b {
+		a, b = b, a
+	}
+	exp := expected(vals[0], vals[1], vals[2], vals[3], a, b)
+	input := fmt.Sprintf("%d %d %d %d %d %d\n", vals[0], vals[1], vals[2], vals[3], a, b)
+	return input, exp
+}
+
+func runCase(bin, input string, exp int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/68/verifierB.go
+++ b/0-999/0-99/60-69/68/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func check(a float64, arr []float64, k float64) bool {
+	b := 0.0
+	for _, v := range arr {
+		if v > a {
+			b += (v - a) / 100 * (100 - k)
+		} else {
+			b -= a - v
+		}
+	}
+	return b > 0
+}
+
+func expectedValue(arr []float64, k float64) float64 {
+	low, high := 0.0, 1000.0
+	for it := 0; it < 100; it++ {
+		mid := (low + high) / 2
+		if check(mid, arr, k) {
+			low = mid
+		} else {
+			high = mid
+		}
+	}
+	return (low + high) / 2
+}
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	n := rng.Intn(20) + 1
+	k := float64(rng.Intn(100))
+	arr := make([]float64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = float64(rng.Intn(1001))
+	}
+	exp := expectedValue(arr, k)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, int(k)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%.0f", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), exp
+}
+
+func runCase(bin, input string, exp float64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if diff := got - exp; diff < -1e-6 || diff > 1e-6 {
+		return fmt.Errorf("expected %.6f got %.6f", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/68/verifierC.go
+++ b/0-999/0-99/60-69/68/verifierC.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "68C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 2 // 2..4
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	// edges for i<j
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			l := rng.Intn(3)       // 0..2
+			h := l + rng.Intn(6-l) // l..5
+			a := rng.Intn(7)       // 0..6
+			sb.WriteString(fmt.Sprintf("%d %d %d %d %d\n", i, j, l, h, a))
+		}
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/68/verifierD.go
+++ b/0-999/0-99/60-69/68/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "68D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	h := rng.Intn(5) + 1 // 1..5
+	q := rng.Intn(15) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", h, q))
+	maxV := 1<<(h+1) - 1
+	decayCount := 0
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			v := rng.Intn(maxV) + 1
+			e := rng.Intn(101)
+			sb.WriteString(fmt.Sprintf("add %d %d\n", v, e))
+		} else {
+			sb.WriteString("decay\n")
+			decayCount++
+		}
+	}
+	if decayCount == 0 {
+		sb.WriteString("decay\n")
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expectedLines := strings.Fields(strings.TrimSpace(outO.String()))
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotLines := strings.Fields(strings.TrimSpace(out.String()))
+	if len(gotLines) != len(expectedLines) {
+		return fmt.Errorf("expected %d lines got %d", len(expectedLines), len(gotLines))
+	}
+	for i := range gotLines {
+		var g, e float64
+		fmt.Sscan(gotLines[i], &g)
+		fmt.Sscan(expectedLines[i], &e)
+		if diff := g - e; diff < -1e-4 || diff > 1e-4 {
+			return fmt.Errorf("line %d: expected %.4f got %.4f", i+1, e, g)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/68/verifierE.go
+++ b/0-999/0-99/60-69/68/verifierE.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "68E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func nonDegenerate(x1, y1, x2, y2, x3, y3 int) bool {
+	return (x2-x1)*(y3-y1)-(y2-y1)*(x3-x1) != 0
+}
+
+func generateCase(rng *rand.Rand) string {
+	var sb strings.Builder
+	for i := 0; i < 4; i++ {
+		for {
+			x1 := rng.Intn(21)
+			y1 := rng.Intn(21)
+			x2 := rng.Intn(21)
+			y2 := rng.Intn(21)
+			x3 := rng.Intn(21)
+			y3 := rng.Intn(21)
+			if nonDegenerate(x1, y1, x2, y2, x3, y3) {
+				sb.WriteString(fmt.Sprintf("%d %d %d %d %d %d\n", x1, y1, x2, y2, x3, y3))
+				break
+			}
+		}
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add random-based verifiers for problems A–E of contest 68
- each verifier runs 100 test cases and supports any binary
- complex problems compile provided Go solutions as oracle

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e617591948324b9627eae444bff0b