### PR TITLE
Add Go verifiers for contest 392

### DIFF
--- a/0-999/300-399/390-399/392/392D.go
+++ b/0-999/300-399/390-399/392/392D.go
@@ -1,241 +1,256 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
-   "sort"
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
 )
 
 // Segment tree for range chmax (a2[v] = max(a2[v], x)) and querying min(v + a2[v])
-const INF = 1e18
+const INF int64 = 1e18
 
 type segNode struct {
-   l, r      int
-   min1      int   // minimal a2
-   min2      int   // second minimal a2
-   cnt1      int   // count of elements == min1
-   minv1     int   // minimal v among elements == min1
-   minB2     int64 // minimal b2 = v + a2
-   minB2Alt  int64 // minimal b2 among elements with a2 > min1
+	l, r     int
+	min1     int   // minimal a2
+	min2     int   // second minimal a2
+	cnt1     int   // count of elements == min1
+	minv1    int   // minimal v among elements == min1
+	minB2    int64 // minimal b2 = v + a2
+	minB2Alt int64 // minimal b2 among elements with a2 > min1
 }
 
 type segTree struct {
-   n    int
-   tree []segNode
+	n    int
+	tree []segNode
 }
 
 func newSegTree(n int) *segTree {
-   size := 4 * n
-   st := &segTree{n: n, tree: make([]segNode, size)}
-   st.build(1, 0, n-1)
-   return st
+	size := 4 * n
+	st := &segTree{n: n, tree: make([]segNode, size)}
+	st.build(1, 0, n-1)
+	return st
 }
 
 func (st *segTree) build(idx, l, r int) {
-   node := &st.tree[idx]
-   node.l, node.r = l, r
-   if l == r {
-       node.min1 = 0
-       node.min2 = int(1e9)
-       node.cnt1 = 1
-       node.minv1 = l
-       node.minB2 = int64(l)
-       node.minB2Alt = INF
-       return
-   }
-   mid := (l + r) >> 1
-   st.build(idx<<1, l, mid)
-   st.build(idx<<1|1, mid+1, r)
-   st.pushUp(idx)
+	node := &st.tree[idx]
+	node.l, node.r = l, r
+	if l == r {
+		node.min1 = 0
+		node.min2 = int(1e9)
+		node.cnt1 = 1
+		node.minv1 = l
+		node.minB2 = int64(l)
+		node.minB2Alt = INF
+		return
+	}
+	mid := (l + r) >> 1
+	st.build(idx<<1, l, mid)
+	st.build(idx<<1|1, mid+1, r)
+	st.pushUp(idx)
 }
 
