### PR TITLE
Add contest 39 Go verifiers

### DIFF
--- a/0-999/0-99/30-39/39/verifierA.go
+++ b/0-999/0-99/30-39/39/verifierA.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+// solveA implements the logic of 39A using the code from 39A.go.
+func solveA(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var a0 int
+	var expr string
+	if _, err := fmt.Fscan(reader, &a0, &expr); err != nil {
+		return ""
+	}
+	type Task struct {
+		w    int
+		c    int
+		pre  bool
+		sign int
+	}
+	tasks := make([]Task, 0, len(expr))
+	i := 0
+	n := len(expr)
+	sign := 1
+	for i < n {
+		coef := 1
+		start := i
+		tmp := 0
+		for i < n && expr[i] >= '0' && expr[i] <= '9' {
+			tmp = tmp*10 + int(expr[i]-'0')
+			i++
+		}
+		if i < n && expr[i] == '*' && i > start {
+			coef = tmp
+			i++
+		} else {
+			i = start
+			coef = 1
+		}
+		pre := false
+		if i+1 < n && expr[i] == '+' && expr[i+1] == '+' {
+			pre = true
+			i += 2
+			i++
+		} else if i < n && expr[i] == 'a' {
+			i++
+			if i+1 < n && expr[i] == '+' && expr[i+1] == '+' {
+				pre = false
+				i += 2
+			}
+		}
+		tasks = append(tasks, Task{w: sign * coef, c: coef, pre: pre, sign: sign})
+		if i < n {
+			if expr[i] == '+' {
+				sign = 1
+			} else if expr[i] == '-' {
+				sign = -1
+			}
+			i++
+		}
+	}
+	sort.Slice(tasks, func(i, j int) bool { return tasks[i].w < tasks[j].w })
+	a := a0
+	var total int64
+	for _, t := range tasks {
+		if t.pre {
+			a++
+			total += int64(t.sign) * int64(t.c) * int64(a)
+		} else {
+			total += int64(t.sign) * int64(t.c) * int64(a)
+			a++
+		}
+	}
+	return fmt.Sprintf("%d\n", total)
+}
+
+func generateCaseA(rng *rand.Rand) string {
+	a := rng.Intn(2001) - 1000
+	terms := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", a))
+	for i := 0; i < terms; i++ {
+		if i > 0 {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('+')
+			} else {
+				sb.WriteByte('-')
+			}
+		}
+		coef := 1
+		if rng.Intn(3) == 0 {
+			coef = rng.Intn(5) + 1
+		}
+		if coef != 1 {
+			sb.WriteString(fmt.Sprintf("%d*", coef))
+		}
+		if rng.Intn(2) == 0 {
+			sb.WriteString("a++")
+		} else {
+			sb.WriteString("++a")
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseA(rng)
+	}
+	for i, tc := range cases {
+		expect := solveA(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/39/verifierB.go
+++ b/0-999/0-99/30-39/39/verifierB.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return ""
+	}
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	pos := make(map[int][]int)
+	for i := 1; i <= n; i++ {
+		v := a[i]
+		pos[v] = append(pos[v], i)
+	}
+	var years []int
+	last := 0
+	for t := 1; ; t++ {
+		found := -1
+		for _, idx := range pos[t] {
+			if idx > last {
+				found = idx
+				break
+			}
+		}
+		if found == -1 {
+			break
+		}
+		years = append(years, found)
+		last = found
+	}
+	k := len(years)
+	if k == 0 {
+		return "0\n"
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", k))
+	for i, idx := range years {
+		year := 2000 + idx
+		if i+1 < k {
+			sb.WriteString(fmt.Sprintf("%d ", year))
+		} else {
+			sb.WriteString(fmt.Sprintf("%d\n", year))
+		}
+	}
+	return sb.String()
+}
+
+func generateCaseB(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(5) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseB(rng)
+	}
+	for i, tc := range cases {
+		expect := solveB(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/39/verifierC.go
+++ b/0-999/0-99/30-39/39/verifierC.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(input string) string {
+	cmd := exec.Command("go", "run", "39C.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return ""
+	}
+	return out.String()
+}
+
+func generateCaseC(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := rng.Intn(10) + 1
+		y := rng.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseC(rng)
+	}
+	for i, tc := range cases {
+		expect := solveC(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/39/verifierD.go
+++ b/0-999/0-99/30-39/39/verifierD.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var x1, y1, z1 int
+	var x2, y2, z2 int
+	if _, err := fmt.Fscan(r, &x1, &y1, &z1, &x2, &y2, &z2); err != nil {
+		return ""
+	}
+	if x1 == x2 || y1 == y2 || z1 == z2 {
+		return "YES\n"
+	}
+	return "NO\n"
+}
+
+func generateCaseD(rng *rand.Rand) string {
+	a := make([]int, 6)
+	for i := range a {
+		a[i] = rng.Intn(2)
+	}
+	return fmt.Sprintf("%d %d %d %d %d %d\n", a[0], a[1], a[2], a[3], a[4], a[5])
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseD(rng)
+	}
+	for i, tc := range cases {
+		expect := solveD(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/39/verifierE.go
+++ b/0-999/0-99/30-39/39/verifierE.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(input string) string {
+	cmd := exec.Command("go", "run", "39E.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return ""
+	}
+	return out.String()
+}
+
+func generateCaseE(rng *rand.Rand) string {
+	a := rng.Intn(3) + 1
+	b := rng.Intn(3) + 1
+	n := int64(1)
+	for i := 0; i < b; i++ {
+		n *= int64(a)
+	}
+	n += int64(rng.Intn(10) + 1)
+	return fmt.Sprintf("%d %d %d\n", a, b, n)
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseE(rng)
+	}
+	for i, tc := range cases {
+		expect := solveE(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/39/verifierF.go
+++ b/0-999/0-99/30-39/39/verifierF.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveF(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n int64
+	var m, k int
+	if _, err := fmt.Fscan(r, &n, &m, &k); err != nil {
+		return ""
+	}
+	d := make([]int64, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(r, &d[i])
+	}
+	p := make([]int64, k)
+	for i := 0; i < k; i++ {
+		fmt.Fscan(r, &p[i])
+	}
+	cnt := make([]int, m)
+	minc := k + 1
+	for i := 0; i < m; i++ {
+		c := 0
+		for j := 0; j < k; j++ {
+			if p[j]%d[i] == 0 {
+				c++
+			}
+		}
+		cnt[i] = c
+		if c < minc {
+			minc = c
+		}
+	}
+	var res []int
+	for i := 0; i < m; i++ {
+		if cnt[i] == minc {
+			res = append(res, i+1)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(res)))
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func generateCaseF(rng *rand.Rand) string {
+	n := int64(rng.Intn(100) + 1)
+	m := rng.Intn(5) + 1
+	k := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(10) + 1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < k; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(20) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseF(rng)
+	}
+	for i, tc := range cases {
+		expect := solveF(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/39/verifierG.go
+++ b/0-999/0-99/30-39/39/verifierG.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveG(input string) string {
+	cmd := exec.Command("go", "run", "39G.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return ""
+	}
+	return out.String()
+}
+
+func generateCaseG(rng *rand.Rand) string {
+	typ := rng.Intn(3)
+	switch typ {
+	case 0:
+		target := rng.Intn(32768)
+		return fmt.Sprintf("%d\nreturn n;\n", target)
+	case 1:
+		c := rng.Intn(10) + 1
+		n := rng.Intn(32768)
+		var target int
+		if n > c {
+			target = (n - c) % 32768
+		} else {
+			target = n
+		}
+		code := fmt.Sprintf("if (n>%d) return n-%d; return n;", c, c)
+		return fmt.Sprintf("%d\n%s\n", target, code)
+	default:
+		c := rng.Intn(10) + 1
+		n := rng.Intn(32768)
+		var target int
+		if n < c {
+			target = n
+		} else {
+			target = n - c
+		}
+		code := fmt.Sprintf("if (n<%d) return n; return n-%d;", c, c)
+		return fmt.Sprintf("%d\n%s\n", target, code)
+	}
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseG(rng)
+	}
+	for i, tc := range cases {
+		expect := solveG(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/39/verifierH.go
+++ b/0-999/0-99/30-39/39/verifierH.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func toBase(n, base int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		d := n % base
+		digits = append(digits, byte('0'+d))
+		n /= base
+	}
+	for l, r := 0, len(digits)-1; l < r; l, r = l+1, r-1 {
+		digits[l], digits[r] = digits[r], digits[l]
+	}
+	return string(digits)
+}
+
+func solveH(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var k int
+	if _, err := fmt.Fscan(r, &k); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for i := 1; i < k; i++ {
+		for j := 1; j < k; j++ {
+			if j > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(toBase(i*j, k))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func generateCaseH(rng *rand.Rand) string {
+	k := rng.Intn(9) + 2
+	return fmt.Sprintf("%d\n", k)
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseH(rng)
+	}
+	for i, tc := range cases {
+		expect := solveH(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/39/verifierI.go
+++ b/0-999/0-99/30-39/39/verifierI.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveI(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return ""
+	}
+	adj := make([][]int, n+1)
+	for i := 0; i < m; i++ {
+		var u, v int
+		fmt.Fscan(in, &u, &v)
+		adj[u] = append(adj[u], v)
+	}
+	dist := make([]int, n+1)
+	for i := range dist {
+		dist[i] = -1
+	}
+	q := make([]int, 0, n)
+	dist[1] = 0
+	q = append(q, 1)
+	for qi := 0; qi < len(q); qi++ {
+		u := q[qi]
+		for _, v := range adj[u] {
+			if dist[v] == -1 {
+				dist[v] = dist[u] + 1
+				q = append(q, v)
+			}
+		}
+	}
+	g := 0
+	for u := 1; u <= n; u++ {
+		if dist[u] < 0 {
+			continue
+		}
+		for _, v := range adj[u] {
+			if dist[v] >= 0 {
+				d := dist[u] + 1 - dist[v]
+				if d < 0 {
+					d = -d
+				}
+				g = gcd(g, d)
+			}
+		}
+	}
+	t := g
+	if t <= 0 {
+		t = 1
+	}
+	cams := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		if dist[i] >= 0 && dist[i]%t == 0 {
+			cams = append(cams, i)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	sb.WriteString(fmt.Sprintf("%d\n", len(cams)))
+	for i, v := range cams {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func generateCaseI(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	maxEdges := n * (n - 1)
+	m := rng.Intn(maxEdges) + 1
+	edges := make(map[[2]int]bool)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	count := 0
+	for count < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		key := [2]int{u, v}
+		if edges[key] {
+			continue
+		}
+		edges[key] = true
+		sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+		count++
+	}
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseI(rng)
+	}
+	for i, tc := range cases {
+		expect := solveI(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/39/verifierJ.go
+++ b/0-999/0-99/30-39/39/verifierJ.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveJ(input string) string {
+	fields := bytes.Fields([]byte(input))
+	if len(fields) < 2 {
+		return "0\n"
+	}
+	s := fields[0]
+	t := fields[1]
+	n := len(s)
+	if len(t) != n-1 {
+		return "0\n"
+	}
+	pre := make([]bool, n)
+	pre[0] = true
+	for i := 1; i < n; i++ {
+		if pre[i-1] && s[i-1] == t[i-1] {
+			pre[i] = true
+		}
+	}
+	suf := make([]bool, n)
+	suf[n-1] = true
+	for i := n - 2; i >= 0; i-- {
+		if s[i+1] == t[i] && suf[i+1] {
+			suf[i] = true
+		}
+	}
+	var pos []int
+	for i := 0; i < n; i++ {
+		if pre[i] && suf[i] {
+			pos = append(pos, i+1)
+		}
+	}
+	if len(pos) == 0 {
+		return "0\n"
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(pos)))
+	for i, v := range pos {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func generateCaseJ(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	s := randString(rng, n)
+	p := rng.Intn(n)
+	t := s[:p] + s[p+1:]
+	return fmt.Sprintf("%s %s\n", s, t)
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierJ.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseJ(rng)
+	}
+	for i, tc := range cases {
+		expect := solveJ(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/39/verifierK.go
+++ b/0-999/0-99/30-39/39/verifierK.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveK(input string) string {
+	cmd := exec.Command("go", "run", "39K.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return ""
+	}
+	return out.String()
+}
+
+func ok(grid [][]byte, r, c int) bool {
+	n := len(grid)
+	m := len(grid[0])
+	for i := r - 1; i <= r+1; i++ {
+		for j := c - 1; j <= c+1; j++ {
+			if i >= 0 && i < n && j >= 0 && j < m {
+				if grid[i][j] == '*' {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func generateCaseK(rng *rand.Rand) string {
+	n := rng.Intn(3) + 2
+	m := rng.Intn(3) + 2
+	k := rng.Intn(2) + 1
+	grid := make([][]byte, n)
+	for i := range grid {
+		grid[i] = make([]byte, m)
+		for j := range grid[i] {
+			grid[i][j] = '.'
+		}
+	}
+	placed := 0
+	attempts := 0
+	for placed < k && attempts < 100 {
+		r := rng.Intn(n)
+		c := rng.Intn(m)
+		if grid[r][c] == '.' && ok(grid, r, c) {
+			grid[r][c] = '*'
+			placed++
+		}
+		attempts++
+	}
+	k = placed
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierK.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseK(rng)
+	}
+	for i, tc := range cases {
+		expect := solveK(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all contest 39 problems
- each verifier generates 100 random test cases and checks output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build verifierI.go`
- `go build verifierJ.go`
- `go build verifierK.go`


------
https://chatgpt.com/codex/tasks/task_e_687e60e36bcc832497c85aa05cc6ec67