### PR TITLE
Add Go verifiers for contest 49

### DIFF
--- a/0-999/0-99/40-49/49/verifierA.go
+++ b/0-999/0-99/40-49/49/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	q string
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		expect := solveA(t.q)
+		out, err := runBinary(bin, t.q)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveA(q string) string {
+	q = strings.TrimRight(q, "\r\n")
+	var last byte
+	for i := len(q) - 1; i >= 0; i-- {
+		c := q[i]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			last = c
+			break
+		}
+	}
+	last = byte(strings.ToUpper(string(last))[0])
+	vowels := "AEIOUY"
+	ans := "NO"
+	if strings.ContainsRune(vowels, rune(last)) {
+		ans = "YES"
+	}
+	return ans + "\n"
+}
+
+func generateTests() []testCase {
+	rand.Seed(1)
+	tests := make([]testCase, 0, 100)
+	fixed := []string{
+		"Q?\n",
+		"A?\n",
+		"z?\n",
+		"Hello?\n",
+		"abcde?\n",
+		"y?\n",
+		"Why??\n",
+		"Sly fox?\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, testCase{q: f})
+	}
+	for len(tests) < 100 {
+		l := rand.Intn(50) + 1
+		var sb strings.Builder
+		for i := 0; i < l-1; i++ {
+			if rand.Intn(10) == 0 {
+				sb.WriteByte(' ')
+			} else {
+				x := rand.Intn(52)
+				if x < 26 {
+					sb.WriteByte(byte('a' + x))
+				} else {
+					sb.WriteByte(byte('A' + x - 26))
+				}
+			}
+		}
+		sb.WriteByte('?')
+		sb.WriteByte('\n')
+		tests = append(tests, testCase{q: sb.String()})
+	}
+	return tests
+}

