### PR TITLE
Add verifiers for contest 65

### DIFF
--- a/0-999/0-99/60-69/65/verifierA.go
+++ b/0-999/0-99/60-69/65/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(a, b, c, d, e, f int64) string {
+	if c == 0 && d > 0 {
+		return "Ron"
+	}
+	if a == 0 && b > 0 && ((c > 0 && d > 0) || (c == 0 && d > 0)) {
+		return "Ron"
+	}
+	if e == 0 && f > 0 && (a > 0 && b > 0) && ((c > 0 && d > 0) || (c == 0 && d > 0)) {
+		return "Ron"
+	}
+	if a > 0 && b > 0 && c > 0 && d > 0 && e > 0 && f > 0 {
+		if b*d*f > a*c*e {
+			return "Ron"
+		}
+	}
+	return "Hermione"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	a := rng.Int63n(1001)
+	b := rng.Int63n(1001)
+	c := rng.Int63n(1001)
+	d := rng.Int63n(1001)
+	e := rng.Int63n(1001)
+	f := rng.Int63n(1001)
+	input := fmt.Sprintf("%d %d %d %d %d %d\n", a, b, c, d, e, f)
+	exp := expected(a, b, c, d, e, f)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/65/verifierB.go
+++ b/0-999/0-99/60-69/65/verifierB.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func candidates(y int) []int {
+	ystr := fmt.Sprintf("%04d", y)
+	cands := make([]int, 0, 50)
+	if y >= 1000 && y <= 2011 {
+		cands = append(cands, y)
+	}
+	for j := 0; j < 4; j++ {
+		for d := byte('0'); d <= '9'; d++ {
+			if d == ystr[j] {
+				continue
+			}
+			if j == 0 && d == '0' {
+				continue
+			}
+			zbytes := []byte(ystr)
+			zbytes[j] = d
+			z := int(zbytes[0]-'0')*1000 + int(zbytes[1]-'0')*100 + int(zbytes[2]-'0')*10 + int(zbytes[3]-'0')
+			if z < 1000 || z > 2011 {
+				continue
+			}
+			cands = append(cands, z)
+		}
+	}
+	sort.Ints(cands)
+	uniq := make([]int, 0, len(cands))
+	prev := -1
+	for _, z := range cands {
+		if z != prev {
+			uniq = append(uniq, z)
+			prev = z
+		}
+	}
+	return uniq
+}
+
+func expected(n int, years []int) (string, bool) {
+	prev := 1000
+	res := make([]int, n)
+	for i, y := range years {
+		cands := candidates(y)
+		pick := -1
+		for _, z := range cands {
+			if z >= prev {
+				pick = z
+				break
+			}
+		}
+		if pick < 0 {
+			return "No solution", false
+		}
+		res[i] = pick
+		prev = pick
+	}
+	var sb strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String(), true
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	years := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		years[i] = rng.Intn(9000) + 1000
+		sb.WriteString(fmt.Sprintf("%d\n", years[i]))
+	}
+	input := sb.String()
+	exp, ok := expected(n, years)
+	if !ok {
+		exp = "No solution"
+	}
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/65/verifierC.go
+++ b/0-999/0-99/60-69/65/verifierC.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type P struct{ x, y, z float64 }
+
+func (p P) add(q P) P       { return P{p.x + q.x, p.y + q.y, p.z + q.z} }
+func (p P) sub(q P) P       { return P{p.x - q.x, p.y - q.y, p.z - q.z} }
+func (p P) mul(s float64) P { return P{p.x * s, p.y * s, p.z * s} }
+func (p P) norm() float64   { return math.Sqrt(p.x*p.x + p.y*p.y + p.z*p.z) }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, v []P, vh, vs float64, h P) string {
+	eps := 1e-11
+	can := func(a P, t float64) bool {
+		return a.sub(h).norm()/vh < t+eps
+	}
+	var onde P
+	onde.x = -1e10
+	var endIdx int
+	var tAccum float64
+	for i := 0; i < n; i++ {
+		segDist := v[i].sub(v[i+1]).norm()
+		dt := segDist / vs
+		if can(v[i+1], tAccum+dt) {
+			lo, hi := 0.0, 1.0
+			for it := 0; it < 100; it++ {
+				mid := (lo + hi) / 2.0
+				m := v[i].add(v[i+1].sub(v[i]).mul(mid))
+				tPerson := tAccum + v[i].sub(m).norm()/vs
+				if can(m, tPerson) {
+					hi = mid
+				} else {
+					lo = mid
+				}
+			}
+			onde = v[i].add(v[i+1].sub(v[i]).mul(lo))
+			endIdx = i
+			break
+		}
+		tAccum += dt
+	}
+	if onde.x <= -1e8 {
+		return "NO"
+	}
+	tPerson := tAccum + v[endIdx].sub(onde).norm()/vs
+	tHeli := onde.sub(h).norm() / vh
+	tFinal := math.Max(tPerson, tHeli)
+	return fmt.Sprintf("YES\n%.10f\n%.10f %.10f %.10f", tFinal, onde.x, onde.y, onde.z)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	v := make([]P, n+1)
+	for i := 0; i <= n; i++ {
+		v[i] = P{float64(rng.Intn(21) - 10), float64(rng.Intn(21) - 10), float64(rng.Intn(21) - 10)}
+		if i > 0 {
+			for v[i] == v[i-1] {
+				v[i] = P{float64(rng.Intn(21) - 10), float64(rng.Intn(21) - 10), float64(rng.Intn(21) - 10)}
+			}
+		}
+	}
+	vh := float64(rng.Intn(10) + 5)
+	vs := float64(rng.Intn(int(vh)) + 1)
+	h := P{float64(rng.Intn(21) - 10), float64(rng.Intn(21) - 10), float64(rng.Intn(21) - 10)}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%.0f %.0f %.0f\n", v[i].x, v[i].y, v[i].z))
+	}
+	sb.WriteString(fmt.Sprintf("%.0f %.0f\n", vh, vs))
+	sb.WriteString(fmt.Sprintf("%.0f %.0f %.0f\n", h.x, h.y, h.z))
+	input := sb.String()
+	exp := expected(n, v, vh, vs, h)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/65/verifierD.go
+++ b/0-999/0-99/60-69/65/verifierD.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, s string) string {
+	c := [4]int{}
+	k := 0
+	for i := 0; i < n && i < len(s); i++ {
+		switch s[i] {
+		case 'G':
+			c[0]++
+		case 'H':
+			c[1]++
+		case 'R':
+			c[2]++
+		case 'S':
+			c[3]++
+		case '?':
+			k++
+		}
+	}
+	type pair struct{ val, idx int }
+	p := []pair{{c[0], 0}, {c[1], 1}, {c[2], 2}, {c[3], 3}}
+	for i := 0; i < 4; i++ {
+		for j := i + 1; j < 4; j++ {
+			if p[j].val < p[i].val {
+				p[i], p[j] = p[j], p[i]
+			}
+		}
+	}
+	kLeft := k
+	level := p[0].val
+	idxGroup := 1
+	for idxGroup < 4 {
+		need := idxGroup * (p[idxGroup].val - level)
+		if kLeft >= need {
+			kLeft -= need
+			level = p[idxGroup].val
+			idxGroup++
+		} else {
+			break
+		}
+	}
+	if idxGroup > 0 {
+		f := kLeft / idxGroup
+		level += f
+		kLeft -= f * idxGroup
+	}
+	names := []string{"Gryffindor", "Hufflepuff", "Ravenclaw", "Slytherin"}
+	res := make([]string, 0, idxGroup)
+	for i := 0; i < idxGroup; i++ {
+		res = append(res, names[p[i].idx])
+	}
+	for i := 0; i < len(res); i++ {
+		for j := i + 1; j < len(res); j++ {
+			if res[j] < res[i] {
+				res[i], res[j] = res[j], res[i]
+			}
+		}
+	}
+	return strings.Join(res, "\n")
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	letters := []byte{'G', 'H', 'R', 'S', '?'}
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	s := string(b)
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	exp := expected(n, s)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/65/verifierE.go
+++ b/0-999/0-99/60-69/65/verifierE.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "65E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	edges := make(map[[2]int]struct{})
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		edges[[2]int{u, v}] = struct{}{}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	idx := 1
+	for e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		idx++
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if out != exp {
+		return fmt.Errorf("expected\n%s\ngot\n%s", exp, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–E of contest 65
- verifiers generate 100 random test cases and check output
- verifier for problem E compiles the official solution as an oracle

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6166392c83248c7566633cacc2a9