### PR TITLE
Add Go verifiers for contest 444

### DIFF
--- a/0-999/400-499/440-449/444/verifierA.go
+++ b/0-999/400-499/440-449/444/verifierA.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v, w int }
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	n := rng.Intn(5) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	values := make([]int, n)
+	for i := range values {
+		values[i] = rng.Intn(10) + 1
+	}
+	edges := make([]edge, 0, m)
+	used := make(map[[2]int]bool)
+	for len(edges) < m {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		key := [2]int{u, v}
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		w := rng.Intn(10) + 1
+		edges = append(edges, edge{u + 1, v + 1, w})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range values {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.u, e.v, e.w))
+	}
+	ans := 0.0
+	for _, e := range edges {
+		val := float64(values[e.u-1]+values[e.v-1]) / float64(e.w)
+		if val > ans {
+			ans = val
+		}
+	}
+	return sb.String(), ans
+}
+
+func runCase(bin string, input string, expected float64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	diff := math.Abs(got - expected)
+	if diff > 1e-6*math.Max(1, math.Abs(expected)) {
+		return fmt.Errorf("expected %.6f got %.6f", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/444/verifierB.go
+++ b/0-999/400-499/440-449/444/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func expected(n int, d int, x int64) []int {
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = i + 1
+	}
+	for i := 0; i < n; i++ {
+		x = (x*7 + 13) % mod
+		j := int(x % int64(i+1))
+		a[i], a[j] = a[j], a[i]
+	}
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		x = (x*7 + 13) % mod
+		if x&1 == 1 {
+			b[i] = 1
+		}
+	}
+	c := make([]int, n)
+	for i := 0; i < n; i++ {
+		mx := 0
+		for j := 0; j <= i; j++ {
+			val := a[j] * b[i-j]
+			if val > mx {
+				mx = val
+			}
+		}
+		c[i] = mx
+	}
+	return c
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(6) + 1
+	d := rng.Intn(n) + 1
+	x := rng.Int63n(mod)
+	if x == 27777500 {
+		x++
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, d, x))
+	return sb.String(), expected(n, d, x)
+}
+
+func runCase(bin string, input string, expect []int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	scanner.Split(bufio.ScanWords)
+	got := make([]int, 0, len(expect))
+	for scanner.Scan() {
+		v, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		got = append(got, v)
+	}
+	if len(got) != len(expect) {
+		return fmt.Errorf("expected %d numbers got %d", len(expect), len(got))
+	}
+	for i, v := range expect {
+		if got[i] != v {
+			return fmt.Errorf("pos %d expected %d got %d", i, v, got[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/444/verifierC.go
+++ b/0-999/400-499/440-449/444/verifierC.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func generateCase(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	colors := make([]int, n)
+	for i := 0; i < n; i++ {
+		colors[i] = i + 1
+	}
+	colorful := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	answers := make([]int64, 0)
+	for i := 0; i < m; i++ {
+		typ := rng.Intn(2) + 1
+		if typ == 1 {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			x := rng.Intn(10) + 1
+			sb.WriteString(fmt.Sprintf("1 %d %d %d\n", l, r, x))
+			for j := l - 1; j < r; j++ {
+				diff := abs(x - colors[j])
+				colorful[j] += int64(diff)
+				colors[j] = x
+			}
+		} else {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", l, r))
+			sum := int64(0)
+			for j := l - 1; j < r; j++ {
+				sum += colorful[j]
+			}
+			answers = append(answers, sum)
+		}
+	}
+	return sb.String(), answers
+}
+
+func runCase(bin string, input string, answers []int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	scanner.Split(bufio.ScanWords)
+	var got []int64
+	for scanner.Scan() {
+		v, err := strconv.ParseInt(scanner.Text(), 10, 64)
+		if err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		got = append(got, v)
+	}
+	if len(got) != len(answers) {
+		return fmt.Errorf("expected %d numbers got %d", len(answers), len(got))
+	}
+	for i, v := range answers {
+		if got[i] != v {
+			return fmt.Errorf("query %d expected %d got %d", i, v, got[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/444/verifierD.go
+++ b/0-999/400-499/440-449/444/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(8) + 1
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	var sb strings.Builder
+	sRunes := make([]rune, n)
+	for i := 0; i < n; i++ {
+		sRunes[i] = letters[rng.Intn(len(letters))]
+	}
+	s := string(sRunes)
+	sb.WriteString(fmt.Sprintf("%s\n", s))
+	q := rng.Intn(3) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	answers := make([]int, q)
+	for i := 0; i < q; i++ {
+		alen := rng.Intn(4) + 1
+		blen := rng.Intn(4) + 1
+		a := make([]rune, alen)
+		b := make([]rune, blen)
+		for j := 0; j < alen; j++ {
+			a[j] = letters[rng.Intn(len(letters))]
+		}
+		for j := 0; j < blen; j++ {
+			b[j] = letters[rng.Intn(len(letters))]
+		}
+		as := string(a)
+		bs := string(b)
+		sb.WriteString(fmt.Sprintf("%s %s\n", as, bs))
+		ans := -1
+		for l := 0; l < len(s); l++ {
+			for r := l; r < len(s); r++ {
+				sub := s[l : r+1]
+				if strings.Contains(sub, as) && strings.Contains(sub, bs) {
+					length := r - l + 1
+					if ans == -1 || length < ans {
+						ans = length
+					}
+				}
+			}
+		}
+		answers[i] = ans
+	}
+	return sb.String(), answers
+}
+
+func runCase(bin string, input string, expected []int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	scanner.Split(bufio.ScanWords)
+	got := make([]int, 0, len(expected))
+	for scanner.Scan() {
+		v, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		got = append(got, v)
+	}
+	if len(got) != len(expected) {
+		return fmt.Errorf("expected %d numbers got %d", len(expected), len(got))
+	}
+	for i, v := range expected {
+		if got[i] != v {
+			return fmt.Errorf("query %d expected %d got %d", i, v, got[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/444/verifierE.go
+++ b/0-999/400-499/440-449/444/verifierE.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Edge struct{ u, v, w int }
+
+type DSU struct{ p []int }
+
+func NewDSU(n int) *DSU {
+	p := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = -1
+	}
+	return &DSU{p}
+}
+func (d *DSU) Find(x int) int {
+	if d.p[x] < 0 {
+		return x
+	}
+	d.p[x] = d.Find(d.p[x])
+	return d.p[x]
+}
+func (d *DSU) Union(x, y int) {
+	x = d.Find(x)
+	y = d.Find(y)
+	if x == y {
+		return
+	}
+	if d.p[x] > d.p[y] {
+		x, y = y, x
+	}
+	d.p[x] += d.p[y]
+	d.p[y] = x
+}
+
+func check(T int, n int, edges []Edge, x []int, total int) bool {
+	d := NewDSU(n)
+	for _, e := range edges {
+		if e.w >= T {
+			break
+		}
+		d.Union(e.u, e.v)
+	}
+	compSize := make(map[int]int)
+	compCap := make(map[int]int)
+	for i := 0; i < n; i++ {
+		r := d.Find(i)
+		compSize[r]++
+		compCap[r] += x[i]
+	}
+	for r, sz := range compSize {
+		if sz+compCap[r] > total {
+			return false
+		}
+	}
+	return true
+}
+
+func expected(n int, edges []Edge, x []int) int {
+	weights := []int{0}
+	for _, e := range edges {
+		weights = append(weights, e.w)
+	}
+	sort.Ints(weights)
+	uniq := weights[:0]
+	for _, v := range weights {
+		if len(uniq) == 0 || uniq[len(uniq)-1] != v {
+			uniq = append(uniq, v)
+		}
+	}
+	sort.Slice(edges, func(i, j int) bool { return edges[i].w < edges[j].w })
+	total := 0
+	for _, v := range x {
+		total += v
+	}
+	lo, hi := 0, len(uniq)-1
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if check(uniq[mid], n, edges, x, total) {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return uniq[lo]
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(5) + 1
+	edges := make([]Edge, n-1)
+	for i := 1; i < n; i++ {
+		u := rng.Intn(i)
+		v := i
+		w := rng.Intn(10) + 1
+		edges[i-1] = Edge{u, v, w}
+	}
+	x := make([]int, n)
+	for i := 0; i < n; i++ {
+		x[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.u+1, e.v+1, e.w))
+	}
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d\n", x[i]))
+	}
+	ans := expected(n, edges, x)
+	return sb.String(), ans
+}
+
+func runCase(bin string, input string, expect int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out.String()))
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` through `verifierE.go` under contest 444
- each verifier creates random tests, runs a submitted binary and checks the output
- 100 test cases are generated for each problem

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`


------
https://chatgpt.com/codex/tasks/task_e_687ecf65afc4832487bf147e82c1f5db