### PR TITLE
Add Go verifiers for contest 58

### DIFF
--- a/0-999/0-99/50-59/58/verifierA.go
+++ b/0-999/0-99/50-59/58/verifierA.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) string {
+	target := "hello"
+	j := 0
+	for i := 0; i < len(s) && j < len(target); i++ {
+		if s[i] == target[j] {
+			j++
+		}
+	}
+	if j == len(target) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func randString(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func runCase(bin string, s string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(s + "\n")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := expected(strings.TrimSpace(s))
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{"hello", "hlelo", "ahhellllloou", "hloel"}
+	for len(cases) < 100 {
+		cases = append(cases, randString(rng))
+	}
+	for i, s := range cases {
+		if err := runCase(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %s\n", i+1, err, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/58/verifierB.go
+++ b/0-999/0-99/50-59/58/verifierB.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) string {
+	cur := n
+	tmp := n
+	res := []int{n}
+	for p := 2; p*p <= tmp; p++ {
+		for tmp%p == 0 {
+			tmp /= p
+			cur /= p
+			res = append(res, cur)
+		}
+	}
+	if tmp > 1 {
+		cur /= tmp
+		res = append(res, cur)
+	}
+	parts := make([]string, len(res))
+	for i, v := range res {
+		parts[i] = fmt.Sprintf("%d", v)
+	}
+	return strings.Join(parts, " ")
+}
+
+func runCase(bin string, n int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(fmt.Sprintf("%d\n", n))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := expected(n)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	nums := []int{1, 2, 3, 4, 5, 6, 10, 12, 100, 99991}
+	for len(nums) < 100 {
+		nums = append(nums, rng.Intn(1000000)+1)
+	}
+	for i, n := range nums {
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %d\n", i+1, err, n)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/58/verifierC.go
+++ b/0-999/0-99/50-59/58/verifierC.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(a []int) int {
+	n := len(a)
+	freq := map[int]int{}
+	maxf := 0
+	for i, v := range a {
+		d := i
+		if n-1-i < d {
+			d = n - 1 - i
+		}
+		x := v - d
+		if x > 0 {
+			freq[x]++
+			if freq[x] > maxf {
+				maxf = freq[x]
+			}
+		}
+	}
+	return n - maxf
+}
+
+func runCase(bin string, a []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(a)))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	var got int
+	fmt.Sscan(gotStr, &got)
+	exp := expected(a)
+	if got != exp {
+		return fmt.Errorf("expected %d got %s", exp, gotStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([][]int, 0, 100)
+	cases = append(cases, []int{1})
+	cases = append(cases, []int{2, 2, 2})
+	for len(cases) < 100 {
+		n := rng.Intn(10) + 1
+		arr := make([]int, n)
+		for i := range arr {
+			arr[i] = rng.Intn(20) + 1
+		}
+		cases = append(cases, arr)
+	}
+	for i, a := range cases {
+		if err := runCase(bin, a); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %v\n", i+1, err, a)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/58/verifierD.go
+++ b/0-999/0-99/50-59/58/verifierD.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(names []string, sep string) []string {
+	groups := make(map[int][]string)
+	lengths := []int{}
+	for _, s := range names {
+		l := len(s)
+		if _, ok := groups[l]; !ok {
+			lengths = append(lengths, l)
+		}
+		groups[l] = append(groups[l], s)
+	}
+	sort.Ints(lengths)
+	minL := lengths[0]
+	maxL := lengths[len(lengths)-1]
+	K := minL + maxL
+	for _, l := range lengths {
+		sort.Strings(groups[l])
+	}
+	res := []string{}
+	i, j := 0, len(lengths)-1
+	for i <= j {
+		li := lengths[i]
+		lj := lengths[j]
+		sum := li + lj
+		if sum < K {
+			i++
+		} else if sum > K {
+			j--
+		} else {
+			if i < j {
+				A := groups[li]
+				B := groups[lj]
+				for idx := 0; idx < len(A) && idx < len(B); idx++ {
+					a := A[idx]
+					b := B[idx]
+					s1 := a + sep + b
+					s2 := b + sep + a
+					if s1 < s2 {
+						res = append(res, s1)
+					} else {
+						res = append(res, s2)
+					}
+				}
+			} else {
+				A := groups[li]
+				for idx := 0; idx+1 < len(A); idx += 2 {
+					a := A[idx]
+					b := A[idx+1]
+					s1 := a + sep + b
+					s2 := b + sep + a
+					if s1 < s2 {
+						res = append(res, s1)
+					} else {
+						res = append(res, s2)
+					}
+				}
+			}
+			i++
+			j--
+		}
+	}
+	sort.Strings(res)
+	return res
+}
+
+func runCase(bin string, names []string, sep string) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(names)))
+	for _, n := range names {
+		sb.WriteString(n)
+		sb.WriteByte('\n')
+	}
+	sb.WriteString(sep)
+	sb.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotLines := []string{}
+	sc := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line != "" {
+			gotLines = append(gotLines, line)
+		}
+	}
+	exp := expected(names, sep)
+	if len(gotLines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(gotLines))
+	}
+	for i := range exp {
+		if gotLines[i] != exp[i] {
+			return fmt.Errorf("line %d expected %s got %s", i+1, exp[i], gotLines[i])
+		}
+	}
+	return nil
+}
+
+func randName(rng *rand.Rand) string {
+	l := rng.Intn(5) + 1
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 2
+		names := make([]string, n)
+		for j := range names {
+			names[j] = randName(rng)
+		}
+		sep := string('a' + rng.Intn(26))
+		if err := runCase(bin, names, sep); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %v sep:%s\n", i+1, err, names, sep)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/58/verifierE.go
+++ b/0-999/0-99/50-59/58/verifierE.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCase(bin string, a, b int) error {
+	c := a + b
+	expr := fmt.Sprintf("%d+%d=%d\n", a, b, c)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(expr)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := strings.TrimSpace(expr)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		a := rng.Intn(1000000)
+		b := rng.Intn(1000000)
+		if err := runCase(bin, a, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` – test 100+ random strings for problem A
- add `verifierB.go` – verify divisor chain output for random `n`
- add `verifierC.go` – test arrays for minimal changes to become beautiful
- add `verifierD.go` – pair names according to rules in problem D
- add `verifierE.go` – check valid sums for problem E

## Testing
- `go build verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`
- `go run verifierA.go ./A_bin`
- `go run verifierB.go ./B_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e6143650883248809010597990ed1