### PR TITLE
Add Go verifiers for contest 442

### DIFF
--- a/0-999/400-499/440-449/442/verifierA.go
+++ b/0-999/400-499/440-449/442/verifierA.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func colorIndex(c byte) int {
+	switch c {
+	case 'R':
+		return 0
+	case 'G':
+		return 1
+	case 'B':
+		return 2
+	case 'Y':
+		return 3
+	case 'W':
+		return 4
+	}
+	return -1
+}
+
+func solveA(r *bufio.Reader) string {
+	var n int
+	fmt.Fscan(r, &n)
+	cards := make([]string, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &cards[i])
+	}
+	present := make([][]bool, 5)
+	for i := range present {
+		present[i] = make([]bool, 5)
+	}
+	for _, s := range cards {
+		ci := colorIndex(s[0])
+		vi := int(s[1] - '1')
+		if ci >= 0 && vi >= 0 && ci < 5 && vi < 5 {
+			present[ci][vi] = true
+		}
+	}
+	types := make([][2]int, 0, 25)
+	for ci := 0; ci < 5; ci++ {
+		for vi := 0; vi < 5; vi++ {
+			if present[ci][vi] {
+				types = append(types, [2]int{ci, vi})
+			}
+		}
+	}
+	best := 10
+	for mask := 0; mask < (1 << 10); mask++ {
+		cnt := bits.OnesCount(uint(mask))
+		if cnt >= best {
+			continue
+		}
+		ok := true
+		for i := 0; i < len(types) && ok; i++ {
+			for j := i + 1; j < len(types); j++ {
+				c1, v1 := types[i][0], types[i][1]
+				c2, v2 := types[j][0], types[j][1]
+				distinguished := false
+				for bit := 0; bit < 10; bit++ {
+					if mask&(1<<bit) == 0 {
+						continue
+					}
+					if bit < 5 {
+						if (c1 == bit) != (c2 == bit) {
+							distinguished = true
+							break
+						}
+					} else {
+						vb := bit - 5
+						if (v1 == vb) != (v2 == vb) {
+							distinguished = true
+							break
+						}
+					}
+				}
+				if !distinguished {
+					ok = false
+					break
+				}
+			}
+		}
+		if ok {
+			best = cnt
+		}
+	}
+	return fmt.Sprintf("%d\n", best)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	colors := []byte{'R', 'G', 'B', 'Y', 'W'}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		c := colors[rng.Intn(5)]
+		v := rng.Intn(5) + 1
+		fmt.Fprintf(&b, "%c%d", c, v)
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		expect := solveA(bufio.NewReader(strings.NewReader(tc)))
+		out, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %sinput:\n%s", i+1, expect, out, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/442/verifierB.go
+++ b/0-999/400-499/440-449/442/verifierB.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func solveB(r *bufio.Reader) string {
+	var n int
+	fmt.Fscan(r, &n)
+	p := make([]float64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &p[i])
+	}
+	sort.Float64s(p)
+	const eps = 1e-9
+	if n > 0 && math.Abs(p[n-1]-1.0) < eps {
+		return fmt.Sprintf("%.15f\n", 1.0)
+	}
+	prod := make([]float64, n+1)
+	rev := make([]float64, n+1)
+	prod[0] = 1.0
+	for i := 0; i < n; i++ {
+		prod[i+1] = prod[i] * (1.0 - p[i])
+	}
+	rev[n] = 1.0
+	for i := n - 1; i >= 0; i-- {
+		rev[i] = rev[i+1] * (1.0 - p[i])
+	}
+	best := 0.0
+	for i := 0; i <= n; i++ {
+		for j := n; j >= i; j-- {
+			pr := prod[i] * rev[j]
+			cnd := 0.0
+			for k := 0; k < i; k++ {
+				if 1.0-p[k] > eps {
+					cnd += p[k] * pr / (1.0 - p[k])
+				}
+			}
+			for k := n - 1; k >= j; k-- {
+				if 1.0-p[k] > eps {
+					cnd += p[k] * pr / (1.0 - p[k])
+				}
+			}
+			if cnd > best {
+				best = cnd
+			}
+		}
+	}
+	return fmt.Sprintf("%.15f\n", best)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		val := rng.Float64()
+		fmt.Fprintf(&b, "%.6f", val)
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solveB(bufio.NewReader(strings.NewReader(tc)))
+		out, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseFloat(strings.TrimSpace(out), 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: cannot parse output\n", i+1)
+			os.Exit(1)
+		}
+		exp, _ := strconv.ParseFloat(strings.TrimSpace(expect), 64)
+		if math.Abs(got-exp) > 1e-6 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.6f got %.6f\ninput:\n%s", i+1, exp, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/442/verifierC.go
+++ b/0-999/400-499/440-449/442/verifierC.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+type Item struct {
+	score int
+	idx   int
+}
+
+type MaxHeap []Item
+
+func (h MaxHeap) Len() int           { return len(h) }
+func (h MaxHeap) Less(i, j int) bool { return h[i].score > h[j].score }
+func (h MaxHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(Item)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	it := old[n-1]
+	*h = old[0 : n-1]
+	return it
+}
+
+func solveC(r *bufio.Reader) string {
+	var n int
+	fmt.Fscan(r, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &a[i])
+	}
+	if n < 3 {
+		return "0\n"
+	}
+	L := make([]int, n)
+	R := make([]int, n)
+	removed := make([]bool, n)
+	for i := 0; i < n; i++ {
+		L[i] = i - 1
+		R[i] = i + 1
+	}
+	R[n-1] = -1
+	getScore := func(i int) int {
+		if i < 0 || i >= n || removed[i] {
+			return -1
+		}
+		l := L[i]
+		r := R[i]
+		if l < 0 || r < 0 {
+			return -1
+		}
+		if a[l] < a[r] {
+			return a[l]
+		}
+		return a[r]
+	}
+	h := &MaxHeap{}
+	heap.Init(h)
+	for i := 1; i < n-1; i++ {
+		sc := getScore(i)
+		if sc >= 0 {
+			heap.Push(h, Item{score: sc, idx: i})
+		}
+	}
+	var total int64
+	for h.Len() > 0 {
+		it := heap.Pop(h).(Item)
+		i := it.idx
+		if removed[i] {
+			continue
+		}
+		sc := getScore(i)
+		if sc != it.score {
+			continue
+		}
+		total += int64(sc)
+		removed[i] = true
+		l := L[i]
+		r := R[i]
+		if l >= 0 {
+			R[l] = r
+		}
+		if r >= 0 {
+			L[r] = l
+		}
+		if sc2 := getScore(l); sc2 >= 0 {
+			heap.Push(h, Item{score: sc2, idx: l})
+		}
+		if sc3 := getScore(r); sc3 >= 0 {
+			heap.Push(h, Item{score: sc3, idx: r})
+		}
+	}
+	return fmt.Sprintf("%d\n", total)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 3
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", rng.Intn(1000)+1)
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solveC(bufio.NewReader(strings.NewReader(tc)))
+		out, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %sinput:\n%s", i+1, expect, out, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/442/verifierD.go
+++ b/0-999/400-499/440-449/442/verifierD.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveD(r *bufio.Reader) string {
+	var n int
+	fmt.Fscan(r, &n)
+	parent := make([]int, n+2)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(r, &parent[i+1])
+	}
+	N := n + 1
+	size := make([]int, N+1)
+	dp := make([]int, N+1)
+	bestNon := make([]int, N+1)
+	heavy1 := make([]int, N+1)
+	heavy2 := make([]int, N+1)
+	for i := 1; i <= N; i++ {
+		bestNon[i] = -1
+	}
+	var buf strings.Builder
+	for i := 1; i <= n; i++ {
+		v := i + 1
+		size[v] = 1
+		dp[v] = 0
+		prev := v
+		u := parent[v]
+		for u != 0 {
+			size[u]++
+			heavyChanged := false
+			if u == 1 {
+				if heavy1[u] == 0 {
+					heavy1[u] = prev
+					heavyChanged = true
+				} else if heavy2[u] == 0 {
+					if size[prev] > size[heavy1[u]] {
+						heavy2[u] = heavy1[u]
+						heavy1[u] = prev
+					} else {
+						heavy2[u] = prev
+					}
+					heavyChanged = true
+				} else {
+					var minh int
+					if size[heavy1[u]] < size[heavy2[u]] {
+						minh = heavy1[u]
+					} else {
+						minh = heavy2[u]
+					}
+					if size[prev] > size[minh] {
+						if minh == heavy1[u] {
+							heavy1[u] = prev
+						} else {
+							heavy2[u] = prev
+						}
+						heavyChanged = true
+						bestNon[u] = max(bestNon[u], dp[minh])
+					} else {
+						bestNon[u] = max(bestNon[u], dp[prev])
+					}
+				}
+			} else {
+				if heavy1[u] == 0 {
+					heavy1[u] = prev
+					heavyChanged = true
+				} else if size[prev] > size[heavy1[u]] {
+					old := heavy1[u]
+					heavy1[u] = prev
+					heavyChanged = true
+					bestNon[u] = max(bestNon[u], dp[old])
+				} else {
+					bestNon[u] = max(bestNon[u], dp[prev])
+				}
+			}
+			oldDp := dp[u]
+			bestH := -1
+			if heavy1[u] != 0 {
+				bestH = max(bestH, dp[heavy1[u]])
+			}
+			if u == 1 && heavy2[u] != 0 {
+				bestH = max(bestH, dp[heavy2[u]])
+			}
+			ndp := bestH
+			if u == 1 {
+				ndp = max(ndp, bestNon[u])
+			} else {
+				if bestNon[u] >= 0 {
+					ndp = max(ndp, bestNon[u]+1)
+				}
+			}
+			if ndp < 0 {
+				ndp = 0
+			}
+			dp[u] = ndp
+			if dp[u] == oldDp && !heavyChanged {
+				break
+			}
+			prev = u
+			u = parent[u]
+		}
+		buf.WriteString(fmt.Sprintf("%d", dp[1]+1))
+		if i < n {
+			buf.WriteByte(' ')
+		}
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", rng.Intn(i)+1)
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solveD(bufio.NewReader(strings.NewReader(tc)))
+		out, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %sinput:\n%s", i+1, expect, out, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/442/verifierE.go
+++ b/0-999/400-499/440-449/442/verifierE.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+const eps = 1e-9
+
+func cut(x, y []float64, aa, bb, cc float64) ([]float64, []float64) {
+	n := len(x)
+	if n == 0 {
+		return x, y
+	}
+	var nx, ny []float64
+	for i := 0; i < n; i++ {
+		xi, yi := x[i], y[i]
+		zi := aa*xi + bb*yi + cc
+		if zi < eps {
+			nx = append(nx, xi)
+			ny = append(ny, yi)
+		}
+		j := i + 1
+		if j == n {
+			j = 0
+		}
+		xj, yj := x[j], y[j]
+		zj := aa*xj + bb*yj + cc
+		if (zi < -eps && zj > eps) || (zi > eps && zj < -eps) {
+			a := yj - yi
+			b := xi - xj
+			c := -a*xi - b*yi
+			d := a*bb - b*aa
+			ix := (b*cc - c*bb) / d
+			iy := (c*aa - a*cc) / d
+			nx = append(nx, ix)
+			ny = append(ny, iy)
+		}
+	}
+	return nx, ny
+}
+
+func solveE(r *bufio.Reader) string {
+	var w, h, n int
+	fmt.Fscan(r, &w, &h, &n)
+	pts := make([]struct{ x, y int }, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &pts[i].x, &pts[i].y)
+	}
+	sort.Slice(pts, func(i, j int) bool {
+		if pts[i].x != pts[j].x {
+			return pts[i].x < pts[j].x
+		}
+		return pts[i].y < pts[j].y
+	})
+	xs := make([]struct{ x, y int }, 0, n)
+	ws := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		if i > 0 && pts[i] == pts[i-1] {
+			ws[len(ws)-1]++
+		} else {
+			xs = append(xs, pts[i])
+			ws = append(ws, 1)
+		}
+	}
+	pts = xs
+	n = len(pts)
+	ansSq := 0.0
+	for st := 0; st < n; st++ {
+		x := []float64{0, float64(w), float64(w), 0}
+		y := []float64{0, 0, float64(h), float64(h)}
+		for i := 0; i < n; i++ {
+			dx := float64(pts[i].x - pts[st].x)
+			dy := float64(pts[i].y - pts[st].y)
+			midx := float64(pts[i].x+pts[st].x) * 0.5
+			midy := float64(pts[i].y+pts[st].y) * 0.5
+			cc := -dx*midx - dy*midy
+			x, y = cut(x, y, dx, dy, cc)
+			if len(x) == 0 {
+				break
+			}
+		}
+		if ws[st] >= 2 {
+			for i := 0; i < len(x); i++ {
+				dx := x[i] - float64(pts[st].x)
+				dy := y[i] - float64(pts[st].y)
+				d := dx*dx + dy*dy
+				if d > ansSq {
+					ansSq = d
+				}
+			}
+			continue
+		}
+		m := len(x)
+		ptsIdx := make([]int, m)
+		for i := 0; i < m; i++ {
+			j := (i + 1) % m
+			mx := (x[i] + x[j]) * 0.5
+			my := (y[i] + y[j]) * 0.5
+			best := -1
+			bestD := 1e100
+			for k := 0; k < n; k++ {
+				if k == st {
+					continue
+				}
+				dx := mx - float64(pts[k].x)
+				dy := my - float64(pts[k].y)
+				d := dx*dx + dy*dy
+				if d < bestD {
+					bestD = d
+					best = k
+				}
+			}
+			ptsIdx[i] = best
+		}
+		ox := make([]float64, len(x))
+		oy := make([]float64, len(y))
+		copy(ox, x)
+		copy(oy, y)
+		sz := len(ptsIdx)
+		for jj := 0; jj < sz; jj++ {
+			pt := ptsIdx[jj]
+			x = make([]float64, len(ox))
+			y = make([]float64, len(oy))
+			copy(x, ox)
+			copy(y, oy)
+			for u := 0; u < sz; u++ {
+				if u == jj {
+					continue
+				}
+				i := ptsIdx[u]
+				dx := float64(pts[i].x - pts[pt].x)
+				dy := float64(pts[i].y - pts[pt].y)
+				midx := float64(pts[i].x+pts[pt].x) * 0.5
+				midy := float64(pts[i].y+pts[pt].y) * 0.5
+				cc := -dx*midx - dy*midy
+				x, y = cut(x, y, dx, dy, cc)
+				if len(x) == 0 {
+					break
+				}
+			}
+			for i := 0; i < len(x); i++ {
+				dx := x[i] - float64(pts[pt].x)
+				dy := y[i] - float64(pts[pt].y)
+				d := dx*dx + dy*dy
+				if d > ansSq {
+					ansSq = d
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("%.17f\n", math.Sqrt(ansSq))
+}
+
+func generateCase(rng *rand.Rand) string {
+	w := rng.Intn(10) + 1
+	h := rng.Intn(10) + 1
+	n := rng.Intn(4) + 2
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %d %d\n", w, h, n)
+	for i := 0; i < n; i++ {
+		x := rng.Intn(w + 1)
+		y := rng.Intn(h + 1)
+		fmt.Fprintf(&b, "%d %d\n", x, y)
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solveE(bufio.NewReader(strings.NewReader(tc)))
+		out, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseFloat(strings.TrimSpace(out), 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: cannot parse output\n", i+1)
+			os.Exit(1)
+		}
+		exp, _ := strconv.ParseFloat(strings.TrimSpace(expect), 64)
+		if math.Abs(got-exp) > 1e-6 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.6f got %.6f\ninput:\n%s", i+1, exp, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`..`verifierE.go` under contest 442
- each verifier generates at least 100 random test cases
- verifiers run any provided binary (or Go source) and compare output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687eced9969c8324b07ac81da8f39ba6