### PR TITLE
Add verifiers for Codeforces Round 32

### DIFF
--- a/0-999/0-99/30-39/32/verifierA.go
+++ b/0-999/0-99/30-39/32/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func absInt64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(200) + 1
+	d := rng.Int63n(1000000000)
+	heights := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, d))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		heights[i] = rng.Int63n(1000000000)
+		sb.WriteString(fmt.Sprintf("%d", heights[i]))
+	}
+	sb.WriteByte('\n')
+	var count int64
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if absInt64(heights[i]-heights[j]) <= d {
+				count += 2
+			}
+		}
+	}
+	return sb.String(), fmt.Sprintf("%d", count)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/32/verifierB.go
+++ b/0-999/0-99/30-39/32/verifierB.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	length := rng.Intn(100) + 1
+	var input strings.Builder
+	var output strings.Builder
+	for i := 0; i < length; i++ {
+		digit := rng.Intn(3)
+		output.WriteByte('0' + byte(digit))
+		switch digit {
+		case 0:
+			input.WriteByte('.')
+		case 1:
+			input.WriteString("-.")
+		case 2:
+			input.WriteString("--")
+		}
+	}
+	input.WriteByte('\n')
+	return input.String(), output.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/32/verifierC.go
+++ b/0-999/0-99/30-39/32/verifierC.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m, s int64) int64 {
+	qx := n / s
+	rx := n % s
+	var sumX int64
+	if rx > 0 {
+		sumX = rx * (qx + 1)
+	} else {
+		sumX = s * qx
+	}
+	qy := m / s
+	ry := m % s
+	var sumY int64
+	if ry > 0 {
+		sumY = ry * (qy + 1)
+	} else {
+		sumY = s * qy
+	}
+	return sumX * sumY
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1000) + 1
+	m := rng.Int63n(1000) + 1
+	s := rng.Int63n(1000) + 1
+	input := fmt.Sprintf("%d %d %d\n", n, m, s)
+	exp := fmt.Sprintf("%d", expected(n, m, s))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/32/verifierD.go
+++ b/0-999/0-99/30-39/32/verifierD.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Cross struct {
+	r, i, j int
+}
+
+func expected(n, m int, k int64, grid []string) string {
+	up := make([][]int, n)
+	down := make([][]int, n)
+	left := make([][]int, n)
+	right := make([][]int, n)
+	for i := 0; i < n; i++ {
+		up[i] = make([]int, m)
+		down[i] = make([]int, m)
+		left[i] = make([]int, m)
+		right[i] = make([]int, m)
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '*' {
+				if i > 0 {
+					up[i][j] = up[i-1][j] + 1
+				} else {
+					up[i][j] = 1
+				}
+				if j > 0 {
+					left[i][j] = left[i][j-1] + 1
+				} else {
+					left[i][j] = 1
+				}
+			}
+		}
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if grid[i][j] == '*' {
+				if i < n-1 {
+					down[i][j] = down[i+1][j] + 1
+				} else {
+					down[i][j] = 1
+				}
+				if j < m-1 {
+					right[i][j] = right[i][j+1] + 1
+				} else {
+					right[i][j] = 1
+				}
+			}
+		}
+	}
+	var crosses []Cross
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '*' {
+				rmax := up[i][j] - 1
+				if down[i][j]-1 < rmax {
+					rmax = down[i][j] - 1
+				}
+				if left[i][j]-1 < rmax {
+					rmax = left[i][j] - 1
+				}
+				if right[i][j]-1 < rmax {
+					rmax = right[i][j] - 1
+				}
+				for r := 1; r <= rmax; r++ {
+					crosses = append(crosses, Cross{r, i + 1, j + 1})
+				}
+			}
+		}
+	}
+	sort.Slice(crosses, func(a, b int) bool {
+		if crosses[a].r != crosses[b].r {
+			return crosses[a].r < crosses[b].r
+		}
+		if crosses[a].i != crosses[b].i {
+			return crosses[a].i < crosses[b].i
+		}
+		return crosses[a].j < crosses[b].j
+	})
+	if int64(len(crosses)) < k {
+		return "-1"
+	}
+	c := crosses[k-1]
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", c.i, c.j))
+	sb.WriteString(fmt.Sprintf("%d %d\n", c.i-c.r, c.j))
+	sb.WriteString(fmt.Sprintf("%d %d\n", c.i+c.r, c.j))
+	sb.WriteString(fmt.Sprintf("%d %d\n", c.i, c.j-c.r))
+	sb.WriteString(fmt.Sprintf("%d %d", c.i, c.j+c.r))
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(7) + 3
+	m := rng.Intn(7) + 3
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		var row strings.Builder
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				row.WriteByte('.')
+			} else {
+				row.WriteByte('*')
+			}
+		}
+		grid[i] = row.String()
+	}
+	crosses := make([]Cross, 0)
+	up := make([][]int, n)
+	down := make([][]int, n)
+	left := make([][]int, n)
+	right := make([][]int, n)
+	for i := 0; i < n; i++ {
+		up[i] = make([]int, m)
+		down[i] = make([]int, m)
+		left[i] = make([]int, m)
+		right[i] = make([]int, m)
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '*' {
+				if i > 0 {
+					up[i][j] = up[i-1][j] + 1
+				} else {
+					up[i][j] = 1
+				}
+				if j > 0 {
+					left[i][j] = left[i][j-1] + 1
+				} else {
+					left[i][j] = 1
+				}
+			}
+		}
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if grid[i][j] == '*' {
+				if i < n-1 {
+					down[i][j] = down[i+1][j] + 1
+				} else {
+					down[i][j] = 1
+				}
+				if j < m-1 {
+					right[i][j] = right[i][j+1] + 1
+				} else {
+					right[i][j] = 1
+				}
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '*' {
+				rmax := up[i][j] - 1
+				if down[i][j]-1 < rmax {
+					rmax = down[i][j] - 1
+				}
+				if left[i][j]-1 < rmax {
+					rmax = left[i][j] - 1
+				}
+				if right[i][j]-1 < rmax {
+					rmax = right[i][j] - 1
+				}
+				for r := 1; r <= rmax; r++ {
+					crosses = append(crosses, Cross{r, i + 1, j + 1})
+				}
+			}
+		}
+	}
+	k := int64(rng.Intn(len(crosses)+3) + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		sb.WriteString(grid[i])
+		sb.WriteByte('\n')
+	}
+	exp := expected(n, m, k, grid)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/32/verifierE.go
+++ b/0-999/0-99/30-39/32/verifierE.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Point struct{ x, y float64 }
+
+func sub(a, b Point) Point         { return Point{a.x - b.x, a.y - b.y} }
+func add(a, b Point) Point         { return Point{a.x + b.x, a.y + b.y} }
+func mul(a Point, k float64) Point { return Point{a.x * k, a.y * k} }
+func dot(a, b Point) float64       { return a.x*b.x + a.y*b.y }
+func cross(a, b Point) float64     { return a.x*b.y - a.y*b.x }
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func orient(a, b, c Point) float64 {
+	return cross(sub(b, a), sub(c, a))
+}
+
+func onSegment(a, b, c Point) bool {
+	if abs(orient(a, b, c)) > 1e-9 {
+		return false
+	}
+	minx, maxx := math.Min(a.x, b.x), math.Max(a.x, b.x)
+	miny, maxy := math.Min(a.y, b.y), math.Max(a.y, b.y)
+	return c.x >= minx-1e-9 && c.x <= maxx+1e-9 && c.y >= miny-1e-9 && c.y <= maxy+1e-9
+}
+
+func segIntersect(a, b, c, d Point) bool {
+	o1 := orient(a, b, c)
+	o2 := orient(a, b, d)
+	o3 := orient(c, d, a)
+	o4 := orient(c, d, b)
+	if o1*o2 < 0 && o3*o4 < 0 {
+		return true
+	}
+	if abs(o1) < 1e-9 && onSegment(a, b, c) {
+		return true
+	}
+	if abs(o2) < 1e-9 && onSegment(a, b, d) {
+		return true
+	}
+	if abs(o3) < 1e-9 && onSegment(c, d, a) {
+		return true
+	}
+	if abs(o4) < 1e-9 && onSegment(c, d, b) {
+		return true
+	}
+	return false
+}
+
+func lineIntersect(p, r, q, s Point) (Point, bool, float64) {
+	rxs := cross(r, s)
+	if abs(rxs) < 1e-9 {
+		return Point{}, false, 0
+	}
+	qp := sub(q, p)
+	t := cross(qp, s) / rxs
+	u := cross(qp, r) / rxs
+	ip := add(p, mul(r, t))
+	return ip, true, u
+}
+
+func solveCase(V, P, W1, W2, M1, M2 Point) string {
+	if !segIntersect(V, P, W1, W2) && !segIntersect(V, P, M1, M2) {
+		return "YES"
+	}
+	oV := orient(M1, M2, V)
+	oP := orient(M1, M2, P)
+	if oV*oP <= 0 {
+		return "NO"
+	}
+	ap := sub(P, M1)
+	ab := sub(M2, M1)
+	ab2 := dot(ab, ab)
+	t := dot(ap, ab) / ab2
+	proj := add(M1, mul(ab, t))
+	Pp := Point{2*proj.x - P.x, 2*proj.y - P.y}
+	rVec := sub(Pp, V)
+	sVec := ab
+	R, ok, u := lineIntersect(V, rVec, M1, sVec)
+	if !ok || u < -1e-9 || u > 1+1e-9 {
+		return "NO"
+	}
+	if segIntersect(V, R, W1, W2) || segIntersect(R, P, W1, W2) {
+		return "NO"
+	}
+	return "YES"
+}
+
+func randPoint(rng *rand.Rand) Point {
+	return Point{float64(rng.Intn(41) - 20), float64(rng.Intn(41) - 20)}
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	for {
+		V := randPoint(rng)
+		P := randPoint(rng)
+		if V == P {
+			continue
+		}
+		W1 := randPoint(rng)
+		W2 := randPoint(rng)
+		if W1 == W2 {
+			continue
+		}
+		M1 := randPoint(rng)
+		M2 := randPoint(rng)
+		if M1 == M2 {
+			continue
+		}
+		if segIntersect(W1, W2, M1, M2) {
+			continue
+		}
+		if onSegment(W1, W2, V) || onSegment(W1, W2, P) || onSegment(M1, M2, V) || onSegment(M1, M2, P) {
+			continue
+		}
+		input := fmt.Sprintf("%.0f %.0f\n%.0f %.0f\n%.0f %.0f %.0f %.0f\n%.0f %.0f %.0f %.0f\n",
+			V.x, V.y, P.x, P.y, W1.x, W1.y, W2.x, W2.y, M1.x, M1.y, M2.x, M2.y)
+		exp := solveCase(V, P, W1, W2, M1, M2)
+		return input, exp
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all five problems of contest 32
- each verifier generates 100 random test cases and checks a provided binary
- verifiers support running either executables or `.go` source files

## Testing
- `go build verifierA.go`
- `./verifierA 32A.go`
- `go build verifierB.go`
- `./verifierB 32B.go`
- `go build verifierC.go`
- `./verifierC 32C.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e60c0bf4c83248be3c2e3df05c7b2