--- a/0-999/0-99/40-49/49/verifierB.go
+++ b/0-999/0-99/40-49/49/verifierB.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCase struct {
+	a int
+	b int
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.a, t.b)
+		expect := solveB(t.a, t.b)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveB(a, b int) string {
+	sa := strconv.Itoa(a)
+	sb := strconv.Itoa(b)
+	la, lb := len(sa), len(sb)
+	L := la
+	if lb > L {
+		L = lb
+	}
+	ai := make([]int, L)
+	bi := make([]int, L)
+	for i := 0; i < la; i++ {
+		ai[i] = int(sa[la-1-i] - '0')
+	}
+	for i := 0; i < lb; i++ {
+		bi[i] = int(sb[lb-1-i] - '0')
+	}
+	maxDigit := 0
+	sumMax := 0
+	for i := 0; i < L; i++ {
+		if ai[i] > maxDigit {
+			maxDigit = ai[i]
+		}
+		if bi[i] > maxDigit {
+			maxDigit = bi[i]
+		}
+		s := ai[i] + bi[i]
+		if s > sumMax {
+			sumMax = s
+		}
+	}
+	minBase := maxDigit + 1
+	if minBase < 2 {
+		minBase = 2
+	}
+	ans := L
+	for p := minBase; p <= sumMax; p++ {
+		carry := 0
+		length := 0
+		for i := 0; i < L; i++ {
+			s := ai[i] + bi[i] + carry
+			carry = s / p
+			length++
+		}
+		for carry > 0 {
+			carry /= p
+			length++
+		}
+		if length > ans {
+			ans = length
+		}
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func generateTests() []testCase {
+	rand.Seed(2)
+	tests := make([]testCase, 0, 100)
+	fixed := []testCase{
+		{1, 1}, {9, 9}, {15, 15}, {123, 456}, {999, 1}, {500, 500},
+	}
+	tests = append(tests, fixed...)
+	for len(tests) < 100 {
+		a := rand.Intn(1000) + 1
+		b := rand.Intn(1000) + 1
+		tests = append(tests, testCase{a, b})
+	}
+	return tests
+}

--- a/0-999/0-99/40-49/49/verifierC.go
+++ b/0-999/0-99/40-49/49/verifierC.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	n int
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n", t.n)
+		expect := solveC(t.n)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveC(n int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d ", n))
+	for i := 1; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", i))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func generateTests() []testCase {
+	rand.Seed(3)
+	tests := make([]testCase, 0, 100)
+	fixed := []int{1, 2, 3, 4, 5, 10, 50, 100}
+	for _, f := range fixed {
+		tests = append(tests, testCase{f})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(100) + 1
+		tests = append(tests, testCase{n})
+	}
+	return tests
+}

--- a/0-999/0-99/40-49/49/verifierD.go
+++ b/0-999/0-99/40-49/49/verifierD.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	n int
+	s string
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n%s\n", t.n, t.s)
+		expect := solveD(t.n, t.s)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveD(n int, s string) string {
+	ans := 0
+	for i := 0; i < n; {
+		j := i + 1
+		for j < n && s[j] == s[i] {
+			j++
+		}
+		ans += (j - i) / 2
+		i = j
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func generateTests() []testCase {
+	rand.Seed(4)
+	tests := make([]testCase, 0, 100)
+	fixed := []string{"0", "1", "01", "10", "0000", "1111", "0101", "1010"}
+	for _, f := range fixed {
+		tests = append(tests, testCase{len(f), f})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			if rand.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		tests = append(tests, testCase{n, sb.String()})
+	}
+	return tests
+}

--- a/0-999/0-99/40-49/49/verifierE.go
+++ b/0-999/0-99/40-49/49/verifierE.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input string
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		expect := solveE(strings.NewReader(t.input))
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type prod struct{ a, b, c int }
+
+func solveE(r *strings.Reader) string {
+	in := bufio.NewReader(r)
+	var s1, s2 string
+	var n int
+	fmt.Fscan(in, &s1, &s2, &n)
+	prods := make([]prod, 0, n)
+	for i := 0; i < n; i++ {
+		var rule string
+		fmt.Fscan(in, &rule)
+		if len(rule) == 5 && rule[1] == '-' && rule[2] == '>' {
+			A := int(rule[0] - 'a')
+			B := int(rule[3] - 'a')
+			C := int(rule[4] - 'a')
+			prods = append(prods, prod{A, B, C})
+		}
+	}
+	n1 := len(s1)
+	n2 := len(s2)
+	dp1 := make([][]uint32, n1)
+	for i := range dp1 {
+		dp1[i] = make([]uint32, n1)
+	}
+	dp2 := make([][]uint32, n2)
+	for i := range dp2 {
+		dp2[i] = make([]uint32, n2)
+	}
+	for i := 0; i < n1; i++ {
+		dp1[i][i] = 1 << (s1[i] - 'a')
+	}
+	for i := 0; i < n2; i++ {
+		dp2[i][i] = 1 << (s2[i] - 'a')
+	}
+	for length := 2; length <= n1; length++ {
+		for i := 0; i+length <= n1; i++ {
+			j := i + length - 1
+			var mask uint32
+			for k := i; k < j; k++ {
+				left := dp1[i][k]
+				right := dp1[k+1][j]
+				if left == 0 || right == 0 {
+					continue
+				}
+				for _, p := range prods {
+					if (left>>p.b)&1 != 0 && (right>>p.c)&1 != 0 {
+						mask |= 1 << p.a
+					}
+				}
+			}
+			dp1[i][j] = mask
+		}
+	}
+	for length := 2; length <= n2; length++ {
+		for i := 0; i+length <= n2; i++ {
+			j := i + length - 1
+			var mask uint32
+			for k := i; k < j; k++ {
+				left := dp2[i][k]
+				right := dp2[k+1][j]
+				if left == 0 || right == 0 {
+					continue
+				}
+				for _, p := range prods {
+					if (left>>p.b)&1 != 0 && (right>>p.c)&1 != 0 {
+						mask |= 1 << p.a
+					}
+				}
+			}
+			dp2[i][j] = mask
+		}
+	}
+	const INF = 1e9
+	dist := make([][]int, n1+1)
+	for i := range dist {
+		dist[i] = make([]int, n2+1)
+		for j := range dist[i] {
+			dist[i][j] = INF
+		}
+	}
+	type pair struct{ i, j int }
+	q := make([]pair, 0, (n1+1)*(n2+1))
+	dist[0][0] = 0
+	q = append(q, pair{0, 0})
+	for head := 0; head < len(q); head++ {
+		u := q[head]
+		d := dist[u.i][u.j]
+		for i2 := u.i + 1; i2 <= n1; i2++ {
+			for j2 := u.j + 1; j2 <= n2; j2++ {
+				m1 := dp1[u.i][i2-1]
+				if m1 == 0 {
+					continue
+				}
+				m2 := dp2[u.j][j2-1]
+				if m2 == 0 {
+					continue
+				}
+				if (m1 & m2) == 0 {
+					continue
+				}
+				if dist[i2][j2] > d+1 {
+					dist[i2][j2] = d + 1
+					q = append(q, pair{i2, j2})
+				}
+			}
+		}
+	}
+	ans := dist[n1][n2]
+	if ans >= INF {
+		return "-1\n"
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func generateTests() []testCase {
+	rand.Seed(5)
+	tests := make([]testCase, 0, 100)
+	letters := []byte{'a', 'b', 'c'}
+	for i := 0; i < 20; i++ {
+		tests = append(tests, testCase{input: "a a 0\n"})
+	}
+	for len(tests) < 100 {
+		n1 := rand.Intn(3) + 1
+		n2 := rand.Intn(3) + 1
+		var s1, s2 strings.Builder
+		for i := 0; i < n1; i++ {
+			s1.WriteByte(letters[rand.Intn(len(letters))])
+		}
+		for i := 0; i < n2; i++ {
+			s2.WriteByte(letters[rand.Intn(len(letters))])
+		}
+		rules := rand.Intn(3)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%s %s %d\n", s1.String(), s2.String(), rules)
+		for i := 0; i < rules; i++ {
+			a := letters[rand.Intn(len(letters))]
+			b := letters[rand.Intn(len(letters))]
+			c := letters[rand.Intn(len(letters))]
+			fmt.Fprintf(&sb, "%c->%c%c\n", a, b, c)
+		}
+		tests = append(tests, testCase{input: sb.String()})
+	}
+	return tests
+}


### PR DESCRIPTION
## Summary
- add standalone verifiers for problems 49A-49E
- each verifier runs 100 deterministic tests against any binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6115b35083249b149fad9f56019c