### PR TITLE
Add Go verifiers for CF contest 440

### DIFF
--- a/0-999/400-499/440-449/440/verifierA.go
+++ b/0-999/400-499/440-449/440/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func generate() []testCase {
+	const T = 100
+	rand.Seed(1)
+	cases := make([]testCase, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(100) + 2 // at least 2
+		missing := rand.Intn(n) + 1
+		var in strings.Builder
+		fmt.Fprintf(&in, "%d\n", n)
+		first := true
+		for j := 1; j <= n; j++ {
+			if j == missing {
+				continue
+			}
+			if !first {
+				in.WriteByte(' ')
+			}
+			fmt.Fprintf(&in, "%d", j)
+			first = false
+		}
+		in.WriteByte('\n')
+		cases[i] = testCase{
+			in:  in.String(),
+			out: fmt.Sprintf("%d\n", missing),
+		}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generate()
+	for idx, tc := range cases {
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(tc.in)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != strings.TrimSpace(tc.out) {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", idx+1, tc.out, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/400-499/440-449/440/verifierB.go
+++ b/0-999/400-499/440-449/440/verifierB.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solve(a []int64) int64 {
+	var sum int64
+	for _, v := range a {
+		sum += v
+	}
+	avg := sum / int64(len(a))
+	var ans int64
+	var pref int64
+	for i := 0; i < len(a)-1; i++ {
+		pref += a[i] - avg
+		if pref < 0 {
+			ans -= pref
+		} else {
+			ans += pref
+		}
+	}
+	return ans
+}
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func generate() []testCase {
+	const T = 100
+	rand.Seed(2)
+	cases := make([]testCase, T)
+	for t := 0; t < T; t++ {
+		n := rand.Intn(50) + 1
+		a := make([]int64, n)
+		var sum int64
+		for i := 0; i < n; i++ {
+			a[i] = int64(rand.Intn(1000))
+			sum += a[i]
+		}
+		mod := sum % int64(n)
+		if mod != 0 {
+			a[0] += int64(n) - mod
+			sum += int64(n) - mod
+		}
+		var in strings.Builder
+		fmt.Fprintf(&in, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				in.WriteByte(' ')
+			}
+			fmt.Fprintf(&in, "%d", a[i])
+		}
+		in.WriteByte('\n')
+		cases[t] = testCase{
+			in:  in.String(),
+			out: fmt.Sprintf("%d\n", solve(a)),
+		}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generate()
+	for idx, tc := range cases {
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(tc.in)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != strings.TrimSpace(tc.out) {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", idx+1, tc.out, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- implemented new solution verifiers for problems A and B of contest 440
- verifiers generate 100 random test cases and run the provided binary on each

## Testing
- `go run 0-999/400-499/440-449/440/verifierA.go 0-999/400-499/440-449/440/solA`
- `go run 0-999/400-499/440-449/440/verifierB.go 0-999/400-499/440-449/440/solB`

------
https://chatgpt.com/codex/tasks/task_e_687ece4d81fc83248682a36342174a81