### PR TITLE
Add Go solution verifiers for Contest 419

### DIFF
--- a/0-999/400-499/410-419/419/verifierA.go
+++ b/0-999/400-499/410-419/419/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(word string) string {
+	sym := map[rune]bool{
+		'A': true, 'H': true, 'I': true, 'M': true,
+		'O': true, 'T': true, 'U': true, 'V': true,
+		'W': true, 'X': true, 'Y': true,
+	}
+	n := len(word)
+	for i, r := range word {
+		if !sym[r] || r != rune(word[n-1-i]) {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func generateCaseA(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	letters := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseA(rng)
+		expect := solveA(strings.TrimSpace(tc))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/419/verifierB.go
+++ b/0-999/400-499/410-419/419/verifierB.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type event struct {
+	t  int
+	op byte
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func hasBad(pref []int, l, r int) bool {
+	if l == 0 {
+		return pref[r] > 0
+	}
+	return pref[r]-pref[l-1] > 0
+}
+
+func solveB(n, m int, ops []event, ids []int) string {
+	events := make([][]event, n+1)
+	first := make([]byte, n+1)
+	opByte := make([]byte, m+1)
+	for i := 1; i <= m; i++ {
+		b := ops[i-1].op
+		id := ids[i-1]
+		opByte[i] = b
+		if first[id] == 0 {
+			first[id] = b
+		}
+		events[id] = append(events[id], event{t: i, op: b})
+	}
+	initial := make([]bool, n+1)
+	initCnt := 0
+	for id := 1; id <= n; id++ {
+		if first[id] == '-' {
+			initial[id] = true
+			initCnt++
+		}
+	}
+	cur := make([]int, m+1)
+	bad := make([]int, m+1)
+	pref := make([]int, m+1)
+	cur[0] = initCnt
+	if cur[0] > 0 {
+		bad[0] = 1
+	}
+	pref[0] = bad[0]
+	for i := 1; i <= m; i++ {
+		if opByte[i] == '+' {
+			cur[i] = cur[i-1] + 1
+		} else {
+			cur[i] = cur[i-1] - 1
+		}
+		if cur[i] > 0 {
+			bad[i] = 1
+		}
+		pref[i] = pref[i-1] + bad[i]
+	}
+	res := make([]int, 0)
+	for id := 1; id <= n; id++ {
+		userEvents := events[id]
+		last := 0
+		online := initial[id]
+		possible := true
+		for _, e := range userEvents {
+			if !online {
+				if last <= e.t-1 && hasBad(pref, last, e.t-1) {
+					possible = false
+					break
+				}
+			}
+			if e.op == '+' {
+				online = true
+			} else {
+				online = false
+			}
+			last = e.t
+		}
+		if possible && !online {
+			if last <= m && hasBad(pref, last, m) {
+				possible = false
+			}
+		}
+		if possible {
+			res = append(res, id)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d", len(res)))
+	if len(res) > 0 {
+		sb.WriteByte('\n')
+		for i, id := range res {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", id)
+		}
+	}
+	return sb.String()
+}
+
+func generateCaseB(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(10) + 1
+	states := make([]bool, n+1)
+	for i := 1; i <= n; i++ {
+		states[i] = rng.Intn(2) == 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			off := []int{}
+			for id := 1; id <= n; id++ {
+				if !states[id] {
+					off = append(off, id)
+				}
+			}
+			if len(off) == 0 {
+				on := []int{}
+				for id := 1; id <= n; id++ {
+					if states[id] {
+						on = append(on, id)
+					}
+				}
+				id := on[rng.Intn(len(on))]
+				states[id] = false
+				fmt.Fprintf(&sb, "- %d\n", id)
+				continue
+			}
+			id := off[rng.Intn(len(off))]
+			states[id] = true
+			fmt.Fprintf(&sb, "+ %d\n", id)
+		} else {
+			on := []int{}
+			for id := 1; id <= n; id++ {
+				if states[id] {
+					on = append(on, id)
+				}
+			}
+			if len(on) == 0 {
+				off := []int{}
+				for id := 1; id <= n; id++ {
+					if !states[id] {
+						off = append(off, id)
+					}
+				}
+				id := off[rng.Intn(len(off))]
+				states[id] = true
+				fmt.Fprintf(&sb, "+ %d\n", id)
+				continue
+			}
+			id := on[rng.Intn(len(on))]
+			states[id] = false
+			fmt.Fprintf(&sb, "- %d\n", id)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseB(rng)
+		scanner := bufio.NewScanner(strings.NewReader(tc))
+		scanner.Split(bufio.ScanWords)
+		var nums []string
+		for scanner.Scan() {
+			nums = append(nums, scanner.Text())
+		}
+		n, _ := strconv.Atoi(nums[0])
+		m, _ := strconv.Atoi(nums[1])
+		ops := make([]event, m)
+		ids := make([]int, m)
+		idx := 2
+		for j := 0; j < m; j++ {
+			op := nums[idx]
+			id, _ := strconv.Atoi(nums[idx+1])
+			ops[j] = event{t: j + 1, op: op[0]}
+			ids[j] = id
+			idx += 2
+		}
+		expect := solveB(n, m, ops, ids)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/419/verifierC.go
+++ b/0-999/400-499/410-419/419/verifierC.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type pair struct{ u, v int }
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(n, p int, edges []pair) string {
+	deg := make([]int, n+1)
+	for _, e := range edges {
+		deg[e.u]++
+		deg[e.v]++
+	}
+	sortedDeg := make([]int, n)
+	for i := 1; i <= n; i++ {
+		sortedDeg[i-1] = deg[i]
+	}
+	sort.Ints(sortedDeg)
+	var ans int64
+	for i := 0; i < n; i++ {
+		need := p - sortedDeg[i]
+		j := sort.Search(n, func(j int) bool { return sortedDeg[j] >= need })
+		if j < i+1 {
+			j = i + 1
+		}
+		if j < n {
+			ans += int64(n - j)
+		}
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].u != edges[j].u {
+			return edges[i].u < edges[j].u
+		}
+		return edges[i].v < edges[j].v
+	})
+	for i := 0; i < len(edges); {
+		j := i + 1
+		for j < len(edges) && edges[j] == edges[i] {
+			j++
+		}
+		cnt := j - i
+		u, v := edges[i].u, edges[i].v
+		if deg[u]+deg[v] >= p && deg[u]+deg[v]-cnt < p {
+			ans--
+		}
+		i = j
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCaseC(rng *rand.Rand) string {
+	n := rng.Intn(6) + 2
+	p := rng.Intn(n + 1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, p)
+	for i := 1; i <= n; i++ {
+		x := rng.Intn(n) + 1
+		for x == i {
+			x = rng.Intn(n) + 1
+		}
+		y := rng.Intn(n) + 1
+		for y == i || y == x {
+			y = rng.Intn(n) + 1
+		}
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseC(rng)
+		scanner := bufio.NewScanner(strings.NewReader(tc))
+		scanner.Split(bufio.ScanWords)
+		var fields []string
+		for scanner.Scan() {
+			fields = append(fields, scanner.Text())
+		}
+		n, _ := strconv.Atoi(fields[0])
+		pVal, _ := strconv.Atoi(fields[1])
+		edges := make([]pair, n)
+		idx := 2
+		for j := 0; j < n; j++ {
+			x, _ := strconv.Atoi(fields[idx])
+			y, _ := strconv.Atoi(fields[idx+1])
+			u, v := x, y
+			if u > v {
+				u, v = v, u
+			}
+			edges[j] = pair{u, v}
+			idx += 2
+		}
+		expect := solveC(n, pVal, edges)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/419/verifierD.go
+++ b/0-999/400-499/410-419/419/verifierD.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Node struct {
+	left, right *Node
+	sz          int
+	label       int
+	prio        int
+}
+
+func upd(n *Node) {
+	n.sz = 1
+	if n.left != nil {
+		n.sz += n.left.sz
+	}
+	if n.right != nil {
+		n.sz += n.right.sz
+	}
+}
+
+func merge(a, b *Node) *Node {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	if a.prio < b.prio {
+		a.right = merge(a.right, b)
+		upd(a)
+		return a
+	}
+	b.left = merge(a, b.left)
+	upd(b)
+	return b
+}
+
+func split(n *Node, k int) (a, b *Node) {
+	if n == nil {
+		return nil, nil
+	}
+	lsz := 0
+	if n.left != nil {
+		lsz = n.left.sz
+	}
+	if k <= lsz {
+		a, n.left = split(n.left, k)
+		upd(n)
+		return a, n
+	}
+	n.right, b = split(n.right, k-lsz-1)
+	upd(n)
+	return n, b
+}
+
+func solveD(n, m int, ops [][2]int) string {
+	rand.Seed(42)
+	var root *Node
+	for i := 0; i < n; i++ {
+		nd := &Node{prio: rand.Int()}
+		nd.sz = 1
+		root = merge(root, nd)
+	}
+	assigned := make([]bool, n+1)
+	for i := 0; i < m; i++ {
+		x := ops[i][0]
+		y := ops[i][1]
+		if y < 1 || y > root.sz {
+			return "-1"
+		}
+		t1, t2 := split(root, y-1)
+		tmid, t3 := split(t2, 1)
+		if tmid == nil {
+			return "-1"
+		}
+		if tmid.label != 0 && tmid.label != x {
+			return "-1"
+		}
+		if tmid.label == 0 {
+			if assigned[x] {
+				return "-1"
+			}
+			tmid.label = x
+			assigned[x] = true
+		}
+		tmp := merge(t1, t3)
+		root = merge(tmid, tmp)
+	}
+	res := make([]int, 0, n)
+	var stack []*Node
+	cur := root
+	curLabel := 1
+	for cur != nil || len(stack) > 0 {
+		for cur != nil {
+			stack = append(stack, cur)
+			cur = cur.left
+		}
+		node := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if node.label == 0 {
+			for curLabel <= n && assigned[curLabel] {
+				curLabel++
+			}
+			node.label = curLabel
+			assigned[curLabel] = true
+		}
+		res = append(res, node.label)
+		cur = node.right
+	}
+	var sb strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	return sb.String()
+}
+
+func generateCaseD(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(n) + 1
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	arr := make([]int, len(perm))
+	copy(arr, perm)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		y := rng.Intn(n) + 1
+		x := arr[y-1]
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+		arr = append([]int{x}, append(arr[:y-1], arr[y:]...)...)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseD(rng)
+		scanner := bufio.NewScanner(strings.NewReader(tc))
+		scanner.Split(bufio.ScanWords)
+		var fields []string
+		for scanner.Scan() {
+			fields = append(fields, scanner.Text())
+		}
+		n, _ := strconv.Atoi(fields[0])
+		m, _ := strconv.Atoi(fields[1])
+		ops := make([][2]int, m)
+		idx := 2
+		for j := 0; j < m; j++ {
+			x, _ := strconv.Atoi(fields[idx])
+			y, _ := strconv.Atoi(fields[idx+1])
+			ops[j] = [2]int{x, y}
+			idx += 2
+		}
+		expect := solveD(n, m, ops)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/419/verifierE.go
+++ b/0-999/400-499/410-419/419/verifierE.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type event struct {
+	angle float64
+	delta int
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveE(n int, d float64, circles [][3]float64) string {
+	events := make([]event, 0, n*8)
+	twoPi := 2 * math.Pi
+	for i := 0; i < n; i++ {
+		xi, yi, ri := circles[i][0], circles[i][1], circles[i][2]
+		Di := math.Hypot(xi, yi)
+		phi := math.Atan2(yi, xi)
+		kmin := int(math.Ceil((Di - ri) / d))
+		if kmin < 1 {
+			kmin = 1
+		}
+		kmax := int(math.Floor((Di + ri) / d))
+		for k := kmin; k <= kmax; k++ {
+			kd := float64(k) * d
+			A := (kd - ri) / Di
+			B := (kd + ri) / Di
+			if A > 1 || B < -1 {
+				continue
+			}
+			if A < -1 {
+				A = -1
+			}
+			if B > 1 {
+				B = 1
+			}
+			al := math.Acos(A)
+			au := math.Acos(B)
+			intervals := [][2]float64{{phi + au, phi + al}, {phi + twoPi - al, phi + twoPi - au}}
+			for _, iv := range intervals {
+				s, e := iv[0], iv[1]
+				if s < 0 {
+					s += twoPi * (math.Floor(-s/twoPi) + 1)
+				}
+				if e < 0 {
+					e += twoPi * (math.Floor(-e/twoPi) + 1)
+				}
+				s = math.Mod(s, twoPi)
+				e = math.Mod(e, twoPi)
+				if e < s {
+					events = append(events, event{s, 1})
+					events = append(events, event{twoPi, -1})
+					events = append(events, event{0, 1})
+					events = append(events, event{e, -1})
+				} else {
+					events = append(events, event{s, 1})
+					events = append(events, event{e, -1})
+				}
+			}
+		}
+	}
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].angle == events[j].angle {
+			return events[i].delta > events[j].delta
+		}
+		return events[i].angle < events[j].angle
+	})
+	maxCnt := 0
+	cur := 0
+	for _, ev := range events {
+		cur += ev.delta
+		if cur > maxCnt {
+			maxCnt = cur
+		}
+	}
+	return fmt.Sprintf("%d", maxCnt)
+}
+
+func generateCaseE(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	d := float64(rng.Intn(6) + 5)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %.0f\n", n, d)
+	for i := 0; i < n; i++ {
+		xi := float64(rng.Intn(21) - 10)
+		yi := float64(rng.Intn(21) - 10)
+		ri := float64(rng.Intn(5) + 1)
+		for math.Hypot(xi, yi) <= ri {
+			xi = float64(rng.Intn(21) - 10)
+			yi = float64(rng.Intn(21) - 10)
+		}
+		fmt.Fprintf(&sb, "%.0f %.0f %.0f\n", xi, yi, ri)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseE(rng)
+		scanner := bufio.NewScanner(strings.NewReader(tc))
+		scanner.Split(bufio.ScanWords)
+		var fields []string
+		for scanner.Scan() {
+			fields = append(fields, scanner.Text())
+		}
+		n, _ := strconv.Atoi(fields[0])
+		dVal, _ := strconv.ParseFloat(fields[1], 64)
+		circles := make([][3]float64, n)
+		idx := 2
+		for j := 0; j < n; j++ {
+			x, _ := strconv.ParseFloat(fields[idx], 64)
+			y, _ := strconv.ParseFloat(fields[idx+1], 64)
+			r, _ := strconv.ParseFloat(fields[idx+2], 64)
+			circles[j] = [3]float64{x, y, r}
+			idx += 3
+		}
+		expect := solveE(n, dVal, circles)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go through verifierE.go for contest 419
- each verifier runs 100 random tests and checks a supplied binary (or Go file)

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ec88e86108324b5bf413a6846389d