### PR TITLE
Add Go verifiers for Codeforces Round 457

### DIFF
--- a/0-999/400-499/450-459/457/verifierA.go
+++ b/0-999/400-499/450-459/457/verifierA.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func compute(input string) string {
+	rdr := strings.NewReader(strings.TrimSpace(input) + "\n")
+	var s, t string
+	fmt.Fscan(rdr, &s, &t)
+	n, m := len(s), len(t)
+	L := n
+	if m > L {
+		L = m
+	}
+	pos := -1
+	for i := 0; i < L; i++ {
+		var cs, ct byte
+		if i < L-n {
+			cs = '0'
+		} else {
+			cs = s[i-(L-n)]
+		}
+		if i < L-m {
+			ct = '0'
+		} else {
+			ct = t[i-(L-m)]
+		}
+		if cs != ct {
+			pos = i
+			break
+		}
+	}
+	if pos == -1 {
+		return "="
+	}
+	var cs, ct byte
+	if pos < L-n {
+		cs = '0'
+	} else {
+		cs = s[pos-(L-n)]
+	}
+	if pos < L-m {
+		ct = '0'
+	} else {
+		ct = t[pos-(L-m)]
+	}
+	var sign0 float64
+	if cs == '1' {
+		sign0 = 1.0
+	} else {
+		sign0 = -1.0
+	}
+	invQ := 2.0 / (1.0 + math.Sqrt(5.0))
+	tval := sign0
+	power := 1.0
+	for j := pos + 1; j < L; j++ {
+		power *= invQ
+		if power < 1e-18 {
+			break
+		}
+		if j < L-n {
+			cs = '0'
+		} else {
+			cs = s[j-(L-n)]
+		}
+		if j < L-m {
+			ct = '0'
+		} else {
+			ct = t[j-(L-m)]
+		}
+		if cs == ct {
+			continue
+		}
+		if cs == '1' {
+			tval += power
+		} else {
+			tval -= power
+		}
+	}
+	const eps = 1e-9
+	if tval > eps {
+		return ">"
+	} else if tval < -eps {
+		return "<"
+	}
+	return "="
+}
+
+func generateCases() []testCase {
+	rand.Seed(1)
+	cases := []testCase{}
+	fixed := []struct{ a, b string }{
+		{"0", "0"},
+		{"1", "0"},
+		{"0", "1"},
+		{"101", "101"},
+		{"1111", "10000"},
+		{"0", "11111"},
+	}
+	for _, f := range fixed {
+		inp := fmt.Sprintf("%s\n%s\n", f.a, f.b)
+		cases = append(cases, testCase{inp, compute(inp)})
+	}
+	for len(cases) < 100 {
+		n := rand.Intn(20) + 1
+		m := rand.Intn(20) + 1
+		a := make([]byte, n)
+		b := make([]byte, m)
+		for i := 0; i < n; i++ {
+			if rand.Intn(2) == 0 {
+				a[i] = '0'
+			} else {
+				a[i] = '1'
+			}
+		}
+		for i := 0; i < m; i++ {
+			if rand.Intn(2) == 0 {
+				b[i] = '0'
+			} else {
+				b[i] = '1'
+			}
+		}
+		inp := fmt.Sprintf("%s\n%s\n", string(a), string(b))
+		cases = append(cases, testCase{inp, compute(inp)})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierA.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/457/verifierB.go
+++ b/0-999/400-499/450-459/457/verifierB.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func compute(input string) string {
+	rdr := strings.NewReader(strings.TrimSpace(input) + "\n")
+	var m, n int
+	fmt.Fscan(rdr, &m, &n)
+	sumA, sumB := uint64(0), uint64(0)
+	maxA, maxB := uint64(0), uint64(0)
+	for i := 0; i < m; i++ {
+		var x uint64
+		fmt.Fscan(rdr, &x)
+		sumA += x
+		if x > maxA {
+			maxA = x
+		}
+	}
+	for i := 0; i < n; i++ {
+		var x uint64
+		fmt.Fscan(rdr, &x)
+		sumB += x
+		if x > maxB {
+			maxB = x
+		}
+	}
+	cost1 := (sumA - maxA) + sumB
+	cost2 := sumA + (sumB - maxB)
+	cost3 := sumB * uint64(m)
+	cost4 := sumA * uint64(n)
+	ans := cost1
+	if cost2 < ans {
+		ans = cost2
+	}
+	if cost3 < ans {
+		ans = cost3
+	}
+	if cost4 < ans {
+		ans = cost4
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCases() []testCase {
+	rand.Seed(2)
+	cases := []testCase{}
+	fixed := []string{
+		"1 1\n5\n7\n",
+		"2 2\n1 2\n3 4\n",
+		"3 1\n10 20 30\n5\n",
+	}
+	for _, f := range fixed {
+		cases = append(cases, testCase{f, compute(f)})
+	}
+	for len(cases) < 100 {
+		m := rand.Intn(4) + 1
+		n := rand.Intn(4) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", m, n)
+		for i := 0; i < m; i++ {
+			fmt.Fprintf(&sb, "%d", rand.Intn(100)+1)
+			if i+1 < m {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d", rand.Intn(100)+1)
+			if i+1 < n {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		cases = append(cases, testCase{inp, compute(inp)})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierB.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%sexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/457/verifierC.go
+++ b/0-999/400-499/450-459/457/verifierC.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+type IntHeap []int
+
+func (h IntHeap) Len() int            { return len(h) }
+func (h IntHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h IntHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *IntHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *IntHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func compute(input string) string {
+	rdr := strings.NewReader(strings.TrimSpace(input) + "\n")
+	var n int
+	fmt.Fscan(rdr, &n)
+	costsMap := make(map[int][]int)
+	c0 := 0
+	for i := 0; i < n; i++ {
+		var a, b int
+		fmt.Fscan(rdr, &a, &b)
+		if a == 0 {
+			c0++
+		} else {
+			costsMap[a] = append(costsMap[a], b)
+		}
+	}
+	maxCount := 0
+	buckets := make([][]int, n+1)
+	for _, costs := range costsMap {
+		cnt := len(costs)
+		if cnt > maxCount {
+			maxCount = cnt
+		}
+		sort.Ints(costs)
+		buckets[cnt] = append(buckets[cnt], costs...)
+	}
+	h := &IntHeap{}
+	heap.Init(h)
+	bribes := 0
+	var costSum int64
+	ans := int64(1<<63 - 1)
+	for d := maxCount; d >= 0; d-- {
+		for _, c := range buckets[d] {
+			heap.Push(h, c)
+		}
+		needed := d - (c0 + bribes) + 1
+		for needed > 0 && h.Len() > 0 {
+			minCost := heap.Pop(h).(int)
+			costSum += int64(minCost)
+			bribes++
+			needed--
+		}
+		if c0+bribes > d && costSum < ans {
+			ans = costSum
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genRandomCase() string {
+	n := rand.Intn(6) + 1
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, n)
+	for i := 0; i < n; i++ {
+		a := rand.Intn(3)
+		b := rand.Intn(20) + 1
+		fmt.Fprintf(&buf, "%d %d\n", a, b)
+	}
+	return buf.String()
+}
+
+func generateCases() []testCase {
+	rand.Seed(3)
+	cases := []testCase{}
+	fixed := []string{
+		"1\n0 5\n",
+		"3\n0 1\n1 2\n2 3\n",
+	}
+	for _, f := range fixed {
+		cases = append(cases, testCase{f, compute(f)})
+	}
+	for len(cases) < 100 {
+		inp := genRandomCase()
+		cases = append(cases, testCase{inp, compute(inp)})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierC.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%sexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/457/verifierD.go
+++ b/0-999/400-499/450-459/457/verifierD.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func compute(input string) string {
+	rdr := strings.NewReader(strings.TrimSpace(input) + "\n")
+	var n, m, k int
+	fmt.Fscan(rdr, &n, &m, &k)
+	fac := make([]float64, m+1)
+	fac[0] = 0.0
+	for i := 1; i <= m; i++ {
+		fac[i] = fac[i-1] + math.Log(float64(i))
+	}
+	C := func(a, b int) float64 { return fac[b] - fac[a] - fac[b-a] }
+	var ans float64
+	for i := 0; i <= n; i++ {
+		for j := 0; j <= n; j++ {
+			t := i*n + j*n - i*j
+			if t > k {
+				break
+			}
+			tmp := C(k-t, m-t) + C(i, n) + C(j, n) - C(k, m)
+			ans += math.Exp(tmp)
+			if ans > 1e99 {
+				return "1e99"
+			}
+		}
+	}
+	return fmt.Sprintf("%.15f", ans)
+}
+
+func genRandomCase() string {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(5) + n
+	k := rand.Intn(m + 1)
+	return fmt.Sprintf("%d %d %d\n", n, m, k)
+}
+
+func generateCases() []testCase {
+	rand.Seed(4)
+	cases := []testCase{}
+	fixed := []string{
+		"1 1 0\n",
+		"2 3 1\n",
+	}
+	for _, f := range fixed {
+		cases = append(cases, testCase{f, compute(f)})
+	}
+	for len(cases) < 100 {
+		inp := genRandomCase()
+		cases = append(cases, testCase{inp, compute(inp)})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierD.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:%sexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/457/verifierE.go
+++ b/0-999/400-499/450-459/457/verifierE.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	p    []int
+	diff []int64
+}
+
+func NewDSU(n int) *DSU {
+	p := make([]int, n+1)
+	diff := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		p[i] = i
+		diff[i] = 0
+	}
+	return &DSU{p: p, diff: diff}
+}
+
+func (d *DSU) find(x int) (int, int64) {
+	if d.p[x] == x {
+		return x, 0
+	}
+	r, dr := d.find(d.p[x])
+	d.diff[x] += dr
+	d.p[x] = r
+	return r, d.diff[x]
+}
+
+func (d *DSU) unite(f, t int, delta int64) bool {
+	rf, df := d.find(f)
+	rt, dt := d.find(t)
+	if rf == rt {
+		return df-dt == delta
+	}
+	d.p[rf] = rt
+	d.diff[rf] = delta + dt - df
+	return true
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func compute(input string) string {
+	rdr := strings.NewReader(strings.TrimSpace(input) + "\n")
+	var n, m int
+	fmt.Fscan(rdr, &n, &m)
+	dsu := NewDSU(n)
+	bad := 0
+	for i := 1; i <= m; i++ {
+		var f, t int
+		var w, b int64
+		fmt.Fscan(rdr, &f, &t, &w, &b)
+		if bad != 0 {
+			continue
+		}
+		delta := 2 * w * b
+		if !dsu.unite(f, t, delta) {
+			bad = i
+		}
+	}
+	if bad != 0 {
+		return fmt.Sprintf("BAD %d", bad)
+	}
+	r1, d1 := dsu.find(1)
+	rn, dn := dsu.find(n)
+	if r1 != rn {
+		return "UNKNOWN"
+	}
+	diff := d1 - dn
+	var ans int64
+	if diff >= 0 {
+		ans = (diff + 1) / 2
+	} else {
+		ans = (diff - 1) / 2
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genRandomCase() string {
+	n := rand.Intn(4) + 2
+	m := rand.Intn(5) + 1
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		f := rand.Intn(n) + 1
+		t := rand.Intn(n) + 1
+		w := rand.Intn(5) + 1
+		b := rand.Intn(5) + 1
+		fmt.Fprintf(&buf, "%d %d %d %d\n", f, t, w, b)
+	}
+	return buf.String()
+}
+
+func generateCases() []testCase {
+	rand.Seed(5)
+	cases := []testCase{}
+	fixed := []string{
+		"2 1\n1 2 1 1\n",
+		"3 2\n1 2 1 1\n2 3 1 1\n",
+	}
+	for _, f := range fixed {
+		cases = append(cases, testCase{f, compute(f)})
+	}
+	for len(cases) < 100 {
+		inp := genRandomCase()
+		cases = append(cases, testCase{inp, compute(inp)})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierE.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:%sexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/457/verifierF.go
+++ b/0-999/400-499/450-459/457/verifierF.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func dfs(u int, vals []int, left []int, right []int, isLeaf []bool) ([]int, int) {
+	if isLeaf[u] {
+		return []int{vals[u]}, 0
+	}
+	a, hl := dfs(left[u], vals, left, right, isLeaf)
+	b, hr := dfs(right[u], vals, left, right, isLeaf)
+	v := append(a, b...)
+	sort.Ints(v)
+	h := hl
+	if hr > h {
+		h = hr
+	}
+	h++
+	if h%2 == 1 {
+		v = v[1:]
+	} else {
+		v = v[:len(v)-1]
+	}
+	return v, h
+}
+
+func compute(input string) string {
+	rdr := strings.NewReader(strings.TrimSpace(input) + "\n")
+	var t int
+	fmt.Fscan(rdr, &t)
+	var outputs []string
+	for tc := 0; tc < t; tc++ {
+		var n int
+		fmt.Fscan(rdr, &n)
+		vals := make([]int, n)
+		left := make([]int, n)
+		right := make([]int, n)
+		isLeaf := make([]bool, n)
+		for i := 0; i < n; i++ {
+			var a int
+			fmt.Fscan(rdr, &a)
+			if a >= 0 {
+				vals[i] = a
+				isLeaf[i] = true
+			} else {
+				var l, r int
+				fmt.Fscan(rdr, &l, &r)
+				left[i] = l
+				right[i] = r
+			}
+		}
+		res, _ := dfs(0, vals, left, right, isLeaf)
+		if len(res) > 0 {
+			outputs = append(outputs, fmt.Sprintf("%d", res[0]))
+		} else {
+			outputs = append(outputs, "0")
+		}
+	}
+	return strings.Join(outputs, "\n")
+}
+
+func genTreeCase() string {
+	n := rand.Intn(5) + 1
+	vals := make([]int, n)
+	left := make([]int, n)
+	right := make([]int, n)
+	isLeaf := make([]bool, n)
+	for i := 0; i < n; i++ {
+		if i > 0 && rand.Intn(2) == 0 {
+			// leaf
+			vals[i] = rand.Intn(10)
+			isLeaf[i] = true
+		} else if i > 0 {
+			// non-leaf, connect to previous nodes less than i
+			l := rand.Intn(i)
+			r := rand.Intn(i)
+			left[i] = l
+			right[i] = r
+		} else {
+			// root may be leaf or not
+			vals[i] = rand.Intn(10)
+			isLeaf[i] = true
+		}
+	}
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, 1)
+	fmt.Fprintln(&buf, n)
+	for i := 0; i < n; i++ {
+		if isLeaf[i] {
+			fmt.Fprintf(&buf, "%d\n", vals[i])
+		} else {
+			fmt.Fprintf(&buf, "-1 %d %d\n", left[i], right[i])
+		}
+	}
+	return buf.String()
+}
+
+func generateCases() []testCase {
+	rand.Seed(6)
+	cases := []testCase{}
+	fixed := []string{
+		"1\n1\n5\n",
+	}
+	for _, f := range fixed {
+		cases = append(cases, testCase{f, compute(f)})
+	}
+	for len(cases) < 100 {
+		inp := genTreeCase()
+		cases = append(cases, testCase{inp, compute(inp)})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierF.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:%sexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for all six problems of contest 457
- each verifier runs a target binary against 100+ generated test cases

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_687ed2f447548324832315c97f67a179