### PR TITLE
Add verifiers for contest 432

### DIFF
--- a/0-999/400-499/430-439/432/verifierA.go
+++ b/0-999/400-499/430-439/432/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n   int
+	k   int
+	arr []int
+}
+
+func expected(n, k int, arr []int) int {
+	valid := 0
+	for _, v := range arr {
+		if v+k <= 5 {
+			valid++
+		}
+	}
+	return valid / 3
+}
+
+func runCase(exe string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := expected(tc.n, tc.k, tc.arr)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(2000) + 1
+		k := rng.Intn(5) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(6) // 0..5
+		}
+		tc := testCase{n: n, k: k, arr: arr}
+		if err := runCase(exe, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/432/verifierB.go
+++ b/0-999/400-499/430-439/432/verifierB.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n  int
+	xs []int
+	ys []int
+}
+
+func expected(tc testCase) [][2]int {
+	count := make(map[int]int)
+	for _, x := range tc.xs {
+		count[x]++
+	}
+	res := make([][2]int, tc.n)
+	for i := 0; i < tc.n; i++ {
+		conflicts := count[tc.ys[i]]
+		res[i][0] = (tc.n - 1) + conflicts
+		res[i][1] = (tc.n - 1) - conflicts
+	}
+	return res
+}
+
+func runCase(exe string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i := 0; i < tc.n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.xs[i], tc.ys[i]))
+	}
+	input := sb.String()
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	r := strings.Fields(out.String())
+	if len(r) != 2*tc.n {
+		return fmt.Errorf("expected %d numbers, got %d", 2*tc.n, len(r))
+	}
+	res := expected(tc)
+	for i := 0; i < tc.n; i++ {
+		var gotHome, gotAway int
+		fmt.Sscan(r[2*i], &gotHome)
+		fmt.Sscan(r[2*i+1], &gotAway)
+		if gotHome != res[i][0] || gotAway != res[i][1] {
+			return fmt.Errorf("team %d expected %d %d got %d %d", i+1, res[i][0], res[i][1], gotHome, gotAway)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(50) + 2
+		xs := make([]int, n)
+		ys := make([]int, n)
+		for j := 0; j < n; j++ {
+			xs[j] = rng.Intn(100000) + 1
+			for {
+				ys[j] = rng.Intn(100000) + 1
+				if ys[j] != xs[j] {
+					break
+				}
+			}
+		}
+		tc := testCase{n: n, xs: xs, ys: ys}
+		if err := runCase(exe, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/432/verifierC.go
+++ b/0-999/400-499/430-439/432/verifierC.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func sieve(n int) []bool {
+	prime := make([]bool, n+1)
+	for i := 2; i <= n; i++ {
+		prime[i] = true
+	}
+	for i := 2; i*i <= n; i++ {
+		if prime[i] {
+			for j := i * i; j <= n; j += i {
+				prime[j] = false
+			}
+		}
+	}
+	return prime
+}
+
+func runCase(exe string, arr []int, primes []bool) error {
+	n := len(arr)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	reader := bufio.NewReader(bytes.NewReader(out.Bytes()))
+	var m int
+	if _, err := fmt.Fscan(reader, &m); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if m > 5*n {
+		return fmt.Errorf("too many operations: %d", m)
+	}
+	ops := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		if _, err := fmt.Fscan(reader, &ops[i][0], &ops[i][1]); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if ops[i][0] < 1 || ops[i][1] < ops[i][0] || ops[i][1] > n {
+			return fmt.Errorf("invalid indices in operation")
+		}
+		if ops[i][1]-ops[i][0]+1 >= len(primes) || !primes[ops[i][1]-ops[i][0]+1] {
+			return fmt.Errorf("swap length not prime")
+		}
+	}
+	arrCopy := append([]int(nil), arr...)
+	for _, op := range ops {
+		i, j := op[0]-1, op[1]-1
+		arrCopy[i], arrCopy[j] = arrCopy[j], arrCopy[i]
+	}
+	for i := 0; i < n; i++ {
+		if arrCopy[i] != i+1 {
+			return fmt.Errorf("array not sorted")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	primes := sieve(1000)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(30) + 1
+		arr := rand.Perm(n)
+		for j := 0; j < n; j++ {
+			arr[j]++
+		}
+		if err := runCase(exe, arr, primes); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/432/verifierD.go
+++ b/0-999/400-499/430-439/432/verifierD.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) [][2]int {
+	n := len(s)
+	z := make([]int, n)
+	l, r := 0, 0
+	for i := 1; i < n; i++ {
+		if i <= r {
+			if r-i+1 < z[i-l] {
+				z[i] = r - i + 1
+			} else {
+				z[i] = z[i-l]
+			}
+		}
+		for i+z[i] < n && s[z[i]] == s[i+z[i]] {
+			z[i]++
+		}
+		if i+z[i]-1 > r {
+			l = i
+			r = i + z[i] - 1
+		}
+	}
+	cnt := make([]int, n+2)
+	for i := 1; i < n; i++ {
+		cnt[1]++
+		cnt[z[i]+1]--
+	}
+	for i := 1; i <= n; i++ {
+		cnt[i] += cnt[i-1]
+		cnt[i]++
+	}
+	pi := make([]int, n)
+	for i := 1; i < n; i++ {
+		j := pi[i-1]
+		for j > 0 && s[i] != s[j] {
+			j = pi[j-1]
+		}
+		if s[i] == s[j] {
+			j++
+		}
+		pi[i] = j
+	}
+	var borders []int
+	k := n
+	for k > 0 {
+		borders = append(borders, k)
+		if k == n {
+			k = pi[n-1]
+		} else {
+			k = pi[k-1]
+		}
+	}
+	for i, j := 0, len(borders)-1; i < j; i, j = i+1, j-1 {
+		borders[i], borders[j] = borders[j], borders[i]
+	}
+	res := make([][2]int, len(borders))
+	for i, b := range borders {
+		res[i] = [2]int{b, cnt[b]}
+	}
+	return res
+}
+
+func runCase(exe string, s string) error {
+	input := s + "\n"
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	reader := bufio.NewReader(bytes.NewReader(out.Bytes()))
+	var k int
+	if _, err := fmt.Fscan(reader, &k); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	pairs := make([][2]int, k)
+	for i := 0; i < k; i++ {
+		if _, err := fmt.Fscan(reader, &pairs[i][0], &pairs[i][1]); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+	}
+	expectedRes := expected(s)
+	if len(expectedRes) != k {
+		return fmt.Errorf("expected %d pairs got %d", len(expectedRes), k)
+	}
+	for i := 0; i < k; i++ {
+		if pairs[i][0] != expectedRes[i][0] || pairs[i][1] != expectedRes[i][1] {
+			return fmt.Errorf("pair %d expected %d %d got %d %d", i+1, expectedRes[i][0], expectedRes[i][1], pairs[i][0], pairs[i][1])
+		}
+	}
+	return nil
+}
+
+func randomString(rng *rand.Rand, length int) string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		length := rng.Intn(20) + 1
+		s := randomString(rng, length)
+		if err := runCase(exe, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/432/verifierE.go
+++ b/0-999/400-499/430-439/432/verifierE.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, m int) []string {
+	grid := make([][]byte, n)
+	for i := range grid {
+		grid[i] = make([]byte, m)
+	}
+	for r := 0; r < n; r++ {
+		for c := 0; c < m; c++ {
+			if grid[r][c] != 0 {
+				continue
+			}
+			var color byte
+			for ch := byte('A'); ch <= 'Z'; ch++ {
+				ok := true
+				if r > 0 && grid[r-1][c] == ch {
+					ok = false
+				}
+				if c > 0 && grid[r][c-1] == ch {
+					ok = false
+				}
+				if ok {
+					color = ch
+					break
+				}
+			}
+			maxs := 0
+			limit := n - r
+			if m-c < limit {
+				limit = m - c
+			}
+			for s := 1; s <= limit; s++ {
+				bad := false
+				for i := r; i < r+s && !bad; i++ {
+					for j := c; j < c+s; j++ {
+						if grid[i][j] != 0 {
+							bad = true
+							break
+						}
+					}
+				}
+				if bad {
+					break
+				}
+				if r-1 >= 0 {
+					for j := c; j < c+s; j++ {
+						if grid[r-1][j] == color {
+							bad = true
+							break
+						}
+					}
+				}
+				if bad {
+					break
+				}
+				if c-1 >= 0 {
+					for i := r; i < r+s; i++ {
+						if grid[i][c-1] == color {
+							bad = true
+							break
+						}
+					}
+				}
+				if bad {
+					break
+				}
+				if r+s < n {
+					for j := c; j < c+s; j++ {
+						if grid[r+s][j] == color {
+							bad = true
+							break
+						}
+					}
+				}
+				if bad {
+					break
+				}
+				if c+s < m {
+					for i := r; i < r+s; i++ {
+						if grid[i][c+s] == color {
+							bad = true
+							break
+						}
+					}
+				}
+				if bad {
+					break
+				}
+				maxs = s
+			}
+			for i := r; i < r+maxs; i++ {
+				for j := c; j < c+maxs; j++ {
+					grid[i][j] = color
+				}
+			}
+		}
+	}
+	res := make([]string, n)
+	for i := 0; i < n; i++ {
+		res[i] = string(grid[i])
+	}
+	return res
+}
+
+func runCase(exe string, n, m int) error {
+	input := fmt.Sprintf("%d %d\n", n, m)
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != n {
+		return fmt.Errorf("expected %d lines got %d", n, len(lines))
+	}
+	for _, line := range lines {
+		if len(line) != m {
+			return fmt.Errorf("wrong line length")
+		}
+	}
+	expectedGrid := expected(n, m)
+	for i := 0; i < n; i++ {
+		if lines[i] != expectedGrid[i] {
+			return fmt.Errorf("line %d mismatch", i+1)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		if err := runCase(exe, n, m); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 432 problems A–E

## Testing
- `go run verifierA.go ./432A`
- `go run verifierB.go ./432B`
- `go run verifierC.go ./432C`
- `go run verifierD.go ./432D`
- `go run verifierE.go ./432E`


------
https://chatgpt.com/codex/tasks/task_e_687ecc1d16308324a57e68fc47ead794