### PR TITLE
Add verifiers for Codeforces 478 problems

### DIFF
--- a/0-999/400-499/470-479/478/verifierA.go
+++ b/0-999/400-499/470-479/478/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(nums [5]int) string {
+	sum := 0
+	for _, v := range nums {
+		sum += v
+	}
+	if sum%5 != 0 || sum == 0 {
+		return "-1"
+	}
+	return fmt.Sprintf("%d", sum/5)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	var nums [5]int
+	var sb strings.Builder
+	for i := 0; i < 5; i++ {
+		nums[i] = rng.Intn(101)
+		sb.WriteString(fmt.Sprintf("%d", nums[i]))
+		if i < 4 {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	exp := expected(nums)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/478/verifierB.go
+++ b/0-999/400-499/470-479/478/verifierB.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m int64) string {
+	maxSize := n - m + 1
+	kmax := maxSize * (maxSize - 1) / 2
+	q := n / m
+	r := n % m
+	cBig := (q + 1) * q / 2
+	cSmall := q * (q - 1) / 2
+	kmin := r*cBig + (m-r)*cSmall
+	return fmt.Sprintf("%d %d", kmin, kmax)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000) + 1
+	m := rng.Int63n(n) + 1
+	input := fmt.Sprintf("%d %d\n", n, m)
+	return input, expected(n, m)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/478/verifierC.go
+++ b/0-999/400-499/470-479/478/verifierC.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(r, g, b int64) string {
+	sum := r + g + b
+	mx := r
+	if g > mx {
+		mx = g
+	}
+	if b > mx {
+		mx = b
+	}
+	other := sum - mx
+	var ans int64
+	if mx > 2*other {
+		ans = other
+	} else {
+		ans = sum / 3
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	r := rng.Int63n(2_000_000_000)
+	g := rng.Int63n(2_000_000_000)
+	b := rng.Int63n(2_000_000_000)
+	input := fmt.Sprintf("%d %d %d\n", r, g, b)
+	return input, expected(r, g, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/478/verifierD.go
+++ b/0-999/400-499/470-479/478/verifierD.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func intSqrt(x int) int {
+	lo, hi := 0, x
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		if mid*mid <= x {
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	return hi
+}
+
+func expected(r, g int) string {
+	total := r + g
+	h := int((-1 + intSqrt(1+8*total)) / 2)
+	S := h * (h + 1) / 2
+	small, big := r, g
+	if small > big {
+		small, big = big, small
+	}
+	low := S - big
+	if low < 0 {
+		low = 0
+	}
+	dp := make([]int, small+1)
+	dp[0] = 1
+	for i := 1; i <= h; i++ {
+		if i > small {
+			continue
+		}
+		for s := small; s >= i; s-- {
+			dp[s] += dp[s-i]
+			if dp[s] >= mod {
+				dp[s] -= mod
+			}
+		}
+	}
+	ans := 0
+	for s := low; s <= small; s++ {
+		ans += dp[s]
+		if ans >= mod {
+			ans -= mod
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	r := rng.Intn(200000 + 1)
+	g := rng.Intn(200000 + 1)
+	input := fmt.Sprintf("%d %d\n", r, g)
+	return input, expected(r, g)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/478/verifierE.go
+++ b/0-999/400-499/470-479/478/verifierE.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+var wavies []int64
+
+func dfs(num int64, p1, p2, length, maxLen int) {
+	if length >= maxLen {
+		return
+	}
+	for d := 0; d <= 9; d++ {
+		if (p2 > p1 && p2 > d) || (p2 < p1 && p2 < d) {
+			newNum := num*10 + int64(d)
+			wavies = append(wavies, newNum)
+			dfs(newNum, p2, d, length+1, maxLen)
+		}
+	}
+}
+
+func generateWavies() {
+	const maxLen = 14
+	for d := 1; d <= 9; d++ {
+		wavies = append(wavies, int64(d))
+	}
+	type seed struct {
+		num    int64
+		p1, p2 int
+	}
+	var seeds []seed
+	for d1 := 1; d1 <= 9; d1++ {
+		for d2 := 0; d2 <= 9; d2++ {
+			num := int64(d1*10 + d2)
+			wavies = append(wavies, num)
+			seeds = append(seeds, seed{num, d1, d2})
+		}
+	}
+	for _, s := range seeds {
+		dfs(s.num, s.p1, s.p2, 2, maxLen)
+	}
+	sort.Slice(wavies, func(i, j int) bool { return wavies[i] < wavies[j] })
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, k int64) string {
+	var cnt int64
+	for _, v := range wavies {
+		if v%n == 0 {
+			cnt++
+			if cnt == k {
+				return fmt.Sprintf("%d", v)
+			}
+		}
+	}
+	return "-1"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000) + 1
+	k := rng.Int63n(50) + 1
+	input := fmt.Sprintf("%d %d\n", n, k)
+	return input, expected(n, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	generateWavies()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 478 problems A–E
- each verifier runs 100 randomised tests against a specified binary

## Testing
- `go run verifierA.go 478A.bin`
- `go run verifierB.go 478B.bin`
- `timeout 60s go run verifierD.go 478D.bin`


------
https://chatgpt.com/codex/tasks/task_e_687ed8b3768c8324b66c84ae1da57a1e