### PR TITLE
Add solution verifiers for contest 56

### DIFF
--- a/0-999/0-99/50-59/56/verifierA.go
+++ b/0-999/0-99/50-59/56/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var alcohols = map[string]struct{}{
+	"ABSINTH": {}, "BEER": {}, "BRANDY": {}, "CHAMPAGNE": {},
+	"GIN": {}, "RUM": {}, "SAKE": {}, "TEQUILA": {},
+	"VODKA": {}, "WHISKEY": {}, "WINE": {},
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	count := 0
+	drinks := []string{"ABSINTH", "BEER", "BRANDY", "CHAMPAGNE", "GIN", "RUM", "SAKE", "TEQUILA", "VODKA", "WHISKEY", "WINE"}
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 { // age
+			age := rng.Intn(1010) // 0..1009
+			fmt.Fprintf(&b, "%d\n", age)
+			if age < 18 {
+				count++
+			}
+		} else {
+			var drink string
+			if rng.Intn(2) == 0 {
+				drink = drinks[rng.Intn(len(drinks))]
+				count++
+			} else {
+				// non-alcohol string
+				drink = fmt.Sprintf("NONALC%d", rng.Intn(1000))
+			}
+			fmt.Fprintf(&b, "%s\n", drink)
+		}
+	}
+	return b.String(), count
+}
+
+func runCase(bin string, input string, expected int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(gotStr)
+	if err != nil {
+		return fmt.Errorf("invalid output: %s", gotStr)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := generateCase(rng)
+		if err := runCase(bin, input, expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/56/verifierB.go
+++ b/0-999/0-99/50-59/56/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedAnswer(p []int) (int, int) {
+	n := len(p) - 1
+	l := 1
+	for l <= n && p[l] == l {
+		l++
+	}
+	if l > n {
+		return 0, 0
+	}
+	r := n
+	for r >= l && p[r] != l {
+		r--
+	}
+	if r <= l {
+		return 0, 0
+	}
+	for i := l; i <= r; i++ {
+		if p[i] != l+r-i {
+			return 0, 0
+		}
+	}
+	for i := 1; i < l; i++ {
+		if p[i] != i {
+			return 0, 0
+		}
+	}
+	for i := r + 1; i <= n; i++ {
+		if p[i] != i {
+			return 0, 0
+		}
+	}
+	return l, r
+}
+
+func generateCase(rng *rand.Rand) (string, int, int) {
+	n := rng.Intn(20) + 2 // at least 2
+	perm := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		perm[i] = i
+	}
+	if rng.Intn(2) == 0 {
+		l := rng.Intn(n-1) + 1
+		r := rng.Intn(n-l) + l + 1
+		for i, j := l, r; i < j; i, j = i+1, j-1 {
+			perm[i], perm[j] = perm[j], perm[i]
+		}
+	} else {
+		// random permutation not necessarily single reversal
+		for i := n; i >= 1; i-- {
+			j := rng.Intn(i) + 1
+			perm[i], perm[j] = perm[j], perm[i]
+		}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&b, "%d ", perm[i])
+	}
+	b.WriteByte('\n')
+	l, r := expectedAnswer(perm)
+	return b.String(), l, r
+}
+
+func runCase(bin, input string, l, r int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	parts := strings.Fields(strings.TrimSpace(out.String()))
+	if len(parts) != 2 {
+		return fmt.Errorf("expected two numbers, got: %s", out.String())
+	}
+	gotL, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("bad output: %s", parts[0])
+	}
+	gotR, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return fmt.Errorf("bad output: %s", parts[1])
+	}
+	if gotL != l || gotR != r {
+		return fmt.Errorf("expected %d %d got %d %d", l, r, gotL, gotR)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, l, r := generateCase(rng)
+		if err := runCase(bin, input, l, r); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/56/verifierC.go
+++ b/0-999/0-99/50-59/56/verifierC.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Node struct {
+	name     string
+	children []*Node
+}
+
+func randomName(rng *rand.Rand) string {
+	l := rng.Intn(5) + 1
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('A' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func buildTree(rng *rand.Rand, depth int) *Node {
+	node := &Node{name: randomName(rng)}
+	if depth < 3 {
+		c := rng.Intn(3)
+		node.children = make([]*Node, c)
+		for i := 0; i < c; i++ {
+			node.children[i] = buildTree(rng, depth+1)
+		}
+	}
+	return node
+}
+
+func writeDesc(b *strings.Builder, n *Node) {
+	b.WriteString(n.name)
+	if len(n.children) > 0 {
+		b.WriteByte(':')
+		for i, ch := range n.children {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			writeDesc(b, ch)
+		}
+	}
+	b.WriteByte('.')
+}
+
+func expected(desc string) int64 {
+	s := desc
+	pos := 0
+	cnt := map[string]int{}
+	var ans int64
+	var parse func()
+	parse = func() {
+		start := pos
+		for pos < len(s) && s[pos] >= 'A' && s[pos] <= 'Z' {
+			pos++
+		}
+		name := s[start:pos]
+		ans += int64(cnt[name])
+		cnt[name]++
+		if pos < len(s) && s[pos] == ':' {
+			pos++
+			for {
+				parse()
+				if pos < len(s) && s[pos] == ',' {
+					pos++
+					continue
+				}
+				break
+			}
+		}
+		if pos < len(s) && s[pos] == '.' {
+			pos++
+		}
+		cnt[name]--
+	}
+	parse()
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	root := buildTree(rng, 0)
+	var b strings.Builder
+	writeDesc(&b, root)
+	desc := b.String()
+	exp := expected(desc)
+	return desc + "\n", exp
+}
+
+func runCase(bin, input string, expected int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	var got int64
+	_, err := fmt.Sscan(gotStr, &got)
+	if err != nil {
+		return fmt.Errorf("invalid output: %s", gotStr)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/56/verifierD.go
+++ b/0-999/0-99/50-59/56/verifierD.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func editDistance(s, t string) int {
+	n, m := len(s), len(t)
+	dp := make([][]int, n+1)
+	for i := 0; i <= n; i++ {
+		dp[i] = make([]int, m+1)
+	}
+	for i := 0; i <= n; i++ {
+		dp[i][0] = i
+	}
+	for j := 0; j <= m; j++ {
+		dp[0][j] = j
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			cost := 0
+			if s[i-1] != t[j-1] {
+				cost = 1
+			}
+			dp[i][j] = dp[i-1][j-1] + cost
+			if dp[i-1][j]+1 < dp[i][j] {
+				dp[i][j] = dp[i-1][j] + 1
+			}
+			if dp[i][j-1]+1 < dp[i][j] {
+				dp[i][j] = dp[i][j-1] + 1
+			}
+		}
+	}
+	return dp[n][m]
+}
+
+type op struct {
+	typ string
+	pos int
+	ch  byte
+}
+
+func applyOps(s string, ops []op) (string, error) {
+	b := []byte(s)
+	for _, o := range ops {
+		switch o.typ {
+		case "INSERT":
+			if o.pos < 1 || o.pos > len(b)+1 {
+				return "", fmt.Errorf("bad insert pos")
+			}
+			b = append(b[:o.pos-1], append([]byte{o.ch}, b[o.pos-1:]...)...)
+		case "DELETE":
+			if o.pos < 1 || o.pos > len(b) {
+				return "", fmt.Errorf("bad delete pos")
+			}
+			b = append(b[:o.pos-1], b[o.pos:]...)
+		case "REPLACE":
+			if o.pos < 1 || o.pos > len(b) {
+				return "", fmt.Errorf("bad replace pos")
+			}
+			b[o.pos-1] = o.ch
+		default:
+			return "", fmt.Errorf("unknown op %s", o.typ)
+		}
+	}
+	return string(b), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	l1 := rng.Intn(6) + 1
+	l2 := rng.Intn(6) + 1
+	letters := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	sb := make([]byte, l1)
+	tb := make([]byte, l2)
+	for i := 0; i < l1; i++ {
+		sb[i] = letters[rng.Intn(len(letters))]
+	}
+	for i := 0; i < l2; i++ {
+		tb[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(sb), string(tb)
+}
+
+func runCase(bin, s, t string) error {
+	input := fmt.Sprintf("%s\n%s\n", s, t)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(scanner.Text())
+	if err != nil {
+		return fmt.Errorf("bad k: %s", scanner.Text())
+	}
+	ops := make([]op, k)
+	for i := 0; i < k; i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("missing operation type")
+		}
+		typ := scanner.Text()
+		if !scanner.Scan() {
+			return fmt.Errorf("missing op pos")
+		}
+		pos, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("bad pos")
+		}
+		var ch byte
+		if typ != "DELETE" {
+			if !scanner.Scan() {
+				return fmt.Errorf("missing char")
+			}
+			token := scanner.Text()
+			if len(token) != 1 {
+				return fmt.Errorf("bad char")
+			}
+			ch = token[0]
+		}
+		ops[i] = op{typ, pos, ch}
+	}
+	// ignore any extra whitespace
+	if scanner.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	if k != editDistance(s, t) {
+		return fmt.Errorf("expected %d operations, got %d", editDistance(s, t), k)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s, t := generateCase(rng)
+		if err := runCase(bin, s, t); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n%s\n", i+1, err, s, t)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/56/verifierE.go
+++ b/0-999/0-99/50-59/56/verifierE.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type domino struct {
+	x, h int
+	idx  int
+}
+
+func expectedAnswer(dom []domino) []int {
+	n := len(dom)
+	sort.Slice(dom, func(i, j int) bool { return dom[i].x < dom[j].x })
+	far := make([]int, n)
+	R := make([]int, n)
+	stack := make([]int, 0, n)
+	for i := n - 1; i >= 0; i-- {
+		far[i] = dom[i].x + dom[i].h - 1
+		R[i] = i
+		for len(stack) > 0 {
+			j := stack[len(stack)-1]
+			if dom[j].x > far[i] {
+				break
+			}
+			stack = stack[:len(stack)-1]
+			if far[j] > far[i] {
+				far[i] = far[j]
+			}
+			if R[j] > R[i] {
+				R[i] = R[j]
+			}
+		}
+		stack = append(stack, i)
+	}
+	ans := make([]int, n)
+	for i := 0; i < n; i++ {
+		ans[dom[i].idx] = R[i] - i + 1
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(20) + 1
+	dom := make([]domino, n)
+	x := 0
+	for i := 0; i < n; i++ {
+		x += rng.Intn(5) + 1
+		dom[i] = domino{x: x, h: rng.Intn(10) + 2, idx: i}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "%d %d\n", dom[i].x, dom[i].h)
+	}
+	ans := expectedAnswer(append([]domino(nil), dom...))
+	return b.String(), ans
+}
+
+func runCase(bin, input string, expected []int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	parts := strings.Fields(strings.TrimSpace(out.String()))
+	if len(parts) != len(expected) {
+		return fmt.Errorf("expected %d numbers got %d", len(expected), len(parts))
+	}
+	for i, p := range parts {
+		v, err := strconv.Atoi(p)
+		if err != nil || v != expected[i] {
+			return fmt.Errorf("mismatch at %d: expected %d got %s", i+1, expected[i], p)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 56 problems A–E
- each verifier generates 100 random tests and checks a provided binary
- compiles without errors

## Testing
- `go run 0-999/0-99/50-59/56/verifierA.go /tmp/56A`
- `go run 0-999/0-99/50-59/56/verifierB.go /tmp/56B`
- `go run 0-999/0-99/50-59/56/verifierC.go /tmp/56C`
- `go run 0-999/0-99/50-59/56/verifierD.go /tmp/56D`
- `go run 0-999/0-99/50-59/56/verifierE.go /tmp/56E`


------
https://chatgpt.com/codex/tasks/task_e_687e61390c6883249ca269bdb002ce09