### PR TITLE
Add contest 43 solution verifiers

### DIFF
--- a/0-999/0-99/40-49/43/verifierA.go
+++ b/0-999/0-99/40-49/43/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func winner(names []string) string {
+	counts := make(map[string]int)
+	best := ""
+	max := -1
+	for _, n := range names {
+		counts[n]++
+		if counts[n] > max {
+			max = counts[n]
+			best = n
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	teams := []string{"ALPHA", "BETA", "GAMMA", "DELTA", "OMEGA"}
+	t1 := teams[rng.Intn(len(teams))]
+	t2 := t1
+	if rng.Intn(2) == 1 {
+		for t2 == t1 {
+			t2 = teams[rng.Intn(len(teams))]
+		}
+	}
+	n := rng.Intn(100) + 1
+	names := make([]string, n)
+	var c1 int
+	if t1 == t2 {
+		c1 = n
+	} else {
+		c1 = rng.Intn(n)
+		if c1 == n-c1 {
+			if c1 == 0 {
+				c1 = 1
+			} else {
+				c1++
+			}
+		}
+	}
+	for i := 0; i < c1; i++ {
+		names[i] = t1
+	}
+	for i := c1; i < n; i++ {
+		names[i] = t2
+	}
+	rng.Shuffle(n, func(i, j int) { names[i], names[j] = names[j], names[i] })
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, name := range names {
+		fmt.Fprintln(&sb, name)
+	}
+	return sb.String(), winner(names)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/43/verifierB.go
+++ b/0-999/0-99/40-49/43/verifierB.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func canCompose(s1, s2 string) bool {
+	count := make(map[rune]int)
+	for _, c := range s1 {
+		if c != ' ' {
+			count[c]++
+		}
+	}
+	for _, c := range s2 {
+		if c == ' ' {
+			continue
+		}
+		if count[c] == 0 {
+			return false
+		}
+		count[c]--
+	}
+	return true
+}
+
+func randString(rng *rand.Rand, n int) string {
+	letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(5) == 0 {
+			sb.WriteByte(' ')
+		} else {
+			sb.WriteByte(letters[rng.Intn(len(letters))])
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string, string) {
+	s1 := randString(rng, rng.Intn(20)+1)
+	s2 := randString(rng, rng.Intn(20)+1)
+	var sb strings.Builder
+	sb.WriteString(s1)
+	sb.WriteByte('\n')
+	sb.WriteString(s2)
+	sb.WriteByte('\n')
+	exp := "NO"
+	if canCompose(s1, s2) {
+		exp = "YES"
+	}
+	return sb.String(), exp, fmt.Sprintf("%q\n%q\n", s1, s2)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp, _ := generateCase(rng)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/43/verifierC.go
+++ b/0-999/0-99/40-49/43/verifierC.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(nums []int) int {
+	cnt := [3]int{}
+	for _, v := range nums {
+		cnt[v%3]++
+	}
+	ans := cnt[0] / 2
+	if cnt[1] < cnt[2] {
+		ans += cnt[1]
+	} else {
+		ans += cnt[2]
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1
+	nums := make([]int, n)
+	for i := range nums {
+		nums[i] = rng.Intn(100000000) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(nums)
+}
+
+func runCase(exe, input string, exp int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/43/verifierD.go
+++ b/0-999/0-99/40-49/43/verifierD.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type coord struct{ x, y int }
+
+type tele struct{ from, to coord }
+
+func minTeleporters(n, m int) int {
+	if (n == 1 && m == 1) || (n == 1 && m == 2) || (n == 2 && m == 1) {
+		return 0
+	}
+	if n == 1 || m == 1 {
+		return 1
+	}
+	if (n*m)%2 == 0 {
+		return 0
+	}
+	return 1
+}
+
+func generateCases() [][2]int {
+	cases := [][2]int{{1, 1}, {1, 2}, {2, 1}, {2, 2}, {3, 3}, {2, 3}, {3, 2}, {4, 5}}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(cases) < 100 {
+		n := rng.Intn(7) + 1
+		m := rng.Intn(7) + 1
+		if n*m < 2 {
+			continue
+		}
+		cases = append(cases, [2]int{n, m})
+	}
+	return cases
+}
+
+func verify(n, m int, exe string) error {
+	input := fmt.Sprintf("%d %d\n", n, m)
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(strings.TrimSpace(scanner.Text()))
+	if err != nil {
+		return fmt.Errorf("invalid teleporter count: %v", err)
+	}
+	if k != minTeleporters(n, m) {
+		return fmt.Errorf("expected %d teleporters got %d", minTeleporters(n, m), k)
+	}
+	teleports := make(map[coord]coord)
+	for i := 0; i < k; i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("missing teleporter line %d", i+1)
+		}
+		var x1, y1, x2, y2 int
+		if _, err := fmt.Sscan(scanner.Text(), &x1, &y1, &x2, &y2); err != nil {
+			return fmt.Errorf("invalid teleporter line: %v", err)
+		}
+		if x1 < 1 || x1 > n || y1 < 1 || y1 > m || x2 < 1 || x2 > n || y2 < 1 || y2 > m {
+			return fmt.Errorf("teleporter coords out of range")
+		}
+		from := coord{x1, y1}
+		if _, ok := teleports[from]; ok {
+			return fmt.Errorf("duplicate teleporter from %v", from)
+		}
+		teleports[from] = coord{x2, y2}
+	}
+	path := make([]coord, 0, n*m+1)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var x, y int
+		if _, err := fmt.Sscan(line, &x, &y); err != nil {
+			return fmt.Errorf("bad path line: %v", err)
+		}
+		path = append(path, coord{x, y})
+	}
+	if len(path) != n*m+1 {
+		return fmt.Errorf("path length %d expected %d", len(path), n*m+1)
+	}
+	if path[0] != (coord{1, 1}) || path[len(path)-1] != (coord{1, 1}) {
+		return fmt.Errorf("path must start and end at 1 1")
+	}
+	counts := make(map[coord]int)
+	counts[path[0]]++
+	cur := path[0]
+	for i := 1; i < len(path); i++ {
+		nxt := path[i]
+		if nxt.x < 1 || nxt.x > n || nxt.y < 1 || nxt.y > m {
+			return fmt.Errorf("path coordinate out of range")
+		}
+		if t, ok := teleports[cur]; ok && t == nxt {
+			// teleport
+		} else {
+			dx := cur.x - nxt.x
+			if dx < 0 {
+				dx = -dx
+			}
+			dy := cur.y - nxt.y
+			if dy < 0 {
+				dy = -dy
+			}
+			if dx+dy != 1 {
+				return fmt.Errorf("invalid move from %v to %v", cur, nxt)
+			}
+		}
+		counts[nxt]++
+		cur = nxt
+	}
+	for x := 1; x <= n; x++ {
+		for y := 1; y <= m; y++ {
+			c := counts[coord{x, y}]
+			if x == 1 && y == 1 {
+				if c != 2 {
+					return fmt.Errorf("(1,1) visited %d times", c)
+				}
+			} else if c != 1 {
+				return fmt.Errorf("cell %d %d visited %d times", x, y, c)
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	for i, tc := range generateCases() {
+		if err := verify(tc[0], tc[1], exe); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d (%d %d) failed: %v\n", i+1, tc[0], tc[1], err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/43/verifierE.go
+++ b/0-999/0-99/40-49/43/verifierE.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Segment struct {
+	speed int
+	time  int
+}
+
+func countCrosses(a, b []Segment) int64 {
+	i, j := 0, 0
+	remA, remB := a[0].time, b[0].time
+	vA, vB := a[0].speed, b[0].speed
+	posA, posB := 0, 0
+	var crosses int64
+	for i < len(a) && j < len(b) {
+		dur := remA
+		if remB < dur {
+			dur = remB
+		}
+		delta0 := posA - posB
+		dv := vA - vB
+		if dv > 0 {
+			if delta0 < 0 && delta0+dv*dur > 0 {
+				crosses++
+			}
+		} else if dv < 0 {
+			if delta0 > 0 && delta0+dv*dur < 0 {
+				crosses++
+			}
+		}
+		posA += vA * dur
+		posB += vB * dur
+		remA -= dur
+		remB -= dur
+		if remA == 0 {
+			i++
+			if i < len(a) {
+				remA = a[i].time
+				vA = a[i].speed
+			}
+		}
+		if remB == 0 {
+			j++
+			if j < len(b) {
+				remB = b[j].time
+				vB = b[j].speed
+			}
+		}
+	}
+	return crosses
+}
+
+func expected(cars [][]Segment) int64 {
+	var total int64
+	for i := 0; i < len(cars); i++ {
+		for j := i + 1; j < len(cars); j++ {
+			total += countCrosses(cars[i], cars[j])
+		}
+	}
+	return total
+}
+
+func randomSegments(rng *rand.Rand, s int) []Segment {
+	k := rng.Intn(3) + 1
+	segs := make([]Segment, k)
+	remaining := s
+	for i := 0; i < k-1; i++ {
+		v := rng.Intn(10) + 1
+		maxLen := remaining - (k - i - 1)
+		if maxLen < 1 {
+			maxLen = 1
+		}
+		length := rng.Intn(maxLen) + 1
+		t := length / v
+		if t == 0 {
+			t = 1
+			length = v
+		} else {
+			length = v * t
+		}
+		if length > remaining-(k-i-1) {
+			length = remaining - (k - i - 1)
+			t = length / v
+		}
+		segs[i] = Segment{v, t}
+		remaining -= length
+	}
+	segs[k-1] = Segment{1, remaining}
+	return segs
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(4) + 2
+	s := rng.Intn(40) + 10
+	cars := make([][]Segment, n)
+	for i := 0; i < n; i++ {
+		cars[i] = randomSegments(rng, s)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, s)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d", len(cars[i]))
+		for _, seg := range cars[i] {
+			fmt.Fprintf(&sb, " %d %d", seg.speed, seg.time)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), expected(cars)
+}
+
+func runCase(exe, input string, exp int64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 43
- each verifier generates at least 100 random tests and checks a solution binary

## Testing
- `go build 0-999/0-99/40-49/43/verifierA.go`
- `go build 0-999/0-99/40-49/43/verifierB.go`
- `go build 0-999/0-99/40-49/43/verifierC.go`
- `go build 0-999/0-99/40-49/43/verifierD.go`
- `go build 0-999/0-99/40-49/43/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e60f7c7248324b758d75b0ccab63d