### PR TITLE
Add Go verifiers for Codeforces contest 46

### DIFF
--- a/0-999/0-99/40-49/46/verifierA.go
+++ b/0-999/0-99/40-49/46/verifierA.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expected(n int) []int {
+	pos := 1
+	res := make([]int, 0, n-1)
+	for i := 1; i < n; i++ {
+		pos = (pos+i-1)%n + 1
+		res = append(res, pos)
+	}
+	return res
+}
+
+func runCase(exe string, n int) error {
+	input := fmt.Sprintf("%d\n", n)
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != n-1 {
+		return fmt.Errorf("expected %d numbers got %d", n-1, len(fields))
+	}
+	exp := expected(n)
+	for i, f := range fields {
+		var v int
+		if _, err := fmt.Sscan(f, &v); err != nil {
+			return fmt.Errorf("bad output %q", f)
+		}
+		if v != exp[i] {
+			return fmt.Errorf("at position %d expected %d got %d", i+1, exp[i], v)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	for n := 2; n <= 100; n++ {
+		if err := runCase(exe, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case n=%d failed: %v\n", n, err)
+			os.Exit(1)
+		}
+	}
+	if err := runCase(exe, 50); err != nil {
+		fmt.Fprintf(os.Stderr, "case n=50 failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/46/verifierB.go
+++ b/0-999/0-99/40-49/46/verifierB.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var sizes = []string{"S", "M", "L", "XL", "XXL"}
+
+func expected(ns, nm, nl, nxl, nxxl int, req []string) []string {
+	counts := []int{ns, nm, nl, nxl, nxxl}
+	res := make([]string, len(req))
+	for i, d := range req {
+		var idx int
+		switch d {
+		case "S":
+			idx = 0
+		case "M":
+			idx = 1
+		case "L":
+			idx = 2
+		case "XL":
+			idx = 3
+		case "XXL":
+			idx = 4
+		}
+		assigned := -1
+		for dist := 0; assigned == -1 && dist < len(counts); dist++ {
+			if idx+dist < len(counts) && counts[idx+dist] > 0 {
+				assigned = idx + dist
+				break
+			}
+			if dist > 0 && idx-dist >= 0 && counts[idx-dist] > 0 {
+				assigned = idx - dist
+				break
+			}
+		}
+		counts[assigned]--
+		res[i] = sizes[assigned]
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	k := rng.Intn(7) + 1
+	counts := make([]int, 5)
+	for i := 0; i < 5; i++ {
+		counts[i] = rng.Intn(6)
+	}
+	sum := 0
+	for _, c := range counts {
+		sum += c
+	}
+	if sum < k {
+		counts[0] += k - sum
+	}
+	req := make([]string, k)
+	for i := 0; i < k; i++ {
+		req[i] = sizes[rng.Intn(5)]
+	}
+	sb := strings.Builder{}
+	fmt.Fprintf(&sb, "%d %d %d %d %d\n%d\n", counts[0], counts[1], counts[2], counts[3], counts[4], k)
+	for i := 0; i < k; i++ {
+		sb.WriteString(req[i])
+		sb.WriteByte('\n')
+	}
+	expect := expected(counts[0], counts[1], counts[2], counts[3], counts[4], req)
+	return sb.String(), expect
+}
+
+func runCase(exe, input string, expect []string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Fields(out.String())
+	if len(lines) != len(expect) {
+		return fmt.Errorf("expected %d lines got %d", len(expect), len(lines))
+	}
+	for i, l := range lines {
+		if l != expect[i] {
+			return fmt.Errorf("line %d expected %s got %s", i+1, expect[i], l)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/46/verifierC.go
+++ b/0-999/0-99/40-49/46/verifierC.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) int {
+	n := len(s)
+	totalH := 0
+	bad := make([]int, n)
+	for i, ch := range s {
+		if ch == 'H' {
+			totalH++
+		} else {
+			bad[i] = 1
+		}
+	}
+	m := totalH
+	curr := 0
+	for i := 0; i < m; i++ {
+		curr += bad[i]
+	}
+	minSwaps := curr
+	for i := 1; i < n; i++ {
+		curr -= bad[i-1]
+		add := i + m - 1
+		if add >= n {
+			add -= n
+		}
+		curr += bad[add]
+		if curr < minSwaps {
+			minSwaps = curr
+		}
+	}
+	return minSwaps
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(19) + 2
+	sb := strings.Builder{}
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('H')
+		} else {
+			sb.WriteByte('T')
+		}
+	}
+	s := sb.String()
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	return input, expected(s)
+}
+
+func runCase(exe, input string, expect int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/46/verifierD.go
+++ b/0-999/0-99/40-49/46/verifierD.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type car struct {
+	id int
+	x  int
+	l  int
+}
+
+type op struct {
+	typ int
+	val int
+}
+
+func simulate(L, b, f int, ops []op) []int {
+	parked := make([]car, 0)
+	info := make(map[int]car)
+	out := make([]int, 0)
+	reqID := 1
+	for _, op := range ops {
+		if op.typ == 1 {
+			length := op.val
+			placed := -1
+			if len(parked) == 0 {
+				if length <= L {
+					placed = 0
+				}
+			} else {
+				first := parked[0]
+				if first.x-f-length >= 0 {
+					placed = 0
+				}
+			}
+			if placed < 0 {
+				for i := 0; i+1 < len(parked); i++ {
+					cur := parked[i]
+					next := parked[i+1]
+					low := cur.x + cur.l + b
+					high := next.x - f - length
+					if high >= low {
+						placed = low
+						break
+					}
+				}
+			}
+			if placed < 0 && len(parked) > 0 {
+				last := parked[len(parked)-1]
+				low := last.x + last.l + b
+				if low+length <= L {
+					placed = low
+				}
+			}
+			if placed >= 0 {
+				c := car{id: reqID, x: placed, l: length}
+				idx := 0
+				for idx < len(parked) && parked[idx].x < placed {
+					idx++
+				}
+				parked = append(parked, car{})
+				copy(parked[idx+1:], parked[idx:])
+				parked[idx] = c
+				info[reqID] = c
+			} else {
+				info[reqID] = car{id: reqID, x: -1, l: length}
+			}
+			out = append(out, placed)
+			reqID++
+		} else {
+			rid := op.val
+			c, ok := info[rid]
+			if ok && c.x >= 0 {
+				for i, pc := range parked {
+					if pc.id == rid {
+						parked = append(parked[:i], parked[i+1:]...)
+						break
+					}
+				}
+				info[rid] = car{id: rid, x: -1, l: c.l}
+			}
+		}
+	}
+	return out
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	L := rng.Intn(91) + 10
+	b := rng.Intn(5) + 1
+	f := rng.Intn(5) + 1
+	n := rng.Intn(5) + 1
+	ops := make([]op, n)
+	nextID := 1
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 || nextID == 1 {
+			ops[i] = op{1, rng.Intn(9) + 1}
+			nextID++
+		} else {
+			ops[i] = op{2, rng.Intn(nextID-1) + 1}
+		}
+	}
+	sb := strings.Builder{}
+	fmt.Fprintf(&sb, "%d %d %d\n%d\n", L, b, f, n)
+	for _, op := range ops {
+		fmt.Fprintf(&sb, "%d %d\n", op.typ, op.val)
+	}
+	expect := simulate(L, b, f, ops)
+	return sb.String(), expect
+}
+
+func runCase(exe, input string, expect []int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != len(expect) {
+		return fmt.Errorf("expected %d outputs got %d", len(expect), len(fields))
+	}
+	for i, f := range fields {
+		var v int
+		if _, err := fmt.Sscan(f, &v); err != nil {
+			return fmt.Errorf("bad output %q", f)
+		}
+		if v != expect[i] {
+			return fmt.Errorf("output %d expected %d got %d", i+1, expect[i], v)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/46/verifierE.go
+++ b/0-999/0-99/40-49/46/verifierE.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func expected(mat [][]int64) int64 {
+	n := len(mat)
+	m := len(mat[0])
+	ps := make([][]int64, n)
+	for i := 0; i < n; i++ {
+		ps[i] = make([]int64, m+1)
+		for j := 1; j <= m; j++ {
+			ps[i][j] = ps[i][j-1] + mat[i][j-1]
+		}
+	}
+	const INF int64 = -1 << 60
+	prev := make([]int64, m+2)
+	curr := make([]int64, m+2)
+	for j := 1; j <= m; j++ {
+		prev[j] = ps[0][j]
+	}
+	for i := 2; i <= n; i++ {
+		pref := make([]int64, m+2)
+		suff := make([]int64, m+3)
+		pref[0] = INF
+		for j := 1; j <= m; j++ {
+			pref[j] = max64(pref[j-1], prev[j])
+		}
+		suff[m+1] = INF
+		for j := m; j >= 1; j-- {
+			suff[j] = max64(suff[j+1], prev[j])
+		}
+		row := ps[i-1]
+		if i%2 == 0 {
+			for j := 1; j <= m; j++ {
+				val := suff[j+1]
+				if val <= INF/2 {
+					curr[j] = INF
+				} else {
+					curr[j] = row[j] + val
+				}
+			}
+		} else {
+			for j := 1; j <= m; j++ {
+				val := pref[j-1]
+				if val <= INF/2 {
+					curr[j] = INF
+				} else {
+					curr[j] = row[j] + val
+				}
+			}
+		}
+		prev, curr = curr, prev
+	}
+	ans := int64(-1 << 60)
+	for j := 1; j <= m; j++ {
+		if prev[j] > ans {
+			ans = prev[j]
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(4) + 2
+	m := rng.Intn(4) + 2
+	mat := make([][]int64, n)
+	sb := strings.Builder{}
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		mat[i] = make([]int64, m)
+		for j := 0; j < m; j++ {
+			mat[i][j] = int64(rng.Intn(21) - 10)
+			fmt.Fprintf(&sb, "%d ", mat[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	expect := expected(mat)
+	return sb.String(), expect
+}
+
+func runCase(exe, input string, expect int64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/46/verifierF.go
+++ b/0-999/0-99/40-49/46/verifierF.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	p []int
+}
+
+func NewDSU(n int) *DSU {
+	p := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		p[i] = i
+	}
+	return &DSU{p: p}
+}
+
+func (d *DSU) Find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.Find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *DSU) Union(x, y int) int {
+	rx := d.Find(x)
+	ry := d.Find(y)
+	if rx == ry {
+		return rx
+	}
+	d.p[ry] = rx
+	return rx
+}
+
+type person struct {
+	name string
+	room int
+	keys []int
+}
+
+func check(n, m int, edges [][2]int, initOwner, finalOwner []int, initRoom, finalRoom map[string]int) bool {
+	dsu := NewDSU(n)
+	keysIn := make([][]int, n+1)
+	for key := 1; key <= m; key++ {
+		r := initOwner[key]
+		keysIn[r] = append(keysIn[r], key)
+	}
+	used := make([]bool, m+1)
+	queue := make([]int, 0, n)
+	inq := make([]bool, n+1)
+	for room := 1; room <= n; room++ {
+		if len(keysIn[room]) > 0 {
+			queue = append(queue, room)
+			inq[room] = true
+		}
+	}
+	for head := 0; head < len(queue); head++ {
+		r0 := queue[head]
+		inq[r0] = false
+		r := dsu.Find(r0)
+		for _, key := range keysIn[r] {
+			if used[key] {
+				continue
+			}
+			u := edges[key-1][0]
+			v := edges[key-1][1]
+			if dsu.Find(u) != r && dsu.Find(v) != r {
+				continue
+			}
+			used[key] = true
+			oldU := dsu.Find(u)
+			oldV := dsu.Find(v)
+			newR := dsu.Union(u, v)
+			other := oldU
+			if newR == oldU {
+				other = oldV
+			}
+			if other != newR {
+				keysIn[newR] = append(keysIn[newR], keysIn[other]...)
+				keysIn[other] = nil
+			}
+			if !inq[newR] {
+				queue = append(queue, newR)
+				inq[newR] = true
+			}
+		}
+	}
+	for name, r1 := range initRoom {
+		r2 := finalRoom[name]
+		if dsu.Find(r1) != dsu.Find(r2) {
+			return false
+		}
+	}
+	for key := 1; key <= m; key++ {
+		r1 := initOwner[key]
+		r2 := finalOwner[key]
+		if dsu.Find(r1) != dsu.Find(r2) {
+			return false
+		}
+	}
+	return true
+}
+
+func generateYesCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 2
+	m := rng.Intn(3) + 1
+	k := rng.Intn(3) + 1
+	edges := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		for v == u {
+			v = rng.Intn(n) + 1
+		}
+		edges[i] = [2]int{u, v}
+	}
+	names := make([]string, k)
+	for i := 0; i < k; i++ {
+		names[i] = fmt.Sprintf("A%d", i+1)
+	}
+	initRoom := make(map[string]int, k)
+	initOwner := make([]int, m+1)
+	for _, name := range names {
+		initRoom[name] = rng.Intn(n) + 1
+	}
+	perm := rng.Perm(m)
+	for i, idx := range perm {
+		initOwner[idx+1] = initRoom[names[i%k]]
+	}
+	finalRoom := make(map[string]int, k)
+	finalOwner := make([]int, m+1)
+	for k, v := range initRoom {
+		finalRoom[k] = v
+	}
+	copy(finalOwner, initOwner)
+	sb := strings.Builder{}
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", edges[i][0], edges[i][1])
+	}
+	for _, name := range names {
+		room := initRoom[name]
+		keys := []int{}
+		for key := 1; key <= m; key++ {
+			if initOwner[key] == room {
+				keys = append(keys, key)
+			}
+		}
+		fmt.Fprintf(&sb, "%s %d %d", name, room, len(keys))
+		for _, key := range keys {
+			fmt.Fprintf(&sb, " %d", key)
+		}
+		sb.WriteByte('\n')
+	}
+	for _, name := range names {
+		room := finalRoom[name]
+		keys := []int{}
+		for key := 1; key <= m; key++ {
+			if finalOwner[key] == room {
+				keys = append(keys, key)
+			}
+		}
+		fmt.Fprintf(&sb, "%s %d %d", name, room, len(keys))
+		for _, key := range keys {
+			fmt.Fprintf(&sb, " %d", key)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), "YES"
+}
+
+func generateNoCase() (string, string) {
+	sb := strings.Builder{}
+	sb.WriteString("2 0 1\n")
+	sb.WriteString("A 1 0\n")
+	sb.WriteString("A 2 0\n")
+	return sb.String(), "NO"
+}
+
+func runCase(exe, input, expect string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	res := strings.TrimSpace(out.String())
+	if res != expect {
+		return fmt.Errorf("expected %s got %s", expect, res)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		var in, exp string
+		if i%2 == 0 {
+			in, exp = generateYesCase(rng)
+		} else {
+			in, exp = generateNoCase()
+		}
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/46/verifierG.go
+++ b/0-999/0-99/40-49/46/verifierG.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const M = 200010
+
+var vis [M]bool
+
+type pair struct{ first, second int }
+
+var p [M]pair
+
+func init() {
+	for i := 0; i < 310; i++ {
+		for j := 0; j < 310; j++ {
+			s := i*i + j*j
+			if s < M {
+				vis[s] = true
+				p[s] = pair{i, j}
+			}
+		}
+	}
+}
+
+func getSign(arr []int) {
+	type pi struct{ val, idx int }
+	n := len(arr)
+	arrp := make([]pi, n)
+	for i := 0; i < n; i++ {
+		arrp[i] = pi{arr[i], i}
+	}
+	sort.Slice(arrp, func(i, j int) bool { return arrp[i].val > arrp[j].val })
+	d := 0
+	for i := 0; i+1 < n; i += 2 {
+		if arrp[i].val == arrp[i+1].val {
+			idx := arrp[i].idx
+			arr[idx] = -arr[idx]
+		} else {
+			diff := arrp[i].val - arrp[i+1].val
+			if d <= 0 {
+				idx := arrp[i+1].idx
+				arr[idx] = -arr[idx]
+				d += diff
+			} else {
+				idx := arrp[i].idx
+				arr[idx] = -arr[idx]
+				d -= diff
+			}
+		}
+	}
+	if n%2 == 1 {
+		idx := arrp[n-1].idx
+		arr[idx] = -arr[idx]
+	}
+}
+
+func polygon(n int) [][2]int {
+	x := make([]int, n)
+	y := make([]int, n)
+	cnt := 0
+	sum := 0
+	i := 1
+	for cnt < n-1 {
+		if i < M && vis[i] {
+			x[cnt] = p[i].first
+			y[cnt] = p[i].second
+			sum += i
+			cnt++
+		}
+		i++
+	}
+	var a, b, tcount int
+	for j := i; tcount < 2; j++ {
+		if j < M && vis[j] {
+			if tcount == 0 {
+				a = j
+			} else {
+				b = j
+			}
+			tcount++
+		}
+	}
+	ok := false
+	if (sum+a)%2 == 0 {
+		x[cnt] = p[a].first
+		y[cnt] = p[a].second
+	} else if (sum+b)%2 == 0 {
+		x[cnt] = p[b].first
+		y[cnt] = p[b].second
+	} else {
+		x[cnt] = p[a].first
+		y[cnt] = p[a].second
+		if sum%2 != 0 {
+			x[0] = p[b].first
+			y[0] = p[b].second
+		} else {
+			if n >= 4 {
+				x[3] = p[b].first
+				y[3] = p[b].second
+			} else {
+				x[0] = p[b].first
+				y[0] = p[b].second
+			}
+		}
+		ok = true
+	}
+	cnt++
+	sum = 0
+	for k := 0; k < n; k++ {
+		sum += x[k]
+	}
+	if sum%2 != 0 {
+		if !ok {
+			x[0], y[0] = y[0], x[0]
+		} else {
+			if n >= 4 {
+				x[3], y[3] = y[3], x[3]
+			} else {
+				x[0], y[0] = y[0], x[0]
+			}
+		}
+	}
+	getSign(x)
+	getSign(y)
+	ang := make([]float64, n)
+	for k := 0; k < n; k++ {
+		ang[k] = math.Atan2(float64(y[k]), float64(x[k]))
+	}
+	ids := make([]int, n)
+	for k := 0; k < n; k++ {
+		ids[k] = k
+	}
+	sort.Slice(ids, func(i, j int) bool { return ang[ids[i]] < ang[ids[j]] })
+	coords := make([][2]int, n)
+	tx, ty := 0, 0
+	for idx, id := range ids {
+		tx += x[id]
+		ty += y[id]
+		coords[idx] = [2]int{tx, ty}
+	}
+	return coords
+}
+
+func runCase(exe string, n int) error {
+	input := fmt.Sprintf("%d\n", n)
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	tokens := strings.Fields(out.String())
+	if len(tokens) != 1+2*n {
+		return fmt.Errorf("expected %d tokens got %d", 1+2*n, len(tokens))
+	}
+	if tokens[0] != "YES" {
+		return fmt.Errorf("expected YES got %s", tokens[0])
+	}
+	exp := polygon(n)
+	idx := 1
+	for i := 0; i < n; i++ {
+		var x, y int
+		if _, err := fmt.Sscan(tokens[idx], &x); err != nil {
+			return fmt.Errorf("bad output token %q", tokens[idx])
+		}
+		idx++
+		if _, err := fmt.Sscan(tokens[idx], &y); err != nil {
+			return fmt.Errorf("bad output token %q", tokens[idx])
+		}
+		idx++
+		if x != exp[i][0] || y != exp[i][1] {
+			return fmt.Errorf("vertex %d mismatch", i+1)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	for n := 3; n <= 102; n++ {
+		if err := runCase(exe, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case n=%d failed: %v\n", n, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go verifying outputs for problem A using 100 cases
- add verifierB.go with random T‑shirt distribution cases
- add verifierC.go checking hamster/tiger swaps
- add verifierD.go modelling parking requests
- add verifierE.go computing DP for comb tables
- add verifierF.go generating YES/NO scenarios for keys and rooms
- add verifierG.go validating polygon construction

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6106bed883248941c4bd76221481