### PR TITLE
Add Go verifiers for Codeforces contest 497

### DIFF
--- a/0-999/400-499/490-499/497/verifierA.go
+++ b/0-999/400-499/490-499/497/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestA struct {
+	grid []string
+}
+
+func expectedA(t TestA) int {
+	n := len(t.grid)
+	m := len(t.grid[0])
+	removed := 0
+	good := make([]bool, n-1)
+	for col := 0; col < m; col++ {
+		remove := false
+		for i := 0; i < n-1 && !remove; i++ {
+			if !good[i] && t.grid[i][col] > t.grid[i+1][col] {
+				remove = true
+			}
+		}
+		if remove {
+			removed++
+			continue
+		}
+		for i := 0; i < n-1; i++ {
+			if !good[i] && t.grid[i][col] < t.grid[i+1][col] {
+				good[i] = true
+			}
+		}
+	}
+	return removed
+}
+
+func genCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			b[j] = byte('a' + rng.Intn(3))
+		}
+		grid[i] = string(b)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		sb.WriteString(grid[i])
+		sb.WriteByte('\n')
+	}
+	exp := fmt.Sprintf("%d\n", expectedA(TestA{grid}))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseA(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/497/verifierB.go
+++ b/0-999/400-499/490-499/497/verifierB.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type pair struct{ s, t int }
+
+func check(seq []int, t int) (int, bool) {
+	s1, s2 := 0, 0
+	p1, p2 := 0, 0
+	last := 0
+	for _, v := range seq {
+		if v == 1 {
+			p1++
+		} else {
+			p2++
+		}
+		if p1 == t || p2 == t {
+			if p1 == t && p2 == t {
+				return 0, false
+			}
+			if p1 == t {
+				s1++
+				last = 1
+			} else {
+				s2++
+				last = 2
+			}
+			p1, p2 = 0, 0
+		}
+	}
+	if p1 != 0 || p2 != 0 {
+		return 0, false
+	}
+	if s1 == s2 {
+		return 0, false
+	}
+	if s1 > s2 && last == 1 {
+		return s1, true
+	}
+	if s2 > s1 && last == 2 {
+		return s2, true
+	}
+	return 0, false
+}
+
+func expectedB(seq []int) []pair {
+	res := []pair{}
+	for t := 1; t <= len(seq); t++ {
+		if s, ok := check(seq, t); ok {
+			res = append(res, pair{s, t})
+		}
+	}
+	sort.Slice(res, func(i, j int) bool {
+		if res[i].s == res[j].s {
+			return res[i].t < res[j].t
+		}
+		return res[i].s < res[j].s
+	})
+	return res
+}
+
+func genCaseB(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	seq := make([]int, n)
+	for i := 0; i < n; i++ {
+		seq[i] = rng.Intn(2) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range seq {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	pairs := expectedB(seq)
+	var exp strings.Builder
+	exp.WriteString(fmt.Sprintf("%d\n", len(pairs)))
+	for _, p := range pairs {
+		fmt.Fprintf(&exp, "%d %d\n", p.s, p.t)
+	}
+	return sb.String(), exp.String()
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseB(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/497/verifierC.go
+++ b/0-999/400-499/490-499/497/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Part struct{ a, b int }
+type Actor struct{ c, d, k int }
+
+func canPerform(act Actor, p Part) bool {
+	return act.c <= p.a && p.b <= act.d
+}
+
+func search(idx int, parts []Part, actors []Actor, assign []int, rem []int) bool {
+	if idx == len(parts) {
+		return true
+	}
+	for i := range actors {
+		if rem[i] > 0 && canPerform(actors[i], parts[idx]) {
+			rem[i]--
+			assign[idx] = i + 1
+			if search(idx+1, parts, actors, assign, rem) {
+				return true
+			}
+			rem[i]++
+		}
+	}
+	return false
+}
+
+func expectedC(parts []Part, actors []Actor) (bool, []int) {
+	rem := make([]int, len(actors))
+	for i, a := range actors {
+		rem[i] = a.k
+	}
+	assign := make([]int, len(parts))
+	if search(0, parts, actors, assign, rem) {
+		return true, assign
+	}
+	return false, nil
+}
+
+func genCaseC(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	parts := make([]Part, n)
+	for i := 0; i < n; i++ {
+		x := rng.Intn(10) + 1
+		y := x + rng.Intn(5)
+		parts[i] = Part{x, y}
+	}
+	actors := make([]Actor, m)
+	for i := 0; i < m; i++ {
+		c := rng.Intn(10) + 1
+		d := c + rng.Intn(7)
+		k := rng.Intn(2) + 1
+		actors[i] = Actor{c, d, k}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", parts[i].a, parts[i].b)
+	}
+	fmt.Fprintf(&sb, "%d\n", m)
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&sb, "%d %d %d\n", actors[i].c, actors[i].d, actors[i].k)
+	}
+	ok, assign := expectedC(parts, actors)
+	if !ok {
+		return sb.String(), "NO\n"
+	}
+	var exp strings.Builder
+	exp.WriteString("YES\n")
+	for i, v := range assign {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		fmt.Fprintf(&exp, "%d", v)
+	}
+	exp.WriteByte('\n')
+	return sb.String(), exp.String()
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseC(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/497/verifierD.go
+++ b/0-999/400-499/490-499/497/verifierD.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type IPoint struct{ x, y int64 }
+
+func solveD(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var Px, Py, Qx, Qy int64
+	var n, m int
+	if _, err := fmt.Fscan(in, &Px, &Py); err != nil {
+		return ""
+	}
+	fmt.Fscan(in, &n)
+	A := make([]IPoint, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &A[i].x, &A[i].y)
+	}
+	fmt.Fscan(in, &Qx, &Qy)
+	fmt.Fscan(in, &m)
+	B := make([]IPoint, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(in, &B[i].x, &B[i].y)
+	}
+	Dx := Qx - Px
+	Dy := Qy - Py
+	Cx := float64(-Dx)
+	Cy := float64(-Dy)
+	R2i := Dx*Dx + Dy*Dy
+	if R2i == 0 {
+		return "NO\n"
+	}
+	R2 := float64(R2i)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			dx := A[i].x - B[j].x + Dx
+			dy := A[i].y - B[j].y + Dy
+			if dx*dx+dy*dy == R2i {
+				return "YES\n"
+			}
+		}
+	}
+	eps := 1e-9
+	for j := 0; j < m; j++ {
+		bvx := float64(B[j].x)
+		bvy := float64(B[j].y)
+		for i := 0; i < n; i++ {
+			ni := (i + 1) % n
+			u1x := float64(A[i].x) - bvx
+			u1y := float64(A[i].y) - bvy
+			u2x := float64(A[ni].x) - bvx
+			u2y := float64(A[ni].y) - bvy
+			dx := u2x - u1x
+			dy := u2y - u1y
+			a := dx*dx + dy*dy
+			ux := u1x - Cx
+			uy := u1y - Cy
+			if a < eps {
+				if math.Abs(ux*ux+uy*uy-R2) < eps {
+					return "YES\n"
+				}
+				continue
+			}
+			bq := 2 * (dx*ux + dy*uy)
+			cq := ux*ux + uy*uy - R2
+			disc := bq*bq - 4*a*cq
+			if disc < 0 {
+				continue
+			}
+			sd := math.Sqrt(disc)
+			t1 := (-bq - sd) / (2 * a)
+			t2 := (-bq + sd) / (2 * a)
+			if (t1 >= -eps && t1 <= 1+eps) || (t2 >= -eps && t2 <= 1+eps) {
+				return "YES\n"
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		avx := float64(A[i].x)
+		avy := float64(A[i].y)
+		for j := 0; j < m; j++ {
+			nj := (j + 1) % m
+			u1x := avx - float64(B[j].x)
+			u1y := avy - float64(B[j].y)
+			u2x := avx - float64(B[nj].x)
+			u2y := avy - float64(B[nj].y)
+			dx := u2x - u1x
+			dy := u2y - u1y
+			a := dx*dx + dy*dy
+			ux := u1x - Cx
+			uy := u1y - Cy
+			if a < eps {
+				if math.Abs(ux*ux+uy*uy-R2) < eps {
+					return "YES\n"
+				}
+				continue
+			}
+			bq := 2 * (dx*ux + dy*uy)
+			cq := ux*ux + uy*uy - R2
+			disc := bq*bq - 4*a*cq
+			if disc < 0 {
+				continue
+			}
+			sd := math.Sqrt(disc)
+			t1 := (-bq - sd) / (2 * a)
+			t2 := (-bq + sd) / (2 * a)
+			if (t1 >= -eps && t1 <= 1+eps) || (t2 >= -eps && t2 <= 1+eps) {
+				return "YES\n"
+			}
+		}
+	}
+	return "NO\n"
+}
+
+func randPoly(rng *rand.Rand, n int) []IPoint {
+	pts := make([]IPoint, n)
+	for i := 0; i < n; i++ {
+		pts[i] = IPoint{int64(rng.Intn(21) - 10), int64(rng.Intn(21) - 10)}
+	}
+	cx, cy := 0.0, 0.0
+	for _, p := range pts {
+		cx += float64(p.x)
+		cy += float64(p.y)
+	}
+	cx /= float64(n)
+	cy /= float64(n)
+	sort.Slice(pts, func(i, j int) bool {
+		ai := math.Atan2(float64(pts[i].y)-cy, float64(pts[i].x)-cx)
+		aj := math.Atan2(float64(pts[j].y)-cy, float64(pts[j].x)-cx)
+		return ai < aj
+	})
+	return pts
+}
+
+func genCaseD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 3
+	m := rng.Intn(3) + 3
+	P := IPoint{int64(rng.Intn(11) - 5), int64(rng.Intn(11) - 5)}
+	Q := IPoint{int64(rng.Intn(11) - 5), int64(rng.Intn(11) - 5)}
+	if P.x == Q.x && P.y == Q.y {
+		Q.x++
+	}
+	A := randPoly(rng, n)
+	B := randPoly(rng, m)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", P.x, P.y)
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", A[i].x, A[i].y)
+	}
+	fmt.Fprintf(&sb, "%d %d\n", Q.x, Q.y)
+	fmt.Fprintf(&sb, "%d\n", m)
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", B[i].x, B[i].y)
+	}
+	inp := sb.String()
+	exp := solveD(inp)
+	return inp, exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseD(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/497/verifierE.go
+++ b/0-999/400-499/490-499/497/verifierE.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+func sumDigitsBase(x, base int) int {
+	sum := 0
+	for x > 0 {
+		sum += x % base
+		x /= base
+	}
+	return sum
+}
+
+func expectedE(n int, k int) int {
+	dp := 1
+	last := make([]int, k)
+	for j := 0; j < n; j++ {
+		s := sumDigitsBase(j, k) % k
+		ndp := (dp * 2) % MOD
+		ndp = (ndp - last[s] + MOD) % MOD
+		last[s] = dp
+		dp = ndp
+	}
+	return dp
+}
+
+func genCaseE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(30) + 1
+	k := rng.Intn(5) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	exp := fmt.Sprintf("%d\n", expectedE(n, k))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseE(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add automated solution verifiers for problems A–E of contest 497
- each verifier generates 100 random cases and checks the target binary
- includes expected logic for the problems to validate answers

## Testing
- `go build 0-999/400-499/490-499/497/verifierA.go`
- `go build 0-999/400-499/490-499/497/verifierB.go`
- `go build 0-999/400-499/490-499/497/verifierC.go`
- `go build 0-999/400-499/490-499/497/verifierD.go`
- `go build 0-999/400-499/490-499/497/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687edde61de083248fb1a6444937d369