### PR TITLE
Add Go verifiers for contest 404

### DIFF
--- a/0-999/400-499/400-409/404/verifierA.go
+++ b/0-999/400-499/400-409/404/verifierA.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseA struct {
+	n    int
+	grid []string
+}
+
+func generateTestsA() []testCaseA {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]testCaseA, 0, 100)
+	for len(tests) < 100 {
+		n := 3 + 2*r.Intn(5) // odd size 3..11
+		diag := byte('a' + r.Intn(26))
+		other := byte('a' + r.Intn(26))
+		for other == diag {
+			other = byte('a' + r.Intn(26))
+		}
+		grid := make([]string, n)
+		for i := 0; i < n; i++ {
+			row := make([]byte, n)
+			for j := 0; j < n; j++ {
+				if i == j || i+j == n-1 {
+					row[j] = diag
+				} else {
+					row[j] = other
+				}
+			}
+			grid[i] = string(row)
+		}
+		// randomly corrupt one cell to create invalid cases
+		if r.Intn(2) == 0 {
+			i := r.Intn(n)
+			j := r.Intn(n)
+			row := []byte(grid[i])
+			row[j] = byte('a' + r.Intn(26))
+			grid[i] = string(row)
+		}
+		tests = append(tests, testCaseA{n: n, grid: grid})
+	}
+	return tests
+}
+
+func expectedA(t testCaseA) string {
+	diag := t.grid[0][0]
+	other := t.grid[0][1]
+	if diag == other {
+		return "NO"
+	}
+	for i := 0; i < t.n; i++ {
+		for j := 0; j < t.n; j++ {
+			c := t.grid[i][j]
+			if i == j || i+j == t.n-1 {
+				if c != diag {
+					return "NO"
+				}
+			} else {
+				if c != other {
+					return "NO"
+				}
+			}
+		}
+	}
+	return "YES"
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run failed: %v\n%s", err, errb.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsA()
+	for i, t := range tests {
+		var b strings.Builder
+		b.WriteString(fmt.Sprintf("%d\n", t.n))
+		for _, row := range t.grid {
+			b.WriteString(row)
+			b.WriteByte('\n')
+		}
+		out, err := runBinary(bin, b.String())
+		if err != nil {
+			fmt.Printf("test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expected := expectedA(t)
+		if strings.TrimSpace(out) != expected {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, expected, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/400-409/404/verifierB.go
+++ b/0-999/400-499/400-409/404/verifierB.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCaseB struct {
+	a float64
+	d float64
+	n int
+}
+
+func generateTestsB() []testCaseB {
+	r := rand.New(rand.NewSource(2))
+	tests := make([]testCaseB, 0, 100)
+	for len(tests) < 100 {
+		a := 1 + r.Float64()*9
+		d := 0.1 + r.Float64()*5
+		n := 1 + r.Intn(10)
+		tests = append(tests, testCaseB{a: a, d: d, n: n})
+	}
+	return tests
+}
+
+func expectedB(t testCaseB) string {
+	per := 4 * t.a
+	dist := 0.0
+	var buf strings.Builder
+	for i := 0; i < t.n; i++ {
+		dist += t.d
+		dist = math.Mod(dist, per)
+		var x, y float64
+		switch {
+		case dist <= t.a:
+			x = dist
+			y = 0
+		case dist <= 2*t.a:
+			x = t.a
+			y = dist - t.a
+		case dist <= 3*t.a:
+			x = t.a - (dist - 2*t.a)
+			y = t.a
+		default:
+			x = 0
+			y = t.a - (dist - 3*t.a)
+		}
+		fmt.Fprintf(&buf, "%.6f %.6f\n", x, y)
+	}
+	return buf.String()
+}
+
+func approxEqual(out, expect string) bool {
+	outLines := strings.Fields(out)
+	expLines := strings.Fields(expect)
+	if len(outLines) != len(expLines) {
+		return false
+	}
+	for i := 0; i < len(outLines); i++ {
+		of, err1 := strconv.ParseFloat(outLines[i], 64)
+		ef, err2 := strconv.ParseFloat(expLines[i], 64)
+		if err1 != nil || err2 != nil {
+			return false
+		}
+		if math.Abs(of-ef) > 1e-3 {
+			return false
+		}
+	}
+	return true
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run failed: %v\n%s", err, errb.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsB()
+	for i, t := range tests {
+		input := fmt.Sprintf("%.4f %.4f\n%d\n", t.a, t.d, t.n)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expect := expectedB(t)
+		if !approxEqual(strings.TrimSpace(out), strings.TrimSpace(expect)) {
+			fmt.Printf("test %d failed\nexpected:\n%s\nGot:\n%s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/400-409/404/verifierC.go
+++ b/0-999/400-499/400-409/404/verifierC.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseC struct {
+	n int
+	k int
+	d []int
+}
+
+type edge struct{ u, v int }
+
+func generateValidC(r *rand.Rand) testCaseC {
+	for {
+		n := 3 + r.Intn(6)
+		k := 1 + r.Intn(3)
+		parents := make([]int, n+1)
+		depth := make([]int, n+1)
+		deg := make([]int, n+1)
+		ok := true
+		for i := 2; i <= n; i++ {
+			cand := []int{}
+			for p := 1; p < i; p++ {
+				if deg[p] < k {
+					cand = append(cand, p)
+				}
+			}
+			if len(cand) == 0 {
+				ok = false
+				break
+			}
+			par := cand[r.Intn(len(cand))]
+			parents[i] = par
+			depth[i] = depth[par] + 1
+			deg[par]++
+		}
+		if !ok {
+			continue
+		}
+		d := make([]int, n)
+		for i := 1; i <= n; i++ {
+			d[i-1] = depth[i]
+		}
+		return testCaseC{n: n, k: k, d: d}
+	}
+}
+
+func generateInvalidC(r *rand.Rand) testCaseC {
+	n := 3 + r.Intn(6)
+	k := 1 + r.Intn(3)
+	d := make([]int, n)
+	for i := 0; i < n; i++ {
+		d[i] = r.Intn(n)
+	}
+	if r.Intn(2) == 0 && n > 1 {
+		d[0] = 0
+		d[1] = 0
+	}
+	return testCaseC{n: n, k: k, d: d}
+}
+
+func generateTestsC() []testCaseC {
+	r := rand.New(rand.NewSource(3))
+	tests := make([]testCaseC, 0, 100)
+	for len(tests) < 50 {
+		tests = append(tests, generateValidC(r))
+	}
+	for len(tests) < 100 {
+		tests = append(tests, generateInvalidC(r))
+	}
+	return tests
+}
+
+func solveC(t testCaseC) (bool, []edge) {
+	n, k := t.n, t.k
+	d := make([]int, n+1)
+	levels := make([][]int, n)
+	maxD := 0
+	for i := 1; i <= n; i++ {
+		di := t.d[i-1]
+		if di < 0 || di >= n {
+			return false, nil
+		}
+		d[i] = di
+		levels[di] = append(levels[di], i)
+		if di > maxD {
+			maxD = di
+		}
+	}
+	if len(levels[0]) != 1 {
+		return false, nil
+	}
+	for dist := 1; dist <= maxD; dist++ {
+		cnt := len(levels[dist])
+		if cnt == 0 {
+			continue
+		}
+		parentCnt := len(levels[dist-1])
+		cap := parentCnt * (k - 1)
+		if dist == 1 {
+			cap = parentCnt * k
+		}
+		if cnt > cap {
+			return false, nil
+		}
+	}
+	edges := make([]edge, 0, n-1)
+	if maxD >= 1 {
+		root := levels[0][0]
+		for _, v := range levels[1] {
+			edges = append(edges, edge{root, v})
+		}
+	}
+	for dist := 2; dist <= maxD; dist++ {
+		parents := levels[dist-1]
+		children := levels[dist]
+		if len(children) == 0 {
+			continue
+		}
+		count := make([]int, len(parents))
+		idx := 0
+		for _, v := range children {
+			for idx < len(parents) && count[idx] >= k-1 {
+				idx++
+			}
+			if idx >= len(parents) {
+				return false, nil
+			}
+			u := parents[idx]
+			edges = append(edges, edge{u, v})
+			count[idx]++
+		}
+	}
+	return true, edges
+}
+
+func validateOutput(t testCaseC, out string) bool {
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "-1" {
+		ok, _ := solveC(t)
+		return !ok
+	}
+	in := bufio.NewReader(strings.NewReader(out))
+	var m int
+	if _, err := fmt.Fscan(in, &m); err != nil {
+		return false
+	}
+	edges := make([]edge, m)
+	for i := 0; i < m; i++ {
+		if _, err := fmt.Fscan(in, &edges[i].u, &edges[i].v); err != nil {
+			return false
+		}
+	}
+	_, _ = io.ReadAll(in)
+	return checkGraph(t, edges)
+}
+
+func checkGraph(t testCaseC, edges []edge) bool {
+	n, k := t.n, t.k
+	root := -1
+	for i, di := range t.d {
+		if di == 0 {
+			if root != -1 {
+				return false
+			}
+			root = i + 1
+		}
+	}
+	if root == -1 {
+		return false
+	}
+	deg := make([]int, n+1)
+	adj := make([][]int, n+1)
+	seen := make(map[[2]int]bool)
+	for _, e := range edges {
+		if e.u < 1 || e.u > n || e.v < 1 || e.v > n || e.u == e.v {
+			return false
+		}
+		p := [2]int{e.u, e.v}
+		if p[0] > p[1] {
+			p[0], p[1] = p[1], p[0]
+		}
+		if seen[p] {
+			return false
+		}
+		seen[p] = true
+		deg[e.u]++
+		deg[e.v]++
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	for i := 1; i <= n; i++ {
+		if deg[i] > k {
+			return false
+		}
+	}
+	dist := make([]int, n+1)
+	for i := range dist {
+		dist[i] = -1
+	}
+	q := []int{root}
+	dist[root] = 0
+	for len(q) > 0 {
+		v := q[0]
+		q = q[1:]
+		for _, to := range adj[v] {
+			if dist[to] == -1 {
+				dist[to] = dist[v] + 1
+				q = append(q, to)
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if dist[i] != t.d[i-1] {
+			return false
+		}
+	}
+	return true
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run failed: %v\n%s", err, errb.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsC()
+	for i, t := range tests {
+		var b strings.Builder
+		b.WriteString(fmt.Sprintf("%d %d\n", t.n, t.k))
+		for idx, di := range t.d {
+			if idx > 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteString(fmt.Sprint(di))
+		}
+		b.WriteByte('\n')
+		out, err := runBinary(bin, b.String())
+		if err != nil {
+			fmt.Printf("test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !validateOutput(t, out) {
+			fmt.Printf("test %d failed\n", i+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/400-409/404/verifierD.go
+++ b/0-999/400-499/400-409/404/verifierD.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod = 1000000007
+
+type testCaseD struct{ s string }
+
+func generateTestsD() []testCaseD {
+	r := rand.New(rand.NewSource(4))
+	tests := make([]testCaseD, 0, 100)
+	for len(tests) < 100 {
+		n := 1 + r.Intn(6)
+		var b strings.Builder
+		for i := 0; i < n; i++ {
+			switch r.Intn(4) {
+			case 0:
+				b.WriteByte('*')
+			case 1:
+				b.WriteByte('?')
+			case 2:
+				b.WriteByte('0' + byte(r.Intn(3)))
+			case 3:
+				b.WriteByte('0' + byte(r.Intn(3)))
+			}
+		}
+		tests = append(tests, testCaseD{s: b.String()})
+	}
+	return tests
+}
+
+func waysD(board []byte) int64 {
+	n := len(board)
+	for i := 0; i < n; i++ {
+		if board[i] == '*' {
+			continue
+		}
+		c := int(board[i] - '0')
+		cnt := 0
+		if i-1 >= 0 && board[i-1] == '*' {
+			cnt++
+		}
+		if i+1 < n && board[i+1] == '*' {
+			cnt++
+		}
+		if cnt != c {
+			return 0
+		}
+	}
+	return 1
+}
+
+func solveDRec(s []byte, idx int, cur []byte) int64 {
+	if idx == len(s) {
+		return waysD(cur) % mod
+	}
+	ch := s[idx]
+	if ch == '?' {
+		sum := int64(0)
+		for _, c := range []byte{'*', '0', '1', '2'} {
+			cur[idx] = c
+			sum = (sum + solveDRec(s, idx+1, cur)) % mod
+		}
+		return sum
+	}
+	cur[idx] = ch
+	return solveDRec(s, idx+1, cur)
+}
+
+func solveDString(s string) int64 {
+	b := []byte(s)
+	cur := make([]byte, len(b))
+	return solveDRec(b, 0, cur)
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run failed: %v\n%s", err, errb.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsD()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.s+"\n")
+		if err != nil {
+			fmt.Printf("test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expect := solveDString(t.s)
+		got := strings.TrimSpace(out)
+		if fmt.Sprint(expect) != got {
+			fmt.Printf("test %d failed: expected %d got %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/400-499/400-409/404/verifierE.go
+++ b/0-999/400-499/400-409/404/verifierE.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseE struct{ s string }
+
+func generateTestsE() []testCaseE {
+	r := rand.New(rand.NewSource(5))
+	tests := make([]testCaseE, 0, 100)
+	for len(tests) < 100 {
+		n := 1 + r.Intn(6)
+		var b strings.Builder
+		for i := 0; i < n; i++ {
+			if r.Intn(2) == 0 {
+				b.WriteByte('L')
+			} else {
+				b.WriteByte('R')
+			}
+		}
+		tests = append(tests, testCaseE{s: b.String()})
+	}
+	return tests
+}
+
+func simulate(s string, finish int, obstacles map[int]bool) (bool, bool) {
+	pos := 0
+	visitedFinish := false
+	for i := 0; i < len(s); i++ {
+		move := 0
+		if s[i] == 'L' {
+			move = -1
+		} else {
+			move = 1
+		}
+		next := pos + move
+		if obstacles[next] {
+			continue
+		}
+		pos = next
+		if pos == finish {
+			if i != len(s)-1 || visitedFinish {
+				return false, false
+			}
+			visitedFinish = true
+		}
+	}
+	return visitedFinish && pos == finish, visitedFinish
+}
+
+func bruteForceE(s string) int64 {
+	n := len(s)
+	minObs := 1<<31 - 1
+	var count int64
+	posRange := 2*n + 1
+	cells := make([]int, 0, posRange)
+	for i := -n; i <= n; i++ {
+		if i != 0 {
+			cells = append(cells, i)
+		}
+	}
+	totalCells := len(cells)
+	for obsMask := 0; obsMask < 1<<uint(totalCells); obsMask++ {
+		obstacles := make(map[int]bool)
+		for j, c := range cells {
+			if obsMask&(1<<uint(j)) != 0 {
+				obstacles[c] = true
+			}
+		}
+		for finish := -n; finish <= n; finish++ {
+			if finish == 0 {
+				continue
+			}
+			ok, visited := simulate(s, finish, obstacles)
+			if ok {
+				k := len(obstacles)
+				if k < minObs {
+					minObs = k
+					count = 1
+				} else if k == minObs {
+					count++
+				}
+			} else if visited {
+				// visited but not valid -> ignore
+			}
+		}
+	}
+	if minObs == 1<<31-1 {
+		return 0
+	}
+	return count
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("run failed: %v\n%s", err, errb.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTestsE()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.s+"\n")
+		if err != nil {
+			fmt.Printf("test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expect := bruteForceE(t.s)
+		got := strings.TrimSpace(out)
+		if fmt.Sprint(expect) != got {
+			fmt.Printf("test %d failed: expected %d got %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go solution verifiers for contest 404 problems A–E
- each verifier runs 100 autogenerated test cases
- verifiers can be executed as `go run verifierX.go /path/to/binary`

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `./verifierA ./404A`
- `./verifierB ./404B`
- `./verifierC ./404C`
- `./verifierD ./404D`
- `./verifierE ./404E` *(fails as 404E.go is incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_687ec47636b88324b7ed740af34b2960