### PR TITLE
Add Go verifiers for contest 61

### DIFF
--- a/0-999/0-99/60-69/61/verifierA.go
+++ b/0-999/0-99/60-69/61/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type test struct {
+    input    string
+    expected string
+}
+
+func solve(input string) string {
+    lines := strings.Split(strings.TrimSpace(input), "\n")
+    if len(lines) < 2 {
+        return ""
+    }
+    a := strings.TrimSpace(lines[0])
+    b := strings.TrimSpace(lines[1])
+    n := len(a)
+    res := make([]byte, n)
+    for i := 0; i < n; i++ {
+        if a[i] != b[i] {
+            res[i] = '1'
+        } else {
+            res[i] = '0'
+        }
+    }
+    return string(res)
+}
+
+func generateTests() []test {
+    rand.Seed(42)
+    var tests []test
+    fixed := []struct{ a, b string }{
+        {"0", "0"},
+        {"1", "0"},
+        {"1010", "0101"},
+        {"1111", "0000"},
+        {"101010", "101010"},
+    }
+    for _, f := range fixed {
+        inp := fmt.Sprintf("%s\n%s\n", f.a, f.b)
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    for len(tests) < 100 {
+        n := rand.Intn(100) + 1
+        a := make([]byte, n)
+        b := make([]byte, n)
+        for i := 0; i < n; i++ {
+            a[i] = byte('0' + rand.Intn(2))
+            b[i] = byte('0' + rand.Intn(2))
+        }
+        inp := fmt.Sprintf("%s\n%s\n", string(a), string(b))
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/0-999/0-99/60-69/61/verifierB.go
+++ b/0-999/0-99/60-69/61/verifierB.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+func clean(s string) string {
+    var b strings.Builder
+    for _, r := range s {
+        switch r {
+        case '-', ';', '_':
+        default:
+            if 'A' <= r && r <= 'Z' {
+                b.WriteRune(r + ('a' - 'A'))
+            } else {
+                b.WriteRune(r)
+            }
+        }
+    }
+    return b.String()
+}
+
+type test struct {
+    input    string
+    expected string
+}
+
+func solve(input string) string {
+    lines := strings.Split(strings.TrimSpace(input), "\n")
+    if len(lines) < 4 {
+        return ""
+    }
+    orig := []string{strings.TrimSpace(lines[0]), strings.TrimSpace(lines[1]), strings.TrimSpace(lines[2])}
+    t := make([]string, 3)
+    for i, s := range orig {
+        t[i] = clean(s)
+    }
+    perms := [][3]int{{0,1,2},{0,2,1},{1,0,2},{1,2,0},{2,0,1},{2,1,0}}
+    valid := map[string]struct{}{}
+    for _, p := range perms {
+        valid[t[p[0]]+t[p[1]]+t[p[2]]] = struct{}{}
+    }
+    n, _ := strconv.Atoi(strings.TrimSpace(lines[3]))
+    var out strings.Builder
+    for i:=0;i<n;i++ {
+        ans := clean(strings.TrimSpace(lines[4+i]))
+        if _, ok := valid[ans]; ok {
+            out.WriteString("ACC\n")
+        } else {
+            out.WriteString("WA\n")
+        }
+    }
+    return strings.TrimRight(out.String(), "\n")
+}
+
+func generateRandomString(maxLen int) string {
+    letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_";
+    l := rand.Intn(maxLen) + 1
+    var b strings.Builder
+    for i := 0; i < l; i++ {
+        b.WriteByte(letters[rand.Intn(len(letters))])
+    }
+    return b.String()
+}
+
+func generateTests() []test {
+    rand.Seed(43)
+    var tests []test
+    fixed := []string{
+        "a\nb\nc\n1\nabc\n",
+        "A-B\nC;D\n_E\n2\nabcd\nXYZ\n",
+    }
+    for _, f := range fixed {
+        tests = append(tests, test{f, solve(f)})
+    }
+    for len(tests) < 100 {
+        s1 := generateRandomString(5)
+        s2 := generateRandomString(5)
+        s3 := generateRandomString(5)
+        cleaned := []string{clean(s1), clean(s2), clean(s3)}
+        perms := [][3]int{{0,1,2},{0,2,1},{1,0,2},{1,2,0},{2,0,1},{2,1,0}}
+        var answers []string
+        for _, p := range perms {
+            answers = append(answers, cleaned[p[0]]+cleaned[p[1]]+cleaned[p[2]])
+        }
+        n := rand.Intn(5) + 1
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%s\n%s\n%s\n%d\n", s1, s2, s3, n))
+        for i:=0;i<n;i++ {
+            if rand.Intn(2) == 0 {
+                // correct answer maybe with random signs/case
+                ans := answers[rand.Intn(len(answers))]
+                // add random signs and random case
+                var sbAns strings.Builder
+                for _, ch := range ans {
+                    if rand.Intn(3)==0 {
+                        sbAns.WriteByte('-')
+                    }
+                    if rand.Intn(3)==0 {
+                        sbAns.WriteByte(';')
+                    }
+                    if rand.Intn(3)==0 {
+                        sbAns.WriteByte('_')
+                    }
+                    if rand.Intn(2)==0 {
+                        sbAns.WriteByte(byte(ch))
+                    } else {
+                        if 'a' <= ch && ch <= 'z' {
+                            sbAns.WriteByte(byte(ch - ('a'-'A')))
+                        } else {
+                            sbAns.WriteByte(byte(ch))
+                        }
+                    }
+                }
+                sb.WriteString(sbAns.String())
+            } else {
+                // incorrect string
+                sb.WriteString(generateRandomString(6))
+            }
+            sb.WriteByte('\n')
+        }
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/0-999/0-99/60-69/61/verifierC.go
+++ b/0-999/0-99/60-69/61/verifierC.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/big"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+type test struct {
+    input    string
+    expected string
+}
+
+func toRoman(n int) string {
+    vals := []int{1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1}
+    syms := []string{"M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"}
+    var sb strings.Builder
+    for i := 0; i < len(vals); i++ {
+        for n >= vals[i] {
+            sb.WriteString(syms[i])
+            n -= vals[i]
+        }
+    }
+    return sb.String()
+}
+
+func solve(input string) string {
+    in := bufio.NewReader(strings.NewReader(input))
+    var a int
+    var bstr string
+    if _, err := fmt.Fscan(in, &a, &bstr); err != nil {
+        return ""
+    }
+    var cstr string
+    fmt.Fscan(in, &cstr)
+    num := new(big.Int)
+    num.SetString(strings.TrimSpace(cstr), a)
+    if bstr == "R" {
+        val := int(num.Int64())
+        return toRoman(val)
+    }
+    b, _ := strconv.Atoi(bstr)
+    out := strings.ToUpper(num.Text(b))
+    out = strings.TrimLeft(out, "0")
+    if out == "" { out = "0" }
+    return out
+}
+
+func randNumber(max int64) int64 { return rand.Int63n(max) }
+
+func generateTests() []test {
+    rand.Seed(44)
+    var tests []test
+    fixed := []string{
+        "2 10\n1010\n",
+        "10 R\n1990\n",
+        "16 2\nFF\n",
+    }
+    for _, f := range fixed {
+        tests = append(tests, test{f, solve(f)})
+    }
+    for len(tests) < 100 {
+        a := rand.Intn(24)+2
+        useRoman := rand.Intn(3)==0
+        var bstr string
+        if useRoman {
+            bstr = "R"
+        } else {
+            b := rand.Intn(24)+2
+            bstr = strconv.Itoa(b)
+        }
+        var value int64
+        if useRoman {
+            value = randNumber(300000)+1
+        } else {
+            value = randNumber(1_000_000_000)
+        }
+        cstr := strings.ToUpper(strconv.FormatInt(value, a))
+        if rand.Intn(4)==0 {
+            cstr = "0"+cstr
+        }
+        inp := fmt.Sprintf("%d %s\n%s\n", a, bstr, cstr)
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/0-999/0-99/60-69/61/verifierD.go
+++ b/0-999/0-99/60-69/61/verifierD.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+type edge struct{ to int; w int64 }
+
+type test struct{ input, expected string }
+
+func solve(input string) string {
+    in := bufio.NewReader(strings.NewReader(input))
+    var n int
+    if _, err := fmt.Fscan(in, &n); err != nil { return "" }
+    adj := make([][]edge, n+1)
+    var total int64
+    for i:=0;i<n-1;i++ {
+        var u,v int; var w int64
+        fmt.Fscan(in,&u,&v,&w)
+        adj[u] = append(adj[u], edge{v,w})
+        adj[v] = append(adj[v], edge{u,w})
+        total += w
+    }
+    dist := make([]int64,n+1)
+    vis := make([]bool,n+1)
+    q := []int{1}; vis[1]=true
+    var maxd int64
+    for idx:=0; idx<len(q); idx++ {
+        cur := q[idx]
+        for _, e := range adj[cur] {
+            if !vis[e.to] {
+                vis[e.to]=true
+                dist[e.to]=dist[cur]+e.w
+                if dist[e.to]>maxd { maxd = dist[e.to] }
+                q = append(q,e.to)
+            }
+        }
+    }
+    ans := total*2 - maxd
+    return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+    rand.Seed(45)
+    var tests []test
+    fixed := []string{ "1\n", "2\n1 2 5\n" }
+    for _, f := range fixed {
+        tests = append(tests, test{f, solve(f)})
+    }
+    for len(tests) < 100 {
+        n := rand.Intn(15)+1
+        if n==1 { tests = append(tests, test{"1\n", "0"}); continue }
+        edges := make([][3]int64, n-1)
+        for i:=0;i<n-1;i++ { edges[i][0]=int64(i+1); edges[i][1]=int64(rand.Intn(i+1)+1); edges[i][2]=int64(rand.Intn(1000)) }
+        var sb strings.Builder
+        sb.WriteString(strconv.Itoa(n)+"\n")
+        for _, e := range edges {
+            sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+        }
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/0-999/0-99/60-69/61/verifierE.go
+++ b/0-999/0-99/60-69/61/verifierE.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strconv"
+    "strings"
+)
+
+type BIT struct { n int; tree []int }
+
+func NewBIT(n int) *BIT { return &BIT{n:n, tree: make([]int, n+1)} }
+func (b *BIT) Add(i, v int) { for ; i<=b.n; i+= i&-i { b.tree[i]+=v } }
+func (b *BIT) Sum(i int) int { s:=0; for ; i>0; i-= i&-i { s += b.tree[i] }; return s }
+
+type test struct{ input, expected string }
+
+func solve(input string) string {
+    in := bufio.NewReader(strings.NewReader(input))
+    var n int
+    fmt.Fscan(in, &n)
+    vals := make([]int, n)
+    for i:=0;i<n;i++ { fmt.Fscan(in, &vals[i]) }
+    type pair struct{ val, idx int }
+    arr := make([]pair, n)
+    for i,v := range vals { arr[i] = pair{v,i} }
+    sort.Slice(arr, func(i,j int) bool { return arr[i].val < arr[j].val })
+    ranks := make([]int,n)
+    for i,p := range arr { ranks[p.idx] = i+1 }
+    rightLess := make([]int,n)
+    bit := NewBIT(n)
+    for j:=n-1; j>=0; j-- { r := ranks[j]; if r>1 { rightLess[j] = bit.Sum(r-1) }; bit.Add(r,1) }
+    bit = NewBIT(n)
+    var ans int64
+    for j:=0; j<n; j++ { r := ranks[j]; leftGt := j - bit.Sum(r); ans += int64(leftGt) * int64(rightLess[j]); bit.Add(r,1) }
+    return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+    rand.Seed(46)
+    var tests []test
+    fixed := []string{
+        "3\n3 2 1\n",
+        "4\n1 2 3 4\n",
+        "5\n5 4 3 2 1\n",
+    }
+    for _, f := range fixed { tests = append(tests, test{f, solve(f)}) }
+    for len(tests) < 100 {
+        n := rand.Intn(20)+3
+        vals := make([]int,n)
+        for i := range vals { vals[i] = rand.Intn(1000*n) }
+        // ensure unique
+        used := map[int]bool{}
+        for i := range vals {
+            for {
+                v := vals[i]
+                if !used[v] {
+                    used[v] = true
+                    break
+                }
+                vals[i] = rand.Intn(1000*n)
+            }
+        }
+        var sb strings.Builder
+        sb.WriteString(strconv.Itoa(n)+"\n")
+        for i:=0;i<n;i++ { sb.WriteString(fmt.Sprintf("%d ", vals[i])) }
+        sb.WriteByte('\n')
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+


### PR DESCRIPTION
## Summary
- implement verifierA.go..verifierE.go for contest 61
- each verifier runs a binary on at least 100 generated tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go run verifierA.go ./61A_bin`
- `go run verifierB.go ./61B_bin`
- `go run verifierC.go ./61C_bin`
- `go run verifierD.go ./61D_bin`
- `go run verifierE.go ./61E_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e61523e408324bae30c51ea0d730f