### PR TITLE
Add verifiers for contest 413

### DIFF
--- a/0-999/400-499/410-419/413/verifierA.go
+++ b/0-999/400-499/410-419/413/verifierA.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m   int
+	minVal int
+	maxVal int
+	temps  []int
+}
+
+func expected(tc testCase) string {
+	hasMin := false
+	hasMax := false
+	for _, t := range tc.temps {
+		if t < tc.minVal || t > tc.maxVal {
+			return "Incorrect"
+		}
+		if t == tc.minVal {
+			hasMin = true
+		}
+		if t == tc.maxVal {
+			hasMax = true
+		}
+	}
+	need := 0
+	if !hasMin {
+		need++
+	}
+	if !hasMax {
+		need++
+	}
+	if need <= tc.n-tc.m {
+		return "Correct"
+	}
+	return "Incorrect"
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", tc.n, tc.m, tc.minVal, tc.maxVal))
+	for i := 0; i < tc.m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(tc.temps[i]))
+	}
+	if tc.m > 0 {
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	input := buildInput(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	exp := expected(tc)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 2
+	m := rng.Intn(n-1) + 1
+	minVal := rng.Intn(98) + 1
+	maxVal := rng.Intn(100-minVal) + minVal + 1
+	temps := make([]int, m)
+	for i := 0; i < m; i++ {
+		temps[i] = rng.Intn(100) + 1
+	}
+	return testCase{n: n, m: m, minVal: minVal, maxVal: maxVal, temps: temps}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var tests []testCase
+	tests = append(tests, testCase{n: 2, m: 1, minVal: 1, maxVal: 2, temps: []int{1}})
+	tests = append(tests, testCase{n: 3, m: 2, minVal: 1, maxVal: 3, temps: []int{1, 3}})
+	for len(tests) < 100 {
+		tests = append(tests, randomCase(rng))
+	}
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/410-419/413/verifierB.go
+++ b/0-999/400-499/410-419/413/verifierB.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m, k int
+	matrix  [][]bool
+	events  [][2]int
+}
+
+func expected(tc testCase) []int {
+	totalMsgs := make([]int, tc.m)
+	userMsgs := make([][]int, tc.n)
+	for i := range userMsgs {
+		userMsgs[i] = make([]int, tc.m)
+	}
+	for _, e := range tc.events {
+		u := e[0]
+		c := e[1]
+		totalMsgs[c]++
+		userMsgs[u][c]++
+	}
+	res := make([]int, tc.n)
+	for i := 0; i < tc.n; i++ {
+		sum := 0
+		for j := 0; j < tc.m; j++ {
+			if tc.matrix[i][j] {
+				sum += totalMsgs[j] - userMsgs[i][j]
+			}
+		}
+		res[i] = sum
+	}
+	return res
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.m, tc.k))
+	for i := 0; i < tc.n; i++ {
+		for j := 0; j < tc.m; j++ {
+			val := 0
+			if tc.matrix[i][j] {
+				val = 1
+			}
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(val))
+		}
+		sb.WriteByte('\n')
+	}
+	for _, e := range tc.events {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+	}
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	input := buildInput(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	gotFields := strings.Fields(strings.TrimSpace(out.String()))
+	exp := expected(tc)
+	if len(gotFields) != len(exp) {
+		return fmt.Errorf("expected %d numbers got %d", len(exp), len(gotFields))
+	}
+	for i, f := range gotFields {
+		var v int
+		fmt.Sscan(f, &v)
+		if v != exp[i] {
+			return fmt.Errorf("expected %v got %v", exp, gotFields)
+		}
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 2
+	m := rng.Intn(3) + 1
+	k := rng.Intn(30)
+	matrix := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		matrix[i] = make([]bool, m)
+	}
+	// ensure each chat has at least two participants
+	for j := 0; j < m; j++ {
+		p1 := rng.Intn(n)
+		p2 := rng.Intn(n)
+		for p2 == p1 {
+			p2 = rng.Intn(n)
+		}
+		matrix[p1][j] = true
+		matrix[p2][j] = true
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 0 {
+				matrix[i][j] = true
+			}
+		}
+	}
+	events := make([][2]int, k)
+	for i := 0; i < k; i++ {
+		u := rng.Intn(n)
+		c := rng.Intn(m)
+		for !matrix[u][c] {
+			u = rng.Intn(n)
+			c = rng.Intn(m)
+		}
+		events[i] = [2]int{u, c}
+	}
+	return testCase{n: n, m: m, k: k, matrix: matrix, events: events}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var tests []testCase
+	// simple deterministic case
+	matrix := [][]bool{{true}, {true}}
+	tests = append(tests, testCase{n: 2, m: 1, k: 1, matrix: matrix, events: [][2]int{{0, 0}}})
+	for len(tests) < 100 {
+		tests = append(tests, randomCase(rng))
+	}
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/410-419/413/verifierC.go
+++ b/0-999/400-499/410-419/413/verifierC.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m     int
+	prices   []int64
+	auctions []int
+}
+
+func expected(tc testCase) int64 {
+	isAuction := make([]bool, tc.n)
+	for _, v := range tc.auctions {
+		if v >= 1 && v <= tc.n {
+			isAuction[v-1] = true
+		}
+	}
+	var regSum int64
+	var A []int64
+	for i := 0; i < tc.n; i++ {
+		if isAuction[i] {
+			A = append(A, tc.prices[i])
+		} else {
+			regSum += tc.prices[i]
+		}
+	}
+	sort.Slice(A, func(i, j int) bool { return A[i] < A[j] })
+	totalSum := regSum
+	for _, v := range A {
+		totalSum += v
+	}
+	mA := len(A)
+	PS := make([]int64, mA+1)
+	for i := 1; i <= mA; i++ {
+		PS[i] = PS[i-1] + A[i-1]
+	}
+	best := totalSum
+	for d := 1; d <= mA; d++ {
+		sumD := PS[d]
+		S0 := totalSum - sumD
+		if S0 <= 0 {
+			continue
+		}
+		cur := S0
+		ok := true
+		for j := 1; j <= d; j++ {
+			if cur <= A[j-1] {
+				ok = false
+				break
+			}
+			cur <<= 1
+		}
+		if !ok {
+			continue
+		}
+		endScore := S0 << uint(d)
+		if endScore > best {
+			best = endScore
+		}
+	}
+	return best
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for i := 0; i < tc.n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(tc.prices[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < tc.m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(tc.auctions[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	input := buildInput(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	var got int64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := expected(tc)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(n + 1)
+	prices := make([]int64, n)
+	for i := 0; i < n; i++ {
+		prices[i] = int64(rng.Intn(20) + 1)
+	}
+	auctions := make([]int, m)
+	used := map[int]bool{}
+	for i := 0; i < m; i++ {
+		for {
+			x := rng.Intn(n) + 1
+			if !used[x] {
+				auctions[i] = x
+				used[x] = true
+				break
+			}
+		}
+	}
+	return testCase{n: n, m: m, prices: prices, auctions: auctions}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var tests []testCase
+	tests = append(tests, testCase{n: 1, m: 0, prices: []int64{5}, auctions: nil})
+	for len(tests) < 100 {
+		tests = append(tests, randomCase(rng))
+	}
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/410-419/413/verifierD.go
+++ b/0-999/400-499/410-419/413/verifierD.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, k int
+	seq  []int
+}
+
+func expected(tc testCase) int64 {
+	mod := int64(1000000007)
+	n := tc.n
+	k := tc.k
+	seq := tc.seq
+	maxMask := 1 << (k - 1)
+	suff := make([]int64, n)
+	if n > 0 {
+		suff[n-1] = 1
+		for i := n - 2; i >= 0; i-- {
+			mult := int64(1)
+			if seq[i+1] == 0 {
+				mult = 2
+			}
+			suff[i] = suff[i+1] * mult % mod
+		}
+	}
+	maskNext := make([][]int, 3)
+	willWin := make([][]bool, 3)
+	for h := 1; h <= 2; h++ {
+		maskNext[h] = make([]int, maxMask)
+		willWin[h] = make([]bool, maxMask)
+		for mask := 0; mask < maxMask; mask++ {
+			t := h
+			cur := mask
+			for {
+				if t == k {
+					willWin[h][mask] = true
+					break
+				}
+				bit := 1 << (t - 1)
+				if cur&bit == 0 {
+					cur |= bit
+					maskNext[h][mask] = cur
+					break
+				}
+				cur &^= bit
+				t++
+			}
+		}
+	}
+	dp := make([]int64, maxMask)
+	dp[0] = 1
+	var ans int64
+	for i, v := range seq {
+		newDp := make([]int64, maxMask)
+		hs := []int{}
+		if v == 0 {
+			hs = []int{1, 2}
+		} else if v == 2 {
+			hs = []int{1}
+		} else if v == 4 {
+			hs = []int{2}
+		}
+		for mask := 0; mask < maxMask; mask++ {
+			ways := dp[mask]
+			if ways == 0 {
+				continue
+			}
+			for _, h := range hs {
+				if willWin[h][mask] {
+					ans = (ans + ways*suff[i]) % mod
+				} else {
+					nm := maskNext[h][mask]
+					newDp[nm] = (newDp[nm] + ways) % mod
+				}
+			}
+		}
+		dp = newDp
+	}
+	return ans % mod
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+	for i := 0; i < tc.n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(tc.seq[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	input := buildInput(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	var got int64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := expected(tc)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(15) + 1
+	k := rng.Intn(5) + 3
+	seq := make([]int, n)
+	for i := 0; i < n; i++ {
+		v := rng.Intn(3)
+		if v == 0 {
+			seq[i] = 0
+		} else if v == 1 {
+			seq[i] = 2
+		} else {
+			seq[i] = 4
+		}
+	}
+	return testCase{n: n, k: k, seq: seq}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var tests []testCase
+	tests = append(tests, testCase{n: 1, k: 3, seq: []int{2}})
+	for len(tests) < 100 {
+		tests = append(tests, randomCase(rng))
+	}
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/410-419/413/verifierE.go
+++ b/0-999/400-499/410-419/413/verifierE.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m    int
+	grid    [2]string
+	queries [][2]int
+}
+
+func bfs(grid [2]string, n int, s, t int) int {
+	sr := (s - 1) / n
+	sc := (s - 1) % n
+	tr := (t - 1) / n
+	tc := (t - 1) % n
+	if grid[sr][sc] == 'X' || grid[tr][tc] == 'X' {
+		return -1
+	}
+	type node struct{ r, c int }
+	dist := make([][]int, 2)
+	for i := 0; i < 2; i++ {
+		dist[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			dist[i][j] = -1
+		}
+	}
+	q := []node{{sr, sc}}
+	dist[sr][sc] = 0
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		if cur.r == tr && cur.c == tc {
+			return dist[cur.r][cur.c]
+		}
+		for _, d := range dirs {
+			nr, nc := cur.r+d[0], cur.c+d[1]
+			if nr < 0 || nr >= 2 || nc < 0 || nc >= n {
+				continue
+			}
+			if grid[nr][nc] == 'X' {
+				continue
+			}
+			if dist[nr][nc] == -1 {
+				dist[nr][nc] = dist[cur.r][cur.c] + 1
+				q = append(q, node{nr, nc})
+			}
+		}
+	}
+	return -1
+}
+
+func expected(tc testCase) []int {
+	res := make([]int, len(tc.queries))
+	for i, q := range tc.queries {
+		res[i] = bfs(tc.grid, tc.n, q[0], q[1])
+	}
+	return res
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	sb.WriteString(tc.grid[0])
+	sb.WriteByte('\n')
+	sb.WriteString(tc.grid[1])
+	sb.WriteByte('\n')
+	for _, q := range tc.queries {
+		sb.WriteString(fmt.Sprintf("%d %d\n", q[0], q[1]))
+	}
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	input := buildInput(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	exp := expected(tc)
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, line := range lines {
+		var v int
+		if _, err := fmt.Sscan(strings.TrimSpace(line), &v); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if v != exp[i] {
+			return fmt.Errorf("expected %v got %v", exp, lines)
+		}
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(5) + 1
+	var g [2]string
+	for r := 0; r < 2; r++ {
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			if rng.Intn(4) == 0 {
+				b[i] = 'X'
+			} else {
+				b[i] = '.'
+			}
+		}
+		g[r] = string(b)
+	}
+	// ensure start and end cells open
+	queries := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		for {
+			v := rng.Intn(2*n) + 1
+			u := rng.Intn(2*n) + 1
+			sr := (v - 1) / n
+			sc := (v - 1) % n
+			tr := (u - 1) / n
+			tc := (u - 1) % n
+			if g[sr][sc] == '.' && g[tr][tc] == '.' {
+				queries[i] = [2]int{v, u}
+				break
+			}
+		}
+	}
+	return testCase{n: n, m: m, grid: g, queries: queries}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var tests []testCase
+	// trivial deterministic
+	tests = append(tests, testCase{n: 1, m: 1, grid: [2]string{".", "."}, queries: [][2]int{{1, 2}}})
+	for len(tests) < 100 {
+		tests = append(tests, randomCase(rng))
+	}
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 413
- each verifier runs at least 100 randomized test cases against a specified binary

## Testing
- `go build 0-999/400-499/410-419/413/verifierA.go`
- `go build 0-999/400-499/410-419/413/verifierB.go`
- `go build 0-999/400-499/410-419/413/verifierC.go`
- `go build 0-999/400-499/410-419/413/verifierD.go`
- `go build 0-999/400-499/410-419/413/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687ec6ea43608324b90bf5ecb70fc456