### PR TITLE
Add Go verifiers for contest 37

### DIFF
--- a/0-999/0-99/30-39/37/verifierA.go
+++ b/0-999/0-99/30-39/37/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type caseA struct {
+	n   int
+	arr []int
+}
+
+func generateCase(rng *rand.Rand) caseA {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(1000) + 1
+	}
+	return caseA{n, arr}
+}
+
+func solveCase(tc caseA) (int, int) {
+	counts := make(map[int]int)
+	maxH := 0
+	for _, v := range tc.arr {
+		counts[v]++
+		if counts[v] > maxH {
+			maxH = counts[v]
+		}
+	}
+	return maxH, len(counts)
+}
+
+func runCase(bin string, tc caseA) error {
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", tc.n)
+	for i, v := range tc.arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprintf(&input, "%d", v)
+	}
+	input.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) < 2 {
+		return fmt.Errorf("output too short: %s", out.String())
+	}
+	got1, err1 := strconv.Atoi(fields[0])
+	got2, err2 := strconv.Atoi(fields[1])
+	if err1 != nil || err2 != nil {
+		return fmt.Errorf("invalid integers in output: %s", out.String())
+	}
+	exp1, exp2 := solveCase(tc)
+	if got1 != exp1 || got2 != exp2 {
+		return fmt.Errorf("expected %d %d got %d %d", exp1, exp2, got1, got2)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput n=%d arr=%v\n", i+1, err, tc.n, tc.arr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/37/verifierB.go
+++ b/0-999/0-99/30-39/37/verifierB.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type spell struct {
+	pow int
+	dmg int
+}
+
+type Item struct{ dmg, idx int }
+type MaxHeap []Item
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i].dmg > h[j].dmg }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(Item)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+type caseB struct {
+	n      int
+	maxH   int
+	reg    int
+	spells []spell
+}
+
+func generateCase(rng *rand.Rand) caseB {
+	n := rng.Intn(5) + 1
+	maxH := rng.Intn(50) + 1
+	reg := rng.Intn(20) + 1
+	sp := make([]spell, n)
+	for i := range sp {
+		sp[i] = spell{pow: rng.Intn(101), dmg: rng.Intn(20) + 1}
+	}
+	return caseB{n, maxH, reg, sp}
+}
+
+// solver replicating 37B.go
+func solveCase(tc caseB) (bool, int, [][2]int) {
+	type Spell struct {
+		thr      int
+		dmg, idx int
+	}
+	spells := make([]Spell, tc.n)
+	for i, s := range tc.spells {
+		spells[i] = Spell{thr: s.pow * tc.maxH, dmg: s.dmg, idx: i + 1}
+	}
+	sort.Slice(spells, func(i, j int) bool { return spells[i].thr > spells[j].thr })
+	h := tc.maxH
+	D := 0
+	actions := make([][2]int, 0, tc.n)
+	heapItems := &MaxHeap{}
+	heap.Init(heapItems)
+	j := 0
+	pushAvail := func() {
+		for j < len(spells) && spells[j].thr >= 100*h {
+			heap.Push(heapItems, Item{spells[j].dmg, spells[j].idx})
+			j++
+		}
+	}
+	pushAvail()
+	if heapItems.Len() == 0 {
+		return false, 0, nil
+	}
+	it := heap.Pop(heapItems).(Item)
+	D += it.dmg
+	actions = append(actions, [2]int{0, it.idx})
+	t := 1
+	for {
+		h -= D
+		h += tc.reg
+		if h > tc.maxH {
+			h = tc.maxH
+		}
+		if h <= 0 {
+			break
+		}
+		pushAvail()
+		if heapItems.Len() > 0 {
+			it = heap.Pop(heapItems).(Item)
+			D += it.dmg
+			actions = append(actions, [2]int{t, it.idx})
+		} else if D <= tc.reg {
+			return false, 0, nil
+		}
+		t++
+		if t > 1000 {
+			return false, 0, nil
+		} // safety
+	}
+	return true, t, actions
+}
+
+func runCase(bin string, tc caseB) error {
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d %d %d\n", tc.n, tc.maxH, tc.reg)
+	for _, sp := range tc.spells {
+		fmt.Fprintf(&input, "%d %d\n", sp.pow, sp.dmg)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	ok, tExp, actsExp := solveCase(tc)
+	if !ok {
+		if len(lines) == 0 || strings.TrimSpace(lines[0]) != "NO" {
+			return fmt.Errorf("expected NO, got %s", out.String())
+		}
+		return nil
+	}
+	if len(lines) < 2 {
+		return fmt.Errorf("incomplete output: %s", out.String())
+	}
+	if strings.TrimSpace(lines[0]) != "YES" {
+		return fmt.Errorf("expected YES")
+	}
+	fields := strings.Fields(lines[1])
+	if len(fields) < 2 {
+		return fmt.Errorf("missing second line")
+	}
+	tGot, err1 := strconv.Atoi(fields[0])
+	kGot, err2 := strconv.Atoi(fields[1])
+	if err1 != nil || err2 != nil {
+		return fmt.Errorf("bad integers on line2")
+	}
+	if tGot != tExp || kGot != len(actsExp) {
+		return fmt.Errorf("expected %d %d got %d %d", tExp, len(actsExp), tGot, kGot)
+	}
+	if len(lines)-2 != len(actsExp) {
+		return fmt.Errorf("expected %d action lines, got %d", len(actsExp), len(lines)-2)
+	}
+	for i, a := range actsExp {
+		f := strings.Fields(lines[2+i])
+		if len(f) < 2 {
+			return fmt.Errorf("bad action line %d", i+1)
+		}
+		tg, _ := strconv.Atoi(f[0])
+		idx, _ := strconv.Atoi(f[1])
+		if tg != a[0] || idx != a[1] {
+			return fmt.Errorf("expected %d %d got %d %d", a[0], a[1], tg, idx)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/37/verifierC.go
+++ b/0-999/0-99/30-39/37/verifierC.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type caseC struct {
+	n       int
+	lengths []int
+}
+
+func generateCase(rng *rand.Rand) caseC {
+	n := rng.Intn(5) + 1
+	lengths := make([]int, n)
+	for i := range lengths {
+		lengths[i] = rng.Intn(4) + 1
+	}
+	return caseC{n, lengths}
+}
+
+func solveCase(tc caseC) (bool, []string) {
+	n := tc.n
+	a := tc.lengths
+	maxD := 0
+	for _, v := range a {
+		if v > maxD {
+			maxD = v
+		}
+	}
+	b := make([]int, maxD+2)
+	q := make([][]int, maxD+2)
+	for i, d := range a {
+		b[d]++
+		q[d] = append(q[d], i)
+	}
+	cur := int64(2)
+	const inf = 100000000
+	for depth := 1; depth <= maxD; depth++ {
+		if int64(b[depth]) > cur {
+			return false, nil
+		}
+		cur = (cur - int64(b[depth])) * 2
+		if cur > inf {
+			break
+		}
+	}
+	ans := make([][]byte, n)
+	for i := range ans {
+		ans[i] = make([]byte, a[i])
+	}
+	c := make([]byte, maxD+2)
+	q1 := make([]int, maxD+2)
+	all := n
+	var dfs func(int)
+	END := false
+	dfs = func(depth int) {
+		if END {
+			return
+		}
+		if depth <= maxD && b[depth] > 0 {
+			b[depth]--
+			all--
+			idx := q[depth][q1[depth]]
+			for i := 0; i < depth; i++ {
+				ans[idx][i] = c[i]
+			}
+			q1[depth]++
+			if all == 0 {
+				END = true
+			}
+			return
+		}
+		if depth > maxD {
+			return
+		}
+		c[depth] = '0'
+		dfs(depth + 1)
+		if END {
+			return
+		}
+		c[depth] = '1'
+		dfs(depth + 1)
+	}
+	dfs(0)
+	words := make([]string, n)
+	for i := range ans {
+		words[i] = string(ans[i])
+	}
+	return true, words
+}
+
+func runCase(bin string, tc caseC) error {
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", tc.n)
+	for i, v := range tc.lengths {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprintf(&input, "%d", v)
+	}
+	input.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	ok, _ := solveCase(tc)
+	if !ok {
+		if len(lines) == 0 || strings.TrimSpace(lines[0]) != "NO" {
+			return fmt.Errorf("expected NO, got %s", out.String())
+		}
+		return nil
+	}
+	if len(lines) != tc.n+1 {
+		return fmt.Errorf("expected %d lines, got %d", tc.n+1, len(lines))
+	}
+	if strings.TrimSpace(lines[0]) != "YES" {
+		return fmt.Errorf("expected YES")
+	}
+	for i := 0; i < tc.n; i++ {
+		w := strings.TrimSpace(lines[i+1])
+		if len(w) != tc.lengths[i] {
+			return fmt.Errorf("word %d length mismatch", i)
+		}
+		for j := 0; j < len(w); j++ {
+			if w[j] != '0' && w[j] != '1' {
+				return fmt.Errorf("bad char in word")
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/37/verifierD.go
+++ b/0-999/0-99/30-39/37/verifierD.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+type caseD struct {
+	m int
+	X []int
+	Y []int
+}
+
+func generateCase(rng *rand.Rand) caseD {
+	m := rng.Intn(5) + 1
+	X := make([]int, m)
+	Y := make([]int, m)
+	sum := 0
+	for i := 0; i < m; i++ {
+		X[i] = rng.Intn(3)
+		sum += X[i]
+	}
+	if sum == 0 {
+		idx := rng.Intn(m)
+		X[idx] = 1
+		sum = 1
+	}
+	for i := 0; i < m; i++ {
+		Y[i] = X[i] + rng.Intn(3)
+	}
+	return caseD{m, X, Y}
+}
+
+func binom(n, k int, c [][]int) int {
+	if k < 0 || k > n {
+		return 0
+	}
+	if c[n][k] != 0 {
+		return c[n][k]
+	}
+	if k == 0 || k == n {
+		c[n][k] = 1
+	} else {
+		c[n][k] = (binom(n-1, k-1, c) + binom(n-1, k, c)) % mod
+	}
+	return c[n][k]
+}
+
+func solveCase(tc caseD) int {
+	N := 0
+	for _, v := range tc.X {
+		N += v
+	}
+	c := make([][]int, N+1)
+	for i := range c {
+		c[i] = make([]int, N+1)
+	}
+	for i := 0; i <= N; i++ {
+		c[i][0] = 1
+		c[i][i] = 1
+	}
+	for i := 2; i <= N; i++ {
+		for j := 1; j < i; j++ {
+			c[i][j] = (c[i-1][j-1] + c[i-1][j]) % mod
+		}
+	}
+	dpPrev := make([]int, N+1)
+	dpCurr := make([]int, N+1)
+	dpPrev[0] = 1
+	for idx := 0; idx < tc.m; idx++ {
+		xi := tc.X[idx]
+		yi := tc.Y[idx]
+		for i := range dpCurr {
+			dpCurr[i] = 0
+		}
+		for open := 0; open <= N; open++ {
+			v := dpPrev[open]
+			if v == 0 {
+				continue
+			}
+			t := open + xi
+			maxK := yi
+			if maxK > t {
+				maxK = t
+			}
+			for k := 0; k <= maxK; k++ {
+				ways := c[t][k]
+				val := v * ways % mod
+				dpCurr[t-k] = (dpCurr[t-k] + val) % mod
+			}
+		}
+		dpPrev, dpCurr = dpCurr, dpPrev
+	}
+	return dpPrev[0]
+}
+
+func runCase(bin string, tc caseD) error {
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", tc.m)
+	for i, v := range tc.X {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprintf(&input, "%d", v)
+	}
+	input.WriteByte('\n')
+	for i, v := range tc.Y {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprintf(&input, "%d", v)
+	}
+	input.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := fmt.Sprintf("%d", solveCase(tc))
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/37/verifierE.go
+++ b/0-999/0-99/30-39/37/verifierE.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type caseE struct {
+	n, m int
+	grid [][]byte
+}
+
+func generateCase(rng *rand.Rand) caseE {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = 'B'
+			} else {
+				row[j] = 'W'
+			}
+		}
+		grid[i] = row
+	}
+	return caseE{n, m, grid}
+}
+
+func countComp(grid [][]byte, color byte) int {
+	n := len(grid)
+	m := len(grid[0])
+	vis := make([][]bool, n)
+	for i := range vis {
+		vis[i] = make([]bool, m)
+	}
+	dirs := [][2]int{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
+	cnt := 0
+	var q [][2]int
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if !vis[i][j] && grid[i][j] == color {
+				cnt++
+				vis[i][j] = true
+				q = q[:0]
+				q = append(q, [2]int{i, j})
+				for qi := 0; qi < len(q); qi++ {
+					x, y := q[qi][0], q[qi][1]
+					for _, d := range dirs {
+						nx, ny := x+d[0], y+d[1]
+						if nx >= 0 && nx < n && ny >= 0 && ny < m && !vis[nx][ny] && grid[nx][ny] == color {
+							vis[nx][ny] = true
+							q = append(q, [2]int{nx, ny})
+						}
+					}
+				}
+			}
+		}
+	}
+	return cnt
+}
+
+func solveCase(tc caseE) int {
+	b := countComp(tc.grid, 'B')
+	w := countComp(tc.grid, 'W')
+	ans := b
+	if w+1 < ans {
+		ans = w + 1
+	}
+	return ans
+}
+
+func runCase(bin string, tc caseE) error {
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d %d\n", tc.n, tc.m)
+	for i := 0; i < tc.n; i++ {
+		for j := 0; j < tc.m; j++ {
+			input.WriteByte(tc.grid[i][j])
+		}
+		input.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := fmt.Sprintf("%d", solveCase(tc))
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifierA.go to check towers problem
- add Go verifierB.go implementing spell battle simulation
- add Go verifierC.go for prefix-free words
- add Go verifierD.go for timetable count
- add Go verifierE.go for slab repainting

Each verifier generates 100 random test cases and runs a provided binary to ensure correctness.

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e60d9ac6083249588500d717b329c