### PR TITLE
Add Go verifiers for contest 60

### DIFF
--- a/0-999/0-99/60-69/60/verifierA.go
+++ b/0-999/0-99/60-69/60/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(r *bufio.Reader) string {
+	var n, m int
+	if _, err := fmt.Fscan(r, &n, &m); err != nil {
+		return ""
+	}
+	left, right := 1, n
+	for i := 0; i < m; i++ {
+		var w1, w2, dir, w4 string
+		var idx int
+		fmt.Fscan(r, &w1, &w2, &dir, &w4, &idx)
+		if dir == "left" {
+			if idx-1 < right {
+				right = idx - 1
+			}
+		} else {
+			if idx+1 > left {
+				left = idx + 1
+			}
+		}
+	}
+	if left > right {
+		return "-1"
+	}
+	return fmt.Sprintf("%d", right-left+1)
+}
+
+func generateCaseA(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1 // 1..20
+	m := rng.Intn(20)     // 0..19
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		idx := rng.Intn(n) + 1
+		if rng.Intn(2) == 0 {
+			fmt.Fprintf(&sb, "To the left of %d\n", idx)
+		} else {
+			fmt.Fprintf(&sb, "To the right of %d\n", idx)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		tc := generateCaseA(rng)
+		expect := solveA(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/60/verifierB.go
+++ b/0-999/0-99/60-69/60/verifierB.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type node struct{ z, x, y int }
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(r *bufio.Reader) string {
+	var k, n, m int
+	fmt.Fscan(r, &k, &n, &m)
+	grid := make([][][]byte, k)
+	for z := 0; z < k; z++ {
+		grid[z] = make([][]byte, n)
+		for i := 0; i < n; i++ {
+			var line string
+			fmt.Fscan(r, &line)
+			grid[z][i] = []byte(line)
+		}
+	}
+	var x, y int
+	fmt.Fscan(r, &x, &y)
+	sx, sy := x-1, y-1
+	visited := make([][][]bool, k)
+	for z := 0; z < k; z++ {
+		visited[z] = make([][]bool, n)
+		for i := 0; i < n; i++ {
+			visited[z][i] = make([]bool, m)
+		}
+	}
+	q := []node{{0, sx, sy}}
+	visited[0][sx][sy] = true
+	dirs := []node{{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1}}
+	count := 0
+	for head := 0; head < len(q); head++ {
+		u := q[head]
+		count++
+		for _, d := range dirs {
+			nz, nx, ny := u.z+d.z, u.x+d.x, u.y+d.y
+			if nz >= 0 && nz < k && nx >= 0 && nx < n && ny >= 0 && ny < m {
+				if !visited[nz][nx][ny] && grid[nz][nx][ny] == '.' {
+					visited[nz][nx][ny] = true
+					q = append(q, node{nz, nx, ny})
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("%d", count)
+}
+
+func generateCaseB(rng *rand.Rand) string {
+	k := rng.Intn(3) + 1
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", k, n, m)
+	for z := 0; z < k; z++ {
+		for i := 0; i < n; i++ {
+			line := make([]byte, m)
+			for j := 0; j < m; j++ {
+				if rng.Float64() < 0.3 {
+					line[j] = '#'
+				} else {
+					line[j] = '.'
+				}
+			}
+			if z == 0 && i == 0 {
+				line[0] = '.'
+			}
+			sb.WriteString(string(line) + "\n")
+		}
+	}
+	x := 1
+	y := 1
+	fmt.Fprintf(&sb, "%d %d\n", x, y)
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseB(rng)
+		expect := solveB(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/60/verifierC.go
+++ b/0-999/0-99/60-69/60/verifierC.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to   int
+	g, l int64
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int64) int64 {
+	return a / gcd(a, b) * b
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(r *bufio.Reader) string {
+	var n, m int
+	fmt.Fscan(r, &n, &m)
+	adj := make([][]Edge, n+1)
+	for i := 0; i < m; i++ {
+		var x, y int
+		var g, l int64
+		fmt.Fscan(r, &x, &y, &g, &l)
+		adj[x] = append(adj[x], Edge{y, g, l})
+		adj[y] = append(adj[y], Edge{x, g, l})
+	}
+	A := make([]int64, n+1)
+	visited := make([]bool, n+1)
+	var order []int
+	var okFlag bool
+	var dfs func(int)
+	dfs = func(u int) {
+		visited[u] = true
+		order = append(order, u)
+		for _, e := range adj[u] {
+			v := e.to
+			if visited[v] {
+				if lcm(A[u], A[v]) != e.l || gcd(A[u], A[v]) != e.g {
+					okFlag = false
+				}
+				continue
+			}
+			if e.l%A[u] != 0 {
+				okFlag = false
+				continue
+			}
+			A[v] = e.l / A[u] * e.g
+			dfs(v)
+			if !okFlag {
+				return
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if visited[i] || len(adj[i]) == 0 {
+			continue
+		}
+		var tmp, tmp2 int64
+		for j, e := range adj[i] {
+			if j == 0 {
+				tmp = e.l
+				tmp2 = e.g
+			} else {
+				tmp = gcd(tmp, e.l)
+				tmp2 = lcm(tmp2, e.g)
+			}
+		}
+		if tmp2 > tmp {
+			return "NO"
+		}
+		var cands []int64
+		for d := int64(1); d*d <= tmp; d++ {
+			if tmp%d == 0 {
+				if d%tmp2 == 0 {
+					cands = append(cands, d)
+				}
+				oth := tmp / d
+				if oth != d && oth%tmp2 == 0 {
+					cands = append(cands, oth)
+				}
+			}
+		}
+		ok := false
+		for _, D := range cands {
+			A[i] = D
+			order = order[:0]
+			okFlag = true
+			dfs(i)
+			if okFlag {
+				ok = true
+				break
+			}
+			for _, u := range order {
+				visited[u] = false
+			}
+		}
+		if !ok {
+			return "NO"
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if A[i] == 0 {
+			A[i] = 1
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&sb, "%d ", A[i])
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCaseC(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	A := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		A[i] = int64(rng.Intn(20) + 1)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	edges := make([][2]int, 0, m)
+	// create list of all pairs
+	pairs := make([][2]int, 0, maxEdges)
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			pairs = append(pairs, [2]int{i, j})
+		}
+	}
+	rng.Shuffle(len(pairs), func(i, j int) { pairs[i], pairs[j] = pairs[j], pairs[i] })
+	if m > len(pairs) {
+		m = len(pairs)
+	}
+	pairs = pairs[:m]
+	for _, p := range pairs {
+		i, j := p[0], p[1]
+		g := gcd(A[i], A[j])
+		l := lcm(A[i], A[j])
+		if rng.Float64() < 0.3 { // corrupt
+			if rng.Intn(2) == 0 {
+				g += int64(rng.Intn(3) + 1)
+			} else {
+				l += int64(rng.Intn(3) + 1)
+			}
+		}
+		fmt.Fprintf(&sb, "%d %d %d %d\n", i, j, g, l)
+		edges = append(edges, [2]int{i, j})
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseC(rng)
+		expect := solveC(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/60/verifierD.go
+++ b/0-999/0-99/60-69/60/verifierD.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+var parent []int
+var rankArr []int
+
+func find(u int) int {
+	if parent[u] != u {
+		parent[u] = find(parent[u])
+	}
+	return parent[u]
+}
+
+func union(u, v int) {
+	ru, rv := find(u), find(v)
+	if ru == rv {
+		return
+	}
+	if rankArr[ru] < rankArr[rv] {
+		parent[ru] = rv
+	} else if rankArr[ru] > rankArr[rv] {
+		parent[rv] = ru
+	} else {
+		parent[rv] = ru
+		rankArr[ru]++
+	}
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveD(r *bufio.Reader) string {
+	var n int
+	if _, err := fmt.Fscan(r, &n); err != nil {
+		return ""
+	}
+	vals := make([]int, n)
+	maxA := 0
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &vals[i])
+		if vals[i] > maxA {
+			maxA = vals[i]
+		}
+	}
+	mv := make([]int, maxA+1)
+	for i := 0; i <= maxA; i++ {
+		mv[i] = -1
+	}
+	for i, v := range vals {
+		mv[v] = i
+	}
+	parent = make([]int, n)
+	rankArr = make([]int, n)
+	for i := 0; i < n; i++ {
+		parent[i] = i
+	}
+	uMax := int(math.Sqrt(float64(maxA)))
+	for u := 2; u <= uMax; u++ {
+		vStart := 1
+		if u%2 == 1 {
+			vStart = 2
+		}
+		for v := vStart; v < u; v += 2 {
+			if gcd(u, v) != 1 {
+				continue
+			}
+			uu, vv := u*u, v*v
+			x := uu - vv
+			y := 2 * u * v
+			z := uu + vv
+			if x <= maxA && y <= maxA {
+				ix, iy := mv[x], mv[y]
+				if ix >= 0 && iy >= 0 {
+					union(ix, iy)
+				}
+			}
+			if x <= maxA && z <= maxA {
+				ix, iz := mv[x], mv[z]
+				if ix >= 0 && iz >= 0 {
+					union(ix, iz)
+				}
+			}
+			if y <= maxA && z <= maxA {
+				iy, iz := mv[y], mv[z]
+				if iy >= 0 && iz >= 0 {
+					union(iy, iz)
+				}
+			}
+		}
+	}
+	seen := make(map[int]bool)
+	comps := 0
+	for i := 0; i < n; i++ {
+		r := find(i)
+		if !seen[r] {
+			seen[r] = true
+			comps++
+		}
+	}
+	return fmt.Sprintf("%d", comps)
+}
+
+func generateCaseD(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	vals := make([]int, n)
+	for i := 0; i < n; i++ {
+		vals[i] = rng.Intn(40) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseD(rng)
+		expect := solveD(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/60-69/60/verifierE.go
+++ b/0-999/0-99/60-69/60/verifierE.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func fastPowMod(a, e, m int64) int64 {
+	a %= m
+	var res int64 = 1
+	for e > 0 {
+		if e&1 == 1 {
+			res = (res * a) % m
+		}
+		a = (a * a) % m
+		e >>= 1
+	}
+	return res
+}
+
+func fibPair(n, m int64) (int64, int64) {
+	if n == 0 {
+		return 0, 1
+	}
+	a, b := fibPair(n>>1, m)
+	c := (a * ((2*b%m - a + m) % m)) % m
+	d := (a*a%m + b*b%m) % m
+	if n&1 == 0 {
+		return c, d
+	}
+	return d, (c + d) % m
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveE(r *bufio.Reader) string {
+	var n int
+	var x, y, p int64
+	fmt.Fscan(r, &n, &x, &y, &p)
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &a[i])
+	}
+	if n == 1 {
+		return fmt.Sprintf("%d", a[0]%p)
+	}
+	var midSumModP int64
+	for i := 1; i+1 < n; i++ {
+		midSumModP = (midSumModP + a[i]) % p
+	}
+	a0 := a[0]
+	alast := a[n-1]
+	mod2p := p * 2
+	pow3x := fastPowMod(3, x, mod2p)
+	num := ((2*midSumModP%mod2p)*pow3x%mod2p + ((a0+alast)%mod2p)*((pow3x+1)%mod2p)%mod2p) % mod2p
+	Sx := (num / 2) % p
+	Fx, Fx1 := fibPair(x, mod2p)
+	L := a[n-2] % mod2p
+	R := a[n-1] % mod2p
+	Mx := (Fx*L + Fx1*R) % mod2p
+	D := (a0%mod2p + Mx) % mod2p
+	pow3y := fastPowMod(3, y, mod2p)
+	twoSx := (2 * Sx) % mod2p
+	term1 := (pow3y * twoSx) % mod2p
+	term2 := (D * ((pow3y - 1 + mod2p) % mod2p)) % mod2p
+	twoSy := (term1 - term2 + mod2p) % mod2p
+	Sy := (twoSy / 2) % p
+	return fmt.Sprintf("%d", Sy)
+}
+
+func generateCaseE(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	x := rng.Int63n(1000)
+	y := rng.Int63n(1000)
+	if x == 0 && y == 0 {
+		x = 1
+	}
+	p := int64(rng.Intn(1000) + 2)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", n, x, y, p)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(1000))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseE(rng)
+		expect := solveE(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for all problems in contest 60
- each verifier runs 100 randomized test cases
- verifiers execute a provided binary (or go file) and compare to a reference solution

## Testing
- `go run verifierA.go ./60A_bin`
- `go run verifierB.go ./60B_bin`
- `go run verifierC.go ./60C_bin`
- `go run verifierD.go ./60D_bin`
- `go run verifierE.go ./60E_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e614d718883248f745e3c7c477638