### PR TITLE
Add Go verifiers for Codeforces contest 490

### DIFF
--- a/0-999/400-499/490-499/490/verifierA.go
+++ b/0-999/400-499/490-499/490/verifierA.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type caseA struct {
+	n   int
+	arr []int
+}
+
+func generateTests() []caseA {
+	r := rand.New(rand.NewSource(42))
+	var tests []caseA
+	tests = append(tests, caseA{3, []int{1, 2, 3}})
+	tests = append(tests, caseA{1, []int{1}})
+	tests = append(tests, caseA{4, []int{2, 2, 2, 2}})
+	for len(tests) < 120 {
+		n := r.Intn(20) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = r.Intn(3) + 1
+		}
+		tests = append(tests, caseA{n, arr})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func verify(t caseA, out string) error {
+	parts := strings.Fields(out)
+	if len(parts) == 0 {
+		return fmt.Errorf("no output")
+	}
+	w, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("invalid integer: %v", parts[0])
+	}
+	c1, c2, c3 := 0, 0, 0
+	for _, v := range t.arr {
+		switch v {
+		case 1:
+			c1++
+		case 2:
+			c2++
+		case 3:
+			c3++
+		}
+	}
+	expected := c1
+	if c2 < expected {
+		expected = c2
+	}
+	if c3 < expected {
+		expected = c3
+	}
+	if w != expected {
+		return fmt.Errorf("expected %d teams, got %d", expected, w)
+	}
+	used := make([]bool, t.n+1)
+	idx := 1
+	for i := 0; i < w; i++ {
+		if idx+2 >= len(parts) {
+			return fmt.Errorf("missing team line %d", i+1)
+		}
+		a, err1 := strconv.Atoi(parts[idx])
+		b, err2 := strconv.Atoi(parts[idx+1])
+		c, err3 := strconv.Atoi(parts[idx+2])
+		if err1 != nil || err2 != nil || err3 != nil {
+			return fmt.Errorf("invalid team indices")
+		}
+		idx += 3
+		vals := []int{a, b, c}
+		seen := make(map[int]bool)
+		types := make(map[int]bool)
+		for _, v := range vals {
+			if v < 1 || v > t.n {
+				return fmt.Errorf("index out of range")
+			}
+			if used[v] {
+				return fmt.Errorf("index used twice")
+			}
+			used[v] = true
+			seen[v] = true
+			types[t.arr[v-1]] = true
+		}
+		if len(types) != 3 {
+			return fmt.Errorf("team %d does not contain all skills", i+1)
+		}
+	}
+	if idx != len(parts) {
+		return fmt.Errorf("extra output")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(tc.n))
+		sb.WriteByte('\n')
+		for j, v := range tc.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := verify(tc, out); err != nil {
+			fmt.Printf("wrong answer on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/490-499/490/verifierB.go
+++ b/0-999/400-499/490-499/490/verifierB.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type caseB struct {
+	n     int
+	pairs [][2]int
+	order []int
+}
+
+func generateTests() []caseB {
+	r := rand.New(rand.NewSource(43))
+	var tests []caseB
+	tests = append(tests, genCase(r, 1))
+	tests = append(tests, genCase(r, 2))
+	for len(tests) < 120 {
+		n := r.Intn(20) + 1
+		tests = append(tests, genCase(r, n))
+	}
+	return tests
+}
+
+func genCase(r *rand.Rand, n int) caseB {
+	ids := r.Perm(n)
+	order := make([]int, n)
+	for i, v := range ids {
+		order[i] = v + 1
+	}
+	pairs := make([][2]int, n)
+	for i := 0; i < n-1; i++ {
+		pairs[i] = [2]int{order[i], order[i+1]}
+	}
+	pairs[n-1] = [2]int{order[n-1], 0}
+	r.Shuffle(n, func(i, j int) { pairs[i], pairs[j] = pairs[j], pairs[i] })
+	return caseB{n: n, pairs: pairs, order: order}
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(pairs [][2]int) []int {
+	next := make(map[int]int)
+	prev := make(map[int]int)
+	for _, pr := range pairs {
+		next[pr[0]] = pr[1]
+		prev[pr[1]] = pr[0]
+	}
+	var start int
+	for k := range next {
+		if prev[k] == 0 {
+			start = k
+			break
+		}
+	}
+	res := make([]int, 0)
+	cur := start
+	for cur != 0 {
+		res = append(res, cur)
+		cur = next[cur]
+	}
+	return res
+}
+
+func verify(tc caseB, out string) error {
+	parts := strings.Fields(out)
+	if len(parts) != tc.n {
+		return fmt.Errorf("expected %d numbers, got %d", tc.n, len(parts))
+	}
+	got := make([]int, tc.n)
+	for i, p := range parts {
+		v, err := strconv.Atoi(p)
+		if err != nil {
+			return fmt.Errorf("invalid integer")
+		}
+		got[i] = v
+	}
+	expected := solveCase(tc.pairs)
+	for i := range expected {
+		if got[i] != expected[i] {
+			return fmt.Errorf("mismatch at position %d", i+1)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(tc.n))
+		sb.WriteByte('\n')
+		for _, pr := range tc.pairs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", pr[0], pr[1]))
+		}
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := verify(tc, out); err != nil {
+			fmt.Printf("wrong answer on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/490-499/490/verifierC.go
+++ b/0-999/400-499/490-499/490/verifierC.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type caseC struct {
+	s     string
+	a     int64
+	b     int64
+	ok    bool
+	left  string
+	right string
+}
+
+func modStr(s string, mod int64) int64 {
+	var res int64
+	for _, ch := range s {
+		res = (res*10 + int64(ch-'0')) % mod
+	}
+	return res
+}
+
+func solveCaseC(s string, a, b int64) (bool, string, string) {
+	n := len(s)
+	prefix := make([]int64, n)
+	for i := 0; i < n; i++ {
+		d := int64(s[i] - '0')
+		if i == 0 {
+			prefix[i] = d % a
+		} else {
+			prefix[i] = (prefix[i-1]*10 + d) % a
+		}
+	}
+	suffix := make([]int64, n+1)
+	var mult int64 = 1
+	for i := n - 1; i >= 0; i-- {
+		d := int64(s[i] - '0')
+		suffix[i] = (d*mult + suffix[i+1]) % b
+		mult = (mult * 10) % b
+	}
+	for i := 1; i < n; i++ {
+		if prefix[i-1] == 0 && suffix[i] == 0 && s[i] != '0' {
+			return true, s[:i], s[i:]
+		}
+	}
+	return false, "", ""
+}
+
+func generateTests() []caseC {
+	r := rand.New(rand.NewSource(44))
+	var tests []caseC
+	fixed := []struct {
+		s    string
+		a, b int64
+	}{
+		{"35", 5, 7},
+		{"100", 10, 2},
+		{"999", 3, 9},
+	}
+	for _, f := range fixed {
+		ok, l, r := solveCaseC(f.s, f.a, f.b)
+		tests = append(tests, caseC{f.s, f.a, f.b, ok, l, r})
+	}
+	for len(tests) < 120 {
+		n := r.Intn(18) + 2
+		var sb strings.Builder
+		sb.WriteByte(byte('1' + r.Intn(9)))
+		for i := 1; i < n; i++ {
+			sb.WriteByte(byte('0' + r.Intn(10)))
+		}
+		s := sb.String()
+		a := int64(r.Intn(1000) + 1)
+		b := int64(r.Intn(1000) + 1)
+		ok, l, rp := solveCaseC(s, a, b)
+		tests = append(tests, caseC{s, a, b, ok, l, rp})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func verify(tc caseC, out string) error {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) == 0 {
+		return fmt.Errorf("no output")
+	}
+	if lines[0] == "NO" {
+		if tc.ok {
+			return fmt.Errorf("should be YES")
+		}
+		if len(lines) != 1 {
+			return fmt.Errorf("extra output after NO")
+		}
+		return nil
+	}
+	if lines[0] != "YES" {
+		return fmt.Errorf("first line must be YES or NO")
+	}
+	if len(lines) < 3 {
+		return fmt.Errorf("missing parts")
+	}
+	left := strings.TrimSpace(lines[1])
+	right := strings.TrimSpace(lines[2])
+	if left+right != tc.s {
+		return fmt.Errorf("concatenation mismatch")
+	}
+	if len(left) > 1 && left[0] == '0' {
+		return fmt.Errorf("left leading zero")
+	}
+	if len(right) > 1 && right[0] == '0' {
+		return fmt.Errorf("right leading zero")
+	}
+	if modStr(left, tc.a) != 0 || modStr(right, tc.b) != 0 {
+		return fmt.Errorf("parts not divisible")
+	}
+	if !tc.ok {
+		return fmt.Errorf("should be NO")
+	}
+	if len(lines) != 3 {
+		return fmt.Errorf("extra output")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%s\n%d %d\n", tc.s, tc.a, tc.b)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := verify(tc, out); err != nil {
+			fmt.Printf("wrong answer on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/490-499/490/verifierD.go
+++ b/0-999/400-499/490-499/490/verifierD.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type caseD struct {
+	a1, b1, a2, b2 int64
+	ops            int
+	r1, r2         int64
+	r3, r4         int64
+}
+
+func countFactors(n int64) (int, int, int64) {
+	cnt2, cnt3 := 0, 0
+	for n%2 == 0 {
+		n /= 2
+		cnt2++
+	}
+	for n%3 == 0 {
+		n /= 3
+		cnt3++
+	}
+	return cnt2, cnt3, n
+}
+
+func solveCase(a1, b1, a2, b2 int64) (int, int64, int64, int64, int64) {
+	p1a, q1a, x1 := countFactors(a1)
+	p1b, q1b, y1 := countFactors(b1)
+	p2a, q2a, x2 := countFactors(a2)
+	p2b, q2b, y2 := countFactors(b2)
+	if x1*y1 != x2*y2 {
+		return -1, 0, 0, 0, 0
+	}
+	p1 := p1a + p1b
+	q1 := q1a + q1b
+	p2 := p2a + p2b
+	q2 := q2a + q2b
+	qT := q1
+	if q2 < qT {
+		qT = q2
+	}
+	d3_1 := q1 - qT
+	d3_2 := q2 - qT
+	np1 := p1 + d3_1
+	np2 := p2 + d3_2
+	pT := np1
+	if np2 < pT {
+		pT = np2
+	}
+	d2_1 := np1 - pT
+	d2_2 := np2 - pT
+	m := d3_1 + d3_2 + d2_1 + d2_2
+	A1, B1 := a1, b1
+	A2, B2 := a2, b2
+	for i := 0; i < d3_1; i++ {
+		if A1%3 == 0 {
+			A1 = A1 / 3 * 2
+		} else {
+			B1 = B1 / 3 * 2
+		}
+	}
+	for i := 0; i < d2_1; i++ {
+		if A1%2 == 0 {
+			A1 /= 2
+		} else {
+			B1 /= 2
+		}
+	}
+	for i := 0; i < d3_2; i++ {
+		if A2%3 == 0 {
+			A2 = A2 / 3 * 2
+		} else {
+			B2 = B2 / 3 * 2
+		}
+	}
+	for i := 0; i < d2_2; i++ {
+		if A2%2 == 0 {
+			A2 /= 2
+		} else {
+			B2 /= 2
+		}
+	}
+	return m, A1, B1, A2, B2
+}
+
+func generateTests() []caseD {
+	r := rand.New(rand.NewSource(45))
+	var tests []caseD
+	fixed := []caseD{{1, 1, 1, 1, 0, 1, 1, 1, 1}}
+	for _, f := range fixed {
+		m, x1, x2, x3, x4 := solveCase(f.a1, f.b1, f.a2, f.b2)
+		tests = append(tests, caseD{f.a1, f.b1, f.a2, f.b2, m, x1, x2, x3, x4})
+	}
+	for len(tests) < 120 {
+		a1 := int64(r.Intn(1000) + 1)
+		b1 := int64(r.Intn(1000) + 1)
+		a2 := int64(r.Intn(1000) + 1)
+		b2 := int64(r.Intn(1000) + 1)
+		m, x1, x2, x3, x4 := solveCase(a1, b1, a2, b2)
+		tests = append(tests, caseD{a1, b1, a2, b2, m, x1, x2, x3, x4})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func verify(tc caseD, out string) error {
+	parts := strings.Fields(out)
+	if tc.ops == -1 {
+		if len(parts) != 1 {
+			return fmt.Errorf("expected -1")
+		}
+		if parts[0] != "-1" {
+			return fmt.Errorf("should be -1")
+		}
+		return nil
+	}
+	if len(parts) != 5 {
+		return fmt.Errorf("expected 5 numbers")
+	}
+	gotM, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("bad m")
+	}
+	a1, _ := strconv.ParseInt(parts[1], 10, 64)
+	b1, _ := strconv.ParseInt(parts[2], 10, 64)
+	a2, _ := strconv.ParseInt(parts[3], 10, 64)
+	b2, _ := strconv.ParseInt(parts[4], 10, 64)
+	if gotM != tc.ops || a1 != tc.r1 || b1 != tc.r2 || a2 != tc.r3 || b2 != tc.r4 {
+		return fmt.Errorf("incorrect result")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d\n%d %d\n", tc.a1, tc.b1, tc.a2, tc.b2)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := verify(tc, out); err != nil {
+			fmt.Printf("wrong answer on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/490-499/490/verifierE.go
+++ b/0-999/400-499/490-499/490/verifierE.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type caseE struct {
+	n        int
+	patterns []string
+	ok       bool
+	seq      []int64
+}
+
+func dfsFill(pat, lb, cur []byte, pos int, tight bool) bool {
+	if pos == len(pat) {
+		return true
+	}
+	if pat[pos] == '?' {
+		for d := byte('0'); d <= '9'; d++ {
+			if pos == 0 && d == '0' {
+				continue
+			}
+			if tight && d < lb[pos] {
+				continue
+			}
+			cur[pos] = d
+			nt := tight && d == lb[pos]
+			if dfsFill(pat, lb, cur, pos+1, nt) {
+				return true
+			}
+		}
+	} else {
+		d := pat[pos]
+		if tight && d < lb[pos] {
+			return false
+		}
+		cur[pos] = d
+		nt := tight && d == lb[pos]
+		if dfsFill(pat, lb, cur, pos+1, nt) {
+			return true
+		}
+	}
+	return false
+}
+
+func solveCase(patterns []string) (bool, []int64) {
+	n := len(patterns)
+	res := make([]int64, n)
+	var prev int64
+	for i, pat := range patterns {
+		k := len(pat)
+		lb := prev + 1
+		lbStr := strconv.FormatInt(lb, 10)
+		var cur []byte
+		var ok bool
+		if k < len(lbStr) {
+			ok = false
+		} else if k > len(lbStr) {
+			cur = make([]byte, k)
+			for j := 0; j < k; j++ {
+				if pat[j] == '?' {
+					if j == 0 {
+						cur[j] = '1'
+					} else {
+						cur[j] = '0'
+					}
+				} else {
+					cur[j] = pat[j]
+				}
+			}
+			ok = true
+		} else {
+			lbBytes := []byte(lbStr)
+			cur = make([]byte, k)
+			ok = dfsFill([]byte(pat), lbBytes, cur, 0, true)
+		}
+		if !ok {
+			return false, nil
+		}
+		x, err := strconv.ParseInt(string(cur), 10, 64)
+		if err != nil {
+			return false, nil
+		}
+		res[i] = x
+		prev = x
+	}
+	return true, res
+}
+
+func generateTests() []caseE {
+	r := rand.New(rand.NewSource(46))
+	var tests []caseE
+	fixed := [][]string{{"1", "2"}, {"?", "?"}, {"9", "10", "11"}}
+	for _, f := range fixed {
+		ok, seq := solveCase(f)
+		tests = append(tests, caseE{len(f), f, ok, seq})
+	}
+	for len(tests) < 120 {
+		n := r.Intn(5) + 1
+		patterns := make([]string, n)
+		for i := 0; i < n; i++ {
+			l := r.Intn(4) + 1
+			var sb strings.Builder
+			for j := 0; j < l; j++ {
+				if r.Intn(3) == 0 {
+					sb.WriteByte('?')
+				} else {
+					sb.WriteByte(byte('0' + r.Intn(10)))
+				}
+			}
+			if sb.String()[0] == '0' && l > 1 {
+				bs := []byte(sb.String())
+				bs[0] = '?'
+				sb.Reset()
+				sb.Write(bs)
+			}
+			patterns[i] = sb.String()
+		}
+		ok, seq := solveCase(patterns)
+		tests = append(tests, caseE{n, patterns, ok, seq})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func matches(pattern string, val int64) bool {
+	s := strconv.FormatInt(val, 10)
+	if len(s) != len(pattern) {
+		return false
+	}
+	if len(s) > 1 && s[0] == '0' {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if pattern[i] != '?' && pattern[i] != s[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func verify(tc caseE, out string) error {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) == 0 {
+		return fmt.Errorf("no output")
+	}
+	if lines[0] == "NO" {
+		if tc.ok {
+			return fmt.Errorf("should be YES")
+		}
+		if len(lines) != 1 {
+			return fmt.Errorf("extra output")
+		}
+		return nil
+	}
+	if lines[0] != "YES" {
+		return fmt.Errorf("first line must be YES or NO")
+	}
+	if len(lines) != 1+tc.n {
+		return fmt.Errorf("expected %d numbers", tc.n)
+	}
+	seq := make([]int64, tc.n)
+	var prev int64 = -1
+	for i := 0; i < tc.n; i++ {
+		v, err := strconv.ParseInt(strings.TrimSpace(lines[i+1]), 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid number")
+		}
+		if v <= prev {
+			return fmt.Errorf("sequence not increasing")
+		}
+		if !matches(tc.patterns[i], v) {
+			return fmt.Errorf("pattern mismatch")
+		}
+		seq[i] = v
+		prev = v
+	}
+	if !tc.ok {
+		return fmt.Errorf("should be NO")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(tc.n))
+		sb.WriteByte('\n')
+		for _, p := range tc.patterns {
+			sb.WriteString(p)
+			sb.WriteByte('\n')
+		}
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := verify(tc, out); err != nil {
+			fmt.Printf("wrong answer on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/490-499/490/verifierF.go
+++ b/0-999/400-499/490-499/490/verifierF.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type caseF struct {
+	n     int
+	pop   []int
+	edges [][2]int
+	ans   int
+}
+
+func LIS(arr []int) int {
+	if len(arr) == 0 {
+		return 0
+	}
+	d := []int{arr[0]}
+	for i := 1; i < len(arr); i++ {
+		x := arr[i]
+		l, r := 0, len(d)
+		for l < r {
+			m := (l + r) / 2
+			if d[m] < x {
+				l = m + 1
+			} else {
+				r = m
+			}
+		}
+		if l == len(d) {
+			d = append(d, x)
+		} else {
+			d[l] = x
+		}
+	}
+	return len(d)
+}
+
+func path(adj [][]int, u, v int) []int {
+	n := len(adj)
+	prev := make([]int, n)
+	for i := 0; i < n; i++ {
+		prev[i] = -1
+	}
+	q := []int{u}
+	prev[u] = u
+	for len(q) > 0 {
+		x := q[0]
+		q = q[1:]
+		if x == v {
+			break
+		}
+		for _, nb := range adj[x] {
+			if prev[nb] == -1 {
+				prev[nb] = x
+				q = append(q, nb)
+			}
+		}
+	}
+	if prev[v] == -1 {
+		return nil
+	}
+	var p []int
+	cur := v
+	for cur != u {
+		p = append(p, cur)
+		cur = prev[cur]
+	}
+	p = append(p, u)
+	for i, j := 0, len(p)-1; i < j; i, j = i+1, j-1 {
+		p[i], p[j] = p[j], p[i]
+	}
+	return p
+}
+
+func solveCase(n int, pop []int, edges [][2]int) int {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		a, b := e[0]-1, e[1]-1
+		adj[a] = append(adj[a], b)
+		adj[b] = append(adj[b], a)
+	}
+	ans := 1
+	for i := 0; i < n; i++ {
+		for j := i; j < n; j++ {
+			p := path(adj, i, j)
+			if p == nil {
+				continue
+			}
+			arr := make([]int, len(p))
+			for k, idx := range p {
+				arr[k] = pop[idx]
+			}
+			l := LIS(arr)
+			if l > ans {
+				ans = l
+			}
+		}
+	}
+	return ans
+}
+
+func genCase(r *rand.Rand, n int) caseF {
+	pop := make([]int, n)
+	for i := 0; i < n; i++ {
+		pop[i] = r.Intn(100) + 1
+	}
+	edges := make([][2]int, n-1)
+	for i := 1; i < n; i++ {
+		p := r.Intn(i)
+		edges[i-1] = [2]int{i + 1, p + 1}
+	}
+	ans := solveCase(n, pop, edges)
+	return caseF{n, pop, edges, ans}
+}
+
+func generateTests() []caseF {
+	r := rand.New(rand.NewSource(47))
+	var tests []caseF
+	tests = append(tests, genCase(r, 2))
+	for len(tests) < 120 {
+		n := r.Intn(8) + 2
+		tests = append(tests, genCase(r, n))
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func verify(tc caseF, out string) error {
+	v, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("invalid integer")
+	}
+	if v != tc.ans {
+		return fmt.Errorf("expected %d got %d", tc.ans, v)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(tc.n))
+		sb.WriteByte('\n')
+		for j, v := range tc.pop {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		for _, e := range tc.edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := verify(tc, out); err != nil {
+			fmt.Printf("wrong answer on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` through `verifierF.go` for contest 490
- each verifier generates 100+ random tests and checks outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_687edbfbd2448324b9d8a8b6ca969934