### PR TITLE
Add Go verifiers for CF contest 431

### DIFF
--- a/0-999/400-499/430-439/431/verifierA.go
+++ b/0-999/400-499/430-439/431/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(a [5]int, s string) string {
+	total := 0
+	for _, ch := range s {
+		idx := int(ch - '0')
+		if idx >= 1 && idx <= 4 {
+			total += a[idx]
+		}
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	var a [5]int
+	for i := 1; i <= 4; i++ {
+		a[i] = rng.Intn(1000)
+	}
+	l := rng.Intn(20) + 1
+	b := make([]byte, l)
+	for i := 0; i < l; i++ {
+		b[i] = byte('1' + rng.Intn(4))
+	}
+	s := string(b)
+	input := fmt.Sprintf("%d %d %d %d\n%s\n", a[1], a[2], a[3], a[4], s)
+	return input, solveA(a, s)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expStr := strings.TrimSpace(expected)
+	if outStr != expStr {
+		return fmt.Errorf("expected %q got %q", expStr, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []struct{ in, out string }{
+		{"1 1 1 1\n1111\n", "4"},
+		{"10 20 30 40\n2143\n", "100"},
+	}
+	for i := 0; i < 100; i++ {
+		in, out := generateCase(rng)
+		cases = append(cases, struct{ in, out string }{in, out})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc.in, tc.out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/431/verifierB.go
+++ b/0-999/400-499/430-439/431/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(g [5][5]int64) string {
+	perm := []int{0, 1, 2, 3, 4}
+	var maxH int64
+	var dfs func(int)
+	dfs = func(idx int) {
+		if idx == 5 {
+			p := perm
+			var sum int64
+			sum += g[p[0]][p[1]] + g[p[1]][p[0]]
+			sum += g[p[2]][p[3]] + g[p[3]][p[2]]
+			sum += g[p[1]][p[2]] + g[p[2]][p[1]]
+			sum += g[p[3]][p[4]] + g[p[4]][p[3]]
+			sum += g[p[2]][p[3]] + g[p[3]][p[2]]
+			sum += g[p[3]][p[4]] + g[p[4]][p[3]]
+			if sum > maxH {
+				maxH = sum
+			}
+			return
+		}
+		for i := idx; i < 5; i++ {
+			perm[idx], perm[i] = perm[i], perm[idx]
+			dfs(idx + 1)
+			perm[idx], perm[i] = perm[i], perm[idx]
+		}
+	}
+	dfs(0)
+	return fmt.Sprintf("%d", maxH)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	var g [5][5]int64
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 5; j++ {
+			g[i][j] = int64(rng.Intn(10))
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 5; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", g[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), solveB(g)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expStr := strings.TrimSpace(expected)
+	if outStr != expStr {
+		return fmt.Errorf("expected %q got %q", expStr, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []struct{ in, out string }{}
+	for i := 0; i < 102; i++ {
+		in, out := generateCase(rng)
+		cases = append(cases, struct{ in, out string }{in, out})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc.in, tc.out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/431/verifierC.go
+++ b/0-999/400-499/430-439/431/verifierC.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func solveC(n, k, d int) string {
+	dp := make([][2]int, n+1)
+	dp[0][0] = 1
+	for s := 1; s <= n; s++ {
+		var without, with int
+		for i := 1; i <= k && i <= s; i++ {
+			if i < d {
+				without = (without + dp[s-i][0]) % mod
+				with = (with + dp[s-i][1]) % mod
+			} else {
+				with = (with + dp[s-i][0] + dp[s-i][1]) % mod
+			}
+		}
+		dp[s][0] = without
+		dp[s][1] = with
+	}
+	return fmt.Sprintf("%d", dp[n][1])
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(10) + 1
+	d := rng.Intn(k) + 1
+	input := fmt.Sprintf("%d %d %d\n", n, k, d)
+	return input, solveC(n, k, d)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expStr := strings.TrimSpace(expected)
+	if outStr != expStr {
+		return fmt.Errorf("expected %q got %q", expStr, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []struct{ in, out string }{}
+	for i := 0; i < 102; i++ {
+		in, out := generateCase(rng)
+		cases = append(cases, struct{ in, out string }{in, out})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc.in, tc.out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/431/verifierD.go
+++ b/0-999/400-499/430-439/431/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var dp [70][70]int64
+var x [70]int
+var K int
+
+func dfs(pos, cnt int, flag bool) int64 {
+	if pos == 0 {
+		if cnt == K {
+			return 1
+		}
+		return 0
+	}
+	if !flag && dp[pos][cnt] != -1 {
+		return dp[pos][cnt]
+	}
+	u := 1
+	if flag {
+		u = x[pos]
+	}
+	var ret int64
+	for i := 0; i <= u; i++ {
+		ret += dfs(pos-1, cnt+i, flag && i == u)
+	}
+	if !flag {
+		dp[pos][cnt] = ret
+	}
+	return ret
+}
+
+func ju(mid int64) int64 {
+	e := 0
+	for mid > 0 {
+		e++
+		x[e] = int(mid & 1)
+		mid >>= 1
+	}
+	tmp1 := dfs(e, 0, true)
+	e++
+	for i := e; i >= 2; i-- {
+		x[i] = x[i-1]
+	}
+	x[1] = 0
+	tmp2 := dfs(e, 0, true)
+	return tmp2 - tmp1
+}
+
+func solveD(m int64, k int) string {
+	K = k
+	for i := range dp {
+		for j := range dp[i] {
+			dp[i][j] = -1
+		}
+	}
+	l, r := int64(1), int64(1e18+1)
+	for l < r {
+		mid := (l + r) >> 1
+		if ju(mid) >= m {
+			r = mid
+		} else {
+			l = mid + 1
+		}
+	}
+	return fmt.Sprintf("%d", l)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	m := rng.Int63n(1000)
+	k := rng.Intn(10) + 1
+	input := fmt.Sprintf("%d %d\n", m, k)
+	return input, solveD(m, k)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expStr := strings.TrimSpace(expected)
+	if outStr != expStr {
+		return fmt.Errorf("expected %q got %q", expStr, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []struct{ in, out string }{}
+	for i := 0; i < 102; i++ {
+		in, out := generateCase(rng)
+		cases = append(cases, struct{ in, out string }{in, out})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc.in, tc.out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/430-439/431/verifierE.go
+++ b/0-999/400-499/430-439/431/verifierE.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func lowbit(x int) int { return x & -x }
+
+func solveE(n int, h []int, queries []Query) string {
+	disc := make([]int, len(h))
+	copy(disc, h)
+	for _, q := range queries {
+		if q.typ == 1 {
+			disc = append(disc, q.newv)
+		}
+	}
+	sort.Ints(disc)
+	m := 0
+	for i := 0; i < len(disc); i++ {
+		if i == 0 || disc[i] != disc[i-1] {
+			disc[m] = disc[i]
+			m++
+		}
+	}
+	disc = disc[:m]
+	cntFen := make([]int, m+1)
+	sumFen := make([]int64, m+1)
+	update := func(i, delta int) {
+		d := int64(disc[i-1]) * int64(delta)
+		for ; i <= m; i += lowbit(i) {
+			cntFen[i] += delta
+			sumFen[i] += d
+		}
+	}
+	queryFen := func(i int) (cnt int, sum int64) {
+		for ; i > 0; i -= lowbit(i) {
+			cnt += cntFen[i]
+			sum += sumFen[i]
+		}
+		return
+	}
+	for _, v := range h {
+		id := sort.SearchInts(disc, v) + 1
+		update(id, 1)
+	}
+	var out strings.Builder
+	for _, qr := range queries {
+		if qr.typ == 1 {
+			idx := qr.idx - 1
+			oldv := h[idx]
+			tidOld := sort.SearchInts(disc, oldv) + 1
+			update(tidOld, -1)
+			tidNew := sort.SearchInts(disc, qr.newv) + 1
+			update(tidNew, 1)
+			h[idx] = qr.newv
+		} else {
+			v := qr.v
+			l, r := 1, m
+			nl := 1
+			for l <= r {
+				mid := (l + r) >> 1
+				cnt, sum := queryFen(mid)
+				if v+sum > int64(cnt)*int64(disc[mid-1]) {
+					nl = mid
+					l = mid + 1
+				} else {
+					r = mid - 1
+				}
+			}
+			cnt, sum := queryFen(nl)
+			avg := float64(v+sum) / float64(cnt)
+			fmt.Fprintf(&out, "%f\n", avg)
+		}
+	}
+	return out.String()
+}
+
+type Query struct {
+	typ  int
+	idx  int
+	newv int
+	v    int64
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	q := rng.Intn(5) + 1
+	h := make([]int, n)
+	for i := range h {
+		h[i] = rng.Intn(10)
+	}
+	queries := make([]Query, q)
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			idx := rng.Intn(n) + 1
+			newv := rng.Intn(10)
+			queries[i] = Query{typ: 1, idx: idx, newv: newv}
+		} else {
+			v := rng.Int63n(20)
+			queries[i] = Query{typ: 2, v: v}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i, v := range h {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for _, qr := range queries {
+		if qr.typ == 1 {
+			fmt.Fprintf(&sb, "1 %d %d\n", qr.idx, qr.newv)
+		} else {
+			fmt.Fprintf(&sb, "2 %d\n", qr.v)
+		}
+	}
+	return sb.String(), solveE(n, append([]int(nil), h...), queries)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expStr := strings.TrimSpace(expected)
+	if outStr != expStr {
+		return fmt.Errorf("expected %q got %q", expStr, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []struct{ in, out string }{}
+	for i := 0; i < 102; i++ {
+		in, out := generateCase(rng)
+		cases = append(cases, struct{ in, out string }{in, out})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc.in, tc.out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A-E of contest 431
- each verifier executes a provided binary and runs over 100 random tests
- verifiers also support running Go source directly via `go run`

## Testing
- `gofmt -w 0-999/400-499/430-439/431/verifierA.go`
- `gofmt -w 0-999/400-499/430-439/431/verifierB.go`
- `gofmt -w 0-999/400-499/430-439/431/verifierC.go`
- `gofmt -w 0-999/400-499/430-439/431/verifierD.go`
- `gofmt -w 0-999/400-499/430-439/431/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687ecbd721848324877145f0caad72e7