### PR TITLE
Add solution verifiers for contest 397

### DIFF
--- a/0-999/300-399/390-399/397/verifierA.go
+++ b/0-999/300-399/390-399/397/verifierA.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type interval struct {
+	l int
+	r int
+}
+
+func compute(n int, segs []interval) int {
+	l1, r1 := segs[0].l, segs[0].r
+	var inter []interval
+	for i := 1; i < n; i++ {
+		s := segs[i].l
+		if s < l1 {
+			s = l1
+		}
+		e := segs[i].r
+		if e > r1 {
+			e = r1
+		}
+		if s < e {
+			inter = append(inter, interval{s, e})
+		}
+	}
+	if len(inter) == 0 {
+		return r1 - l1
+	}
+	sort.Slice(inter, func(i, j int) bool {
+		if inter[i].l == inter[j].l {
+			return inter[i].r < inter[j].r
+		}
+		return inter[i].l < inter[j].l
+	})
+	covered := 0
+	curL, curR := inter[0].l, inter[0].r
+	for _, iv := range inter[1:] {
+		if iv.l <= curR {
+			if iv.r > curR {
+				curR = iv.r
+			}
+		} else {
+			covered += curR - curL
+			curL, curR = iv.l, iv.r
+		}
+	}
+	covered += curR - curL
+	res := (r1 - l1) - covered
+	if res < 0 {
+		res = 0
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1
+	segs := make([]interval, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(100)
+		r := l + 1 + rng.Intn(100-l)
+		segs[i] = interval{l, r}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", segs[i].l, segs[i].r))
+	}
+	ans := compute(n, segs)
+	return sb.String(), ans
+}
+
+func runCase(exe, input string, expected int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	var got int
+	fmt.Sscan(outStr, &got)
+	if got != expected {
+		return fmt.Errorf("expected %d got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/390-399/397/verifierB.go
+++ b/0-999/300-399/390-399/397/verifierB.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	expected := make([]string, t)
+	for i := 0; i < t; i++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		l := rng.Int63n(1_000_000_000) + 1
+		r := rng.Int63n(1_000_000_000) + 1
+		if l > r {
+			l, r = r, l
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, l, r))
+		minX := (n + r - 1) / r
+		maxX := n / l
+		if minX <= maxX {
+			expected[i] = "Yes"
+		} else {
+			expected[i] = "No"
+		}
+	}
+	return sb.String(), expected
+}
+
+func runCase(exe, input string, expected []string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	tokens := strings.Fields(strings.TrimSpace(out.String()))
+	if len(tokens) != len(expected) {
+		return fmt.Errorf("expected %d tokens got %d", len(expected), len(tokens))
+	}
+	for i, exp := range expected {
+		if tokens[i] != exp {
+			return fmt.Errorf("line %d: expected %s got %s", i+1, exp, tokens[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` and `verifierB.go` for contest 397
- verifiers generate random test cases and check output from a compiled binary

## Testing
- `go vet 0-999/300-399/390-399/397/verifierA.go`
- `go vet 0-999/300-399/390-399/397/verifierB.go`
- `go build 0-999/300-399/390-399/397/verifierA.go`
- `go build 0-999/300-399/390-399/397/verifierB.go`

------
https://chatgpt.com/codex/tasks/task_e_687ec28963d88324a2c0ceab2f93efc6