### PR TITLE
Add Go verifiers for contest 486

### DIFF
--- a/0-999/400-499/480-489/486/verifierA.go
+++ b/0-999/400-499/480-489/486/verifierA.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int64) int64 {
+	if n%2 == 0 {
+		return n / 2
+	}
+	return -(n + 1) / 2
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		n := rng.Int63n(1_000_000_000_000_000) + 1 // up to 1e15
+		input := fmt.Sprintf("%d\n", n)
+		want := fmt.Sprintf("%d", expected(n))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s (n=%d)\n", i+1, want, got, n)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/400-499/480-489/486/verifierB.go
+++ b/0-999/400-499/480-489/486/verifierB.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func computeB(A [][]int) [][]int {
+	m := len(A)
+	n := len(A[0])
+	B := make([][]int, m)
+	for i := 0; i < m; i++ {
+		B[i] = make([]int, n)
+		rowOR := 0
+		for _, v := range A[i] {
+			if v == 1 {
+				rowOR = 1
+				break
+			}
+		}
+		for j := 0; j < n; j++ {
+			colOR := 0
+			if rowOR == 1 {
+				B[i][j] = 1
+				continue
+			}
+			for k := 0; k < m; k++ {
+				if A[k][j] == 1 {
+					colOR = 1
+					break
+				}
+			}
+			if colOR == 1 {
+				B[i][j] = 1
+			}
+		}
+	}
+	return B
+}
+
+func validAFromB(B [][]int) ([][]int, bool) {
+	m := len(B)
+	n := len(B[0])
+	rowAll := make([]int, m)
+	colAll := make([]int, n)
+	for i := 0; i < m; i++ {
+		all1 := 1
+		for j := 0; j < n; j++ {
+			if B[i][j] == 0 {
+				all1 = 0
+				break
+			}
+		}
+		rowAll[i] = all1
+	}
+	for j := 0; j < n; j++ {
+		all1 := 1
+		for i := 0; i < m; i++ {
+			if B[i][j] == 0 {
+				all1 = 0
+				break
+			}
+		}
+		colAll[j] = all1
+	}
+	A := make([][]int, m)
+	for i := 0; i < m; i++ {
+		A[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			if rowAll[i] == 1 && colAll[j] == 1 {
+				A[i][j] = 1
+			}
+		}
+	}
+	B2 := computeB(A)
+	for i := 0; i < m; i++ {
+		for j := 0; j < n; j++ {
+			if B2[i][j] != B[i][j] {
+				return nil, false
+			}
+		}
+	}
+	return A, true
+}
+
+func parseMatrix(lines []string, m, n int) [][]int {
+	A := make([][]int, m)
+	for i := 0; i < m; i++ {
+		fields := strings.Fields(lines[i])
+		if len(fields) != n {
+			return nil
+		}
+		A[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			if fields[j] == "1" {
+				A[i][j] = 1
+			} else if fields[j] == "0" {
+				A[i][j] = 0
+			} else {
+				return nil
+			}
+		}
+	}
+	return A
+}
+
+func verifyCase(bin string, B [][]int) error {
+	m := len(B)
+	n := len(B[0])
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", m, n))
+	for i := 0; i < m; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteByte(byte('0' + B[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	got, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	outLines := strings.Split(strings.TrimSpace(got), "\n")
+	if len(outLines) == 0 {
+		return fmt.Errorf("empty output")
+	}
+	first := strings.TrimSpace(outLines[0])
+	if strings.ToUpper(first) == "NO" {
+		if _, ok := validAFromB(B); ok {
+			return fmt.Errorf("solver answered NO but solution exists")
+		}
+		return nil
+	}
+	if strings.ToUpper(first) != "YES" {
+		return fmt.Errorf("first line must be YES or NO")
+	}
+	if len(outLines)-1 != m {
+		return fmt.Errorf("expected %d rows of matrix", m)
+	}
+	A := parseMatrix(outLines[1:], m, n)
+	if A == nil {
+		return fmt.Errorf("failed to parse matrix")
+	}
+	B2 := computeB(A)
+	for i := 0; i < m; i++ {
+		for j := 0; j < n; j++ {
+			if B2[i][j] != B[i][j] {
+				return fmt.Errorf("produced matrix A does not match B")
+			}
+		}
+	}
+	return nil
+}
+
+func genValidCase(rng *rand.Rand, m, n int) [][]int {
+	A := make([][]int, m)
+	for i := 0; i < m; i++ {
+		A[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 1 {
+				A[i][j] = 1
+			}
+		}
+	}
+	return computeB(A)
+}
+
+func genInvalidCase(rng *rand.Rand, m, n int) [][]int {
+	// generate random B until it's invalid
+	for {
+		B := make([][]int, m)
+		for i := 0; i < m; i++ {
+			B[i] = make([]int, n)
+			for j := 0; j < n; j++ {
+				B[i][j] = rng.Intn(2)
+			}
+		}
+		if _, ok := validAFromB(B); !ok {
+			return B
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		m := rng.Intn(4) + 1 // 1..4
+		n := rng.Intn(4) + 1
+		var B [][]int
+		if rng.Float64() < 0.7 {
+			B = genValidCase(rng, m, n)
+		} else {
+			B = genInvalidCase(rng, m, n)
+		}
+		if err := verifyCase(bin, B); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/400-499/480-489/486/verifierC.go
+++ b/0-999/400-499/480-489/486/verifierC.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expected(n, p int, s string) int {
+	// convert to left half
+	half := n / 2
+	if p > half {
+		p = n - p + 1
+	}
+	totalChange := 0
+	left, right := n, 0
+	for i := 1; i <= half; i++ {
+		a := s[i-1]
+		b := s[n-i]
+		diff := int(a) - int(b)
+		if diff < 0 {
+			diff = -diff
+		}
+		cost := min(diff, 26-diff)
+		if cost > 0 {
+			totalChange += cost
+			if i < left {
+				left = i
+			}
+			if i > right {
+				right = i
+			}
+		}
+	}
+	if totalChange == 0 {
+		return 0
+	}
+	span := right - left
+	mv := span + min(abs(p-left), abs(p-right))
+	return totalChange + mv
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		n := rng.Intn(20) + 1
+		p := rng.Intn(n) + 1
+		s := randomString(rng, n)
+		input := fmt.Sprintf("%d %d\n%s\n", n, p, s)
+		want := fmt.Sprintf("%d", expected(n, p, s))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/400-499/480-489/486/verifierD.go
+++ b/0-999/400-499/480-489/486/verifierD.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func bfsConnected(mask int, adj [][]int) bool {
+	n := len(adj)
+	var start int
+	for i := 0; i < n; i++ {
+		if mask&(1<<i) != 0 {
+			start = i
+			break
+		}
+	}
+	vis := make([]bool, n)
+	q := []int{start}
+	vis[start] = true
+	for len(q) > 0 {
+		u := q[0]
+		q = q[1:]
+		for _, v := range adj[u] {
+			if mask&(1<<v) == 0 || vis[v] {
+				continue
+			}
+			vis[v] = true
+			q = append(q, v)
+		}
+	}
+	for i := 0; i < n; i++ {
+		if mask&(1<<i) != 0 && !vis[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func expected(d int, a []int, adj [][]int) int {
+	n := len(a)
+	ans := 0
+	for mask := 1; mask < (1 << n); mask++ {
+		minV := 3000
+		maxV := -1
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) != 0 {
+				if a[i] < minV {
+					minV = a[i]
+				}
+				if a[i] > maxV {
+					maxV = a[i]
+				}
+			}
+		}
+		if maxV-minV > d {
+			continue
+		}
+		if bfsConnected(mask, adj) {
+			ans++
+			if ans >= mod {
+				ans -= mod
+			}
+		}
+	}
+	return ans
+}
+
+func genTree(rng *rand.Rand, n int) [][]int {
+	adj := make([][]int, n)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		adj[i] = append(adj[i], p)
+		adj[p] = append(adj[p], i)
+	}
+	return adj
+}
+
+func verifyCase(bin string, d int, a []int, adj [][]int) error {
+	n := len(a)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", d, n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 1; i < n; i++ {
+		u := i + 1
+		for _, v := range adj[i] {
+			if v < i {
+				sb.WriteString(fmt.Sprintf("%d %d\n", u, v+1))
+			}
+		}
+	}
+	got, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	var res int
+	if _, err := fmt.Sscan(got, &res); err != nil {
+		return fmt.Errorf("invalid output")
+	}
+	want := expected(d, a, adj)
+	if res%mod != want%mod {
+		return fmt.Errorf("expected %d got %d", want%mod, res%mod)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		n := rng.Intn(6) + 2 // 2..7
+		d := rng.Intn(5)
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rng.Intn(6)
+		}
+		adj := genTree(rng, n)
+		if err := verifyCase(bin, d, a, adj); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/400-499/480-489/486/verifierE.go
+++ b/0-999/400-499/480-489/486/verifierE.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+// BIT for prefix max
+type BIT struct {
+	n    int
+	tree []int
+}
+
+func NewBIT(n int) *BIT {
+	return &BIT{n: n, tree: make([]int, n+1)}
+}
+
+func (b *BIT) Update(i, v int) {
+	for ; i <= b.n; i += i & -i {
+		if b.tree[i] < v {
+			b.tree[i] = v
+		}
+	}
+}
+
+func (b *BIT) Query(i int) int {
+	m := 0
+	for ; i > 0; i -= i & -i {
+		if b.tree[i] > m {
+			m = b.tree[i]
+		}
+	}
+	return m
+}
+
+func expected(a []int) string {
+	n := len(a)
+	maxVal := 0
+	for _, v := range a {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	bit1 := NewBIT(maxVal + 2)
+	dp1 := make([]int, n)
+	L := 0
+	for i := 0; i < n; i++ {
+		v := a[i]
+		best := 0
+		if v > 1 {
+			best = bit1.Query(v - 1)
+		}
+		dp1[i] = best + 1
+		if dp1[i] > L {
+			L = dp1[i]
+		}
+		bit1.Update(v, dp1[i])
+	}
+	bit2 := NewBIT(maxVal + 2)
+	dp2 := make([]int, n)
+	for i := n - 1; i >= 0; i-- {
+		v := a[i]
+		ra := maxVal - v + 1
+		best := 0
+		if ra > 1 {
+			best = bit2.Query(ra - 1)
+		}
+		dp2[i] = best + 1
+		bit2.Update(ra, dp2[i])
+	}
+	cnt := make([]int, L+1)
+	for i := 0; i < n; i++ {
+		if dp1[i]+dp2[i]-1 == L {
+			cnt[dp1[i]]++
+		}
+	}
+	res := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if dp1[i]+dp2[i]-1 < L {
+			res[i] = '1'
+		} else if cnt[dp1[i]] == 1 {
+			res[i] = '3'
+		} else {
+			res[i] = '2'
+		}
+	}
+	return string(res)
+}
+
+func verifyCase(bin string, a []int) error {
+	n := len(a)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	got, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	want := expected(a)
+	if strings.TrimSpace(got) != want {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		n := rng.Intn(20) + 1
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rng.Intn(20) + 1
+		}
+		if err := verifyCase(bin, a); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`, `verifierB.go`, `verifierC.go`, `verifierD.go`, and `verifierE.go`
- each verifier runs 100 randomized test cases and checks an arbitrary binary

## Testing
- `go run verifierA.go ./Abin`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687edae427f48324bd46cae6a86f128b