### PR TITLE
Add verifiers for contest 42

### DIFF
--- a/0-999/0-99/40-49/42/verifierA.go
+++ b/0-999/0-99/40-49/42/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func computeVolume(n int, V float64, a, b []float64) float64 {
+	sumA := 0.0
+	for _, v := range a {
+		sumA += v
+	}
+	maxPan := V / sumA
+	maxIng := math.Inf(1)
+	for i := 0; i < n; i++ {
+		ratio := b[i] / a[i]
+		if ratio < maxIng {
+			maxIng = ratio
+		}
+	}
+	x := maxPan
+	if maxIng < x {
+		x = maxIng
+	}
+	return sumA * x
+}
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	n := rng.Intn(5) + 1
+	V := float64(rng.Intn(20) + 1)
+	a := make([]float64, n)
+	b := make([]float64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %.0f\n", n, V))
+	for i := 0; i < n; i++ {
+		a[i] = float64(rng.Intn(10) + 1)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%.0f", a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		b[i] = float64(rng.Intn(20))
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%.0f", b[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), computeVolume(n, V, a, b)
+}
+
+func runCase(bin, input string, expected float64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	diff := math.Abs(got - expected)
+	tol := 1e-4 * math.Max(1, math.Abs(expected))
+	if diff > tol {
+		return fmt.Errorf("expected %.5f got %.5f", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/42/verifierB.go
+++ b/0-999/0-99/40-49/42/verifierB.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Pos struct{ x, y int }
+
+func posFrom(s string) Pos {
+	return Pos{int(s[0] - 'a'), int(s[1] - '1')}
+}
+
+func pathClear(a, b Pos, occ [][]int) bool {
+	dx, dy := 0, 0
+	if b.x > a.x {
+		dx = 1
+	} else if b.x < a.x {
+		dx = -1
+	}
+	if b.y > a.y {
+		dy = 1
+	} else if b.y < a.y {
+		dy = -1
+	}
+	x, y := a.x+dx, a.y+dy
+	for x != b.x || y != b.y {
+		if occ[y][x] != 0 {
+			return false
+		}
+		x += dx
+		y += dy
+	}
+	return true
+}
+
+func isAttacked(occ [][]int, rooks []Pos, wk Pos, p Pos) bool {
+	for _, r := range rooks {
+		if r.x == p.x || r.y == p.y {
+			if pathClear(r, p, occ) {
+				return true
+			}
+		}
+	}
+	dx := wk.x - p.x
+	if dx < 0 {
+		dx = -dx
+	}
+	dy := wk.y - p.y
+	if dy < 0 {
+		dy = -dy
+	}
+	if dx <= 1 && dy <= 1 {
+		return true
+	}
+	return false
+}
+
+func solve(s1, s2, s3, s4 string) string {
+	rk1 := posFrom(s1)
+	rk2 := posFrom(s2)
+	wk := posFrom(s3)
+	bk := posFrom(s4)
+	occ := make([][]int, 8)
+	for i := range occ {
+		occ[i] = make([]int, 8)
+	}
+	occ[rk1.y][rk1.x] = 1
+	occ[rk2.y][rk2.x] = 1
+	occ[wk.y][wk.x] = 2
+	occ[bk.y][bk.x] = 3
+	rooks := []Pos{rk1, rk2}
+	if !isAttacked(occ, rooks, wk, bk) {
+		return "OTHER"
+	}
+	dirs := []int{-1, 0, 1}
+	for _, dx := range dirs {
+		for _, dy := range dirs {
+			if dx == 0 && dy == 0 {
+				continue
+			}
+			nx, ny := bk.x+dx, bk.y+dy
+			if nx < 0 || nx > 7 || ny < 0 || ny > 7 {
+				continue
+			}
+			if nx == wk.x && ny == wk.y {
+				continue
+			}
+			newRooks := make([]Pos, 0, 2)
+			for _, r := range rooks {
+				if r.x == nx && r.y == ny {
+					continue
+				}
+				newRooks = append(newRooks, r)
+			}
+			occ2 := make([][]int, 8)
+			for i := range occ2 {
+				occ2[i] = make([]int, 8)
+			}
+			for _, r := range newRooks {
+				occ2[r.y][r.x] = 1
+			}
+			occ2[wk.y][wk.x] = 2
+			occ2[ny][nx] = 3
+			if !isAttacked(occ2, newRooks, wk, Pos{nx, ny}) {
+				return "OTHER"
+			}
+		}
+	}
+	return "CHECKMATE"
+}
+
+func randomPos(rng *rand.Rand) string {
+	x := rng.Intn(8)
+	y := rng.Intn(8)
+	return fmt.Sprintf("%c%d", 'a'+x, y+1)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	for {
+		s1 := randomPos(rng)
+		s2 := randomPos(rng)
+		s3 := randomPos(rng)
+		s4 := randomPos(rng)
+		if s1 == s2 || s1 == s3 || s1 == s4 || s2 == s3 || s2 == s4 || s3 == s4 {
+			continue
+		}
+		// kings cannot attack each other
+		wk := posFrom(s3)
+		bk := posFrom(s4)
+		dx := wk.x - bk.x
+		if dx < 0 {
+			dx = -dx
+		}
+		dy := wk.y - bk.y
+		if dy < 0 {
+			dy = -dy
+		}
+		if dx <= 1 && dy <= 1 {
+			continue
+		}
+		input := fmt.Sprintf("%s %s %s %s\n", s1, s2, s3, s4)
+		return input, solve(s1, s2, s3, s4)
+	}
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	outStr = strings.ToUpper(outStr)
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/42/verifierC.go
+++ b/0-999/0-99/40-49/42/verifierC.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func applyOps(nums []int, ops []string) error {
+	if len(ops) > 1000 {
+		return fmt.Errorf("too many operations")
+	}
+	for _, op := range ops {
+		if len(op) < 2 {
+			return fmt.Errorf("bad operation %q", op)
+		}
+		pos := int(op[1] - '1')
+		if pos < 0 || pos > 3 {
+			return fmt.Errorf("bad position in %q", op)
+		}
+		j := (pos + 1) % 4
+		switch op[0] {
+		case '+':
+			nums[pos]++
+			nums[j]++
+		case '/':
+			if nums[pos]%2 != 0 || nums[j]%2 != 0 {
+				return fmt.Errorf("invalid divide in %q", op)
+			}
+			nums[pos] /= 2
+			nums[j] /= 2
+		default:
+			return fmt.Errorf("invalid op %q", op)
+		}
+	}
+	for _, v := range nums {
+		if v != 1 {
+			return fmt.Errorf("final numbers not all ones: %v", nums)
+		}
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	nums := make([]int, 4)
+	for i := range nums {
+		nums[i] = rng.Intn(20) + 1
+	}
+	input := fmt.Sprintf("%d %d %d %d\n", nums[0], nums[1], nums[2], nums[3])
+	cp := make([]int, 4)
+	copy(cp, nums)
+	return input, cp
+}
+
+func runCase(bin, input string, nums []int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) == 1 && strings.TrimSpace(lines[0]) == "-1" {
+		return fmt.Errorf("reported impossible but solution exists")
+	}
+	ops := make([]string, 0, len(lines))
+	for _, ln := range lines {
+		ln = strings.TrimSpace(ln)
+		if ln == "" {
+			continue
+		}
+		ops = append(ops, ln)
+	}
+	if err := applyOps(nums, ops); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, nums := generateCase(rng)
+		if err := runCase(bin, in, nums); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/42/verifierD.go
+++ b/0-999/0-99/40-49/42/verifierD.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func validateMatrix(mat [][]int) error {
+	n := len(mat)
+	seen := map[int]bool{}
+	base := make([]int, n)
+	for i := 0; i < n; i++ {
+		if len(mat[i]) != n {
+			return fmt.Errorf("row %d length mismatch", i)
+		}
+		if mat[i][i] != 0 {
+			return fmt.Errorf("diagonal not zero")
+		}
+		if i > 0 {
+			base[i] = mat[0][i]
+			if base[i] <= 0 || base[i] > 1000 {
+				return fmt.Errorf("edge weight out of range")
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if mat[i][j] != mat[j][i] {
+				return fmt.Errorf("matrix not symmetric")
+			}
+			if mat[i][j] <= 0 || mat[i][j] > 1000 {
+				return fmt.Errorf("edge weight out of range")
+			}
+			if seen[mat[i][j]] {
+				return fmt.Errorf("weights not distinct")
+			}
+			seen[mat[i][j]] = true
+			if base[i]+base[j] != mat[i][j] {
+				return fmt.Errorf("does not satisfy sum property")
+			}
+		}
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 3 // 3..6
+	return fmt.Sprintf("%d\n", n)
+}
+
+func runCase(bin, input string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	n := 0
+	fmt.Sscan(strings.TrimSpace(input), &n)
+	if len(lines) != n {
+		return fmt.Errorf("expected %d lines got %d", n, len(lines))
+	}
+	mat := make([][]int, n)
+	for i := 0; i < n; i++ {
+		parts := strings.Fields(lines[i])
+		if len(parts) != n {
+			return fmt.Errorf("line %d expected %d numbers", i+1, n)
+		}
+		mat[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			fmt.Sscan(parts[j], &mat[i][j])
+		}
+	}
+	return validateMatrix(mat)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/42/verifierE.go
+++ b/0-999/0-99/40-49/42/verifierE.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v, w int }
+
+type DSU struct{ p, r []int }
+
+func newDSU(n int) *DSU {
+	p := make([]int, n)
+	r := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = i
+	}
+	return &DSU{p, r}
+}
+
+func (d *DSU) find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *DSU) union(x, y int) bool {
+	rx, ry := d.find(x), d.find(y)
+	if rx == ry {
+		return false
+	}
+	if d.r[rx] < d.r[ry] {
+		d.p[rx] = ry
+	} else if d.r[ry] < d.r[rx] {
+		d.p[ry] = rx
+	} else {
+		d.p[ry] = rx
+		d.r[rx]++
+	}
+	return true
+}
+
+func mstCost(n int, edges []edge) int64 {
+	sort.Slice(edges, func(i, j int) bool { return edges[i].w < edges[j].w })
+	d := newDSU(n)
+	var total int64
+	cnt := 0
+	for _, e := range edges {
+		if d.union(e.u, e.v) {
+			total += int64(e.w)
+			cnt++
+			if cnt == n-1 {
+				break
+			}
+		}
+	}
+	if cnt != n-1 {
+		return -1
+	}
+	return total
+}
+
+func generateCase(rng *rand.Rand) (string, int64, int) {
+	n := rng.Intn(4) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges) + 1
+	edges := make([]edge, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n%d\n", n, m))
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		for v == u {
+			v = rng.Intn(n)
+		}
+		w := rng.Intn(20) + 1
+		edges[i] = edge{u, v, w}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", u+1, v+1, w))
+	}
+	q := rng.Intn(5) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		a := rng.Intn(n)
+		b := rng.Intn(n)
+		for b == a {
+			b = rng.Intn(n)
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", a+1, b+1))
+	}
+	cost := mstCost(n, edges)
+	return sb.String(), cost, q
+}
+
+func runCase(bin, input string, cost int64, q int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != q {
+		return fmt.Errorf("expected %d lines, got %d", q, len(lines))
+	}
+	for i := 0; i < q; i++ {
+		var val int64
+		if _, err := fmt.Sscan(strings.TrimSpace(lines[i]), &val); err != nil {
+			return fmt.Errorf("bad output line %d", i+1)
+		}
+		if val != cost {
+			return fmt.Errorf("line %d: expected %d got %d", i+1, cost, val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, cost, q := generateCase(rng)
+		if err := runCase(bin, in, cost, q); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E in contest 42
- each verifier generates 100 random test cases and checks a binary solution

## Testing
- `go run 0-999/0-99/40-49/42/verifierA.go /tmp/42A_bin`
- `go run 0-999/0-99/40-49/42/verifierB.go /tmp/42B_bin`
- `go run 0-999/0-99/40-49/42/verifierC.go /tmp/42C_bin`
- `go run 0-999/0-99/40-49/42/verifierD.go /tmp/42D_bin`
- `go run 0-999/0-99/40-49/42/verifierE.go /tmp/42E_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e60f29f988324b7b6b2daa6c7f914