### PR TITLE
Add verifiers for contest 54

### DIFF
--- a/0-999/0-99/50-59/54/verifierA.go
+++ b/0-999/0-99/50-59/54/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(n, k int, holidays []int) int {
+	last := 0
+	ans := 0
+	idx := 0
+	for idx < len(holidays) {
+		h := holidays[idx]
+		for last+k < h {
+			last += k
+			ans++
+		}
+		ans++
+		last = h
+		idx++
+	}
+	for last+k <= n {
+		last += k
+		ans++
+	}
+	return ans
+}
+
+func runCase(exe string, input string, expectedOut int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expectedOut {
+		return fmt.Errorf("expected %d got %d", expectedOut, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(365) + 1
+		k := rng.Intn(n) + 1
+		c := rng.Intn(n + 1)
+		daysMap := make(map[int]struct{})
+		for len(daysMap) < c {
+			d := rng.Intn(n) + 1
+			daysMap[d] = struct{}{}
+		}
+		days := make([]int, 0, c)
+		for d := range daysMap {
+			days = append(days, d)
+		}
+		sort.Ints(days)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		sb.WriteString(fmt.Sprintf("%d", len(days)))
+		for _, d := range days {
+			sb.WriteString(fmt.Sprintf(" %d", d))
+		}
+		sb.WriteString("\n")
+		inp := sb.String()
+		expectedOut := expected(n, k, days)
+		if err := runCase(exe, inp, expectedOut); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/54/verifierB.go
+++ b/0-999/0-99/50-59/54/verifierB.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ x, y int }
+
+func repr(piece [][]byte) string {
+	var b strings.Builder
+	for i, row := range piece {
+		b.Write(row)
+		if i+1 < len(piece) {
+			b.WriteByte('|')
+		}
+	}
+	return b.String()
+}
+
+func rot180(p [][]byte) [][]byte {
+	x := len(p)
+	y := len(p[0])
+	r := make([][]byte, x)
+	for i := 0; i < x; i++ {
+		r[i] = make([]byte, y)
+		for j := 0; j < y; j++ {
+			r[i][j] = p[x-1-i][y-1-j]
+		}
+	}
+	return r
+}
+
+func rot90(p [][]byte) [][]byte {
+	x := len(p)
+	y := len(p[0])
+	r := make([][]byte, x)
+	for i := range r {
+		r[i] = make([]byte, y)
+	}
+	for i := 0; i < x; i++ {
+		for j := 0; j < y; j++ {
+			r[j][x-1-i] = p[i][j]
+		}
+	}
+	return r
+}
+
+func rot270(p [][]byte) [][]byte { return rot180(rot90(p)) }
+
+func good(grid [][]byte, X, Y int) bool {
+	A := len(grid)
+	B := len(grid[0])
+	rows := A / X
+	cols := B / Y
+	seen := make(map[string]struct{})
+	for i := 0; i < rows; i++ {
+		for j := 0; j < cols; j++ {
+			piece := make([][]byte, X)
+			for k := 0; k < X; k++ {
+				piece[k] = grid[i*X+k][j*Y : j*Y+Y]
+			}
+			reps := []string{repr(piece), repr(rot180(piece))}
+			if X == Y {
+				reps = append(reps, repr(rot90(piece)), repr(rot270(piece)))
+			}
+			m := reps[0]
+			for _, s := range reps[1:] {
+				if s < m {
+					m = s
+				}
+			}
+			if _, ok := seen[m]; ok {
+				return false
+			}
+			seen[m] = struct{}{}
+		}
+	}
+	return true
+}
+
+func solve(grid [][]byte) (int, pair) {
+	A := len(grid)
+	B := len(grid[0])
+	var divA, divB []int
+	for x := 1; x <= A; x++ {
+		if A%x == 0 {
+			divA = append(divA, x)
+		}
+	}
+	for y := 1; y <= B; y++ {
+		if B%y == 0 {
+			divB = append(divB, y)
+		}
+	}
+	var res []pair
+	for _, X := range divA {
+		for _, Y := range divB {
+			if good(grid, X, Y) {
+				res = append(res, pair{X, Y})
+			}
+		}
+	}
+	best := res[0]
+	bestArea := best.x * best.y
+	for _, p := range res[1:] {
+		area := p.x * p.y
+		if area < bestArea || (area == bestArea && p.x < best.x) {
+			best = p
+			bestArea = area
+		}
+	}
+	return len(res), best
+}
+
+func runCase(exe string, input string, expCount int, expPair pair) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var c, x, y int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &c, &x, &y); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if c != expCount || x != expPair.x || y != expPair.y {
+		return fmt.Errorf("expected %d %d %d got %s", expCount, expPair.x, expPair.y, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	letters := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	for i := 0; i < 100; i++ {
+		A := rng.Intn(5) + 1
+		B := rng.Intn(5) + 1
+		grid := make([][]byte, A)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", A, B))
+		for r := 0; r < A; r++ {
+			row := make([]byte, B)
+			for c := 0; c < B; c++ {
+				row[c] = letters[rng.Intn(26)]
+			}
+			grid[r] = row
+			sb.Write(row)
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		cnt, best := solve(grid)
+		if err := runCase(exe, input, cnt, best); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/54/verifierC.go
+++ b/0-999/0-99/50-59/54/verifierC.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func getn(a int64) int64 {
+	if a <= 0 {
+		return 0
+	}
+	var c int64 = 1
+	for i := 0; i < 20; i++ {
+		if a/c == 0 {
+			c /= 10
+			break
+		}
+		c *= 10
+	}
+	var ans int64
+	if a/c != 1 {
+		ans += c
+	} else {
+		ans += a%c + 1
+	}
+	c /= 10
+	for c > 0 {
+		ans += c
+		c /= 10
+	}
+	return ans
+}
+
+func probability(l, r int64) float64 {
+	total := r - l + 1
+	cnt := getn(r) - getn(l-1)
+	return float64(cnt) / float64(total)
+}
+
+func solve(ranges [][2]int64, kPercent int) float64 {
+	n := len(ranges)
+	pro := make([]float64, n)
+	for i, lr := range ranges {
+		pro[i] = probability(lr[0], lr[1])
+	}
+	k := (n*kPercent + 99) / 100
+	dp := make([][]float64, n+1)
+	for i := range dp {
+		dp[i] = make([]float64, k+1)
+	}
+	dp[0][0] = 1
+	for i := 1; i <= n; i++ {
+		for j := 0; j <= i && j <= k; j++ {
+			if j == 0 {
+				dp[i][j] = dp[i-1][j] * (1 - pro[i-1])
+			} else {
+				dp[i][j] = dp[i-1][j-1]*pro[i-1] + dp[i-1][j]*(1-pro[i-1])
+			}
+		}
+	}
+	sum := 0.0
+	for j := 0; j < k; j++ {
+		sum += dp[n][j]
+	}
+	ans := 1.0 - sum
+	if ans < 0 {
+		ans = 0
+	}
+	if ans > 1 {
+		ans = 1
+	}
+	return ans
+}
+
+func runCase(exe string, input string, expected float64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if math.Abs(got-expected) > 1e-6*math.Max(1, math.Abs(expected)) {
+		return fmt.Errorf("expected %f got %f", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		ranges := make([][2]int64, n)
+		for j := 0; j < n; j++ {
+			l := rng.Int63n(1_000_000) + 1
+			r := l + rng.Int63n(1000)
+			ranges[j] = [2]int64{l, r}
+			sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+		}
+		k := rng.Intn(101)
+		sb.WriteString(fmt.Sprintf("%d\n", k))
+		input := sb.String()
+		exp := solve(ranges, k)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/54/verifierD.go
+++ b/0-999/0-99/50-59/54/verifierD.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+
+	lines := strings.Split(strings.TrimSpace(input), "\n")
+	var n, k int
+	fmt.Sscan(lines[0], &n, &k)
+	p := strings.TrimSpace(lines[1])
+	mask := strings.TrimSpace(lines[2])
+	ls := len(p)
+	required := strings.Count(mask, "1")
+
+	check := func(s string) bool {
+		if len(s) != n {
+			return false
+		}
+		for i := 0; i < n; i++ {
+			if s[i] < 'a' || s[i] >= 'a'+byte(k) {
+				return false
+			}
+		}
+		cnt := 0
+		for i := 0; i+ls <= n; i++ {
+			if s[i:i+ls] == p {
+				cnt++
+			}
+		}
+		if cnt != required {
+			return false
+		}
+		for i := 0; i < len(mask); i++ {
+			if mask[i] == '1' && s[i:i+ls] != p {
+				return false
+			}
+			if mask[i] == '0' && s[i:i+ls] == p {
+				return false
+			}
+		}
+		return true
+	}
+
+	if expected == "" {
+		if got != "No solution" {
+			return fmt.Errorf("expected No solution got %s", got)
+		}
+	} else {
+		if got == "No solution" {
+			return fmt.Errorf("expected solution got No solution")
+		}
+		if !check(got) {
+			return fmt.Errorf("invalid solution: %s", got)
+		}
+	}
+	return nil
+}
+
+func construct(n, k int, p, mask string) string {
+	ls := len(p)
+	st := make([]byte, n)
+	for i := range st {
+		st[i] = '!'
+	}
+	expected := 0
+	for i := 0; i < len(mask); i++ {
+		if mask[i] == '1' {
+			expected++
+			for j := 0; j < ls; j++ {
+				idx := i + j
+				if st[idx] != '!' && st[idx] != p[j] {
+					return ""
+				}
+				st[idx] = p[j]
+			}
+		}
+	}
+	check := func(s []byte) bool {
+		count := 0
+		for i := 0; i+ls <= n; i++ {
+			match := true
+			for j := 0; j < ls; j++ {
+				if s[i+j] != p[j] {
+					match = false
+					break
+				}
+			}
+			if match {
+				count++
+			}
+		}
+		return count == expected
+	}
+	for ch := byte('a'); ch < byte('a')+byte(k); ch++ {
+		s := make([]byte, n)
+		for i := 0; i < n; i++ {
+			if st[i] == '!' {
+				s[i] = ch
+			} else {
+				s[i] = st[i]
+			}
+		}
+		if check(s) {
+			return string(s)
+		}
+	}
+	return ""
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(5) + 2
+		if k > 26 {
+			k = 26
+		}
+		pLen := rng.Intn(min(n, 5)) + 1
+		letters := []rune("abcdefghijklmnopqrstuvwxyz")[:k]
+		var p strings.Builder
+		for j := 0; j < pLen; j++ {
+			p.WriteRune(letters[rng.Intn(len(letters))])
+		}
+		maskLen := n - pLen + 1
+		var maskBuilder strings.Builder
+		for j := 0; j < maskLen; j++ {
+			if rng.Intn(2) == 0 {
+				maskBuilder.WriteByte('0')
+			} else {
+				maskBuilder.WriteByte('1')
+			}
+		}
+		pStr := p.String()
+		mask := maskBuilder.String()
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		sb.WriteString(pStr + "\n")
+		sb.WriteString(mask + "\n")
+		input := sb.String()
+		expected := construct(n, k, pStr, mask)
+		if err := runCase(exe, input, expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/0-999/0-99/50-59/54/verifierE.go
+++ b/0-999/0-99/50-59/54/verifierE.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type pt struct{ x, y float64 }
+
+func sub(a, b pt) pt        { return pt{a.x - b.x, a.y - b.y} }
+func cross(a, b pt) float64 { return a.x*b.y - a.y*b.x }
+func dot(a, b pt) float64   { return a.x*b.x + a.y*b.y }
+
+func work(ext []pt, n int, ans *float64) {
+	sum := 0.0
+	j := 1
+	for i := 0; i < n; i++ {
+		for j+1 < len(ext) && dot(sub(ext[i+1], ext[i]), sub(ext[j], ext[j+1])) < 0 {
+			sum += cross(ext[j+1], ext[j])
+			j++
+		}
+		u := sub(ext[i+1], ext[i])
+		l1 := math.Hypot(u.x, u.y)
+		w := sub(ext[j], ext[i])
+		l2 := math.Hypot(w.x, w.y)
+		h := cross(w, u) / l1
+		l := math.Sqrt(l2*l2 - h*h)
+		t := l / l1
+		res := pt{ext[i].x + u.x*t, ext[i].y + u.y*t}
+		area := cross(ext[j], res) + cross(res, ext[i+1]) - sum
+		if area < *ans {
+			*ans = area
+		}
+		if i+2 < len(ext) {
+			sum -= cross(ext[i+2], ext[i+1])
+		}
+	}
+}
+
+func solve(pts []pt) float64 {
+	n := len(pts)
+	ext := make([]pt, 0, 2*n)
+	ext = append(ext, pts...)
+	ext = append(ext, pts...)
+	if n >= 3 {
+		u := sub(ext[1], ext[0])
+		v := sub(ext[2], ext[1])
+		if cross(u, v) > 0 {
+			for i, j := 0, len(ext)-1; i < j; i, j = i+1, j-1 {
+				ext[i], ext[j] = ext[j], ext[i]
+			}
+		}
+	}
+	ans := math.Inf(1)
+	work(ext, n, &ans)
+	for i := range ext {
+		ext[i].x = -ext[i].x
+	}
+	for i, j := 0, len(ext)-1; i < j; i, j = i+1, j-1 {
+		ext[i], ext[j] = ext[j], ext[i]
+	}
+	work(ext, n, &ans)
+	return ans / 2
+}
+
+func convexHull(pts []pt) []pt {
+	sort.Slice(pts, func(i, j int) bool {
+		if pts[i].x == pts[j].x {
+			return pts[i].y < pts[j].y
+		}
+		return pts[i].x < pts[j].x
+	})
+	n := len(pts)
+	if n <= 1 {
+		return pts
+	}
+	hull := make([]pt, 0, 2*n)
+	for _, p := range pts {
+		for len(hull) >= 2 && cross(sub(hull[len(hull)-1], hull[len(hull)-2]), sub(p, hull[len(hull)-1])) <= 0 {
+			hull = hull[:len(hull)-1]
+		}
+		hull = append(hull, p)
+	}
+	t := len(hull)
+	for i := n - 2; i >= 0; i-- {
+		p := pts[i]
+		for len(hull) > t && cross(sub(hull[len(hull)-1], hull[len(hull)-2]), sub(p, hull[len(hull)-1])) <= 0 {
+			hull = hull[:len(hull)-1]
+		}
+		hull = append(hull, p)
+	}
+	if len(hull) > 1 {
+		hull = hull[:len(hull)-1]
+	}
+	return hull
+}
+
+func runCase(exe string, input string, expected float64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if math.Abs(got-expected) > 1e-6*math.Max(1, math.Abs(expected)) {
+		return fmt.Errorf("expected %f got %f", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		m := rng.Intn(5) + 3
+		raw := make([]pt, m)
+		for j := 0; j < m; j++ {
+			raw[j] = pt{rng.Float64()*20 - 10, rng.Float64()*20 - 10}
+		}
+		hull := convexHull(raw)
+		n := len(hull)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for _, p := range hull {
+			sb.WriteString(fmt.Sprintf("%f %f\n", p.x, p.y))
+		}
+		input := sb.String()
+		exp := solve(hull)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for contest 54 problems A–E
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e612ef0d08324b29f4b9d0e3e6f5f