### PR TITLE
Add verifiers for contest 62

### DIFF
--- a/0-999/0-99/60-69/62/verifierA.go
+++ b/0-999/0-99/60-69/62/verifierA.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func canHold(girl, boy int) bool {
+	return boy >= girl-1 && boy <= 2*(girl+1)
+}
+
+func solveCase(al, ar, bl, br int) string {
+	if canHold(al, br) || canHold(ar, bl) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runCase(bin string, al, ar, bl, br int) (string, error) {
+	input := fmt.Sprintf("%d %d\n%d %d\n", al, ar, bl, br)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		al := rng.Intn(6)
+		ar := rng.Intn(6)
+		bl := rng.Intn(6)
+		br := rng.Intn(6)
+		expected := solveCase(al, ar, bl, br)
+		got, err := runCase(bin, al, ar, bl, br)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s (input: %d %d %d %d)\n", i+1, expected, got, al, ar, bl, br)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/62/verifierB.go
+++ b/0-999/0-99/60-69/62/verifierB.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func computeF(s string, c string) int64 {
+	pos := make([][]int, 26)
+	for i, ch := range s {
+		pos[ch-'a'] = append(pos[ch-'a'], i+1)
+	}
+	var f int64
+	for i, ch := range c {
+		lst := pos[ch-'a']
+		if len(lst) == 0 {
+			f += int64(len(c))
+		} else {
+			target := i + 1
+			idx := sort.Search(len(lst), func(j int) bool { return lst[j] >= target })
+			d := 1<<31 - 1
+			if idx < len(lst) {
+				if diff := lst[idx] - target; diff < d {
+					if diff < 0 {
+						d = -diff
+					} else {
+						d = diff
+					}
+				}
+			}
+			if idx > 0 {
+				diff := lst[idx-1] - target
+				if diff < 0 {
+					diff = -diff
+				}
+				if diff < d {
+					d = diff
+				}
+			}
+			f += int64(d)
+		}
+	}
+	return f
+}
+
+func runCase(bin string, n, k int, s string, cands []string) (string, error) {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n%s\n", n, k, s))
+	for _, c := range cands {
+		sb.WriteString(c)
+		sb.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	letters := []rune("abcde")
+	for t := 0; t < 100; t++ {
+		k := rng.Intn(5) + 1
+		n := rng.Intn(4) + 1
+		var sb strings.Builder
+		for i := 0; i < k; i++ {
+			sb.WriteRune(letters[rng.Intn(len(letters))])
+		}
+		s := sb.String()
+		cands := make([]string, n)
+		for i := 0; i < n; i++ {
+			clen := rng.Intn(5) + 1
+			sb.Reset()
+			for j := 0; j < clen; j++ {
+				sb.WriteRune(letters[rng.Intn(len(letters))])
+			}
+			cands[i] = sb.String()
+		}
+		expectedVals := make([]string, n)
+		for i, c := range cands {
+			expectedVals[i] = fmt.Sprintf("%d", computeF(s, c))
+		}
+		expected := strings.Join(expectedVals, "\n")
+		got, err := runCase(bin, n, k, s, cands)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\ngot:\n%s\n", t+1, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/62/verifierC.go
+++ b/0-999/0-99/60-69/62/verifierC.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Point struct{ x, y float64 }
+
+func cross(a, b Point) float64 { return a.x*b.y - a.y*b.x }
+
+func segmentIntersect(p, r, q, s Point) (float64, bool) {
+	denom := cross(r, s)
+	if math.Abs(denom) < 1e-9 {
+		return 0, false
+	}
+	qp := Point{q.x - p.x, q.y - p.y}
+	t := cross(qp, s) / denom
+	u := cross(qp, r) / denom
+	if t > -1e-9 && t < 1+1e-9 && u > -1e-9 && u < 1+1e-9 {
+		return t, true
+	}
+	return 0, false
+}
+
+func pointInTriangle(p, a, b, c Point) bool {
+	ab := Point{b.x - a.x, b.y - a.y}
+	bc := Point{c.x - b.x, c.y - b.y}
+	ca := Point{a.x - c.x, a.y - c.y}
+	ap := Point{p.x - a.x, p.y - a.y}
+	bp := Point{p.x - b.x, p.y - b.y}
+	cp := Point{p.x - c.x, p.y - c.y}
+	c1 := cross(ab, ap)
+	c2 := cross(bc, bp)
+	c3 := cross(ca, cp)
+	if (c1 >= -1e-9 && c2 >= -1e-9 && c3 >= -1e-9) || (c1 <= 1e-9 && c2 <= 1e-9 && c3 <= 1e-9) {
+		return true
+	}
+	return false
+}
+
+func solveCase(tris [][3]Point) float64 {
+	n := len(tris)
+	total := 0.0
+	for i := 0; i < n; i++ {
+		for e := 0; e < 3; e++ {
+			a := tris[i][e]
+			b := tris[i][(e+1)%3]
+			r := Point{b.x - a.x, b.y - a.y}
+			ts := []float64{0.0, 1.0}
+			for j := 0; j < n; j++ {
+				if j == i {
+					continue
+				}
+				for f := 0; f < 3; f++ {
+					c := tris[j][f]
+					d := tris[j][(f+1)%3]
+					s := Point{d.x - c.x, d.y - c.y}
+					if t, ok := segmentIntersect(a, r, c, s); ok {
+						if t > 1e-9 && t < 1-1e-9 {
+							ts = append(ts, t)
+						}
+					}
+				}
+			}
+			sort.Float64s(ts)
+			unique := ts[:0]
+			for _, t := range ts {
+				if len(unique) == 0 || math.Abs(t-unique[len(unique)-1]) > 1e-8 {
+					unique = append(unique, t)
+				}
+			}
+			for k := 0; k+1 < len(unique); k++ {
+				t0 := unique[k]
+				t1 := unique[k+1]
+				tm := (t0 + t1) * 0.5
+				pm := Point{a.x + r.x*tm, a.y + r.y*tm}
+				covered := false
+				for j := 0; j < n && !covered; j++ {
+					if j == i {
+						continue
+					}
+					if pointInTriangle(pm, tris[j][0], tris[j][1], tris[j][2]) {
+						covered = true
+					}
+				}
+				if !covered {
+					total += (t1 - t0) * math.Hypot(r.x, r.y)
+				}
+			}
+		}
+	}
+	return total
+}
+
+func runCase(bin string, tris [][3]Point) (string, error) {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(tris)))
+	for _, tr := range tris {
+		sb.WriteString(fmt.Sprintf("%.2f %.2f %.2f %.2f %.2f %.2f\n", tr[0].x, tr[0].y, tr[1].x, tr[1].y, tr[2].x, tr[2].y))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(3) + 1
+		tris := make([][3]Point, n)
+		for i := 0; i < n; i++ {
+			for {
+				a := Point{rng.Float64() * 10, rng.Float64() * 10}
+				b := Point{rng.Float64() * 10, rng.Float64() * 10}
+				c := Point{rng.Float64() * 10, rng.Float64() * 10}
+				if math.Abs(cross(Point{b.x - a.x, b.y - a.y}, Point{c.x - a.x, c.y - a.y})) > 1e-3 {
+					tris[i] = [3]Point{a, b, c}
+					break
+				}
+			}
+		}
+		expected := solveCase(tris)
+		gotStr, err := runCase(bin, tris)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseFloat(strings.TrimSpace(gotStr), 64)
+		if err != nil || math.Abs(got-expected) > 1e-4 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.6f got %s\n", t+1, expected, gotStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/62/verifierD.go
+++ b/0-999/0-99/60-69/62/verifierD.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refD-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "62D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (int, int, []int) {
+	n := rng.Intn(3) + 3 // 3..5
+	m := n
+	nodes := make([]int, n)
+	for i := 0; i < n; i++ {
+		nodes[i] = i + 1
+	}
+	rng.Shuffle(n-1, func(i, j int) {
+		if i > 0 && j > 0 {
+			nodes[i], nodes[j] = nodes[j], nodes[i]
+		}
+	})
+	path := make([]int, m+1)
+	for i := 0; i < n; i++ {
+		path[i] = nodes[i]
+	}
+	path[n] = nodes[0]
+	return n, m, path
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n, m, p := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i, v := range p {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\ngot: %s\n", t+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/62/verifierE.go
+++ b/0-999/0-99/60-69/62/verifierE.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	exe, err := os.CreateTemp("", "refE-*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	path := exe.Name()
+	cmd := exec.Command("go", "build", "-o", path, "62E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return path, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (int, int, [][]int64, [][]int64) {
+	n := rng.Intn(4) + 2 // 2..5 but keep small
+	m := rng.Intn(3) + 2 // 2..4
+	h := make([][]int64, m-1)
+	for j := 0; j < m-1; j++ {
+		row := make([]int64, n)
+		for i := 0; i < n; i++ {
+			row[i] = int64(rng.Intn(10))
+		}
+		h[j] = row
+	}
+	v := make([][]int64, m)
+	for j := 0; j < m; j++ {
+		row := make([]int64, n)
+		for i := 0; i < n; i++ {
+			row[i] = int64(rng.Intn(10))
+		}
+		v[j] = row
+	}
+	return n, m, h, v
+}
+
+func buildInput(n, m int, h [][]int64, v [][]int64) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for j := 0; j < m-1; j++ {
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", h[j][i]))
+		}
+		sb.WriteByte('\n')
+	}
+	for j := 0; j < m; j++ {
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v[j][i]))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n, m, h, v := genCase(rng)
+		input := buildInput(n, m, h, v)
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected: %s\ngot: %s\n", t+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 62
- each verifier generates 100 randomized tests
- verifiers for D and E compile the reference solutions and compare outputs

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e61572e588324a025c77b65be0297