### PR TITLE
Add verifiers for Codeforces Round 417

### DIFF
--- a/0-999/400-499/410-419/417/verifierA.go
+++ b/0-999/400-499/410-419/417/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(c, d, n, m, k int) int {
+	total := n*m - k
+	if total < 0 {
+		total = 0
+	}
+	maxMain := 0
+	if n > 0 {
+		maxMain = (total + n - 1) / n
+	}
+	best := int(^uint(0) >> 1)
+	for x := 0; x <= maxMain; x++ {
+		rem := total - x*n
+		if rem < 0 {
+			rem = 0
+		}
+		cost := x*c + rem*d
+		if cost < best {
+			best = cost
+		}
+	}
+	return best
+}
+
+func runCase(bin string, c, d, n, m, k int) error {
+	input := fmt.Sprintf("%d %d\n%d %d\n%d\n", c, d, n, m, k)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := expected(c, d, n, m, k)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := rng.Intn(100) + 1
+		d := rng.Intn(100) + 1
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		k := rng.Intn(n*m + 5)
+		if err := runCase(bin, c, d, n, m, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: c=%d d=%d n=%d m=%d k=%d\n", i+1, err, c, d, n, m, k)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/417/verifierB.go
+++ b/0-999/400-499/410-419/417/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int, pairs [][2]int) string {
+	const maxK = 100000
+	mex := make([]int, maxK+1)
+	for i := 0; i < n; i++ {
+		x := pairs[i][0]
+		k := pairs[i][1]
+		cur := mex[k]
+		if x > cur {
+			return "NO"
+		}
+		if x == cur {
+			mex[k] = cur + 1
+		}
+	}
+	return "YES"
+}
+
+func runCase(bin string, n int, pairs [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", pairs[i][0], pairs[i][1]))
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expected(n, pairs)
+	if strings.ToUpper(got) != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(15) + 1
+		pairs := make([][2]int, n)
+		tmpMex := make(map[int]int)
+		for j := 0; j < n; j++ {
+			k := rng.Intn(10) + 1
+			cur := tmpMex[k]
+			var x int
+			if rng.Intn(3) == 0 {
+				x = cur + rng.Intn(3) + 1 // invalid
+			} else {
+				if cur > 0 {
+					x = rng.Intn(cur + 1)
+				} else {
+					if rng.Intn(2) == 0 {
+						x = 0
+					} else {
+						x = 1
+					}
+				}
+				if x == cur {
+					tmpMex[k] = cur + 1
+				}
+			}
+			if x < 0 {
+				x = 0
+			}
+			pairs[j] = [2]int{x, k}
+		}
+		if err := runCase(bin, n, pairs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			fmt.Fprintf(os.Stderr, "input:\n%d\n", n)
+			for _, p := range pairs {
+				fmt.Fprintf(os.Stderr, "%d %d\n", p[0], p[1])
+			}
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/417/verifierC.go
+++ b/0-999/400-499/410-419/417/verifierC.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func allowedK(n int) int {
+	if n%2 == 0 {
+		return n/2 - 1
+	}
+	return n / 2
+}
+
+func runCase(bin string, n, k int) error {
+	input := fmt.Sprintf("%d %d\n", n, k)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+
+	rdr := bufio.NewReader(strings.NewReader(out.String()))
+	var first int
+	if _, err := fmt.Fscan(rdr, &first); err != nil {
+		return fmt.Errorf("bad output")
+	}
+	if first == -1 {
+		if k <= allowedK(n) {
+			return fmt.Errorf("unexpected -1 output")
+		}
+		return nil
+	}
+	total := first
+	if total != n*k {
+		return fmt.Errorf("expected %d pairs, got %d", n*k, total)
+	}
+	wins := make([]int, n+1)
+	seen := make(map[[2]int]bool)
+	for i := 0; i < total; i++ {
+		var a, b int
+		if _, err := fmt.Fscan(rdr, &a, &b); err != nil {
+			return fmt.Errorf("not enough pairs")
+		}
+		if a < 1 || a > n || b < 1 || b > n || a == b {
+			return fmt.Errorf("invalid pair")
+		}
+		key := [2]int{a, b}
+		if seen[key] {
+			return fmt.Errorf("duplicate pair")
+		}
+		seen[key] = true
+		wins[a]++
+	}
+	for i := 1; i <= n; i++ {
+		if wins[i] != k {
+			return fmt.Errorf("team %d wins %d times", i, wins[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 2 // at least 2
+		k := rng.Intn(n)
+		if err := runCase(bin, n, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d k=%d\n", i+1, err, n, k)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/417/verifierD.go
+++ b/0-999/400-499/410-419/417/verifierD.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Friend struct {
+	k    int64
+	x    int64
+	mask int
+}
+
+func solveCase(n, m int, b int64, fs []Friend) int64 {
+	sort.Slice(fs, func(i, j int) bool { return fs[i].k < fs[j].k })
+	full := (1 << m) - 1
+	const INF int64 = 1<<63 - 1
+	dp := make([]int64, 1<<m)
+	for i := 1; i <= full; i++ {
+		dp[i] = INF
+	}
+	dp[0] = 0
+	ans := INF
+	for i := 0; i < n; {
+		curK := fs[i].k
+		j := i
+		for j < n && fs[j].k == curK {
+			f := fs[j]
+			for mask := full; ; mask-- {
+				prev := dp[mask]
+				if prev < INF {
+					nm := mask | f.mask
+					cost := prev + f.x
+					if cost < dp[nm] {
+						dp[nm] = cost
+					}
+				}
+				if mask == 0 {
+					break
+				}
+			}
+			j++
+		}
+		if dp[full] < INF {
+			total := dp[full] + curK*b
+			if total < ans {
+				ans = total
+			}
+		}
+		i = j
+	}
+	if ans == INF {
+		return -1
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(4) + 1
+	b := int64(rng.Intn(5) + 1)
+	friends := make([]Friend, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, b)
+	for i := 0; i < n; i++ {
+		xi := int64(rng.Intn(10) + 1)
+		ki := int64(rng.Intn(5) + 1)
+		mi := rng.Intn(m) + 1
+		probs := rng.Perm(m)[:mi]
+		mask := 0
+		for _, p := range probs {
+			mask |= 1 << p
+		}
+		friends[i] = Friend{k: ki, x: xi, mask: mask}
+		fmt.Fprintf(&sb, "%d %d %d\n", xi, ki, mi)
+		for idx, p := range probs {
+			if idx > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", p+1)
+		}
+		sb.WriteByte('\n')
+	}
+	expect := solveCase(n, m, b, friends)
+	return sb.String(), expect
+}
+
+func runCase(bin, input string, expected int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output")
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/417/verifierE.go
+++ b/0-999/400-499/410-419/417/verifierE.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isSquare(x int64) bool {
+	r := int64(math.Round(math.Sqrt(float64(x))))
+	return r*r == x
+}
+
+func runCase(bin string, n, m int) error {
+	input := fmt.Sprintf("%d %d\n", n, m)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	numbers := []int64{}
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		for _, f := range fields {
+			var v int64
+			if _, err := fmt.Sscan(f, &v); err == nil {
+				numbers = append(numbers, v)
+			}
+		}
+	}
+	if len(numbers) != n*m {
+		return fmt.Errorf("expected %d numbers got %d", n*m, len(numbers))
+	}
+	mat := make([][]int64, n)
+	idx := 0
+	for i := 0; i < n; i++ {
+		row := make([]int64, m)
+		for j := 0; j < m; j++ {
+			v := numbers[idx]
+			if v <= 0 || v > 1e8 {
+				return fmt.Errorf("invalid value")
+			}
+			row[j] = v
+			idx++
+		}
+		mat[i] = row
+	}
+	for i := 0; i < n; i++ {
+		var sum int64
+		for j := 0; j < m; j++ {
+			sum += mat[i][j] * mat[i][j]
+		}
+		if !isSquare(sum) {
+			return fmt.Errorf("row %d not square", i+1)
+		}
+	}
+	for j := 0; j < m; j++ {
+		var sum int64
+		for i := 0; i < n; i++ {
+			sum += mat[i][j] * mat[i][j]
+		}
+		if !isSquare(sum) {
+			return fmt.Errorf("col %d not square", j+1)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 1
+		m := rng.Intn(4) + 1
+		if err := runCase(bin, n, m); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d m=%d\n", i+1, err, n, m)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for all problems A–E of contest 417
- each verifier generates 100 random tests and runs a candidate binary (or Go source)
- verifiers check correctness according to the official solutions

## Testing
- `go build 0-999/400-499/410-419/417/verifierA.go`
- `go build 0-999/400-499/410-419/417/verifierB.go`
- `go build 0-999/400-499/410-419/417/verifierC.go`
- `go build 0-999/400-499/410-419/417/verifierD.go`
- `go build 0-999/400-499/410-419/417/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687ec80268088324a03c45e454af6feb