### PR TITLE
Add verifiers for Codeforces contest 386

### DIFF
--- a/0-999/300-399/380-389/386/verifierA.go
+++ b/0-999/300-399/380-389/386/verifierA.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(bids []int) (int, int) {
+	maxVal, secondVal := -1, -1
+	maxIdx := -1
+	for i, v := range bids {
+		if v > maxVal {
+			secondVal = maxVal
+			maxVal = v
+			maxIdx = i + 1
+		} else if v > secondVal {
+			secondVal = v
+		}
+	}
+	return maxIdx, secondVal
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(999) + 2 // 2..1000
+	seen := make(map[int]bool)
+	bids := make([]int, 0, n)
+	for len(bids) < n {
+		x := rng.Intn(10000) + 1
+		if !seen[x] {
+			seen[x] = true
+			bids = append(bids, x)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range bids {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	idx, price := solveCase(bids)
+	expect := fmt.Sprintf("%d %d", idx, price)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// some deterministic edge cases
+	cases := []struct{ in, out string }{}
+	// smallest
+	cases = append(cases, func() (string, string) {
+		bids := []int{1, 2}
+		in := "2\n1 2\n"
+		idx, price := solveCase(bids)
+		return in, fmt.Sprintf("%d %d", idx, price)
+	}())
+	// large n
+	cases = append(cases, func() (string, string) {
+		n := 1000
+		bids := make([]int, n)
+		for i := 0; i < n; i++ {
+			bids[i] = i + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := range bids {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", bids[i]))
+		}
+		sb.WriteByte('\n')
+		idx, price := solveCase(bids)
+		return sb.String(), fmt.Sprintf("%d %d", idx, price)
+	}())
+
+	for i := 0; i < 100; i++ {
+		in, out := generateCase(rng)
+		cases = append(cases, struct{ in, out string }{in, out})
+	}
+
+	for i, tc := range cases {
+		got, err := runCandidate(bin, tc.in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(tc.out) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.out, got, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/386/verifierB.go
+++ b/0-999/300-399/380-389/386/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(times []int, T int) int {
+	sort.Ints(times)
+	best := 0
+	r := 0
+	for l := 0; l < len(times); l++ {
+		for r < len(times) && times[r]-times[l] <= T {
+			r++
+		}
+		if r-l > best {
+			best = r - l
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	times := make([]int, n)
+	for i := 0; i < n; i++ {
+		times[i] = rng.Intn(1000) + 1
+	}
+	T := rng.Intn(1000) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range times {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", T))
+	expect := fmt.Sprintf("%d", solveCase(append([]int(nil), times...), T))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []struct{ in, out string }{}
+	// simple case
+	cases = append(cases, "1\n5\n0\n", "1")
+	cases = append(cases, "3\n1 3 8\n4\n", "2")
+
+	for i := 0; i < 100; i++ {
+		in, out := generateCase(rng)
+		cases = append(cases, struct{ in, out string }{in, out})
+	}
+
+	for i, tc := range cases {
+		got, err := runCandidate(bin, tc.in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(tc.out) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.out, got, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/386/verifierC.go
+++ b/0-999/300-399/380-389/386/verifierC.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(s string) string {
+	n := len(s)
+	seen := make([]bool, 26)
+	d := 0
+	for i := 0; i < n; i++ {
+		idx := s[i] - 'a'
+		if !seen[idx] {
+			seen[idx] = true
+			d++
+		}
+	}
+	f := make([]int64, d+1)
+	for k := 1; k <= d; k++ {
+		var cnt [26]int
+		distinct := 0
+		l := 0
+		var res int64
+		for r := 0; r < n; r++ {
+			idx := s[r] - 'a'
+			if cnt[idx] == 0 {
+				distinct++
+			}
+			cnt[idx]++
+			for distinct > k {
+				idxl := s[l] - 'a'
+				cnt[idxl]--
+				if cnt[idxl] == 0 {
+					distinct--
+				}
+				l++
+			}
+			res += int64(r - l + 1)
+		}
+		f[k] = res
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", d))
+	for k := 1; k <= d; k++ {
+		tk := f[k]
+		if k > 1 {
+			tk -= f[k-1]
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", tk))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(30) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte(rng.Intn(26)) + 'a'
+	}
+	s := string(b)
+	return fmt.Sprintf("%s\n", s), solveCase(s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []struct{ in, out string }{
+		{"a\n", solveCase("a")},
+		{"abca\n", solveCase("abca")},
+	}
+	for i := 0; i < 100; i++ {
+		in, out := generateCase(rng)
+		cases = append(cases, struct{ in, out string }{in, out})
+	}
+
+	for i, tc := range cases {
+		got, err := runCandidate(bin, tc.in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(tc.out) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.out, got, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/386/verifierD.go
+++ b/0-999/300-399/380-389/386/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "386D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 3 // 3..8
+	pos := rng.Perm(n)[:3]
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	fmt.Fprintf(&sb, "%d %d %d\n", pos[0]+1, pos[1]+1, pos[2]+1)
+	matrix := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		matrix[i] = make([]byte, n)
+		for j := 0; j < n; j++ {
+			if i == j {
+				matrix[i][j] = '*'
+			} else if j < i {
+				matrix[i][j] = matrix[j][i]
+			} else {
+				matrix[i][j] = byte(rng.Intn(26)) + 'a'
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		sb.Write(matrix[i])
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []string{}
+	// simple deterministic case
+	cases = append(cases, func() string {
+		n := 3
+		var sb strings.Builder
+		sb.WriteString("3\n1 2 3\n")
+		sb.WriteString("*aa\n")
+		sb.WriteString("a*a\n")
+		sb.WriteString("aa*\n")
+		return sb.String()
+	}())
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for i, in := range cases {
+		// run oracle
+		cmdO := exec.Command(oracle)
+		cmdO.Stdin = strings.NewReader(in)
+		var outO bytes.Buffer
+		cmdO.Stdout = &outO
+		if err := cmdO.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "oracle run error: %v\n", err)
+			os.Exit(1)
+		}
+		expected := strings.TrimSpace(outO.String())
+
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, in)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–D of contest 386
- each verifier runs candidate binaries against 100+ cases
- include random case generation and edge case coverage

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go`


------
https://chatgpt.com/codex/tasks/task_e_687ebf86d6688324ace37af6fc4596f8