### PR TITLE
Add verifiers for contest 436

### DIFF
--- a/0-999/400-499/430-439/436/verifierA.go
+++ b/0-999/400-499/430-439/436/verifierA.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Candy struct {
+	t int
+	h int
+	m int
+}
+
+// simulate logic copied from solution
+func simulate(startType int, candies0, candies1 []Candy, initialX int) int {
+	x := initialX
+	next := startType
+	eaten := 0
+	used0 := make([]bool, len(candies0))
+	used1 := make([]bool, len(candies1))
+	for {
+		bestIdx, bestMass := -1, -1
+		if next == 0 {
+			for i, c := range candies0 {
+				if !used0[i] && c.h <= x && c.m > bestMass {
+					bestMass = c.m
+					bestIdx = i
+				}
+			}
+			if bestIdx == -1 {
+				break
+			}
+			used0[bestIdx] = true
+			x += candies0[bestIdx].m
+		} else {
+			for i, c := range candies1 {
+				if !used1[i] && c.h <= x && c.m > bestMass {
+					bestMass = c.m
+					bestIdx = i
+				}
+			}
+			if bestIdx == -1 {
+				break
+			}
+			used1[bestIdx] = true
+			x += candies1[bestIdx].m
+		}
+		eaten++
+		next ^= 1
+	}
+	return eaten
+}
+
+func expected(n, x int, candies []Candy) string {
+	var c0, c1 []Candy
+	for _, c := range candies {
+		if c.t == 0 {
+			c0 = append(c0, c)
+		} else {
+			c1 = append(c1, c)
+		}
+	}
+	a0 := simulate(0, c0, c1, x)
+	a1 := simulate(1, c0, c1, x)
+	if a1 > a0 {
+		return fmt.Sprintf("%d", a1)
+	}
+	return fmt.Sprintf("%d", a0)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 1
+		x := rng.Intn(20) + 1
+		candies := make([]Candy, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+		for j := 0; j < n; j++ {
+			t := rng.Intn(2)
+			h := rng.Intn(20) + 1
+			m := rng.Intn(20) + 1
+			candies[j] = Candy{t: t, h: h, m: m}
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", t, h, m))
+		}
+		input := sb.String()
+		exp := expected(n, x, candies)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/436/verifierB.go
+++ b/0-999/400-499/430-439/436/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, m int, grid []string) string {
+	ans := make([]int, m)
+	for i := 1; i <= n; i++ {
+		line := grid[i-1]
+		for j := 1; j <= m; j++ {
+			switch line[j-1] {
+			case 'L':
+				target := j - i + 1
+				if target >= 1 && target <= m {
+					ans[target-1]++
+				}
+			case 'R':
+				target := j + i - 1
+				if target >= 1 && target <= m {
+					ans[target-1]++
+				}
+			case 'U':
+				if i%2 == 1 {
+					ans[j-1]++
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		grid := make([]string, n)
+		k := 0
+		for r := 0; r < n; r++ {
+			lineBytes := make([]byte, m)
+			for c := 0; c < m; c++ {
+				if r == 0 {
+					lineBytes[c] = '.'
+					continue
+				}
+				ch := ".LRU"[rng.Intn(4)]
+				lineBytes[c] = ch
+				if ch != '.' {
+					k++
+				}
+			}
+			grid[r] = string(lineBytes)
+		}
+		input := fmt.Sprintf("%d %d %d\n%s\n", n, m, k, strings.Join(grid, "\n"))
+		exp := expected(n, m, grid)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/436/verifierC.go
+++ b/0-999/400-499/430-439/436/verifierC.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct {
+	v int
+	p int
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expected(n, m, k, w int, levels [][]string) string {
+	maxCost := n * m
+	dist := make([][]int, k)
+	for i := 0; i < k; i++ {
+		dist[i] = make([]int, k)
+	}
+	for i := 0; i < k; i++ {
+		for j := i + 1; j < k; j++ {
+			diff := 0
+			for r := 0; r < n; r++ {
+				a := levels[i][r]
+				b := levels[j][r]
+				for c := 0; c < m; c++ {
+					if a[c] != b[c] {
+						diff++
+					}
+				}
+			}
+			cost := min(maxCost, diff*w)
+			dist[i][j] = cost
+			dist[j][i] = cost
+		}
+	}
+	used := make([]bool, k)
+	minCost := make([]int, k)
+	prev := make([]int, k)
+	used[0] = true
+	total := maxCost
+	ans := []pair{{0, -1}}
+	for i := 1; i < k; i++ {
+		minCost[i] = dist[0][i]
+		prev[i] = 0
+	}
+	for cnt := 1; cnt < k; cnt++ {
+		v := -1
+		for i := 0; i < k; i++ {
+			if !used[i] && (v == -1 || minCost[i] < minCost[v]) {
+				v = i
+			}
+		}
+		if minCost[v] >= maxCost {
+			total += maxCost
+			ans = append(ans, pair{v, -1})
+		} else {
+			total += minCost[v]
+			ans = append(ans, pair{v, prev[v]})
+		}
+		used[v] = true
+		for u := 0; u < k; u++ {
+			if !used[u] && dist[v][u] < minCost[u] {
+				minCost[u] = dist[v][u]
+				prev[u] = v
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", total))
+	for _, pr := range ans {
+		x := pr.v + 1
+		y := pr.p + 1
+		if pr.p < 0 {
+			y = 0
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(2) + 1
+		m := rng.Intn(2) + 1
+		k := rng.Intn(2) + 1
+		w := rng.Intn(3) + 1
+		levels := make([][]string, k)
+		for lvl := 0; lvl < k; lvl++ {
+			levels[lvl] = make([]string, n)
+			for r := 0; r < n; r++ {
+				rowBytes := make([]byte, m)
+				for c := 0; c < m; c++ {
+					rowBytes[c] = byte('a' + rng.Intn(3))
+				}
+				levels[lvl][r] = string(rowBytes)
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, k, w))
+		for lvl := 0; lvl < k; lvl++ {
+			for r := 0; r < n; r++ {
+				sb.WriteString(levels[lvl][r])
+				sb.WriteByte('\n')
+			}
+		}
+		input := sb.String()
+		exp := expected(n, m, k, w, levels)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/436/verifierD.go
+++ b/0-999/400-499/430-439/436/verifierD.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(n, m int, A, B []int) string {
+	sort.Ints(A)
+	sort.Ints(B)
+	type block struct{ a, c, length int }
+	blocks := make([]block, 0, n)
+	for i := 0; i < n; i++ {
+		start := A[i]
+		j := i
+		for j+1 < n && A[j+1] == A[j]+1 {
+			j++
+		}
+		blocks = append(blocks, block{a: start, c: A[j], length: j - i + 1})
+		i = j
+	}
+	total := 0
+	infL := -2000000000
+	infR := 2000000000
+	for i, b := range blocks {
+		L := infL
+		R := infR
+		if i > 0 {
+			L = blocks[i-1].c + 1
+		}
+		if i+1 < len(blocks) {
+			R = blocks[i+1].a - 1
+		}
+		l := sort.Search(len(B), func(j int) bool { return B[j] >= L })
+		r := sort.Search(len(B), func(j int) bool { return B[j] > R }) - 1
+		if l >= len(B) || r < l {
+			continue
+		}
+		best := 0
+		right := l
+		maxDist := b.length - 1
+		for left := l; left <= r; left++ {
+			for right <= r && B[right]-B[left] <= maxDist {
+				right++
+			}
+			cnt := right - left
+			if cnt > best {
+				best = cnt
+			}
+		}
+		total += best
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		setA := make(map[int]struct{})
+		for len(setA) < n {
+			setA[rng.Intn(20)] = struct{}{}
+		}
+		setB := make(map[int]struct{})
+		for len(setB) < m {
+			setB[rng.Intn(20)] = struct{}{}
+		}
+		A := make([]int, 0, n)
+		for v := range setA {
+			A = append(A, v)
+		}
+		B := make([]int, 0, m)
+		for v := range setB {
+			B = append(B, v)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i2, v := range A {
+			if i2 > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		for i2, v := range B {
+			if i2 > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(len(A), len(B), A, B)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/436/verifierE.go
+++ b/0-999/400-499/430-439/436/verifierE.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type node struct {
+	x   int64
+	id  int
+	id2 int
+}
+
+func expected(n, m int, aVals, bVals []int64) string {
+	t := make([]node, 2*n)
+	for i := 1; i <= n; i++ {
+		ai := aVals[i]
+		bi := bVals[i]
+		if bi-ai < ai {
+			t[i-1] = node{bi >> 1, i, i << 1}
+			t[i-1+n] = node{bi >> 1, i + n, i<<1 | 1}
+		} else {
+			t[i-1] = node{ai, i, i << 1}
+			t[i-1+n] = node{bi - ai, i + n, i<<1 | 1}
+		}
+	}
+	sort.Slice(t, func(i, j int) bool {
+		if t[i].x != t[j].x {
+			return t[i].x < t[j].x
+		}
+		if t[i].id2 != t[j].id2 {
+			return t[i].id2 < t[j].id2
+		}
+		return t[i].id < t[j].id
+	})
+	cnt := make([]int, 2*n+2)
+	var ans int64
+	for i := 0; i < m; i++ {
+		ans += t[i].x
+		cnt[t[i].id]++
+	}
+	if t[m-1].id <= n && cnt[t[m-1].id+n] == 0 {
+		id0 := t[m-1].id
+		if t[m-1].x != aVals[id0] {
+			tmp := ans - t[m-1].x
+			ans = tmp + aVals[id0]
+			cnt[id0]--
+			C := []int{id0}
+			Cval := []int{1}
+			for i := 1; i <= n; i++ {
+				if i == id0 {
+					continue
+				}
+				if cnt[i] == 0 {
+					if aVals[i]+tmp < ans {
+						ans = aVals[i] + tmp
+						C = []int{i}
+						Cval = []int{1}
+					}
+				}
+				if cnt[i] > 0 && cnt[i+n] == 0 {
+					if tmp+(bVals[i]-aVals[i]) < ans {
+						ans = tmp + (bVals[i] - aVals[i])
+						C = []int{i + n}
+						Cval = []int{1}
+					}
+					if tmp-aVals[i]+bVals[id0] < ans {
+						ans = tmp - aVals[i] + bVals[id0]
+						C = []int{i, id0, id0 + n}
+						Cval = []int{-1, 1, 1}
+					}
+				}
+				if cnt[i] > 0 && cnt[i+n] > 0 {
+					if tmp-(bVals[i]-aVals[i])+bVals[id0] < ans {
+						ans = tmp - (bVals[i] - aVals[i]) + bVals[id0]
+						C = []int{i + n, id0, id0 + n}
+						Cval = []int{-1, 1, 1}
+					}
+				}
+			}
+			for k, idx := range C {
+				cnt[idx] += Cval[k]
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", ans>>1))
+	for i := 1; i <= n; i++ {
+		sel := cnt[i] + cnt[i+n]
+		sb.WriteByte(byte('0' + sel))
+	}
+	return sb.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(3) + 1
+		m := rng.Intn(2*n) + 1
+		a := make([]int64, n+1)
+		b := make([]int64, n+1)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j := 1; j <= n; j++ {
+			ai := int64(rng.Intn(10) + 1)
+			bi := ai + int64(rng.Intn(10)+1)
+			a[j] = ai << 1
+			b[j] = bi << 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", ai, bi))
+		}
+		input := sb.String()
+		exp := expected(n, m, a, b)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/436/verifierF.go
+++ b/0-999/400-499/430-439/436/verifierF.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	maxg = 303
+	INF  = int(0x3f3f3f3f)
+)
+
+type pair struct {
+	first  int
+	second int
+}
+
+type block struct {
+	ans      int64
+	pans     int
+	rightcnt int
+	nextrcnt int
+	ld, ldx  int
+}
+
+var (
+	ab      []pair
+	have    []bool
+	blocks  []block
+	userByB [][]int
+)
+
+func (b *block) getLeader(from, to int) {
+	ourcnt := 0
+	b.ans = 0
+	b.pans = 0
+	for i := to - 1; i >= from; i-- {
+		if !have[i] {
+			continue
+		}
+		ourcnt++
+		cur := int64(b.rightcnt+ourcnt) * int64(ab[i].first)
+		if cur > b.ans {
+			b.ans = cur
+			b.pans = ab[i].first
+			b.ld = i
+			b.ldx = b.rightcnt + ourcnt
+		}
+	}
+}
+
+func (b *block) recalc(from, to int) {
+	b.getLeader(from, to)
+	ourcnt := 0
+	b.nextrcnt = INF
+	for i := to - 1; i >= from; i-- {
+		if !have[i] {
+			continue
+		}
+		ourcnt++
+		if i == b.ld || ab[i].first <= ab[b.ld].first {
+			continue
+		}
+		curx := b.rightcnt + ourcnt
+		lp := int64(ab[b.ld].first)*int64(b.ldx) - int64(ab[i].first)*int64(curx)
+		rp := int64(ab[i].first) - int64(ab[b.ld].first)
+		t := int(lp/rp) + 1
+		if t < INF {
+			nxt := b.rightcnt + t
+			if nxt < b.nextrcnt {
+				b.nextrcnt = nxt
+			}
+		}
+	}
+}
+
+func (b *block) update(from, to int) {
+	b.rightcnt++
+	b.ans += int64(b.pans)
+	if b.rightcnt >= b.nextrcnt {
+		b.recalc(from, to)
+	}
+}
+
+func expected(n int, w int64, arr []pair) string {
+	ab = make([]pair, n)
+	copy(ab, arr)
+	sort.Slice(ab, func(i, j int) bool { return ab[i].first < ab[j].first })
+	mb := 0
+	for _, p := range ab {
+		if p.second > mb {
+			mb = p.second
+		}
+	}
+	userByB = make([][]int, mb+1)
+	for i := 0; i < n; i++ {
+		b := ab[i].second
+		userByB[b] = append(userByB[b], i)
+	}
+	have = make([]bool, n)
+	blockCount := (n + maxg - 1) / maxg
+	blocks = make([]block, blockCount)
+	for i := range blocks {
+		blocks[i].nextrcnt = INF
+	}
+	watchAds := n
+	var sb strings.Builder
+	for c := 0; c <= mb+1; c++ {
+		if c > 0 {
+			for _, u := range userByB[c-1] {
+				watchAds--
+				if ab[u].first == 0 {
+					continue
+				}
+				have[u] = true
+				gid := u / maxg
+				from := gid * maxg
+				to := from + maxg
+				if to > n {
+					to = n
+				}
+				blocks[gid].recalc(from, to)
+				for i := 0; i < gid; i++ {
+					f := i * maxg
+					t := f + maxg
+					if t > n {
+						t = n
+					}
+					blocks[i].update(f, t)
+				}
+			}
+		}
+		bestAns := int64(0)
+		bestPans := 0
+		for i := range blocks {
+			if blocks[i].ans > bestAns {
+				bestAns = blocks[i].ans
+				bestPans = blocks[i].pans
+			}
+		}
+		total := bestAns + w*int64(c)*int64(watchAds)
+		sb.WriteString(fmt.Sprintf("%d %d\n", total, bestPans))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 1
+		w := int64(rng.Intn(5) + 1)
+		arr := make([]pair, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, w))
+		for j := 0; j < n; j++ {
+			a := rng.Intn(5) + 1
+			b := rng.Intn(5) + 1
+			arr[j] = pair{a, b}
+			sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+		}
+		input := sb.String()
+		exp := expected(n, w, arr)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 436 problems A–F

## Testing
- `go build 0-999/400-499/430-439/436/verifierA.go`
- `go build 0-999/400-499/430-439/436/verifierB.go`
- `go build 0-999/400-499/430-439/436/verifierC.go`
- `go build 0-999/400-499/430-439/436/verifierD.go`
- `go build 0-999/400-499/430-439/436/verifierE.go`
- `go build 0-999/400-499/430-439/436/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_687ecd35492883249e77b20309b5fd4e