### PR TITLE
Add verifiers for contest 488

### DIFF
--- a/0-999/400-499/480-489/488/verifierA.go
+++ b/0-999/400-499/480-489/488/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func has8(x int64) bool {
+	if x < 0 {
+		x = -x
+	}
+	for x > 0 {
+		if x%10 == 8 {
+			return true
+		}
+		x /= 10
+	}
+	return false
+}
+
+func solve(a int64) string {
+	for i := int64(1); ; i++ {
+		if has8(a + i) {
+			return fmt.Sprintf("%d", i)
+		}
+	}
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	a := rng.Int63n(2000000001) - 1000000000
+	input := fmt.Sprintf("%d\n", a)
+	expected := solve(a)
+	return testCase{input: input, expected: expected}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	var cases []testCase
+	// simple deterministic case
+	cases = append(cases, testCase{input: "7\n", expected: solve(7)})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/480-489/488/verifierB.go
+++ b/0-999/400-499/480-489/488/verifierB.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		v := rng.Intn(500) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", v))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	ref := "488B.go"
+	var cases []string
+	// simple deterministic cases
+	cases = append(cases, "0\n")
+	cases = append(cases, "4\n1\n1\n3\n3\n")
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 488 problem A and problem B
- over 100 random test cases are generated in each verifier
- verifierB.go uses `488B.go` as the reference solution

## Testing
- `go vet 0-999/400-499/480-489/488/verifierA.go`
- `go vet 0-999/400-499/480-489/488/verifierB.go`
- `go build 0-999/400-499/480-489/488/verifierA.go`
- `go build 0-999/400-499/480-489/488/verifierB.go`


------
https://chatgpt.com/codex/tasks/task_e_687edb6fbd988324a00bbd2112ce7cad