### PR TITLE
Add verifiers for contest 451

### DIFF
--- a/0-999/400-499/450-459/451/verifierA.go
+++ b/0-999/400-499/450-459/451/verifierA.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, m int) string {
+	if n > m {
+		n = m
+	}
+	if n%2 == 1 {
+		return "Akshat"
+	}
+	return "Malvika"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	m := rng.Intn(100) + 1
+	input := fmt.Sprintf("%d %d\n", n, m)
+	expect := solveCase(n, m)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/451/verifierB.go
+++ b/0-999/400-499/450-459/451/verifierB.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(a []int) string {
+	n := len(a)
+	l := -1
+	for i := 0; i < n-1; i++ {
+		if a[i] > a[i+1] {
+			l = i
+			break
+		}
+	}
+	if l == -1 {
+		return "yes\n1 1"
+	}
+	r := -1
+	for j := n - 1; j > 0; j-- {
+		if a[j-1] > a[j] {
+			r = j
+			break
+		}
+	}
+	b := append([]int(nil), a...)
+	for i, j := l, r; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	ok := true
+	for i := 0; i < n-1; i++ {
+		if b[i] > b[i+1] {
+			ok = false
+			break
+		}
+	}
+	if ok {
+		return fmt.Sprintf("yes\n%d %d", l+1, r+1)
+	}
+	return "no"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	vals := rng.Perm(n)
+	for i := range vals {
+		vals[i]++
+	}
+	// shuffle more to make unsorted arrays too
+	for i := 0; i < n; i++ {
+		j := rng.Intn(n)
+		vals[i], vals[j] = vals[j], vals[i]
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	expect := solveCase(vals)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/451/verifierC.go
+++ b/0-999/400-499/450-459/451/verifierC.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, k, d1, d2 int64) string {
+	if n%3 != 0 {
+		return "no"
+	}
+	target := n / 3
+	for _, s1 := range []int64{1, -1} {
+		for _, s2 := range []int64{1, -1} {
+			num := k - s1*d1 + s2*d2
+			if num%3 != 0 {
+				continue
+			}
+			w2 := num / 3
+			w1 := w2 + s1*d1
+			w3 := w2 - s2*d2
+			if w1 < 0 || w2 < 0 || w3 < 0 {
+				continue
+			}
+			if w1 > target || w2 > target || w3 > target {
+				continue
+			}
+			return "yes"
+		}
+	}
+	return "no"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(300) + 3)
+	k := int64(rng.Intn(int(n + 1)))
+	d1 := int64(rng.Intn(int(k + 1)))
+	d2 := int64(rng.Intn(int(k + 1)))
+	input := fmt.Sprintf("1\n%d %d %d %d\n", n, k, d1, d2)
+	expect := solveCase(n, k, d1, d2)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/451/verifierD.go
+++ b/0-999/400-499/450-459/451/verifierD.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func isGood(s string) bool {
+	if len(s) == 0 {
+		return true
+	}
+	comp := []byte{s[0]}
+	for i := 1; i < len(s); i++ {
+		if s[i] != s[i-1] {
+			comp = append(comp, s[i])
+		}
+	}
+	for i := 0; i < len(comp)/2; i++ {
+		if comp[i] != comp[len(comp)-1-i] {
+			return false
+		}
+	}
+	return true
+}
+
+func solveCase(str string) (int, int) {
+	even, odd := 0, 0
+	n := len(str)
+	for i := 0; i < n; i++ {
+		for j := i; j < n; j++ {
+			if isGood(str[i : j+1]) {
+				if (j-i+1)%2 == 0 {
+					even++
+				} else {
+					odd++
+				}
+			}
+		}
+	}
+	return even, odd
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = 'a'
+		} else {
+			b[i] = 'b'
+		}
+	}
+	s := string(b)
+	even, odd := solveCase(s)
+	input := fmt.Sprintf("%s\n", s)
+	expect := fmt.Sprintf("%d %d", even, odd)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/450-459/451/verifierE.go
+++ b/0-999/400-499/450-459/451/verifierE.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	a %= mod
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func solveCase(n int, s int64, f []int64) string {
+	fplus := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fplus[i] = f[i] + 1
+	}
+	maxR := n
+	fact := make([]int64, maxR+1)
+	invFact := make([]int64, maxR+1)
+	fact[0] = 1
+	for i := 1; i <= maxR; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invFact[maxR] = modPow(fact[maxR], mod-2)
+	for i := maxR; i > 0; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % mod
+	}
+	N := 1 << n
+	sumF := make([]int64, N)
+	pc := make([]int, N)
+	for mask := 1; mask < N; mask++ {
+		lb := mask & -mask
+		i := bits.TrailingZeros(uint(lb))
+		prev := mask ^ lb
+		sumF[mask] = sumF[prev] + fplus[i]
+		pc[mask] = pc[prev] + 1
+	}
+	r := n - 1
+	var ans int64
+	for mask := 0; mask < N; mask++ {
+		k := pc[mask]
+		total := sumF[mask]
+		a := s - total + int64(n-1)
+		if a < int64(r) {
+			continue
+		}
+		var num int64 = 1
+		for i := 0; i < r; i++ {
+			t := (a - int64(i)) % mod
+			if t < 0 {
+				t += mod
+			}
+			num = num * t % mod
+		}
+		comb := num * invFact[r] % mod
+		if k&1 == 1 {
+			ans = (ans - comb + mod) % mod
+		} else {
+			ans = (ans + comb) % mod
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	s := int64(rng.Intn(50))
+	f := make([]int64, n)
+	for i := 0; i < n; i++ {
+		f[i] = int64(rng.Intn(20))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, s))
+	for i, v := range f {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	expect := solveCase(n, s, f)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 451 problems A–E
- each verifier generates 100 randomized tests and can run any binary

## Testing
- `go run verifierA.go ./451A_bin`
- `go run verifierB.go ./451B_bin`
- `go run verifierC.go ./451C_bin`
- `go run verifierD.go ./451D_bin` *(fails: expected 4 8 got 2 8)*
- `go run verifierE.go ./451E_bin`


------
https://chatgpt.com/codex/tasks/task_e_687ed150086c8324b4edccb0647d4bc0