### PR TITLE
Add verifiers for Codeforces Round 460

### DIFF
--- a/0-999/400-499/460-469/460/verifierA.go
+++ b/0-999/400-499/460-469/460/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedDays(n, m int) int {
+	days := 0
+	socks := n
+	for socks > 0 {
+		days++
+		socks--
+		if days%m == 0 {
+			socks++
+		}
+	}
+	return days
+}
+
+func runCase(bin string, n, m int) error {
+	input := fmt.Sprintf("%d %d\n", n, m)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := expectedDays(n, m)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	edges := []struct{ n, m int }{
+		{1, 2}, {100, 2}, {1, 100}, {100, 100},
+	}
+	for i, e := range edges {
+		if err := runCase(bin, e.n, e.m); err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(100) + 1 // 1..100
+		m := rng.Intn(99) + 2  // 2..100
+		if err := runCase(bin, n, m); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %d %d\n", i+1, err, n, m)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/460-469/460/verifierB.go
+++ b/0-999/400-499/460-469/460/verifierB.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func powInt(x, a int) int64 {
+	res := int64(1)
+	for i := 0; i < a; i++ {
+		res *= int64(x)
+	}
+	return res
+}
+
+func sumDigits(x int64) int {
+	s := 0
+	for x > 0 {
+		s += int(x % 10)
+		x /= 10
+	}
+	return s
+}
+
+func expectedB(a, b, c int) []int {
+	var res []int
+	for s := 1; s <= 81; s++ {
+		x := int64(b)*powInt(s, a) + int64(c)
+		if x > 0 && x < 1000000000 && sumDigits(x) == s {
+			res = append(res, int(x))
+		}
+	}
+	sort.Ints(res)
+	return res
+}
+
+func runCase(bin string, a, b, c int) error {
+	input := fmt.Sprintf("%d %d %d\n", a, b, c)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	scanner.Split(bufio.ScanWords)
+	var nums []int
+	for scanner.Scan() {
+		var x int
+		fmt.Sscan(scanner.Text(), &x)
+		nums = append(nums, x)
+	}
+	if len(nums) < 1 {
+		return fmt.Errorf("no output")
+	}
+	n := nums[0]
+	if n != len(nums)-1 {
+		return fmt.Errorf("expected %d numbers but got %d", n, len(nums)-1)
+	}
+	nums = nums[1:]
+	expect := expectedB(a, b, c)
+	if len(nums) != len(expect) {
+		return fmt.Errorf("expected %v got %v", expect, nums)
+	}
+	for i := range nums {
+		if nums[i] != expect[i] {
+			return fmt.Errorf("expected %v got %v", expect, nums)
+		}
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (int, int, int) {
+	a := rng.Intn(5) + 1
+	b := rng.Intn(10000) + 1
+	c := rng.Intn(20001) - 10000
+	return a, b, c
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	edges := []struct{ a, b, c int }{
+		{1, 1, 0}, {5, 10000, -10000}, {5, 1, 10000}, {3, 100, 0},
+	}
+	for i, e := range edges {
+		if err := runCase(bin, e.a, e.b, e.c); err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		a, b, c := generateCase(rng)
+		if err := runCase(bin, a, b, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %d %d %d\n", i+1, err, a, b, c)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/460-469/460/verifierC.go
+++ b/0-999/400-499/460-469/460/verifierC.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func canReach(a []int64, m, w int, h int64) bool {
+	n := len(a)
+	ops := make([]int64, n)
+	var added, used int64
+	for i := 0; i < n; i++ {
+		if i >= w {
+			added -= ops[i-w]
+		}
+		curr := a[i] + added
+		if curr < h {
+			need := h - curr
+			used += need
+			if used > int64(m) {
+				return false
+			}
+			added += need
+			ops[i] = need
+		}
+	}
+	return true
+}
+
+func expectedC(a []int64, m, w int) int64 {
+	minA := a[0]
+	for _, v := range a {
+		if v < minA {
+			minA = v
+		}
+	}
+	low := minA
+	high := minA + int64(m) + 1
+	ans := minA
+	for low <= high {
+		mid := (low + high) / 2
+		if canReach(a, m, w, mid) {
+			ans = mid
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	return ans
+}
+
+func runCase(bin string, n, m, w int, arr []int64) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, w))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := expectedC(arr, m, w)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (int, int, int, []int64) {
+	n := rng.Intn(20) + 1
+	w := rng.Intn(n) + 1
+	m := rng.Intn(30) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = int64(rng.Intn(20) + 1)
+	}
+	return n, m, w, arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// some edge cases
+	edges := []struct {
+		n, m, w int
+		arr     []int64
+	}{
+		{1, 1, 1, []int64{1}},
+		{3, 5, 2, []int64{1, 2, 3}},
+		{5, 10, 3, []int64{5, 5, 5, 5, 5}},
+	}
+	for i, e := range edges {
+		if err := runCase(bin, e.n, e.m, e.w, e.arr); err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		n, m, w, arr := generateCase(rng)
+		if err := runCase(bin, n, m, w, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/460-469/460/verifierD.go
+++ b/0-999/400-499/460-469/460/verifierD.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedD(l, r int64, k int) (int64, []int64) {
+	result := l
+	S := []int64{l}
+	maxK := 4
+	if k < maxK {
+		maxK = k
+	}
+	for K := 2; K <= maxK; K++ {
+		for i := 0; i < 2; i++ {
+			start := l + int64(i)
+			if start+int64(K)-1 > r {
+				continue
+			}
+			temp := int64(0)
+			V := make([]int64, 0, K)
+			for j := start; j < start+int64(K); j++ {
+				V = append(V, j)
+				temp ^= j
+			}
+			if temp < result {
+				result = temp
+				S = V
+			}
+		}
+	}
+	if k >= 3 {
+		msb := 0
+		for b := 62; b >= 0; b-- {
+			if (l & (1 << uint(b))) != 0 {
+				msb = b
+				break
+			}
+		}
+		A := (int64(1) << uint(msb+1)) | (int64(1) << uint(msb))
+		B := (int64(1) << uint(msb+1)) | (l ^ (int64(1) << uint(msb)))
+		if A <= r {
+			result = 0
+			S = []int64{l, A, B}
+		}
+	}
+	return result, S
+}
+
+func runCase(bin string, l, r int64, k int) error {
+	input := fmt.Sprintf("%d %d %d\n", l, r, k)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	scanner.Split(bufio.ScanWords)
+	var nums []int64
+	for scanner.Scan() {
+		var x int64
+		fmt.Sscan(scanner.Text(), &x)
+		nums = append(nums, x)
+	}
+	if len(nums) < 2 {
+		return fmt.Errorf("bad output")
+	}
+	result := nums[0]
+	cnt := nums[1]
+	if int(cnt) != len(nums)-2 {
+		return fmt.Errorf("expected %d numbers but got %d", cnt, len(nums)-2)
+	}
+	vals := nums[2:]
+	expectVal, expectSet := expectedD(l, r, k)
+	if result != expectVal {
+		return fmt.Errorf("expected value %d got %d", expectVal, result)
+	}
+	if len(vals) != len(expectSet) {
+		return fmt.Errorf("expected set %v got %v", expectSet, vals)
+	}
+	for i := range vals {
+		if vals[i] != expectSet[i] {
+			return fmt.Errorf("expected set %v got %v", expectSet, vals)
+		}
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (int64, int64, int) {
+	l := rng.Int63n(1000) + 1
+	r := l + rng.Int63n(20)
+	k := rng.Intn(10) + 1
+	if int64(k) > r-l+1 {
+		k = int(r - l + 1)
+	}
+	return l, r, k
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	edges := []struct {
+		l, r int64
+		k    int
+	}{
+		{1, 1, 1},
+		{1, 10, 3},
+		{100, 120, 4},
+	}
+	for i, e := range edges {
+		if err := runCase(bin, e.l, e.r, e.k); err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		l, r, k := generateCase(rng)
+		if err := runCase(bin, l, r, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/460-469/460/verifierE.go
+++ b/0-999/400-499/460-469/460/verifierE.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int }
+
+func generatePoints(r int) []point {
+	var v []point
+	for i := -r; i <= r; i++ {
+		for j := -r; j <= r; j++ {
+			d2 := i*i + j*j
+			if d2 <= r*r && d2 >= (r-1)*(r-1) {
+				v = append(v, point{i, j})
+			}
+		}
+	}
+	sort.Slice(v, func(i, j int) bool {
+		di := v[i].x*v[i].x + v[i].y*v[i].y
+		dj := v[j].x*v[j].x + v[j].y*v[j].y
+		return di > dj
+	})
+	return v
+}
+
+func dfs(v []point, n int, k int, cur []point, best *[]point, maxSum *int64) {
+	if k == n {
+		var sum int64
+		for i := 0; i < len(cur); i++ {
+			for j := i + 1; j < len(cur); j++ {
+				dx := int64(cur[i].x - cur[j].x)
+				dy := int64(cur[i].y - cur[j].y)
+				sum += dx*dx + dy*dy
+			}
+		}
+		if sum > *maxSum {
+			*maxSum = sum
+			tmp := make([]point, len(cur))
+			copy(tmp, cur)
+			*best = tmp
+		}
+		return
+	}
+	limit := len(v)
+	cut := 30 - 2*n
+	if cut < limit {
+		limit = cut
+	}
+	for i := k; i < limit; i++ {
+		cur = append(cur, v[i])
+		dfs(v, n, i, cur, best, maxSum)
+		cur = cur[:len(cur)-1]
+	}
+}
+
+func expectedE(n, r int) (int64, []point) {
+	v := generatePoints(r)
+	var best []point
+	var maxSum int64 = -1 << 60
+	dfs(v, n, 0, nil, &best, &maxSum)
+	return maxSum, best
+}
+
+func runCase(bin string, n, r int) error {
+	input := fmt.Sprintf("%d %d\n", n, r)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	scanner.Split(bufio.ScanWords)
+	var nums []int
+	for scanner.Scan() {
+		var x int
+		fmt.Sscan(scanner.Text(), &x)
+		nums = append(nums, x)
+	}
+	if len(nums) < 1+2*n {
+		return fmt.Errorf("bad output")
+	}
+	expectSum, expectPts := expectedE(n, r)
+	if int64(nums[0]) != expectSum {
+		return fmt.Errorf("expected sum %d got %d", expectSum, nums[0])
+	}
+	idx := 1
+	for i := 0; i < n; i++ {
+		x := nums[idx]
+		y := nums[idx+1]
+		if x != expectPts[i].x || y != expectPts[i].y {
+			return fmt.Errorf("expected points %v got %v", expectPts, nums[1:])
+		}
+		idx += 2
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (int, int) {
+	n := rng.Intn(7) + 2
+	r := rng.Intn(10) + 1
+	return n, r
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	edges := []struct{ n, r int }{
+		{2, 1}, {3, 2}, {5, 5},
+	}
+	for i, e := range edges {
+		if err := runCase(bin, e.n, e.r); err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		n, r := generateCase(rng)
+		if err := runCase(bin, n, r); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for contest 460 problems A–E
- each verifier runs more than 100 test cases against any provided binary

## Testing
- `go build ./0-999/400-499/460-469/460/verifierA.go`
- `go build ./0-999/400-499/460-469/460/verifierB.go`
- `go build ./0-999/400-499/460-469/460/verifierC.go`
- `go build ./0-999/400-499/460-469/460/verifierD.go`
- `go build ./0-999/400-499/460-469/460/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ed3c66a84832497a30cbe62c782e9