### PR TITLE
Add Go verifiers for contest 394

### DIFF
--- a/0-999/300-399/390-399/394/verifierA.go
+++ b/0-999/300-399/390-399/394/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "394A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() []string {
+	const T = 100
+	rand.Seed(1)
+	tests := make([]string, T)
+	for i := 0; i < T; i++ {
+		a := rand.Intn(20) + 1
+		b := rand.Intn(20) + 1
+		c := rand.Intn(20) + 1
+		expr := strings.Repeat("|", a) + "+" + strings.Repeat("|", b) + "=" + strings.Repeat("|", c)
+		tests[i] = expr + "\n"
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := generate()
+	for idx, input := range tests {
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\nexpected:\n%s\n\ngot:\n%s\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/300-399/390-399/394/verifierB.go
+++ b/0-999/300-399/390-399/394/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "394B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() []string {
+	const T = 100
+	rand.Seed(2)
+	tests := make([]string, T)
+	for i := 0; i < T; i++ {
+		p := rand.Intn(20) + 1
+		x := rand.Intn(9) + 1
+		tests[i] = fmt.Sprintf("%d %d\n", p, x)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := generate()
+	for idx, input := range tests {
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\nexpected:\n%s\n\ngot:\n%s\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/300-399/390-399/394/verifierC.go
+++ b/0-999/300-399/390-399/394/verifierC.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "394C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() []string {
+	const T = 100
+	rand.Seed(3)
+	tests := make([]string, T)
+	for t := 0; t < T; t++ {
+		n := rand.Intn(3) + 1
+		m := rand.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				switch rand.Intn(4) {
+				case 0:
+					sb.WriteString("11")
+				case 1:
+					sb.WriteString("10")
+				case 2:
+					sb.WriteString("01")
+				default:
+					sb.WriteString("00")
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		tests[t] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := generate()
+	for idx, input := range tests {
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\nexpected:\n%s\n\ngot:\n%s\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/300-399/390-399/394/verifierD.go
+++ b/0-999/300-399/390-399/394/verifierD.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "394D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() []string {
+	const T = 100
+	rand.Seed(4)
+	tests := make([]string, T)
+	for t := 0; t < T; t++ {
+		n := rand.Intn(5) + 2
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(21)-10))
+		}
+		sb.WriteByte('\n')
+		tests[t] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := generate()
+	for idx, input := range tests {
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\nexpected:\n%s\n\ngot:\n%s\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/300-399/390-399/394/verifierE.go
+++ b/0-999/300-399/390-399/394/verifierE.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "394E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate() []string {
+	const T = 100
+	rand.Seed(5)
+	tests := make([]string, T)
+	for t := 0; t < T; t++ {
+		n := rand.Intn(4) + 2
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			x := rand.Intn(21) - 5
+			y := rand.Intn(21) - 5
+			fmt.Fprintf(&sb, "%d %d\n", x, y)
+		}
+		sb.WriteString("4\n")
+		sb.WriteString("0 0\n0 10\n10 10\n10 0\n")
+		tests[t] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := generate()
+	for idx, input := range tests {
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\nexpected:\n%s\n\ngot:\n%s\n", idx+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add verifierA.go, verifierB.go, verifierC.go, verifierD.go, verifierE.go for contest 394
- each verifier builds the official solution as an oracle and runs 100 random tests
- running `go run verifierA.go /path/to/binary` now validates solutions for problem A and similarly for other problems

## Testing
- `go build 0-999/300-399/390-399/394/verifierA.go`
- `go build 0-999/300-399/390-399/394/verifierB.go`
- `go build 0-999/300-399/390-399/394/verifierC.go`
- `go build 0-999/300-399/390-399/394/verifierD.go`
- `go build 0-999/300-399/390-399/394/verifierE.go`
- `go build -o 394A_bin 0-999/300-399/390-399/394/394A.go`
- `go run 0-999/300-399/390-399/394/verifierA.go ./0-999/300-399/390-399/394/394A_bin`

------
https://chatgpt.com/codex/tasks/task_e_687ec1b73aa8832496cdcb6b321d880d