### PR TITLE
Add Go solution verifiers for contest 439

### DIFF
--- a/0-999/400-499/430-439/439/439E.go
+++ b/0-999/400-499/430-439/439/439E.go
@@ -1,103 +1,105 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
 const MOD int64 = 1000000007
 const MAXN = 100000
 
-var mu [MAXN+1]int
-var fac, invfac [MAXN+1]int64
-var divisors [MAXN+1][]int
+var mu [MAXN + 1]int
+var fac, invfac [MAXN + 1]int64
+var divisors [MAXN + 1][]int
 
 func modexp(a, e int64) int64 {
-   res := int64(1)
-   for e > 0 {
-       if e&1 == 1 {
-           res = (res * a) % MOD
-       }
-       a = (a * a) % MOD
-       e >>= 1
-   }
-   return res
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = (res * a) % MOD
+		}
+		a = (a * a) % MOD
+		e >>= 1
+	}
+	return res
 }
 
 func initMuAndDivs() {
-   mu[1] = 1
-   primes := make([]int, 0, MAXN/10)
-   isComp := make([]bool, MAXN+1)
-   for i := 2; i <= MAXN; i++ {
-       if !isComp[i] {
-           primes = append(primes, i)
-           mu[i] = -1
-       }
-       for _, p := range primes {
-           if ip := i * p; ip > MAXN {
-               break
-           };
-           isComp[ip] = true
-           if i%p == 0 {
-               mu[ip] = 0
-               break
-           } else {
-               mu[ip] = -mu[i]
-           }
-       }
-   }
-   for i := 1; i <= MAXN; i++ {
-       for j := i; j <= MAXN; j += i {
-           divisors[j] = append(divisors[j], i)
-       }
-   }
+	mu[1] = 1
+	primes := make([]int, 0, MAXN/10)
+	isComp := make([]bool, MAXN+1)
+	for i := 2; i <= MAXN; i++ {
+		if !isComp[i] {
+			primes = append(primes, i)
+			mu[i] = -1
+		}
+		for _, p := range primes {
+			ip := i * p
+			if ip > MAXN {
+				break
+			}
+			isComp[ip] = true
+			if i%p == 0 {
+				mu[ip] = 0
+				break
+			} else {
+				mu[ip] = -mu[i]
+			}
+		}
+	}
+	for i := 1; i <= MAXN; i++ {
+		for j := i; j <= MAXN; j += i {
+			divisors[j] = append(divisors[j], i)
+		}
+	}
 }
 
 func initFactorials() {
-   fac[0] = 1
-   for i := 1; i <= MAXN; i++ {
-       fac[i] = (fac[i-1] * int64(i)) % MOD
-   }
-   invfac[MAXN] = modexp(fac[MAXN], MOD-2)
-   for i := MAXN; i > 0; i-- {
-       invfac[i-1] = (invfac[i] * int64(i)) % MOD
-   }
+	fac[0] = 1
+	for i := 1; i <= MAXN; i++ {
+		fac[i] = (fac[i-1] * int64(i)) % MOD
+	}
+	invfac[MAXN] = modexp(fac[MAXN], MOD-2)
+	for i := MAXN; i > 0; i-- {
+		invfac[i-1] = (invfac[i] * int64(i)) % MOD
+	}
 }
 
 // comb returns C(n, k)
 func comb(n, k int) int64 {
-   if k < 0 || k > n {
-       return 0
-   }
-   return fac[n] * invfac[k] % MOD * invfac[n-k] % MOD
+	if k < 0 || k > n {
+		return 0
+	}
+	return fac[n] * invfac[k] % MOD * invfac[n-k] % MOD
+}
 
 func main() {
-   initMuAndDivs()
-   initFactorials()
-   reader := bufio.NewReader(os.Stdin)
-   writer := bufio.NewWriter(os.Stdout)
-   defer writer.Flush()
+	initMuAndDivs()
+	initFactorials()
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
 
-   var q int
-   fmt.Fscan(reader, &q)
-   for ; q > 0; q-- {
-       var n, f int
-       fmt.Fscan(reader, &n, &f)
-       var ans int64
-       // sum over d|n mu[d] * C(n/d -1, f-1)
-       for _, d := range divisors[n] {
-           nd := n / d
-           if nd < f {
-               continue
-           }
-           c := comb(nd-1, f-1)
-           m := mu[d]
-           if m == 0 || c == 0 {
-               continue
-           }
-           ans = (ans + int64(m)*c%MOD + MOD) % MOD
-       }
-       fmt.Fprintln(writer, ans)
-   }
+	var q int
+	fmt.Fscan(reader, &q)
+	for ; q > 0; q-- {
+		var n, f int
+		fmt.Fscan(reader, &n, &f)
+		var ans int64
+		// sum over d|n mu[d] * C(n/d -1, f-1)
+		for _, d := range divisors[n] {
+			nd := n / d
+			if nd < f {
+				continue
+			}
+			c := comb(nd-1, f-1)
+			m := mu[d]
+			if m == 0 || c == 0 {
+				continue
+			}
+			ans = (ans + int64(m)*c%MOD + MOD) % MOD
+		}
+		fmt.Fprintln(writer, ans)
+	}
 }

