### PR TITLE
Add verifiers for contest 408

### DIFF
--- a/0-999/400-499/400-409/408/verifierA.go
+++ b/0-999/400-499/400-409/408/verifierA.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// solveA computes expected output for given input.
+func solveA(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return ""
+	}
+	ks := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &ks[i])
+	}
+	minTime := -1
+	for i := 0; i < n; i++ {
+		total := 0
+		for j := 0; j < ks[i]; j++ {
+			var m int
+			fmt.Fscan(in, &m)
+			total += m*5 + 15
+		}
+		if minTime == -1 || total < minTime {
+			minTime = total
+		}
+	}
+	return fmt.Sprintf("%d\n", minTime)
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(1))
+	var tests []testCase
+	// some fixed edge cases
+	fixed := []string{
+		"1\n1\n1\n",
+		"1\n3\n1 1 1\n",
+		"2\n1 1\n1\n1\n",
+		"3\n2 2 2\n1 1\n1 1\n1 1\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, testCase{f, solveA(f)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		ks := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			ks[i] = rng.Intn(5) + 1
+			sb.WriteString(fmt.Sprintf("%d ", ks[i]))
+		}
+		sb.WriteString("\n")
+		for i := 0; i < n; i++ {
+			for j := 0; j < ks[i]; j++ {
+				m := rng.Intn(10) + 1
+				sb.WriteString(fmt.Sprintf("%d ", m))
+			}
+			sb.WriteString("\n")
+		}
+		inp := sb.String()
+		tests = append(tests, testCase{inp, solveA(inp)})
+	}
+	return tests
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected: %sGot: %s\n", i+1, t.input, strings.TrimSpace(t.expected), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/400-499/400-409/408/verifierB.go
+++ b/0-999/400-499/400-409/408/verifierB.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// solveB computes expected output for given input.
+func solveB(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var supply, demand string
+	if _, err := fmt.Fscan(in, &supply); err != nil {
+		return ""
+	}
+	if _, err := fmt.Fscan(in, &demand); err != nil {
+		return ""
+	}
+	count := make([]int, 26)
+	for _, c := range supply {
+		count[c-'a']++
+	}
+	need := make([]bool, 26)
+	for _, c := range demand {
+		need[c-'a'] = true
+	}
+	total := 0
+	for i, b := range need {
+		if b {
+			if count[i] == 0 {
+				return "-1\n"
+			}
+			total += count[i]
+		}
+	}
+	return fmt.Sprintf("%d\n", total)
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(2))
+	var tests []testCase
+	fixed := []string{
+		"abc\nabc\n",
+		"aabbcc\nabc\n",
+		"abc\nabz\n",
+		"zzz\nz\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, testCase{f, solveB(f)})
+	}
+	for len(tests) < 100 {
+		l1 := rng.Intn(10) + 1
+		l2 := rng.Intn(10) + 1
+		var sb strings.Builder
+		for i := 0; i < l1; i++ {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < l2; i++ {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, testCase{inp, solveB(inp)})
+	}
+	return tests
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected: %sGot: %s\n", i+1, t.input, strings.TrimSpace(t.expected), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for round 408 problems A and B
- each verifier generates at least 100 deterministic test cases
- verifiers run an arbitrary binary and check output against reference solutions

## Testing
- `go run 0-999/400-499/400-409/408/verifierA.go 0-999/400-499/400-409/408/408A.bin`
- `go run 0-999/400-499/400-409/408/verifierB.go 0-999/400-499/400-409/408/408B.bin`

------
https://chatgpt.com/codex/tasks/task_e_687ec58c00b48324b96b24ff0af49cf8