### PR TITLE
Add Go verifiers for contest 411

### DIFF
--- a/0-999/400-499/410-419/411/verifierA.go
+++ b/0-999/400-499/410-419/411/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func expected(password string) string {
+	if len(password) < 5 {
+		return "Too weak"
+	}
+	hasUpper, hasLower, hasDigit := false, false, false
+	for i := 0; i < len(password); i++ {
+		c := password[i]
+		if c >= 'A' && c <= 'Z' {
+			hasUpper = true
+		} else if c >= 'a' && c <= 'z' {
+			hasLower = true
+		} else if c >= '0' && c <= '9' {
+			hasDigit = true
+		}
+	}
+	if hasUpper && hasLower && hasDigit {
+		return "Correct"
+	}
+	return "Too weak"
+}
+
+const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!?.,_"
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(alphabet[rng.Intn(len(alphabet))])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, input string) error {
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	ans := strings.TrimSpace(out)
+	exp := expected(strings.TrimSpace(input))
+	if ans != exp {
+		return fmt.Errorf("expected %q got %q", exp, ans)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tests := []string{
+		"aaaaa\n",
+		"Aaaaa\n",
+		"A1a11\n",
+		"AA11a\n",
+		"1234\n",
+	}
+	for i := 0; i < 100; i++ {
+		tests = append(tests, generateCase(rng))
+	}
+
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/411/verifierB.go
+++ b/0-999/400-499/410-419/411/verifierB.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func solve(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n, m, k int
+	fmt.Fscan(in, &n, &m, &k)
+	instr := make([][]int, n)
+	for i := 0; i < n; i++ {
+		instr[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			fmt.Fscan(in, &instr[i][j])
+		}
+	}
+
+	coreLocked := make([]bool, n)
+	coreLockTime := make([]int, n)
+	cellLocked := make([]bool, k+1)
+
+	for cycle := 1; cycle <= m; cycle++ {
+		writes := make(map[int][]int)
+		for i := 0; i < n; i++ {
+			if coreLocked[i] {
+				continue
+			}
+			x := instr[i][cycle-1]
+			if x == 0 {
+				continue
+			}
+			if cellLocked[x] {
+				coreLocked[i] = true
+				coreLockTime[i] = cycle
+			} else {
+				writes[x] = append(writes[x], i)
+			}
+		}
+		for cell, cores := range writes {
+			if len(cores) >= 2 {
+				cellLocked[cell] = true
+				for _, ci := range cores {
+					if !coreLocked[ci] {
+						coreLocked[ci] = true
+						coreLockTime[ci] = cycle
+					}
+				}
+			}
+		}
+	}
+
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d\n", coreLockTime[i])
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	k := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			x := rng.Intn(k + 1)
+			fmt.Fprintf(&sb, "%d", x)
+			if j+1 < m {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(bin, input string) error {
+	expect := solve(input)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expect), strings.TrimSpace(out))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []string{
+		"1 1 1\n0\n",
+		"2 1 1\n1\n1\n",
+		"2 2 2\n1 0\n0 1\n",
+		"3 3 1\n1 1 1\n0 0 0\n1 1 1\n",
+		"1 3 1\n1 1 1\n",
+	}
+	for i := 0; i < 100; i++ {
+		tests = append(tests, generateCase(rng))
+	}
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/410-419/411/verifierC.go
+++ b/0-999/400-499/410-419/411/verifierC.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func solve(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var a [5]int
+	var b [5]int
+	for i := 1; i <= 4; i++ {
+		fmt.Fscan(in, &a[i], &b[i])
+	}
+	var payoff [2][2]int
+	for c1 := 0; c1 < 2; c1++ {
+		var t1atk, t1def int
+		if c1 == 0 {
+			t1atk = b[1]
+			t1def = a[2]
+		} else {
+			t1atk = b[2]
+			t1def = a[1]
+		}
+		for c2 := 0; c2 < 2; c2++ {
+			var t2atk, t2def int
+			if c2 == 0 {
+				t2atk = b[3]
+				t2def = a[4]
+			} else {
+				t2atk = b[4]
+				t2def = a[3]
+			}
+			if t1def > t2atk && t1atk > t2def {
+				payoff[c1][c2] = 1
+			} else if t2def > t1atk && t2atk > t1def {
+				payoff[c1][c2] = -1
+			} else {
+				payoff[c1][c2] = 0
+			}
+		}
+	}
+	r0 := payoff[0][0]
+	if payoff[0][1] < r0 {
+		r0 = payoff[0][1]
+	}
+	r1 := payoff[1][0]
+	if payoff[1][1] < r1 {
+		r1 = payoff[1][1]
+	}
+	result := r0
+	if r1 > result {
+		result = r1
+	}
+	switch result {
+	case 1:
+		return "Team 1\n"
+	case -1:
+		return "Team 2\n"
+	default:
+		return "Draw\n"
+	}
+}
+
+func generateCase(rng *rand.Rand) string {
+	var sb strings.Builder
+	for i := 0; i < 4; i++ {
+		a := rng.Intn(100) + 1
+		b := rng.Intn(100) + 1
+		fmt.Fprintf(&sb, "%d %d\n", a, b)
+	}
+	return sb.String()
+}
+
+func runCase(bin, input string) error {
+	expect := strings.TrimSpace(solve(input))
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(out) != expect {
+		return fmt.Errorf("expected %q got %q", expect, strings.TrimSpace(out))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []string{}
+	for i := 0; i < 100; i++ {
+		tests = append(tests, generateCase(rng))
+	}
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add automated solution verifiers for contest 411 (problems A–C)
- each verifier runs 100+ randomized tests using the reference algorithm

## Testing
- `go run 0-999/400-499/410-419/411/verifierA.go 0-999/400-499/410-419/411/411A_bin`
- `go run 0-999/400-499/410-419/411/verifierB.go 0-999/400-499/410-419/411/411B_bin`
- `go run 0-999/400-499/410-419/411/verifierC.go 0-999/400-499/410-419/411/411C_bin`


------
https://chatgpt.com/codex/tasks/task_e_687ec65e37d0832499e20042e9ccc796