### PR TITLE
Add solution verifiers for contest 30

### DIFF
--- a/0-999/0-99/30-39/30/verifierA.go
+++ b/0-999/0-99/30-39/30/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(a, b, n int) string {
+	if a == 0 {
+		if b == 0 {
+			return "0"
+		}
+		return "No solution"
+	}
+	for x := -1000; x <= 1000; x++ {
+		val := float64(a) * math.Pow(float64(x), float64(n))
+		if math.Abs(val-float64(b)) < 0.5 {
+			return fmt.Sprint(x)
+		}
+	}
+	return "No solution"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	if rng.Float64() < 0.5 {
+		// generate solvable case
+		a := rng.Intn(21) - 10
+		if a == 0 {
+			a = 1
+		}
+		x := rng.Intn(11) - 5
+		b := int(math.Round(float64(a) * math.Pow(float64(x), float64(n))))
+		input := fmt.Sprintf("%d %d %d\n", a, b, n)
+		return input, solve(a, b, n)
+	}
+	for {
+		a := rng.Intn(41) - 20
+		b := rng.Intn(41) - 20
+		if a == 0 {
+			if b != 0 {
+				input := fmt.Sprintf("%d %d %d\n", a, b, n)
+				return input, solve(a, b, n)
+			}
+			continue
+		}
+		if solve(a, b, n) == "No solution" {
+			input := fmt.Sprintf("%d %d %d\n", a, b, n)
+			return input, "No solution"
+		}
+	}
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/30/verifierB.go
+++ b/0-999/0-99/30-39/30/verifierB.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func daysInMonth(m, y int) int {
+	switch m {
+	case 1, 3, 5, 7, 8, 10, 12:
+		return 31
+	case 4, 6, 9, 11:
+		return 30
+	case 2:
+		if y%4 == 0 {
+			return 29
+		}
+		return 28
+	default:
+		return 0
+	}
+}
+
+func canParticipate(fd, fm, fy int, tokens [3]int) bool {
+	perms := [6][3]int{{0, 1, 2}, {0, 2, 1}, {1, 0, 2}, {1, 2, 0}, {2, 0, 1}, {2, 1, 0}}
+	for _, p := range perms {
+		d := tokens[p[0]]
+		m := tokens[p[1]]
+		y := tokens[p[2]]
+		if m < 1 || m > 12 {
+			continue
+		}
+		yearBirth := 2000 + y
+		if d < 1 || d > daysInMonth(m, yearBirth) {
+			continue
+		}
+		yearFinal := 2000 + fy
+		age := yearFinal - yearBirth
+		if fm < m || (fm == m && fd < d) {
+			age--
+		}
+		if age >= 18 {
+			return true
+		}
+	}
+	return false
+}
+
+func solve(final, birth string) string {
+	var fd, fm, fy int
+	fmt.Sscanf(final, "%d.%d.%d", &fd, &fm, &fy)
+	var t0, t1, t2 int
+	fmt.Sscanf(birth, "%d.%d.%d", &t0, &t1, &t2)
+	if canParticipate(fd, fm, fy, [3]int{t0, t1, t2}) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func randomDate(rng *rand.Rand) string {
+	y := rng.Intn(99) + 1
+	m := rng.Intn(12) + 1
+	d := rng.Intn(daysInMonth(m, 2000+y)) + 1
+	return fmt.Sprintf("%02d.%02d.%02d", d, m, y)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	final := randomDate(rng)
+	birth := randomDate(rng)
+	input := final + "\n" + birth + "\n"
+	expected := solve(final, birth)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/30/verifierC.go
+++ b/0-999/0-99/30-39/30/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type node struct {
+	x, y, t int
+	p       float64
+}
+
+func solve(nodes []node) float64 {
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].t < nodes[j].t })
+	n := len(nodes)
+	dp := make([]float64, n)
+	res := 0.0
+	eps := 1e-9
+	for i := 0; i < n; i++ {
+		dp[i] = nodes[i].p
+		for j := 0; j < i; j++ {
+			dt := float64(nodes[i].t - nodes[j].t)
+			dx := float64(nodes[i].x - nodes[j].x)
+			dy := float64(nodes[i].y - nodes[j].y)
+			if dt*dt-dx*dx-dy*dy > -eps {
+				if dp[j]+nodes[i].p > dp[i] {
+					dp[i] = dp[j] + nodes[i].p
+				}
+			}
+		}
+		if dp[i] > res {
+			res = dp[i]
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	nodes := make([]node, n)
+	used := map[[2]int]bool{}
+	for i := 0; i < n; i++ {
+		for {
+			x := rng.Intn(11) - 5
+			y := rng.Intn(11) - 5
+			if !used[[2]int{x, y}] {
+				used[[2]int{x, y}] = true
+				nodes[i].x = x
+				nodes[i].y = y
+				break
+			}
+		}
+		nodes[i].t = rng.Intn(51)
+		nodes[i].p = rng.Float64()
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d %.6f\n", nodes[i].x, nodes[i].y, nodes[i].t, nodes[i].p))
+	}
+	expected := fmt.Sprintf("%.9f", solve(nodes))
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if valOut, err := strconv.ParseFloat(outStr, 64); err == nil {
+		valExp, _ := strconv.ParseFloat(expected, 64)
+		if math.Abs(valOut-valExp) > 1e-6 {
+			return fmt.Errorf("expected %.9f got %s", valExp, outStr)
+		}
+	} else {
+		return fmt.Errorf("invalid output %s", outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/30/verifierD.go
+++ b/0-999/0-99/30-39/30/verifierD.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y float64 }
+
+func dist(a, b point) float64 {
+	return math.Hypot(a.x-b.x, a.y-b.y)
+}
+
+func solve(n, k int, xs []int, py int) float64 {
+	axis := make([]int, n)
+	copy(axis, xs[:n])
+	sort.Ints(axis)
+	L := float64(axis[0])
+	R := float64(axis[n-1])
+	dLine := R - L
+	px := float64(xs[n])
+	pyf := float64(py)
+	if n <= 2 {
+		m := n + 1
+		xsF := make([]float64, m)
+		ysF := make([]float64, m)
+		for i := 0; i < n; i++ {
+			xsF[i] = float64(xs[i])
+		}
+		for i := 0; i < n; i++ {
+			ysF[i] = 0
+		}
+		xsF[n] = px
+		ysF[n] = pyf
+		start := k - 1
+		others := make([]int, 0, m-1)
+		for i := 0; i < m; i++ {
+			if i != start {
+				others = append(others, i)
+			}
+		}
+		best := math.Inf(1)
+		var permute func([]int, int)
+		permute = func(a []int, l int) {
+			if l == len(a) {
+				cur := 0.0
+				prev := start
+				for _, idx := range a {
+					cur += dist(point{xsF[prev], ysF[prev]}, point{xsF[idx], ysF[idx]})
+					prev = idx
+				}
+				if cur < best {
+					best = cur
+				}
+				return
+			}
+			for i := l; i < len(a); i++ {
+				a[l], a[i] = a[i], a[l]
+				permute(a, l+1)
+				a[l], a[i] = a[i], a[l]
+			}
+		}
+		permute(others, 0)
+		return best
+	}
+	idx := sort.Search(n, func(i int) bool { return float64(axis[i]) >= px })
+	dv := math.Inf(1)
+	for _, j := range []int{idx - 1, idx} {
+		if j >= 0 && j < n {
+			d := dist(point{px, pyf}, point{float64(axis[j]), 0})
+			if d < dv {
+				dv = d
+			}
+		}
+	}
+	ans := math.Inf(1)
+	if k == n+1 {
+		d1 := dist(point{px, pyf}, point{L, 0})
+		d2 := dist(point{px, pyf}, point{R, 0})
+		ans = dLine + math.Min(d1, d2)
+	} else {
+		sx := float64(xs[k-1])
+		for dir := 0; dir < 2; dir++ {
+			var e1, e2 float64
+			if dir == 0 {
+				e1, e2 = L, R
+			} else {
+				e1, e2 = R, L
+			}
+			base := math.Abs(sx-e1) + dLine
+			ans = math.Min(ans, base+2*dv)
+			ans = math.Min(ans, dist(point{sx, 0}, point{px, pyf})+dist(point{px, pyf}, point{e1, 0})+dLine)
+			ans = math.Min(ans, base+dist(point{px, pyf}, point{e2, 0}))
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	xs := make([]int, n+1)
+	used := map[int]bool{}
+	for i := 0; i < n; i++ {
+		for {
+			v := rng.Intn(21) - 10
+			if !used[v] {
+				used[v] = true
+				xs[i] = v
+				break
+			}
+		}
+	}
+	for {
+		v := rng.Intn(21) - 10
+		if !used[v] {
+			xs[n] = v
+			break
+		}
+	}
+	py := rng.Intn(21) - 10
+	if py == 0 {
+		py = 1
+	}
+	k := rng.Intn(n+1) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", xs[i]))
+	}
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("%d\n", py))
+	expected := fmt.Sprintf("%.10f", solve(n, k, xs, py))
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	valExp, _ := strconv.ParseFloat(expected, 64)
+	if valOut, err := strconv.ParseFloat(outStr, 64); err == nil {
+		if math.Abs(valOut-valExp) > 1e-6 {
+			return fmt.Errorf("expected %.10f got %s", valExp, outStr)
+		}
+	} else {
+		return fmt.Errorf("invalid output %s", outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/30-39/30/verifierE.go
+++ b/0-999/0-99/30-39/30/verifierE.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func isPalindrome(s string) bool {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		if s[i] != s[j] {
+			return false
+		}
+	}
+	return true
+}
+
+type segment struct{ pos, len int }
+
+func bruteForce(s string) (int, []segment) {
+	n := len(s)
+	best := 0
+	bestK := 1
+	bestSeg := []segment{{1, 1}}
+	// k=1
+	for i := 0; i < n; i++ {
+		for l := 1; i+l <= n; l++ {
+			if l%2 == 1 && isPalindrome(s[i:i+l]) {
+				if l > best {
+					best = l
+					bestK = 1
+					bestSeg = []segment{{i + 1, l}}
+				}
+			}
+		}
+	}
+	// k=3
+	for i1 := 0; i1 < n; i1++ {
+		for l1 := 1; i1+l1 <= n; l1++ {
+			prefix := s[i1 : i1+l1]
+			for i3 := i1 + l1; i3+l1 <= n; i3++ {
+				if s[i3:i3+l1] != prefix {
+					continue
+				}
+				for i2 := i1 + l1; i2 < i3; i2++ {
+					for l2 := 1; i2+l2 <= i3; l2++ {
+						if l2%2 == 1 && isPalindrome(s[i2:i2+l2]) {
+							total := 2*l1 + l2
+							if total > best {
+								best = total
+								bestK = 3
+								bestSeg = []segment{{i1 + 1, l1}, {i2 + 1, l2}, {i3 + 1, l1}}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return bestK, bestSeg
+}
+
+func segmentsValid(s string, segs []segment) bool {
+	if len(segs) == 1 {
+		if segs[0].len%2 == 1 && isPalindrome(s[segs[0].pos-1:segs[0].pos-1+segs[0].len]) {
+			return true
+		}
+		return false
+	}
+	if len(segs) != 3 {
+		return false
+	}
+	a := segs[0]
+	b := segs[1]
+	c := segs[2]
+	if !(a.pos+a.len-1 <= b.pos-1 && b.pos+b.len-1 <= c.pos-1) {
+		return false
+	}
+	pre := s[a.pos-1 : a.pos-1+a.len]
+	suf := s[c.pos-1 : c.pos-1+c.len]
+	if pre != suf {
+		return false
+	}
+	if b.len%2 == 0 || !isPalindrome(s[b.pos-1:b.pos-1+b.len]) {
+		return false
+	}
+	return true
+}
+
+func generateCase(rng *rand.Rand) (string, string, int, []segment) {
+	n := rng.Intn(8) + 1
+	bytesS := make([]byte, n)
+	for i := 0; i < n; i++ {
+		bytesS[i] = byte('a' + rng.Intn(3))
+	}
+	s := string(bytesS)
+	k, segs := bruteForce(s)
+	var sb strings.Builder
+	sb.WriteString(s + "\n")
+	var exp strings.Builder
+	exp.WriteString(fmt.Sprint(k, "\n"))
+	for _, seg := range segs {
+		exp.WriteString(fmt.Sprintf("%d %d\n", seg.pos, seg.len))
+	}
+	return sb.String(), strings.TrimSpace(exp.String()), k, segs
+}
+
+func runCase(bin, input, expected string, s string, segs []segment) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(outLines) == 0 {
+		return fmt.Errorf("no output")
+	}
+	kOut, err := strconv.Atoi(strings.TrimSpace(outLines[0]))
+	if err != nil {
+		return fmt.Errorf("invalid k")
+	}
+	var resSegs []segment
+	for i := 1; i < len(outLines); i++ {
+		var x, l int
+		fmt.Sscanf(outLines[i], "%d %d", &x, &l)
+		resSegs = append(resSegs, segment{x, l})
+	}
+	if kOut != len(resSegs) {
+		return fmt.Errorf("k mismatch")
+	}
+	if !segmentsValid(s, resSegs) {
+		return fmt.Errorf("invalid segments")
+	}
+	// check length optimality
+	_, best := bruteForce(s)
+	bestLen := 0
+	for _, sg := range best {
+		bestLen += sg.len
+	}
+	outLen := 0
+	for _, sg := range resSegs {
+		outLen += sg.len
+	}
+	if outLen != bestLen {
+		return fmt.Errorf("expected length %d got %d", bestLen, outLen)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp, _, segs := generateCase(rng)
+		s := strings.TrimSpace(strings.Split(in, "\n")[0])
+		if err := runCase(bin, in, exp, s, segs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–E of contest 30
- each verifier runs 100 randomized tests against a given binary

## Testing
- `go run verifierA.go ./Acheck`

------
https://chatgpt.com/codex/tasks/task_e_687e608e2f8c8324878d265d5126b50c