### PR TITLE
Add verifiers for contest 41

### DIFF
--- a/0-999/0-99/40-49/41/verifierA.go
+++ b/0-999/0-99/40-49/41/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func reverse(s string) string {
+	b := []byte(s)
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	letters := make([]byte, n)
+	for i := 0; i < n; i++ {
+		letters[i] = byte('a' + rng.Intn(26))
+	}
+	s := string(letters)
+	if rng.Intn(2) == 0 {
+		t := reverse(s)
+		return fmt.Sprintf("%s\n%s\n", s, t), "YES\n"
+	}
+	// make t different
+	t := reverse(s)
+	idx := rng.Intn(len(t))
+	tBytes := []byte(t)
+	orig := tBytes[idx]
+	for tBytes[idx] == orig {
+		tBytes[idx] = byte('a' + rng.Intn(26))
+	}
+	t = string(tBytes)
+	return fmt.Sprintf("%s\n%s\n", s, t), "NO\n"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/41/verifierB.go
+++ b/0-999/0-99/40-49/41/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solve(n, b int, a []int) int {
+	ans := b
+	for i := 0; i < n; i++ {
+		if a[i] > b {
+			continue
+		}
+		k := b / a[i]
+		for j := i + 1; j < n; j++ {
+			if a[j] <= a[i] {
+				continue
+			}
+			val := b + k*(a[j]-a[i])
+			if val > ans {
+				ans = val
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(8) + 1
+	b := rng.Intn(1000) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(1000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, b))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", a[i]))
+	}
+	sb.WriteString("\n")
+	return sb.String(), solve(n, b, a)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err2 := strconv.Atoi(strings.TrimSpace(out))
+		if err2 != nil || got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/41/verifierC.go
+++ b/0-999/0-99/40-49/41/verifierC.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(s string) string {
+	n := len(s)
+	type state struct {
+		ok  bool
+		str string
+	}
+	dp := make([][2]state, n+1)
+	dp[0][0] = state{true, ""}
+	update := func(i, used int, cand string) {
+		st := &dp[i][used]
+		if !st.ok || len(cand) < len(st.str) || (len(cand) == len(st.str) && cand < st.str) {
+			st.ok = true
+			st.str = cand
+		}
+	}
+	for i := 0; i < n; i++ {
+		for used := 0; used < 2; used++ {
+			cur := dp[i][used]
+			if !cur.ok {
+				continue
+			}
+			c := s[i]
+			update(i+1, used, cur.str+string(c))
+			if used == 0 && i > 0 && i+2 < n {
+				if s[i] == 'a' && s[i+1] == 't' {
+					update(i+2, 1, cur.str+"@")
+				}
+			}
+			if i > 0 && i+3 < n {
+				if s[i] == 'd' && s[i+1] == 'o' && s[i+2] == 't' {
+					update(i+3, used, cur.str+".")
+				}
+			}
+		}
+	}
+	if dp[n][1].ok {
+		return dp[n][1].str
+	}
+	return ""
+}
+
+func genEmail(rng *rand.Rand) string {
+	parts := rng.Intn(3) + 1
+	var sb strings.Builder
+	for i := 0; i < parts; i++ {
+		l := rng.Intn(5) + 1
+		for j := 0; j < l; j++ {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		}
+		if i+1 < parts {
+			sb.WriteByte('.')
+		}
+	}
+	local := sb.String()
+	sb.Reset()
+	domParts := rng.Intn(2) + 1
+	for i := 0; i < domParts; i++ {
+		l := rng.Intn(5) + 1
+		for j := 0; j < l; j++ {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		}
+		if i+1 < domParts {
+			sb.WriteByte('.')
+		}
+	}
+	domain := sb.String()
+	return local + "@" + domain
+}
+
+func describe(email string) string {
+	email = strings.ReplaceAll(email, ".", "dot")
+	email = strings.ReplaceAll(email, "@", "at")
+	return email
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	email := genEmail(rng)
+	desc := describe(email)
+	exp := solve(desc)
+	return desc + "\n", exp
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/41/verifierD.go
+++ b/0-999/0-99/40-49/41/verifierD.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// solve uses the DP algorithm from 41D.go to compute expected result
+func solve(n, m, k int, grid []string) (int, int, string) {
+	K := k + 1
+	mp := make([][]int, n+1)
+	for i := 0; i <= n; i++ {
+		mp[i] = make([]int, m+1)
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			mp[i][j] = int(grid[i-1][j-1] - '0')
+		}
+	}
+	f := make([][][]int, n+1)
+	dir := make([][][]byte, n+1)
+	for i := 0; i <= n; i++ {
+		f[i] = make([][]int, m+1)
+		dir[i] = make([][]byte, m+1)
+		for j := 0; j <= m; j++ {
+			f[i][j] = make([]int, K)
+			dir[i][j] = make([]byte, K)
+			for u := 0; u < K; u++ {
+				f[i][j][u] = -1
+			}
+		}
+	}
+	for j := 1; j <= m; j++ {
+		r := mp[n][j] % K
+		f[n][j][r] = mp[n][j]
+	}
+	for i := n - 1; i >= 1; i-- {
+		for j := 1; j <= m; j++ {
+			for u := 0; u < K; u++ {
+				u0 := (u + mp[i][j]) % K
+				if j > 1 && f[i+1][j-1][u] >= 0 {
+					v := f[i+1][j-1][u] + mp[i][j]
+					if v > f[i][j][u0] {
+						f[i][j][u0] = v
+						dir[i][j][u0] = 'R'
+					}
+				}
+				if j < m && f[i+1][j+1][u] >= 0 {
+					v := f[i+1][j+1][u] + mp[i][j]
+					if v > f[i][j][u0] {
+						f[i][j][u0] = v
+						dir[i][j][u0] = 'L'
+					}
+				}
+			}
+		}
+	}
+	ans := -1
+	startCol := 1
+	for j := 1; j <= m; j++ {
+		if f[1][j][0] > ans {
+			ans = f[1][j][0]
+			startCol = j
+		}
+	}
+	if ans < 0 {
+		return -1, 0, ""
+	}
+	var path []byte
+	var start int
+	var find func(i, j, u int)
+	find = func(i, j, u int) {
+		if i == n {
+			start = j
+			return
+		}
+		sum := f[i][j][u]
+		u0 := (sum - mp[i][j]) % K
+		if u0 < 0 {
+			u0 += K
+		}
+		d := dir[i][j][u]
+		if d == 'R' {
+			find(i+1, j-1, u0)
+		} else {
+			find(i+1, j+1, u0)
+		}
+		path = append(path, d)
+	}
+	find(1, startCol, 0)
+	return ans, start, string(path)
+}
+
+func generateCase(rng *rand.Rand) (string, int, int, string) {
+	n := rng.Intn(4) + 2
+	m := rng.Intn(4) + 2
+	k := rng.Intn(3)
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			b[j] = byte('0' + rng.Intn(10))
+		}
+		grid[i] = string(b)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		sb.WriteString(grid[i] + "\n")
+	}
+	ans, start, path := solve(n, m, k, grid)
+	if ans < 0 {
+		return sb.String(), -1, 0, ""
+	}
+	return sb.String(), ans, start, path
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expAns, expStart, expPath := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		lines := strings.Split(out, "\n")
+		if expAns < 0 {
+			if strings.TrimSpace(lines[0]) != "-1" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected -1 got %s\ninput:\n%s", i+1, out, in)
+				os.Exit(1)
+			}
+			continue
+		}
+		if len(lines) < 3 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected 3 lines got %d\ninput:\n%s", i+1, len(lines), in)
+			os.Exit(1)
+		}
+		gotAns, err1 := strconv.Atoi(strings.TrimSpace(lines[0]))
+		gotStart, err2 := strconv.Atoi(strings.TrimSpace(lines[1]))
+		gotPath := strings.TrimSpace(lines[2])
+		if err1 != nil || err2 != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid integers\ninput:\n%s", i+1, in)
+			os.Exit(1)
+		}
+		if gotAns != expAns || gotStart != expStart || gotPath != expPath {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d %d %q got %d %d %q\ninput:\n%s", i+1, expAns, expStart, expPath, gotAns, gotStart, gotPath, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/40-49/41/verifierE.go
+++ b/0-999/0-99/40-49/41/verifierE.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solve(n int) (int, []string) {
+	a := n / 2
+	b := n - a
+	m := a * b
+	edges := make([]string, 0, m)
+	for i := 0; i < a; i++ {
+		for j := a; j < n; j++ {
+			edges = append(edges, fmt.Sprintf("%d %d", i+1, j+1))
+		}
+	}
+	return m, edges
+}
+
+func generateCase(rng *rand.Rand) (string, int, []string) {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	m, edges := solve(n)
+	return sb.String(), m, edges
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expM, expEdges := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		lines := strings.Split(out, "\n")
+		if len(lines) < 1+expM {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected at least %d lines got %d\ninput:\n%s", i+1, 1+expM, len(lines), in)
+			os.Exit(1)
+		}
+		gotM, err := strconv.Atoi(strings.TrimSpace(lines[0]))
+		if err != nil || gotM != expM {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected m=%d got %s\ninput:\n%s", i+1, expM, lines[0], in)
+			os.Exit(1)
+		}
+		for j := 0; j < expM; j++ {
+			if strings.TrimSpace(lines[j+1]) != expEdges[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed at edge %d: expected %q got %q\ninput:\n%s", i+1, j+1, expEdges[j], strings.TrimSpace(lines[j+1]), in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 41 problems A through E
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go run verifierA.go ./41A_bin`
- `go run verifierB.go ./41B_bin`
- `go run verifierC.go ./41C_bin`
- `go run verifierD.go ./41D_bin`
- `go run verifierE.go ./41E_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e60eda02c832481cb7872babf3e52