### PR TITLE
Add Go verifiers for contest 64

### DIFF
--- a/0-999/0-99/60-69/64/verifierA.go
+++ b/0-999/0-99/60-69/64/verifierA.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func factorial(n int) int {
+	res := 1
+	for i := 2; i <= n; i++ {
+		res *= i
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1 // 1..10
+		input := fmt.Sprintf("%d\n", n)
+		expected := factorial(n)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got int
+		fmt.Sscan(out, &got)
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/64/verifierB.go
+++ b/0-999/0-99/60-69/64/verifierB.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func compute(a int, op byte, b int) int {
+	if op == '+' {
+		return a + b
+	}
+	return a - b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	ops := []byte{'+', '-'}
+	for i := 0; i < 100; i++ {
+		a := rng.Intn(10)
+		b := rng.Intn(10)
+		op := ops[rng.Intn(2)]
+		input := fmt.Sprintf("%d%c%d\n", a, op, b)
+		expected := compute(a, op, b)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got int
+		fmt.Sscan(out, &got)
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/64/verifierC.go
+++ b/0-999/0-99/60-69/64/verifierC.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func compute(n, m, k int64) int64 {
+	k--
+	row := k % n
+	col := k / n
+	return row*m + col + 1
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := int64(rng.Intn(20000) + 1)
+		m := int64(rng.Intn(20000) + 1)
+		maxK := n * m
+		k := int64(rng.Int63n(maxK) + 1)
+		input := fmt.Sprintf("%d %d %d\n", n, m, k)
+		expected := compute(n, m, k)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got int64
+		fmt.Sscan(out, &got)
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/64/verifierD.go
+++ b/0-999/0-99/60-69/64/verifierD.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func validAssignment(prices [3]int, ans [3]int) bool {
+	used := [4]bool{}
+	for i := 0; i < 3; i++ {
+		if ans[i] < 1 || ans[i] > 3 || used[ans[i]] {
+			return false
+		}
+		used[ans[i]] = true
+	}
+	for i := 0; i < 3; i++ {
+		for j := 0; j < 3; j++ {
+			if prices[i] > prices[j] && ans[i] >= ans[j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		prices := [3]int{rng.Intn(100) + 1, rng.Intn(100) + 1, rng.Intn(100) + 1}
+		input := fmt.Sprintf("%d %d %d\n", prices[0], prices[1], prices[2])
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var ans [3]int
+		n, _ := fmt.Sscan(out, &ans[0], &ans[1], &ans[2])
+		if n != 3 || !validAssignment(prices, ans) {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid answer %s\ninput:%s", i+1, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/64/verifierE.go
+++ b/0-999/0-99/60-69/64/verifierE.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func sieve(limit int) []bool {
+	isPrime := make([]bool, limit+1)
+	for i := 2; i <= limit; i++ {
+		isPrime[i] = true
+	}
+	for i := 2; i*i <= limit; i++ {
+		if isPrime[i] {
+			for j := i * i; j <= limit; j += i {
+				isPrime[j] = false
+			}
+		}
+	}
+	return isPrime
+}
+
+var primes = sieve(20005)
+
+func compute(n int) (int, int) {
+	a := 0
+	for i := n; i >= 2; i-- {
+		if primes[i] {
+			a = i
+			break
+		}
+	}
+	b := 0
+	for i := n; i < len(primes); i++ {
+		if primes[i] {
+			b = i
+			break
+		}
+	}
+	return a, b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10000-2+1) + 2
+		input := fmt.Sprintf("%d\n", n)
+		a, b := compute(n)
+		expected := fmt.Sprintf("%d %d", a, b)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/64/verifierF.go
+++ b/0-999/0-99/60-69/64/verifierF.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func isDomain(s string) bool {
+	if len(s) == 0 || s[0] == '.' || s[len(s)-1] == '.' {
+		return false
+	}
+	prevDot := false
+	lastDot := -1
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '.' {
+			if prevDot {
+				return false
+			}
+			prevDot = true
+			lastDot = i
+		} else if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
+			prevDot = false
+		} else {
+			return false
+		}
+	}
+	var lastLen int
+	if lastDot == -1 {
+		lastLen = len(s)
+	} else {
+		lastLen = len(s) - lastDot - 1
+	}
+	return lastLen == 2 || lastLen == 3
+}
+
+func randToken(rng *rand.Rand, min, max int) string {
+	n := rng.Intn(max-min+1) + min
+	b := make([]byte, n)
+	for i := range b {
+		if rng.Intn(2) == 0 {
+			b[i] = byte('a' + rng.Intn(26))
+		} else {
+			b[i] = byte('0' + rng.Intn(10))
+		}
+	}
+	return string(b)
+}
+
+func generateValid(rng *rand.Rand) string {
+	parts := rng.Intn(3) + 1
+	var sb strings.Builder
+	for i := 0; i < parts; i++ {
+		if i > 0 {
+			sb.WriteByte('.')
+		}
+		sb.WriteString(randToken(rng, 1, 5))
+	}
+	tldLen := 2 + rng.Intn(2)
+	sb.WriteByte('.')
+	sb.WriteString(randToken(rng, tldLen, tldLen))
+	return sb.String()
+}
+
+func mutateInvalid(rng *rand.Rand, s string) string {
+	choice := rng.Intn(4)
+	switch choice {
+	case 0:
+		return "." + s
+	case 1:
+		return s + "."
+	case 2:
+		return strings.ReplaceAll(s, ".", "..")
+	default:
+		return s + "#"
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		valid := rng.Intn(2) == 0
+		dom := generateValid(rng)
+		if !valid {
+			dom = mutateInvalid(rng, dom)
+		}
+		input := dom + "\n"
+		expected := "NO"
+		if isDomain(dom) {
+			expected = "YES"
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/64/verifierG.go
+++ b/0-999/0-99/60-69/64/verifierG.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func canonical(path string) (string, bool) {
+	parts := strings.Split(path, "/")
+	var stack []string
+	for _, p := range parts {
+		if p == "" || p == "." {
+			continue
+		}
+		if p == ".." {
+			if len(stack) == 0 {
+				return "-1", false
+			}
+			stack = stack[:len(stack)-1]
+		} else {
+			stack = append(stack, p)
+		}
+	}
+	if len(stack) == 0 {
+		return "/", true
+	}
+	return "/" + strings.Join(stack, "/"), true
+}
+
+func randToken(rng *rand.Rand) string {
+	l := rng.Intn(5) + 1
+	b := make([]byte, l)
+	for i := range b {
+		if rng.Intn(2) == 0 {
+			b[i] = byte('a' + rng.Intn(26))
+		} else {
+			b[i] = byte('0' + rng.Intn(10))
+		}
+	}
+	return string(b)
+}
+
+func generatePath(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	var parts []string
+	parts = append(parts, "") // start with root
+	for i := 0; i < n; i++ {
+		choice := rng.Intn(5)
+		switch choice {
+		case 0:
+			parts = append(parts, ".")
+		case 1:
+			parts = append(parts, "..")
+		default:
+			parts = append(parts, randToken(rng))
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		path := generatePath(rng)
+		input := path + "\n"
+		exp, ok := canonical(path)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if !ok {
+			if out != "-1" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected -1 got %s\ninput:%s", i+1, out, input)
+				os.Exit(1)
+			}
+			continue
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/64/verifierH.go
+++ b/0-999/0-99/60-69/64/verifierH.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type participant struct {
+	name  string
+	score int
+}
+
+func expectedTable(ps []participant) []string {
+	sort.Slice(ps, func(i, j int) bool {
+		if ps[i].score != ps[j].score {
+			return ps[i].score > ps[j].score
+		}
+		return ps[i].name < ps[j].name
+	})
+	var res []string
+	n := len(ps)
+	i := 0
+	for i < n {
+		j := i + 1
+		for j < n && ps[j].score == ps[i].score {
+			j++
+		}
+		place := ""
+		if j-i == 1 {
+			place = fmt.Sprintf("%d", i+1)
+		} else {
+			place = fmt.Sprintf("%d-%d", i+1, j)
+		}
+		for k := i; k < j; k++ {
+			res = append(res, fmt.Sprintf("%s %s", place, ps[k].name))
+		}
+		i = j
+	}
+	return res
+}
+
+func randName(rng *rand.Rand) string {
+	l := rng.Intn(8) + 3
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(10) + 1
+	ps := make([]participant, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	used := make(map[string]bool)
+	for i := 0; i < n; i++ {
+		name := randName(rng)
+		for used[name] {
+			name = randName(rng)
+		}
+		used[name] = true
+		score := rng.Intn(1001)
+		ps[i] = participant{name, score}
+		sb.WriteString(fmt.Sprintf("%s %d\n", name, score))
+	}
+	exp := expectedTable(ps)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expectedLines := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		outLines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(outLines) != len(expectedLines) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", i+1, len(expectedLines), len(outLines), input)
+			os.Exit(1)
+		}
+		for j := range expectedLines {
+			if strings.TrimSpace(outLines[j]) != expectedLines[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed: line %d expected '%s' got '%s'\ninput:\n%s", i+1, j+1, expectedLines[j], outLines[j], input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/64/verifierI.go
+++ b/0-999/0-99/60-69/64/verifierI.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type rule struct {
+	idx int
+	asc bool
+}
+
+type row struct {
+	cells []string
+	idx   int
+}
+
+func sortTable(header []string, rules []rule, rows []row) []row {
+	sort.SliceStable(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		for _, r := range rules {
+			if a.cells[r.idx] == b.cells[r.idx] {
+				continue
+			}
+			if r.asc {
+				return a.cells[r.idx] < b.cells[r.idx]
+			}
+			return a.cells[r.idx] > b.cells[r.idx]
+		}
+		return a.idx < b.idx
+	})
+	return rows
+}
+
+func randWord(rng *rand.Rand) string {
+	l := rng.Intn(5) + 1
+	b := make([]byte, l)
+	for i := range b {
+		if rng.Intn(2) == 0 {
+			b[i] = byte('A' + rng.Intn(26))
+		} else {
+			b[i] = byte('a' + rng.Intn(26))
+		}
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	cols := rng.Intn(3) + 2
+	headers := make([]string, cols)
+	for i := range headers {
+		headers[i] = randWord(rng)
+	}
+	var sb strings.Builder
+	sb.WriteString(strings.Join(headers, " ") + "\n")
+	// rules
+	ruleCnt := rng.Intn(cols) + 1
+	perm := rand.Perm(cols)
+	var rules []rule
+	var ruleParts []string
+	for i := 0; i < ruleCnt; i++ {
+		idx := perm[i]
+		asc := rng.Intn(2) == 0
+		order := "ASC"
+		if !asc {
+			order = "DESC"
+		}
+		ruleParts = append(ruleParts, fmt.Sprintf("%s %s", headers[idx], order))
+		rules = append(rules, rule{idx: idx, asc: asc})
+	}
+	sb.WriteString(strings.Join(ruleParts, ", ") + "\n")
+	rowsN := rng.Intn(10) + 1
+	rows := make([]row, rowsN)
+	for i := 0; i < rowsN; i++ {
+		cells := make([]string, cols)
+		for j := 0; j < cols; j++ {
+			cells[j] = randWord(rng)
+		}
+		rows[i] = row{cells: cells, idx: i}
+		sb.WriteString(strings.Join(cells, " ") + "\n")
+	}
+	sorted := sortTable(headers, rules, append([]row(nil), rows...))
+	var expected []string
+	expected = append(expected, strings.Join(headers, " "))
+	for _, r := range sorted {
+		expected = append(expected, strings.Join(r.cells, " "))
+	}
+	return sb.String(), expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expectedLines := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		outLines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(outLines) != len(expectedLines) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", i+1, len(expectedLines), len(outLines), input)
+			os.Exit(1)
+		}
+		for j := range expectedLines {
+			if strings.TrimSpace(outLines[j]) != expectedLines[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed: line %d expected '%s' got '%s'\ninput:\n%s", i+1, j+1, expectedLines[j], outLines[j], input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go solution verifiers for contest 64 problems A–I
- each verifier generates 100 randomized test cases
- verifiers run any binary or `.go` source passed as argument
- use internal reference implementations for checking results

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`
- `go run verifierF.go ./solF`
- `go run verifierG.go ./solG`
- `go run verifierH.go ./solH`
- `go run verifierI.go ./solI`


------
https://chatgpt.com/codex/tasks/task_e_687e61618e7c8324aedb52e07e3d72cc