### PR TITLE
Add solution verifiers for contest 425

### DIFF
--- a/0-999/400-499/420-429/425/verifierA.go
+++ b/0-999/400-499/420-429/425/verifierA.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type testCaseA struct {
+	n   int
+	k   int
+	arr []int
+}
+
+func genTestsA() []testCaseA {
+	rand.Seed(1)
+	tests := make([]testCaseA, 100)
+	for i := range tests {
+		n := rand.Intn(8) + 2 // 2..9
+		k := rand.Intn(4)
+		if k > n {
+			k = n
+		}
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(11) - 5
+		}
+		tests[i] = testCaseA{n, k, arr}
+	}
+	return tests
+}
+
+func solveA(tc testCaseA) int64 {
+	n, k := tc.n, tc.k
+	a := tc.arr
+	prefix := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i] + a[i]
+	}
+	maxSum := int64(-1 << 60)
+	for l := 0; l < n; l++ {
+		for r := l; r < n; r++ {
+			base := prefix[r+1] - prefix[l]
+			inside := make([]int, 0, r-l+1)
+			outside := make([]int, 0, n-(r-l+1))
+			for i := 0; i < n; i++ {
+				if i >= l && i <= r {
+					inside = append(inside, a[i])
+				} else {
+					outside = append(outside, a[i])
+				}
+			}
+			sort.Ints(inside)
+			sort.Sort(sort.Reverse(sort.IntSlice(outside)))
+			cur := int64(base)
+			if cur > maxSum {
+				maxSum = cur
+			}
+			maxSwap := k
+			if len(inside) < maxSwap {
+				maxSwap = len(inside)
+			}
+			if len(outside) < maxSwap {
+				maxSwap = len(outside)
+			}
+			for t := 0; t < maxSwap; t++ {
+				if outside[t] > inside[t] {
+					cur += int64(outside[t] - inside[t])
+					if cur > maxSum {
+						maxSum = cur
+					}
+				} else {
+					break
+				}
+			}
+		}
+	}
+	return maxSum
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+	for i, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		for j, v := range tc.arr {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		expect := solveA(tc)
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: non-integer output %q\n", i+1, out)
+			os.Exit(1)
+		}
+		if val != expect {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d got %d\n", i+1, expect, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/420-429/425/verifierB.go
+++ b/0-999/400-499/420-429/425/verifierB.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCaseB struct {
+	n    int
+	m    int
+	k    int
+	grid [][]int
+}
+
+func genTestsB() []testCaseB {
+	rand.Seed(2)
+	tests := make([]testCaseB, 100)
+	for i := range tests {
+		n := rand.Intn(3) + 2 // 2..4
+		m := rand.Intn(3) + 2
+		k := rand.Intn(4)
+		grid := make([][]int, n)
+		for r := 0; r < n; r++ {
+			grid[r] = make([]int, m)
+			for c := 0; c < m; c++ {
+				grid[r][c] = rand.Intn(2)
+			}
+		}
+		tests[i] = testCaseB{n, m, k, grid}
+	}
+	return tests
+}
+
+type cell struct{ r, c int }
+
+func valid(grid [][]int) bool {
+	n := len(grid)
+	m := len(grid[0])
+	vis := make([][]bool, n)
+	for i := range vis {
+		vis[i] = make([]bool, m)
+	}
+	dirs := []cell{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if vis[i][j] {
+				continue
+			}
+			v := grid[i][j]
+			q := []cell{{i, j}}
+			vis[i][j] = true
+			cells := []cell{{i, j}}
+			minR, maxR := i, i
+			minC, maxC := j, j
+			for len(q) > 0 {
+				u := q[0]
+				q = q[1:]
+				if u.r < minR {
+					minR = u.r
+				}
+				if u.r > maxR {
+					maxR = u.r
+				}
+				if u.c < minC {
+					minC = u.c
+				}
+				if u.c > maxC {
+					maxC = u.c
+				}
+				for _, d := range dirs {
+					nr, nc := u.r+d.r, u.c+d.c
+					if nr >= 0 && nr < n && nc >= 0 && nc < m && !vis[nr][nc] && grid[nr][nc] == v {
+						vis[nr][nc] = true
+						q = append(q, cell{nr, nc})
+						cells = append(cells, cell{nr, nc})
+					}
+				}
+			}
+			area := (maxR - minR + 1) * (maxC - minC + 1)
+			if area != len(cells) {
+				return false
+			}
+			for rr := minR; rr <= maxR; rr++ {
+				for cc := minC; cc <= maxC; cc++ {
+					if grid[rr][cc] != v {
+						return false
+					}
+				}
+			}
+		}
+	}
+	return true
+}
+
+func minChanges(grid [][]int, k int) int {
+	n := len(grid)
+	m := len(grid[0])
+	cells := make([]cell, 0, n*m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			cells = append(cells, cell{i, j})
+		}
+	}
+	best := k + 1
+	N := len(cells)
+	for mask := 0; mask < 1<<N; mask++ {
+		cnt := bits.OnesCount(uint(mask))
+		if cnt > k {
+			continue
+		}
+		changed := make([][]int, n)
+		for i := 0; i < n; i++ {
+			changed[i] = make([]int, m)
+			copy(changed[i], grid[i])
+		}
+		for b := 0; b < N; b++ {
+			if mask&(1<<b) != 0 {
+				c := cells[b]
+				changed[c.r][c.c] ^= 1
+			}
+		}
+		if valid(changed) {
+			if cnt < best {
+				best = cnt
+			}
+		}
+	}
+	if best > k {
+		return -1
+	}
+	return best
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+	for i, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d %d\n", tc.n, tc.m, tc.k)
+		for r := 0; r < tc.n; r++ {
+			for c := 0; c < tc.m; c++ {
+				if c > 0 {
+					input.WriteByte(' ')
+				}
+				fmt.Fprint(&input, tc.grid[r][c])
+			}
+			input.WriteByte('\n')
+		}
+		expect := minChanges(tc.grid, tc.k)
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: non-integer output %q\n", i+1, out)
+			os.Exit(1)
+		}
+		if val != expect {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d got %d\n", i+1, expect, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/420-429/425/verifierC.go
+++ b/0-999/400-499/420-429/425/verifierC.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type testCaseC struct {
+	n, m, s, e int
+	a          []int
+	b          []int
+}
+
+func genTestsC() []testCaseC {
+	rand.Seed(3)
+	tests := make([]testCaseC, 100)
+	for i := range tests {
+		n := rand.Intn(8) + 2 //2..9
+		m := rand.Intn(8) + 2
+		s := rand.Intn(15) + 5 //5..19
+		e := rand.Intn(3) + 1  //1..3
+		a := make([]int, n)
+		b := make([]int, m)
+		for j := range a {
+			a[j] = rand.Intn(5) + 1
+		}
+		for j := range b {
+			b[j] = rand.Intn(5) + 1
+		}
+		tests[i] = testCaseC{n, m, s, e, a, b}
+	}
+	return tests
+}
+
+func solveC(tc testCaseC) int {
+	n, m, s, e := tc.n, tc.m, tc.s, tc.e
+	a, b := tc.a, tc.b
+	maxVal := 0
+	for _, v := range b {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	posList := make([][]int, maxVal+1)
+	for i, v := range b {
+		posList[v] = append(posList[v], i+1)
+	}
+	maxK := s / e
+	if maxK > n {
+		maxK = n
+	}
+	if maxK > m {
+		maxK = m
+	}
+	INFJ := m + 1
+	dp := make([]int, maxK+2)
+	for i := range dp {
+		dp[i] = INFJ
+	}
+	dp[0] = 0
+	INF_SUM := n + m + 5
+	minSum := make([]int, maxK+2)
+	for i := range minSum {
+		minSum[i] = INF_SUM
+	}
+	curMax := 0
+	for i := 1; i <= n; i++ {
+		v := a[i-1]
+		if v <= maxVal {
+			lst := posList[v]
+			if len(lst) == 0 {
+				continue
+			}
+			ub := curMax
+			if ub > maxK-1 {
+				ub = maxK - 1
+			}
+			for t := ub; t >= 0; t-- {
+				prevJ := dp[t]
+				if prevJ >= INFJ {
+					continue
+				}
+				idx := sort.Search(len(lst), func(k int) bool { return lst[k] > prevJ })
+				if idx < len(lst) {
+					j := lst[idx]
+					if j < dp[t+1] {
+						dp[t+1] = j
+					}
+					sum := i + j
+					if sum < minSum[t+1] {
+						minSum[t+1] = sum
+					}
+					if t+1 > curMax {
+						curMax = t + 1
+					}
+				}
+			}
+		}
+	}
+	ans := 0
+	for t := 1; t <= curMax; t++ {
+		if t*e > s {
+			break
+		}
+		if minSum[t] <= s-t*e {
+			ans = t
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+	for i, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d %d %d\n", tc.n, tc.m, tc.s, tc.e)
+		for j, v := range tc.a {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		for j, v := range tc.b {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		expect := solveC(tc)
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: non-integer output %q\n", i+1, out)
+			os.Exit(1)
+		}
+		if val != expect {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d got %d\n", i+1, expect, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/420-429/425/verifierD.go
+++ b/0-999/400-499/420-429/425/verifierD.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCaseD struct {
+	n   int
+	pts [][2]int
+}
+
+func genTestsD() []testCaseD {
+	rand.Seed(4)
+	tests := make([]testCaseD, 100)
+	for i := range tests {
+		n := rand.Intn(8) + 1 //1..8
+		pts := make([][2]int, n)
+		for j := range pts {
+			pts[j][0] = rand.Intn(7)
+			pts[j][1] = rand.Intn(7)
+		}
+		tests[i] = testCaseD{n, pts}
+	}
+	return tests
+}
+
+func solveD(tc testCaseD) int64 {
+	pts := tc.pts
+	xsAtY := map[int][]int{}
+	ysAtX := map[int][]int{}
+	pointSet := map[int64]struct{}{}
+	for _, p := range pts {
+		x, y := p[0], p[1]
+		xsAtY[y] = append(xsAtY[y], x)
+		ysAtX[x] = append(ysAtX[x], y)
+		key := (int64(x) << 32) | int64(y)
+		pointSet[key] = struct{}{}
+	}
+	for y := range xsAtY {
+		sortInts(xsAtY[y])
+	}
+	for x := range ysAtX {
+		sortInts(ysAtX[x])
+	}
+	var result int64
+	for _, p := range pts {
+		x, y := p[0], p[1]
+		xs := xsAtY[y]
+		ys := ysAtX[x]
+		if len(xs) < len(ys) {
+			for _, x2 := range xs {
+				if x2 <= x {
+					continue
+				}
+				d := x2 - x
+				key1 := (int64(x) << 32) | int64(y+d)
+				key2 := (int64(x2) << 32) | int64(y+d)
+				if _, ok := pointSet[key1]; ok {
+					if _, ok2 := pointSet[key2]; ok2 {
+						result++
+					}
+				}
+			}
+		} else {
+			for _, y2 := range ys {
+				if y2 <= y {
+					continue
+				}
+				d := y2 - y
+				key1 := (int64(x+d) << 32) | int64(y)
+				key2 := (int64(x+d) << 32) | int64(y2)
+				if _, ok := pointSet[key1]; ok {
+					if _, ok2 := pointSet[key2]; ok2 {
+						result++
+					}
+				}
+			}
+		}
+	}
+	return result
+}
+
+func sortInts(a []int) {
+	if len(a) < 2 {
+		return
+	}
+	for i := 1; i < len(a); i++ {
+		v := a[i]
+		j := i - 1
+		for j >= 0 && a[j] > v {
+			a[j+1] = a[j]
+			j--
+		}
+		a[j+1] = v
+	}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+	for i, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintln(&input, tc.n)
+		for _, p := range tc.pts {
+			fmt.Fprintf(&input, "%d %d\n", p[0], p[1])
+		}
+		expect := solveD(tc)
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: non-integer output %q\n", i+1, out)
+			os.Exit(1)
+		}
+		if val != expect {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d got %d\n", i+1, expect, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/420-429/425/verifierE.go
+++ b/0-999/400-499/420-429/425/verifierE.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const mod = 1000000007
+
+type testCaseE struct {
+	n int
+	k int
+}
+
+func genTestsE() []testCaseE {
+	rand.Seed(5)
+	tests := make([]testCaseE, 100)
+	for i := range tests {
+		n := rand.Intn(8) + 1 //1..8
+		k := rand.Intn(n + 1)
+		tests[i] = testCaseE{n, k}
+	}
+	return tests
+}
+
+func solveE(tc testCaseE) int {
+	n, k := tc.n, tc.k
+	if k > n {
+		return 0
+	}
+	maxExp := n * n
+	pow2 := make([]int, maxExp+1)
+	pow2[0] = 1
+	for i := 1; i <= maxExp; i++ {
+		pow2[i] = pow2[i-1] * 2 % mod
+	}
+	A := make([][]int, n+1)
+	for prev := 0; prev <= n; prev++ {
+		A[prev] = make([]int, n+1)
+		for i := prev + 1; i <= n; i++ {
+			d := i - prev
+			v := pow2[d] - 1
+			if v < 0 {
+				v += mod
+			}
+			e := d * prev
+			v = int(int64(v) * int64(pow2[e]) % mod)
+			A[prev][i] = v
+		}
+	}
+	dp := make([][]int, k+1)
+	for t := 0; t <= k; t++ {
+		dp[t] = make([]int, n+1)
+	}
+	dp[0][0] = 1
+	for t := 1; t <= k; t++ {
+		for i := 1; i <= n; i++ {
+			var sum int64
+			for prev := 0; prev < i; prev++ {
+				if dp[t-1][prev] != 0 {
+					sum += int64(dp[t-1][prev]) * int64(A[prev][i])
+					sum %= mod
+				}
+			}
+			dp[t][i] = int(sum % mod)
+		}
+	}
+	var ans int64
+	for i := 0; i <= n; i++ {
+		if dp[k][i] == 0 {
+			continue
+		}
+		e := (n - i) * i
+		ans = (ans + int64(dp[k][i])*int64(pow2[e])) % mod
+	}
+	return int(ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+	for i, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		expect := solveE(tc)
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: non-integer output %q\n", i+1, out)
+			os.Exit(1)
+		}
+		if val != expect {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d got %d\n", i+1, expect, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–E of contest 425
- each verifier generates 100 random tests
- run candidate solution binaries or `.go` files and check outputs

## Testing
- `go build 0-999/400-499/420-429/425/verifierA.go`
- `go build 0-999/400-499/420-429/425/verifierB.go`
- `go build 0-999/400-499/420-429/425/verifierC.go`
- `go build 0-999/400-499/420-429/425/verifierD.go`
- `go build 0-999/400-499/420-429/425/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687eca32bd2883249b8073e0f989ca82