### PR TITLE
Add verifiers for contest 412

### DIFF
--- a/0-999/400-499/410-419/412/verifierA.go
+++ b/0-999/400-499/410-419/412/verifierA.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedA(n, k int, s string) string {
+	p := k - 1
+	flag1, flag2 := 0, 0
+	if p == 0 {
+		flag1, flag2 = 1, 0
+	} else if p == n-1 {
+		flag1, flag2 = 0, 0
+	} else if p < n-1-p {
+		flag1, flag2 = 0, 1
+	} else {
+		flag1, flag2 = 1, 1
+	}
+	var cmds []string
+	cmds = append(cmds, fmt.Sprintf("PRINT %c", s[p]))
+	if flag1 == 1 {
+		cnt := p + 1
+		for cnt < n-1 {
+			cmds = append(cmds, "RIGHT")
+			cmds = append(cmds, fmt.Sprintf("PRINT %c", s[cnt]))
+			cnt++
+		}
+		if cnt < n {
+			cmds = append(cmds, "RIGHT")
+			cmds = append(cmds, fmt.Sprintf("PRINT %c", s[cnt]))
+		}
+		cnt = n - 1
+		if flag2 == 1 {
+			for cnt >= p {
+				cmds = append(cmds, "LEFT")
+				cnt--
+			}
+			for cnt > 0 {
+				cmds = append(cmds, fmt.Sprintf("PRINT %c", s[cnt]))
+				cmds = append(cmds, "LEFT")
+				cnt--
+			}
+			if cnt >= 0 {
+				cmds = append(cmds, fmt.Sprintf("PRINT %c", s[cnt]))
+			}
+		}
+	} else {
+		cnt := p - 1
+		for cnt > 0 {
+			cmds = append(cmds, "LEFT")
+			cmds = append(cmds, fmt.Sprintf("PRINT %c", s[cnt]))
+			cnt--
+		}
+		if cnt >= 0 {
+			cmds = append(cmds, "LEFT")
+			cmds = append(cmds, fmt.Sprintf("PRINT %c", s[cnt]))
+		}
+		cnt = 0
+		if flag2 == 1 {
+			for cnt <= p {
+				cmds = append(cmds, "RIGHT")
+				cnt++
+			}
+			for cnt < n-1 {
+				cmds = append(cmds, fmt.Sprintf("PRINT %c", s[cnt]))
+				cmds = append(cmds, "RIGHT")
+				cnt++
+			}
+			if cnt < n {
+				cmds = append(cmds, fmt.Sprintf("PRINT %c", s[cnt]))
+			}
+		}
+	}
+	return strings.Join(cmds, "\n")
+}
+
+func runCase(bin string, n, k int, s string) error {
+	input := fmt.Sprintf("%d %d\n%s\n", n, k, s)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(expectedA(n, k, s))
+	if got != expect {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expect, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (int, int, string) {
+	n := rng.Intn(100) + 1
+	k := rng.Intn(n) + 1
+	alphabet := "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.!?,"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = alphabet[rng.Intn(len(alphabet))]
+	}
+	return n, k, string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, s := genCase(rng)
+		if err := runCase(bin, n, k, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %d\n%s\n", i+1, err, n, k, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/412/verifierB.go
+++ b/0-999/400-499/410-419/412/verifierB.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expectedB(arr []int, k int) int {
+	b := append([]int(nil), arr...)
+	sort.Ints(b)
+	return b[len(b)-k]
+}
+
+func runCase(bin string, n, k int, arr []int) error {
+	input := fmt.Sprintf("%d %d\n", n, k)
+	for i, v := range arr {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprint(v)
+	}
+	input += "\n"
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(strings.TrimSpace(out.String())), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := expectedB(arr, k)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (int, int, []int) {
+	n := rng.Intn(100) + 1
+	k := rng.Intn(n) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(32768-16+1) + 16
+	}
+	return n, k, arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, arr := genCase(rng)
+		if err := runCase(bin, n, k, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %d\n%v\n", i+1, err, n, k, arr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/412/verifierC.go
+++ b/0-999/400-499/410-419/412/verifierC.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedC(patterns []string) string {
+	if len(patterns) == 0 {
+		return ""
+	}
+	k := len(patterns[0])
+	res := make([]rune, k)
+	for j := 0; j < k; j++ {
+		ch := rune('?')
+		conflict := false
+		for _, p := range patterns {
+			c := rune(p[j])
+			if c == '?' {
+				continue
+			}
+			if ch == '?' {
+				ch = c
+			} else if ch != c {
+				conflict = true
+				break
+			}
+		}
+		if conflict {
+			res[j] = '?'
+		} else if ch == '?' {
+			res[j] = 'x'
+		} else {
+			res[j] = ch
+		}
+	}
+	return string(res)
+}
+
+func runCase(bin string, patterns []string) error {
+	input := fmt.Sprintf("%d\n", len(patterns))
+	for _, p := range patterns {
+		input += p + "\n"
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(expectedC(patterns))
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) []string {
+	n := rng.Intn(6) + 1
+	l := rng.Intn(10) + 1
+	patterns := make([]string, n)
+	alphabet := "abcdefghijklmnopqrstuvwxyz"
+	for i := 0; i < n; i++ {
+		var sb strings.Builder
+		for j := 0; j < l; j++ {
+			if rng.Intn(4) == 0 {
+				sb.WriteByte('?')
+			} else {
+				sb.WriteByte(alphabet[rng.Intn(len(alphabet))])
+			}
+		}
+		patterns[i] = sb.String()
+	}
+	return patterns
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		patterns := genCase(rng)
+		if err := runCase(bin, patterns); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%v\n", i+1, err, patterns)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/412/verifierD.go
+++ b/0-999/400-499/410-419/412/verifierD.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedD(n int, edges [][2]int) string {
+	g := make([][]int, n)
+	for _, e := range edges {
+		a, b := e[0]-1, e[1]-1
+		g[a] = append(g[a], b)
+	}
+	vis := make([]bool, n)
+	var res []int
+	var dfs func(int)
+	dfs = func(v int) {
+		vis[v] = true
+		for _, u := range g[v] {
+			if !vis[u] {
+				dfs(u)
+			}
+		}
+		res = append(res, v+1)
+	}
+	for v := 0; v < n; v++ {
+		if !vis[v] {
+			dfs(v)
+		}
+	}
+	strs := make([]string, len(res))
+	for i, x := range res {
+		strs[i] = fmt.Sprint(x)
+	}
+	return strings.Join(strs, " ")
+}
+
+func runCase(bin string, n int, edges [][2]int) error {
+	input := fmt.Sprintf("%d %d\n", n, len(edges))
+	for _, e := range edges {
+		input += fmt.Sprintf("%d %d\n", e[0], e[1])
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(expectedD(n, edges))
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (int, [][2]int) {
+	n := rng.Intn(12) + 2
+	maxE := n * (n - 1) / 2
+	m := rng.Intn(maxE + 1)
+	if m > 40 {
+		m = 40
+	}
+	edges := make([][2]int, 0, m)
+	used := make(map[[2]int]bool)
+	for len(edges) < m {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a == b {
+			continue
+		}
+		if used[[2]int{a, b}] || used[[2]int{b, a}] {
+			continue
+		}
+		used[[2]int{a, b}] = true
+		edges = append(edges, [2]int{a, b})
+	}
+	return n, edges
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, edges := genCase(rng)
+		if err := runCase(bin, n, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/412/verifierE.go
+++ b/0-999/400-499/410-419/412/verifierE.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedE(s string) string {
+	n := len(s)
+	L := make([]int, n)
+	PL := make([]int, n)
+	isLetter := func(c byte) bool { return c >= 'a' && c <= 'z' }
+	isDigit := func(c byte) bool { return c >= '0' && c <= '9' }
+	isLocal := func(c byte) bool { return isLetter(c) || isDigit(c) || c == '_' }
+	isDomain := func(c byte) bool { return isLetter(c) || isDigit(c) }
+	for i := 0; i < n; i++ {
+		if isLocal(s[i]) {
+			if i > 0 {
+				L[i] = L[i-1] + 1
+			} else {
+				L[i] = 1
+			}
+		}
+		if isLetter(s[i]) {
+			if i > 0 {
+				PL[i] = PL[i-1] + 1
+			} else {
+				PL[i] = 1
+			}
+		} else if i > 0 {
+			PL[i] = PL[i-1]
+		}
+	}
+	R1 := make([]int, n)
+	for i := n - 1; i >= 0; i-- {
+		if isDomain(s[i]) {
+			if i+1 < n {
+				R1[i] = R1[i+1] + 1
+			} else {
+				R1[i] = 1
+			}
+		}
+	}
+	R2 := make([]int, n)
+	for i := n - 1; i >= 0; i-- {
+		if isLetter(s[i]) {
+			if i+1 < n {
+				R2[i] = R2[i+1] + 1
+			} else {
+				R2[i] = 1
+			}
+		}
+	}
+	DotValue := make([]int64, n)
+	for i := 0; i < n-1; i++ {
+		if s[i] == '.' {
+			DotValue[i] = int64(R2[i+1])
+		}
+	}
+	PDOV := make([]int64, n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			PDOV[i] = PDOV[i-1] + DotValue[i]
+		} else {
+			PDOV[i] = DotValue[i]
+		}
+	}
+	var ans int64
+	for i := 0; i < n; i++ {
+		if s[i] != '@' {
+			continue
+		}
+		if i == 0 || i+1 >= n {
+			continue
+		}
+		leftLen := L[i-1]
+		if leftLen < 1 {
+			continue
+		}
+		start := i - leftLen
+		end := i - 1
+		var letters int
+		if start > 0 {
+			letters = PL[end] - PL[start-1]
+		} else {
+			letters = PL[end]
+		}
+		if letters == 0 {
+			continue
+		}
+		domMax := 0
+		if i+1 < n {
+			domMax = R1[i+1]
+		}
+		if domMax < 1 {
+			continue
+		}
+		dLow := i + 2
+		if dLow >= n {
+			continue
+		}
+		dHigh := i + 1 + domMax
+		if dHigh >= n {
+			dHigh = n - 1
+		}
+		var rightSum int64
+		if dLow > 0 {
+			rightSum = PDOV[dHigh] - PDOV[dLow-1]
+		} else {
+			rightSum = PDOV[dHigh]
+		}
+		if rightSum <= 0 {
+			continue
+		}
+		ans += int64(letters) * rightSum
+	}
+	return fmt.Sprint(ans)
+}
+
+func runCase(bin string, s string) error {
+	input := s + "\n"
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedE(s)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) string {
+	l := rng.Intn(20) + 1
+	alphabet := "abcdefghijklmnopqrstuvwxyz0123456789_@."
+	var sb strings.Builder
+	for i := 0; i < l; i++ {
+		sb.WriteByte(alphabet[rng.Intn(len(alphabet))])
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := genCase(rng)
+		if err := runCase(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s\n", i+1, err, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 412
- each verifier generates 100 random tests and checks output using the contest solution logic

## Testing
- `go build 0-999/400-499/410-419/412/verifierA.go`
- `go run 0-999/400-499/410-419/412/verifierA.go ./412A_bin`
- `go build 0-999/400-499/410-419/412/verifierB.go`
- `go run 0-999/400-499/410-419/412/verifierB.go ./412B_bin`
- `go build 0-999/400-499/410-419/412/verifierC.go`
- `go run 0-999/400-499/410-419/412/verifierC.go ./412C_bin`
- `go build 0-999/400-499/410-419/412/verifierD.go`
- `go run 0-999/400-499/410-419/412/verifierD.go ./412D_bin`
- `go build 0-999/400-499/410-419/412/verifierE.go`
- `go run 0-999/400-499/410-419/412/verifierE.go ./412E_bin`


------
https://chatgpt.com/codex/tasks/task_e_687ec6a431b88324bef9e59b1f826e28