### PR TITLE
Add Go verifiers for contest 487

### DIFF
--- a/0-999/400-499/480-489/487/verifierA.go
+++ b/0-999/400-499/480-489/487/verifierA.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		hpy := rng.Intn(100) + 1
+		atky := rng.Intn(100) + 1
+		defy := rng.Intn(100) + 1
+		hpm := rng.Intn(100) + 1
+		atkm := rng.Intn(100) + 1
+		defm := rng.Intn(100) + 1
+		costh := rng.Intn(100) + 1
+		costa := rng.Intn(100) + 1
+		costd := rng.Intn(100) + 1
+		input := fmt.Sprintf("%d %d %d\n%d %d %d\n%d %d %d\n", hpy, atky, defy, hpm, atkm, defm, costh, costa, costd)
+		expected, err := run("487A.go", input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal reference failed on case %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/480-489/487/verifierB.go
+++ b/0-999/400-499/480-489/487/verifierB.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(20) + 1
+		s := rng.Intn(100)
+		l := rng.Intn(n) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(201) - 100
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, s, l))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected, err := run("487B.go", input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal reference failed on case %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/480-489/487/verifierC.go
+++ b/0-999/400-499/480-489/487/verifierC.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseOutput(out string, n int) ([]int, bool, error) {
+	tokens := strings.Fields(out)
+	if len(tokens) == 0 {
+		return nil, false, fmt.Errorf("no output")
+	}
+	if tokens[0] == "NO" {
+		if len(tokens) != 1 {
+			return nil, false, fmt.Errorf("extra tokens after NO")
+		}
+		return nil, false, nil
+	}
+	if tokens[0] != "YES" {
+		return nil, false, fmt.Errorf("first token must be YES or NO")
+	}
+	if len(tokens) != n+1 {
+		return nil, true, fmt.Errorf("expected %d numbers, got %d", n, len(tokens)-1)
+	}
+	seq := make([]int, n)
+	for i := 0; i < n; i++ {
+		v, err := strconv.Atoi(tokens[i+1])
+		if err != nil {
+			return nil, true, fmt.Errorf("invalid int %q", tokens[i+1])
+		}
+		seq[i] = v
+	}
+	return seq, true, nil
+}
+
+func validSequence(n int, seq []int) error {
+	if len(seq) != n {
+		return fmt.Errorf("wrong length")
+	}
+	used := make([]bool, n+1)
+	for _, v := range seq {
+		if v < 1 || v > n || used[v] {
+			return fmt.Errorf("not a permutation")
+		}
+		used[v] = true
+	}
+	prefUsed := make([]bool, n)
+	prod := 1
+	for i, v := range seq {
+		if i == 0 {
+			prod = v % n
+		} else {
+			prod = (prod * v) % n
+		}
+		if prefUsed[prod] {
+			return fmt.Errorf("duplicate prefix value")
+		}
+		prefUsed[prod] = true
+	}
+	for i := 0; i < n; i++ {
+		if !prefUsed[i] {
+			return fmt.Errorf("missing prefix value %d", i)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(20) + 1
+		input := fmt.Sprintf("%d\n", n)
+		expOut, err := run("487C.go", input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal reference failed on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		expYes := strings.HasPrefix(expOut, "YES")
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		seq, gotYes, err := parseOutput(got, n)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\noutput:\n%s\ninput:\n%s", t+1, err, got, input)
+			os.Exit(1)
+		}
+		if gotYes != expYes {
+			fmt.Fprintf(os.Stderr, "case %d: expected %v got %v\ninput:\n%s", t+1, expYes, gotYes, input)
+			os.Exit(1)
+		}
+		if gotYes {
+			if err := validSequence(n, seq); err != nil {
+				fmt.Fprintf(os.Stderr, "case %d: invalid sequence: %v\noutput:\n%s\ninput:\n%s", t+1, err, got, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/480-489/487/verifierD.go
+++ b/0-999/400-499/480-489/487/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+var dir = []byte{'<', '^', '>'}
+
+func randBoard(rng *rand.Rand, n, m int) []string {
+	board := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			b[j] = dir[rng.Intn(3)]
+		}
+		board[i] = string(b)
+	}
+	return board
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(4) + 1
+		m := rng.Intn(4) + 1
+		q := rng.Intn(5) + 1
+		board := randBoard(rng, n, m)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+		for i := 0; i < n; i++ {
+			sb.WriteString(board[i])
+			sb.WriteByte('\n')
+		}
+		for i := 0; i < q; i++ {
+			if rng.Intn(2) == 0 {
+				x := rng.Intn(n) + 1
+				y := rng.Intn(m) + 1
+				sb.WriteString(fmt.Sprintf("A %d %d\n", x, y))
+			} else {
+				x := rng.Intn(n) + 1
+				y := rng.Intn(m) + 1
+				c := string(dir[rng.Intn(3)])
+				sb.WriteString(fmt.Sprintf("C %d %d %s\n", x, y, c))
+			}
+		}
+		input := sb.String()
+		expected, err := run("487D.go", input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal reference failed on case %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\ngot:\n%s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/480-489/487/verifierE.go
+++ b/0-999/400-499/480-489/487/verifierE.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genGraph(rng *rand.Rand, n, m int) [][2]int {
+	edges := make([][2]int, 0, m)
+	for i := 1; i < n; i++ {
+		edges = append(edges, [2]int{i, i + 1})
+	}
+	for len(edges) < m {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a == b {
+			continue
+		}
+		exist := false
+		for _, e := range edges {
+			if (e[0] == a && e[1] == b) || (e[0] == b && e[1] == a) {
+				exist = true
+				break
+			}
+		}
+		if !exist {
+			edges = append(edges, [2]int{a, b})
+		}
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(4) + 2
+		m := rng.Intn(3) + n - 1
+		q := rng.Intn(5) + 1
+		weights := make([]int, n)
+		for i := 0; i < n; i++ {
+			weights[i] = rng.Intn(100) + 1
+		}
+		edges := genGraph(rng, n, m)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", weights[i]))
+		}
+		sb.WriteByte('\n')
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		for i := 0; i < q; i++ {
+			if rng.Intn(2) == 0 {
+				a := rng.Intn(n) + 1
+				b := rng.Intn(n) + 1
+				sb.WriteString(fmt.Sprintf("A %d %d\n", a, b))
+			} else {
+				a := rng.Intn(n) + 1
+				w := rng.Intn(100) + 1
+				sb.WriteString(fmt.Sprintf("C %d %d\n", a, w))
+			}
+		}
+		input := sb.String()
+		expected, err := run("487E.go", input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal reference failed on case %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\ngot:\n%s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`, `verifierB.go`, `verifierC.go`, `verifierD.go`, and `verifierE.go` under contest 487
- each verifier uses random tests and checks a candidate solution against the reference Go programs (`487A.go` .. `487E.go`)
- over 100 cases are generated for each verifier

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687edb29af0483249d1f42ef0d42fa7a