### PR TITLE
Add Go verifiers for contest 459 problems

### DIFF
--- a/0-999/400-499/450-459/459/verifierA.go
+++ b/0-999/400-499/450-459/459/verifierA.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func hasSolution(x1, y1, x2, y2 int) bool {
+	if x1 == x2 || y1 == y2 || abs(x1-x2) == abs(y1-y2) {
+		return true
+	}
+	return false
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func validOutput(out string, x1, y1, x2, y2 int) bool {
+	out = strings.TrimSpace(out)
+	if out == "-1" {
+		return !hasSolution(x1, y1, x2, y2)
+	}
+	var x3, y3, x4, y4 int
+	n, err := fmt.Sscanf(out, "%d %d %d %d", &x3, &y3, &x4, &y4)
+	if err != nil || n != 4 {
+		return false
+	}
+	if x3 == x4 && y3 == y4 {
+		return false
+	}
+	// verify square with sides parallel to axes
+	// gather points
+	pts := [][2]int{{x1, y1}, {x2, y2}, {x3, y3}, {x4, y4}}
+	// compute unique x and y values
+	xs := map[int]bool{}
+	ys := map[int]bool{}
+	for _, p := range pts {
+		xs[p[0]] = true
+		ys[p[1]] = true
+	}
+	if len(xs) != 2 || len(ys) != 2 {
+		return false
+	}
+	var ax, bx int
+	i := 0
+	for v := range xs {
+		if i == 0 {
+			ax = v
+		} else {
+			bx = v
+		}
+		i++
+	}
+	var ay, by int
+	i = 0
+	for v := range ys {
+		if i == 0 {
+			ay = v
+		} else {
+			by = v
+		}
+		i++
+	}
+	w1 := abs(ax - bx)
+	w2 := abs(ay - by)
+	if w1 != w2 || w1 == 0 {
+		return false
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		x1 := rand.Intn(201) - 100
+		y1 := rand.Intn(201) - 100
+		x2 := rand.Intn(201) - 100
+		y2 := rand.Intn(201) - 100
+		if x1 == x2 && y1 == y2 {
+			x2++
+		}
+		input := fmt.Sprintf("%d %d %d %d\n", x1, y1, x2, y2)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if !validOutput(out, x1, y1, x2, y2) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%soutput:\n%s\n", t+1, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/400-499/450-459/459/verifierB.go
+++ b/0-999/400-499/450-459/459/verifierB.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expectedAnswer(arr []int64) (int64, int64) {
+	minv := arr[0]
+	maxv := arr[0]
+	for _, v := range arr {
+		if v < minv {
+			minv = v
+		}
+		if v > maxv {
+			maxv = v
+		}
+	}
+	diff := maxv - minv
+	var cntMin, cntMax int64
+	for _, v := range arr {
+		if v == minv {
+			cntMin++
+		}
+		if v == maxv {
+			cntMax++
+		}
+	}
+	var ways int64
+	if diff == 0 {
+		n := int64(len(arr))
+		ways = n * (n - 1) / 2
+	} else {
+		ways = cntMin * cntMax
+	}
+	return diff, ways
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 2
+		arr := make([]int64, n)
+		for i := range arr {
+			arr[i] = int64(rand.Intn(1000))
+		}
+		input := fmt.Sprintf("%d\n", n)
+		for i, v := range arr {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+
+		expectedDiff, expectedWays := expectedAnswer(arr)
+		outStr, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		var gotDiff, gotWays int64
+		nRead, err := fmt.Sscanf(outStr, "%d %d", &gotDiff, &gotWays)
+		if err != nil || nRead != 2 {
+			fmt.Printf("invalid output on test %d\ninput:\n%soutput:\n%s\n", t+1, input, outStr)
+			os.Exit(1)
+		}
+		if gotDiff != expectedDiff || gotWays != expectedWays {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %d %d\n got: %d %d\n", t+1, input, expectedDiff, expectedWays, gotDiff, gotWays)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/400-499/450-459/459/verifierC.go
+++ b/0-999/400-499/450-459/459/verifierC.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func possible(n, k, d int) bool {
+	limit := big.NewInt(int64(n))
+	cur := big.NewInt(1)
+	for i := 0; i < d; i++ {
+		cur.Mul(cur, big.NewInt(int64(k)))
+		if cur.Cmp(limit) >= 0 {
+			return true
+		}
+	}
+	return cur.Cmp(limit) >= 0
+}
+
+func validArrangement(out string, n, k, d int) bool {
+	lines := strings.Fields(out)
+	if len(lines) == 1 && lines[0] == "-1" {
+		return false
+	}
+	nums := []int{}
+	for _, tok := range lines {
+		var v int
+		if _, err := fmt.Sscanf(tok, "%d", &v); err != nil {
+			return false
+		}
+		nums = append(nums, v)
+	}
+	if len(nums) != n*d {
+		return false
+	}
+	mat := make([][]int, d)
+	idx := 0
+	for i := 0; i < d; i++ {
+		mat[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			v := nums[idx]
+			if v < 1 || v > k {
+				return false
+			}
+			mat[i][j] = v
+			idx++
+		}
+	}
+	for a := 0; a < n; a++ {
+		for b := a + 1; b < n; b++ {
+			same := true
+			for i := 0; i < d; i++ {
+				if mat[i][a] != mat[i][b] {
+					same = false
+					break
+				}
+			}
+			if same {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(5) + 1
+		d := rand.Intn(5) + 1
+		input := fmt.Sprintf("%d %d %d\n", n, k, d)
+		possibleFlag := possible(n, k, d)
+		outStr, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if !possibleFlag {
+			if strings.TrimSpace(outStr) != "-1" {
+				fmt.Printf("wrong answer on test %d (should be -1)\ninput:%soutput:%s\n", t+1, input, outStr)
+				os.Exit(1)
+			}
+			continue
+		}
+		if !validArrangement(outStr, n, k, d) {
+			fmt.Printf("invalid arrangement on test %d\ninput:%soutput:%s\n", t+1, input, outStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/400-499/450-459/459/verifierD.go
+++ b/0-999/400-499/450-459/459/verifierD.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "459D.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return "./" + ref, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(30) + 1
+		input := fmt.Sprintf("%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", rand.Intn(20))
+		}
+		input += "\n"
+
+		expect, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Println("reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:%sexpected:%s\n got:%s\n", t+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/400-499/450-459/459/verifierE.go
+++ b/0-999/400-499/450-459/459/verifierE.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "459E.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return "./" + ref, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(8) + 2
+		maxEdges := n * (n - 1)
+		m := rand.Intn(maxEdges) + 1
+		input := fmt.Sprintf("%d %d\n", n, m)
+		for i := 0; i < m; i++ {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			w := rand.Intn(20) + 1
+			input += fmt.Sprintf("%d %d %d\n", u, v, w)
+		}
+
+		expect, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Println("reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:%sexpected:%s\n got:%s\n", t+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for each problem of contest 459
- each verifier generates 100 random tests and runs a given binary
- verifierA checks geometry output directly
- verifierB-D-E compare to reference solutions
- verifierC validates bus assignments for correctness

## Testing
- `go run verifierA.go ./459A.bin`
- `go run verifierB.go ./459B.bin`
- `go run verifierC.go ./459C.bin`
- `go run verifierD.go ./459D.bin`
- `go run verifierE.go ./459E.bin`


------
https://chatgpt.com/codex/tasks/task_e_687ed380ba748324b723c6f045bad64a