### PR TITLE
Add verifiers for contest 44

### DIFF
--- a/0-999/0-99/40-49/44/verifierA.go
+++ b/0-999/0-99/40-49/44/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(lines []string) string {
+	n := len(lines) / 2
+	m := make(map[string]struct{})
+	for i := 0; i < n; i++ {
+		species := lines[2*i]
+		color := lines[2*i+1]
+		key := species + " " + color
+		m[key] = struct{}{}
+	}
+	return fmt.Sprintf("%d", len(m))
+}
+
+var species = []string{"oak", "maple", "birch", "pine", "elm"}
+var colors = []string{"red", "green", "yellow", "orange", "brown"}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	lines := make([]string, 0, 2*n)
+	for i := 0; i < n; i++ {
+		sp := species[rng.Intn(len(species))]
+		co := colors[rng.Intn(len(colors))]
+		sb.WriteString(sp + " " + co + "\n")
+		lines = append(lines, sp, co)
+	}
+	return testCase{input: sb.String(), expected: solveCase(lines)}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	var cases []testCase
+	// deterministic simple case
+	cases = append(cases, testCase{input: "1\noak red\n", expected: "1"})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/44/verifierB.go
+++ b/0-999/0-99/40-49/44/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func countWays(n, a, b, c int) int64 {
+	var total int64
+	zmax := n / 2
+	if c < zmax {
+		zmax = c
+	}
+	for z := 0; z <= zmax; z++ {
+		S := 2*n - 4*z
+		t := S - a
+		L := (t + 1) / 2
+		if L < 0 {
+			L = 0
+		}
+		U := S / 2
+		if U > b {
+			U = b
+		}
+		if L <= U {
+			total += int64(U - L + 1)
+		}
+	}
+	return total
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 1
+	a := rng.Intn(50)
+	b := rng.Intn(50)
+	c := rng.Intn(50)
+	input := fmt.Sprintf("%d %d %d %d\n", n, a, b, c)
+	expected := fmt.Sprintf("%d", countWays(n, a, b, c))
+	return testCase{input: input, expected: expected}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	var cases []testCase
+	// simple deterministic
+	cases = append(cases, testCase{input: "1 0 0 0\n", expected: "1"})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/44/verifierC.go
+++ b/0-999/0-99/40-49/44/verifierC.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(n int, ranges [][2]int) string {
+	cnt := make([]int, n+1)
+	for _, r := range ranges {
+		for d := r[0]; d <= r[1]; d++ {
+			cnt[d]++
+		}
+	}
+	for d := 1; d <= n; d++ {
+		if cnt[d] != 1 {
+			return fmt.Sprintf("%d %d", d, cnt[d])
+		}
+	}
+	return "OK"
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	ranges := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n-a+1) + a
+		ranges[i] = [2]int{a, b}
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	return testCase{input: sb.String(), expected: solveCase(n, ranges)}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %q got %q", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCase{{input: "1 1\n1 1\n", expected: "OK"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/44/verifierD.go
+++ b/0-999/0-99/40-49/44/verifierD.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct{ input string }
+
+func compileRef() (string, error) {
+	exe := filepath.Join(os.TempDir(), "ref44D")
+	cmd := exec.Command("go", "build", "-o", exe, "44D.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 3
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := rng.Intn(21) - 10
+		y := rng.Intn(21) - 10
+		z := rng.Intn(21) - 10
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", x, y, z))
+	}
+	return testCase{input: sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	run := func(path string) (string, error) {
+		cmd := exec.Command(path)
+		cmd.Stdin = strings.NewReader(tc.input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err := cmd.Run()
+		return strings.TrimSpace(out.String()), err
+	}
+	exp, err := run(ref)
+	if err != nil {
+		return fmt.Errorf("ref error: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, got)
+	}
+	if exp != got {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := make([]testCase, 0, 101)
+	cases = append(cases, testCase{input: "3\n0 0 0\n1 0 0\n0 1 0\n"})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/44/verifierE.go
+++ b/0-999/0-99/40-49/44/verifierE.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(k, a, b int, s string) string {
+	n := len(s)
+	if n < a*k || n > b*k {
+		return "No solution"
+	}
+	var sb strings.Builder
+	ix := 0
+	for k > 0 {
+		seg := (n - ix) / k
+		sb.WriteString(s[ix : ix+seg])
+		if k > 1 {
+			sb.WriteByte('\n')
+		}
+		ix += seg
+		k--
+	}
+	return sb.String()
+}
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyz")
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]rune, n)
+	for i := 0; i < n; i++ {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	k := rng.Intn(5) + 1
+	a := rng.Intn(5) + 1
+	b := a + rng.Intn(5)
+	n := rng.Intn(b*k-a*k+1) + a*k
+	s := randString(rng, n)
+	input := fmt.Sprintf("%d %d %d\n%s\n", k, a, b, s)
+	return testCase{input: input, expected: solveCase(k, a, b, s)}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCase{{input: "1 1 1\na\n", expected: "a"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/44/verifierF.go
+++ b/0-999/0-99/40-49/44/verifierF.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct{ input string }
+
+func compileRef() (string, error) {
+	exe := filepath.Join(os.TempDir(), "ref44F")
+	cmd := exec.Command("g++", "-std=c++17", "solF.cpp", "-O2", "-o", exe)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func randColor(rng *rand.Rand) string {
+	colors := []string{"red", "blue", "green", "yellow"}
+	return colors[rng.Intn(len(colors))]
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	W := rng.Intn(8) + 3
+	H := rng.Intn(8) + 3
+	n := rng.Intn(3)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", W, H))
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x1 := rng.Intn(W-1) + 1
+		x2 := rng.Intn(W-1) + 1
+		y1 := rng.Intn(H-1) + 1
+		y2 := rng.Intn(H-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", x1, y1, x2, y2))
+	}
+	m := rng.Intn(3)
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		x := rng.Intn(W-1) + 1
+		y := rng.Intn(H-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %s\n", x, y, randColor(rng)))
+	}
+	return testCase{input: sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	run := func(path string) (string, error) {
+		cmd := exec.Command(path)
+		cmd.Stdin = strings.NewReader(tc.input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err := cmd.Run()
+		return strings.TrimSpace(out.String()), err
+	}
+	exp, err := run(ref)
+	if err != nil {
+		return fmt.Errorf("ref error: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, got)
+	}
+	if exp != got {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCase{{input: "3 3\n0\n0\n"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/44/verifierG.go
+++ b/0-999/0-99/40-49/44/verifierG.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct{ input string }
+
+func compileRef() (string, error) {
+	exe := filepath.Join(os.TempDir(), "ref44G")
+	cmd := exec.Command("go", "build", "-o", exe, "44G.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		xl := rng.Intn(10)
+		xr := xl + rng.Intn(3) + 1
+		yl := rng.Intn(10)
+		yr := yl + rng.Intn(3) + 1
+		z := rng.Intn(10)
+		sb.WriteString(fmt.Sprintf("%d %d %d %d %d\n", xl, xr, yl, yr, z))
+	}
+	m := rng.Intn(3) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		x := rng.Intn(12)
+		y := rng.Intn(12)
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return testCase{input: sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	run := func(path string) (string, error) {
+		cmd := exec.Command(path)
+		cmd.Stdin = strings.NewReader(tc.input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err := cmd.Run()
+		return strings.TrimSpace(out.String()), err
+	}
+	exp, err := run(ref)
+	if err != nil {
+		return fmt.Errorf("ref error: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, got)
+	}
+	if exp != got {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCase{{input: "1\n0 1 0 1 0\n1\n0 0\n"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/44/verifierH.go
+++ b/0-999/0-99/40-49/44/verifierH.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(s string) string {
+	n := len(s)
+	dpPrev := make([]*big.Int, 10)
+	dpCur := make([]*big.Int, 10)
+	for i := 0; i < 10; i++ {
+		dpPrev[i] = big.NewInt(1)
+		dpCur[i] = big.NewInt(0)
+	}
+	for i := 1; i < n; i++ {
+		for d := 0; d < 10; d++ {
+			dpCur[d].SetInt64(0)
+		}
+		ai := int(s[i] - '0')
+		for prev := 0; prev < 10; prev++ {
+			count := dpPrev[prev]
+			if count.Sign() == 0 {
+				continue
+			}
+			sum := ai + prev
+			if sum%2 == 0 {
+				next := sum / 2
+				dpCur[next].Add(dpCur[next], count)
+			} else {
+				low := sum / 2
+				high := low + 1
+				dpCur[low].Add(dpCur[low], count)
+				dpCur[high].Add(dpCur[high], count)
+			}
+		}
+		dpPrev, dpCur = dpCur, dpPrev
+	}
+	res := big.NewInt(0)
+	for d := 0; d < 10; d++ {
+		res.Add(res, dpPrev[d])
+	}
+	return res.String()
+}
+
+func randDigits(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('0' + rng.Intn(10))
+	}
+	return string(b)
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	s := randDigits(rng, n)
+	return testCase{input: s + "\n", expected: solveCase(s)}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCase{{input: "0\n", expected: "1"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/44/verifierI.go
+++ b/0-999/0-99/40-49/44/verifierI.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct{ input string }
+
+func compileRef() (string, error) {
+	exe := filepath.Join(os.TempDir(), "ref44I")
+	cmd := exec.Command("go", "build", "-o", exe, "44I.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	return testCase{input: fmt.Sprintf("%d\n", n)}
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	run := func(path string) (string, error) {
+		cmd := exec.Command(path)
+		cmd.Stdin = strings.NewReader(tc.input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err := cmd.Run()
+		return strings.TrimSpace(out.String()), err
+	}
+	exp, err := run(ref)
+	if err != nil {
+		return fmt.Errorf("ref error: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, got)
+	}
+	if exp != got {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCase{{input: "1\n"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/44/verifierJ.go
+++ b/0-999/0-99/40-49/44/verifierJ.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct{ input string }
+
+func compileRef() (string, error) {
+	exe := filepath.Join(os.TempDir(), "ref44J")
+	cmd := exec.Command("go", "build", "-o", exe, "44J.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func randGrid(rng *rand.Rand, n, m int) []string {
+	chars := []byte{'b', 'w', '.'}
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			b[j] = chars[rng.Intn(len(chars))]
+		}
+		grid[i] = string(b)
+	}
+	return grid
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	grid := randGrid(rng, n, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, row := range grid {
+		sb.WriteString(row + "\n")
+	}
+	return testCase{input: sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	run := func(path string) (string, error) {
+		cmd := exec.Command(path)
+		cmd.Stdin = strings.NewReader(tc.input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err := cmd.Run()
+		return strings.TrimSpace(out.String()), err
+	}
+	exp, err := run(ref)
+	if err != nil {
+		return fmt.Errorf("ref error: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, got)
+	}
+	if exp != got {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierJ.go /path/to/binary")
+		os.Exit(1)
+	}
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCase{{input: "1 1\n.\n"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for contest 44 problems (A–J)
- each verifier generates 100+ tests and compares against either a reference implementation or an internal solver

## Testing
- `go build 0-999/0-99/40-49/44/verifierA.go`

------
https://chatgpt.com/codex/tasks/task_e_687e60fd2f948324b10d32bdc33b4577