### PR TITLE
Add Go verifiers for Codeforces Round 482

### DIFF
--- a/0-999/400-499/480-489/482/verifierA.go
+++ b/0-999/400-499/480-489/482/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (int, int) {
+	n := rng.Intn(49) + 2 // 2..50
+	k := rng.Intn(n-1) + 1
+	return n, k
+}
+
+func check(n, k int, out string) error {
+	scan := bufio.NewScanner(strings.NewReader(out))
+	scan.Split(bufio.ScanWords)
+	arr := make([]int, 0, n)
+	for scan.Scan() {
+		if len(arr) == n {
+			return fmt.Errorf("extra output")
+		}
+		v, err := strconv.Atoi(scan.Text())
+		if err != nil {
+			return fmt.Errorf("invalid integer")
+		}
+		arr = append(arr, v)
+	}
+	if len(arr) != n {
+		return fmt.Errorf("expected %d numbers got %d", n, len(arr))
+	}
+	seen := make([]bool, n+1)
+	for _, v := range arr {
+		if v < 1 || v > n {
+			return fmt.Errorf("value out of range")
+		}
+		if seen[v] {
+			return fmt.Errorf("duplicate value")
+		}
+		seen[v] = true
+	}
+	diffs := make(map[int]struct{})
+	for i := 0; i < n-1; i++ {
+		d := arr[i] - arr[i+1]
+		if d < 0 {
+			d = -d
+		}
+		diffs[d] = struct{}{}
+	}
+	if len(diffs) != k {
+		return fmt.Errorf("expected %d distinct diffs got %d", k, len(diffs))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k := generateCase(rng)
+		input := fmt.Sprintf("%d %d\n", n, k)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(n, k, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/480-489/482/verifierB.go
+++ b/0-999/400-499/480-489/482/verifierB.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type constraint struct{ l, r, q int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n int, cons []constraint) (bool, []int) {
+	const B = 30
+	diff := make([][]int, B)
+	for b := 0; b < B; b++ {
+		diff[b] = make([]int, n+1)
+	}
+	for _, c := range cons {
+		for b := 0; b < B; b++ {
+			if (c.q>>b)&1 == 1 {
+				diff[b][c.l-1]++
+				diff[b][c.r]--
+			}
+		}
+	}
+	a := make([]int, n)
+	for b := 0; b < B; b++ {
+		cnt := 0
+		for i := 0; i < n; i++ {
+			cnt += diff[b][i]
+			if cnt > 0 {
+				a[i] |= 1 << b
+			}
+		}
+	}
+	size := 1
+	for size < n {
+		size <<= 1
+	}
+	allOnes := (1 << B) - 1
+	seg := make([]int, 2*size)
+	for i := 0; i < n; i++ {
+		seg[size+i] = a[i]
+	}
+	for i := n; i < size; i++ {
+		seg[size+i] = allOnes
+	}
+	for i := size - 1; i > 0; i-- {
+		seg[i] = seg[2*i] & seg[2*i+1]
+	}
+	query := func(l, r int) int {
+		l += size
+		r += size
+		res := allOnes
+		for l <= r {
+			if l&1 == 1 {
+				res &= seg[l]
+				l++
+			}
+			if r&1 == 0 {
+				res &= seg[r]
+				r--
+			}
+			l >>= 1
+			r >>= 1
+		}
+		return res
+	}
+	for _, c := range cons {
+		if query(c.l-1, c.r-1) != c.q {
+			return false, nil
+		}
+	}
+	return true, a
+}
+
+func generateCase(rng *rand.Rand) (int, []constraint) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(20) + 1
+	cons := make([]constraint, m)
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n) + 1
+		if l > r {
+			l, r = r, l
+		}
+		q := rng.Intn(1 << 30)
+		cons[i] = constraint{l, r, q}
+	}
+	return n, cons
+}
+
+func check(n int, cons []constraint, out string) error {
+	scan := bufio.NewScanner(strings.NewReader(out))
+	scan.Split(bufio.ScanWords)
+	if !scan.Scan() {
+		return fmt.Errorf("no output")
+	}
+	tok := strings.ToUpper(scan.Text())
+	expectOK, _ := solve(n, cons)
+	if tok == "NO" {
+		if expectOK {
+			return fmt.Errorf("solution exists but got NO")
+		}
+		if scan.Scan() {
+			return fmt.Errorf("extra output after NO")
+		}
+		return nil
+	}
+	if tok != "YES" {
+		return fmt.Errorf("expected YES/NO")
+	}
+	arr := make([]int, 0, n)
+	for scan.Scan() {
+		v, err := strconv.Atoi(scan.Text())
+		if err != nil {
+			return fmt.Errorf("invalid integer")
+		}
+		arr = append(arr, v)
+	}
+	if len(arr) != n {
+		return fmt.Errorf("expected %d numbers got %d", n, len(arr))
+	}
+	if !expectOK {
+		return fmt.Errorf("expected NO but got YES")
+	}
+	for _, c := range cons {
+		andVal := arr[c.l-1]
+		for i := c.l; i <= c.r; i++ {
+			andVal &= arr[i-1]
+		}
+		if andVal != c.q {
+			return fmt.Errorf("constraint failed")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, cons := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, len(cons)))
+		for _, c := range cons {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", c.l, c.r, c.q))
+		}
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(n, cons, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/480-489/482/verifierC.go
+++ b/0-999/400-499/480-489/482/verifierC.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(stringsList []string) float64 {
+	n := len(stringsList)
+	m := len(stringsList[0])
+	size := 1 << m
+	c := make([]uint64, size)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			mask := 0
+			for w := 0; w < m; w++ {
+				if stringsList[i][w] == stringsList[j][w] {
+					mask |= 1 << w
+				}
+			}
+			bit := (uint64(1) << uint(i)) | (uint64(1) << uint(j))
+			c[mask] |= bit
+		}
+	}
+	for mask := size - 1; mask >= 0; mask-- {
+		for b := 0; b < m; b++ {
+			if (mask & (1 << b)) == 0 {
+				c[mask] |= c[mask|(1<<b)]
+			}
+		}
+		if mask == 0 {
+			break
+		}
+	}
+	d := make([][]float64, m+1)
+	for i := 0; i <= m; i++ {
+		d[i] = make([]float64, i+1)
+		d[i][0] = 1
+		d[i][i] = 1
+		for j := 1; j < i; j++ {
+			d[i][j] = d[i-1][j] + d[i-1][j-1]
+		}
+	}
+	ans := 0.0
+	for mask := 0; mask < size; mask++ {
+		t := bits.OnesCount(uint(mask))
+		cnt := bits.OnesCount64(c[mask])
+		ans += float64(cnt) / float64(n) * (1.0 / d[m][t])
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) []string {
+	m := rng.Intn(5) + 1
+	n := rng.Intn(4) + 1
+	used := make(map[string]bool)
+	res := make([]string, 0, n)
+	for len(res) < n {
+		b := make([]byte, m)
+		for i := 0; i < m; i++ {
+			b[i] = byte('a' + rng.Intn(26))
+		}
+		s := string(b)
+		if !used[s] {
+			used[s] = true
+			res = append(res, s)
+		}
+	}
+	return res
+}
+
+func check(stringsList []string, out string) error {
+	got, err := strconv.ParseFloat(strings.TrimSpace(out), 64)
+	if err != nil {
+		return fmt.Errorf("invalid float output")
+	}
+	want := expected(stringsList)
+	if diff := got - want; diff < -1e-6 || diff > 1e-6 {
+		return fmt.Errorf("expected %.6f got %.6f", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		strs := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(strs)))
+		for _, s := range strs {
+			sb.WriteString(s)
+			sb.WriteByte('\n')
+		}
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(strs, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/480-489/482/verifierD.go
+++ b/0-999/400-499/480-489/482/verifierD.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(parents []int) int {
+	n := len(parents) - 1
+	children := make([][]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := parents[i]
+		children[p] = append(children[p], i)
+	}
+	dp := make([]int64, n+1)
+	for i := n; i >= 1; i-- {
+		if len(children[i]) == 0 {
+			dp[i] = 3
+		} else {
+			prod := int64(1)
+			for _, c := range children[i] {
+				prod = prod * dp[c] % mod
+			}
+			dp[i] = (prod + 2) % mod
+		}
+	}
+	return int(dp[1] % mod)
+}
+
+func generateCase(rng *rand.Rand) []int {
+	n := rng.Intn(49) + 2 // 2..50
+	parents := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		parents[i] = rng.Intn(i-1) + 1
+	}
+	return parents
+}
+
+func check(parents []int, out string) error {
+	want := expected(parents)
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("invalid integer output")
+	}
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		parents := generateCase(rng)
+		var sb strings.Builder
+		n := len(parents) - 1
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 2; j <= n; j++ {
+			if j > 2 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(parents[j]))
+		}
+		sb.WriteByte('\n')
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(parents, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/480-489/482/verifierE.go
+++ b/0-999/400-499/480-489/482/verifierE.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type query struct {
+	op byte
+	x  int
+	y  int
+}
+
+func buildChildren(n int, parent []int) [][]int {
+	ch := make([][]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := parent[i]
+		ch[p] = append(ch[p], i)
+	}
+	return ch
+}
+
+func computeDepth(n int, parent []int) []int {
+	ch := buildChildren(n, parent)
+	depth := make([]int, n+1)
+	var dfs func(int, int)
+	dfs = func(v, d int) {
+		depth[v] = d
+		for _, u := range ch[v] {
+			dfs(u, d+1)
+		}
+	}
+	dfs(1, 0)
+	return depth
+}
+
+func lca(a, b int, parent []int, depth []int) int {
+	for depth[a] > depth[b] {
+		a = parent[a]
+	}
+	for depth[b] > depth[a] {
+		b = parent[b]
+	}
+	for a != b {
+		a = parent[a]
+		b = parent[b]
+	}
+	return a
+}
+
+func expected(n int, parent []int, val []int) float64 {
+	depth := computeDepth(n, parent)
+	sum := 0.0
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= n; j++ {
+			l := lca(i, j, parent, depth)
+			sum += float64(val[l])
+		}
+	}
+	return sum / float64(n*n)
+}
+
+func inSubtree(n int, parent []int, v, u int) bool {
+	ch := buildChildren(n, parent)
+	stack := []int{v}
+	for len(stack) > 0 {
+		x := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if x == u {
+			return true
+		}
+		for _, w := range ch[x] {
+			stack = append(stack, w)
+		}
+	}
+	return false
+}
+
+func solve(n int, parent []int, val []int, qs []query) []float64 {
+	res := make([]float64, 0, len(qs)+1)
+	res = append(res, expected(n, parent, val))
+	for _, q := range qs {
+		if q.op == 'V' {
+			val[q.x] = q.y
+		} else {
+			if inSubtree(n, parent, q.x, q.y) {
+				parent[q.y] = q.x
+			} else {
+				parent[q.x] = q.y
+			}
+		}
+		res = append(res, expected(n, parent, val))
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (int, []int, []int, []query) {
+	n := rng.Intn(5) + 2
+	parent := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		parent[i] = rng.Intn(i-1) + 1
+	}
+	val := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		val[i] = rng.Intn(11)
+	}
+	q := rng.Intn(5) + 1
+	qs := make([]query, q)
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			v := rng.Intn(n) + 1
+			u := rng.Intn(n) + 1
+			for u == v {
+				u = rng.Intn(n) + 1
+			}
+			qs[i] = query{'P', v, u}
+		} else {
+			v := rng.Intn(n) + 1
+			t := rng.Intn(11)
+			qs[i] = query{'V', v, t}
+		}
+	}
+	return n, parent, val, qs
+}
+
+func formatInput(n int, parent []int, val []int, qs []query) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		if i > 2 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(parent[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(val[i]))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", len(qs)))
+	for _, qu := range qs {
+		if qu.op == 'P' {
+			sb.WriteString(fmt.Sprintf("P %d %d\n", qu.x, qu.y))
+		} else {
+			sb.WriteString(fmt.Sprintf("V %d %d\n", qu.x, qu.y))
+		}
+	}
+	return sb.String()
+}
+
+func check(exp []float64, out string) error {
+	lines := strings.Fields(out)
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d numbers got %d", len(exp), len(lines))
+	}
+	for i, s := range lines {
+		val, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return fmt.Errorf("invalid float")
+		}
+		diff := val - exp[i]
+		if diff < -1e-6 || diff > 1e-6 {
+			return fmt.Errorf("line %d expected %.6f got %.6f", i+1, exp[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, parent, val, qs := generateCase(rng)
+		input := formatInput(n, append([]int(nil), parent...), append([]int(nil), val...), qs)
+		exp := solve(n, append([]int(nil), parent...), append([]int(nil), val...), append([]query(nil), qs...))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(exp, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for permutation difference problem
- add verifierB.go for interesting array constraints
- add verifierC.go for expected questions calculation
- add verifierD.go for tree painting possibilities
- add verifierE.go for LCA expectation queries

## Testing
- `go run verifierA.go ./482A.bin`
- `go run verifierB.go ./482B.bin`
- `go run verifierC.go ./482C.bin`
- `go run verifierD.go ./482D.bin`


------
https://chatgpt.com/codex/tasks/task_e_687ed9cb6f948324bb55e465347106ef