### PR TITLE
Add Go verifiers for contest 55

### DIFF
--- a/0-999/0-99/50-59/55/verifierA.go
+++ b/0-999/0-99/50-59/55/verifierA.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) string {
+	if n > 0 && n&(n-1) == 0 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase() (string, string) {
+	n := rand.Intn(1000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	return input, expected(n)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase()
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/55/verifierB.go
+++ b/0-999/0-99/50-59/55/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func dfs(nums []int64, ops []string, idx int) int64 {
+	if len(nums) == 1 {
+		return nums[0]
+	}
+	minRes := int64(1<<63 - 1)
+	op := ops[idx]
+	n := len(nums)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			var t int64
+			if op == "*" {
+				t = nums[i] * nums[j]
+			} else {
+				t = nums[i] + nums[j]
+			}
+			next := make([]int64, 0, n-1)
+			for k := 0; k < n; k++ {
+				if k == i || k == j {
+					continue
+				}
+				next = append(next, nums[k])
+			}
+			next = append(next, t)
+			res := dfs(next, ops, idx+1)
+			if res < minRes {
+				minRes = res
+			}
+		}
+	}
+	return minRes
+}
+
+func expected(a, b, c, d int64, ops []string) string {
+	nums := []int64{a, b, c, d}
+	res := dfs(nums, ops, 0)
+	return fmt.Sprintf("%d", res)
+}
+
+func generateCase() (string, string) {
+	a := rand.Intn(1001)
+	b := rand.Intn(1001)
+	c := rand.Intn(1001)
+	d := rand.Intn(1001)
+	ops := make([]string, 3)
+	for i := 0; i < 3; i++ {
+		if rand.Intn(2) == 0 {
+			ops[i] = "+"
+		} else {
+			ops[i] = "*"
+		}
+	}
+	input := fmt.Sprintf("%d %d %d %d\n%s %s %s\n", a, b, c, d, ops[0], ops[1], ops[2])
+	return input, expected(int64(a), int64(b), int64(c), int64(d), ops)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase()
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/55/verifierC.go
+++ b/0-999/0-99/50-59/55/verifierC.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func expected(n, m int, pies [][2]int) string {
+	INF := n + m + 5
+	T := make([]int, 0, 2*(n+m))
+	for j := 1; j <= m; j++ {
+		best := INF
+		for _, p := range pies {
+			d := p[0] + abs(p[1]-j)
+			if d < best {
+				best = d
+			}
+		}
+		T = append(T, best)
+	}
+	for j := 1; j <= m; j++ {
+		best := INF
+		for _, p := range pies {
+			d := (n - p[0] + 1) + abs(p[1]-j)
+			if d < best {
+				best = d
+			}
+		}
+		T = append(T, best)
+	}
+	for i := 1; i <= n; i++ {
+		best := INF
+		for _, p := range pies {
+			d := p[1] + abs(p[0]-i)
+			if d < best {
+				best = d
+			}
+		}
+		T = append(T, best)
+	}
+	for i := 1; i <= n; i++ {
+		best := INF
+		for _, p := range pies {
+			d := (m - p[1] + 1) + abs(p[0]-i)
+			if d < best {
+				best = d
+			}
+		}
+		T = append(T, best)
+	}
+	sort.Ints(T)
+	ans := "NO"
+	for idx, t := range T {
+		if t <= idx+1 {
+			ans = "YES"
+			break
+		}
+	}
+	return ans
+}
+
+func generateCase() (string, string) {
+	n := rand.Intn(100) + 1
+	m := rand.Intn(100) + 1
+	k := rand.Intn(101)
+	pies := make([][2]int, k)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < k; i++ {
+		x := rand.Intn(n) + 1
+		y := rand.Intn(m) + 1
+		pies[i] = [2]int{x, y}
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	return sb.String(), expected(n, m, pies)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase()
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/55/verifierD.go
+++ b/0-999/0-99/50-59/55/verifierD.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	lcmVals   []int
+	lcmIndex  map[int]int
+	nextLcm   [][]int
+	totalMods = 2520
+	divCnt    int
+	dp        [][][]int64
+	used      [][][]bool
+	digits    []int
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func initPrecomp() {
+	for i := 1; i <= totalMods; i++ {
+		if totalMods%i == 0 {
+			lcmVals = append(lcmVals, i)
+		}
+	}
+	divCnt = len(lcmVals)
+	lcmIndex = make(map[int]int, divCnt)
+	for i, v := range lcmVals {
+		lcmIndex[v] = i
+	}
+	nextLcm = make([][]int, divCnt)
+	for i := 0; i < divCnt; i++ {
+		nextLcm[i] = make([]int, 10)
+		for d := 0; d < 10; d++ {
+			if d == 0 {
+				nextLcm[i][d] = i
+			} else {
+				cur := lcmVals[i]
+				g := gcd(cur, d)
+				nl := cur / g * d
+				nextLcm[i][d] = lcmIndex[nl]
+			}
+		}
+	}
+	dp = make([][][]int64, 20)
+	used = make([][][]bool, 20)
+	for i := 0; i < 20; i++ {
+		dp[i] = make([][]int64, divCnt)
+		used[i] = make([][]bool, divCnt)
+		for j := 0; j < divCnt; j++ {
+			dp[i][j] = make([]int64, totalMods)
+			used[i][j] = make([]bool, totalMods)
+		}
+	}
+}
+
+func dfs(pos, lidx, rem int, tight bool) int64 {
+	if pos == len(digits) {
+		if rem%lcmVals[lidx] == 0 {
+			return 1
+		}
+		return 0
+	}
+	if !tight && used[pos][lidx][rem] {
+		return dp[pos][lidx][rem]
+	}
+	var res int64
+	limit := 9
+	if tight {
+		limit = digits[pos]
+	}
+	for d := 0; d <= limit; d++ {
+		nt := tight && d == limit
+		nlidx := nextLcm[lidx][d]
+		nrem := (rem*10 + d) % totalMods
+		res += dfs(pos+1, nlidx, nrem, nt)
+	}
+	if !tight {
+		used[pos][lidx][rem] = true
+		dp[pos][lidx][rem] = res
+	}
+	return res
+}
+
+func solveNumber(n uint64) int64 {
+	s := strconv.FormatUint(n, 10)
+	digits = make([]int, len(s))
+	for i, ch := range s {
+		digits[i] = int(ch - '0')
+	}
+	for i := 0; i <= len(digits); i++ {
+		for j := 0; j < divCnt; j++ {
+			for k := 0; k < totalMods; k++ {
+				used[i][j][k] = false
+			}
+		}
+	}
+	total := dfs(0, lcmIndex[1], 0, true)
+	return total - 1
+}
+
+func expected(ranges [][2]uint64) string {
+	var sb strings.Builder
+	for idx, r := range ranges {
+		l := r[0]
+		rr := r[1]
+		left := uint64(0)
+		if l > 0 {
+			left = l - 1
+		}
+		ans := solveNumber(rr) - solveNumber(left)
+		if idx+1 == len(ranges) {
+			fmt.Fprintf(&sb, "%d", ans)
+		} else {
+			fmt.Fprintf(&sb, "%d\n", ans)
+		}
+	}
+	return sb.String()
+}
+
+func generateCase() (string, string) {
+	t := rand.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	ranges := make([][2]uint64, t)
+	for i := 0; i < t; i++ {
+		l := rand.Uint64()%1000000000000 + 1
+		r := l + uint64(rand.Intn(1000000))
+		ranges[i] = [2]uint64{l, r}
+		fmt.Fprintf(&sb, "%d %d\n", l, r)
+	}
+	return sb.String(), expected(ranges)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	initPrecomp()
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase()
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/55/verifierE.go
+++ b/0-999/0-99/50-59/55/verifierE.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Vec struct {
+	x, y int64
+	half int
+}
+
+type Vecs []Vec
+
+func (v Vecs) Len() int      { return len(v) }
+func (v Vecs) Swap(i, j int) { v[i], v[j] = v[j], v[i] }
+func (v Vecs) Less(i, j int) bool {
+	if v[i].half != v[j].half {
+		return v[i].half < v[j].half
+	}
+	return v[i].x*v[j].y-v[i].y*v[j].x > 0
+}
+
+func countTriangles(n int, px, py int64, xs, ys []int64) int64 {
+	vecs := make(Vecs, n)
+	for i := 0; i < n; i++ {
+		dx := xs[i] - px
+		dy := ys[i] - py
+		half := 1
+		if dy > 0 || (dy == 0 && dx > 0) {
+			half = 0
+		}
+		vecs[i] = Vec{x: dx, y: dy, half: half}
+	}
+	sort.Sort(vecs)
+	vecs = append(vecs, vecs...)
+	var bad int64
+	j := 0
+	for i := 0; i < n; i++ {
+		if j < i+1 {
+			j = i + 1
+		}
+		for j < i+n && (vecs[i].x*vecs[j].y-vecs[i].y*vecs[j].x) > 0 {
+			j++
+		}
+		k := int64(j - i - 1)
+		if k >= 2 {
+			bad += k * (k - 1) / 2
+		}
+	}
+	total := int64(n)
+	total = total * (total - 1) * (total - 2) / 6
+	return total - bad
+}
+
+func generatePolygon(n int) ([]int64, []int64) {
+	r := rand.Int63n(1000) + 10
+	xs := make([]int64, n)
+	ys := make([]int64, n)
+	for i := 0; i < n; i++ {
+		angle := -2 * math.Pi * float64(i) / float64(n)
+		xs[i] = int64(math.Round(float64(r) * math.Cos(angle)))
+		ys[i] = int64(math.Round(float64(r) * math.Sin(angle)))
+	}
+	return xs, ys
+}
+
+func expected(n int, xs, ys []int64, queries [][2]int64) string {
+	var sb strings.Builder
+	for i, q := range queries {
+		ans := countTriangles(n, q[0], q[1], xs, ys)
+		if i+1 == len(queries) {
+			fmt.Fprintf(&sb, "%d", ans)
+		} else {
+			fmt.Fprintf(&sb, "%d\n", ans)
+		}
+	}
+	return sb.String()
+}
+
+func generateCase() (string, string) {
+	n := rand.Intn(4) + 3 // 3..6
+	xs, ys := generatePolygon(n)
+	t := rand.Intn(5) + 1
+	queries := make([][2]int64, t)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", xs[i], ys[i])
+	}
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		px := rand.Int63n(2000) - 1000
+		py := rand.Int63n(2000) - 1000
+		queries[i] = [2]int64{px, py}
+		fmt.Fprintf(&sb, "%d %d\n", px, py)
+	}
+	return sb.String(), expected(n, xs, ys, queries)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase()
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e6133fbc8832493b20b57164b533b