### PR TITLE
Add solution verifiers for contest 474

### DIFF
--- a/0-999/400-499/470-479/474/verifierA.go
+++ b/0-999/400-499/470-479/474/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const keyboard = "1234567890-=QWERTYUIOP[]\\ASDFGHJKL;'ZXCVBNM,./"
+
+func expected(dir string, typed string) string {
+	pos := make(map[rune]int)
+	for i, r := range keyboard {
+		pos[r] = i
+	}
+	var b strings.Builder
+	for _, r := range typed {
+		idx := pos[r]
+		if dir == "R" {
+			b.WriteByte(keyboard[idx-1])
+		} else {
+			b.WriteByte(keyboard[idx+1])
+		}
+	}
+	return b.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	dir := "L"
+	if rng.Intn(2) == 0 {
+		dir = "R"
+	}
+	length := rng.Intn(20) + 1
+	var sb strings.Builder
+	for i := 0; i < length; i++ {
+		sb.WriteByte(keyboard[rng.Intn(len(keyboard))])
+	}
+	return dir, sb.String()
+}
+
+func runCase(bin, dir, typed string) error {
+	in := fmt.Sprintf("%s\n%s\n", dir, typed)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := expected(dir, typed)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		dir, typed := genCase(rng)
+		if err := runCase(bin, dir, typed); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n%s\n", i+1, err, dir, typed)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/474/verifierB.go
+++ b/0-999/400-499/470-479/474/verifierB.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedB(n int, piles []int, queries []int) []int {
+	pref := make([]int, n)
+	sum := 0
+	for i, v := range piles {
+		sum += v
+		pref[i] = sum
+	}
+	ans := make([]int, len(queries))
+	for i, q := range queries {
+		for j, p := range pref {
+			if q <= p {
+				ans[i] = j + 1
+				break
+			}
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (int, []int, int, []int) {
+	n := rng.Intn(10) + 1
+	piles := make([]int, n)
+	for i := range piles {
+		piles[i] = rng.Intn(20) + 1
+	}
+	m := rng.Intn(10) + 1
+	sum := 0
+	for _, v := range piles {
+		sum += v
+	}
+	queries := make([]int, m)
+	for i := range queries {
+		queries[i] = rng.Intn(sum) + 1
+	}
+	return n, piles, m, queries
+}
+
+func runCase(bin string, n int, piles []int, m int, queries []int, exp []int) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range piles {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", m)
+	for i, v := range queries {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Fields(strings.TrimSpace(out.String()))
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, v := range lines {
+		var val int
+		fmt.Sscan(v, &val)
+		if val != exp[i] {
+			return fmt.Errorf("query %d expected %d got %d", i+1, exp[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, piles, m, queries := genCase(rng)
+		exp := expectedB(n, piles, queries)
+		if err := runCase(bin, n, piles, m, queries, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			fmt.Fprintf(os.Stderr, "n=%d piles=%v m=%d queries=%v\n", n, piles, m, queries)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/474/verifierC.go
+++ b/0-999/400-499/470-479/474/verifierC.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Mole struct {
+	x, y, a, b int
+}
+
+func rotate90(x, y, a, b int) (int, int) {
+	dx := x - a
+	dy := y - b
+	return a - dy, b + dx
+}
+
+func isSquare(px, py [4]int) bool {
+	dists := make([]int, 0, 6)
+	for i := 0; i < 4; i++ {
+		for j := i + 1; j < 4; j++ {
+			dx := px[i] - px[j]
+			dy := py[i] - py[j]
+			dists = append(dists, dx*dx+dy*dy)
+		}
+	}
+	sort.Ints(dists)
+	if dists[0] == 0 {
+		return false
+	}
+	side := dists[0]
+	for i := 1; i < 4; i++ {
+		if dists[i] != side {
+			return false
+		}
+	}
+	return dists[4] == dists[5] && dists[4] == 2*side
+}
+
+func minMoves(moles [4]Mole) int {
+	var rx [4][4]int
+	var ry [4][4]int
+	for j := 0; j < 4; j++ {
+		cx, cy := moles[j].x, moles[j].y
+		for k := 0; k < 4; k++ {
+			rx[j][k] = cx
+			ry[j][k] = cy
+			cx, cy = rotate90(cx, cy, moles[j].a, moles[j].b)
+		}
+	}
+	best := -1
+	for k0 := 0; k0 < 4; k0++ {
+		for k1 := 0; k1 < 4; k1++ {
+			for k2 := 0; k2 < 4; k2++ {
+				for k3 := 0; k3 < 4; k3++ {
+					cost := k0 + k1 + k2 + k3
+					if best != -1 && cost >= best {
+						continue
+					}
+					px := [4]int{rx[0][k0], rx[1][k1], rx[2][k2], rx[3][k3]}
+					py := [4]int{ry[0][k0], ry[1][k1], ry[2][k2], ry[3][k3]}
+					if isSquare(px, py) {
+						best = cost
+					}
+				}
+			}
+		}
+	}
+	return best
+}
+
+func genCase(rng *rand.Rand) []Mole {
+	n := rng.Intn(5) + 1
+	moles := make([]Mole, 4*n)
+	for i := 0; i < 4*n; i++ {
+		moles[i] = Mole{
+			x: rng.Intn(11) - 5,
+			y: rng.Intn(11) - 5,
+			a: rng.Intn(11) - 5,
+			b: rng.Intn(11) - 5,
+		}
+	}
+	return moles
+}
+
+func expectedC(moles []Mole) []int {
+	n := len(moles) / 4
+	res := make([]int, n)
+	for i := 0; i < n; i++ {
+		var g [4]Mole
+		copy(g[:], moles[i*4:(i+1)*4])
+		res[i] = minMoves(g)
+	}
+	return res
+}
+
+func runCase(bin string, moles []Mole, exp []int) error {
+	n := len(moles) / 4
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < 4*n; i++ {
+		fmt.Fprintf(&sb, "%d %d %d %d\n", moles[i].x, moles[i].y, moles[i].a, moles[i].b)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Fields(strings.TrimSpace(out.String()))
+	if len(lines) != n {
+		return fmt.Errorf("expected %d lines got %d", n, len(lines))
+	}
+	for i, l := range lines {
+		var val int
+		fmt.Sscan(l, &val)
+		if val != exp[i] {
+			return fmt.Errorf("regiment %d expected %d got %d", i+1, exp[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		moles := genCase(rng)
+		exp := expectedC(moles)
+		if err := runCase(bin, moles, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/474/verifierD.go
+++ b/0-999/400-499/470-479/474/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func calcWays(k int, a, b int) int {
+	const mod = 1000000007
+	dp := make([]int, b+1)
+	dp[0] = 1
+	for i := 1; i <= b; i++ {
+		dp[i] = dp[i-1]
+		if i >= k {
+			dp[i] = (dp[i] + dp[i-k]) % mod
+		}
+	}
+	pref := make([]int, b+1)
+	for i := 1; i <= b; i++ {
+		pref[i] = pref[i-1] + dp[i]
+		if pref[i] >= mod {
+			pref[i] -= mod
+		}
+	}
+	res := pref[b]
+	if a > 1 {
+		res -= pref[a-1]
+	}
+	if res < 0 {
+		res += mod
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (int, int, [][2]int) {
+	t := rng.Intn(5) + 1
+	k := rng.Intn(5) + 1
+	pairs := make([][2]int, t)
+	for i := range pairs {
+		a := rng.Intn(20) + 1
+		b := a + rng.Intn(20)
+		pairs[i] = [2]int{a, b}
+	}
+	return k, t, pairs
+}
+
+func runCase(bin string, k, t int, pairs [][2]int, exp []int) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", t, k)
+	for i := range pairs {
+		fmt.Fprintf(&sb, "%d %d\n", pairs[i][0], pairs[i][1])
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Fields(strings.TrimSpace(out.String()))
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, l := range lines {
+		var val int
+		fmt.Sscan(l, &val)
+		if val != exp[i] {
+			return fmt.Errorf("test %d expected %d got %d", i+1, exp[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		k, t, pairs := genCase(rng)
+		exp := make([]int, t)
+		for j := 0; j < t; j++ {
+			exp[j] = calcWays(k, pairs[j][0], pairs[j][1])
+		}
+		if err := runCase(bin, k, t, pairs, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/474/verifierE.go
+++ b/0-999/400-499/470-479/474/verifierE.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func longestSeq(h []int64, d int64) []int {
+	n := len(h)
+	dp := make([]int, n)
+	prev := make([]int, n)
+	best := 0
+	bestIdx := 0
+	for i := 0; i < n; i++ {
+		dp[i] = 1
+		prev[i] = -1
+		for j := 0; j < i; j++ {
+			if abs64(h[i]-h[j]) >= d && dp[j]+1 > dp[i] {
+				dp[i] = dp[j] + 1
+				prev[i] = j
+			}
+		}
+		if dp[i] > best {
+			best = dp[i]
+			bestIdx = i
+		}
+	}
+	seq := make([]int, 0, best)
+	for idx := bestIdx; idx != -1; idx = prev[idx] {
+		seq = append(seq, idx+1)
+	}
+	for i, j := 0, len(seq)-1; i < j; i, j = i+1, j-1 {
+		seq[i], seq[j] = seq[j], seq[i]
+	}
+	return seq
+}
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func genCase(rng *rand.Rand) (int64, []int64) {
+	n := rng.Intn(10) + 1
+	d := int64(rng.Intn(5))
+	h := make([]int64, n)
+	for i := range h {
+		h[i] = int64(rng.Intn(50) + 1)
+	}
+	return d, h
+}
+
+func runCase(bin string, d int64, h []int64, exp []int) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", len(h), d)
+	for i, v := range h {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	var k int
+	fmt.Sscan(fields[0], &k)
+	if k != len(exp) {
+		return fmt.Errorf("expected length %d got %d", len(exp), k)
+	}
+	if k == 0 {
+		return nil
+	}
+	if len(fields[1:]) != k {
+		return fmt.Errorf("expected %d indices got %d", k, len(fields[1:]))
+	}
+	idxs := make([]int, k)
+	for i := 0; i < k; i++ {
+		fmt.Sscan(fields[1+i], &idxs[i])
+	}
+	prevIdx := 0
+	for i, idx := range idxs {
+		if idx < 1 || idx > len(h) {
+			return fmt.Errorf("index %d out of range", idx)
+		}
+		if i > 0 && idx <= prevIdx {
+			return fmt.Errorf("indices not increasing")
+		}
+		if i > 0 {
+			if abs64(h[idx-1]-h[idxs[i-1]-1]) < d {
+				return fmt.Errorf("invalid jump")
+			}
+		}
+		prevIdx = idx
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		d, h := genCase(rng)
+		exp := longestSeq(h, d)
+		if err := runCase(bin, d, h, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			fmt.Fprintf(os.Stderr, "d=%d heights=%v\n", d, h)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/470-479/474/verifierF.go
+++ b/0-999/400-499/470-479/474/verifierF.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func expectedF(arr []int, queries [][2]int) []int {
+	res := make([]int, len(queries))
+	for i, q := range queries {
+		l, r := q[0]-1, q[1]-1
+		g := arr[l]
+		for j := l + 1; j <= r; j++ {
+			g = gcd(g, arr[j])
+		}
+		cnt := 0
+		for j := l; j <= r; j++ {
+			if arr[j] == g {
+				cnt++
+			}
+		}
+		res[i] = (r - l + 1) - cnt
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) ([]int, [][2]int) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(30) + 1
+	}
+	t := rng.Intn(10) + 1
+	queries := make([][2]int, t)
+	for i := range queries {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		queries[i] = [2]int{l, r}
+	}
+	return arr, queries
+}
+
+func runCase(bin string, arr []int, queries [][2]int, exp []int) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(arr))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", len(queries))
+	for _, q := range queries {
+		fmt.Fprintf(&sb, "%d %d\n", q[0], q[1])
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Fields(strings.TrimSpace(out.String()))
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, l := range lines {
+		var val int
+		fmt.Sscan(l, &val)
+		if val != exp[i] {
+			return fmt.Errorf("query %d expected %d got %d", i+1, exp[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr, queries := genCase(rng)
+		exp := expectedF(arr, queries)
+		if err := runCase(bin, arr, queries, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- create Go verifiers `verifierA.go`-`verifierF.go` for contest 474
- each verifier generates 100 random test cases and checks the provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_687ed79b59888324b396d58cb14c14fc