### PR TITLE
Add verifiers for Codeforces contest 449

### DIFF
--- a/0-999/400-499/440-449/449/verifierA.go
+++ b/0-999/400-499/440-449/449/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input, expected string
+}
+
+func solve(input string) string {
+	var n, m, k int64
+	fmt.Sscan(strings.TrimSpace(input), &n, &m, &k)
+	if k > n+m-2 {
+		return "-1"
+	}
+	ans := int64(0)
+	if k <= n-1 {
+		h := n / (k + 1)
+		area := h * m
+		if area > ans {
+			ans = area
+		}
+	}
+	if k <= m-1 {
+		w := m / (k + 1)
+		area := w * n
+		if area > ans {
+			ans = area
+		}
+	}
+	if k > n-1 {
+		y := k - (n - 1)
+		w := m / (y + 1)
+		if w > ans {
+			ans = w
+		}
+	}
+	if k > m-1 {
+		x := k - (m - 1)
+		h := n / (x + 1)
+		if h > ans {
+			ans = h
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+	rand.Seed(449)
+	tests := []test{
+		{"1 1 0\n", solve("1 1 0\n")},
+		{"2 3 4\n", solve("2 3 4\n")},
+		{"5 6 5\n", solve("5 6 5\n")},
+		{"1000000000 1000000000 0\n", solve("1000000000 1000000000 0\n")},
+		{"1 1000000000 999999999\n", solve("1 1000000000 999999999\n")},
+	}
+	for len(tests) < 100 {
+		n := rand.Int63n(1e9) + 1
+		m := rand.Int63n(1e9) + 1
+		k := rand.Int63n(2e9) + 1
+		inp := fmt.Sprintf("%d %d %d\n", n, m, k)
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, strings.TrimSpace(t.expected), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/440-449/449/verifierB.go
+++ b/0-999/400-499/440-449/449/verifierB.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Edge struct {
+	to int
+	w  int64
+}
+
+type Item struct {
+	v    int
+	dist int64
+}
+
+// Priority queue for Dijkstra
+type PQ []Item
+
+func (pq PQ) Len() int            { return len(pq) }
+func (pq PQ) Less(i, j int) bool  { return pq[i].dist < pq[j].dist }
+func (pq PQ) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PQ) Push(x interface{}) { *pq = append(*pq, x.(Item)) }
+func (pq *PQ) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	it := old[n-1]
+	*pq = old[:n-1]
+	return it
+}
+
+type test struct {
+	input, expected string
+}
+
+func solve(input string) string {
+	rdr := bufio.NewReader(strings.NewReader(input))
+	var n, m, k int
+	if _, err := fmt.Fscan(rdr, &n, &m, &k); err != nil {
+		return ""
+	}
+	graph := make([][]Edge, n+1)
+	roads := make([]struct {
+		u, v int
+		w    int64
+	}, m)
+	for i := 0; i < m; i++ {
+		var u, v int
+		var w int64
+		fmt.Fscan(rdr, &u, &v, &w)
+		graph[u] = append(graph[u], Edge{v, w})
+		graph[v] = append(graph[v], Edge{u, w})
+		roads[i] = struct {
+			u, v int
+			w    int64
+		}{u, v, w}
+	}
+	trainsTo := make([][]int64, n+1)
+	for i := 0; i < k; i++ {
+		var s int
+		var y int64
+		fmt.Fscan(rdr, &s, &y)
+		trainsTo[s] = append(trainsTo[s], y)
+		graph[1] = append(graph[1], Edge{s, y})
+		graph[s] = append(graph[s], Edge{1, y})
+	}
+	const INF int64 = 4e18
+	dist := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = INF
+	}
+	dist[1] = 0
+	pq := &PQ{{1, 0}}
+	heap.Init(pq)
+	for pq.Len() > 0 {
+		it := heap.Pop(pq).(Item)
+		if it.dist != dist[it.v] {
+			continue
+		}
+		for _, e := range graph[it.v] {
+			nd := it.dist + e.w
+			if nd < dist[e.to] {
+				dist[e.to] = nd
+				heap.Push(pq, Item{e.to, nd})
+			}
+		}
+	}
+	hasRoad := make([]bool, n+1)
+	for _, r := range roads {
+		if dist[r.u]+r.w == dist[r.v] {
+			hasRoad[r.v] = true
+		}
+		if dist[r.v]+r.w == dist[r.u] {
+			hasRoad[r.u] = true
+		}
+	}
+	var ans int64
+	for v := 2; v <= n; v++ {
+		var match int64
+		for _, y := range trainsTo[v] {
+			if y > dist[v] {
+				ans++
+			} else if y == dist[v] {
+				match++
+			}
+		}
+		if match > 0 {
+			if hasRoad[v] {
+				ans += match
+			} else {
+				ans += match - 1
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+	rand.Seed(450)
+	var tests []test
+	// fixed small cases
+	fixed := []string{
+		"2 1 1\n1 2 5\n2 3\n",
+		"3 2 1\n1 2 1\n2 3 2\n3 2\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(6) + 2
+		maxm := n * (n - 1) / 2
+		m := rand.Intn(maxm) + 1
+		k := rand.Intn(n) + 1
+		edges := make([][3]int64, 0, m)
+		used := make(map[[2]int]bool)
+		for len(edges) < m {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			key1 := [2]int{u, v}
+			key2 := [2]int{v, u}
+			if used[key1] || used[key2] {
+				continue
+			}
+			used[key1] = true
+			used[key2] = true
+			w := rand.Int63n(10) + 1
+			edges = append(edges, [3]int64{int64(u), int64(v), w})
+		}
+		trains := make([][2]int64, k)
+		for i := 0; i < k; i++ {
+			s := rand.Intn(n-1) + 2
+			y := rand.Int63n(10) + 1
+			trains[i] = [2]int64{int64(s), y}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+		for _, e := range edges {
+			fmt.Fprintf(&sb, "%d %d %d\n", e[0], e[1], e[2])
+		}
+		for _, t := range trains {
+			fmt.Fprintf(&sb, "%d %d\n", t[0], t[1])
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, strings.TrimSpace(t.expected), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/440-449/449/verifierC.go
+++ b/0-999/400-499/440-449/449/verifierC.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type pair struct{ a, b int }
+
+type test struct {
+	input, expected string
+}
+
+func solve(input string) string {
+	var n int
+	fmt.Sscan(strings.TrimSpace(input), &n)
+	used := make([]bool, n+1)
+	grp := make([]pair, 0, n/2)
+	var p int
+	for i := 3; i <= n/2; i += 2 {
+		if !used[i] {
+			p = i
+			for j := i * 3; j <= n; j += i {
+				if !used[j] {
+					if p != 0 {
+						grp = append(grp, pair{p, j})
+						used[p], used[j] = true, true
+						p = 0
+					} else {
+						p = j
+					}
+				}
+			}
+			if p != 0 {
+				pairv := i * 2
+				if pairv <= n && !used[p] && !used[pairv] {
+					grp = append(grp, pair{p, pairv})
+					used[p], used[pairv] = true, true
+				}
+			}
+		}
+	}
+	p = 0
+	for i := 2; i <= n; i += 2 {
+		if !used[i] {
+			if p != 0 {
+				grp = append(grp, pair{p, i})
+				used[p], used[i] = true, true
+				p = 0
+			} else {
+				p = i
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(grp))
+	for _, pr := range grp {
+		fmt.Fprintf(&sb, "%d %d\n", pr.a, pr.b)
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateTests() []test {
+	rand.Seed(451)
+	var tests []test
+	fixed := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 50}
+	for _, n := range fixed {
+		inp := fmt.Sprintf("%d\n", n)
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(100) + 1
+		inp := fmt.Sprintf("%d\n", n)
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != t.expected {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/440-449/449/verifierD.go
+++ b/0-999/400-499/440-449/449/verifierD.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod = 1000000007
+
+func solve(input string) string {
+	rdr := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(rdr, &n); err != nil {
+		return ""
+	}
+	a := make([]int, n)
+	maxA := 0
+	for i := 0; i < n; i++ {
+		fmt.Fscan(rdr, &a[i])
+		if a[i] > maxA {
+			maxA = a[i]
+		}
+	}
+	B := 0
+	for (1 << B) <= maxA {
+		B++
+	}
+	size := 1 << B
+	f := make([]int, size)
+	for _, v := range a {
+		f[v]++
+	}
+	for i := 0; i < B; i++ {
+		bit := 1 << i
+		for mask := 0; mask < size; mask++ {
+			if mask&bit == 0 {
+				f[mask] += f[mask|bit]
+			}
+		}
+	}
+	pow2 := make([]int, n+1)
+	pow2[0] = 1
+	for i := 1; i <= n; i++ {
+		pow2[i] = (pow2[i-1] * 2) % mod
+	}
+	dp := make([]int, size)
+	for mask := 0; mask < size; mask++ {
+		cnt := f[mask]
+		if cnt > 0 {
+			dp[mask] = pow2[cnt] - 1
+			if dp[mask] < 0 {
+				dp[mask] += mod
+			}
+		}
+	}
+	for i := 0; i < B; i++ {
+		bit := 1 << i
+		for mask := 0; mask < size; mask++ {
+			if mask&bit == 0 {
+				dp[mask] -= dp[mask|bit]
+				if dp[mask] < 0 {
+					dp[mask] += mod
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("%d", dp[0])
+}
+
+func generateTests() []test {
+	rand.Seed(452)
+	var tests []test
+	fixed := []string{
+		"1\n0\n",
+		"2\n1 1\n",
+		"3\n1 2 3\n",
+		"4\n0 0 0 0\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(10) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			val := rand.Intn(64)
+			fmt.Fprintf(&sb, "%d", val)
+			if i+1 < n {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+type test struct {
+	input, expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, strings.TrimSpace(t.expected), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/440-449/449/verifierE.go
+++ b/0-999/400-499/440-449/449/verifierE.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const MOD = 1000000007
+
+func solve(input string) string {
+	rdr := bufio.NewReader(strings.NewReader(input))
+	var t int
+	fmt.Fscan(rdr, &t)
+	ns := make([]int, t)
+	ms := make([]int, t)
+	maxK := 0
+	for i := 0; i < t; i++ {
+		fmt.Fscan(rdr, &ns[i], &ms[i])
+		k := ns[i]
+		if ms[i] < k {
+			k = ms[i]
+		}
+		if k > maxK {
+			maxK = k
+		}
+	}
+	phi := make([]int, maxK+1)
+	for i := 0; i <= maxK; i++ {
+		phi[i] = i
+	}
+	for i := 2; i <= maxK; i++ {
+		if phi[i] == i {
+			for j := i; j <= maxK; j += i {
+				phi[j] -= phi[j] / i
+			}
+		}
+	}
+	f2 := make([]int64, maxK+1)
+	for i := 1; i <= maxK; i++ {
+		pi := int64(phi[i])
+		for k0 := i; k0 <= maxK; k0 += i {
+			d := int64(k0 / i)
+			f2[k0] += d * pi
+		}
+	}
+	G := make([]int64, maxK+1)
+	A := make([]int64, maxK+1)
+	B := make([]int64, maxK+1)
+	C := make([]int64, maxK+1)
+	inv2 := int64((MOD + 1) / 2)
+	inv6 := int64(166666668)
+	for k := 1; k <= maxK; k++ {
+		kk := int64(k)
+		t1 := kk * (kk + 1) % MOD * (2*kk + 1) % MOD * inv6 % MOD
+		t3 := kk * (kk + 1) % MOD * inv2 % MOD
+		sg := (f2[k] + kk) % MOD
+		gk := (2*t1%MOD - 4*t3%MOD + 2*sg%MOD) % MOD
+		gk = (gk - (kk * kk % MOD) + MOD) % MOD
+		G[k] = gk
+		A[k] = (A[k-1] + gk) % MOD
+		B[k] = (B[k-1] + gk*kk) % MOD
+		C[k] = (C[k-1] + gk*kk%MOD*kk%MOD) % MOD
+	}
+	var out strings.Builder
+	idx := 0
+	for idx < t {
+		n, m := ns[idx], ms[idx]
+		K := n
+		if m < K {
+			K = m
+		}
+		if K <= 0 {
+			fmt.Fprintln(&out, 0)
+			idx++
+			continue
+		}
+		np := int64(n + 1)
+		mp := int64(m + 1)
+		s0 := A[K]
+		s1 := B[K]
+		s2 := C[K]
+		ans := (np*mp%MOD*s0%MOD - (np+mp)%MOD*s1%MOD + s2) % MOD
+		if ans < 0 {
+			ans += MOD
+		}
+		fmt.Fprintln(&out, ans)
+		idx++
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateTests() []test {
+	rand.Seed(453)
+	var tests []test
+	fixed := []string{
+		"1\n1 1\n",
+		"2\n1 2\n2 1\n",
+		"3\n5 5\n10 1\n2 2\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		t := rand.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for i := 0; i < t; i++ {
+			n := rand.Intn(50) + 1
+			m := rand.Intn(50) + 1
+			fmt.Fprintf(&sb, "%d %d\n", n, m)
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+type test struct {
+	input, expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, strings.TrimSpace(t.expected), got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 449
- each verifier generates at least 100 deterministic tests
- run the given binary on every test and compare with reference solution

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`


------
https://chatgpt.com/codex/tasks/task_e_687ed0c3f23c8324a8676a570550495f