### PR TITLE
Add Go verifiers for Codeforces contest 465

### DIFF
--- a/0-999/400-499/460-469/465/verifierA.go
+++ b/0-999/400-499/460-469/465/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type TestCase struct {
+	n   int
+	s   string
+	ans int
+}
+
+func compute(n int, s string) int {
+	for i := 0; i < n; i++ {
+		if s[i] == '0' {
+			return i + 1
+		}
+	}
+	return n
+}
+
+func genCases() []TestCase {
+	var cases []TestCase
+	for n := 1; n <= 7; n++ {
+		for mask := 0; mask < (1 << n); mask++ {
+			b := make([]byte, n)
+			for i := 0; i < n; i++ {
+				if mask&(1<<i) != 0 {
+					b[i] = '1'
+				} else {
+					b[i] = '0'
+				}
+			}
+			s := string(b)
+			cases = append(cases, TestCase{n, s, compute(n, s)})
+		}
+	}
+	return cases
+}
+
+func runCase(bin string, tc TestCase) error {
+	input := fmt.Sprintf("%d\n%s\n", tc.n, tc.s)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	output := strings.TrimSpace(out.String())
+	val, err := strconv.Atoi(output)
+	if err != nil {
+		return fmt.Errorf("invalid output: %s", output)
+	}
+	if val != tc.ans {
+		return fmt.Errorf("expected %d got %d", tc.ans, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	cases := genCases()
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%d\n%s\n", i+1, err, tc.n, tc.s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/460-469/465/verifierB.go
+++ b/0-999/400-499/460-469/465/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type TestCase struct {
+	n   int
+	arr []int
+	ans int
+}
+
+func compute(arr []int) int {
+	total, segments := 0, 0
+	for i, v := range arr {
+		if v == 1 {
+			total++
+			if i == 0 || arr[i-1] == 0 {
+				segments++
+			}
+		}
+	}
+	if total == 0 {
+		return 0
+	}
+	return total + segments - 1
+}
+
+func genCases() []TestCase {
+	var cases []TestCase
+	for n := 1; n <= 7; n++ {
+		for mask := 0; mask < (1 << n); mask++ {
+			arr := make([]int, n)
+			for i := 0; i < n; i++ {
+				if mask&(1<<i) != 0 {
+					arr[i] = 1
+				}
+			}
+			cases = append(cases, TestCase{n, arr, compute(arr)})
+		}
+	}
+	return cases
+}
+
+func runCase(bin string, tc TestCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	output := strings.TrimSpace(out.String())
+	val, err := strconv.Atoi(output)
+	if err != nil {
+		return fmt.Errorf("invalid output: %s", output)
+	}
+	if val != tc.ans {
+		return fmt.Errorf("expected %d got %d", tc.ans, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	cases := genCases()
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` in contest 465
- generate 127 deterministic test cases for each problem
- run binaries or `.go` sources and handle `--` argument separator

## Testing
- `go run verifierA.go -- ./0-999/400-499/460-469/465/465A.go`
- `go run verifierB.go -- ./0-999/400-499/460-469/465/465B.go`


------
https://chatgpt.com/codex/tasks/task_e_687ed524af5883248ced9eb1a48df046