### PR TITLE
Add solution verifiers for Codeforces contest 498

### DIFF
--- a/0-999/400-499/490-499/498/verifierA.go
+++ b/0-999/400-499/490-499/498/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(x1, y1, x2, y2 int, lines [][3]int) string {
+	cnt := 0
+	for _, line := range lines {
+		a, b, c := line[0], line[1], line[2]
+		f1 := a*x1 + b*y1 + c
+		f2 := a*x2 + b*y2 + c
+		if (f1 < 0 && f2 > 0) || (f1 > 0 && f2 < 0) {
+			cnt++
+		}
+	}
+	return fmt.Sprintf("%d", cnt)
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	x1 := rng.Intn(21) - 10
+	y1 := rng.Intn(21) - 10
+	x2 := rng.Intn(21) - 10
+	y2 := rng.Intn(21) - 10
+	n := rng.Intn(9) + 1 // 1..9
+	lines := make([][3]int, n)
+	for i := 0; i < n; i++ {
+		a := rng.Intn(21) - 10
+		b := rng.Intn(21) - 10
+		if a == 0 && b == 0 {
+			a = 1
+		}
+		c := rng.Intn(21) - 10
+		// ensure points are not on line
+		for a*x1+b*y1+c == 0 || a*x2+b*y2+c == 0 {
+			a = rng.Intn(21) - 10
+			b = rng.Intn(21) - 10
+			if a == 0 && b == 0 {
+				a = 1
+			}
+			c = rng.Intn(21) - 10
+		}
+		lines[i] = [3]int{a, b, c}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", x1, y1))
+	sb.WriteString(fmt.Sprintf("%d %d\n", x2, y2))
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, line := range lines {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", line[0], line[1], line[2]))
+	}
+	return testCase{input: sb.String(), expected: solveCase(x1, y1, x2, y2, lines)}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{input: "0 0\n1 1\n1\n1 0 -1\n", expected: "1"},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected: %s\nfound: %s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/498/verifierB.go
+++ b/0-999/400-499/490-499/498/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input string
+	n, T  int
+	p, t  []int
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expected(n, T int, p, t []int) float64 {
+	dp := make([][]float64, 2)
+	dp[0] = make([]float64, T+1)
+	dp[1] = make([]float64, T+1)
+	cur := 0
+	for idx := n - 1; idx >= 0; idx-- {
+		cur ^= 1
+		prev := cur ^ 1
+		prob := float64(p[idx]) / 100.0
+		P := math.Pow(1-prob, float64(t[idx]-1))
+		sum := 0.0
+		dp[cur][0] = 0
+		for j := 1; j <= T; j++ {
+			sum *= 1 - prob
+			sum += (dp[prev][j-1] + 1) * prob
+			if j >= t[idx] {
+				sum += (dp[prev][j-t[idx]] + 1) * P * (1 - prob)
+			}
+			if j > t[idx] {
+				sum -= (dp[prev][j-t[idx]-1] + 1) * P * (1 - prob)
+			}
+			dp[cur][j] = sum
+		}
+	}
+	return dp[cur][T]
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	T := rng.Intn(20) + 1
+	p := make([]int, n)
+	t := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = rng.Intn(101)
+		t[i] = rng.Intn(T) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, T))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p[i], t[i]))
+	}
+	return testCase{input: sb.String(), n: n, T: T, p: p, t: t}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 101)
+	cases = append(cases, testCase{input: "1 1\n100 1\n", n: 1, T: 1, p: []int{100}, t: []int{1}})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		outStr, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var outVal float64
+		fmt.Sscanf(outStr, "%f", &outVal)
+		exp := expected(tc.n, tc.T, tc.p, tc.t)
+		if math.Abs(outVal-exp) > 1e-4 {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected: %.6f\nfound: %s\n", i+1, tc.input, exp, outStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/498/verifierC.go
+++ b/0-999/400-499/490-499/498/verifierC.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to, rev, cap int
+}
+
+type Dinic struct {
+	n   int
+	adj [][]Edge
+	lvl []int
+	it  []int
+}
+
+func NewDinic(n int) *Dinic {
+	d := &Dinic{n: n, adj: make([][]Edge, n), lvl: make([]int, n), it: make([]int, n)}
+	return d
+}
+
+func (d *Dinic) AddEdge(u, v, c int) {
+	d.adj[u] = append(d.adj[u], Edge{to: v, rev: len(d.adj[v]), cap: c})
+	d.adj[v] = append(d.adj[v], Edge{to: u, rev: len(d.adj[u]) - 1, cap: 0})
+}
+
+func (d *Dinic) bfs(s, t int) bool {
+	for i := range d.lvl {
+		d.lvl[i] = -1
+	}
+	queue := make([]int, 0, d.n)
+	d.lvl[s] = 0
+	queue = append(queue, s)
+	for qi := 0; qi < len(queue); qi++ {
+		u := queue[qi]
+		for _, e := range d.adj[u] {
+			if e.cap > 0 && d.lvl[e.to] < 0 {
+				d.lvl[e.to] = d.lvl[u] + 1
+				queue = append(queue, e.to)
+				if e.to == t {
+					return true
+				}
+			}
+		}
+	}
+	return d.lvl[t] >= 0
+}
+
+func (d *Dinic) dfs(u, t, f int) int {
+	if u == t {
+		return f
+	}
+	for i := d.it[u]; i < len(d.adj[u]); i++ {
+		d.it[u] = i
+		e := &d.adj[u][i]
+		if e.cap > 0 && d.lvl[e.to] == d.lvl[u]+1 {
+			ret := d.dfs(e.to, t, min(f, e.cap))
+			if ret > 0 {
+				e.cap -= ret
+				d.adj[e.to][e.rev].cap += ret
+				return ret
+			}
+		}
+	}
+	return 0
+}
+
+func (d *Dinic) MaxFlow(s, t int) int {
+	flow := 0
+	for d.bfs(s, t) {
+		for i := range d.it {
+			d.it[i] = 0
+		}
+		for {
+			pushed := d.dfs(s, t, 1<<30)
+			if pushed == 0 {
+				break
+			}
+			flow += pushed
+		}
+	}
+	return flow
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func factor(x int) map[int]int {
+	m := make(map[int]int)
+	d := 2
+	for d*d <= x {
+		for x%d == 0 {
+			m[d]++
+			x /= d
+		}
+		d++
+	}
+	if x > 1 {
+		m[x]++
+	}
+	return m
+}
+
+func solveCase(n, m int, a []int, pairs [][2]int) string {
+	cnt := make([]map[int]int, n+1)
+	primes := make(map[int]struct{})
+	for i := 1; i <= n; i++ {
+		cnt[i] = factor(a[i])
+		for p := range cnt[i] {
+			primes[p] = struct{}{}
+		}
+	}
+	total := 0
+	const INF = 1000000000
+	for p := range primes {
+		oddIds := make(map[int]int)
+		evenIds := make(map[int]int)
+		oid, eid := 0, 0
+		for i := 1; i <= n; i++ {
+			if e, ok := cnt[i][p]; ok && e > 0 {
+				if i%2 == 1 {
+					oid++
+					oddIds[i] = oid
+				} else {
+					eid++
+					evenIds[i] = eid
+				}
+			}
+		}
+		if oid == 0 || eid == 0 {
+			continue
+		}
+		N := 1 + oid + eid + 1
+		src, sink := 0, N-1
+		din := NewDinic(N)
+		for i, id := range oddIds {
+			din.AddEdge(src, id, cnt[i][p])
+		}
+		for i, id := range evenIds {
+			din.AddEdge(oid+id, sink, cnt[i][p])
+		}
+		for _, pr := range pairs {
+			u, v := pr[0], pr[1]
+			ui, uok := oddIds[u]
+			vi, vok := evenIds[v]
+			if uok && vok {
+				din.AddEdge(ui, oid+vi, INF)
+			}
+		}
+		flow := din.MaxFlow(src, sink)
+		total += flow
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase(rng *rand.Rand) (string, int, []int, [][2]int) {
+	n := rng.Intn(6) + 2
+	m := rng.Intn(n)
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = rng.Intn(20) + 1
+	}
+	pairs := make([][2]int, 0, m)
+	used := make(map[[2]int]struct{})
+	for len(pairs) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v || (u+v)%2 != 1 {
+			continue
+		}
+		if u%2 == 0 {
+			u, v = v, u
+		}
+		pr := [2]int{u, v}
+		if _, ok := used[pr]; ok {
+			continue
+		}
+		used[pr] = struct{}{}
+		pairs = append(pairs, pr)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 1; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", a[i]))
+	}
+	sb.WriteString("\n")
+	for _, pr := range pairs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", pr[0], pr[1]))
+	}
+	return sb.String(), n, a, pairs
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	inputs := []string{"2 1\n2 2\n1 2\n"}
+	ns := []int{2}
+	arrays := [][]int{{0, 2, 2}}
+	pairLists := [][][2]int{{{1, 2}}}
+	for i := 0; i < 100; i++ {
+		in, n, arr, pairs := generateCase(rng)
+		inputs = append(inputs, in)
+		ns = append(ns, n)
+		arrays = append(arrays, arr)
+		pairLists = append(pairLists, pairs)
+	}
+	for i := range inputs {
+		out, err := runBinary(bin, inputs[i])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		exp := solveCase(ns[i], len(pairLists[i]), arrays[i], pairLists[i])
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected: %s\nfound: %s\n", i+1, inputs[i], exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/498/verifierD.go
+++ b/0-999/400-499/490-499/498/verifierD.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const M = 60
+
+func nextPow2(n int) int {
+	p := 1
+	for p < n {
+		p <<= 1
+	}
+	return p
+}
+
+func solveCase(n int, a []int, queries []string) string {
+	size := nextPow2(n)
+	total := 2 * size * M
+	f := make([]int32, total)
+	for i := 0; i < size; i++ {
+		node := (i + size) * M
+		if i < n {
+			ai := a[i]
+			for t := 0; t < M; t++ {
+				if t%ai == 0 {
+					f[node+t] = 2
+				} else {
+					f[node+t] = 1
+				}
+			}
+		} else {
+			for t := 0; t < M; t++ {
+				f[node+t] = 0
+			}
+		}
+	}
+	for i := size - 1; i >= 1; i-- {
+		left := 2 * i
+		right := left + 1
+		base := i * M
+		lbase := left * M
+		rbase := right * M
+		for t := 0; t < M; t++ {
+			tL := f[lbase+t]
+			tR := f[rbase+((t+int(tL))%M)]
+			f[base+t] = tL + tR
+		}
+	}
+	var sb strings.Builder
+	for _, q := range queries {
+		parts := strings.Fields(q)
+		if parts[0] == "A" {
+			x := atoi(parts[1])
+			y := atoi(parts[2])
+			l := x - 1 + size
+			r := y - 2 + size
+			tmp := make([]int32, M)
+			leftArr := make([]int32, M)
+			rightNodes := make([]int, 0)
+			for t := 0; t < M; t++ {
+				leftArr[t] = 0
+			}
+			for l <= r {
+				if l&1 == 1 {
+					base := l * M
+					for t := 0; t < M; t++ {
+						tL := leftArr[t]
+						tmp[t] = tL + f[base+((t+int(tL))%M)]
+					}
+					copy(leftArr, tmp)
+					l++
+				}
+				if r&1 == 0 {
+					rightNodes = append(rightNodes, r)
+					r--
+				}
+				l >>= 1
+				r >>= 1
+			}
+			for i := len(rightNodes) - 1; i >= 0; i-- {
+				node := rightNodes[i]
+				base := node * M
+				for t := 0; t < M; t++ {
+					tL := leftArr[t]
+					tmp[t] = tL + f[base+((t+int(tL))%M)]
+				}
+				copy(leftArr, tmp)
+			}
+			sb.WriteString(fmt.Sprintf("%d\n", leftArr[0]))
+		} else {
+			pos := atoi(parts[1]) - 1
+			val := atoi(parts[2])
+			a[pos] = val
+			nodeIdx := pos + size
+			base := nodeIdx * M
+			for t := 0; t < M; t++ {
+				if t%val == 0 {
+					f[base+t] = 2
+				} else {
+					f[base+t] = 1
+				}
+			}
+			for nodeIdx >>= 1; nodeIdx >= 1; nodeIdx >>= 1 {
+				left := 2 * nodeIdx
+				right := left + 1
+				base := nodeIdx * M
+				lbase := left * M
+				rbase := right * M
+				for t := 0; t < M; t++ {
+					tL := f[lbase+t]
+					tR := f[rbase+((t+int(tL))%M)]
+					f[base+t] = tL + tR
+				}
+			}
+		}
+	}
+	return sb.String()
+}
+
+func atoi(s string) int {
+	var v int
+	fmt.Sscanf(s, "%d", &v)
+	return v
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateCase(rng *rand.Rand) (string, int, []int, []string) {
+	n := rng.Intn(10) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(5) + 2
+	}
+	q := rng.Intn(20) + 1
+	queries := make([]string, q)
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(n-x+1) + x + 1
+			queries[i] = fmt.Sprintf("A %d %d", x, y)
+		} else {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(5) + 2
+			queries[i] = fmt.Sprintf("C %d %d", x, y)
+			a[x-1] = y
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", a[i]))
+	}
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for _, qq := range queries {
+		sb.WriteString(fmt.Sprintf("%s\n", qq))
+	}
+	return sb.String(), n, a, queries
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	inputs := make([]string, 0, 101)
+	ns := make([]int, 0, 101)
+	arrays := make([][]int, 0, 101)
+	qlists := make([][]string, 0, 101)
+	in, n, arr, ql := generateCase(rng)
+	inputs = append(inputs, in)
+	ns = append(ns, n)
+	arrays = append(arrays, arr)
+	qlists = append(qlists, ql)
+	for i := 0; i < 100; i++ {
+		in, n, arr, ql := generateCase(rng)
+		inputs = append(inputs, in)
+		ns = append(ns, n)
+		arrays = append(arrays, arr)
+		qlists = append(qlists, ql)
+	}
+	for i := range inputs {
+		out, err := runBinary(bin, inputs[i])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		exp := solveCase(ns[i], arrays[i], qlists[i])
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\nfound:\n%s\n", i+1, inputs[i], exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/498/verifierE.go
+++ b/0-999/400-499/490-499/498/verifierE.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func matMul(a, b [][]int, n int) [][]int {
+	c := make([][]int, n)
+	for i := 0; i < n; i++ {
+		c[i] = make([]int, n)
+		ai := a[i]
+		ci := c[i]
+		for k := 0; k < n; k++ {
+			if ai[k] == 0 {
+				continue
+			}
+			aik := ai[k]
+			bk := b[k]
+			for j := 0; j < n; j++ {
+				ci[j] = (ci[j] + aik*bk[j]) % mod
+			}
+		}
+	}
+	return c
+}
+
+func vecMatMul(v []int, m [][]int, n int) []int {
+	res := make([]int, n)
+	for i := 0; i < n; i++ {
+		if v[i] == 0 {
+			continue
+		}
+		vi := v[i]
+		mi := m[i]
+		for j := 0; j < n; j++ {
+			res[j] = (res[j] + vi*mi[j]) % mod
+		}
+	}
+	return res
+}
+
+func applyPower(dp []int, mat [][]int, exp int) []int {
+	n := len(dp)
+	base := make([][]int, n)
+	for i := 0; i < n; i++ {
+		base[i] = make([]int, n)
+		copy(base[i], mat[i])
+	}
+	res := make([]int, n)
+	copy(res, dp)
+	first := true
+	for exp > 0 {
+		if exp&1 != 0 {
+			if first {
+				res = vecMatMul(res, base, n)
+				first = false
+			} else {
+				res = vecMatMul(res, base, n)
+			}
+		}
+		exp >>= 1
+		if exp > 0 {
+			base = matMul(base, base, n)
+		}
+	}
+	return res
+}
+
+func solveCase(w [8]int) string {
+	T := make([][][]int, 8)
+	for h := 1; h <= 7; h++ {
+		n := 1 << h
+		m := make([][]int, n)
+		for a := 0; a < n; a++ {
+			m[a] = make([]int, n)
+		}
+		maxH := 1 << (h - 1)
+		for a := 0; a < n; a++ {
+			for b := 0; b < n; b++ {
+				cnt := 0
+				for H := 0; H < maxH; H++ {
+					ok := true
+					for r := 0; r < h; r++ {
+						painted := 0
+						if r == 0 {
+							painted++
+						} else if H&(1<<(r-1)) != 0 {
+							painted++
+						}
+						if r == h-1 {
+							painted++
+						} else if H&(1<<r) != 0 {
+							painted++
+						}
+						if a&(1<<r) != 0 {
+							painted++
+						}
+						if b&(1<<r) != 0 {
+							painted++
+						}
+						if painted == 4 {
+							ok = false
+							break
+						}
+					}
+					if ok {
+						cnt++
+					}
+				}
+				m[a][b] = cnt
+			}
+		}
+		T[h] = m
+	}
+	var dp []int
+	hPrev := 0
+	for h := 1; h <= 7; h++ {
+		wi := w[h]
+		if wi == 0 {
+			continue
+		}
+		if hPrev == 0 {
+			size := 1 << h
+			dp = make([]int, size)
+			dp[size-1] = 1
+		} else {
+			size2 := 1 << h
+			newDp := make([]int, size2)
+			min := hPrev
+			if h < hPrev {
+				min = h
+			}
+			onesHi := 0
+			if h > hPrev {
+				onesHi = ((1 << (h - hPrev)) - 1) << hPrev
+			}
+			onesPrev := 0
+			if hPrev > h {
+				onesPrev = ((1 << (hPrev - h)) - 1) << h
+			}
+			for mask1, v := range dp {
+				if v == 0 {
+					continue
+				}
+				if hPrev > h && (mask1&onesPrev) != onesPrev {
+					continue
+				}
+				mask2 := mask1 & ((1 << min) - 1)
+				mask2 |= onesHi
+				newDp[mask2] = (newDp[mask2] + v) % mod
+			}
+			dp = newDp
+		}
+		dp = applyPower(dp, T[h], wi)
+		hPrev = h
+	}
+	ans := dp[(1<<hPrev)-1]
+	return fmt.Sprintf("%d", ans)
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase(rng *rand.Rand) (string, [8]int) {
+	var w [8]int
+	for i := 1; i <= 7; i++ {
+		w[i] = rng.Intn(4)
+	}
+	var sb strings.Builder
+	for i := 1; i <= 7; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", w[i]))
+	}
+	sb.WriteString("\n")
+	return sb.String(), w
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	inputs := []string{"1 1 1 1 1 1 1\n"}
+	ws := [][8]int{{0, 1, 1, 1, 1, 1, 1, 1}}
+	for i := 0; i < 100; i++ {
+		in, w := generateCase(rng)
+		inputs = append(inputs, in)
+		ws = append(ws, w)
+	}
+	for i := range inputs {
+		out, err := runBinary(bin, inputs[i])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		exp := solveCase(ws[i])
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:%sexpected: %s\nfound: %s\n", i+1, inputs[i], exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new Go verifiers for problems A–E of contest 498
- each verifier runs random cases and checks a supplied binary

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ede2c28d4832487038caee23e6b7c