### PR TITLE
Add verifiers for contest 51

### DIFF
--- a/0-999/0-99/50-59/51/verifierA.go
+++ b/0-999/0-99/50-59/51/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func canonical(a, b, c, d int) string {
+	r1 := fmt.Sprintf("%d%d%d%d", a, b, c, d)
+	r2 := fmt.Sprintf("%d%d%d%d", c, a, d, b)
+	r3 := fmt.Sprintf("%d%d%d%d", d, c, b, a)
+	r4 := fmt.Sprintf("%d%d%d%d", b, d, a, c)
+	min := r1
+	if r2 < min {
+		min = r2
+	}
+	if r3 < min {
+		min = r3
+	}
+	if r4 < min {
+		min = r4
+	}
+	return min
+}
+
+func solve(amulets [][4]int) string {
+	seen := make(map[string]struct{})
+	for _, q := range amulets {
+		s := canonical(q[0], q[1], q[2], q[3])
+		seen[s] = struct{}{}
+	}
+	return fmt.Sprintf("%d", len(seen))
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	am := make([][4]int, n)
+	for i := 0; i < n; i++ {
+		a := rng.Intn(6) + 1
+		b := rng.Intn(6) + 1
+		c := rng.Intn(6) + 1
+		d := rng.Intn(6) + 1
+		am[i] = [4]int{a, b, c, d}
+		sb.WriteString(fmt.Sprintf("%d %d\n%d %d\n", a, b, c, d))
+		if i != n-1 {
+			sb.WriteString("**\n")
+		}
+	}
+	input := sb.String()
+	expected := solve(am)
+	return input, expected
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/51/verifierB.go
+++ b/0-999/0-99/50-59/51/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func genTable(rng *rand.Rand, depth int) (string, []int) {
+	var sb strings.Builder
+	counts := []int{}
+	cell := 0
+	sb.WriteString("<table>")
+	rows := rng.Intn(2) + 1
+	for i := 0; i < rows; i++ {
+		sb.WriteString("<tr>")
+		cols := rng.Intn(2) + 1
+		for j := 0; j < cols; j++ {
+			sb.WriteString("<td>")
+			cell++
+			if depth < 2 && rng.Float32() < 0.3 {
+				sub, subc := genTable(rng, depth+1)
+				sb.WriteString(sub)
+				counts = append(counts, subc...)
+			}
+			sb.WriteString("</td>")
+		}
+		sb.WriteString("</tr>")
+	}
+	sb.WriteString("</table>")
+	counts = append(counts, cell)
+	return sb.String(), counts
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	markup, counts := genTable(rng, 0)
+	sort.Ints(counts)
+	var exp strings.Builder
+	for i, v := range counts {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(fmt.Sprintf("%d", v))
+	}
+	expected := exp.String()
+	input := markup + "\n"
+	return input, expected
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/51/verifierC.go
+++ b/0-999/0-99/50-59/51/verifierC.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveC(a []int64) (string, []float64) {
+	n := len(a)
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	st := [3]int{}
+	test := func(x int64) bool {
+		b := 0
+		for i := 0; i < 3; i++ {
+			if b >= n {
+				return false
+			}
+			st[i] = b
+			key := a[b] + x
+			pos := sort.Search(n, func(j int) bool { return a[j] > key })
+			b = pos
+			if b == n {
+				return false
+			}
+		}
+		return true
+	}
+	var l, r int64 = 0, 1000000000
+	for l < r {
+		mid := l + (r-l)/2
+		if test(mid) {
+			l = mid + 1
+		} else {
+			r = mid
+		}
+	}
+	test(l)
+	d := float64(l) / 2.0
+	pos := make([]float64, 3)
+	for i := 0; i < 3; i++ {
+		pos[i] = float64(a[st[i]]) + d
+	}
+	res := fmt.Sprintf("%.6f", d)
+	return res, pos
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 3
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = int64(rng.Intn(1000))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	dStr, pos := solveC(append([]int64(nil), arr...))
+	var exp strings.Builder
+	exp.WriteString(dStr)
+	exp.WriteByte('\n')
+	for _, p := range pos {
+		exp.WriteString(fmt.Sprintf("%.6f ", p))
+	}
+	exp.WriteByte('\n')
+	return sb.String(), strings.TrimSpace(exp.String())
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/51/verifierD.go
+++ b/0-999/0-99/50-59/51/verifierD.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isGP(a []int, skip int) bool {
+	n := len(a)
+	k := 0
+	var pp, p int
+	for i := 0; i < n; i++ {
+		if i == skip {
+			continue
+		}
+		x := a[i]
+		if k == 0 {
+			pp = x
+		} else if k == 1 {
+			p = x
+			if pp == 0 && p != 0 {
+				return false
+			}
+		} else {
+			if pp == 0 {
+				if x != 0 {
+					return false
+				}
+			} else {
+				if int64(p)*int64(p) != int64(pp)*int64(x) {
+					return false
+				}
+			}
+			pp = p
+			p = x
+		}
+		k++
+	}
+	return true
+}
+
+func solveD(a []int) string {
+	if isGP(a, -1) {
+		return "0"
+	}
+	n := len(a)
+	cand := map[int]bool{}
+	have := false
+	if n >= 2 && a[0] == 0 && a[1] != 0 {
+		cand[0] = true
+		cand[1] = true
+		have = true
+	}
+	for i := 2; i < n; i++ {
+		x0, x1, x2 := a[i-2], a[i-1], a[i]
+		fail := false
+		if x0 == 0 {
+			if x1 != 0 {
+				fail = true
+			}
+		} else {
+			if int64(x1)*int64(x1) != int64(x0)*int64(x2) {
+				fail = true
+			}
+		}
+		if fail {
+			tri := []int{i - 2, i - 1, i}
+			if !have {
+				for _, j := range tri {
+					if j >= 0 && j < n {
+						cand[j] = true
+					}
+				}
+				have = true
+			} else {
+				newC := map[int]bool{}
+				for _, j := range tri {
+					if cand[j] {
+						newC[j] = true
+					}
+				}
+				cand = newC
+			}
+			if len(cand) == 0 {
+				return "2"
+			}
+		}
+	}
+	for j := range cand {
+		if isGP(a, j) {
+			return "1"
+		}
+	}
+	return "2"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(10) - 5
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	expected := solveD(arr)
+	return sb.String(), expected
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/51/verifierE.go
+++ b/0-999/0-99/50-59/51/verifierE.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func countCycles(n int, edges [][2]int) int64 {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	vis := make([]bool, n)
+	var ans int64
+	var dfs func(start, u, depth int)
+	dfs = func(start, u, depth int) {
+		if depth == 4 {
+			for _, w := range adj[u] {
+				if w == start {
+					ans++
+					break
+				}
+			}
+			return
+		}
+		for _, w := range adj[u] {
+			if w > start && !vis[w] {
+				vis[w] = true
+				dfs(start, w, depth+1)
+				vis[w] = false
+			}
+		}
+	}
+	for s := 0; s < n; s++ {
+		vis[s] = true
+		for _, v := range adj[s] {
+			if v > s {
+				vis[v] = true
+				dfs(s, v, 1)
+				vis[v] = false
+			}
+		}
+		vis[s] = false
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 5
+	edges := make([][2]int, 0)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if rng.Float32() < 0.3 {
+				edges = append(edges, [2]int{i, j})
+			}
+		}
+	}
+	m := len(edges)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+	}
+	ans := countCycles(n, edges)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/51/verifierF.go
+++ b/0-999/0-99/50-59/51/verifierF.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveF(n int, edges [][2]int) string {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	w := (n + 63) >> 6
+	bs := make([][]uint64, n)
+	for i := 0; i < n; i++ {
+		b := make([]uint64, w)
+		b[i>>6] |= 1 << (uint(i) & 63)
+		for _, v := range adj[i] {
+			b[v>>6] |= 1 << (uint(v) & 63)
+		}
+		bs[i] = b
+	}
+	best := 0
+	for i := 0; i < n; i++ {
+		cnt := 0
+		for j := 0; j < w; j++ {
+			cnt += bits.OnesCount64(bs[i][j])
+		}
+		if cnt > best {
+			best = cnt
+		}
+	}
+	tmp := make([]uint64, w)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		cnt := 0
+		bu, bv := bs[u], bs[v]
+		for j := 0; j < w; j++ {
+			tmp[j] = bu[j] | bv[j]
+			cnt += bits.OnesCount64(tmp[j])
+		}
+		if cnt > best {
+			best = cnt
+		}
+	}
+	res := n - best
+	return fmt.Sprintf("%d", res)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 2
+	edges := make([][2]int, 0)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if rng.Float32() < 0.3 {
+				edges = append(edges, [2]int{i, j})
+			}
+		}
+	}
+	m := len(edges)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+	}
+	ans := solveF(n, edges)
+	return sb.String(), ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- create Go solution verifiers for contest 51 (problems A–F)
- each verifier generates 100 random tests and runs a provided binary or Go file
- support passing argument using `--` for compatibility

## Testing
- `go run verifierA.go -- 51A.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6120099c83249a8fa98668120365