### PR TITLE
Add verifier programs for contest 494

### DIFF
--- a/0-999/400-499/490-499/494/verifierA.go
+++ b/0-999/400-499/490-499/494/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rand.Seed(1)
+	var tests []string
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(30) + 1
+		b := make([]byte, n)
+		has := false
+		for j := 0; j < n; j++ {
+			r := rand.Intn(3)
+			switch r {
+			case 0:
+				b[j] = '('
+			case 1:
+				b[j] = ')'
+			default:
+				b[j] = '#'
+				has = true
+			}
+		}
+		if !has {
+			b[rand.Intn(n)] = '#'
+		}
+		tests = append(tests, string(b))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go <binary>")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candA")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "494A.go")
+	refPath, err := prepareBinary(refSrc, "refA")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	tests := genTests()
+	for i, t := range tests {
+		input := t + "\n"
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput: %s\nExpected:\n%sGot:\n%s", i+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/490-499/494/verifierB.go
+++ b/0-999/400-499/490-499/494/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rand.Intn(26))
+	}
+	return string(b)
+}
+
+func genTests() []string {
+	rand.Seed(1)
+	var tests []string
+	for i := 0; i < 100; i++ {
+		sl := rand.Intn(20) + 1
+		tl := rand.Intn(10) + 1
+		s := randString(sl)
+		t := randString(tl)
+		tests = append(tests, fmt.Sprintf("%s\n%s\n", s, t))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go <binary>")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candB")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "494B.go")
+	refPath, err := prepareBinary(refSrc, "refB")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	tests := genTests()
+	for i, input := range tests {
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/490-499/494/verifierC.go
+++ b/0-999/400-499/490-499/494/verifierC.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type interval struct{ l, r int }
+
+func disjointOrNested(a interval, b interval) bool {
+	if a.r < b.l || b.r < a.l {
+		return true
+	}
+	if a.l <= b.l && b.r <= a.r {
+		return true
+	}
+	if b.l <= a.l && a.r <= b.r {
+		return true
+	}
+	return false
+}
+
+func genTests() []string {
+	rand.Seed(1)
+	var tests []string
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 1
+		q := rand.Intn(3) + 1
+		arr := make([]int, n)
+		for i := range arr {
+			arr[i] = rand.Intn(10)
+		}
+		lines := []string{fmt.Sprintf("%d %d", n, q)}
+		var parts []string
+		for _, v := range arr {
+			parts = append(parts, fmt.Sprintf("%d", v))
+		}
+		lines = append(lines, strings.Join(parts, " "))
+		intervals := []interval{}
+		for i := 0; i < q; i++ {
+			for {
+				l := rand.Intn(n) + 1
+				r := l + rand.Intn(n-l+1)
+				cand := interval{l, r}
+				ok := true
+				for _, iv := range intervals {
+					if !disjointOrNested(cand, iv) {
+						ok = false
+						break
+					}
+				}
+				if ok {
+					intervals = append(intervals, cand)
+					p := float64(rand.Intn(1000)) / 1000.0
+					lines = append(lines, fmt.Sprintf("%d %d %.3f", l, r, p))
+					break
+				}
+			}
+		}
+		tests = append(tests, strings.Join(lines, "\n")+"\n")
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go <binary>")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candC")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "494C.go")
+	refPath, err := prepareBinary(refSrc, "refC")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	tests := genTests()
+	for i, input := range tests {
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/490-499/494/verifierD.go
+++ b/0-999/400-499/490-499/494/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rand.Seed(1)
+	var tests []string
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 2
+		lines := []string{fmt.Sprintf("%d", n)}
+		for i := 2; i <= n; i++ {
+			p := rand.Intn(i-1) + 1
+			w := rand.Intn(10) + 1
+			lines = append(lines, fmt.Sprintf("%d %d %d", p, i, w))
+		}
+		q := rand.Intn(3) + 1
+		lines = append(lines, fmt.Sprintf("%d", q))
+		for i := 0; i < q; i++ {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			lines = append(lines, fmt.Sprintf("%d %d", u, v))
+		}
+		tests = append(tests, strings.Join(lines, "\n")+"\n")
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go <binary>")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candD")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "494D.go")
+	refPath, err := prepareBinary(refSrc, "refD")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	tests := genTests()
+	for i, input := range tests {
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/490-499/494/verifierE.go
+++ b/0-999/400-499/490-499/494/verifierE.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rand.Seed(1)
+	var tests []string
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		m := rand.Intn(5) + 1
+		k := rand.Intn(n) + 1
+		lines := []string{fmt.Sprintf("%d %d %d", n, m, k)}
+		for i := 0; i < m; i++ {
+			a := rand.Intn(n) + 1
+			c := a + rand.Intn(n-a+1)
+			b := rand.Intn(n) + 1
+			d := b + rand.Intn(n-b+1)
+			lines = append(lines, fmt.Sprintf("%d %d %d %d", a, b, c, d))
+		}
+		tests = append(tests, strings.Join(lines, "\n")+"\n")
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go <binary>")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candE")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "494E.go")
+	refPath, err := prepareBinary(refSrc, "refE")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	tests := genTests()
+	for i, input := range tests {
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for contest 494
- verifierA.go through verifierE.go compile a candidate solution, generate 100 random tests and compare output with the reference solution

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687edd13fc348324aedef400b77682db