### PR TITLE
Add Go verifiers for contest 433

### DIFF
--- a/0-999/400-499/430-439/433/verifierA.go
+++ b/0-999/400-499/430-439/433/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input  string
+	output string
+}
+
+func solve(weights []int) string {
+	count100 := 0
+	count200 := 0
+	for _, w := range weights {
+		if w == 100 {
+			count100++
+		} else {
+			count200++
+		}
+	}
+	total := count100*100 + count200*200
+	if total%200 != 0 {
+		return "NO"
+	}
+	if count100 == 0 && count200%2 == 1 {
+		return "NO"
+	}
+	return "YES"
+}
+
+func generateTests() []test {
+	rand.Seed(1)
+	var tests []test
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(100) + 1
+		weights := make([]int, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				weights[j] = 100
+			} else {
+				weights[j] = 200
+			}
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", weights[j])
+		}
+		sb.WriteByte('\n')
+		out := solve(weights)
+		tests = append(tests, test{sb.String(), out})
+	}
+	return tests
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != t.output {
+			fmt.Printf("Test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, t.input, t.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/430-439/433/verifierB.go
+++ b/0-999/400-499/430-439/433/verifierB.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type query struct {
+	typ int
+	l   int
+	r   int
+}
+
+type test struct {
+	input  string
+	output string
+}
+
+func solve(n int, v []int64, qs []query) string {
+	orig := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		orig[i] = orig[i-1] + v[i-1]
+	}
+	u := make([]int64, n)
+	copy(u, v)
+	sort.Slice(u, func(i, j int) bool { return u[i] < u[j] })
+	sorted := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		sorted[i] = sorted[i-1] + u[i-1]
+	}
+	var sb strings.Builder
+	for i, q := range qs {
+		var ans int64
+		if q.typ == 1 {
+			ans = orig[q.r] - orig[q.l-1]
+		} else {
+			ans = sorted[q.r] - sorted[q.l-1]
+		}
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		fmt.Fprintf(&sb, "%d", ans)
+	}
+	return sb.String()
+}
+
+func generateTests() []test {
+	rand.Seed(2)
+	var tests []test
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		v := make([]int64, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			v[j] = int64(rand.Intn(100) + 1)
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v[j])
+		}
+		sb.WriteByte('\n')
+		m := rand.Intn(20) + 1
+		fmt.Fprintf(&sb, "%d\n", m)
+		qs := make([]query, m)
+		for j := 0; j < m; j++ {
+			typ := rand.Intn(2) + 1
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			qs[j] = query{typ, l, r}
+			fmt.Fprintf(&sb, "%d %d %d\n", typ, l, r)
+		}
+		out := solve(n, v, qs)
+		tests = append(tests, test{sb.String(), out})
+	}
+	return tests
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != t.output {
+			fmt.Printf("Test %d failed:\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, t.input, t.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/430-439/433/verifierC.go
+++ b/0-999/400-499/430-439/433/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type test struct {
+	input  string
+	output string
+}
+
+func solve(n, m int, a []int) string {
+	neighbors := make([][]int, n+1)
+	var total int64
+	for i := 1; i < m; i++ {
+		u := a[i-1]
+		v := a[i]
+		if u > v {
+			total += int64(u - v)
+		} else {
+			total += int64(v - u)
+		}
+		neighbors[u] = append(neighbors[u], v)
+		neighbors[v] = append(neighbors[v], u)
+	}
+	bestGain := int64(0)
+	for p := 1; p <= n; p++ {
+		nb := neighbors[p]
+		if len(nb) == 0 {
+			continue
+		}
+		var curr int64
+		for _, t := range nb {
+			if p > t {
+				curr += int64(p - t)
+			} else {
+				curr += int64(t - p)
+			}
+		}
+		sort.Ints(nb)
+		med := nb[len(nb)/2]
+		var newCost int64
+		for _, t := range nb {
+			if med > t {
+				newCost += int64(med - t)
+			} else {
+				newCost += int64(t - med)
+			}
+		}
+		gain := curr - newCost
+		if gain > bestGain {
+			bestGain = gain
+		}
+	}
+	res := total - bestGain
+	return fmt.Sprintf("%d", res)
+}
+
+func generateTests() []test {
+	rand.Seed(3)
+	var tests []test
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		m := rand.Intn(15) + 1
+		a := make([]int, m)
+		for j := 0; j < m; j++ {
+			a[j] = rand.Intn(n) + 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", a[j])
+		}
+		sb.WriteByte('\n')
+		out := solve(n, m, a)
+		tests = append(tests, test{sb.String(), out})
+	}
+	return tests
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != t.output {
+			fmt.Printf("Test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, t.input, t.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/430-439/433/verifierD.go
+++ b/0-999/400-499/430-439/433/verifierD.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type test struct {
+	input  string
+	output string
+}
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "433D.go")
+	ref := filepath.Join(os.TempDir(), "ref433D")
+	cmd := exec.Command("go", "build", "-o", ref, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func generateTests() []string {
+	rand.Seed(4)
+	var tests []string
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(4) + 1
+		m := rand.Intn(4) + 1
+		q := rand.Intn(4) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, m, q)
+		for r := 0; r < n; r++ {
+			for c := 0; c < m; c++ {
+				if c > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteByte(byte('0' + rand.Intn(2)))
+			}
+			sb.WriteByte('\n')
+		}
+		for j := 0; j < q; j++ {
+			op := rand.Intn(2) + 1
+			x := rand.Intn(n) + 1
+			y := rand.Intn(m) + 1
+			fmt.Fprintf(&sb, "%d %d %d\n", op, x, y)
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := generateTests()
+	for i, in := range tests {
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("Test %d failed:\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/430-439/433/verifierE.go
+++ b/0-999/400-499/430-439/433/verifierE.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type test struct {
+	input  string
+	output string
+}
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "433E.go")
+	ref := filepath.Join(os.TempDir(), "ref433E")
+	cmd := exec.Command("go", "build", "-o", ref, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func toBase(x, base int) []int {
+	if x == 0 {
+		return []int{0}
+	}
+	var digits []int
+	for x > 0 {
+		digits = append([]int{x % base}, digits...)
+		x /= base
+	}
+	return digits
+}
+
+func generateTests() []string {
+	rand.Seed(5)
+	var tests []string
+	for i := 0; i < 100; i++ {
+		m := rand.Intn(4) + 2
+		r := rand.Intn(50) + 1
+		l := rand.Intn(r) + 1
+		n := rand.Intn(3) + 1
+		k := rand.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+		ld := toBase(l, m)
+		fmt.Fprintf(&sb, "%d", len(ld))
+		for _, d := range ld {
+			fmt.Fprintf(&sb, " %d", d)
+		}
+		sb.WriteByte('\n')
+		rd := toBase(r, m)
+		fmt.Fprintf(&sb, "%d", len(rd))
+		for _, d := range rd {
+			fmt.Fprintf(&sb, " %d", d)
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			ln := rand.Intn(3) + 1
+			fmt.Fprintf(&sb, "%d", ln)
+			for t := 0; t < ln; t++ {
+				fmt.Fprintf(&sb, " %d", rand.Intn(m))
+			}
+			val := rand.Intn(3) + 1
+			fmt.Fprintf(&sb, " %d\n", val)
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := generateTests()
+	for i, in := range tests {
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("Test %d failed:\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–E of Codeforces contest 433
- each verifier generates 100 random tests and checks a given binary
- problems D and E compile included solutions as references

## Testing
- `go run 0-999/400-499/430-439/433/verifierA.go /tmp/433A`
- `go run 0-999/400-499/430-439/433/verifierB.go /tmp/433B`
- `go run 0-999/400-499/430-439/433/verifierC.go /tmp/433C`
- `go run 0-999/400-499/430-439/433/verifierD.go /tmp/433D`
- `go run 0-999/400-499/430-439/433/verifierE.go /tmp/433E`


------
https://chatgpt.com/codex/tasks/task_e_687ecc632b048324b389ca1136dcb424