### PR TITLE
Add verifiers for contest 452

### DIFF
--- a/0-999/400-499/450-459/452/verifierA.go
+++ b/0-999/400-499/450-459/452/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var pokemons = []string{"vaporeon", "jolteon", "flareon", "espeon", "umbreon", "leafeon", "glaceon", "sylveon"}
+
+func expected(n int, pattern string) string {
+	for _, p := range pokemons {
+		if len(p) != n {
+			continue
+		}
+		ok := true
+		for i := 0; i < n; i++ {
+			if pattern[i] != '.' && pattern[i] != p[i] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return p
+		}
+	}
+	return ""
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	for {
+		name := pokemons[rng.Intn(len(pokemons))]
+		n := len(name)
+		b := []byte(name)
+		for i := range b {
+			if rng.Intn(2) == 0 {
+				b[i] = '.'
+			}
+		}
+		pattern := string(b)
+		// ensure unique solution
+		cnt := 0
+		var ans string
+		for _, p := range pokemons {
+			if len(p) != n {
+				continue
+			}
+			match := true
+			for i := 0; i < n; i++ {
+				if pattern[i] != '.' && pattern[i] != p[i] {
+					match = false
+					break
+				}
+			}
+			if match {
+				cnt++
+				ans = p
+			}
+		}
+		if cnt == 1 {
+			input := fmt.Sprintf("%d\n%s\n", n, pattern)
+			return input, ans
+		}
+	}
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/452/verifierB.go
+++ b/0-999/400-499/450-459/452/verifierB.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Point struct{ x, y int64 }
+
+func dist(a, b Point) int64 {
+	dx := a.x - b.x
+	dy := a.y - b.y
+	if dx < 0 {
+		dx = -dx
+	}
+	if dy < 0 {
+		dy = -dy
+	}
+	return dx*dx + dy*dy
+}
+
+func solve(n, m int64) string {
+	if n == 0 {
+		return fmt.Sprintf("0 1\n0 %d\n0 0\n0 %d\n", m, m-1)
+	}
+	if m == 0 {
+		return fmt.Sprintf("1 0\n%d 0\n0 0\n%d 0\n", n, n-1)
+	}
+	cand := []Point{{0, 0}, {n, 0}, {0, m}, {n, m}, {1, 0}, {0, 1}, {n - 1, 0}, {0, m - 1}, {n, 1}, {1, m}, {n - 1, m}, {n, m - 1}}
+	uniq := make(map[Point]bool)
+	points := make([]Point, 0, len(cand))
+	for _, p := range cand {
+		if p.x < 0 || p.x > n || p.y < 0 || p.y > m {
+			continue
+		}
+		if !uniq[p] {
+			uniq[p] = true
+			points = append(points, p)
+		}
+	}
+	var bestSeq []Point
+	bestSum := int64(-1)
+	var perm func([]Point, int)
+	perm = func(a []Point, l int) {
+		if l == len(a)-1 {
+			s := dist(a[0], a[1]) + dist(a[1], a[2]) + dist(a[2], a[3])
+			if s > bestSum {
+				bestSum = s
+				bestSeq = append([]Point(nil), a...)
+			}
+			return
+		}
+		for i := l; i < len(a); i++ {
+			a[l], a[i] = a[i], a[l]
+			perm(a, l+1)
+			a[l], a[i] = a[i], a[l]
+		}
+	}
+	L := len(points)
+	for i := 0; i < L; i++ {
+		for j := i + 1; j < L; j++ {
+			for k := j + 1; k < L; k++ {
+				for l := k + 1; l < L; l++ {
+					subset := []Point{points[i], points[j], points[k], points[l]}
+					perm(subset, 0)
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	for _, p := range bestSeq {
+		fmt.Fprintf(&sb, "%d %d\n", p.x, p.y)
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	var n, m int64
+	for {
+		n = int64(rng.Intn(1001))
+		m = int64(rng.Intn(1001))
+		if (n+1)*(m+1) >= 4 {
+			break
+		}
+	}
+	input := fmt.Sprintf("%d %d\n", n, m)
+	expected := solve(n, m)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected\n%s\ngot\n%s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/452/verifierC.go
+++ b/0-999/400-499/450-459/452/verifierC.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, m int) string {
+	if n*m == 1 {
+		return "1"
+	}
+	nf := float64(n)
+	mf := float64(m)
+	ans := 1.0/nf + ((nf-1.0)/nf)*((mf-1.0)/(nf*mf-1.0))
+	return fmt.Sprintf("%.9f", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(1000) + 1
+	m := rng.Intn(1000) + 1
+	input := fmt.Sprintf("%d %d\n", n, m)
+	return input, expected(n, m)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/452/verifierD.go
+++ b/0-999/400-499/450-459/452/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type IntHeap []int
+
+func (h IntHeap) Len() int            { return len(h) }
+func (h IntHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h IntHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *IntHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *IntHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func solve(k, n1, n2, n3, t1, t2, t3 int) string {
+	wheap := &IntHeap{}
+	heap.Init(wheap)
+	for i := 0; i < n1; i++ {
+		heap.Push(wheap, 0)
+	}
+	wfin := make([]int, k)
+	for i := 0; i < k; i++ {
+		avail := heap.Pop(wheap).(int)
+		finish := avail + t1
+		wfin[i] = finish
+		heap.Push(wheap, finish)
+	}
+	dheap := &IntHeap{}
+	heap.Init(dheap)
+	for i := 0; i < n2; i++ {
+		heap.Push(dheap, 0)
+	}
+	dfin := make([]int, k)
+	for i, wf := range wfin {
+		avail := heap.Pop(dheap).(int)
+		start := wf
+		if avail > start {
+			start = avail
+		}
+		finish := start + t2
+		dfin[i] = finish
+		heap.Push(dheap, finish)
+	}
+	fheap := &IntHeap{}
+	heap.Init(fheap)
+	for i := 0; i < n3; i++ {
+		heap.Push(fheap, 0)
+	}
+	ans := 0
+	for _, df := range dfin {
+		avail := heap.Pop(fheap).(int)
+		start := df
+		if avail > start {
+			start = avail
+		}
+		finish := start + t3
+		if finish > ans {
+			ans = finish
+		}
+		heap.Push(fheap, finish)
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	k := rng.Intn(20) + 1
+	n1 := rng.Intn(5) + 1
+	n2 := rng.Intn(5) + 1
+	n3 := rng.Intn(5) + 1
+	t1 := rng.Intn(10) + 1
+	t2 := rng.Intn(10) + 1
+	t3 := rng.Intn(10) + 1
+	input := fmt.Sprintf("%d %d %d %d %d %d %d\n", k, n1, n2, n3, t1, t2, t3)
+	expected := solve(k, n1, n2, n3, t1, t2, t3)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/452/verifierE.go
+++ b/0-999/400-499/450-459/452/verifierE.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func solve(s1, s2, s3 string) string {
+	minL := len(s1)
+	if len(s2) < minL {
+		minL = len(s2)
+	}
+	if len(s3) < minL {
+		minL = len(s3)
+	}
+	res := make([]int64, minL+1)
+	for l := 1; l <= minL; l++ {
+		var cnt int64
+		for i := 0; i+l <= len(s1); i++ {
+			sub := s1[i : i+l]
+			for j := 0; j+l <= len(s2); j++ {
+				if s2[j:j+l] != sub {
+					continue
+				}
+				for k := 0; k+l <= len(s3); k++ {
+					if s3[k:k+l] == sub {
+						cnt++
+					}
+				}
+			}
+		}
+		res[l] = cnt % mod
+	}
+	var sb strings.Builder
+	for l := 1; l <= minL; l++ {
+		if l > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(res[l], 10))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n1 := rng.Intn(5) + 1
+	n2 := rng.Intn(5) + 1
+	n3 := rng.Intn(5) + 1
+	s1 := randString(rng, n1)
+	s2 := randString(rng, n2)
+	s3 := randString(rng, n3)
+	input := fmt.Sprintf("%s\n%s\n%s\n", s1, s2, s3)
+	expected := solve(s1, s2, s3)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/452/verifierF.go
+++ b/0-999/400-499/450-459/452/verifierF.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(p []int) string {
+	n := len(p)
+	pos := make([]int, n+1)
+	for i, v := range p {
+		pos[v] = i
+	}
+	for a := 1; a <= n; a++ {
+		for b := a + 1; b <= n; b++ {
+			if (a+b)%2 != 0 {
+				continue
+			}
+			x := (a + b) / 2
+			pa := pos[a]
+			pb := pos[b]
+			px := pos[x]
+			if (pa < px && px < pb) || (pa > px && px > pb) {
+				return "YES"
+			}
+		}
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	arr := rng.Perm(n)
+	for i := 0; i < n; i++ {
+		arr[i]++
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	expected := solve(arr)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for contest 452 problems A–F
- verifiers generate random tests and check provided binaries
- each runs 100 cases and reports runtime errors

## Testing
- `gofmt -w verifier*.go`

------
https://chatgpt.com/codex/tasks/task_e_687ed19709548324b311978e64ee5da8