### PR TITLE
Add solution verifiers for contest 446

### DIFF
--- a/0-999/400-499/440-449/446/verifierA.go
+++ b/0-999/400-499/440-449/446/verifierA.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	arr []int
+}
+
+func expected(a []int) int {
+	n := len(a)
+	if n == 0 {
+		return 0
+	}
+	dp1 := make([]int, n)
+	dp2 := make([]int, n)
+	dp1[0] = 1
+	for i := 1; i < n; i++ {
+		if a[i] > a[i-1] {
+			dp1[i] = dp1[i-1] + 1
+		} else {
+			dp1[i] = 1
+		}
+	}
+	dp2[n-1] = 1
+	for i := n - 2; i >= 0; i-- {
+		if a[i] < a[i+1] {
+			dp2[i] = dp2[i+1] + 1
+		} else {
+			dp2[i] = 1
+		}
+	}
+	maxLen := 1
+	for i := 0; i < n; i++ {
+		if dp1[i] > maxLen {
+			maxLen = dp1[i]
+		}
+	}
+	if n > 1 {
+		if dp2[1]+1 > maxLen {
+			maxLen = dp2[1] + 1
+		}
+		if dp1[n-2]+1 > maxLen {
+			maxLen = dp1[n-2] + 1
+		}
+	}
+	for i := 1; i < n-1; i++ {
+		if a[i+1]-a[i-1] >= 2 {
+			l := dp1[i-1] + dp2[i+1] + 1
+			if l > maxLen {
+				maxLen = l
+			}
+		}
+	}
+	return maxLen
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(20) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(arr)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %d\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/446/verifierB.go
+++ b/0-999/400-499/440-449/446/verifierB.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type MaxHeap []int64
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(int64)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func expected(n, m, k int, p int64, mat [][]int64) int64 {
+	rowSum := make([]int64, n)
+	colSum := make([]int64, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			v := mat[i][j]
+			rowSum[i] += v
+			colSum[j] += v
+		}
+	}
+	bestR := make([]int64, k+1)
+	bestC := make([]int64, k+1)
+	hR := make(MaxHeap, len(rowSum))
+	copy(hR, rowSum)
+	heap.Init(&hR)
+	for i := 1; i <= k; i++ {
+		x := heap.Pop(&hR).(int64)
+		bestR[i] = bestR[i-1] + x
+		heap.Push(&hR, x-int64(m)*p)
+	}
+	hC := make(MaxHeap, len(colSum))
+	copy(hC, colSum)
+	heap.Init(&hC)
+	for i := 1; i <= k; i++ {
+		x := heap.Pop(&hC).(int64)
+		bestC[i] = bestC[i-1] + x
+		heap.Push(&hC, x-int64(n)*p)
+	}
+	ans := int64(-1 << 60)
+	for i := 0; i <= k; i++ {
+		j := k - i
+		val := bestR[i] + bestC[j] - int64(i)*int64(j)*p
+		if val > ans {
+			ans = val
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	k := rng.Intn(3) + 1
+	p := int64(rng.Intn(3) + 1)
+	mat := make([][]int64, n)
+	for i := 0; i < n; i++ {
+		mat[i] = make([]int64, m)
+		for j := 0; j < m; j++ {
+			mat[i][j] = int64(rng.Intn(5))
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, k, p))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(mat[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), expected(n, m, k, p, mat)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %d\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/446/verifierC.go
+++ b/0-999/400-499/440-449/446/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000009
+
+func fibSeq(n int) []int64 {
+	f := make([]int64, n+2)
+	f[1] = 1
+	f[2] = 1
+	for i := 3; i < len(f); i++ {
+		f[i] = (f[i-1] + f[i-2]) % mod
+	}
+	return f
+}
+
+func generateCase(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = int64(rng.Intn(5))
+	}
+	fib := fibSeq(n + m + 5)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	outputs := make([]int64, 0, m)
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", l, r))
+			for j := l - 1; j <= r-1; j++ {
+				arr[j] = (arr[j] + fib[j-l+2]) % mod
+			}
+		} else {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", l, r))
+			sum := int64(0)
+			for j := l - 1; j <= r-1; j++ {
+				sum += arr[j]
+				if sum >= mod {
+					sum -= mod
+				}
+			}
+			outputs = append(outputs, sum%mod)
+		}
+	}
+	return sb.String(), outputs
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		lines := strings.Fields(out)
+		if len(lines) != len(exp) {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d lines got %d\ninput:\n%s", i+1, len(exp), len(lines), in)
+			os.Exit(1)
+		}
+		for j, s := range lines {
+			var got int64
+			if _, err := fmt.Sscan(s, &got); err != nil || got != exp[j] {
+				fmt.Fprintf(os.Stderr, "case %d: wrong answer on query %d expected %d got %s\ninput:\n%s", i+1, j+1, exp[j], s, in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/446/verifierD.go
+++ b/0-999/400-499/440-449/446/verifierD.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Matrix struct {
+	n  [][]float64
+	sz int
+}
+
+func NewMatrix(sz int) *Matrix {
+	n := make([][]float64, sz)
+	for i := range n {
+		n[i] = make([]float64, sz)
+	}
+	return &Matrix{n: n, sz: sz}
+}
+
+func (m *Matrix) Multiply(o *Matrix) *Matrix {
+	sz := m.sz
+	res := NewMatrix(sz)
+	for i := 0; i < sz; i++ {
+		for k := 0; k < sz; k++ {
+			mik := m.n[i][k]
+			if mik != 0 {
+				for j := 0; j < sz; j++ {
+					res.n[i][j] += mik * o.n[k][j]
+				}
+			}
+		}
+	}
+	return res
+}
+
+func (m *Matrix) Pow(exp int64) *Matrix {
+	sz := m.sz
+	res := NewMatrix(sz)
+	for i := 0; i < sz; i++ {
+		res.n[i][i] = 1
+	}
+	base := m
+	for exp > 0 {
+		if exp&1 == 1 {
+			res = res.Multiply(base)
+		}
+		base = base.Multiply(base)
+		exp >>= 1
+	}
+	return res
+}
+
+func expected(n, m int, k int64, a []int, edges [][2]int) float64 {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	comp := make([]int, n+1)
+	W := 0
+	for i := 1; i <= n; i++ {
+		if a[i] == 0 && comp[i] == 0 {
+			W++
+			queue := []int{i}
+			comp[i] = W
+			for len(queue) > 0 {
+				u := queue[0]
+				queue = queue[1:]
+				for _, v := range adj[u] {
+					if a[v] == 0 && comp[v] == 0 {
+						comp[v] = W
+						queue = append(queue, v)
+					}
+				}
+			}
+		}
+	}
+	B := 0
+	for i := 1; i <= n; i++ {
+		if a[i] == 1 {
+			B++
+			comp[i] = B
+		}
+	}
+	cnt := make([][]int, B)
+	for i := 0; i < B; i++ {
+		cnt[i] = make([]int, W)
+	}
+	Cnt := make([][]int, B)
+	for i := 0; i < B; i++ {
+		Cnt[i] = make([]int, B)
+	}
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		if a[u] == 1 && a[v] == 1 {
+			ui, vi := comp[u]-1, comp[v]-1
+			Cnt[ui][vi]++
+			Cnt[vi][ui]++
+		} else if a[u] == 1 && a[v] == 0 {
+			ui, vj := comp[u]-1, comp[v]-1
+			cnt[ui][vj]++
+		} else if a[u] == 0 && a[v] == 1 {
+			ui, vj := comp[v]-1, comp[u]-1
+			cnt[ui][vj]++
+		}
+	}
+	s1 := make([]int, W)
+	for j := 0; j < W; j++ {
+		sum := 0
+		for i := 0; i < B; i++ {
+			sum += cnt[i][j]
+		}
+		s1[j] = sum
+	}
+	s2 := make([]int, B)
+	for i := 0; i < B; i++ {
+		sum := 0
+		for j := 0; j < B; j++ {
+			sum += Cnt[j][i]
+		}
+		for j := 0; j < W; j++ {
+			sum += cnt[i][j]
+		}
+		s2[i] = sum
+	}
+	p := NewMatrix(B)
+	for i := 0; i < B; i++ {
+		if s2[i] == 0 {
+			continue
+		}
+		for j := 0; j < B; j++ {
+			p.n[i][j] = float64(Cnt[i][j]) / float64(s2[i])
+			extra := 0.0
+			for k2 := 0; k2 < W; k2++ {
+				if s1[k2] == 0 {
+					continue
+				}
+				extra += (float64(cnt[i][k2]) / float64(s2[i])) * (float64(cnt[j][k2]) / float64(s1[k2]))
+			}
+			p.n[i][j] += extra
+		}
+	}
+	exp := k - 2
+	pPow := p.Pow(exp)
+	j0 := comp[1] - 1
+	ans := 0.0
+	if j0 >= 0 && j0 < W {
+		for i := 0; i < B; i++ {
+			if s1[j0] > 0 {
+				ans += (float64(cnt[i][j0]) / float64(s1[j0])) * pPow.n[j0][B-1]
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	n := rng.Intn(4) + 2
+	maxM := n * (n - 1) / 2
+	m := n - 1 + rng.Intn(maxM-(n-1)+1)
+	// create connected graph via tree
+	edges := make([][2]int, 0, m)
+	for i := 2; i <= n; i++ {
+		u := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{u, i})
+	}
+	used := make(map[[2]int]bool)
+	for _, e := range edges {
+		if e[0] > e[1] {
+			e[0], e[1] = e[1], e[0]
+		}
+		used[[2]int{e[0], e[1]}] = true
+	}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		a := u
+		b := v
+		if a > b {
+			a, b = b, a
+		}
+		key := [2]int{a, b}
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		edges = append(edges, [2]int{u, v})
+	}
+	k := int64(rng.Intn(4) + 2)
+	a := make([]int, n+1)
+	trapCnt := 1
+	for i := 2; i < n; i++ {
+		if rng.Intn(2) == 0 && trapCnt < 3 {
+			a[i] = 1
+			trapCnt++
+		}
+	}
+	a[n] = 1
+	a[1] = 0
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, len(edges), k))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	ans := expected(n, len(edges), k, a, edges)
+	return sb.String(), ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		var got float64
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if diff := got - exp; diff < -1e-4 || diff > 1e-4 {
+			fmt.Fprintf(os.Stderr, "case %d: expected %.6f got %.6f\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/446/verifierE.go
+++ b/0-999/400-499/440-449/446/verifierE.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MOD = 1051131
+
+func modAdd(a, b int) int {
+	c := a + b
+	if c >= MOD {
+		c -= MOD
+	}
+	return c
+}
+
+func modSub(a, b int) int {
+	c := a - b
+	if c < 0 {
+		c += MOD
+	}
+	return c
+}
+
+func modMul(a, b int) int { return int((int64(a) * int64(b)) % MOD) }
+
+func modPow(a int, e int64) int {
+	res := 1
+	base := a % MOD
+	for e > 0 {
+		if e&1 != 0 {
+			res = modMul(res, base)
+		}
+		base = modMul(base, base)
+		e >>= 1
+	}
+	return res
+}
+
+func modInv(a int) int {
+	var egcd func(int, int) (int, int, int)
+	egcd = func(a, b int) (int, int, int) {
+		if b == 0 {
+			return a, 1, 0
+		}
+		g, x1, y1 := egcd(b, a%b)
+		return g, y1, x1 - (a/b)*y1
+	}
+	_, x, _ := egcd(a, MOD)
+	x %= MOD
+	if x < 0 {
+		x += MOD
+	}
+	return x
+}
+
+func fwht(a []int, invert bool) {
+	n := len(a)
+	for step := 1; step < n; step <<= 1 {
+		for i := 0; i < n; i += step << 1 {
+			for j := 0; j < step; j++ {
+				u := a[i+j]
+				v := a[i+j+step]
+				a[i+j] = modAdd(u, v)
+				a[i+j+step] = modSub(u, v)
+			}
+		}
+	}
+	if invert {
+		invN := modInv(n)
+		for i := 0; i < n; i++ {
+			a[i] = modMul(a[i], invN)
+		}
+	}
+}
+
+func expected(m int, t int64, s int, initial []int) int {
+	N := 1 << m
+	a0 := make([]int, N)
+	copy(a0, initial)
+	for i := s; i < N; i++ {
+		a0[i] = int((101*int64(a0[i-s]) + 10007) % MOD)
+	}
+	fwht(a0, false)
+	pow2m := N % MOD
+	for i := 0; i < N; i++ {
+		hi := pow2m + 1 - ((i * 2) % MOD)
+		hi %= MOD
+		if hi < 0 {
+			hi += MOD
+		}
+		a0[i] = modMul(a0[i], modPow(hi, t))
+	}
+	fwht(a0, true)
+	res := 0
+	for i := 0; i < N; i++ {
+		res ^= a0[i]
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	m := rng.Intn(3) + 1
+	N := 1 << m
+	t := int64(rng.Intn(5) + 1)
+	s := rng.Intn(min(N, 5)) + 1
+	init := make([]int, s)
+	for i := 0; i < s; i++ {
+		init[i] = rng.Intn(1000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", m, t, s))
+	for i, v := range init {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	ans := expected(m, t, s, init)
+	return sb.String(), ans
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %d\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`..`verifierE.go` under contest 446
- verifiers generate 100 random test cases and check any binary's output
- algorithms based on existing reference solutions

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`
- `go vet` and `go test` failed due to missing go modules

------
https://chatgpt.com/codex/tasks/task_e_687ecff1c2548324b984044a275a9db0