### PR TITLE
Add Go verifiers for contest 67

### DIFF
--- a/0-999/0-99/60-69/67/verifierA.go
+++ b/0-999/0-99/60-69/67/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(n int, s string) string {
+	candies := make([]int, n)
+	for i := range candies {
+		candies[i] = 1
+	}
+	for i := 1; i < n; i++ {
+		switch s[i-1] {
+		case 'R':
+			candies[i] = candies[i-1] + 1
+		case '=':
+			candies[i] = candies[i-1]
+		}
+	}
+	for i := n - 2; i >= 0; i-- {
+		switch s[i] {
+		case 'L':
+			if candies[i] <= candies[i+1] {
+				candies[i] = candies[i+1] + 1
+			}
+		case '=':
+			if candies[i] != candies[i+1] {
+				candies[i] = candies[i+1]
+			}
+		}
+	}
+	var sb strings.Builder
+	for i, c := range candies {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", c)
+	}
+	return sb.String()
+}
+
+func generateCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 2
+	b := make([]byte, n-1)
+	letters := []byte{'L', 'R', '='}
+	for i := 0; i < n-1; i++ {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	s := string(b)
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	expected := solveA(n, s)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseA(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/67/verifierB.go
+++ b/0-999/0-99/60-69/67/verifierB.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(n, k int, B []int) string {
+	A := make([]int, 0, n)
+	for j := n; j >= 1; j-- {
+		need := B[j]
+		cnt := 0
+		idx := 0
+		for idx = 0; idx < len(A); idx++ {
+			if cnt == need {
+				break
+			}
+			if A[idx] >= j+k {
+				cnt++
+			}
+		}
+		A = append(A, 0)
+		copy(A[idx+1:], A[idx:])
+		A[idx] = j
+	}
+	var sb strings.Builder
+	for i, v := range A {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	return sb.String()
+}
+
+func generateCaseB(rng *rand.Rand) (string, string) {
+	n := rng.Intn(7) + 1
+	k := rng.Intn(n) + 1
+	A := make([]int, 0, n)
+	Bvals := make([]int, n+1)
+	for j := n; j >= 1; j-- {
+		pos := rng.Intn(len(A) + 1)
+		cnt := 0
+		for i := 0; i < pos; i++ {
+			if A[i] >= j+k {
+				cnt++
+			}
+		}
+		Bvals[j] = cnt
+		A = append(A, 0)
+		copy(A[pos+1:], A[pos:])
+		A[pos] = j
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", Bvals[i])
+	}
+	sb.WriteByte('\n')
+	expected := solveB(n, k, Bvals)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseB(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/67/verifierC.go
+++ b/0-999/0-99/60-69/67/verifierC.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveC(ti, td, tr, te int, a, b string) string {
+	n, m := len(a), len(b)
+	maxCost := ti
+	if td > maxCost {
+		maxCost = td
+	}
+	if tr > maxCost {
+		maxCost = tr
+	}
+	if te > maxCost {
+		maxCost = te
+	}
+	maxdist := (n + m) * maxCost
+	H := make([][]int, n+2)
+	for i := range H {
+		H[i] = make([]int, m+2)
+	}
+	H[0][0] = maxdist
+	for i := 0; i <= n; i++ {
+		H[i+1][0] = maxdist
+		H[i+1][1] = i * td
+	}
+	for j := 0; j <= m; j++ {
+		H[0][j+1] = maxdist
+		H[1][j+1] = j * ti
+	}
+	da := make([]int, 26)
+	for i := 1; i <= n; i++ {
+		db := 0
+		for j := 1; j <= m; j++ {
+			i1 := da[b[j-1]-'a']
+			j1 := db
+			cost := tr
+			if a[i-1] == b[j-1] {
+				cost = 0
+				db = j
+			}
+			h0 := H[i][j] + cost
+			h1 := H[i+1][j] + ti
+			h2 := H[i][j+1] + td
+			h := min(h0, min(h1, h2))
+			trans := H[i1][j1] + (i-i1-1)*td + te + (j-j1-1)*ti
+			if trans < h {
+				h = trans
+			}
+			H[i+1][j+1] = h
+		}
+		da[a[i-1]-'a'] = i
+	}
+	res := H[n+1][m+1]
+	return fmt.Sprintf("%d", res)
+}
+
+func randString(rng *rand.Rand, length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCaseC(rng *rand.Rand) (string, string) {
+	ti := rng.Intn(5) + 1
+	td := rng.Intn(5) + 1
+	tr := rng.Intn(5) + 1
+	te := rng.Intn(5) + 1
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	a := randString(rng, n)
+	b := randString(rng, m)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", ti, td, tr, te)
+	fmt.Fprintf(&sb, "%s\n%s\n", a, b)
+	expected := solveC(ti, td, tr, te, a, b)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseC(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/67/verifierD.go
+++ b/0-999/0-99/60-69/67/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(n int, x, y []int) string {
+	exitPos := make([]int, n+1)
+	for idx, v := range y {
+		pos := idx + 1
+		if v >= 1 && v <= n {
+			exitPos[v] = pos
+		}
+	}
+	tails := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		e := exitPos[x[i]]
+		b := n + 1 - e
+		lo, hi := 0, len(tails)
+		for lo < hi {
+			mid := (lo + hi) >> 1
+			if tails[mid] < b {
+				lo = mid + 1
+			} else {
+				hi = mid
+			}
+		}
+		if lo == len(tails) {
+			tails = append(tails, b)
+		} else {
+			tails[lo] = b
+		}
+	}
+	return fmt.Sprintf("%d", len(tails))
+}
+
+func generatePermutation(rng *rand.Rand, n int) []int {
+	p := rng.Perm(n)
+	for i := 0; i < n; i++ {
+		p[i]++
+	}
+	return p
+}
+
+func generateCaseD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	x := generatePermutation(rng, n)
+	y := generatePermutation(rng, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", x[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", y[i])
+	}
+	sb.WriteByte('\n')
+	expected := solveD(n, x, y)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseD(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/67/verifierE.go
+++ b/0-999/0-99/60-69/67/verifierE.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(n int, pts [][2]float64) string {
+	x1 := pts[0][0]
+	y0 := pts[0][1]
+	x2 := pts[1][0]
+	L, R := x1, x2
+	if L > R {
+		L, R = R, L
+	}
+	const eps = 1e-9
+	for i := 0; i < n; i++ {
+		xi, yi := pts[i][0], pts[i][1]
+		xj, yj := pts[(i+1)%n][0], pts[(i+1)%n][1]
+		dx := xj - xi
+		dy := yj - yi
+		A := dx
+		B := -dy
+		if math.Abs(B) < eps {
+			if A*(y0-yi) > 0 {
+				return "0"
+			}
+			continue
+		}
+		num := -A * (y0 - yi)
+		bound := xi + num/B
+		if B > 0 {
+			if bound < R {
+				R = bound
+			}
+		} else {
+			if bound > L {
+				L = bound
+			}
+		}
+		if L > R {
+			return "0"
+		}
+	}
+	start := math.Ceil(L - eps)
+	end := math.Floor(R + eps)
+	cnt := int(end - start + 1)
+	if cnt < 0 {
+		cnt = 0
+	}
+	return fmt.Sprintf("%d", cnt)
+}
+
+func generateCaseE(rng *rand.Rand) (string, string) {
+	x1 := float64(rng.Intn(21) - 10)
+	x2 := float64(rng.Intn(21) - 10)
+	if x1 == x2 {
+		x2 = x1 + 1
+	}
+	y0 := float64(rng.Intn(21) - 10)
+	y1 := y0 + float64(rng.Intn(10)+1)
+	pts := [][2]float64{
+		{x1, y0},
+		{x2, y0},
+		{x2, y1},
+		{x1, y1},
+	}
+	n := len(pts)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%.0f %.0f\n", pts[i][0], pts[i][1])
+	}
+	expected := solveE(n, pts)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseE(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add random test based verifiers for contest 67 problems A–E

## Testing
- `go build 0-999/0-99/60-69/67/verifierA.go`
- `go build 0-999/0-99/60-69/67/verifierB.go`
- `go build 0-999/0-99/60-69/67/verifierC.go`
- `go build 0-999/0-99/60-69/67/verifierD.go`
- `go build 0-999/0-99/60-69/67/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e617095948324b1e615aa60c8cf19