### PR TITLE
Add Go verifiers for contest 414

### DIFF
--- a/0-999/400-499/410-419/414/verifierA.go
+++ b/0-999/400-499/410-419/414/verifierA.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func checkCase(n, k int, out string) error {
+	out = strings.TrimSpace(out)
+	if out == "-1" {
+		if !(k < n/2 || (n == 1 && k > 0)) {
+			return fmt.Errorf("solution exists but got -1")
+		}
+		return nil
+	}
+	tokens := strings.Fields(out)
+	if len(tokens) != n {
+		return fmt.Errorf("expected %d numbers, got %d", n, len(tokens))
+	}
+	if k < n/2 || (n == 1 && k > 0) {
+		return fmt.Errorf("output provided but no solution should exist")
+	}
+	seen := map[int]bool{}
+	arr := make([]int, n)
+	for i, t := range tokens {
+		val, err := strconv.Atoi(t)
+		if err != nil {
+			return fmt.Errorf("invalid integer %q", t)
+		}
+		if val < 1 || val > 1_000_000_000 {
+			return fmt.Errorf("value out of range: %d", val)
+		}
+		if seen[val] {
+			return fmt.Errorf("duplicate value %d", val)
+		}
+		seen[val] = true
+		arr[i] = val
+	}
+	sum := 0
+	for i := 0; i+1 < n; i += 2 {
+		sum += gcd(arr[i], arr[i+1])
+	}
+	if sum != k {
+		return fmt.Errorf("expected gcd sum %d got %d", k, sum)
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, int, int) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(40)
+	if rng.Intn(5) == 0 {
+		n = 1
+		k = rng.Intn(3)
+	}
+	return fmt.Sprintf("%d %d\n", n, k), n, k
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, n, k := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := checkCase(n, k, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/414/verifierB.go
+++ b/0-999/400-499/410-419/414/verifierB.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(n, k int) int {
+	prev := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		prev[i] = 1
+	}
+	cur := make([]int, n+1)
+	for length := 2; length <= k; length++ {
+		for i := 1; i <= n; i++ {
+			cur[i] = 0
+		}
+		for x := 1; x <= n; x++ {
+			v := prev[x]
+			if v == 0 {
+				continue
+			}
+			for m := x; m <= n; m += x {
+				cur[m] += v
+				if cur[m] >= mod {
+					cur[m] -= mod
+				}
+			}
+		}
+		prev, cur = cur, prev
+	}
+	ans := 0
+	for i := 1; i <= n; i++ {
+		ans += prev[i]
+		if ans >= mod {
+			ans -= mod
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(30) + 1
+	k := rng.Intn(10) + 1
+	input := fmt.Sprintf("%d %d\n", n, k)
+	expected := solveB(n, k)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output\ninput:\n%soutput:\n%s", i+1, input, out)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/414/verifierC.go
+++ b/0-999/400-499/410-419/414/verifierC.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func countInv(a []int) int64 {
+	tmp := make([]int, len(a))
+	var inv func(l, r int) int64
+	inv = func(l, r int) int64 {
+		if r-l <= 1 {
+			return 0
+		}
+		m := (l + r) / 2
+		res := inv(l, m) + inv(m, r)
+		i, j, k := l, m, l
+		for i < m && j < r {
+			if a[i] <= a[j] {
+				tmp[k] = a[i]
+				i++
+			} else {
+				tmp[k] = a[j]
+				res += int64(m - i)
+				j++
+			}
+			k++
+		}
+		for i < m {
+			tmp[k] = a[i]
+			i++
+			k++
+		}
+		for j < r {
+			tmp[k] = a[j]
+			j++
+			k++
+		}
+		for i := l; i < r; i++ {
+			a[i] = tmp[i]
+		}
+		return res
+	}
+	b := make([]int, len(a))
+	copy(b, a)
+	res := inv(0, len(b))
+	return res
+}
+
+func process(a []int, q int) []int {
+	seg := 1 << q
+	n := len(a)
+	res := make([]int, 0, n)
+	for i := 0; i < n; i += seg {
+		end := i + seg
+		if end > n {
+			end = n
+		}
+		for j := end - 1; j >= i; j-- {
+			res = append(res, a[j])
+		}
+	}
+	return res
+}
+
+func solveC(n int, arr []int, queries []int) []int64 {
+	res := make([]int64, len(queries))
+	cur := make([]int, len(arr))
+	copy(cur, arr)
+	for i, q := range queries {
+		cur = process(cur, q)
+		res[i] = countInv(cur)
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(5) + 1
+	N := 1 << n
+	arr := make([]int, N)
+	for i := range arr {
+		arr[i] = rng.Intn(20)
+	}
+	m := rng.Intn(6) + 1
+	queries := make([]int, m)
+	for i := range queries {
+		queries[i] = rng.Intn(n + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i, q := range queries {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(q))
+	}
+	sb.WriteByte('\n')
+	expected := solveC(n, arr, queries)
+	return sb.String(), expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		outTokens := strings.Fields(out)
+		if len(outTokens) != len(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\ninput:\n%soutput:\n%s", i+1, len(exp), len(outTokens), input, out)
+			os.Exit(1)
+		}
+		for j, tok := range outTokens {
+			got, err := strconv.ParseInt(tok, 10, 64)
+			if err != nil || got != exp[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed at output %d: expected %d got %s\ninput:\n%s", i+1, j+1, exp[j], tok, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/414/verifierD.go
+++ b/0-999/400-499/410-419/414/verifierD.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func can(S int64, depths []int, prefix []int64, p int64) bool {
+	if S == 0 {
+		return true
+	}
+	n := int64(len(depths))
+	if S > n {
+		return false
+	}
+	minCost := int64(1<<62 - 1)
+	for i := S; i <= n; i++ {
+		sumSeg := prefix[i] - prefix[i-S]
+		T := int64(depths[i-1])
+		cost := S*T - sumSeg
+		if cost < minCost {
+			minCost = cost
+		}
+		if minCost <= p {
+			return true
+		}
+	}
+	return minCost <= p
+}
+
+func solveD(m int, k, p int64, edges [][2]int) int64 {
+	adj := make([][]int, m+1)
+	for _, e := range edges {
+		u := e[0]
+		v := e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	depth := make([]int, m+1)
+	q := make([]int, 0, m)
+	q = append(q, 1)
+	parent := make([]int, m+1)
+	parent[1] = -1
+	for i := 0; i < len(q); i++ {
+		u := q[i]
+		for _, v := range adj[u] {
+			if v == parent[u] {
+				continue
+			}
+			parent[v] = u
+			depth[v] = depth[u] + 1
+			q = append(q, v)
+		}
+	}
+	n := m - 1
+	depths := make([]int, 0, n)
+	for i := 2; i <= m; i++ {
+		depths = append(depths, depth[i])
+	}
+	sort.Ints(depths)
+	prefix := make([]int64, n+1)
+	for i, d := range depths {
+		prefix[i+1] = prefix[i] + int64(d)
+	}
+	if k > int64(n) {
+		k = int64(n)
+	}
+	lo, hi := int64(0), k
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if can(mid, depths, prefix, p) {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return lo
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	m := rng.Intn(8) + 2
+	edges := make([][2]int, 0, m-1)
+	for v := 2; v <= m; v++ {
+		p := rng.Intn(v-1) + 1
+		edges = append(edges, [2]int{p, v})
+	}
+	k := int64(rng.Intn(m))
+	p := int64(rng.Intn(10))
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", m, k, p))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	ans := solveD(m, k, p, edges)
+	return sb.String(), ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output\ninput:\n%soutput:\n%s", i+1, input, out)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/414/verifierE.go
+++ b/0-999/400-499/410-419/414/verifierE.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type query struct {
+	typ int
+	a   int
+	b   int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func recomputeDepth(children [][]int, parent []int, depth []int) {
+	queue := []int{1}
+	depth[1] = 0
+	for i := 0; i < len(queue); i++ {
+		u := queue[i]
+		for _, v := range children[u] {
+			depth[v] = depth[u] + 1
+			queue = append(queue, v)
+		}
+	}
+}
+
+func lca(u, v int, parent, depth []int) int {
+	if depth[u] < depth[v] {
+		u, v = v, u
+	}
+	for depth[u] > depth[v] {
+		u = parent[u]
+	}
+	for u != v {
+		u = parent[u]
+		v = parent[v]
+	}
+	return u
+}
+
+func solveE(n int, children [][]int, parent []int, qs []query) []int {
+	depth := make([]int, n+1)
+	recomputeDepth(children, parent, depth)
+	var res []int
+	for _, q := range qs {
+		switch q.typ {
+		case 1:
+			u := q.a
+			v := q.b
+			w := lca(u, v, parent, depth)
+			dist := depth[u] + depth[v] - 2*depth[w]
+			res = append(res, dist)
+		case 2:
+			v := q.a
+			h := q.b
+			p := v
+			for i := 0; i < h; i++ {
+				p = parent[p]
+			}
+			old := parent[v]
+			lst := children[old]
+			for i, x := range lst {
+				if x == v {
+					children[old] = append(lst[:i], lst[i+1:]...)
+					break
+				}
+			}
+			children[p] = append(children[p], v)
+			parent[v] = p
+			recomputeDepth(children, parent, depth)
+		case 3:
+			k := q.a
+			ans := -1
+			var dfs func(int)
+			dfs = func(u int) {
+				if depth[u] == k {
+					ans = u
+				}
+				for _, v := range children[u] {
+					dfs(v)
+				}
+			}
+			dfs(1)
+			res = append(res, ans)
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(4) + 2
+	children := make([][]int, n+1)
+	parent := make([]int, n+1)
+	for v := 2; v <= n; v++ {
+		p := rng.Intn(v-1) + 1
+		children[p] = append(children[p], v)
+		parent[v] = p
+	}
+	parent[1] = 0
+	m := rng.Intn(8) + 1
+	qs := make([]query, 0, m)
+	depth := make([]int, n+1)
+	recomputeDepth(children, parent, depth)
+	for i := 0; i < m; i++ {
+		typ := rng.Intn(3) + 1
+		switch typ {
+		case 1:
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			qs = append(qs, query{1, u, v})
+		case 2:
+			// ensure valid vertex with depth>=2
+			cand := []int{}
+			for v := 2; v <= n; v++ {
+				if depth[v] >= 2 {
+					cand = append(cand, v)
+				}
+			}
+			if len(cand) == 0 {
+				typ = 1
+				u := rng.Intn(n) + 1
+				v := rng.Intn(n) + 1
+				qs = append(qs, query{1, u, v})
+				continue
+			}
+			v := cand[rng.Intn(len(cand))]
+			h := rng.Intn(depth[v]-1) + 2
+			qs = append(qs, query{2, v, h})
+			// apply to maintain validity
+			p := v
+			for j := 0; j < h; j++ {
+				p = parent[p]
+			}
+			old := parent[v]
+			lst := children[old]
+			for idx, x := range lst {
+				if x == v {
+					children[old] = append(lst[:idx], lst[idx+1:]...)
+					break
+				}
+			}
+			children[p] = append(children[p], v)
+			parent[v] = p
+			recomputeDepth(children, parent, depth)
+		case 3:
+			// pick random depth value that exists
+			depthMap := map[int]struct{}{}
+			for x := 1; x <= n; x++ {
+				depthMap[depth[x]] = struct{}{}
+			}
+			vals := make([]int, 0, len(depthMap))
+			for d := range depthMap {
+				vals = append(vals, d)
+			}
+			k := vals[rng.Intn(len(vals))]
+			qs = append(qs, query{3, k, 0})
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(qs)))
+	for i := 1; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", len(children[i])))
+		for _, ch := range children[i] {
+			sb.WriteByte(' ')
+			sb.WriteString(strconv.Itoa(ch))
+		}
+		sb.WriteByte('\n')
+	}
+	for _, q := range qs {
+		if q.typ == 1 {
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", q.a, q.b))
+		} else if q.typ == 2 {
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", q.a, q.b))
+		} else {
+			sb.WriteString(fmt.Sprintf("3 %d\n", q.a))
+		}
+	}
+	// compute expected using solver on a fresh copy
+	childrenCopy := make([][]int, n+1)
+	parentCopy := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		parentCopy[i] = parent[i]
+		if len(children[i]) > 0 {
+			childrenCopy[i] = append([]int(nil), children[i]...)
+		}
+	}
+	expected := solveE(n, childrenCopy, parentCopy, qs)
+	return sb.String(), expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		outTok := strings.Fields(out)
+		if len(outTok) != len(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d outputs got %d\ninput:\n%soutput:\n%s", i+1, len(exp), len(outTok), input, out)
+			os.Exit(1)
+		}
+		for j, tok := range outTok {
+			got, err := strconv.Atoi(tok)
+			if err != nil || got != exp[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed at output %d: expected %d got %s\ninput:\n%s", i+1, j+1, exp[j], tok, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for problems A–E of contest 414
- each verifier runs at least 100 generated tests and checks the given binary's output

## Testing
- `go run 0-999/400-499/410-419/414/verifierA.go 0-999/400-499/410-419/414/414A.go`

------
https://chatgpt.com/codex/tasks/task_e_687ec730426483249cd0336e817fa3f4