### PR TITLE
Add solution verifiers for contest 50

### DIFF
--- a/0-999/0-99/50-59/50/verifierA.go
+++ b/0-999/0-99/50-59/50/verifierA.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	type test struct{ m, n int }
+	var tests []test
+	for m := 1; m <= 16; m++ {
+		for n := m; n <= 16; n++ {
+			tests = append(tests, test{m, n})
+		}
+	}
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.m, t.n)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewBufferString(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Fscan(&out, &got); err != nil {
+			fmt.Printf("Test %d failed to parse output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		want := (t.m * t.n) / 2
+		if got != want {
+			fmt.Printf("Test %d failed: expected %d got %d\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/0-99/50-59/50/verifierB.go
+++ b/0-999/0-99/50-59/50/verifierB.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+func expected(s string) int64 {
+	var freq [256]int64
+	for i := 0; i < len(s); i++ {
+		freq[s[i]]++
+	}
+	var ans int64
+	for _, v := range freq {
+		ans += v * v
+	}
+	return ans
+}
+
+func randomString(n int, r *rand.Rand) string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[r.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(42))
+	const cases = 120
+	for i := 0; i < cases; i++ {
+		l := r.Intn(50) + 1
+		s := randomString(l, r)
+		input := s + "\n"
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewBufferString(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Fscan(&out, &got); err != nil {
+			fmt.Printf("Test %d failed to parse output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		want := expected(s)
+		if got != want {
+			fmt.Printf("Test %d failed: expected %d got %d\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/0-99/50-59/50/verifierC.go
+++ b/0-999/0-99/50-59/50/verifierC.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+)
+
+type Point struct{ x, y int64 }
+
+func cross(a, b, c Point) int64 {
+	return (b.x-a.x)*(c.y-a.y) - (b.y-a.y)*(c.x-a.x)
+}
+
+func abs64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func convexHull(pts []Point) []Point {
+	n := len(pts)
+	if n <= 1 {
+		return pts
+	}
+	lower := make([]Point, 0, n)
+	for _, p := range pts {
+		for len(lower) >= 2 && cross(lower[len(lower)-2], lower[len(lower)-1], p) <= 0 {
+			lower = lower[:len(lower)-1]
+		}
+		lower = append(lower, p)
+	}
+	upper := make([]Point, 0, n)
+	for i := n - 1; i >= 0; i-- {
+		p := pts[i]
+		for len(upper) >= 2 && cross(upper[len(upper)-2], upper[len(upper)-1], p) <= 0 {
+			upper = upper[:len(upper)-1]
+		}
+		upper = append(upper, p)
+	}
+	hull := append(lower[:len(lower)-1], upper[:len(upper)-1]...)
+	return hull
+}
+
+func expected(pts []Point) int64 {
+	sort.Slice(pts, func(i, j int) bool {
+		if pts[i].x != pts[j].x {
+			return pts[i].x < pts[j].x
+		}
+		return pts[i].y < pts[j].y
+	})
+	uniq := pts[:0]
+	for i, p := range pts {
+		if i == 0 || p.x != pts[i-1].x || p.y != pts[i-1].y {
+			uniq = append(uniq, p)
+		}
+	}
+	pts = uniq
+	m := len(pts)
+	if m == 0 {
+		return 0
+	}
+	if m == 1 {
+		return 4
+	}
+	hull := convexHull(pts)
+	hsz := len(hull)
+	if hsz == 1 {
+		return 4
+	}
+	if hsz == 2 {
+		dx := abs64(hull[1].x - hull[0].x)
+		dy := abs64(hull[1].y - hull[0].y)
+		d := dx
+		if dy > d {
+			d = dy
+		}
+		return 2*d + 4
+	}
+	var perim int64
+	for i := 0; i < hsz; i++ {
+		j := (i + 1) % hsz
+		dx := abs64(hull[j].x - hull[i].x)
+		dy := abs64(hull[j].y - hull[i].y)
+		if dx > dy {
+			perim += dx
+		} else {
+			perim += dy
+		}
+	}
+	return perim
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(43))
+	const cases = 120
+	for t := 0; t < cases; t++ {
+		n := r.Intn(10) + 1
+		pts := make([]Point, n)
+		for i := 0; i < n; i++ {
+			pts[i] = Point{int64(r.Intn(21) - 10), int64(r.Intn(21) - 10)}
+		}
+		var input bytes.Buffer
+		fmt.Fprintln(&input, n)
+		for _, p := range pts {
+			fmt.Fprintf(&input, "%d %d\n", p.x, p.y)
+		}
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Fscan(&out, &got); err != nil {
+			fmt.Printf("Test %d parse error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		want := expected(append([]Point(nil), pts...))
+		if got != want {
+			fmt.Printf("Test %d failed: expected %d got %d\n", t+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/0-99/50-59/50/verifierD.go
+++ b/0-999/0-99/50-59/50/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+func solve(n, k, e, ix, iy int, xs, ys []int) float64 {
+	prob := make([]float64, n)
+	prev := make([]float64, n+2)
+	cur := make([]float64, n+2)
+	chk := func(x float64) bool {
+		for i := 0; i < n; i++ {
+			dx := float64(xs[i] - ix)
+			dy := float64(ys[i] - iy)
+			d := math.Hypot(dx, dy)
+			switch {
+			case d < x:
+				prob[i] = 1
+			case d > x*1000:
+				prob[i] = 0
+			default:
+				prob[i] = math.Exp(1 - (d*d)/(x*x))
+			}
+		}
+		for i := range prev {
+			prev[i] = 0
+			cur[i] = 0
+		}
+		prev[0] = 1
+		for i := 0; i < n; i++ {
+			p := prob[i]
+			for j := 0; j <= i+1; j++ {
+				cur[j] = 0
+			}
+			for j := 0; j <= i; j++ {
+				cur[j] += prev[j] * (1 - p)
+				cur[j+1] += prev[j] * p
+			}
+			prev, cur = cur, prev
+		}
+		limit := float64(e) / 1000.0
+		sum := 0.0
+		for j := 0; j < k && j < len(prev); j++ {
+			sum += prev[j]
+		}
+		return sum <= limit
+	}
+	lo, hi := 0.0, 10000.0
+	eps := 1e-7
+	for hi-lo > eps {
+		mid := (lo + hi) * 0.5
+		if chk(mid) {
+			hi = mid
+		} else {
+			lo = mid
+		}
+	}
+	return lo
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(44))
+	const cases = 110
+	for t := 0; t < cases; t++ {
+		n := r.Intn(8) + 1
+		k := r.Intn(n) + 1
+		e := r.Intn(999) + 1
+		ix := r.Intn(21) - 10
+		iy := r.Intn(21) - 10
+		xs := make([]int, n)
+		ys := make([]int, n)
+		for i := 0; i < n; i++ {
+			xs[i] = r.Intn(21) - 10
+			ys[i] = r.Intn(21) - 10
+		}
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d %d %d %d\n", n, k, e, ix, iy)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&input, "%d %d\n", xs[i], ys[i])
+		}
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		var got float64
+		if _, err := fmt.Fscan(&out, &got); err != nil {
+			fmt.Printf("Test %d parse error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		want := solve(n, k, e, ix, iy, xs, ys)
+		if math.Abs(got-want) > 1e-4 {
+			fmt.Printf("Test %d failed: expected %.5f got %.5f\n", t+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/0-99/50-59/50/verifierE.go
+++ b/0-999/0-99/50-59/50/verifierE.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+func ceilSqrt(x int64) int {
+	if x <= 0 {
+		return 0
+	}
+	y := int(math.Sqrt(float64(x)))
+	if int64(y)*int64(y) < x {
+		y++
+	}
+	return y
+}
+
+func solve(n int, m int64) int64 {
+	var irr int64
+	for b := 1; b <= n; b++ {
+		b2 := int64(b) * int64(b)
+		var X int64
+		if m < b2-1 {
+			X = m
+		} else {
+			X = b2 - 1
+		}
+		if X <= 0 {
+			continue
+		}
+		t := b2 - X
+		sMin := ceilSqrt(t)
+		sq := b - sMin
+		if sq < 0 {
+			sq = 0
+		}
+		irrC := X - int64(sq)
+		irr += 2 * irrC
+	}
+	maxS := 2 * n
+	mark := make([]byte, maxS+1)
+	for u := 1; u <= n; u++ {
+		vMax1 := int(m / int64(u))
+		vMax2 := 2*n - u
+		vMax := vMax1
+		if vMax2 < vMax {
+			vMax = vMax2
+		}
+		if vMax < u {
+			continue
+		}
+		mark[u] = 1
+		for v := u; v <= vMax; v += 2 {
+			mark[v] = 1
+		}
+	}
+	var intCnt int64
+	for s := 1; s <= maxS; s++ {
+		if mark[s] != 0 {
+			intCnt++
+		}
+	}
+	return irr + intCnt
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(45))
+	const cases = 120
+	for t := 0; t < cases; t++ {
+		n := r.Intn(200) + 1
+		m := int64(r.Intn(200) + 1)
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", n, m)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Fscan(&out, &got); err != nil {
+			fmt.Printf("Test %d parse error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		want := solve(n, m)
+		if got != want {
+			fmt.Printf("Test %d failed: expected %d got %d\n", t+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E in contest 50
- each verifier generates more than 100 random test cases and checks a given binary
- verifiers compute expected answers using reference implementations

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e611b25d08324aafc7c9779fd481f