### PR TITLE
Add Go verifiers for CF contest 441

### DIFF
--- a/0-999/400-499/440-449/441/verifierA.go
+++ b/0-999/400-499/440-449/441/verifierA.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n      int
+	v      int
+	prices [][]int
+}
+
+func (tc testCase) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.v))
+	for i := 0; i < tc.n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", len(tc.prices[i])))
+		for _, p := range tc.prices[i] {
+			sb.WriteString(fmt.Sprintf(" %d", p))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	v := rng.Intn(100) + 1
+	prices := make([][]int, n)
+	for i := range prices {
+		k := rng.Intn(10) + 1
+		prices[i] = make([]int, k)
+		for j := 0; j < k; j++ {
+			prices[i][j] = rng.Intn(200) + 1
+		}
+	}
+	return testCase{n, v, prices}
+}
+
+func expected(tc testCase) []int {
+	var res []int
+	for i := 0; i < tc.n; i++ {
+		ok := false
+		for _, p := range tc.prices[i] {
+			if p < tc.v {
+				ok = true
+				break
+			}
+		}
+		if ok {
+			res = append(res, i+1)
+		}
+	}
+	return res
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	input := tc.Input()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	gotCnt, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("bad count: %v", err)
+	}
+	exp := expected(tc)
+	if gotCnt != len(exp) {
+		return fmt.Errorf("expected count %d got %d", len(exp), gotCnt)
+	}
+	if gotCnt > 0 {
+		if len(fields[1:]) != gotCnt {
+			return fmt.Errorf("expected %d indices got %d", gotCnt, len(fields[1:]))
+		}
+		for i, idx := range exp {
+			val, err := strconv.Atoi(fields[1+i])
+			if err != nil {
+				return fmt.Errorf("bad index: %v", err)
+			}
+			if val != idx {
+				return fmt.Errorf("index %d: expected %d got %d", i+1, idx, val)
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{
+		{n: 1, v: 5, prices: [][]int{{3, 5}}},
+		{n: 3, v: 7, prices: [][]int{{8, 9}, {1}, {7, 4, 9}}},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.Input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/441/verifierB.go
+++ b/0-999/400-499/440-449/441/verifierB.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ a, b int }
+
+type testCase struct {
+	n     int
+	v     int
+	pairs []pair
+}
+
+func (tc testCase) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.v))
+	for _, p := range tc.pairs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.a, p.b))
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	v := rng.Intn(10) + 1
+	pairs := make([]pair, n)
+	for i := 0; i < n; i++ {
+		a := rng.Intn(10) + 1
+		b := rng.Intn(10)
+		pairs[i] = pair{a, b}
+	}
+	return testCase{n, v, pairs}
+}
+
+func expected(tc testCase) int {
+	maxA := 0
+	for _, p := range tc.pairs {
+		if p.a > maxA {
+			maxA = p.a
+		}
+	}
+	fruits := make([]int, maxA+2)
+	for _, p := range tc.pairs {
+		fruits[p.a] += p.b
+	}
+	prev := 0
+	total := 0
+	for day := 1; day <= maxA+1; day++ {
+		takePrev := prev
+		if takePrev > tc.v {
+			takePrev = tc.v
+		}
+		total += takePrev
+		cap := tc.v - takePrev
+		takeCur := fruits[day]
+		if takeCur > cap {
+			takeCur = cap
+		}
+		total += takeCur
+		prev = fruits[day] - takeCur
+	}
+	return total
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	input := tc.Input()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := expected(tc)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{
+		{n: 1, v: 1, pairs: []pair{{1, 1}}},
+		{n: 2, v: 2, pairs: []pair{{1, 1}, {1, 2}}},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.Input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/441/verifierC.go
+++ b/0-999/400-499/440-449/441/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m, k int
+}
+
+func (tc testCase) Input() string {
+	return fmt.Sprintf("%d %d %d\n", tc.n, tc.m, tc.k)
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	k := rng.Intn(n*m) + 1
+	return testCase{n, m, k}
+}
+
+func expected(tc testCase) []string {
+	total := tc.n * tc.m
+	base := total / tc.k
+	extra := total % tc.k
+	coords := make([][2]int, total)
+	idx := 0
+	for i := 0; i < tc.n; i++ {
+		if i%2 == 0 {
+			for j := 0; j < tc.m; j++ {
+				coords[idx] = [2]int{i + 1, j + 1}
+				idx++
+			}
+		} else {
+			for j := tc.m - 1; j >= 0; j-- {
+				coords[idx] = [2]int{i + 1, j + 1}
+				idx++
+			}
+		}
+	}
+	var lines []string
+	pos := 0
+	for t := 1; t <= tc.k; t++ {
+		size := base
+		if t == tc.k {
+			size += extra
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d", size))
+		for i := 0; i < size; i++ {
+			c := coords[pos]
+			sb.WriteString(fmt.Sprintf(" %d %d", c[0], c[1]))
+			pos++
+		}
+		lines = append(lines, sb.String())
+	}
+	return lines
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	input := tc.Input()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	expectLines := expected(tc)
+	if len(gotLines) != len(expectLines) {
+		return fmt.Errorf("expected %d lines got %d", len(expectLines), len(gotLines))
+	}
+	for i := range expectLines {
+		if strings.TrimSpace(gotLines[i]) != expectLines[i] {
+			return fmt.Errorf("line %d mismatch expected '%s' got '%s'", i+1, expectLines[i], strings.TrimSpace(gotLines[i]))
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{{1, 1, 1}, {2, 3, 2}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.Input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/441/verifierD.go
+++ b/0-999/400-499/440-449/441/verifierD.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	p []int
+	m int
+}
+
+func (tc testCase) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, x := range tc.p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", x))
+	}
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("%d\n", tc.m))
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(7) + 1
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	m := rng.Intn(n)
+	return testCase{n: n, p: perm, m: m}
+}
+
+func computeOps(n int, p []int, m int) [][2]int {
+	comp := make([]int, n+1)
+	compList := make(map[int][]int)
+	visited := make([]bool, n+1)
+	compID := 0
+	for i := 1; i <= n; i++ {
+		if !visited[i] {
+			compID++
+			u := i
+			for !visited[u] {
+				visited[u] = true
+				comp[u] = compID
+				compList[compID] = append(compList[compID], u)
+				u = p[u-1]
+			}
+		}
+	}
+	for id := 1; id <= compID; id++ {
+		sort.Ints(compList[id])
+	}
+	cycles := compID
+	targetCycles := n - m
+	var ops [][2]int
+	var rebuild func([]int)
+	rebuild = func(nodes []int) {
+		for _, u := range nodes {
+			visited[u] = false
+			comp[u] = 0
+		}
+		for _, u := range nodes {
+			if !visited[u] {
+				compID++
+				var group []int
+				v := u
+				for !visited[v] {
+					visited[v] = true
+					comp[v] = compID
+					group = append(group, v)
+					v = p[v-1]
+				}
+				sort.Ints(group)
+				compList[compID] = group
+			}
+		}
+	}
+	for cycles < targetCycles {
+		var ai, bi int
+		for i := 1; i <= n; i++ {
+			cl := compList[comp[i]]
+			if len(cl) >= 2 {
+				ai = i
+				for _, x := range cl {
+					if x > i {
+						bi = x
+						break
+					}
+				}
+				break
+			}
+		}
+		ops = append(ops, [2]int{ai, bi})
+		p[ai-1], p[bi-1] = p[bi-1], p[ai-1]
+		old := compList[comp[ai]]
+		delete(compList, comp[ai])
+		rebuild(old)
+		cycles++
+	}
+	for cycles > targetCycles {
+		var ai, bi int
+		for i := 1; i <= n; i++ {
+			for j := i + 1; j <= n; j++ {
+				if comp[i] != comp[j] {
+					ai, bi = i, j
+					break
+				}
+			}
+			if ai != 0 {
+				break
+			}
+		}
+		ops = append(ops, [2]int{ai, bi})
+		p[ai-1], p[bi-1] = p[bi-1], p[ai-1]
+		id1, id2 := comp[ai], comp[bi]
+		nodes := append(compList[id1], compList[id2]...)
+		delete(compList, id1)
+		delete(compList, id2)
+		rebuild(nodes)
+		cycles--
+	}
+	return ops
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	input := tc.Input()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	r := strings.NewReader(out.String())
+	var k int
+	if _, err := fmt.Fscan(r, &k); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	ops := make([][2]int, k)
+	for i := 0; i < k; i++ {
+		if _, err := fmt.Fscan(r, &ops[i][0], &ops[i][1]); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+	}
+	expect := computeOps(tc.n, append([]int(nil), tc.p...), tc.m)
+	if len(ops) != len(expect) {
+		return fmt.Errorf("expected %d ops got %d", len(expect), len(ops))
+	}
+	for i := range expect {
+		if ops[i][0] != expect[i][0] || ops[i][1] != expect[i][1] {
+			return fmt.Errorf("op %d expected %v got %v", i+1, expect[i], ops[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{
+		{n: 1, p: []int{1}, m: 0},
+		{n: 2, p: []int{2, 1}, m: 1},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.Input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/440-449/441/verifierE.go
+++ b/0-999/400-499/440-449/441/verifierE.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	x, k, p int
+}
+
+func (tc testCase) Input() string {
+	return fmt.Sprintf("%d %d %d\n", tc.x, tc.k, tc.p)
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	x := rng.Intn(100) + 1
+	k := rng.Intn(5) + 1
+	p := rng.Intn(101)
+	return testCase{x, k, p}
+}
+
+func expected(tc testCase) float64 {
+	pd := float64(tc.p) / 100.0
+	pp := float64(100-tc.p) / 100.0
+	const MAX = 310
+	dp := make([][]float64, 2)
+	dp[0] = make([]float64, MAX)
+	dp[1] = make([]float64, MAX)
+	dp[0][0] = 1.0
+	next := 1
+	ans := 0.0
+	for i := 0; i < tc.k; i++ {
+		prev := 1 - next
+		for j := 0; j < MAX; j++ {
+			dp[next][j] = 0.0
+		}
+		for j := 0; j < 300; j++ {
+			dp[next][j+1] += dp[prev][j] * pp
+		}
+		for j := 0; j < 300; j += 2 {
+			ans += dp[prev][j] * pd
+			dp[next][j/2] += dp[prev][j] * pd
+		}
+		next = prev
+	}
+	prev := 1 - next
+	for i := 0; i < 300; i++ {
+		r := i + tc.x
+		for r%2 == 0 {
+			r /= 2
+			ans += dp[prev][i]
+		}
+	}
+	return ans
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	input := tc.Input()
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := expected(tc)
+	diff := got - expect
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > 1e-6*maxFloat64(expect, 1.0) && diff > 1e-6 {
+		return fmt.Errorf("expected %.6f got %.6f", expect, got)
+	}
+	return nil
+}
+
+func maxFloat64(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{{1, 1, 0}, {5, 3, 50}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.Input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` – random test runner for problem A
- add `verifierB.go` – random test runner for problem B
- add `verifierC.go` – random test runner for problem C
- add `verifierD.go` – random test runner for problem D
- add `verifierE.go` – random test runner for problem E

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ece939168832489c891b0d304d5e1