### PR TITLE
Add automated verifiers for CF contest 448

### DIFF
--- a/0-999/400-499/440-449/448/verifierA.go
+++ b/0-999/400-499/440-449/448/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func expectedA(a1, a2, a3, b1, b2, b3, n int) string {
+	totalCups := a1 + a2 + a3
+	totalMedals := b1 + b2 + b3
+	cupShelves := (totalCups + 4) / 5
+	medalShelves := (totalMedals + 9) / 10
+	if cupShelves+medalShelves <= n {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		a1 := rng.Intn(101)
+		a2 := rng.Intn(101)
+		a3 := rng.Intn(101)
+		b1 := rng.Intn(101)
+		b2 := rng.Intn(101)
+		b3 := rng.Intn(101)
+		n := rng.Intn(100) + 1
+		input := fmt.Sprintf("%d %d %d\n%d %d %d\n%d\n", a1, a2, a3, b1, b2, b3, n)
+		exp := expectedA(a1, a2, a3, b1, b2, b3, n)
+		cases[i] = testCase{input: input, expected: exp}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if out != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/448/verifierB.go
+++ b/0-999/400-499/440-449/448/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func expectedB(s, t string) string {
+	var freqS, freqT [26]int
+	for _, ch := range s {
+		freqS[ch-'a']++
+	}
+	for _, ch := range t {
+		freqT[ch-'a']++
+	}
+	for i := 0; i < 26; i++ {
+		if freqS[i] < freqT[i] {
+			return "need tree"
+		}
+	}
+	j := 0
+	for i := 0; i < len(s) && j < len(t); i++ {
+		if s[i] == t[j] {
+			j++
+		}
+	}
+	if j == len(t) {
+		if len(s) != len(t) {
+			return "automaton"
+		}
+		return "array"
+	}
+	if len(s) == len(t) {
+		return "array"
+	}
+	return "both"
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		m := rng.Intn(20) + 1
+		sb1 := make([]rune, n)
+		sb2 := make([]rune, m)
+		for j := 0; j < n; j++ {
+			sb1[j] = letters[rng.Intn(len(letters))]
+		}
+		for j := 0; j < m; j++ {
+			sb2[j] = letters[rng.Intn(len(letters))]
+		}
+		s := string(sb1)
+		t := string(sb2)
+		input := fmt.Sprintf("%s\n%s\n", s, t)
+		exp := expectedB(s, t)
+		cases[i] = testCase{input: input, expected: exp}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if out != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/448/verifierC.go
+++ b/0-999/400-499/440-449/448/verifierC.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int
+}
+
+func solveSegment(a []int, l, r, h int) int {
+	if l >= r {
+		return 0
+	}
+	vert := r - l
+	minVal := a[l]
+	minIdx := l
+	for i := l + 1; i < r; i++ {
+		if a[i] < minVal {
+			minVal = a[i]
+			minIdx = i
+		}
+	}
+	hori := minVal - h
+	if hori >= vert {
+		return vert
+	}
+	hori += solveSegment(a, l, minIdx, minVal)
+	hori += solveSegment(a, minIdx+1, r, minVal)
+	if hori < vert {
+		return hori
+	}
+	return vert
+}
+
+func expectedC(arr []int) int {
+	return solveSegment(arr, 0, len(arr), 0)
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(11)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		cases[i] = testCase{input: sb.String(), expected: expectedC(arr)}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		var got int
+		fmt.Sscan(out, &got)
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/448/verifierD.go
+++ b/0-999/400-499/440-449/448/verifierD.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+func countLE(x, n, m int64) int64 {
+	var cnt int64
+	for i := int64(1); i <= n; i++ {
+		t := x / i
+		if t > m {
+			t = m
+		}
+		cnt += t
+	}
+	return cnt
+}
+
+func expectedD(n, m, k int64) int64 {
+	if n > m {
+		n, m = m, n
+	}
+	left, right := int64(1), n*m
+	var ans int64
+	for left <= right {
+		mid := (left + right) / 2
+		cnt := countLE(mid, n, m)
+		if cnt >= k {
+			ans = mid
+			right = mid - 1
+		} else {
+			left = mid + 1
+		}
+	}
+	return ans
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := int64(rng.Intn(20) + 1)
+		m := int64(rng.Intn(20) + 1)
+		k := int64(rng.Intn(int(n*m)) + 1)
+		input := fmt.Sprintf("%d %d %d\n", n, m, k)
+		cases[i] = testCase{input: input, expected: expectedD(n, m, k)}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		var got int64
+		fmt.Sscan(out, &got)
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/448/verifierE.go
+++ b/0-999/400-499/440-449/448/verifierE.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const MaxOut = 100000
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func sequenceE(X, k int64) []int64 {
+	vals := make([]int64, 0)
+	for i := int64(1); i*i <= X; i++ {
+		if X%i == 0 {
+			vals = append(vals, i)
+			if i*i != X {
+				vals = append(vals, X/i)
+			}
+		}
+	}
+	sort.Slice(vals, func(i, j int) bool { return vals[i] < vals[j] })
+	idx := make(map[int64]int, len(vals))
+	for i, v := range vals {
+		idx[v] = i
+	}
+	idx1 := idx[1]
+	children := make([][]int, len(vals))
+	for i := range vals {
+		v := vals[i]
+		for j := 0; j <= i; j++ {
+			if v%vals[j] == 0 {
+				children[i] = append(children[i], j)
+			}
+		}
+	}
+	rem := MaxOut
+	res := make([]int64, 0, MaxOut)
+	var gen func(int, int64)
+	gen = func(vIdx int, depth int64) {
+		if rem <= 0 {
+			return
+		}
+		if vIdx == idx1 {
+			res = append(res, 1)
+			rem--
+			return
+		}
+		ch := children[vIdx]
+		if len(ch) == 2 && ch[0] == idx1 && ch[1] == vIdx {
+			if depth >= int64(rem) {
+				for i := 0; i < rem; i++ {
+					res = append(res, 1)
+				}
+				rem = 0
+			} else {
+				for i := int64(0); i < depth && rem > 0; i++ {
+					res = append(res, 1)
+					rem--
+				}
+				if rem > 0 {
+					res = append(res, vals[vIdx])
+					rem--
+				}
+			}
+			return
+		}
+		if depth == 0 {
+			res = append(res, vals[vIdx])
+			rem--
+			return
+		}
+		for _, u := range ch {
+			if rem <= 0 {
+				return
+			}
+			gen(u, depth-1)
+		}
+	}
+	gen(idx[X], k)
+	return res
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		X := int64(rng.Intn(1000) + 1)
+		k := int64(rng.Intn(10))
+		seq := sequenceE(X, k)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", X, k))
+		var out strings.Builder
+		for j, v := range seq {
+			if j > 0 {
+				out.WriteByte(' ')
+			}
+			out.WriteString(fmt.Sprintf("%d", v))
+		}
+		out.WriteByte('\n')
+		cases[i] = testCase{input: sb.String(), expected: out.String()}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateTests()
+	for i, tc := range cases {
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if out != strings.TrimSpace(tc.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, strings.TrimSpace(tc.expected), out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go based verifiers for problems 448A–E
- each verifier generates 100 randomized test cases
- solutions are embedded to compute expected results
- verifiers run any binary or `.go` file and report failures

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ed07dfa0083248e232d6081071eda