### PR TITLE
Add solution verifiers for contest 493

### DIFF
--- a/0-999/400-499/490-499/493/verifierA.go
+++ b/0-999/400-499/490-499/493/verifierA.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(r *bufio.Reader) string {
+	var home, away string
+	fmt.Fscan(r, &home)
+	fmt.Fscan(r, &away)
+	var n int
+	fmt.Fscan(r, &n)
+	yellowHome := make(map[int]int)
+	yellowAway := make(map[int]int)
+	redHome := make(map[int]bool)
+	redAway := make(map[int]bool)
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		var t int
+		var teamType string
+		var num int
+		var card string
+		fmt.Fscan(r, &t, &teamType, &num, &card)
+		if teamType == "h" {
+			if redHome[num] {
+				continue
+			}
+			if card == "r" {
+				redHome[num] = true
+				fmt.Fprintf(&sb, "%s %d %d\n", home, num, t)
+			} else {
+				yellowHome[num]++
+				if yellowHome[num] == 2 {
+					redHome[num] = true
+					fmt.Fprintf(&sb, "%s %d %d\n", home, num, t)
+				}
+			}
+		} else {
+			if redAway[num] {
+				continue
+			}
+			if card == "r" {
+				redAway[num] = true
+				fmt.Fprintf(&sb, "%s %d %d\n", away, num, t)
+			} else {
+				yellowAway[num]++
+				if yellowAway[num] == 2 {
+					redAway[num] = true
+					fmt.Fprintf(&sb, "%s %d %d\n", away, num, t)
+				}
+			}
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func randName(rng *rand.Rand) string {
+	l := rng.Intn(8) + 3
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('A' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCaseA(rng *rand.Rand) string {
+	home := randName(rng)
+	away := randName(rng)
+	n := rng.Intn(20) + 1
+	minutes := rng.Perm(90)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s\n%s\n%d\n", home, away, n)
+	for i := 0; i < n; i++ {
+		t := minutes[i] + 1
+		teamType := "h"
+		if rng.Intn(2) == 0 {
+			teamType = "a"
+		}
+		num := rng.Intn(30) + 1
+		card := "y"
+		if rng.Intn(4) == 0 {
+			card = "r"
+		}
+		fmt.Fprintf(&sb, "%d %s %d %s\n", t, teamType, num, card)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseA(rng)
+		expect := solveA(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/493/verifierB.go
+++ b/0-999/400-499/490-499/493/verifierB.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(r *bufio.Reader) string {
+	var n int
+	fmt.Fscan(r, &n)
+	var firstSum, secondSum int64
+	firstSeq := make([]int64, 0, n)
+	secondSeq := make([]int64, 0, n)
+	last := 0
+	for i := 0; i < n; i++ {
+		var ai int64
+		fmt.Fscan(r, &ai)
+		if ai > 0 {
+			firstSum += ai
+			firstSeq = append(firstSeq, ai)
+			last = 1
+		} else {
+			val := -ai
+			secondSum += val
+			secondSeq = append(secondSeq, val)
+			last = 2
+		}
+	}
+	if firstSum > secondSum {
+		return "first"
+	} else if firstSum < secondSum {
+		return "second"
+	}
+	minLen := len(firstSeq)
+	if len(secondSeq) < minLen {
+		minLen = len(secondSeq)
+	}
+	for i := 0; i < minLen; i++ {
+		if firstSeq[i] > secondSeq[i] {
+			return "first"
+		} else if firstSeq[i] < secondSeq[i] {
+			return "second"
+		}
+	}
+	if len(firstSeq) > len(secondSeq) {
+		return "first"
+	} else if len(firstSeq) < len(secondSeq) {
+		return "second"
+	}
+	if last == 1 {
+		return "first"
+	}
+	return "second"
+}
+
+func generateCaseB(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		val := rng.Intn(20) + 1
+		if rng.Intn(2) == 0 {
+			val = -val
+		}
+		fmt.Fprintf(&sb, "%d\n", val)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseB(rng)
+		expect := solveB(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/493/verifierC.go
+++ b/0-999/400-499/490-499/493/verifierC.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(r *bufio.Reader) string {
+	var n, m int
+	fmt.Fscan(r, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &a[i])
+	}
+	fmt.Fscan(r, &m)
+	b := make([]int, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(r, &b[i])
+	}
+	sort.Ints(a)
+	sort.Ints(b)
+	score1 := 3 * n
+	score2 := 3 * m
+	best1, best2 := score1, score2
+	bestDiff := score1 - score2
+	i, j := 0, 0
+	for i < n || j < m {
+		var d int
+		if i < n && (j >= m || a[i] < b[j]) {
+			d = a[i]
+		} else if j < m && (i >= n || b[j] < a[i]) {
+			d = b[j]
+		} else {
+			d = a[i]
+		}
+		k1 := 0
+		for i < n && a[i] == d {
+			k1++
+			i++
+		}
+		k2 := 0
+		for j < m && b[j] == d {
+			k2++
+			j++
+		}
+		if k1 > 0 {
+			score1 -= k1
+		}
+		if k2 > 0 {
+			score2 -= k2
+		}
+		diff := score1 - score2
+		if diff > bestDiff || (diff == bestDiff && score1 > best1) {
+			bestDiff = diff
+			best1 = score1
+			best2 = score2
+		}
+	}
+	return fmt.Sprintf("%d:%d", best1, best2)
+}
+
+func generateCaseC(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(6) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(20)+1)
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", m)
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(20)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseC(rng)
+		expect := solveC(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/493/verifierD.go
+++ b/0-999/400-499/490-499/493/verifierD.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveD(r *bufio.Reader) string {
+	var n int64
+	if _, err := fmt.Fscan(r, &n); err != nil {
+		return ""
+	}
+	if n == 2 {
+		return "white\n1 2"
+	}
+	return "black"
+}
+
+func generateCaseD(rng *rand.Rand) string {
+	n := rng.Int63n(20) + 2
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseD(rng)
+		expect := solveD(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/493/verifierE.go
+++ b/0-999/400-499/490-499/493/verifierE.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func max(x, y int64) int64 {
+	if x > y {
+		return x
+	}
+	return y
+}
+
+func solveE(r *bufio.Reader) string {
+	var t, a, b int64
+	if _, err := fmt.Fscan(r, &t, &a, &b); err != nil {
+		return ""
+	}
+	if t == 1 && a == 1 {
+		if b == 1 {
+			return "inf"
+		}
+		return "0"
+	}
+	C := int64(0)
+	powA := int64(1)
+	aa := a
+	for aa > 0 {
+		d := aa % t
+		C += d * powA
+		aa /= t
+		if powA > (1<<62)/max(a, 1) {
+			powA = 0
+		} else {
+			powA *= a
+		}
+	}
+	denom := t*a - 1
+	if denom <= 0 || b < C || (b-C)%denom != 0 {
+		return "0"
+	}
+	return "1"
+}
+
+func generateCaseE(rng *rand.Rand) string {
+	t := rng.Int63n(5) + 1
+	a := rng.Int63n(1000) + 1
+	b := rng.Int63n(1000) + 1
+	return fmt.Sprintf("%d %d %d\n", t, a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseE(rng)
+		expect := solveE(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for contest 493 problems A–E
- each verifier executes a provided binary or Go file and checks its output on 100 random test cases

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*
- `go build ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_687edccdf2408324a4e12511381ca458