### PR TITLE
Add Go verifiers for contest 409

### DIFF
--- a/0-999/400-499/400-409/409/verifierA.go
+++ b/0-999/400-499/400-409/409/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(binary string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	if input != "" {
+		cmd.Stdin = strings.NewReader(input)
+	}
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(s1, s2 string) string {
+	switch {
+	case s1 > s2:
+		return "TEAM 1 WINS"
+	case s2 > s1:
+		return "TEAM 2 WINS"
+	default:
+		return "TIE"
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	type test struct{ s1, s2 string }
+	tests := make([]test, 0, 100)
+	for i := 0; i < 100; i++ {
+		l := 2 + i%19
+		c1 := byte('a' + i%26)
+		c2 := byte('a' + (i*7)%26)
+		s1 := strings.Repeat(string(c1), l)
+		s2 := strings.Repeat(string(c2), l)
+		if i%3 == 0 {
+			s2 = s1
+		}
+		tests = append(tests, test{s1, s2})
+	}
+
+	for i, t := range tests {
+		inp := fmt.Sprintf("%s\n%s\n", t.s1, t.s2)
+		want := expected(t.s1, t.s2)
+		got, err := run(bin, inp)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/400-499/400-409/409/verifierB.go
+++ b/0-999/400-499/400-409/409/verifierB.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(binary string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		out, err := run(bin)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != "Brainfuck" {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, "Brainfuck", out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/400-499/400-409/409/verifierC.go
+++ b/0-999/400-499/400-409/409/verifierC.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(binary string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	req := []int{1, 1, 2, 7, 4}
+	for i := 0; i < 100; i++ {
+		stocks := []int{(i%10 + 1), ((i+3)%10 + 1), ((i*2)%10 + 1), ((i*3)%10 + 1), ((i*5)%10 + 1)}
+		input := fmt.Sprintf("%d %d %d %d %d\n", stocks[0], stocks[1], stocks[2], stocks[3], stocks[4])
+		ans := stocks[0] / req[0]
+		for j := 1; j < 5; j++ {
+			v := stocks[j] / req[j]
+			if v < ans {
+				ans = v
+			}
+		}
+		want := fmt.Sprint(ans)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != want {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/400-499/400-409/409/verifierD.go
+++ b/0-999/400-499/400-409/409/verifierD.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var facts = []int{
+	8848,
+	958,
+	12766,
+	6695,
+	1100,
+	807,
+	31962,
+	146,
+	-68,
+	25,
+	134,
+	10000,
+	663268,
+	154103,
+	1642,
+	106,
+}
+
+func run(binary string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		idx := (i % len(facts)) + 1
+		input := fmt.Sprintf("%d\n", idx)
+		want := strconv.Itoa(facts[idx-1])
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != want {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/400-499/400-409/409/verifierE.go
+++ b/0-999/400-499/400-409/409/verifierE.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(binary string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	idx := 0
+	for p := 1; p <= 10; p++ {
+		for q := 1; q <= 10; q++ {
+			input := strconv.FormatFloat(float64(p)/float64(q), 'f', 6, 64) + "\n"
+			want := fmt.Sprintf("%d %d", p, q)
+			out, err := run(bin, input)
+			if err != nil {
+				fmt.Printf("test %d error: %v\n", idx+1, err)
+				os.Exit(1)
+			}
+			if out != want {
+				fmt.Printf("test %d failed: expected %q got %q\n", idx+1, want, out)
+				os.Exit(1)
+			}
+			idx++
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/400-499/400-409/409/verifierF.go
+++ b/0-999/400-499/400-409/409/verifierF.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/big"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(binary string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func factorial(n int) string {
+	res := big.NewInt(1)
+	for i := 2; i <= n; i++ {
+		res.Mul(res, big.NewInt(int64(i)))
+	}
+	return res.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		n := (i % 64) + 1
+		input := fmt.Sprintf("%d\n", n)
+		want := factorial(n)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != want {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/400-499/400-409/409/verifierG.go
+++ b/0-999/400-499/400-409/409/verifierG.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(binary string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		n := (i % 10) + 1
+		ySum := 0.0
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			x := j
+			y := i + j
+			ySum += float64(y)
+			sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+		}
+		input := sb.String()
+		want := fmt.Sprintf("%.10f", 5+ySum/float64(n))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != want {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/400-499/400-409/409/verifierH.go
+++ b/0-999/400-499/400-409/409/verifierH.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(binary string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		a := i
+		b := 100 - i
+		want := fmt.Sprint(a + b)
+		input := fmt.Sprintf("%d %d\n", a, b)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != want {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/400-499/400-409/409/verifierI.go
+++ b/0-999/400-499/400-409/409/verifierI.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(binary string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(s string) string {
+	n := len(s)
+	const INF = 1 << 30
+	dist := make([][4]int, n)
+	for i := 0; i < n; i++ {
+		for d := 0; d < 4; d++ {
+			dist[i][d] = INF
+		}
+	}
+	type state struct{ p, d int }
+	dq := []state{{0, 0}}
+	dist[0][0] = 0
+	var best = INF
+	pushFront := func(st state) { dq = append([]state{st}, dq...) }
+	pushBack := func(st state) { dq = append(dq, st) }
+	popFront := func() state { st := dq[0]; dq = dq[1:]; return st }
+	for len(dq) > 0 {
+		u := popFront()
+		p, d := u.p, u.d
+		cd := dist[p][d]
+		if cd >= best {
+			continue
+		}
+		c := s[p]
+		if c == '@' {
+			best = cd
+			continue
+		}
+		var ndirs []int
+		switch c {
+		case '>':
+			ndirs = []int{0}
+		case 'v':
+			ndirs = []int{1}
+		case '<':
+			ndirs = []int{2}
+		case '^':
+			ndirs = []int{3}
+		case '_':
+			ndirs = []int{0}
+		case '|':
+			ndirs = []int{1}
+		case '?':
+			ndirs = []int{0, 1, 2, 3}
+		default:
+			ndirs = []int{d}
+		}
+		for _, nd := range ndirs {
+			add := 0
+			if c == '&' {
+				add = 1
+			}
+			np := p
+			switch nd {
+			case 0:
+				np = (p + 1) % n
+			case 2:
+				np = (p - 1 + n) % n
+			case 1, 3:
+				np = p
+			}
+			ndist := cd + add
+			if ndist < dist[np][nd] {
+				dist[np][nd] = ndist
+				st := state{np, nd}
+				if add == 1 {
+					pushBack(st)
+				} else {
+					pushFront(st)
+				}
+			}
+		}
+	}
+	if best == INF {
+		return "false"
+	}
+	if best == 0 {
+		return ""
+	}
+	return strings.Repeat("0", best)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		var program string
+		if i < 50 {
+			program = "@"
+		} else {
+			program = "&@"
+		}
+		input := program + "\n"
+		want := solve(program)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != want {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–I of contest 409
- each verifier runs 100+ tests and checks the output of a given binary

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build verifierI.go`


------
https://chatgpt.com/codex/tasks/task_e_687ec5d20adc83249efd724e9c992fee