### PR TITLE
Add Go verifiers for Codeforces contest 63

### DIFF
--- a/0-999/0-99/60-69/63/verifierA.go
+++ b/0-999/0-99/60-69/63/verifierA.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func generateCases() []testCase {
+	rand.Seed(1)
+	cases := make([]testCase, 100)
+	statuses := []string{"rat", "woman", "child", "man"}
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		buf := bytes.Buffer{}
+		fmt.Fprintln(&buf, n)
+		names := make([]string, n)
+		stat := make([]string, n)
+		capPos := rand.Intn(n)
+		for j := 0; j < n; j++ {
+			names[j] = fmt.Sprintf("N%02d_%02d", i, j)
+			if j == capPos {
+				stat[j] = "captain"
+			} else {
+				stat[j] = statuses[rand.Intn(len(statuses))]
+			}
+			fmt.Fprintf(&buf, "%s %s\n", names[j], stat[j])
+		}
+		// expected output
+		var exp bytes.Buffer
+		for idx := 0; idx < n; idx++ {
+			if stat[idx] == "rat" {
+				fmt.Fprintln(&exp, names[idx])
+			}
+		}
+		for idx := 0; idx < n; idx++ {
+			if stat[idx] == "woman" || stat[idx] == "child" {
+				fmt.Fprintln(&exp, names[idx])
+			}
+		}
+		for idx := 0; idx < n; idx++ {
+			if stat[idx] == "man" {
+				fmt.Fprintln(&exp, names[idx])
+			}
+		}
+		for idx := 0; idx < n; idx++ {
+			if stat[idx] == "captain" {
+				fmt.Fprintln(&exp, names[idx])
+				break
+			}
+		}
+		cases[i] = testCase{input: buf.String(), expected: strings.TrimSpace(exp.String())}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierA.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/63/verifierB.go
+++ b/0-999/0-99/60-69/63/verifierB.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func compute(n, k int, ranks []int) int {
+	counts := make([]int, k+2)
+	for _, r := range ranks {
+		if r >= 1 && r <= k {
+			counts[r]++
+		}
+	}
+	sessions := 0
+	for {
+		done := true
+		for r := 1; r < k; r++ {
+			if counts[r] > 0 {
+				done = false
+				break
+			}
+		}
+		if done {
+			break
+		}
+		sessions++
+		newC := make([]int, k+2)
+		copy(newC, counts)
+		for r := 1; r < k; r++ {
+			if counts[r] > 0 {
+				newC[r]--
+				newC[r+1]++
+			}
+		}
+		counts = newC
+	}
+	return sessions
+}
+
+func generateCases() []testCase {
+	rand.Seed(2)
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(9) + 2
+		ranks := make([]int, n)
+		buf := bytes.Buffer{}
+		fmt.Fprintf(&buf, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			ranks[j] = rand.Intn(k) + 1
+			fmt.Fprintf(&buf, "%d", ranks[j])
+			if j+1 < n {
+				fmt.Fprint(&buf, " ")
+			}
+		}
+		buf.WriteByte('\n')
+		expected := fmt.Sprintf("%d", compute(n, k, ranks))
+		cases[i] = testCase{input: buf.String(), expected: expected}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierB.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/63/verifierC.go
+++ b/0-999/0-99/60-69/63/verifierC.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func bullsCows(a, b string) (int, int) {
+	bulls := 0
+	var seen [10]bool
+	for i := 0; i < 4; i++ {
+		if a[i] == b[i] {
+			bulls++
+		}
+		seen[a[i]-'0'] = true
+	}
+	match := 0
+	for i := 0; i < 4; i++ {
+		if seen[b[i]-'0'] {
+			match++
+		}
+	}
+	return bulls, match - bulls
+}
+
+func enumerate(guesses []string, bulls, cows []int) string {
+	var candidates []string
+	digits := "0123456789"
+	for i := 0; i < len(digits); i++ {
+		for j := 0; j < len(digits); j++ {
+			if j == i {
+				continue
+			}
+			for k := 0; k < len(digits); k++ {
+				if k == i || k == j {
+					continue
+				}
+				for l := 0; l < len(digits); l++ {
+					if l == i || l == j || l == k {
+						continue
+					}
+					cand := []byte{digits[i], digits[j], digits[k], digits[l]}
+					ok := true
+					for idx, g := range guesses {
+						b, c := bullsCows(string(cand), g)
+						if b != bulls[idx] || c != cows[idx] {
+							ok = false
+							break
+						}
+					}
+					if ok {
+						candidates = append(candidates, string(cand))
+						if len(candidates) > 1 {
+							return "Need more data"
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return "Incorrect data"
+	}
+	return candidates[0]
+}
+
+func generateCases() []testCase {
+	rand.Seed(3)
+	cases := make([]testCase, 100)
+	digits := "0123456789"
+	allNums := []string{}
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 10; j++ {
+			if j == i {
+				continue
+			}
+			for k := 0; k < 10; k++ {
+				if k == i || k == j {
+					continue
+				}
+				for l := 0; l < 10; l++ {
+					if l == i || l == j || l == k {
+						continue
+					}
+					allNums = append(allNums, string([]byte{digits[i], digits[j], digits[k], digits[l]}))
+				}
+			}
+		}
+	}
+	for t := 0; t < 100; t++ {
+		secret := allNums[rand.Intn(len(allNums))]
+		n := rand.Intn(5) + 1
+		var guesses []string
+		var bVals []int
+		var cVals []int
+		for i := 0; i < n; i++ {
+			g := allNums[rand.Intn(len(allNums))]
+			b, c := bullsCows(secret, g)
+			if rand.Intn(10) < 3 { // introduce errors sometimes
+				if rand.Intn(2) == 0 {
+					b = (b + rand.Intn(4)) % 5
+					if b+c > 4 {
+						c = 4 - b
+					}
+				} else {
+					c = (c + rand.Intn(4)) % 5
+					if b+c > 4 {
+						b = 4 - c
+					}
+				}
+			}
+			guesses = append(guesses, g)
+			bVals = append(bVals, b)
+			cVals = append(cVals, c)
+		}
+		buf := bytes.Buffer{}
+		fmt.Fprintln(&buf, n)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&buf, "%s %d %d\n", guesses[i], bVals[i], cVals[i])
+		}
+		expected := enumerate(guesses, bVals, cVals)
+		cases[t] = testCase{input: buf.String(), expected: expected}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierC.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/63/verifierD.go
+++ b/0-999/0-99/60-69/63/verifierD.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func solve(a, b, c, d int, sizes []int) string {
+	width := b
+	if d > width {
+		width = d
+	}
+	height := a + c
+	grid := make([][]byte, width)
+	for i := 0; i < width; i++ {
+		row := make([]byte, height)
+		for j := range row {
+			row[j] = '.'
+		}
+		grid[i] = row
+	}
+	x, y, dx := 0, 0, 1
+	if a%2 == 1 {
+		x = b - 1
+		dx = -1
+	}
+	next := func() {
+		nx := x + dx
+		if nx < 0 {
+			dx = 1
+			x = 0
+			y++
+		} else if y < a && nx >= b {
+			dx = -1
+			x = b - 1
+			y++
+		} else if y >= a && nx >= d {
+			dx = -1
+			x = d - 1
+			y++
+		} else {
+			x = nx
+		}
+	}
+	for i := 0; i < len(sizes); i++ {
+		for sizes[i] > 0 {
+			grid[x][y] = byte('a' + i)
+			sizes[i]--
+			next()
+		}
+	}
+	var out bytes.Buffer
+	out.WriteString("YES\n")
+	for i := 0; i < width; i++ {
+		out.Write(grid[i])
+		out.WriteByte('\n')
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateCases() []testCase {
+	rand.Seed(4)
+	cases := make([]testCase, 100)
+	for t := 0; t < 100; t++ {
+		a := rand.Intn(4) + 1
+		b := rand.Intn(4) + 1
+		c := rand.Intn(4) + 1
+		d := rand.Intn(4) + 1
+		n := rand.Intn(5) + 1
+		area := a*b + c*d
+		if n > 26 {
+			n = 26
+		}
+		sizes := make([]int, n)
+		rem := area
+		for i := 0; i < n; i++ {
+			if i == n-1 {
+				sizes[i] = rem
+			} else {
+				maxv := rem - (n - i - 1)
+				val := rand.Intn(maxv) + 1
+				sizes[i] = val
+				rem -= val
+			}
+		}
+		buf := bytes.Buffer{}
+		fmt.Fprintf(&buf, "%d %d %d %d %d\n", a, b, c, d, n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				fmt.Fprint(&buf, " ")
+			}
+			fmt.Fprint(&buf, sizes[i])
+		}
+		buf.WriteByte('\n')
+		expected := solve(a, b, c, d, append([]int(nil), sizes...))
+		cases[t] = testCase{input: buf.String(), expected: expected}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierD.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/63/verifierE.go
+++ b/0-999/0-99/60-69/63/verifierE.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+type coord struct{ q, r int }
+
+func grundy(mask int, lines [][]int) int {
+	dp := make([]int, mask+1)
+	seen := make([]bool, 256)
+	gList := make([]int, 0, 32)
+	for m := 1; m <= mask; m++ {
+		gList = gList[:0]
+		for _, line := range lines {
+			for i := 0; i < len(line); {
+				if (m>>line[i])&1 == 0 {
+					i++
+					continue
+				}
+				j := i
+				for j < len(line) && (m>>line[j])&1 == 1 {
+					j++
+				}
+				for s := i; s < j; s++ {
+					seg := 0
+					for e := s; e < j; e++ {
+						seg |= 1 << line[e]
+						child := m &^ seg
+						g := dp[child]
+						if !seen[g] {
+							seen[g] = true
+							gList = append(gList, g)
+						}
+					}
+				}
+				i = j
+			}
+		}
+		mex := 0
+		for seen[mex] {
+			mex++
+		}
+		dp[m] = mex
+		for _, g := range gList {
+			seen[g] = false
+		}
+	}
+	return dp[mask]
+}
+
+func solve(board []string) string {
+	coords := []coord{}
+	for r := -2; r <= 2; r++ {
+		minq := -2
+		if -r-2 > minq {
+			minq = -r - 2
+		}
+		maxq := 2
+		if -r+2 < maxq {
+			maxq = -r + 2
+		}
+		for q := minq; q <= maxq; q++ {
+			coords = append(coords, coord{q, r})
+		}
+	}
+	idx := make(map[coord]int)
+	for i, c := range coords {
+		idx[c] = i
+	}
+	var lines [][]int
+	for qv := -2; qv <= 2; qv++ {
+		var line []int
+		for i, c := range coords {
+			if c.q == qv {
+				line = append(line, i)
+			}
+		}
+		sort.Slice(line, func(i, j int) bool { return coords[line[i]].r < coords[line[j]].r })
+		lines = append(lines, line)
+	}
+	for rv := -2; rv <= 2; rv++ {
+		var line []int
+		for i, c := range coords {
+			if c.r == rv {
+				line = append(line, i)
+			}
+		}
+		sort.Slice(line, func(i, j int) bool { return coords[line[i]].q < coords[line[j]].q })
+		lines = append(lines, line)
+	}
+	for sv := -2; sv <= 2; sv++ {
+		var line []int
+		for i, c := range coords {
+			if -c.q-c.r == sv {
+				line = append(line, i)
+			}
+		}
+		sort.Slice(line, func(i, j int) bool { return coords[line[i]].q < coords[line[j]].q })
+		lines = append(lines, line)
+	}
+	mask := 0
+	idxOrder := []coord{}
+	for r := -2; r <= 2; r++ {
+		minq := -2
+		if -r-2 > minq {
+			minq = -r - 2
+		}
+		maxq := 2
+		if -r+2 < maxq {
+			maxq = -r + 2
+		}
+		for q := minq; q <= maxq; q++ {
+			idxOrder = append(idxOrder, coord{q, r})
+		}
+	}
+	for i, c := range idxOrder {
+		if board[i] == "O" {
+			mask |= 1 << idx[c]
+		}
+	}
+	if grundy(mask, lines) != 0 {
+		return "Karlsson"
+	}
+	return "Lillebror"
+}
+
+func generateCases() []testCase {
+	rand.Seed(5)
+	cases := make([]testCase, 100)
+	for t := 0; t < 100; t++ {
+		board := make([]string, 19)
+		has := false
+		for i := 0; i < 19; i++ {
+			if rand.Intn(2) == 0 {
+				board[i] = "O"
+				has = true
+			} else {
+				board[i] = "."
+			}
+		}
+		if !has {
+			board[0] = "O"
+		}
+		var buf bytes.Buffer
+		idx := 0
+		layout := []int{3, 4, 5, 4, 3}
+		for _, cnt := range layout {
+			for j := 0; j < cnt; j++ {
+				fmt.Fprintf(&buf, "%s ", board[idx])
+				idx++
+			}
+			if cnt > 0 {
+				buf.Truncate(buf.Len() - 1)
+			}
+			buf.WriteByte('\n')
+		}
+		expected := solve(board)
+		cases[t] = testCase{input: buf.String(), expected: expected}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierE.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement verifierA.go through verifierE.go for contest 63
- each verifier runs the passed binary with 100 deterministic test cases
- algorithms for expected results mirror the official solutions

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e615c7fbc83248a54e74e062f1370