-func minInt(a, b int) int { if a < b { return a }; return b }
-func maxInt(a, b int) int { if a > b { return a }; return b }
-func min64(a, b int64) int64 { if a < b { return a }; return b }
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
 
 func (st *segTree) pushUp(idx int) {
-   a, b := &st.tree[idx<<1], &st.tree[idx<<1|1]
-   node := &st.tree[idx]
-   // min1
-   if a.min1 < b.min1 {
-       node.min1 = a.min1
-       node.cnt1 = a.cnt1
-       node.minv1 = a.minv1
-   } else if b.min1 < a.min1 {
-       node.min1 = b.min1
-       node.cnt1 = b.cnt1
-       node.minv1 = b.minv1
-   } else {
-       node.min1 = a.min1
-       node.cnt1 = a.cnt1 + b.cnt1
-       if a.minv1 < b.minv1 {
-           node.minv1 = a.minv1
-       } else {
-           node.minv1 = b.minv1
-       }
-   }
-   // min2
-   node.min2 = int(1e9)
-   if a.min1 != node.min1 {
-       node.min2 = minInt(node.min2, a.min1)
-   } else {
-       node.min2 = minInt(node.min2, a.min2)
-   }
-   if b.min1 != node.min1 {
-       node.min2 = minInt(node.min2, b.min1)
-   } else {
-       node.min2 = minInt(node.min2, b.min2)
-   }
-   // minB2
-   node.minB2 = min64(a.minB2, b.minB2)
-   // minB2Alt: merge alt from children
-   m := INF
-   // child a
-   if a.min1 > node.min1 {
-       m = min64(m, a.minB2)
-   } else {
-       m = min64(m, a.minB2Alt)
-   }
-   // child b
-   if b.min1 > node.min1 {
-       m = min64(m, b.minB2)
-   } else {
-       m = min64(m, b.minB2Alt)
-   }
-   node.minB2Alt = m
+	a, b := &st.tree[idx<<1], &st.tree[idx<<1|1]
+	node := &st.tree[idx]
+	// min1
+	if a.min1 < b.min1 {
+		node.min1 = a.min1
+		node.cnt1 = a.cnt1
+		node.minv1 = a.minv1
+	} else if b.min1 < a.min1 {
+		node.min1 = b.min1
+		node.cnt1 = b.cnt1
+		node.minv1 = b.minv1
+	} else {
+		node.min1 = a.min1
+		node.cnt1 = a.cnt1 + b.cnt1
+		if a.minv1 < b.minv1 {
+			node.minv1 = a.minv1
+		} else {
+			node.minv1 = b.minv1
+		}
+	}
+	// min2
+	node.min2 = int(1e9)
+	if a.min1 != node.min1 {
+		node.min2 = minInt(node.min2, a.min1)
+	} else {
+		node.min2 = minInt(node.min2, a.min2)
+	}
+	if b.min1 != node.min1 {
+		node.min2 = minInt(node.min2, b.min1)
+	} else {
+		node.min2 = minInt(node.min2, b.min2)
+	}
+	// minB2
+	node.minB2 = min64(a.minB2, b.minB2)
+	// minB2Alt: merge alt from children
+	m := INF
+	// child a
+	if a.min1 > node.min1 {
+		m = min64(m, a.minB2)
+	} else {
+		m = min64(m, a.minB2Alt)
+	}
+	// child b
+	if b.min1 > node.min1 {
+		m = min64(m, b.minB2)
+	} else {
+		m = min64(m, b.minB2Alt)
+	}
+	node.minB2Alt = m
 }
 
 // apply raising a2 == min1 to x (x < min2)
 func (st *segTree) applyChmax(idx, x int) {
-   node := &st.tree[idx]
-   if node.min1 >= x {
-       return
-   }
-   // x < min2 guaranteed when called
-   delta := x - node.min1
-   node.min1 = x
-   // minv1 unchanged
-   // update minB2: if it was from min1 group or alt
-   // new b2 from min1 group = minv1 + x
-   newB2_1 := int64(node.minv1 + x)
-   node.minB2 = min64(newB2_1, node.minB2Alt)
+	node := &st.tree[idx]
+	if node.min1 >= x {
+		return
+	}
+	// x < min2 guaranteed when called
+	_ = x - node.min1
+	node.min1 = x
+	// minv1 unchanged
+	// update minB2: if it was from min1 group or alt
+	// new b2 from min1 group = minv1 + x
+	newB2_1 := int64(node.minv1 + x)
+	node.minB2 = min64(newB2_1, node.minB2Alt)
 }
 
 func (st *segTree) pushDown(idx int) {
-   node := &st.tree[idx]
-   for _, c := range []int{node.min1} {
-       // propagate to children
-       child := &st.tree[idx<<1]
-       if child.min1 < c {
-           st.applyChmax(idx<<1, c)
-       }
-       child = &st.tree[idx<<1|1]
-       if child.min1 < c {
-           st.applyChmax(idx<<1|1, c)
-       }
-   }
+	node := &st.tree[idx]
+	for _, c := range []int{node.min1} {
+		// propagate to children
+		child := &st.tree[idx<<1]
+		if child.min1 < c {
+			st.applyChmax(idx<<1, c)
+		}
+		child = &st.tree[idx<<1|1]
+		if child.min1 < c {
+			st.applyChmax(idx<<1|1, c)
+		}
+	}
 }
 
 func (st *segTree) rangeChmax(lq, rq, x int) {
-   st._chmax(1, lq, rq, x)
+	st._chmax(1, lq, rq, x)
 }
 func (st *segTree) _chmax(idx, lq, rq, x int) {
-   node := &st.tree[idx]
-   if node.r < lq || node.l > rq || node.min1 >= x {
-       return
-   }
-   if lq <= node.l && node.r <= rq && node.min2 > x {
-       st.applyChmax(idx, x)
-       return
-   }
-   st.pushDown(idx)
-   st._chmax(idx<<1, lq, rq, x)
-   st._chmax(idx<<1|1, lq, rq, x)
-   st.pushUp(idx)
+	node := &st.tree[idx]
+	if node.r < lq || node.l > rq || node.min1 >= x {
+		return
+	}
+	if lq <= node.l && node.r <= rq && node.min2 > x {
+		st.applyChmax(idx, x)
+		return
+	}
+	st.pushDown(idx)
+	st._chmax(idx<<1, lq, rq, x)
+	st._chmax(idx<<1|1, lq, rq, x)
+	st.pushUp(idx)
 }
 
 func (st *segTree) minB2() int64 {
-   return st.tree[1].minB2
+	return st.tree[1].minB2
 }
 
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   writer := bufio.NewWriter(os.Stdout)
-   defer writer.Flush()
-   var n int
-   fmt.Fscan(reader, &n)
-   a := make([]int, n)
-   b := make([]int, n)
-   c := make([]int, n)
-   vals := make([]int, 0, 3*n)
-   for i := 0; i < n; i++ {
-       fmt.Fscan(reader, &a[i])
-       vals = append(vals, a[i])
-   }
-   for i := 0; i < n; i++ {
-       fmt.Fscan(reader, &b[i])
-       vals = append(vals, b[i])
-   }
-   for i := 0; i < n; i++ {
-       fmt.Fscan(reader, &c[i])
-       vals = append(vals, c[i])
-   }
-   sort.Ints(vals)
-   mp := make(map[int]int, len(vals))
-   m := 0
-   for _, v := range vals {
-       if _, ok := mp[v]; !ok {
-           mp[v] = m
-           m++
-       }
-   }
-   inf := n + 1
-   iA := make([]int, m)
-   iB := make([]int, m)
-   iC := make([]int, m)
-   for i := 0; i < m; i++ {
-       iA[i], iB[i], iC[i] = inf, inf, inf
-   }
-   for i, v := range a {
-       id := mp[v]
-       if i+1 < iA[id] {
-           iA[id] = i + 1
-       }
-   }
-   for i, v := range b {
-       id := mp[v]
-       if i+1 < iB[id] {
-           iB[id] = i + 1
-       }
-   }
-   for i, v := range c {
-       id := mp[v]
-       if i+1 < iC[id] {
-           iC[id] = i + 1
-       }
-   }
-   addAt := make([][]struct{b, c int}, n+2)
-   for id := 0; id < m; id++ {
-       ua := iA[id]
-       addAt[ua] = append(addAt[ua], struct{b, c int}{iB[id], iC[id]})
-   }
-   st := newSegTree(n + 1)
-   ans := int64(3 * n)
-   for u := n; u >= 0; u-- {
-       if u+1 <= n+1 {
-           for _, p := range addAt[u+1] {
-               l, r := 0, p.b-1
-               if r >= 0 {
-                   st.rangeChmax(l, r, p.c)
-               }
-           }
-       }
-       cur := st.minB2()
-       tot := int64(u) + cur
-       if tot < ans {
-           ans = tot
-       }
-   }
-   fmt.Fprintln(writer, ans)
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	b := make([]int, n)
+	c := make([]int, n)
+	vals := make([]int, 0, 3*n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+		vals = append(vals, a[i])
+	}
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &b[i])
+		vals = append(vals, b[i])
+	}
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &c[i])
+		vals = append(vals, c[i])
+	}
+	sort.Ints(vals)
+	mp := make(map[int]int, len(vals))
+	m := 0
+	for _, v := range vals {
+		if _, ok := mp[v]; !ok {
+			mp[v] = m
+			m++
+		}
+	}
+	inf := n + 1
+	iA := make([]int, m)
+	iB := make([]int, m)
+	iC := make([]int, m)
+	for i := 0; i < m; i++ {
+		iA[i], iB[i], iC[i] = inf, inf, inf
+	}
+	for i, v := range a {
+		id := mp[v]
+		if i+1 < iA[id] {
+			iA[id] = i + 1
+		}
+	}
+	for i, v := range b {
+		id := mp[v]
+		if i+1 < iB[id] {
+			iB[id] = i + 1
+		}
+	}
+	for i, v := range c {
+		id := mp[v]
+		if i+1 < iC[id] {
+			iC[id] = i + 1
+		}
+	}
+	addAt := make([][]struct{ b, c int }, n+2)
+	for id := 0; id < m; id++ {
+		ua := iA[id]
+		addAt[ua] = append(addAt[ua], struct{ b, c int }{iB[id], iC[id]})
+	}
+	st := newSegTree(n + 1)
+	ans := int64(3 * n)
+	for u := n; u >= 0; u-- {
+		if u+1 <= n+1 {
+			for _, p := range addAt[u+1] {
+				l, r := 0, p.b-1
+				if r >= 0 {
+					st.rangeChmax(l, r, p.c)
+				}
+			}
+		}
+		cur := st.minB2()
+		tot := int64(u) + cur
+		if tot < ans {
+			ans = tot
+		}
+	}
+	fmt.Fprintln(writer, ans)
 }

