### PR TITLE
Add Go solution verifiers for contest 492

### DIFF
--- a/0-999/400-499/490-499/492/verifierA.go
+++ b/0-999/400-499/490-499/492/verifierA.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int) string {
+	total := 0
+	h := 0
+	for i := 1; ; i++ {
+		need := i * (i + 1) / 2
+		if total+need > n {
+			break
+		}
+		total += need
+		h++
+	}
+	return fmt.Sprintf("%d", h)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	expect := solveCase(n)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/492/verifierB.go
+++ b/0-999/400-499/490-499/492/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int, l int, arr []int) string {
+	sort.Ints(arr)
+	radius := math.Max(float64(arr[0]), float64(l-arr[n-1]))
+	for i := 0; i+1 < n; i++ {
+		gap := float64(arr[i+1]-arr[i]) / 2.0
+		if gap > radius {
+			radius = gap
+		}
+	}
+	return fmt.Sprintf("%.12f", radius)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	l := rng.Intn(1000) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, l)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(l + 1)
+		if i > 0 {
+			fmt.Fprintf(&sb, " ")
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteString("\n")
+	expect := solveCase(n, l, arr)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/492/verifierC.go
+++ b/0-999/400-499/490-499/492/verifierC.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type exam struct {
+	grade int64
+	cost  int64
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int, r, avg int64, exams []exam) string {
+	sort.Slice(exams, func(i, j int) bool { return exams[i].cost < exams[j].cost })
+	total := int64(0)
+	for _, e := range exams {
+		total += e.grade
+	}
+	need := int64(n)*avg - total
+	if need <= 0 {
+		return "0"
+	}
+	essays := int64(0)
+	for i := 0; i < n && need > 0; i++ {
+		canAdd := r - exams[i].grade
+		if canAdd <= 0 {
+			continue
+		}
+		add := canAdd
+		if need < add {
+			add = need
+		}
+		need -= add
+		essays += add * exams[i].cost
+	}
+	return fmt.Sprintf("%d", essays)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	r := int64(rng.Intn(10) + 1)
+	avg := int64(rng.Intn(int(r)) + 1)
+	exams := make([]exam, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, r, avg)
+	for i := 0; i < n; i++ {
+		exams[i].grade = int64(rng.Intn(int(r) + 1))
+		exams[i].cost = int64(rng.Intn(10) + 1)
+		fmt.Fprintf(&sb, "%d %d\n", exams[i].grade, exams[i].cost)
+	}
+	expect := solveCase(n, r, avg, exams)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/492/verifierD.go
+++ b/0-999/400-499/490-499/492/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int, x, y int64, a []int64) string {
+	var sb strings.Builder
+	for _, hits := range a {
+		low, high := int64(0), hits*min(x, y)
+		for low < high {
+			mid := (low + high) / 2
+			if mid/x+mid/y < hits {
+				low = mid + 1
+			} else {
+				high = mid
+			}
+		}
+		p := low
+		vanya := p%y == 0
+		vova := p%x == 0
+		if vanya && vova {
+			sb.WriteString("Both\n")
+		} else if vanya {
+			sb.WriteString("Vanya\n")
+		} else {
+			sb.WriteString("Vova\n")
+		}
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func min(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	x := int64(rng.Intn(10) + 1)
+	y := int64(rng.Intn(10) + 1)
+	a := make([]int64, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, x, y)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(20) + 1)
+		fmt.Fprintf(&sb, "%d\n", a[i])
+	}
+	expect := solveCase(n, x, y, a)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/490-499/492/verifierE.go
+++ b/0-999/400-499/490-499/492/verifierE.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func exgcd(a, b int64) (g, x, y int64) {
+	if b == 0 {
+		return a, 1, 0
+	}
+	g, x1, y1 := exgcd(b, a%b)
+	x = y1
+	y = x1 - (a/b)*y1
+	return
+}
+
+func solveCase(n, m, dx, dy int64, pts [][2]int64) string {
+	g, invDx, _ := exgcd(dx, n)
+	if g != 1 {
+		return ""
+	}
+	invDx = (invDx%n + n) % n
+	yOffset := (n - invDx) % n
+	counts := make([]int, n)
+	for _, p := range pts {
+		t := (p[0] * yOffset) % n * dy % n
+		k := (p[1] + t) % n
+		counts[k]++
+	}
+	best := 0
+	for i := 1; i < int(n); i++ {
+		if counts[i] > counts[best] {
+			best = i
+		}
+	}
+	return fmt.Sprintf("0 %d", best)
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(20) + 2)
+	var dx, dy int64
+	for {
+		dx = int64(rng.Intn(int(n-1)) + 1)
+		if gcd(n, dx) == 1 {
+			break
+		}
+	}
+	for {
+		dy = int64(rng.Intn(int(n-1)) + 1)
+		if gcd(n, dy) == 1 {
+			break
+		}
+	}
+	m := int64(rng.Intn(20) + 1)
+	pts := make([][2]int64, m)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", n, m, dx, dy)
+	for i := int64(0); i < m; i++ {
+		x := int64(rng.Intn(int(n)))
+		y := int64(rng.Intn(int(n)))
+		pts[i] = [2]int64{x, y}
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	expect := solveCase(n, m, dx, dy, pts)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement verifierA.go-E.go for contest 492
- each verifier generates 100 random test cases and runs a candidate binary
- verifiers include internal solution logic to check outputs

## Testing
- `go build 0-999/400-499/490-499/492/verifierA.go`
- `./verifierA 0-999/400-499/490-499/492/492A.go`
- `go build 0-999/400-499/490-499/492/verifierB.go`
- `./verifierB 0-999/400-499/490-499/492/492B.go`


------
https://chatgpt.com/codex/tasks/task_e_687edc87f140832490137036ccef3930