### PR TITLE
Add Go verifiers for contest 455

### DIFF
--- a/0-999/400-499/450-459/455/verifierA.go
+++ b/0-999/400-499/450-459/455/verifierA.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(nums []int) int64 {
+	maxVal := 0
+	for _, v := range nums {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	freq := make([]int64, maxVal+1)
+	for _, v := range nums {
+		freq[v]++
+	}
+	dp := make([]int64, maxVal+2)
+	if maxVal >= 1 {
+		dp[1] = freq[1]
+	}
+	for i := 2; i <= maxVal; i++ {
+		take := dp[i-2] + freq[i]*int64(i)
+		if dp[i-1] > take {
+			dp[i] = dp[i-1]
+		} else {
+			dp[i] = take
+		}
+	}
+	return dp[maxVal]
+}
+
+func buildCase(nums []int) (string, int64) {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(nums)))
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solve(nums)
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(20) + 1
+	nums := make([]int, n)
+	for i := range nums {
+		nums[i] = rng.Intn(20) + 1
+	}
+	return buildCase(nums)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []struct {
+		input string
+		want  int64
+	}
+	// simple predetermined cases
+	cases = append(cases, func() struct {
+		input string
+		want  int64
+	} { nums := []int{1}; in, w := buildCase(nums); return struct {
+		input string
+		want  int64
+	}{in, w} }())
+	cases = append(cases, func() struct {
+		input string
+		want  int64
+	} { nums := []int{1, 2, 3}; in, w := buildCase(nums); return struct {
+		input string
+		want  int64
+	}{in, w} }())
+	for i := 0; i < 100; i++ {
+		in, w := generateCase(rng)
+		cases = append(cases, struct {
+			input string
+			want  int64
+		}{in, w})
+	}
+
+	for idx, tc := range cases {
+		gotStr, err := runCandidate(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(gotStr, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: bad output %q\n", idx+1, gotStr)
+			os.Exit(1)
+		}
+		if got != tc.want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", idx+1, tc.want, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/400-499/450-459/455/verifierB.go
+++ b/0-999/400-499/450-459/455/verifierB.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type node struct {
+	next [26]*node
+	win  bool
+	lose bool
+}
+
+func dfs(u *node) {
+	has := false
+	u.win = false
+	u.lose = false
+	for i := 0; i < 26; i++ {
+		v := u.next[i]
+		if v == nil {
+			continue
+		}
+		has = true
+		dfs(v)
+		if !v.win {
+			u.win = true
+		}
+		if !v.lose {
+			u.lose = true
+		}
+	}
+	if !has {
+		u.lose = true
+	}
+}
+
+func expected(n int, k int64, words []string) string {
+	root := &node{}
+	for _, s := range words {
+		cur := root
+		for i := 0; i < len(s); i++ {
+			c := s[i] - 'a'
+			if cur.next[c] == nil {
+				cur.next[c] = &node{}
+			}
+			cur = cur.next[c]
+		}
+	}
+	dfs(root)
+	if !root.win {
+		return "Second"
+	}
+	if root.lose {
+		return "First"
+	}
+	if k%2 == 1 {
+		return "First"
+	}
+	return "Second"
+}
+
+func buildCase(n int, k int64, words []string) (string, string) {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for _, w := range words {
+		sb.WriteString(w)
+		sb.WriteByte('\n')
+	}
+	return sb.String(), expected(n, k, words)
+}
+
+func randString(rng *rand.Rand, length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	k := int64(rng.Intn(5) + 1)
+	words := make([]string, n)
+	for i := range words {
+		l := rng.Intn(4) + 1
+		words[i] = randString(rng, l)
+	}
+	return buildCase(n, k, words)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []struct{ in, want string }
+	// simple case
+	{
+		in, want := buildCase(1, 1, []string{"a"})
+		cases = append(cases, struct{ in, want string }{in, want})
+	}
+	for i := 0; i < 100; i++ {
+		in, want := generateCase(rng)
+		cases = append(cases, struct{ in, want string }{in, want})
+	}
+
+	for idx, tc := range cases {
+		got, err := runCandidate(bin, tc.in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != tc.want {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\ngot: %s\ninput:\n%s", idx+1, tc.want, got, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/400-499/450-459/455/verifierC.go
+++ b/0-999/400-499/450-459/455/verifierC.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "455C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runBin(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type dsu struct {
+	p []int
+	s []int
+}
+
+func newDSU(n int) *dsu {
+	p := make([]int, n+1)
+	s := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		p[i] = i
+		s[i] = 1
+	}
+	return &dsu{p: p, s: s}
+}
+
+func (d *dsu) find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *dsu) union(x, y int) bool {
+	rx := d.find(x)
+	ry := d.find(y)
+	if rx == ry {
+		return false
+	}
+	if d.s[rx] < d.s[ry] {
+		rx, ry = ry, rx
+	}
+	d.p[ry] = rx
+	d.s[rx] += d.s[ry]
+	return true
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(n)
+	q := rng.Intn(5) + 1
+	d := newDSU(n)
+	edges := [][2]int{}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if !d.union(u, v) {
+			continue
+		}
+		edges = append(edges, [2]int{u, v})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, len(edges), q))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			x := rng.Intn(n) + 1
+			sb.WriteString(fmt.Sprintf("1 %d\n", x))
+		} else {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(n) + 1
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", x, y))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := make([]string, 0, 102)
+	cases = append(cases, generateCase(rng))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, input := range cases {
+		want, err := runBin(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runBin(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\n\ngot:\n%s\ninput:\n%s", idx+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/400-499/450-459/455/verifierD.go
+++ b/0-999/400-499/450-459/455/verifierD.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "455D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runBin(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(n) + 1
+	}
+	q := rng.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n) + 1
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", l, r))
+		} else {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n) + 1
+			k := rng.Intn(n) + 1
+			sb.WriteString(fmt.Sprintf("2 %d %d %d\n", l, r, k))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := make([]string, 0, 101)
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, input := range cases {
+		want, err := runBin(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runBin(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\n\ngot:\n%s\ninput:\n%s", idx+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/400-499/450-459/455/verifierE.go
+++ b/0-999/400-499/450-459/455/verifierE.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "455E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runBin(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(20)
+	}
+	m := rng.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		x := rng.Intn(n) + 1
+		y := x + rng.Intn(n-x+1)
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := make([]string, 0, 101)
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for idx, input := range cases {
+		want, err := runBin(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runBin(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\n\ngot:\n%s\ninput:\n%s", idx+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` with a built‑in solution and 100+ generated tests
- add `verifierB.go` with trie logic to check strings games
- add oracle‑based verifiers `verifierC.go`, `verifierD.go` and `verifierE.go`
- each verifier runs 100 randomly generated tests

## Testing
- `go build 0-999/400-499/450-459/455/verifierA.go`
- `go build 0-999/400-499/450-459/455/verifierB.go`
- `go build 0-999/400-499/450-459/455/verifierC.go`
- `go build 0-999/400-499/450-459/455/verifierD.go`
- `go build 0-999/400-499/450-459/455/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ed26826608324931d0cb3f8762db0