### PR TITLE
Add verifiers for contest 437

### DIFF
--- a/0-999/400-499/430-439/437/verifierA.go
+++ b/0-999/400-499/430-439/437/verifierA.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedAnswer(lines []string) string {
+	labels := []string{"A", "B", "C", "D"}
+	lens := make([]int, 4)
+	for i := 0; i < 4; i++ {
+		line := strings.TrimSpace(lines[i])
+		if len(line) >= 2 {
+			lens[i] = len(line[2:])
+		}
+	}
+	greatIdx := -1
+	count := 0
+	for i := 0; i < 4; i++ {
+		shorter := true
+		longer := true
+		for j := 0; j < 4; j++ {
+			if i == j {
+				continue
+			}
+			if lens[i]*2 > lens[j] {
+				shorter = false
+			}
+			if lens[i] < 2*lens[j] {
+				longer = false
+			}
+		}
+		if shorter || longer {
+			count++
+			greatIdx = i
+		}
+	}
+	if count == 1 {
+		return labels[greatIdx]
+	}
+	return "C"
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	labels := []string{"A", "B", "C", "D"}
+	lines := make([]string, 4)
+	for i := 0; i < 4; i++ {
+		l := rng.Intn(100) + 1
+		lines[i] = fmt.Sprintf("%s.%s", labels[i], randString(rng, l))
+	}
+	input := strings.Join(lines, "\n") + "\n"
+	exp := expectedAnswer(lines)
+	return input, exp
+}
+
+func manualCase(descs [4]string) (string, string) {
+	labels := []string{"A", "B", "C", "D"}
+	lines := make([]string, 4)
+	for i := 0; i < 4; i++ {
+		lines[i] = fmt.Sprintf("%s.%s", labels[i], descs[i])
+	}
+	input := strings.Join(lines, "\n") + "\n"
+	exp := expectedAnswer(lines)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases [][2]string
+	in1, ex1 := manualCase([4]string{"short", "mediumlength", "another", "tiny"})
+	cases = append(cases, [2]string{in1, ex1})
+	in2, ex2 := manualCase([4]string{"aaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbb", "cccccccccc", "dddddddddd"})
+	cases = append(cases, [2]string{in2, ex2})
+	in3, ex3 := manualCase([4]string{"same", "same", "same", "same"})
+	cases = append(cases, [2]string{in3, ex3})
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		cases = append(cases, [2]string{in, exp})
+	}
+	for idx, tc := range cases {
+		out, err := runBinary(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc[0])
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc[1] {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/400-499/430-439/437/verifierB.go
+++ b/0-999/400-499/430-439/437/verifierB.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(sum, lim int) string {
+	const maxb = 31
+	s := make([]int, maxb)
+	for i := 1; i <= lim; i++ {
+		for j := 0; j < maxb; j++ {
+			if i&(1<<j) != 0 {
+				s[j]++
+				break
+			}
+		}
+	}
+	num := make([]int, maxb)
+	fail := false
+	for i := 0; i < maxb; i++ {
+		if (sum>>i)&1 == 0 {
+			continue
+		}
+		need := 1
+		for j := i; j >= 0; j-- {
+			if s[j] >= need {
+				num[j] += need
+				s[j] -= need
+				break
+			}
+			need -= s[j]
+			num[j] += s[j]
+			need <<= 1
+			s[j] = 0
+			if j == 0 {
+				fail = true
+				break
+			}
+		}
+		if fail {
+			break
+		}
+	}
+	if fail {
+		return "-1"
+	}
+	total := 0
+	for _, v := range num {
+		total += v
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", total)
+	for i := 1; i <= lim; i++ {
+		for j := 0; j < maxb; j++ {
+			if i&(1<<j) != 0 && num[j] > 0 {
+				fmt.Fprintf(&sb, "%d ", i)
+				num[j]--
+				break
+			}
+		}
+	}
+	sb.WriteByte('\n')
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	sum := rng.Intn(1000) + 1
+	lim := rng.Intn(1000) + 1
+	input := fmt.Sprintf("%d %d\n", sum, lim)
+	exp := solveB(sum, lim)
+	return input, exp
+}
+
+func manualCase(sum, lim int) (string, string) {
+	input := fmt.Sprintf("%d %d\n", sum, lim)
+	exp := solveB(sum, lim)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases [][2]string
+	in1, ex1 := manualCase(5, 5)
+	cases = append(cases, [2]string{in1, ex1})
+	in2, ex2 := manualCase(1, 1)
+	cases = append(cases, [2]string{in2, ex2})
+	in3, ex3 := manualCase(100, 50)
+	cases = append(cases, [2]string{in3, ex3})
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		cases = append(cases, [2]string{in, exp})
+	}
+	for idx, tc := range cases {
+		out, err := runBinary(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc[0])
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc[1] {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/400-499/430-439/437/verifierC.go
+++ b/0-999/400-499/430-439/437/verifierC.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(n, m int, vals []int, edges [][2]int) int {
+	ans := 0
+	for _, e := range edges {
+		x := e[0]
+		y := e[1]
+		if vals[x-1] < vals[y-1] {
+			ans += vals[x-1]
+		} else {
+			ans += vals[y-1]
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	vals := make([]int, n)
+	for i := range vals {
+		vals[i] = rng.Intn(100)
+	}
+	edges := make([][2]int, 0, m)
+	used := make(map[[2]int]bool)
+	for len(edges) < m {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a == b {
+			continue
+		}
+		if a > b {
+			a, b = b, a
+		}
+		key := [2]int{a, b}
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		edges = append(edges, [2]int{a, b})
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	input := sb.String()
+	exp := fmt.Sprintf("%d", solveC(n, m, vals, edges))
+	return input, exp
+}
+
+func manualCase() (string, string) {
+	n := 4
+	m := 3
+	vals := []int{10, 20, 30, 40}
+	edges := [][2]int{{1, 2}, {2, 3}, {4, 1}}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	fmt.Fprintf(&sb, "10 20 30 40\n")
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	input := sb.String()
+	exp := fmt.Sprintf("%d", solveC(n, m, vals, edges))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases [][2]string
+	manualIn, manualExp := manualCase()
+	cases = append(cases, [2]string{manualIn, manualExp})
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		cases = append(cases, [2]string{in, exp})
+	}
+	for idx, tc := range cases {
+		out, err := runBinary(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc[0])
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc[1] {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/400-499/430-439/437/verifierD.go
+++ b/0-999/400-499/430-439/437/verifierD.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	parent []int
+	size   []int64
+}
+
+func NewDSU(n int) *DSU {
+	p := make([]int, n)
+	sz := make([]int64, n)
+	for i := 0; i < n; i++ {
+		p[i] = i
+		sz[i] = 1
+	}
+	return &DSU{parent: p, size: sz}
+}
+
+func (d *DSU) Find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.Find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) Union(x, y int, weight int) int64 {
+	rx := d.Find(x)
+	ry := d.Find(y)
+	if rx == ry {
+		return 0
+	}
+	if d.size[rx] < d.size[ry] {
+		rx, ry = ry, rx
+	}
+	contrib := int64(weight) * d.size[rx] * d.size[ry]
+	d.parent[ry] = rx
+	d.size[rx] += d.size[ry]
+	return contrib
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveD(n int, a []int, edges [][2]int) string {
+	g := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0]-1, e[1]-1
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	ord := make([]int, n)
+	for i := 0; i < n; i++ {
+		ord[i] = i
+	}
+	sort.Slice(ord, func(i, j int) bool { return a[ord[i]] > a[ord[j]] })
+	dsu := NewDSU(n)
+	active := make([]bool, n)
+	var sum int64
+	for _, u := range ord {
+		active[u] = true
+		for _, v := range g[u] {
+			if active[v] {
+				sum += dsu.Union(u, v, a[u])
+			}
+		}
+	}
+	denom := float64(n) * float64(n-1)
+	avg := 2.0 * float64(sum) / denom
+	return fmt.Sprintf("%.6f", avg)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges-n+1) + n - 1 // ensure connected by at least tree size
+	// create tree first for connectivity
+	edges := make([][2]int, 0, m)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	used := make(map[[2]int]bool)
+	for _, e := range edges {
+		a, b := e[0], e[1]
+		if a > b {
+			a, b = b, a
+		}
+		used[[2]int{a, b}] = true
+	}
+	for len(edges) < m {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a == b {
+			continue
+		}
+		aa, bb := a, b
+		if aa > bb {
+			aa, bb = bb, aa
+		}
+		if used[[2]int{aa, bb}] {
+			continue
+		}
+		used[[2]int{aa, bb}] = true
+		edges = append(edges, [2]int{a, b})
+	}
+	vals := make([]int, n)
+	for i := range vals {
+		vals[i] = rng.Intn(100)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, len(edges))
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	input := sb.String()
+	exp := solveD(n, vals, edges)
+	return input, exp
+}
+
+func manualCase() (string, string) {
+	n := 3
+	vals := []int{10, 20, 30}
+	edges := [][2]int{{1, 2}, {2, 3}}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, len(edges))
+	fmt.Fprintf(&sb, "10 20 30\n")
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	input := sb.String()
+	exp := solveD(n, vals, edges)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases [][2]string
+	in1, ex1 := manualCase()
+	cases = append(cases, [2]string{in1, ex1})
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		cases = append(cases, [2]string{in, exp})
+	}
+	for idx, tc := range cases {
+		out, err := runBinary(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc[0])
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc[1] {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/400-499/430-439/437/verifierE.go
+++ b/0-999/400-499/430-439/437/verifierE.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+type Point struct {
+	x, y int64
+}
+
+func orient(a, b, c Point) int64 {
+	return (b.x-a.x)*(c.y-a.y) - (b.y-a.y)*(c.x-a.x)
+}
+
+func onSegment(a, b, c Point) bool {
+	return c.x >= minInt64(a.x, b.x) && c.x <= maxInt64(a.x, b.x) &&
+		c.y >= minInt64(a.y, b.y) && c.y <= maxInt64(a.y, b.y)
+}
+
+func intersect(a, b, c, d Point) bool {
+	o1 := orient(a, b, c)
+	o2 := orient(a, b, d)
+	o3 := orient(c, d, a)
+	o4 := orient(c, d, b)
+	if o1 == 0 && onSegment(a, b, c) {
+		return true
+	}
+	if o2 == 0 && onSegment(a, b, d) {
+		return true
+	}
+	if o3 == 0 && onSegment(c, d, a) {
+		return true
+	}
+	if o4 == 0 && onSegment(c, d, b) {
+		return true
+	}
+	return (o1 > 0 && o2 < 0 || o1 < 0 && o2 > 0) &&
+		(o3 > 0 && o4 < 0 || o3 < 0 && o4 > 0)
+}
+
+func minInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func pointInPoly(poly []Point, p struct{ x, y float64 }) bool {
+	cnt := 0
+	n := len(poly)
+	for i := 0; i < n; i++ {
+		a := poly[i]
+		b := poly[(i+1)%n]
+		ay := float64(a.y)
+		by := float64(b.y)
+		if ay > by {
+			ay, by = by, ay
+		}
+		if p.y <= ay || p.y > by {
+			continue
+		}
+		ax := float64(a.x)
+		bx := float64(b.x)
+		xint := ax + (bx-ax)*((p.y-ay)/(by-ay))
+		if xint > p.x {
+			cnt++
+		}
+	}
+	return cnt%2 == 1
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveE(poly []Point) string {
+	n := len(poly)
+	var area2 int64
+	for i := 0; i < n; i++ {
+		j := (i + 1) % n
+		area2 += poly[i].x*poly[j].y - poly[i].y*poly[j].x
+	}
+	ccw := area2 > 0
+	valid := make([][]bool, n)
+	for i := range valid {
+		valid[i] = make([]bool, n)
+	}
+	for i := 0; i < n; i++ {
+		valid[i][(i+1)%n] = true
+		valid[(i+1)%n][i] = true
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 2; j < n; j++ {
+			if i == 0 && j == n-1 {
+				valid[i][j] = true
+				valid[j][i] = true
+				continue
+			}
+			a := poly[i]
+			b := poly[j]
+			ok := true
+			for k := 0; k < n; k++ {
+				k2 := (k + 1) % n
+				if k == i || k == j || k2 == i || k2 == j {
+					continue
+				}
+				if intersect(a, b, poly[k], poly[k2]) {
+					ok = false
+					break
+				}
+			}
+			if !ok {
+				continue
+			}
+			mx := (float64(a.x) + float64(b.x)) * 0.5
+			my := (float64(a.y) + float64(b.y)) * 0.5
+			if !pointInPoly(poly, struct{ x, y float64 }{mx, my}) {
+				continue
+			}
+			valid[i][j] = true
+			valid[j][i] = true
+		}
+	}
+	dp := make([][]int64, n)
+	for i := range dp {
+		dp[i] = make([]int64, n)
+		dp[i][i] = 1
+		if i+1 < n {
+			dp[i][i+1] = 1
+		}
+	}
+	for length := 2; length < n; length++ {
+		for i := 0; i+length < n; i++ {
+			j := i + length
+			if !valid[i][j] {
+				dp[i][j] = 0
+				continue
+			}
+			var ways int64
+			for k := i + 1; k < j; k++ {
+				if !valid[i][k] || !valid[k][j] {
+					continue
+				}
+				o := orient(poly[i], poly[k], poly[j])
+				if (ccw && o <= 0) || (!ccw && o >= 0) {
+					continue
+				}
+				ways = (ways + dp[i][k]*dp[k][j]) % mod
+			}
+			dp[i][j] = ways
+		}
+	}
+	return fmt.Sprintf("%d", dp[0][n-1])
+}
+
+func genPolygon(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 3
+	angles := make([]float64, n)
+	for i := range angles {
+		angles[i] = rng.Float64() * 2 * math.Pi
+	}
+	sort.Float64s(angles)
+	poly := make([]Point, n)
+	for i, ang := range angles {
+		r := rng.Float64()*50 + 1
+		x := int64(math.Round(r * math.Cos(ang) * 100))
+		y := int64(math.Round(r * math.Sin(ang) * 100))
+		poly[i] = Point{x, y}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, p := range poly {
+		fmt.Fprintf(&sb, "%d %d\n", p.x, p.y)
+	}
+	input := sb.String()
+	exp := solveE(poly)
+	return input, exp
+}
+
+func manualCase() (string, string) {
+	poly := []Point{{0, 0}, {100, 0}, {100, 100}, {0, 100}}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "4\n")
+	for _, p := range poly {
+		fmt.Fprintf(&sb, "%d %d\n", p.x, p.y)
+	}
+	input := sb.String()
+	exp := solveE(poly)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases [][2]string
+	in1, ex1 := manualCase()
+	cases = append(cases, [2]string{in1, ex1})
+	for i := 0; i < 100; i++ {
+		in, exp := genPolygon(rng)
+		cases = append(cases, [2]string{in, exp})
+	}
+	for idx, tc := range cases {
+		out, err := runBinary(bin, tc[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc[0])
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc[1] {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc[1], out, tc[0])
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest 437 problems A–E
- each verifier runs a candidate binary on 100+ generated tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ecd7b65b48324ac1a46c1950f2dfd