--- a/0-999/400-499/430-439/439/verifierA.go
+++ b/0-999/400-499/430-439/439/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testA struct {
+	n int
+	d int
+	t []int
+}
+
+func solveA(tc testA) int {
+	sum := 0
+	for _, v := range tc.t {
+		sum += v
+	}
+	if sum+10*(tc.n-1) > tc.d {
+		return -1
+	}
+	return (tc.d - sum) / 5
+}
+
+func generateA(rng *rand.Rand) testA {
+	n := rng.Intn(100) + 1
+	d := rng.Intn(10000) + 1
+	t := make([]int, n)
+	for i := 0; i < n; i++ {
+		t[i] = rng.Intn(100) + 1
+	}
+	return testA{n: n, d: d, t: t}
+}
+
+func runCase(bin string, tc testA) (string, error) {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.d)
+	for i, v := range tc.t {
+		if i > 0 {
+			fmt.Fprint(&sb, " ")
+		}
+		fmt.Fprint(&sb, v)
+	}
+	fmt.Fprint(&sb, "\n")
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testA, 0, 102)
+	// add some edge cases
+	cases = append(cases, testA{n: 1, d: 5, t: []int{5}})
+	cases = append(cases, testA{n: 2, d: 30, t: []int{2, 2}})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateA(rng))
+	}
+	for i, tc := range cases {
+		expect := solveA(tc)
+		got, err := runCase(exe, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if fmt.Sprint(expect) != got {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/439/verifierB.go
+++ b/0-999/400-499/430-439/439/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testB struct {
+	n int
+	x int
+	c []int
+}
+
+func solveB(tc testB) int64 {
+	vals := make([]int, len(tc.c))
+	copy(vals, tc.c)
+	sort.Ints(vals)
+	var total int64
+	for i, v := range vals {
+		t := tc.x - i
+		if t < 1 {
+			t = 1
+		}
+		total += int64(t) * int64(v)
+	}
+	return total
+}
+
+func genB(rng *rand.Rand) testB {
+	n := rng.Intn(50) + 1
+	x := rng.Intn(100) + 1
+	c := make([]int, n)
+	for i := range c {
+		c[i] = rng.Intn(100) + 1
+	}
+	return testB{n: n, x: x, c: c}
+}
+
+func runCase(bin string, tc testB) (string, error) {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.x)
+	for i, v := range tc.c {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testB, 0, 102)
+	cases = append(cases, testB{n: 1, x: 3, c: []int{5}})
+	cases = append(cases, testB{n: 2, x: 1, c: []int{3, 4}})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genB(rng))
+	}
+	for i, tc := range cases {
+		expect := solveB(tc)
+		got, err := runCase(exe, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if fmt.Sprint(expect) != got {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/439/verifierC.go
+++ b/0-999/400-499/430-439/439/verifierC.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testC struct {
+	n   int
+	k   int
+	p   int
+	arr []int
+}
+
+func feasible(tc testC) bool {
+	odd := 0
+	for _, v := range tc.arr {
+		if v%2 != 0 {
+			odd++
+		}
+	}
+	even := tc.n - odd
+	needOdd := tc.k - tc.p
+	if odd < needOdd {
+		return false
+	}
+	if (odd-needOdd)%2 != 0 {
+		return false
+	}
+	if (odd-needOdd)/2+even < tc.p {
+		return false
+	}
+	return true
+}
+
+func genC(rng *rand.Rand) testC {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	p := rng.Intn(k + 1)
+	arr := make([]int, n)
+	used := map[int]bool{}
+	for i := 0; i < n; i++ {
+		for {
+			v := rng.Intn(1000) + 1
+			if !used[v] {
+				arr[i] = v
+				used[v] = true
+				break
+			}
+		}
+	}
+	return testC{n: n, k: k, p: p, arr: arr}
+}
+
+func runCase(bin string, tc testC) (string, error) {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", tc.n, tc.k, tc.p)
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func checkOutput(out string, tc testC) error {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) == 0 {
+		return fmt.Errorf("no output")
+	}
+	ans := strings.TrimSpace(lines[0])
+	possible := feasible(tc)
+	if ans == "NO" {
+		if possible {
+			return fmt.Errorf("should be YES")
+		}
+		return nil
+	}
+	if ans != "YES" {
+		return fmt.Errorf("first line must be YES or NO")
+	}
+	if !possible {
+		return fmt.Errorf("output YES but impossible")
+	}
+	if len(lines)-1 != tc.k {
+		return fmt.Errorf("expected %d parts, got %d", tc.k, len(lines)-1)
+	}
+	used := make(map[int]bool)
+	evenParts := 0
+	for i := 1; i <= tc.k; i++ {
+		f := strings.Fields(lines[i])
+		if len(f) < 1 {
+			return fmt.Errorf("line %d empty", i+1)
+		}
+		cnt, err := strconv.Atoi(f[0])
+		if err != nil {
+			return fmt.Errorf("line %d bad count", i+1)
+		}
+		if cnt != len(f)-1 {
+			return fmt.Errorf("line %d count mismatch", i+1)
+		}
+		if cnt == 0 {
+			return fmt.Errorf("line %d empty part", i+1)
+		}
+		sum := 0
+		for j := 1; j < len(f); j++ {
+			v, err := strconv.Atoi(f[j])
+			if err != nil {
+				return fmt.Errorf("line %d bad number", i+1)
+			}
+			present := false
+			for _, a := range tc.arr {
+				if a == v {
+					present = true
+					break
+				}
+			}
+			if !present {
+				return fmt.Errorf("line %d uses unknown value", i+1)
+			}
+			if used[v] {
+				return fmt.Errorf("value %d repeated", v)
+			}
+			used[v] = true
+			sum += v
+		}
+		if sum%2 == 0 {
+			evenParts++
+		}
+	}
+	if len(used) != tc.n {
+		return fmt.Errorf("not all values used")
+	}
+	if evenParts != tc.p {
+		return fmt.Errorf("expected %d even parts got %d", tc.p, evenParts)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testC{}
+	cases = append(cases, testC{n: 1, k: 1, p: 1, arr: []int{2}})
+	cases = append(cases, testC{n: 3, k: 2, p: 1, arr: []int{1, 2, 3}})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genC(rng))
+	}
+	for i, tc := range cases {
+		out, err := runCase(exe, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := checkOutput(out, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/439/verifierD.go
+++ b/0-999/400-499/430-439/439/verifierD.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testD struct {
+	n int
+	m int
+	a []int64
+	b []int64
+}
+
+func solveD(tc testD) int64 {
+	a := append([]int64(nil), tc.a...)
+	b := append([]int64(nil), tc.b...)
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
+	prefA := make([]int64, len(a)+1)
+	for i := range a {
+		prefA[i+1] = prefA[i] + a[i]
+	}
+	prefB := make([]int64, len(b)+1)
+	for i := range b {
+		prefB[i+1] = prefB[i] + b[i]
+	}
+	totalB := prefB[len(b)]
+	candidates := append(append([]int64{}, a...), b...)
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i] < candidates[j] })
+	uniq := []int64{}
+	var last int64 = -1 << 63
+	for _, v := range candidates {
+		if v != last {
+			uniq = append(uniq, v)
+			last = v
+		}
+	}
+	ans := int64(-1)
+	for _, v := range uniq {
+		ia := sort.Search(len(a), func(i int) bool { return a[i] >= v })
+		ib := sort.Search(len(b), func(i int) bool { return b[i] > v })
+		costA := int64(v)*int64(ia) - prefA[ia]
+		costB := totalB - prefB[ib] - int64(v)*int64(len(b)-ib)
+		total := costA + costB
+		if ans < 0 || total < ans {
+			ans = total
+		}
+	}
+	return ans
+}
+
+func genD(rng *rand.Rand) testD {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(20) + 1
+	a := make([]int64, n)
+	b := make([]int64, m)
+	for i := range a {
+		a[i] = int64(rng.Intn(100) + 1)
+	}
+	for i := range b {
+		b[i] = int64(rng.Intn(100) + 1)
+	}
+	return testD{n: n, m: m, a: a, b: b}
+}
+
+func runCase(bin string, tc testD) (string, error) {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testD{
+		{n: 2, m: 2, a: []int64{1, 2}, b: []int64{3, 4}},
+		{n: 1, m: 1, a: []int64{5}, b: []int64{1}},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genD(rng))
+	}
+	for i, tc := range cases {
+		expect := solveD(tc)
+		out, err := runCase(exe, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if fmt.Sprint(expect) != out {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/439/verifierE.go
+++ b/0-999/400-499/430-439/439/verifierE.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+const MAXN = 100000
+
+var mu [MAXN + 1]int
+var fac, invfac [MAXN + 1]int64
+var divisors [MAXN + 1][]int
+
+func modexp(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = (res * a) % MOD
+		}
+		a = (a * a) % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func initPre() {
+	mu[1] = 1
+	primes := []int{}
+	isComp := make([]bool, MAXN+1)
+	for i := 2; i <= MAXN; i++ {
+		if !isComp[i] {
+			primes = append(primes, i)
+			mu[i] = -1
+		}
+		for _, p := range primes {
+			if i*p > MAXN {
+				break
+			}
+			isComp[i*p] = true
+			if i%p == 0 {
+				mu[i*p] = 0
+				break
+			} else {
+				mu[i*p] = -mu[i]
+			}
+		}
+	}
+	for i := 1; i <= MAXN; i++ {
+		for j := i; j <= MAXN; j += i {
+			divisors[j] = append(divisors[j], i)
+		}
+	}
+	fac[0] = 1
+	for i := 1; i <= MAXN; i++ {
+		fac[i] = fac[i-1] * int64(i) % MOD
+	}
+	invfac[MAXN] = modexp(fac[MAXN], MOD-2)
+	for i := MAXN; i > 0; i-- {
+		invfac[i-1] = invfac[i] * int64(i) % MOD
+	}
+}
+
+func comb(n, k int) int64 {
+	if k < 0 || k > n {
+		return 0
+	}
+	return fac[n] * invfac[k] % MOD * invfac[n-k] % MOD
+}
+
+func solveE(n, f int) int64 {
+	var ans int64
+	for _, d := range divisors[n] {
+		nd := n / d
+		if nd < f {
+			continue
+		}
+		c := comb(nd-1, f-1)
+		if mu[d] == 0 || c == 0 {
+			continue
+		}
+		ans = (ans + int64(mu[d])*c) % MOD
+	}
+	if ans < 0 {
+		ans += MOD
+	}
+	return ans
+}
+
+type testE struct {
+	q     int
+	pairs [][2]int
+}
+
+func genE(rng *rand.Rand) testE {
+	q := rng.Intn(3) + 1
+	pairs := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		n := rng.Intn(50) + 1
+		f := rng.Intn(n) + 1
+		pairs[i] = [2]int{n, f}
+	}
+	return testE{q: q, pairs: pairs}
+}
+
+func runCase(bin string, tc testE) (string, error) {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", tc.q)
+	for _, p := range tc.pairs {
+		fmt.Fprintf(&sb, "%d %d\n", p[0], p[1])
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	initPre()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testE{
+		{q: 1, pairs: [][2]int{{6, 2}}},
+		{q: 1, pairs: [][2]int{{7, 2}}},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genE(rng))
+	}
+	for i, tc := range cases {
+		expectLines := make([]string, tc.q)
+		for j, p := range tc.pairs {
+			expectLines[j] = fmt.Sprint(solveE(p[0], p[1]))
+		}
+		expect := strings.Join(expectLines, "\n")
+		out, err := runCase(exe, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for all problems of contest 439
- fix 439E.go so it builds

## Testing
- `go run verifierA.go ./439A`
- `go run verifierB.go ./439B`
- `go run verifierC.go ./439C`
- `go run verifierD.go ./439D`
- `go run verifierE.go ./439E`


------
https://chatgpt.com/codex/tasks/task_e_687ece0765e48324be738274b630916c