--- a/0-999/300-399/390-399/392/verifierA.go
+++ b/0-999/300-399/390-399/392/verifierA.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	refBin := "./_refA"
+	if err := exec.Command("go", "build", "-o", refBin, "392A.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(1)
+	for tc := 1; tc <= 100; tc++ {
+		n := rand.Int63n(40000001)
+		input := fmt.Sprintf("%d\n", n)
+
+		expOut, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution error:", err)
+			return
+		}
+		gotOut, err := runCmd(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", tc, err)
+			return
+		}
+		if gotOut != expOut {
+			fmt.Printf("wrong answer on test %d\ninput: %sexpected: %s\ngot: %s\n", tc, input, expOut, gotOut)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/300-399/390-399/392/verifierB.go
+++ b/0-999/300-399/390-399/392/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type matrix [3][3]int64
+
+func runCmd(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func min(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveRef(t matrix, n int) int64 {
+	var dp [41][3][3]int64
+	for i := 0; i < 3; i++ {
+		for j := 0; j < 3; j++ {
+			if i == j {
+				dp[1][i][j] = 0
+			} else {
+				k := 3 - i - j
+				dp[1][i][j] = min(t[i][j], t[i][k]+t[k][j])
+			}
+		}
+	}
+	for d := 2; d <= n; d++ {
+		for i := 0; i < 3; i++ {
+			for j := 0; j < 3; j++ {
+				if i == j {
+					dp[d][i][j] = 0
+					continue
+				}
+				k := 3 - i - j
+				cost1 := dp[d-1][i][k] + t[i][j] + dp[d-1][k][j]
+				cost2 := dp[d-1][i][j] + t[i][k] + dp[d-1][j][i] + t[k][j] + dp[d-1][i][j]
+				dp[d][i][j] = min(cost1, cost2)
+			}
+		}
+	}
+	return dp[n][0][2]
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	rand.Seed(1)
+	for tc := 1; tc <= 100; tc++ {
+		var t matrix
+		for i := 0; i < 3; i++ {
+			for j := 0; j < 3; j++ {
+				if i == j {
+					t[i][j] = 0
+				} else {
+					t[i][j] = int64(rand.Intn(10000) + 1)
+				}
+			}
+		}
+		n := rand.Intn(40) + 1
+		inputBuilder := strings.Builder{}
+		for i := 0; i < 3; i++ {
+			for j := 0; j < 3; j++ {
+				inputBuilder.WriteString(fmt.Sprintf("%d ", t[i][j]))
+			}
+			inputBuilder.WriteByte('\n')
+		}
+		inputBuilder.WriteString(fmt.Sprintf("%d\n", n))
+		input := inputBuilder.String()
+
+		expected := fmt.Sprintf("%d", solveRef(t, n))
+		got, err := runCmd(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", tc, err)
+			return
+		}
+		if got != expected {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", tc, input, expected, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/300-399/390-399/392/verifierC.go
+++ b/0-999/300-399/390-399/392/verifierC.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	refBin := "./_refC"
+	if err := exec.Command("go", "build", "-o", refBin, "392C.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(1)
+	for tc := 1; tc <= 100; tc++ {
+		n := rand.Int63n(100000000000000000) + 1
+		k := rand.Intn(40) + 1
+		input := fmt.Sprintf("%d %d\n", n, k)
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution error:", err)
+			return
+		}
+		got, err := runCmd(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", tc, err)
+			return
+		}
+		if got != exp {
+			fmt.Printf("wrong answer on test %d\ninput:%sexpected:%s\ngot:%s\n", tc, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/300-399/390-399/392/verifierD.go
+++ b/0-999/300-399/390-399/392/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randArr(n int) []int {
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rand.Intn(100) + 1
+	}
+	return arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	refBin := "./_refD"
+	if err := exec.Command("go", "build", "-o", refBin, "392D.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(1)
+	for tc := 1; tc <= 100; tc++ {
+		n := rand.Intn(50) + 1
+		a := randArr(n)
+		b := randArr(n)
+		c := randArr(n)
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for i, v := range b {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for i, v := range c {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution error:", err)
+			return
+		}
+		got, err := runCmd(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", tc, err)
+			return
+		}
+		if got != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected:%s\ngot:%s\n", tc, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/300-399/390-399/392/verifierE.go
+++ b/0-999/300-399/390-399/392/verifierE.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randArr(n int, limit int) []int {
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rand.Intn(limit)
+	}
+	return arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+
+	refBin := "./_refE"
+	if err := exec.Command("go", "build", "-o", refBin, "392E.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(1)
+	for tc := 1; tc <= 100; tc++ {
+		n := rand.Intn(50) + 1
+		v := randArr(n, 201)
+		w := randArr(n, 1000)
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, val := range v {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", val))
+		}
+		sb.WriteByte('\n')
+		for i, val := range w {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", val))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution error:", err)
+			return
+		}
+		got, err := runCmd(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", tc, err)
+			return
+		}
+		if got != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected:%s\ngot:%s\n", tc, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- add runtime verifiers for problems A–E of contest 392
- fix build issues in `392D.go`

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`

------
https://chatgpt.com/codex/tasks/task_e_687ec12b26508324bd610f82153da3f2