### PR TITLE
Add Go verifiers for contest 461

### DIFF
--- a/0-999/400-499/460-469/461/verifierA.go
+++ b/0-999/400-499/460-469/461/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n   int
+	arr []int64
+}
+
+func solveCase(a []int64) int64 {
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	var sum int64
+	for _, v := range a {
+		sum += v
+	}
+	ans := sum
+	n := len(a)
+	for i, v := range a {
+		c := i + 1
+		if c > n-1 {
+			c = n - 1
+		}
+		ans += v * int64(c)
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = rng.Int63n(1_000_000) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	ans := solveCase(append([]int64(nil), arr...))
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin string, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/460-469/461/verifierB.go
+++ b/0-999/400-499/460-469/461/verifierB.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func add(a, b int) int {
+	a += b
+	if a >= mod {
+		a -= mod
+	}
+	return a
+}
+
+func mul(a, b int) int {
+	return int((int64(a) * int64(b)) % mod)
+}
+
+func solveCase(n int, parents []int, color []int) int {
+	children := make([][]int, n)
+	for i := 1; i < n; i++ {
+		p := parents[i]
+		children[p] = append(children[p], i)
+	}
+	dp := make([][3]int, n)
+	for u := 0; u < n; u++ {
+		if color[u] == 1 {
+			dp[u][0] = 0
+			dp[u][1] = 1
+			dp[u][2] = 0
+		} else {
+			dp[u][0] = 1
+			dp[u][1] = 0
+			dp[u][2] = 0
+		}
+	}
+	for u := n - 1; u >= 0; u-- {
+		for _, v := range children[u] {
+			t0 := dp[v][0]
+			t1 := dp[v][1]
+			t2 := dp[v][2]
+			cur := dp[u]
+			dp[u][0], dp[u][1], dp[u][2] = 0, 0, 0
+			for j := 0; j < 3; j++ {
+				cj := cur[j]
+				if cj == 0 {
+					continue
+				}
+				dp[u][j] = add(dp[u][j], mul(cj, t1))
+				if t0 != 0 {
+					nj := j
+					dp[u][nj] = add(dp[u][nj], mul(cj, t0))
+				}
+				if t1 != 0 {
+					nj := j + 1
+					if nj > 2 {
+						nj = 2
+					}
+					dp[u][nj] = add(dp[u][nj], mul(cj, t1))
+				}
+				if t2 != 0 {
+					nj := 2
+					dp[u][nj] = add(dp[u][nj], mul(cj, t2))
+				}
+			}
+		}
+	}
+	return dp[0][1]
+}
+
+type caseB struct {
+	n       int
+	parents []int
+	color   []int
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	parents := make([]int, n)
+	for i := 1; i < n; i++ {
+		parents[i] = rng.Intn(i)
+	}
+	color := make([]int, n)
+	black := 0
+	for i := 0; i < n; i++ {
+		color[i] = rng.Intn(2)
+		if color[i] == 1 {
+			black++
+		}
+	}
+	if black == 0 {
+		color[rng.Intn(n)] = 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 1; i < n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", parents[i])
+	}
+	if n > 1 {
+		sb.WriteByte('\n')
+	} else {
+		sb.WriteString("\n")
+	}
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", color[i])
+	}
+	sb.WriteByte('\n')
+	ans := solveCase(n, parents, color)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/460-469/461/verifierC.go
+++ b/0-999/400-499/460-469/461/verifierC.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type BIT struct {
+	n   int
+	bit []int64
+}
+
+func NewBIT(n int) *BIT {
+	return &BIT{n: n, bit: make([]int64, n+1)}
+}
+
+func (b *BIT) Add(i int, v int64) {
+	for x := i; x <= b.n; x += x & -x {
+		b.bit[x] += v
+	}
+}
+
+func (b *BIT) Sum(i int) int64 {
+	var s int64
+	for x := i; x > 0; x -= x & -x {
+		s += b.bit[x]
+	}
+	return s
+}
+
+func (b *BIT) RangeSum(l, r int) int64 {
+	if l > r {
+		return 0
+	}
+	return b.Sum(r) - b.Sum(l-1)
+}
+
+func solveCase(n int, queries []query) string {
+	bit := NewBIT(n)
+	for i := 1; i <= n; i++ {
+		bit.Add(i, 1)
+	}
+	l, r := 0, n
+	rev := false
+	var out strings.Builder
+	for _, q := range queries {
+		if q.t == 1 {
+			p := q.p
+			w := r - l
+			if p <= w-p {
+				for i := 0; i < p; i++ {
+					var x1, x2 int
+					if !rev {
+						x1 = l + i
+						x2 = l + (w - 1 - i)
+					} else {
+						x1 = r - 1 - i
+						x2 = r - 1 - (w - 1 - i)
+					}
+					v := bit.RangeSum(x1+1, x1+1)
+					bit.Add(x2+1, v)
+				}
+				if !rev {
+					l += p
+				} else {
+					r -= p
+				}
+			} else {
+				sz := w - p
+				for i := 0; i < sz; i++ {
+					var x1, x2 int
+					if !rev {
+						x1 = l + (w - 1 - i)
+						x2 = l + i
+					} else {
+						x1 = r - 1 - (w - 1 - i)
+						x2 = r - 1 - i
+					}
+					v := bit.RangeSum(x1+1, x1+1)
+					bit.Add(x2+1, v)
+				}
+				if !rev {
+					r -= sz
+				} else {
+					l += sz
+				}
+				rev = !rev
+			}
+		} else {
+			li := q.l
+			ri := q.r
+			var a, b int
+			if !rev {
+				a = l + li
+				b = l + ri - 1
+			} else {
+				a = r - 1 - li
+				b = r - ri
+			}
+			if a > b {
+				a, b = b, a
+			}
+			ans := bit.RangeSum(a+1, b+1)
+			out.WriteString(fmt.Sprintf("%d\n", ans))
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+type query struct {
+	t int
+	p int
+	l int
+	r int
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	q := rng.Intn(10) + 1
+	var queries []query
+	width := n
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 && width > 1 {
+			p := rng.Intn(width-1) + 1
+			queries = append(queries, query{t: 1, p: p})
+			if p <= width-p {
+				width -= p
+			} else {
+				width = p
+			}
+		} else {
+			li := rng.Intn(width)
+			ri := rng.Intn(width-li) + li + 1
+			queries = append(queries, query{t: 2, l: li, r: ri})
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for _, qu := range queries {
+		if qu.t == 1 {
+			fmt.Fprintf(&sb, "1 %d\n", qu.p)
+		} else {
+			fmt.Fprintf(&sb, "2 %d %d\n", qu.l, qu.r)
+		}
+	}
+	exp := solveCase(n, queries)
+	return sb.String(), exp
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/460-469/461/verifierD.go
+++ b/0-999/400-499/460-469/461/verifierD.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	a %= MOD
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func solveCase(n int, cells []cell) int64 {
+	assign := make(map[int]int)
+	ok := true
+	for _, c := range cells {
+		diff := c.a - c.b
+		if diff < 0 {
+			diff = -diff
+		}
+		val := 0
+		if c.ch == 'o' {
+			val = 1
+		}
+		if prev, found := assign[diff]; found {
+			if prev != val {
+				ok = false
+			}
+		} else {
+			assign[diff] = val
+		}
+	}
+	if !ok {
+		return 0
+	}
+	m := len(assign)
+	exp := int64(n - m)
+	if exp < 0 {
+		exp = 0
+	}
+	return modPow(2, exp)
+}
+
+type cell struct {
+	a  int
+	b  int
+	ch byte
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n + 1)
+	cells := make([]cell, 0, k)
+	used := make(map[[2]int]bool)
+	for len(cells) < k {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if used[[2]int{a, b}] {
+			continue
+		}
+		used[[2]int{a, b}] = true
+		ch := byte('x')
+		if rng.Intn(2) == 0 {
+			ch = 'o'
+		}
+		cells = append(cells, cell{a: a, b: b, ch: ch})
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for _, c := range cells {
+		fmt.Fprintf(&sb, "%d %d %c\n", c.a, c.b, c.ch)
+	}
+	ans := solveCase(n, cells)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/460-469/461/verifierE.go
+++ b/0-999/400-499/460-469/461/verifierE.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n int64, t string) int64 {
+	runs := map[rune]int64{'A': 0, 'B': 0, 'C': 0, 'D': 0}
+	var prev rune
+	var cur int64
+	for i, ch := range t {
+		if i == 0 || ch != prev {
+			cur = 1
+		} else {
+			cur++
+		}
+		if cur > runs[ch] {
+			runs[ch] = cur
+		}
+		prev = ch
+	}
+	rmin := runs['A']
+	for _, c := range []rune{'B', 'C', 'D'} {
+		if runs[c] < rmin {
+			rmin = runs[c]
+		}
+	}
+	if rmin <= 0 {
+		rmin = 1
+	}
+	return (n + rmin - 1) / rmin
+}
+
+func randomString(rng *rand.Rand) string {
+	letters := []byte{'A', 'B', 'C', 'D'}
+	l := rng.Intn(20) + 4
+	s := make([]byte, l)
+	for i := 0; i < 4; i++ {
+		s[i] = letters[i]
+	}
+	for i := 4; i < l; i++ {
+		s[i] = letters[rng.Intn(4)]
+	}
+	rng.Shuffle(l, func(i, j int) { s[i], s[j] = s[j], s[i] })
+	return string(s)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000) + 1
+	t := randomString(rng)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n%s\n", n, t)
+	ans := solveCase(n, t)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go..verifierE.go for contest 461
- each verifier generates 100 random test cases and checks a candidate binary

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687ed40c7524832487c7646df2bb5848