### PR TITLE
Add solution verifiers for contest 57

### DIFF
--- a/0-999/0-99/50-59/57/verifierA.go
+++ b/0-999/0-99/50-59/57/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func perimeterPos(n, x, y int) int {
+	switch {
+	case y == 0:
+		return x
+	case x == n:
+		return n + y
+	case y == n:
+		return 2*n + (n - x)
+	default:
+		return 3*n + (n - y)
+	}
+}
+
+func expected(n, x1, y1, x2, y2 int) int {
+	t1 := perimeterPos(n, x1, y1)
+	t2 := perimeterPos(n, x2, y2)
+	d := t1 - t2
+	if d < 0 {
+		d = -d
+	}
+	per := 4 * n
+	if d > per-d {
+		d = per - d
+	}
+	return d
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(1000) + 1
+	choose := func() (int, int) {
+		side := rng.Intn(4)
+		v := rng.Intn(n + 1)
+		switch side {
+		case 0:
+			return v, 0
+		case 1:
+			return n, v
+		case 2:
+			return n - v, n
+		default:
+			return 0, n - v
+		}
+	}
+	x1, y1 := choose()
+	x2, y2 := choose()
+	input := fmt.Sprintf("%d %d %d %d %d\n", n, x1, y1, x2, y2)
+	return input, expected(n, x1, y1, x2, y2)
+}
+
+func runCase(bin, input string, exp int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/57/verifierB.go
+++ b/0-999/0-99/50-59/57/verifierB.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int, a, b, c []int, queries []int) int64 {
+	var ans int64
+	for _, q := range queries {
+		for i := 0; i < len(a); i++ {
+			if a[i] <= q && q <= b[i] {
+				ans += int64(c[i]) + int64(q-a[i])
+			}
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(50) + 1
+	m := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	a := make([]int, m)
+	b := make([]int, m)
+	c := make([]int, m)
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n) + 1
+		if l > r {
+			l, r = r, l
+		}
+		a[i] = l
+		b[i] = r
+		c[i] = rng.Intn(1000) + 1
+	}
+	queries := make([]int, k)
+	used := make(map[int]bool)
+	for i := 0; i < k; i++ {
+		for {
+			v := rng.Intn(n) + 1
+			if !used[v] {
+				used[v] = true
+				queries[i] = v
+				break
+			}
+		}
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&sb, "%d %d %d\n", a[i], b[i], c[i])
+	}
+	for i := 0; i < k; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", queries[i])
+	}
+	sb.WriteByte('\n')
+
+	return sb.String(), expected(n, a, b, c, queries)
+}
+
+func runCase(bin, input string, exp int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/57/verifierC.go
+++ b/0-999/0-99/50-59/57/verifierC.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	a %= mod
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func expected(n int) int64 {
+	N := 2 * n
+	fac := make([]int64, N+1)
+	invFac := make([]int64, N+1)
+	fac[0] = 1
+	for i := 1; i <= N; i++ {
+		fac[i] = fac[i-1] * int64(i) % mod
+	}
+	invFac[N] = modPow(fac[N], mod-2)
+	for i := N; i > 0; i-- {
+		invFac[i-1] = invFac[i] * int64(i) % mod
+	}
+	comb := fac[2*n-1] * invFac[n] % mod * invFac[n-1] % mod
+	ans := (comb*2 - int64(n)) % mod
+	if ans < 0 {
+		ans += mod
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(1000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	return input, expected(n)
+}
+
+func runCase(bin, input string, exp int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/57/verifierD.go
+++ b/0-999/0-99/50-59/57/verifierD.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type cell struct{ r, c int }
+
+func bfs(grid [][]byte, sr, sc int) [][]int {
+	n := len(grid)
+	m := len(grid[0])
+	dist := make([][]int, n)
+	for i := range dist {
+		dist[i] = make([]int, m)
+		for j := range dist[i] {
+			dist[i][j] = -1
+		}
+	}
+	q := make([]cell, 0, n*m)
+	q = append(q, cell{sr, sc})
+	dist[sr][sc] = 0
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for head := 0; head < len(q); head++ {
+		cur := q[head]
+		for _, d := range dirs {
+			nr := cur.r + d[0]
+			nc := cur.c + d[1]
+			if nr < 0 || nr >= n || nc < 0 || nc >= m {
+				continue
+			}
+			if grid[nr][nc] == 'X' || dist[nr][nc] != -1 {
+				continue
+			}
+			dist[nr][nc] = dist[cur.r][cur.c] + 1
+			q = append(q, cell{nr, nc})
+		}
+	}
+	return dist
+}
+
+func expected(grid [][]byte) float64 {
+	n := len(grid)
+	m := len(grid[0])
+	cells := make([]cell, 0)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] != 'X' {
+				cells = append(cells, cell{i, j})
+			}
+		}
+	}
+	S := len(cells)
+	var sum int
+	for _, start := range cells {
+		dist := bfs(grid, start.r, start.c)
+		for _, end := range cells {
+			d := dist[end.r][end.c]
+			sum += d
+		}
+	}
+	return float64(sum) / float64(S*S)
+}
+
+func genGrid(rng *rand.Rand) [][]byte {
+	n := rng.Intn(4) + 2
+	m := rng.Intn(4) + 2
+	grid := make([][]byte, n)
+	for i := range grid {
+		grid[i] = make([]byte, m)
+		for j := range grid[i] {
+			grid[i][j] = '.'
+		}
+	}
+	rowsUsed := make(map[int]bool)
+	colsUsed := make(map[int]bool)
+	var coords []cell
+	num := rng.Intn(min(n, m) + 1)
+	for len(coords) < num {
+		r := rng.Intn(n)
+		c := rng.Intn(m)
+		if rowsUsed[r] || colsUsed[c] {
+			continue
+		}
+		ok := true
+		for _, p := range coords {
+			if abs(p.r-r) == 1 && abs(p.c-c) == 1 {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+		coords = append(coords, cell{r, c})
+		rowsUsed[r] = true
+		colsUsed[c] = true
+		grid[r][c] = 'X'
+	}
+	return grid
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	grid := genGrid(rng)
+	n := len(grid)
+	m := len(grid[0])
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		sb.WriteByte('\n')
+	}
+	expectedVal := expected(grid)
+	out := fmt.Sprintf("%.9f\n", expectedVal)
+	return sb.String(), out
+}
+
+func runCase(bin, input, exp string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/57/verifierE.go
+++ b/0-999/0-99/50-59/57/verifierE.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+const KMAX = 200
+
+func solve(k int64, blocks [][2]int) int64 {
+	off := KMAX*2 + 5
+	size := off*2 + 1
+	dist := make([][]int, size)
+	for i := range dist {
+		dist[i] = make([]int, size)
+		for j := range dist[i] {
+			dist[i][j] = -1
+		}
+	}
+	moves := [8][2]int{{1, 2}, {2, 1}, {2, -1}, {1, -2}, {-1, -2}, {-2, -1}, {-2, 1}, {-1, 2}}
+	type P struct{ x, y int }
+	q := make([]P, 0, 500000)
+	sx, sy := off, off
+	dist[sx][sy] = 0
+	q = append(q, P{sx, sy})
+	cnt := make([]int64, KMAX+1)
+	cnt[0] = 1
+	for head := 0; head < len(q); head++ {
+		p := q[head]
+		d := dist[p.x][p.y]
+		if d >= KMAX {
+			continue
+		}
+		nd := d + 1
+		for _, mv := range moves {
+			nx, ny := p.x+mv[0], p.y+mv[1]
+			if nx < 0 || ny < 0 || nx >= size || ny >= size {
+				continue
+			}
+			if dist[nx][ny] != -1 {
+				continue
+			}
+			dist[nx][ny] = nd
+			cnt[nd]++
+			q = append(q, P{nx, ny})
+		}
+	}
+	T := make([]int64, KMAX+1)
+	T[0] = cnt[0]
+	for i := 1; i <= KMAX; i++ {
+		T[i] = T[i-1] + cnt[i]
+	}
+	D1 := make([]int64, KMAX+1)
+	for i := 1; i <= KMAX; i++ {
+		D1[i] = T[i] - T[i-1]
+	}
+	D2 := make([]int64, KMAX+1)
+	for i := 2; i <= KMAX; i++ {
+		D2[i] = D1[i] - D1[i-1]
+	}
+	thr := 50
+	D3 := make([]int64, KMAX+1)
+	for i := 3; i <= KMAX; i++ {
+		D3[i] = D2[i] - D2[i-1]
+	}
+	baseD3 := D3[thr]
+	A3 := baseD3 / 6
+	B3 := (D2[thr] - 6*A3*int64(thr-1)) / 2
+	C3 := D1[thr] - A3*(3*int64(thr)*int64(thr)-3*int64(thr)+1) - B3*(2*int64(thr)-1)
+	D0 := T[0]
+	var total int64
+	if k <= KMAX {
+		total = T[k]
+	} else {
+		kk := k % MOD
+		total = A3 % MOD * kk % MOD * kk % MOD * kk % MOD
+		total = (total + B3%MOD*kk%MOD*kk%MOD) % MOD
+		total = (total + C3%MOD*kk%MOD) % MOD
+		total = (total + D0%MOD) % MOD
+		if total < 0 {
+			total += MOD
+		}
+	}
+	var sub int64
+	for _, b := range blocks {
+		x := b[0] + off
+		y := b[1] + off
+		if x >= 0 && x < size && y >= 0 && y < size {
+			d := int64(dist[x][y])
+			if d >= 0 && d <= k {
+				sub++
+			}
+		}
+	}
+	ans := (total - sub) % MOD
+	if ans < 0 {
+		ans += MOD
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	k := rng.Int63n(1000000) + 1
+	n := rng.Intn(10)
+	blocks := make([][2]int, n)
+	used := make(map[[2]int]bool)
+	for i := 0; i < n; i++ {
+		for {
+			x := rng.Intn(21) - 10
+			y := rng.Intn(21) - 10
+			if x == 0 && y == 0 {
+				continue
+			}
+			key := [2]int{x, y}
+			if !used[key] {
+				used[key] = true
+				blocks[i] = key
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", k, n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", blocks[i][0], blocks[i][1])
+	}
+	exp := fmt.Sprintf("%d\n", solve(k, blocks))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, exp string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 57 problems A–E
- each verifier generates 100 random test cases and checks the candidate binary

## Testing
- `go build 0-999/0-99/50-59/57/verifierA.go`
- `go build 0-999/0-99/50-59/57/verifierB.go`
- `go build 0-999/0-99/50-59/57/verifierC.go`
- `go build 0-999/0-99/50-59/57/verifierD.go`
- `go build 0-999/0-99/50-59/57/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e613e8eac83249d76f62ad0b3b0a1