### PR TITLE
Add verifiers for contest 59

### DIFF
--- a/0-999/0-99/50-59/59/verifierA.go
+++ b/0-999/0-99/50-59/59/verifierA.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedA(s string) string {
+	upper, lower := 0, 0
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 'A' && s[i] <= 'Z' {
+			upper++
+		} else {
+			lower++
+		}
+	}
+	if upper > lower {
+		return strings.ToUpper(s)
+	}
+	return strings.ToLower(s)
+}
+
+func generateCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		} else {
+			sb.WriteByte(byte('A' + rng.Intn(26)))
+		}
+	}
+	word := sb.String()
+	return word + "\n", expectedA(word)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseA(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/59/verifierB.go
+++ b/0-999/0-99/50-59/59/verifierB.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedB(arr []int) string {
+	sum := 0
+	minOdd := 101
+	for _, v := range arr {
+		sum += v
+		if v%2 == 1 && v < minOdd {
+			minOdd = v
+		}
+	}
+	if sum%2 == 1 {
+		return fmt.Sprintf("%d", sum)
+	}
+	if minOdd <= 100 {
+		return fmt.Sprintf("%d", sum-minOdd)
+	}
+	return "0"
+}
+
+func generateCaseB(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expectedB(arr)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseB(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/59/verifierC.go
+++ b/0-999/0-99/50-59/59/verifierC.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type slot struct{ i, j int }
+
+func expectedC(k int, s string) string {
+	n := len(s)
+	res := []byte(s)
+	for i := 0; i < n/2; i++ {
+		j := n - 1 - i
+		if res[i] != '?' && res[j] != '?' {
+			if res[i] != res[j] {
+				return "IMPOSSIBLE"
+			}
+		} else if res[i] == '?' && res[j] != '?' {
+			res[i] = res[j]
+		} else if res[i] != '?' && res[j] == '?' {
+			res[j] = res[i]
+		}
+	}
+	used := make([]bool, k)
+	for _, c := range res {
+		if c >= 'a' && int(c-'a') < k {
+			used[c-'a'] = true
+		}
+	}
+	var slots []slot
+	for i := 0; i < n/2; i++ {
+		j := n - 1 - i
+		if res[i] == '?' && res[j] == '?' {
+			slots = append(slots, slot{i, j})
+		}
+	}
+	if n%2 == 1 && res[n/2] == '?' {
+		slots = append(slots, slot{n / 2, n / 2})
+	}
+	var missing []byte
+	for i := 0; i < k; i++ {
+		if !used[i] {
+			missing = append(missing, byte('a'+i))
+		}
+	}
+	if len(missing) > len(slots) {
+		return "IMPOSSIBLE"
+	}
+	for idx, c := range missing {
+		sl := slots[idx]
+		res[sl.i] = c
+		res[sl.j] = c
+	}
+	for idx := len(missing); idx < len(slots); idx++ {
+		sl := slots[idx]
+		res[sl.i] = 'a'
+		res[sl.j] = 'a'
+	}
+	for _, c := range res {
+		if c == '?' {
+			return "IMPOSSIBLE"
+		}
+	}
+	finalUsed := make([]bool, k)
+	for _, c := range res {
+		if int(c-'a') < k {
+			finalUsed[c-'a'] = true
+		}
+	}
+	for i := 0; i < k; i++ {
+		if !finalUsed[i] {
+			return "IMPOSSIBLE"
+		}
+	}
+	return string(res)
+}
+
+func generateCaseC(rng *rand.Rand) (string, string) {
+	k := rng.Intn(5) + 1
+	n := rng.Intn(20) + k
+	letters := make([]byte, n)
+	for i := 0; i < n; i++ {
+		r := rng.Intn(k + 1) // include ?
+		if r == k {
+			letters[i] = '?'
+		} else {
+			letters[i] = byte('a' + r)
+		}
+	}
+	s := string(letters)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", k))
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	return sb.String(), expectedC(k, s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseC(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/59/verifierD.go
+++ b/0-999/0-99/50-59/59/verifierD.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCaseD(n int, results []int, teams [][3]int, k int) string {
+	total := 3 * n
+	rank := make([]int, total+1)
+	for i, id := range results {
+		rank[id] = i + 1
+	}
+	isCap := false
+	capIdx := -1
+	mateA, mateB := 0, 0
+	for i := 0; i < n; i++ {
+		team := teams[i]
+		cap := team[0]
+		for j := 1; j < 3; j++ {
+			if rank[team[j]] < rank[cap] {
+				cap = team[j]
+			}
+		}
+		if cap == k {
+			isCap = true
+			capIdx = i
+			a, b := -1, -1
+			for j := 0; j < 3; j++ {
+				if team[j] == k {
+					continue
+				}
+				if a == -1 {
+					a = team[j]
+				} else {
+					b = team[j]
+				}
+			}
+			if a > b {
+				a, b = b, a
+			}
+			mateA, mateB = a, b
+			break
+		}
+	}
+	var ans []int
+	if !isCap {
+		for i := 1; i <= total; i++ {
+			if i == k {
+				continue
+			}
+			ans = append(ans, i)
+		}
+		sort.Ints(ans)
+	} else {
+		takenBefore := make([]bool, total+1)
+		for i := 0; i < capIdx; i++ {
+			for j := 0; j < 3; j++ {
+				takenBefore[teams[i][j]] = true
+			}
+		}
+		var sBefore []int
+		for i := 1; i <= total; i++ {
+			if i == k {
+				continue
+			}
+			if takenBefore[i] {
+				sBefore = append(sBefore, i)
+			}
+		}
+		sort.Ints(sBefore)
+		var sR []int
+		for i := 1; i <= total; i++ {
+			if i == k || i == mateA || i == mateB {
+				continue
+			}
+			if !takenBefore[i] {
+				sR = append(sR, i)
+			}
+		}
+		sort.Ints(sR)
+		idxB := 0
+		haveA, haveB := false, false
+		for !haveA {
+			if idxB < len(sBefore) && sBefore[idxB] < mateA {
+				ans = append(ans, sBefore[idxB])
+				idxB++
+			} else {
+				ans = append(ans, mateA)
+				haveA = true
+			}
+		}
+		for !haveB {
+			if idxB < len(sBefore) && sBefore[idxB] < mateB {
+				ans = append(ans, sBefore[idxB])
+				idxB++
+			} else {
+				ans = append(ans, mateB)
+				haveB = true
+			}
+		}
+		iB, iR := idxB, 0
+		for iB < len(sBefore) && iR < len(sR) {
+			if sBefore[iB] < sR[iR] {
+				ans = append(ans, sBefore[iB])
+				iB++
+			} else {
+				ans = append(ans, sR[iR])
+				iR++
+			}
+		}
+		for iB < len(sBefore) {
+			ans = append(ans, sBefore[iB])
+			iB++
+		}
+		for iR < len(sR) {
+			ans = append(ans, sR[iR])
+			iR++
+		}
+	}
+	var sb strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String()
+}
+
+func generateCaseD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	total := 3 * n
+	perm := rng.Perm(total)
+	results := make([]int, total)
+	for i := 0; i < total; i++ {
+		results[i] = perm[i] + 1
+	}
+	remaining := make([]int, total)
+	for i := 0; i < total; i++ {
+		remaining[i] = results[i]
+	}
+	rank := make(map[int]int, total)
+	for i, id := range results {
+		rank[id] = i
+	}
+	teams := make([][3]int, n)
+	used := make(map[int]bool, total)
+	for i := 0; i < n; i++ {
+		best := -1
+		bestRank := total + 1
+		for _, id := range remaining {
+			if used[id] {
+				continue
+			}
+			if rank[id] < bestRank {
+				bestRank = rank[id]
+				best = id
+			}
+		}
+		pool := []int{}
+		for _, id := range remaining {
+			if used[id] || id == best {
+				continue
+			}
+			pool = append(pool, id)
+		}
+		m1 := pool[rng.Intn(len(pool))]
+		pool2 := []int{}
+		for _, id := range pool {
+			if id != m1 {
+				pool2 = append(pool2, id)
+			}
+		}
+		m2 := pool2[rng.Intn(len(pool2))]
+		teams[i] = [3]int{best, m1, m2}
+		used[best] = true
+		used[m1] = true
+		used[m2] = true
+	}
+	k := rng.Intn(total) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range results {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d %d\n", teams[i][0], teams[i][1], teams[i][2])
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", k))
+	expect := solveCaseD(n, results, teams, k)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseD(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/50-59/59/verifierE.go
+++ b/0-999/0-99/50-59/59/verifierE.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCaseE(n int, edges [][2]int, forb [][3]int) (string, string) {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		x, y := e[0], e[1]
+		adj[x] = append(adj[x], y)
+		adj[y] = append(adj[y], x)
+	}
+	n1 := int64(n) + 1
+	forbid := make(map[int64]bool)
+	for _, t := range forb {
+		a, b, c := t[0], t[1], t[2]
+		key := (int64(a)*n1+int64(b))*n1 + int64(c)
+		forbid[key] = true
+	}
+	type state struct{ prev, cur int }
+	start := state{0, 1}
+	key := func(s state) int64 { return int64(s.prev)*n1 + int64(s.cur) }
+	dist := map[int64]int{key(start): 0}
+	parent := make(map[int64]int64)
+	q := []state{start}
+	var end state
+	found := false
+	for len(q) > 0 && !found {
+		s := q[0]
+		q = q[1:]
+		if s.cur == n {
+			end = s
+			found = true
+			break
+		}
+		for _, w := range adj[s.cur] {
+			if s.prev != 0 {
+				if forbid[(int64(s.prev)*n1+int64(s.cur))*n1+int64(w)] {
+					continue
+				}
+			}
+			ns := state{s.cur, w}
+			nk := key(ns)
+			if _, ok := dist[nk]; !ok {
+				dist[nk] = dist[key(s)] + 1
+				parent[nk] = key(s)
+				q = append(q, ns)
+			}
+		}
+	}
+	if !found {
+		return "-1", ""
+	}
+	path := []int{end.cur}
+	for k := parent[key(end)]; k != -1; k = parent[k] {
+		prev := int(k % n1)
+		path = append(path, prev)
+		if prev == 1 && int(k/n1) == 0 {
+			break
+		}
+	}
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+	d := len(path) - 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", d))
+	for i, v := range path {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String(), ""
+}
+
+func generateCaseE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	nodes := make([]int, n)
+	for i := range nodes {
+		nodes[i] = i + 1
+	}
+	edges := make([][2]int, 0)
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			if rng.Intn(2) == 0 {
+				edges = append(edges, [2]int{i, j})
+			}
+		}
+	}
+	if len(edges) == 0 {
+		edges = append(edges, [2]int{1, n})
+	}
+	forb := make([][3]int, 0)
+	maxForb := rng.Intn(3)
+	for i := 0; i < maxForb; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		c := rng.Intn(n) + 1
+		for a == b {
+			b = rng.Intn(n) + 1
+		}
+		for c == a || c == b {
+			c = rng.Intn(n) + 1
+		}
+		forb = append(forb, [3]int{a, b, c})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, len(edges), len(forb)))
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	for _, t := range forb {
+		fmt.Fprintf(&sb, "%d %d %d\n", t[0], t[1], t[2])
+	}
+	expect, _ := solveCaseE(n, edges, forb)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseE(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 59
- each verifier generates 100 random tests and checks a supplied binary

## Testing
- `go build 0-999/0-99/50-59/59/verifierA.go`
- `go build 0-999/0-99/50-59/59/verifierB.go`
- `go build 0-999/0-99/50-59/59/verifierC.go`
- `go build 0-999/0-99/50-59/59/verifierD.go`
- `go build 0-999/0-99/50-59/59/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e614803108324bd11a6010d96621b