### PR TITLE
Add Go verifiers for Codeforces contest 400

### DIFF
--- a/0-999/400-499/400-409/400/verifierA.go
+++ b/0-999/400-499/400-409/400/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(tests []string) string {
+	var results []string
+	for _, s := range tests {
+		var pairs []string
+		for a := 1; a <= 12; a++ {
+			if 12%a != 0 {
+				continue
+			}
+			b := 12 / a
+			found := false
+			for j := 0; j < b; j++ {
+				allX := true
+				for i := 0; i < a; i++ {
+					idx := i*b + j
+					if s[idx] != 'X' {
+						allX = false
+						break
+					}
+				}
+				if allX {
+					found = true
+					break
+				}
+			}
+			if found {
+				pairs = append(pairs, fmt.Sprintf("%dx%d", a, b))
+			}
+		}
+		line := fmt.Sprintf("%d", len(pairs))
+		if len(pairs) > 0 {
+			line += " " + strings.Join(pairs, " ")
+		}
+		results = append(results, line)
+	}
+	return strings.Join(results, "\n")
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		t := rng.Intn(4) + 1
+		tests := make([]string, t)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", t))
+		for i := 0; i < t; i++ {
+			var str strings.Builder
+			for j := 0; j < 12; j++ {
+				if rng.Intn(2) == 0 {
+					str.WriteByte('X')
+				} else {
+					str.WriteByte('O')
+				}
+			}
+			s := str.String()
+			tests[i] = s
+			sb.WriteString(s)
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expectedOut := expected(tests)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expectedOut) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", tcase+1, expectedOut, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/400-409/400/verifierB.go
+++ b/0-999/400-499/400-409/400/verifierB.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, m int, grid []string) string {
+	dist := make(map[int]struct{})
+	for i := 0; i < n; i++ {
+		line := grid[i]
+		posG, posS := -1, -1
+		for j := 0; j < m; j++ {
+			switch line[j] {
+			case 'G':
+				posG = j
+			case 'S':
+				posS = j
+			}
+		}
+		if posG > posS {
+			return "-1"
+		}
+		d := posS - posG
+		if d > 0 {
+			dist[d] = struct{}{}
+		}
+	}
+	return fmt.Sprintf("%d", len(dist))
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 2 // ensure m>=2
+		grid := make([]string, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			posG := rng.Intn(m)
+			posS := rng.Intn(m)
+			for posS == posG {
+				posS = rng.Intn(m)
+			}
+			if posG > posS && rng.Intn(2) == 0 {
+				posG, posS = posS, posG // sometimes make G before S
+			}
+			row := make([]byte, m)
+			for j := 0; j < m; j++ {
+				row[j] = '*'
+			}
+			row[posG] = 'G'
+			row[posS] = 'S'
+			grid[i] = string(row)
+			sb.WriteString(grid[i])
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expectedOut := expected(n, m, grid)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expectedOut {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", tcase+1, expectedOut, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/400-409/400/verifierC.go
+++ b/0-999/400-499/400-409/400/verifierC.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func transform(n, m int64, x, y, z int64, points [][2]int64) [][2]int64 {
+	r1 := x % 4
+	f := y % 2
+	r2 := z % 4
+	res := make([][2]int64, len(points))
+	for idx, p := range points {
+		i, j := p[0], p[1]
+		h, w := n, m
+		for t := int64(0); t < r1; t++ {
+			i, j = j, h-i+1
+			h, w = w, h
+		}
+		if f == 1 {
+			j = w - j + 1
+		}
+		for t := int64(0); t < r2; t++ {
+			i, j = w-j+1, i
+			h, w = w, h
+		}
+		res[idx] = [2]int64{i, j}
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		n := int64(rng.Intn(10) + 1)
+		m := int64(rng.Intn(10) + 1)
+		x := int64(rng.Intn(20))
+		y := int64(rng.Intn(20))
+		z := int64(rng.Intn(20))
+		p := rng.Intn(5) + 1
+		points := make([][2]int64, p)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d %d %d %d\n", n, m, x, y, z, p))
+		for i := 0; i < p; i++ {
+			r := int64(rng.Intn(int(n)) + 1)
+			c := int64(rng.Intn(int(m)) + 1)
+			points[i] = [2]int64{r, c}
+			sb.WriteString(fmt.Sprintf("%d %d\n", r, c))
+		}
+		input := sb.String()
+		transformed := transform(n, m, x, y, z, points)
+		var exp strings.Builder
+		for i := 0; i < p; i++ {
+			exp.WriteString(fmt.Sprintf("%d %d\n", transformed[i][0], transformed[i][1]))
+		}
+		expectedOut := strings.TrimSpace(exp.String())
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expectedOut {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", tcase+1, expectedOut, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/400-409/400/verifierD.go
+++ b/0-999/400-499/400-409/400/verifierD.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	p []int
+}
+
+func newDSU(n int) *DSU {
+	d := &DSU{p: make([]int, n+1)}
+	for i := range d.p {
+		d.p[i] = i
+	}
+	return d
+}
+
+func (d *DSU) find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *DSU) union(x, y int) {
+	rx := d.find(x)
+	ry := d.find(y)
+	if rx != ry {
+		d.p[ry] = rx
+	}
+}
+
+type edge struct {
+	u, v, w int
+}
+
+func expected(n, m, k int, c []int, edges []edge) string {
+	typeOf := make([]int, n+1)
+	idx := 1
+	for i := 1; i <= k; i++ {
+		cnt := c[i-1]
+		for j := 0; j < cnt; j++ {
+			typeOf[idx] = i
+			idx++
+		}
+	}
+	dsu := newDSU(n)
+	for _, e := range edges {
+		if e.w == 0 {
+			dsu.union(e.u, e.v)
+		}
+	}
+	idx = 1
+	for i := 1; i <= k; i++ {
+		cnt := c[i-1]
+		if cnt > 0 {
+			root := dsu.find(idx)
+			for j := 0; j < cnt; j++ {
+				if dsu.find(idx+j) != root {
+					return "No"
+				}
+			}
+		}
+		idx += cnt
+	}
+	const INF = int(1e9)
+	dist := make([][]int, k)
+	for i := 0; i < k; i++ {
+		dist[i] = make([]int, k)
+		for j := 0; j < k; j++ {
+			if i == j {
+				dist[i][j] = 0
+			} else {
+				dist[i][j] = INF
+			}
+		}
+	}
+	for _, e := range edges {
+		if e.w == 0 {
+			continue
+		}
+		ti := typeOf[e.u] - 1
+		tj := typeOf[e.v] - 1
+		if ti != tj {
+			if e.w < dist[ti][tj] {
+				dist[ti][tj] = e.w
+				dist[tj][ti] = e.w
+			}
+		}
+	}
+	for p := 0; p < k; p++ {
+		for i := 0; i < k; i++ {
+			if dist[i][p] == INF {
+				continue
+			}
+			for j := 0; j < k; j++ {
+				if dist[p][j] == INF {
+					continue
+				}
+				nd := dist[i][p] + dist[p][j]
+				if nd < dist[i][j] {
+					dist[i][j] = nd
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("Yes\n")
+	for i := 0; i < k; i++ {
+		for j := 0; j < k; j++ {
+			if dist[i][j] >= INF {
+				sb.WriteString("-1")
+			} else {
+				sb.WriteString(fmt.Sprintf("%d", dist[i][j]))
+			}
+			if j+1 < k {
+				sb.WriteByte(' ')
+			}
+		}
+		if i+1 < k {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		k := rng.Intn(3) + 1
+		c := make([]int, k)
+		n := 0
+		for i := 0; i < k; i++ {
+			c[i] = rng.Intn(3) + 1
+			n += c[i]
+		}
+		m := rng.Intn(4*n + 1)
+		var edges []edge
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+		for i := 0; i < k; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", c[i]))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < m; i++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			w := rng.Intn(5)
+			edges = append(edges, edge{u, v, w})
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", u, v, w))
+		}
+		input := sb.String()
+		expectedOut := expected(n, m, k, c, edges)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expectedOut) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", tcase+1, expectedOut, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/400-499/400-409/400/verifierE.go
+++ b/0-999/400-499/400-409/400/verifierE.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func bruteSum(a []int) int64 {
+	n := len(a)
+	total := int64(0)
+	cur := make([]int, n)
+	copy(cur, a)
+	for len(cur) > 0 {
+		for _, v := range cur {
+			total += int64(v)
+		}
+		if len(cur) == 1 {
+			break
+		}
+		next := make([]int, len(cur)-1)
+		for i := 0; i < len(cur)-1; i++ {
+			next[i] = cur[i] & cur[i+1]
+		}
+		cur = next
+	}
+	return total
+}
+
+func expected(n, m int, arr []int, queries [][2]int) string {
+	a := make([]int, n)
+	copy(a, arr)
+	var sb strings.Builder
+	for i := 0; i < m; i++ {
+		p := queries[i][0]
+		v := queries[i][1]
+		a[p-1] = v
+		s := bruteSum(a)
+		sb.WriteString(fmt.Sprintf("%d\n", s))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(5) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(32)
+		}
+		queries := make([][2]int, m)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < m; i++ {
+			p := rng.Intn(n) + 1
+			v := rng.Intn(32)
+			queries[i] = [2]int{p, v}
+			sb.WriteString(fmt.Sprintf("%d %d\n", p, v))
+		}
+		input := sb.String()
+		expectedOut := expected(n, m, arr, queries)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expectedOut {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", tcase+1, expectedOut, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new Go verifiers for contest 400 problems A–E
- verifiers generate 100 randomized test cases and run a given binary to check correctness

## Testing
- `go run verifierA.go ./400A`
- `go run verifierB.go ./400B`
- `go run verifierC.go ./400C`
- `go run verifierD.go ./400D`
- `go run verifierE.go ./400E`

------
https://chatgpt.com/codex/tasks/task_e_687ec35b8b80832497ffcbe4d5055400