### PR TITLE
Add verifiers for contest 405

### DIFF
--- a/0-999/400-499/400-409/405/verifierA.go
+++ b/0-999/400-499/400-409/405/verifierA.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(100) + 1
+	}
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			in.WriteByte(' ')
+		}
+		fmt.Fprintf(&in, "%d", v)
+	}
+	in.WriteByte('\n')
+
+	sort.Ints(a)
+	var out strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprintf(&out, "%d", v)
+	}
+	out.WriteByte('\n')
+	return in.String(), out.String()
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, buf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/400-409/405/verifierB.go
+++ b/0-999/400-499/400-409/405/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type force struct {
+	pos int
+	dir byte
+}
+
+func compute(s string) int {
+	n := len(s)
+	forces := make([]force, 0, n+2)
+	forces = append(forces, force{0, 'L'})
+	for i := 1; i <= n; i++ {
+		c := s[i-1]
+		if c == 'L' || c == 'R' {
+			forces = append(forces, force{i, c})
+		}
+	}
+	forces = append(forces, force{n + 1, 'R'})
+	ans := 0
+	for i := 0; i+1 < len(forces); i++ {
+		left := forces[i]
+		right := forces[i+1]
+		d := right.pos - left.pos - 1
+		if d <= 0 {
+			continue
+		}
+		if left.dir == right.dir {
+			continue
+		}
+		if left.dir == 'L' && right.dir == 'R' {
+			ans += d
+		} else if left.dir == 'R' && right.dir == 'L' {
+			if d%2 == 1 {
+				ans++
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(30) + 1
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		r := rng.Intn(3)
+		if r == 0 {
+			b.WriteByte('L')
+		} else if r == 1 {
+			b.WriteByte('R')
+		} else {
+			b.WriteByte('.')
+		}
+	}
+	s := b.String()
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d\n%s\n", n, s)
+	out := fmt.Sprintf("%d\n", compute(s))
+	return in.String(), out
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, buf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/400-409/405/verifierC.go
+++ b/0-999/400-499/400-409/405/verifierC.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	mat := make([][]int, n)
+	cur := 0
+	for i := 0; i < n; i++ {
+		mat[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			mat[i][j] = rng.Intn(2)
+			if i == j && mat[i][j] == 1 {
+				cur ^= 1
+			}
+		}
+	}
+	q := rng.Intn(50) + 1
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d\n", n)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				in.WriteByte(' ')
+			}
+			fmt.Fprintf(&in, "%d", mat[i][j])
+		}
+		in.WriteByte('\n')
+	}
+	fmt.Fprintf(&in, "%d\n", q)
+	var out strings.Builder
+	for t := 0; t < q; t++ {
+		typ := rng.Intn(3) + 1
+		if typ == 3 {
+			fmt.Fprintln(&in, 3)
+			out.WriteByte(byte('0' + cur))
+		} else {
+			idx := rng.Intn(n) + 1
+			fmt.Fprintf(&in, "%d %d\n", typ, idx)
+			cur ^= 1
+		}
+	}
+	out.WriteByte('\n')
+	return in.String(), out.String()
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, buf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/400-409/405/verifierD.go
+++ b/0-999/400-499/400-409/405/verifierD.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const S = 1000000
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	used := make(map[int]bool)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		for {
+			x := rng.Intn(S) + 1
+			if !used[x] {
+				used[x] = true
+				arr[i] = x
+				break
+			}
+		}
+	}
+	sort.Ints(arr)
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			in.WriteByte(' ')
+		}
+		fmt.Fprintf(&in, "%d", v)
+	}
+	in.WriteByte('\n')
+	return in.String()
+}
+
+func checkAnswer(input, output string) error {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return fmt.Errorf("input parse: %v", err)
+	}
+	X := make(map[int]bool)
+	sumX := int64(0)
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(in, &x)
+		X[x] = true
+		sumX += int64(x)
+	}
+	sumL := sumX - int64(n)
+
+	out := bufio.NewReader(strings.NewReader(output))
+	var m int
+	if _, err := fmt.Fscan(out, &m); err != nil {
+		return fmt.Errorf("output parse m: %v", err)
+	}
+	if m < 1 || m > S-n {
+		return fmt.Errorf("invalid m %d", m)
+	}
+	Ys := make(map[int]bool)
+	sumR := int64(0)
+	for i := 0; i < m; i++ {
+		var y int
+		if _, err := fmt.Fscan(out, &y); err != nil {
+			return fmt.Errorf("read y: %v", err)
+		}
+		if y < 1 || y > S {
+			return fmt.Errorf("y out of range")
+		}
+		if X[y] {
+			return fmt.Errorf("y intersects X")
+		}
+		if Ys[y] {
+			return fmt.Errorf("duplicate y")
+		}
+		Ys[y] = true
+		sumR += int64(S - y)
+	}
+	if sumR != sumL {
+		return fmt.Errorf("sums mismatch")
+	}
+	return nil
+}
+
+func runCase(bin, input string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	return checkAnswer(input, buf.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/400-409/405/verifierE.go
+++ b/0-999/400-499/400-409/405/verifierE.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edgeKey struct{ u, v int }
+
+func key(a, b int) edgeKey {
+	if a > b {
+		a, b = b, a
+	}
+	return edgeKey{a, b}
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges-n+1) + n - 1
+	if m%2 == 1 {
+		if m < maxEdges {
+			m++
+		} else {
+			m--
+		}
+	}
+	edges := make([]edgeKey, 0, m)
+	used := make(map[edgeKey]bool)
+	// generate tree first
+	for i := 2; i <= n; i++ {
+		j := rng.Intn(i-1) + 1
+		ek := key(i, j)
+		edges = append(edges, ek)
+		used[ek] = true
+	}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		ek := key(u, v)
+		if used[ek] {
+			continue
+		}
+		edges = append(edges, ek)
+		used[ek] = true
+	}
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d %d\n", n, m)
+	for _, e := range edges {
+		fmt.Fprintf(&in, "%d %d\n", e.u, e.v)
+	}
+	return in.String()
+}
+
+func solvePossible(n, m int) bool { return m%2 == 0 }
+
+func checkAnswer(input, output string) error {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return fmt.Errorf("input parse: %v", err)
+	}
+	edges := make(map[edgeKey]bool)
+	for i := 0; i < m; i++ {
+		var a, b int
+		fmt.Fscan(in, &a, &b)
+		edges[key(a, b)] = true
+	}
+
+	out := bufio.NewReader(strings.NewReader(output))
+	tok, _ := out.Peek(1)
+	if len(tok) == 0 {
+		return fmt.Errorf("empty output")
+	}
+	if string(tok) == "N" {
+		line, _ := out.ReadString('\n')
+		line = strings.TrimSpace("N" + line)
+		if line != "No solution" {
+			return fmt.Errorf("expected 'No solution' got %q", line)
+		}
+		if solvePossible(n, m) {
+			return fmt.Errorf("solution exists but got No solution")
+		}
+		return nil
+	}
+	if !solvePossible(n, m) {
+		return fmt.Errorf("should output No solution")
+	}
+	need := m / 2
+	used := make(map[edgeKey]bool)
+	for i := 0; i < need; i++ {
+		var x, y, z int
+		if _, err := fmt.Fscan(out, &x, &y, &z); err != nil {
+			return fmt.Errorf("read path %d: %v", i+1, err)
+		}
+		if x < 1 || x > n || y < 1 || y > n || z < 1 || z > n {
+			return fmt.Errorf("vertex out of range")
+		}
+		e1 := key(x, y)
+		e2 := key(y, z)
+		if !edges[e1] || !edges[e2] {
+			return fmt.Errorf("edge not found")
+		}
+		if used[e1] || used[e2] {
+			return fmt.Errorf("edge used twice")
+		}
+		used[e1] = true
+		used[e2] = true
+	}
+	// ensure all edges used
+	if len(used) != len(edges) {
+		return fmt.Errorf("not all edges used")
+	}
+	return nil
+}
+
+func runCase(bin, input string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	return checkAnswer(input, buf.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 405
- each verifier generates 100 random tests and checks an arbitrary solution binary

## Testing
- `go build 0-999/400-499/400-409/405/verifierA.go`
- `go build 0-999/400-499/400-409/405/verifierB.go`
- `go build 0-999/400-499/400-409/405/verifierC.go`
- `go build 0-999/400-499/400-409/405/verifierD.go`
- `go build 0-999/400-499/400-409/405/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ec4b9c6c08324ac13f588d16e7ae4