### PR TITLE
Add solution verifiers for contest 53

### DIFF
--- a/0-999/0-99/50-59/53/verifierA.go
+++ b/0-999/0-99/50-59/53/verifierA.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	alphabet := "abcdefghijklmnopqrstuvwxyz"
+	prefixLen := rng.Intn(5) + 1
+	var prefix strings.Builder
+	for i := 0; i < prefixLen; i++ {
+		prefix.WriteByte(alphabet[rng.Intn(len(alphabet))])
+	}
+	n := rng.Intn(20) + 1
+	pages := make([]string, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(6) + 1
+		var sb strings.Builder
+		for j := 0; j < l; j++ {
+			sb.WriteByte(alphabet[rng.Intn(len(alphabet))])
+		}
+		pages[i] = sb.String()
+	}
+	var input strings.Builder
+	input.WriteString(prefix.String())
+	input.WriteByte('\n')
+	input.WriteString(strconv.Itoa(n))
+	input.WriteByte('\n')
+	for i, p := range pages {
+		if i > 0 {
+			input.WriteByte('\n')
+		}
+		input.WriteString(p)
+	}
+	input.WriteByte('\n')
+
+	best := ""
+	for _, p := range pages {
+		if strings.HasPrefix(p, prefix.String()) {
+			if best == "" || p < best {
+				best = p
+			}
+		}
+	}
+	if best == "" {
+		best = prefix.String()
+	}
+	best += "\n"
+	return input.String(), best
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/53/verifierB.go
+++ b/0-999/0-99/50-59/53/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func bestRect(h, w int64) (int64, int64) {
+	var bestH, bestW, bestArea int64
+	for x := 0; x < 62; x++ {
+		h0 := int64(1) << x
+		if h0 > h {
+			break
+		}
+		wMin := (4*h0 + 5 - 1) / 5
+		wMax := (5 * h0) / 4
+		if wMin < 1 {
+			wMin = 1
+		}
+		if wMax > w {
+			wMax = w
+		}
+		if wMin <= wMax {
+			w0 := wMax
+			area := h0 * w0
+			if area > bestArea || (area == bestArea && h0 > bestH) {
+				bestArea = area
+				bestH = h0
+				bestW = w0
+			}
+		}
+	}
+	for x := 0; x < 62; x++ {
+		w0 := int64(1) << x
+		if w0 > w {
+			break
+		}
+		hMin := (4*w0 + 5 - 1) / 5
+		hMax := (5 * w0) / 4
+		if hMin < 1 {
+			hMin = 1
+		}
+		if hMax > h {
+			hMax = h
+		}
+		if hMin <= hMax {
+			h0 := hMax
+			area := h0 * w0
+			if area > bestArea || (area == bestArea && h0 > bestH) {
+				bestArea = area
+				bestH = h0
+				bestW = w0
+			}
+		}
+	}
+	return bestH, bestW
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	h := rng.Int63n(1_000_000_000) + 1
+	w := rng.Int63n(1_000_000_000) + 1
+	h0, w0 := bestRect(h, w)
+	in := fmt.Sprintf("%d %d\n", h, w)
+	out := fmt.Sprintf("%d %d\n", h0, w0)
+	return in, out
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/53/verifierC.go
+++ b/0-999/0-99/50-59/53/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(50) + 1
+	input := fmt.Sprintf("%d\n", n)
+	return input, n
+}
+
+func validPermutation(n int, arr []int) bool {
+	seen := make([]bool, n)
+	diff := make(map[int]bool)
+	if len(arr) != n {
+		return false
+	}
+	for i, v := range arr {
+		if v < 1 || v > n || seen[v-1] {
+			return false
+		}
+		seen[v-1] = true
+		if i > 0 {
+			d := v - arr[i-1]
+			if d < 0 {
+				d = -d
+			}
+			if diff[d] {
+				return false
+			}
+			diff[d] = true
+		}
+	}
+	return true
+}
+
+func runCase(exe, input string, n int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	arr := make([]int, len(fields))
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("invalid integer %q", f)
+		}
+		arr[i] = v
+	}
+	if !validPermutation(n, arr) {
+		return fmt.Errorf("output is not a valid permutation")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n := generateCase(rng)
+		if err := runCase(exe, in, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/53/verifierD.go
+++ b/0-999/0-99/50-59/53/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, []int, []int) {
+	n := rng.Intn(20) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(100)
+	}
+	b := make([]int, n)
+	copy(b, a)
+	// shuffle b
+	for i := n - 1; i > 0; i-- {
+		j := rng.Intn(i + 1)
+		b[i], b[j] = b[j], b[i]
+	}
+	var sb strings.Builder
+	w := bufio.NewWriter(&sb)
+	fmt.Fprintln(w, n)
+	for i, v := range a {
+		if i > 0 {
+			fmt.Fprint(w, " ")
+		}
+		fmt.Fprint(w, v)
+	}
+	fmt.Fprintln(w)
+	for i, v := range b {
+		if i > 0 {
+			fmt.Fprint(w, " ")
+		}
+		fmt.Fprint(w, v)
+	}
+	fmt.Fprintln(w)
+	w.Flush()
+	return sb.String(), a, b
+}
+
+func applySwaps(b []int, ops [][2]int) {
+	for _, op := range ops {
+		i := op[0]
+		j := op[1]
+		b[i], b[j] = b[j], b[i]
+	}
+}
+
+func runCase(exe, input string, aOrig, bOrig []int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(scanner.Text())
+	if err != nil {
+		return fmt.Errorf("invalid k: %v", err)
+	}
+	if k < 0 || k > 1_000_000 {
+		return fmt.Errorf("k out of range")
+	}
+	ops := make([][2]int, k)
+	for i := 0; i < k; i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("not enough numbers")
+		}
+		x, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("bad op index: %v", err)
+		}
+		if !scanner.Scan() {
+			return fmt.Errorf("not enough numbers")
+		}
+		y, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("bad op index: %v", err)
+		}
+		ops[i] = [2]int{x - 1, y - 1}
+	}
+	b := make([]int, len(bOrig))
+	copy(b, bOrig)
+	for _, op := range ops {
+		if op[0] < 0 || op[1] < 0 || op[0] >= len(b) || op[1] >= len(b) || op[1] != op[0]+1 {
+			return fmt.Errorf("invalid swap indices")
+		}
+		b[op[0]], b[op[1]] = b[op[1]], b[op[0]]
+	}
+	for i := range aOrig {
+		if aOrig[i] != b[i] {
+			return fmt.Errorf("final array incorrect")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, a, b := generateCase(rng)
+		if err := runCase(exe, in, a, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/53/verifierE.go
+++ b/0-999/0-99/50-59/53/verifierE.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func det(mat [][]int64) int64 {
+	n := len(mat)
+	if n == 0 {
+		return 1
+	}
+	M := make([][]int64, n)
+	for i := range mat {
+		M[i] = make([]int64, n)
+		copy(M[i], mat[i])
+	}
+	for k := 0; k < n; k++ {
+		if M[k][k] == 0 {
+			return 0
+		}
+		for i := k + 1; i < n; i++ {
+			for j := k + 1; j < n; j++ {
+				num := M[i][j]*M[k][k] - M[i][k]*M[k][j]
+				den := int64(1)
+				if k > 0 {
+					den = M[k-1][k-1]
+				}
+				M[i][j] = num / den
+			}
+			M[i][k] = 0
+		}
+	}
+	return M[n-1][n-1]
+}
+
+func countWays(n int, edges [][2]int, k int) int64 {
+	adj := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		adj[i] = make([]bool, n)
+	}
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u][v] = true
+		adj[v][u] = true
+	}
+	var total int64
+	fullMask := 1 << n
+	for mask := 0; mask < fullMask; mask++ {
+		if bits.OnesCount(uint(mask)) != k {
+			continue
+		}
+		rmask := (fullMask - 1) ^ mask
+		prod := int64(1)
+		valid := true
+		for v := 0; v < n; v++ {
+			if mask&(1<<v) != 0 {
+				deg := 0
+				for u := 0; u < n; u++ {
+					if rmask&(1<<u) != 0 && adj[v][u] {
+						deg++
+					}
+				}
+				if deg == 0 {
+					valid = false
+					break
+				}
+				prod *= int64(deg)
+			}
+		}
+		if !valid {
+			continue
+		}
+		var rverts []int
+		for v := 0; v < n; v++ {
+			if rmask&(1<<v) != 0 {
+				rverts = append(rverts, v)
+			}
+		}
+		rlen := len(rverts)
+		tcount := int64(1)
+		if rlen > 1 {
+			L := make([][]int64, rlen)
+			for i := range L {
+				L[i] = make([]int64, rlen)
+			}
+			for i := 0; i < rlen; i++ {
+				for j := i + 1; j < rlen; j++ {
+					u := rverts[i]
+					v := rverts[j]
+					if adj[u][v] {
+						L[i][i]++
+						L[j][j]++
+						L[i][j]--
+						L[j][i]--
+					}
+				}
+			}
+			sz := rlen - 1
+			M := make([][]int64, sz)
+			for i := 0; i < sz; i++ {
+				M[i] = make([]int64, sz)
+				for j := 0; j < sz; j++ {
+					M[i][j] = L[i][j]
+				}
+			}
+			tcount = det(M)
+			if tcount == 0 {
+				continue
+			}
+		}
+		total += prod * tcount
+	}
+	return total
+}
+
+func generateGraph(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(5) + 3
+	// build connected graph
+	edges := make([][2]int, 0)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges = append(edges, [2]int{p, i})
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if rng.Float64() < 0.3 {
+				edges = append(edges, [2]int{i, j})
+			}
+		}
+	}
+	m := len(edges)
+	k := rng.Intn(n-2) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+	}
+	exp := countWays(n, edges, k)
+	return sb.String(), exp
+}
+
+func runCase(exe, input string, expected int64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(outStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateGraph(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–E in contest 53
- each verifier runs 100 randomly generated test cases and checks a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `./verifierA ./53A`
- `./verifierB ./53B`
- `./verifierC ./53C`
- `./verifierD ./53D`
- `./verifierE ./53E`


------
https://chatgpt.com/codex/tasks/task_e_687e6129f25083249fe64528425e49ad