### PR TITLE
Add solution verifiers for contest 476

### DIFF
--- a/0-999/400-499/470-479/476/verifierA.go
+++ b/0-999/400-499/470-479/476/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m int) int {
+	kStart := (n + 1) / 2
+	t := (kStart + m - 1) / m * m
+	if t <= n {
+		return t
+	}
+	return -1
+}
+
+type testCase struct {
+	n int
+	m int
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10000) + 1
+	m := rng.Intn(10) + 1
+	return testCase{n, m}
+}
+
+func runCase(bin string, tc testCase) error {
+	input := fmt.Sprintf("%d %d\n", tc.n, tc.m)
+	exp := expected(tc.n, tc.m)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	var got int
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{n: 2, m: 1},
+		{n: 2, m: 2},
+		{n: 5, m: 2},
+		{n: 9, m: 3},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/476/verifierB.go
+++ b/0-999/400-499/470-479/476/verifierB.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func comb(n, k int) int {
+	if k < 0 || k > n {
+		return 0
+	}
+	res := 1
+	for i := 0; i < k; i++ {
+		res = res * (n - i) / (i + 1)
+	}
+	return res
+}
+
+func expected(s1, s2 string) float64 {
+	target := 0
+	for _, c := range s1 {
+		if c == '+' {
+			target++
+		} else {
+			target--
+		}
+	}
+	curr := 0
+	q := 0
+	for _, c := range s2 {
+		switch c {
+		case '+':
+			curr++
+		case '-':
+			curr--
+		case '?':
+			q++
+		}
+	}
+	diff := target - curr
+	if (diff+q)%2 != 0 || int(math.Abs(float64(diff))) > q {
+		return 0
+	}
+	up := (q + diff) / 2
+	ways := comb(q, up)
+	return float64(ways) / math.Pow(2, float64(q))
+}
+
+type testCase struct {
+	s1 string
+	s2 string
+}
+
+func randStr(rng *rand.Rand, n int, alphabet string) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = alphabet[rng.Intn(len(alphabet))]
+	}
+	return string(b)
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	l := rng.Intn(10) + 1
+	s1 := randStr(rng, l, "+-")
+	s2 := randStr(rng, l, "+-?")
+	return testCase{s1, s2}
+}
+
+func runCase(bin string, tc testCase) error {
+	input := fmt.Sprintf("%s\n%s\n", tc.s1, tc.s2)
+	exp := expected(tc.s1, tc.s2)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	var got float64
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if math.Abs(got-exp) > 1e-7 {
+		return fmt.Errorf("expected %.9f got %.9f", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{"++", "+?"},
+		{"+-", "??"},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/476/verifierC.go
+++ b/0-999/400-499/470-479/476/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const mod int64 = 1000000007
+
+func expected(a, b int64) int64 {
+	inv2 := (mod + 1) / 2
+	aMod := a % mod
+	bMod := b % mod
+	sumK := aMod * ((aMod + 1) % mod) % mod * inv2 % mod
+	t := (bMod*sumK%mod + aMod) % mod
+	sumR := ((bMod - 1 + mod) % mod) * bMod % mod * inv2 % mod
+	ans := t * sumR % mod
+	return ans
+}
+
+type testCase struct {
+	a int64
+	b int64
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	a := rng.Int63n(10000000) + 1
+	b := rng.Int63n(10000000) + 1
+	return testCase{a, b}
+}
+
+func runCase(bin string, tc testCase) error {
+	input := fmt.Sprintf("%d %d\n", tc.a, tc.b)
+	exp := expected(tc.a, tc.b)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	var got int64
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{1, 1},
+		{2, 3},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/476/verifierD.go
+++ b/0-999/400-499/470-479/476/verifierD.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct {
+	n int
+	k int
+}
+
+func expected(tc testCase) string {
+	var sb strings.Builder
+	m := (6*tc.n - 1) * tc.k
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < tc.n; i++ {
+		x := 1 + 6*i
+		a := x * tc.k
+		b := (x + 2) * tc.k
+		c := (x + 4) * tc.k
+		d := (x + 1) * tc.k
+		if (x+1)%3 == 0 {
+			d = (x + 3) * tc.k
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", a, b, c, d))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(20) + 1
+	return testCase{n, k}
+}
+
+func runCase(bin string, tc testCase) error {
+	input := fmt.Sprintf("%d %d\n", tc.n, tc.k)
+	exp := expected(tc)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(out) != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{1, 1}, {2, 3}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/476/verifierE.go
+++ b/0-999/400-499/470-479/476/verifierE.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func maxInt16(a, b int16) int16 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveExpected(s, p string) []int {
+	n := len(s)
+	m := len(p)
+	match := make([]bool, n)
+	for i := 0; i+m <= n; i++ {
+		ok := true
+		for j := 0; j < m; j++ {
+			if s[i+j] != p[j] {
+				ok = false
+				break
+			}
+		}
+		match[i] = ok
+	}
+	const negInf int16 = -10000
+	dp := make([][]int16, n+1)
+	for i := range dp {
+		dp[i] = make([]int16, n+1)
+		for j := range dp[i] {
+			dp[i][j] = negInf
+		}
+	}
+	dp[0][0] = 0
+	for i := 0; i <= n; i++ {
+		for j := 0; j <= n; j++ {
+			cur := dp[i][j]
+			if cur < 0 {
+				continue
+			}
+			if i < n {
+				if j+1 <= n {
+					dp[i+1][j+1] = maxInt16(dp[i+1][j+1], cur)
+				}
+				dp[i+1][j] = maxInt16(dp[i+1][j], cur)
+			}
+			if i+m <= n && match[i] {
+				dp[i+m][j] = maxInt16(dp[i+m][j], cur+1)
+			}
+		}
+	}
+	ans := make([]int, n+1)
+	best := int16(0)
+	for x := 0; x <= n; x++ {
+		if dp[n][x] > best {
+			best = dp[n][x]
+		}
+		ans[x] = int(best)
+	}
+	return ans
+}
+
+type testCase struct {
+	s string
+	p string
+}
+
+func randStr(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(min(n, 5)) + 1
+	s := randStr(rng, n)
+	p := randStr(rng, m)
+	return testCase{s, p}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func runCase(bin string, tc testCase) error {
+	input := fmt.Sprintf("%s\n%s\n", tc.s, tc.p)
+	exp := solveExpected(tc.s, tc.p)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(out)
+	if len(fields) != len(exp) {
+		return fmt.Errorf("expected %d numbers got %d", len(exp), len(fields))
+	}
+	for i, f := range fields {
+		var val int
+		if _, err := fmt.Sscan(f, &val); err != nil {
+			return fmt.Errorf("bad number %q", f)
+		}
+		if val != exp[i] {
+			return fmt.Errorf("expected %v got %v", exp, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{"aaaaa", "aa"}, {"abababa", "aba"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest 476 problems A–E
- each verifier runs at least 100 randomized tests against a provided binary
- verifiers allow `go run verifierX.go /path/to/binary`

## Testing
- `go build -o progA 476A.go`
- `go run verifierA.go ./progA`

------
https://chatgpt.com/codex/tasks/task_e_687ed82721708324a6ef5805bb48361b