### PR TITLE
Add verifiers for contest 48

### DIFF
--- a/0-999/0-99/40-49/48/verifierA.go
+++ b/0-999/0-99/40-49/48/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expected(f, m, s string) string {
+	beats := map[string]string{
+		"rock":     "scissors",
+		"scissors": "paper",
+		"paper":    "rock",
+	}
+	gestures := []string{f, m, s}
+	idx := -1
+	common := ""
+	switch {
+	case f == m && f != s:
+		idx = 2
+		common = f
+	case f == s && f != m:
+		idx = 1
+		common = f
+	case m == s && m != f:
+		idx = 0
+		common = m
+	default:
+		return "?"
+	}
+	if beats[gestures[idx]] == common {
+		switch idx {
+		case 0:
+			return "F"
+		case 1:
+			return "M"
+		case 2:
+			return "S"
+		}
+	}
+	return "?"
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	opts := []string{"rock", "paper", "scissors"}
+	f := opts[r.Intn(3)]
+	m := opts[r.Intn(3)]
+	s := opts[r.Intn(3)]
+	input := fmt.Sprintf("%s\n%s\n%s\n", f, m, s)
+	return input, expected(f, m, s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/48/verifierB.go
+++ b/0-999/0-99/40-49/48/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func rectSum(ps [][]int, r, c, h, w int) int {
+	r0, c0 := r, c
+	r1, c1 := r+h, c+w
+	return ps[r1][c1] - ps[r0][c1] - ps[r1][c0] + ps[r0][c0]
+}
+
+func expected(n, m int, grid [][]int, a, b int) string {
+	ps := make([][]int, n+1)
+	for i := 0; i <= n; i++ {
+		ps[i] = make([]int, m+1)
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			ps[i][j] = grid[i-1][j-1] + ps[i-1][j] + ps[i][j-1] - ps[i-1][j-1]
+		}
+	}
+	inf := n*m + 1
+	best := inf
+	if a <= n && b <= m {
+		for i := 0; i+a <= n; i++ {
+			for j := 0; j+b <= m; j++ {
+				s := rectSum(ps, i, j, a, b)
+				if s < best {
+					best = s
+				}
+			}
+		}
+	}
+	if b <= n && a <= m {
+		for i := 0; i+b <= n; i++ {
+			for j := 0; j+a <= m; j++ {
+				s := rectSum(ps, i, j, b, a)
+				if s < best {
+					best = s
+				}
+			}
+		}
+	}
+	if best == inf {
+		best = 0
+	}
+	return fmt.Sprintf("%d", best)
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(5) + 1
+	m := r.Intn(5) + 1
+	grid := make([][]int, n)
+	for i := range grid {
+		grid[i] = make([]int, m)
+		for j := range grid[i] {
+			grid[i][j] = r.Intn(2)
+		}
+	}
+	a := r.Intn(n) + 1
+	b := r.Intn(m) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(grid[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	return sb.String(), expected(n, m, grid, a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/48/verifierC.go
+++ b/0-999/0-99/40-49/48/verifierC.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func floor(x float64) float64 {
+	fx := math.Floor(x)
+	if x < 0 && fx != x {
+		return fx - 1
+	}
+	return fx
+}
+
+func ceil(x float64) float64 {
+	fx := math.Floor(x)
+	if x > fx {
+		return fx + 1
+	}
+	return fx
+}
+
+func solve(stops []int) string {
+	n := len(stops)
+	L := 10.0 * float64(stops[0])
+	R := (10.0*float64(stops[0]) + 10.0)
+	for i := 2; i <= n; i++ {
+		si := float64(stops[i-1])
+		li := 10.0 * si / float64(i)
+		ri := (10.0*si + 10.0) / float64(i)
+		if li > L {
+			L = li
+		}
+		if ri < R {
+			R = ri
+		}
+	}
+	if L < 10 {
+		L = 10
+	}
+	last := stops[n-1]
+	eps := 1e-12
+	uMin := ((float64(n+1) * L) - 10.0) / 10.0
+	uMax := ((float64(n+1) * R) - 10.0) / 10.0
+	mMin := int(floor(uMin + eps))
+	cand1 := mMin + 1
+	if cand1 < last+1 {
+		cand1 = last + 1
+	}
+	mMax1 := int(ceil(uMax - eps))
+	cand2 := mMax1
+	if cand2 < last+1 {
+		cand2 = last + 1
+	}
+	if cand1 == cand2 {
+		return fmt.Sprintf("unique\n%d", cand1)
+	}
+	return "not unique"
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(10) + 1
+	stops := make([]int, n)
+	last := 0
+	for i := 0; i < n; i++ {
+		last += r.Intn(5) + 1
+		stops[i] = last
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(stops[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solve(stops)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/48/verifierD.go
+++ b/0-999/0-99/40-49/48/verifierD.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solve(a []int) string {
+	maxVal := 0
+	for _, v := range a {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	b := make([]int, maxVal+1)
+	for _, v := range a {
+		b[v]++
+	}
+	for i := 2; i < len(b); i++ {
+		if b[i] > b[i-1] {
+			return "-1"
+		}
+	}
+	var sb strings.Builder
+	if len(b) > 1 {
+		sb.WriteString(fmt.Sprintf("%d\n", b[1]))
+	} else {
+		sb.WriteString("0\n")
+	}
+	for _, v := range a {
+		sb.WriteString(fmt.Sprintf("%d ", b[v]))
+		b[v]--
+	}
+	sb.WriteByte('\n')
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(10) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = r.Intn(5) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solve(a)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/48/verifierE.go
+++ b/0-999/0-99/40-49/48/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", out, "48E.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return "./" + out, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(ref, input string) (string, error) {
+	cmd := exec.Command(ref)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase(r *rand.Rand) string {
+	R := r.Intn(10) + 1
+	h0 := r.Intn(R + 1)
+	t0 := r.Intn(R + 1 - h0)
+	n := r.Intn(3) + 1
+	m := r.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", h0, t0, R))
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", r.Intn(R+1), r.Intn(R+1)))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", r.Intn(R+1), r.Intn(R+1)))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(r)
+		expect, err := runRef(ref, in)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/48/verifierF.go
+++ b/0-999/0-99/40-49/48/verifierF.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solve(n, m int, W int64, w, c, a []int64) string {
+	type comp struct {
+		price float64
+		w     int64
+	}
+	comps := make([]comp, m)
+	var answer float64
+	for day := 0; day < n; day++ {
+		for i := 0; i < m; i++ {
+			price := (float64(c[i]) - float64(a[i])*float64(day)) / float64(w[i])
+			comps[i] = comp{price: price, w: w[i]}
+		}
+		sort.Slice(comps, func(i, j int) bool { return comps[i].price < comps[j].price })
+		rem := W
+		for i := 0; i < m && rem > 0; i++ {
+			if comps[i].w <= rem {
+				answer += float64(comps[i].w) * comps[i].price
+				rem -= comps[i].w
+			} else {
+				answer += float64(rem) * comps[i].price
+				rem = 0
+			}
+		}
+	}
+	return fmt.Sprintf("%.9f", answer)
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(5) + 1
+	m := r.Intn(5) + 1
+	W := int64(r.Intn(20) + 1)
+	w := make([]int64, m)
+	c := make([]int64, m)
+	a := make([]int64, m)
+	for i := 0; i < m; i++ {
+		w[i] = int64(r.Intn(5) + 1)
+		c[i] = int64(r.Intn(10) + 1)
+		a[i] = int64(r.Intn(5))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, W))
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(w[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(c[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solve(n, m, W, w, c, a)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/48/verifierG.go
+++ b/0-999/0-99/40-49/48/verifierG.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := "refG.bin"
+	cmd := exec.Command("go", "build", "-o", out, "48G.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return "./" + out, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(ref, input string) (string, error) {
+	cmd := exec.Command(ref)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase(r *rand.Rand) string {
+	n := r.Intn(5) + 3
+	k := r.Intn(n-2) + 3
+	edges := make([][3]int, 0, n)
+	for i := 1; i < k; i++ {
+		edges = append(edges, [3]int{i, i + 1, r.Intn(5) + 1})
+	}
+	edges = append(edges, [3]int{k, 1, r.Intn(5) + 1})
+	for v := k + 1; v <= n; v++ {
+		to := r.Intn(k) + 1
+		edges = append(edges, [3]int{v, to, r.Intn(5) + 1})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(r)
+		expect, err := runRef(ref, in)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/48/verifierH.go
+++ b/0-999/0-99/40-49/48/verifierH.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solve(n, m, a, b, c int) string {
+	H := 2 * n
+	W := 2 * m
+	grid := make([][]byte, H)
+	for i := range grid {
+		grid[i] = make([]byte, W)
+	}
+	type tile struct {
+		pat [2][2]byte
+		cnt *int
+	}
+	cntB, cntW, cntM := a, b, c
+	patterns := []tile{
+		{pat: [2][2]byte{{'B', 'B'}, {'B', 'B'}}, cnt: &cntB},
+		{pat: [2][2]byte{{'W', 'W'}, {'W', 'W'}}, cnt: &cntW},
+		{pat: [2][2]byte{{'B', 'B'}, {'W', 'W'}}, cnt: &cntM},
+		{pat: [2][2]byte{{'W', 'W'}, {'B', 'B'}}, cnt: &cntM},
+		{pat: [2][2]byte{{'B', 'W'}, {'B', 'W'}}, cnt: &cntM},
+		{pat: [2][2]byte{{'W', 'B'}, {'W', 'B'}}, cnt: &cntM},
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			var top [2]byte
+			var left [2]byte
+			hasTop := false
+			hasLeft := false
+			if i > 0 {
+				hasTop = true
+				r := 2 * i
+				c0 := 2 * j
+				top[0] = grid[r-1][c0]
+				top[1] = grid[r-1][c0+1]
+			}
+			if j > 0 {
+				hasLeft = true
+				r0 := 2 * i
+				c := 2 * j
+				left[0] = grid[r0][c-1]
+				left[1] = grid[r0+1][c-1]
+			}
+			placed := false
+			for _, t := range patterns {
+				if *t.cnt <= 0 {
+					continue
+				}
+				ok := true
+				if hasTop {
+					if t.pat[0][0] != top[0] || t.pat[0][1] != top[1] {
+						ok = false
+					}
+				}
+				if ok && hasLeft {
+					if t.pat[0][0] != left[0] || t.pat[1][0] != left[1] {
+						ok = false
+					}
+				}
+				if !ok {
+					continue
+				}
+				r0, c0 := 2*i, 2*j
+				for di := 0; di < 2; di++ {
+					for dj := 0; dj < 2; dj++ {
+						grid[r0+di][c0+dj] = t.pat[di][dj]
+					}
+				}
+				*t.cnt--
+				placed = true
+				break
+			}
+			if !placed {
+				for k := 2; k < len(patterns); k++ {
+					t := &patterns[k]
+					if *t.cnt > 0 {
+						r0, c0 := 2*i, 2*j
+						for di := 0; di < 2; di++ {
+							for dj := 0; dj < 2; dj++ {
+								grid[r0+di][c0+dj] = t.pat[di][dj]
+							}
+						}
+						*t.cnt--
+						placed = true
+						break
+					}
+				}
+			}
+			if !placed {
+				return ""
+			}
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < H; i++ {
+		sb.Write(grid[i])
+		sb.WriteByte('\n')
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(3) + 1
+	m := r.Intn(3) + 1
+	a := r.Intn(5)
+	b := r.Intn(5)
+	c := r.Intn(5)
+	input := fmt.Sprintf("%d %d %d %d %d\n", n, m, a, b, c)
+	return input, solve(n, m, a, b, c)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go solution verifiers for contest 48 problems A–H
- each verifier runs 100 random tests
- some verifiers build and use reference solutions

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_687e61109b108324acc5cc307f8882a4