### PR TITLE
Add solution verifiers for Codeforces contest 427

### DIFF
--- a/0-999/400-499/420-429/427/verifierA.go
+++ b/0-999/400-499/420-429/427/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// generateCase returns an input string and expected answer
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1
+	events := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if rng.Intn(3) == 0 {
+			events[i] = -1
+		} else {
+			events[i] = rng.Intn(10) + 1
+		}
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", events[i]))
+	}
+	sb.WriteByte('\n')
+	available := 0
+	untreated := 0
+	for _, x := range events {
+		if x == -1 {
+			if available > 0 {
+				available--
+			} else {
+				untreated++
+			}
+		} else {
+			available += x
+		}
+	}
+	return sb.String(), untreated
+}
+
+func runCase(exe, input string, expected int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/420-429/427/verifierB.go
+++ b/0-999/400-499/420-429/427/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(arr []int, t, c int) int {
+	cur := 0
+	ans := 0
+	for _, x := range arr {
+		if x <= t {
+			cur++
+		} else {
+			if cur >= c {
+				ans += cur - c + 1
+			}
+			cur = 0
+		}
+	}
+	if cur >= c {
+		ans += cur - c + 1
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(50) + 1
+	t := rng.Intn(20) + 1
+	c := rng.Intn(n) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, t, c))
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(30)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(arr, t, c)
+}
+
+func runCase(exe, input string, exp int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/420-429/427/verifierC.go
+++ b/0-999/400-499/420-429/427/verifierC.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func scc(n int, g, gr [][]int) [][]int {
+	visited := make([]bool, n)
+	order := make([]int, 0, n)
+	var dfs1 func(int)
+	dfs1 = func(v int) {
+		visited[v] = true
+		for _, u := range g[v] {
+			if !visited[u] {
+				dfs1(u)
+			}
+		}
+		order = append(order, v)
+	}
+	for i := 0; i < n; i++ {
+		if !visited[i] {
+			dfs1(i)
+		}
+	}
+	for i := range visited {
+		visited[i] = false
+	}
+	comps := [][]int{}
+	var dfs2 func(int, *[]int)
+	dfs2 = func(v int, comp *[]int) {
+		visited[v] = true
+		*comp = append(*comp, v)
+		for _, u := range gr[v] {
+			if !visited[u] {
+				dfs2(u, comp)
+			}
+		}
+	}
+	for i := len(order) - 1; i >= 0; i-- {
+		v := order[i]
+		if !visited[v] {
+			comp := []int{}
+			dfs2(v, &comp)
+			comps = append(comps, comp)
+		}
+	}
+	return comps
+}
+
+func expected(n int, costs []int64, g, gr [][]int) (int64, int64) {
+	comps := scc(n, g, gr)
+	total := int64(0)
+	ways := int64(1)
+	for _, comp := range comps {
+		minCost := costs[comp[0]]
+		count := int64(0)
+		for _, v := range comp {
+			if costs[v] < minCost {
+				minCost = costs[v]
+				count = 1
+			} else if costs[v] == minCost {
+				count++
+			}
+		}
+		total += minCost
+		ways = (ways * count) % mod
+	}
+	return total, ways
+}
+
+func generateCase(rng *rand.Rand) (string, int64, int64) {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(n*n + 1)
+	costs := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		costs[i] = int64(rng.Intn(100) + 1)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", costs[i]))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	g := make([][]int, n)
+	gr := make([][]int, n)
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		g[u] = append(g[u], v)
+		gr[v] = append(gr[v], u)
+		sb.WriteString(fmt.Sprintf("%d %d\n", u+1, v+1))
+	}
+	total, ways := expected(n, costs, g, gr)
+	return sb.String(), total, ways
+}
+
+func runCase(exe, input string, expTotal, expWays int64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var gotTotal, gotWays int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &gotTotal, &gotWays); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if gotTotal != expTotal || gotWays != expWays {
+		return fmt.Errorf("expected %d %d got %d %d", expTotal, expWays, gotTotal, gotWays)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, t, w := generateCase(rng)
+		if err := runCase(exe, in, t, w); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/420-429/427/verifierD.go
+++ b/0-999/400-499/420-429/427/verifierD.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s1, s2 string) int {
+	n1 := len(s1)
+	n2 := len(s2)
+	maxL := n1
+	if n2 < maxL {
+		maxL = n2
+	}
+	for L := 1; L <= maxL; L++ {
+		cnt1 := make(map[string]int)
+		for i := 0; i+L <= n1; i++ {
+			cnt1[s1[i:i+L]]++
+		}
+		cnt2 := make(map[string]int)
+		for i := 0; i+L <= n2; i++ {
+			cnt2[s2[i:i+L]]++
+		}
+		for sub, c1 := range cnt1 {
+			if c1 == 1 && cnt2[sub] == 1 {
+				return L
+			}
+		}
+	}
+	return -1
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	l1 := rng.Intn(10) + 1
+	l2 := rng.Intn(10) + 1
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	b1 := make([]byte, l1)
+	b2 := make([]byte, l2)
+	for i := range b1 {
+		b1[i] = letters[rng.Intn(len(letters))]
+	}
+	for i := range b2 {
+		b2[i] = letters[rng.Intn(len(letters))]
+	}
+	s1 := string(b1)
+	s2 := string(b2)
+	input := fmt.Sprintf("%s\n%s\n", s1, s2)
+	return input, expected(s1, s2)
+}
+
+func runCase(exe, input string, exp int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/420-429/427/verifierE.go
+++ b/0-999/400-499/420-429/427/verifierE.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, m int, a []int64) int64 {
+	sL := make([]int64, n)
+	for i := 0; i < n; i++ {
+		if i >= m {
+			sL[i] = a[i] + sL[i-m]
+		} else {
+			sL[i] = a[i]
+		}
+	}
+	sR := make([]int64, n)
+	for i := n - 1; i >= 0; i-- {
+		if i+m < n {
+			sR[i] = a[i] + sR[i+m]
+		} else {
+			sR[i] = a[i]
+		}
+	}
+	var best int64 = -1
+	for i := 0; i < n; {
+		j := i + 1
+		for j < n && a[j] == a[i] {
+			j++
+		}
+		S := a[i]
+		L := int64(i)
+		var sumL int64
+		if i > 0 {
+			sumL = sL[i-1]
+		}
+		TL := (L + int64(m) - 1) / int64(m)
+		distL := TL*S - sumL
+		Rn := int64(n - j)
+		var sumRsel int64
+		TR := (Rn + int64(m) - 1) / int64(m)
+		if Rn > 0 {
+			idx0 := int64(n-1) - (TR-1)*int64(m)
+			if idx0 < int64(j) {
+				modR := int64(n-1) % int64(m)
+				rem := int64(j) % int64(m)
+				delta := (modR - rem + int64(m)) % int64(m)
+				idx0 = int64(j) + delta
+			}
+			if idx0 < int64(n) {
+				sumRsel = sR[idx0]
+			}
+		}
+		distR := sumRsel - TR*S
+		total := 2 * (distL + distR)
+		if best < 0 || total < best {
+			best = total
+		}
+		i = j
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(4) + 1
+	a := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(41) - 20)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(n, m, a)
+}
+
+func runCase(exe, input string, exp int64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E in contest 427
- each verifier generates 100 random test cases and runs a given binary
- verifiers implement solution logic to compute expected answers for comparison

## Testing
- `go run verifierA.go ./427A_bin`
- `go run verifierB.go ./427B_bin`
- `go run verifierD.go ./427D_bin`
- `go run verifierE.go ./427E_bin`
- `go run verifierC.go ./427C_bin` *(fails as expected with incorrect binary)*

------
https://chatgpt.com/codex/tasks/task_e_687ecabee9ec83248541f9e743dd2629