### PR TITLE
Add solution verifiers for contest 52

### DIFF
--- a/0-999/0-99/50-59/52/verifierA.go
+++ b/0-999/0-99/50-59/52/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(arr []int) string {
+	counts := [4]int{}
+	for _, v := range arr {
+		if v >= 1 && v <= 3 {
+			counts[v]++
+		}
+	}
+	maxCount := counts[1]
+	if counts[2] > maxCount {
+		maxCount = counts[2]
+	}
+	if counts[3] > maxCount {
+		maxCount = counts[3]
+	}
+	return fmt.Sprintf("%d", len(arr)-maxCount)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(3) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(arr)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/52/verifierB.go
+++ b/0-999/0-99/50-59/52/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(grid []string) string {
+	n := len(grid)
+	m := len(grid[0])
+	row := make([]int, n)
+	col := make([]int, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '*' {
+				row[i]++
+				col[j]++
+			}
+		}
+	}
+	var ans int64
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '*' {
+				rc := row[i] - 1
+				cc := col[j] - 1
+				if rc > 0 && cc > 0 {
+					ans += int64(rc) * int64(cc)
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(9) + 1
+	m := rng.Intn(9) + 1
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				b[j] = '.'
+			} else {
+				b[j] = '*'
+			}
+		}
+		grid[i] = string(b)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, row := range grid {
+		sb.WriteString(row)
+		sb.WriteByte('\n')
+	}
+	return sb.String(), expected(grid)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/52/verifierC.go
+++ b/0-999/0-99/50-59/52/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(21) - 10)
+	}
+	m := rng.Intn(20) + 1
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprintf("%d", v))
+	}
+	input.WriteByte('\n')
+	input.WriteString(fmt.Sprintf("%d\n", m))
+	var expected strings.Builder
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 { // query
+			lf := rng.Intn(n)
+			rg := rng.Intn(n)
+			input.WriteString(fmt.Sprintf("%d %d\n", lf, rg))
+			minVal := int64(math.MaxInt64)
+			if lf <= rg {
+				for j := lf; j <= rg; j++ {
+					if arr[j] < minVal {
+						minVal = arr[j]
+					}
+				}
+			} else {
+				for j := lf; j < n; j++ {
+					if arr[j] < minVal {
+						minVal = arr[j]
+					}
+				}
+				for j := 0; j <= rg; j++ {
+					if arr[j] < minVal {
+						minVal = arr[j]
+					}
+				}
+			}
+			expected.WriteString(fmt.Sprintf("%d\n", minVal))
+		} else { // update
+			lf := rng.Intn(n)
+			rg := rng.Intn(n)
+			v := rng.Intn(21) - 10
+			input.WriteString(fmt.Sprintf("%d %d %d\n", lf, rg, v))
+			if lf <= rg {
+				for j := lf; j <= rg; j++ {
+					arr[j] += int64(v)
+				}
+			} else {
+				for j := lf; j < n; j++ {
+					arr[j] += int64(v)
+				}
+				for j := 0; j <= rg; j++ {
+					arr[j] += int64(v)
+				}
+			}
+		}
+	}
+	return input.String(), strings.TrimSpace(expected.String())
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	expLines := strings.Split(strings.TrimSpace(expected), "\n")
+	if len(outLines) != len(expLines) {
+		return fmt.Errorf("expected %d lines got %d", len(expLines), len(outLines))
+	}
+	for i := range outLines {
+		if strings.TrimSpace(outLines[i]) != strings.TrimSpace(expLines[i]) {
+			return fmt.Errorf("line %d expected %s got %s", i+1, expLines[i], outLines[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A, B and C of contest 52
- each verifier generates 100 random tests and runs the candidate binary (or Go program)

## Testing
- `go run verifierA.go ./52A_bin`
- `go run verifierB.go ./52B_bin`
- `go run verifierC.go ./52C_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e61252c048324b78371f93398d1a1