### PR TITLE
Add verifiers for Codeforces contest 385

### DIFF
--- a/0-999/300-399/380-389/385/verifierA.go
+++ b/0-999/300-399/380-389/385/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedProfit(c int, prices []int) int {
+	maxProfit := 0
+	for i := 0; i+1 < len(prices); i++ {
+		profit := prices[i] - prices[i+1] - c
+		if profit > maxProfit {
+			maxProfit = profit
+		}
+	}
+	return maxProfit
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(99) + 2
+	c := rng.Intn(101)
+	prices := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, c))
+	for i := 0; i < n; i++ {
+		prices[i] = rng.Intn(101)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", prices[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expectedProfit(c, prices)
+}
+
+func runCase(bin, input string, expected int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/385/verifierB.go
+++ b/0-999/300-399/380-389/385/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedCount(s string) int64 {
+	n := len(s)
+	nextOcc := make([]int, n)
+	const inf = int(1e9)
+	last := inf
+	for i := n - 1; i >= 0; i-- {
+		if i <= n-4 && s[i] == 'b' && s[i+1] == 'e' && s[i+2] == 'a' && s[i+3] == 'r' {
+			last = i
+		}
+		nextOcc[i] = last
+	}
+	var ans int64
+	for i := 0; i < n; i++ {
+		p := nextOcc[i]
+		if p <= n-4 {
+			ans += int64(n - (p + 3))
+		}
+	}
+	return ans
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(100) + 1
+	s := randString(rng, n)
+	return s + "\n", expectedCount(s)
+}
+
+func runCase(bin, input string, expected int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/385/verifierC.go
+++ b/0-999/300-399/380-389/385/verifierC.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func sieve(n int) []int {
+	isPrime := make([]bool, n+1)
+	for i := 2; i <= n; i++ {
+		isPrime[i] = true
+	}
+	for p := 2; p*p <= n; p++ {
+		if isPrime[p] {
+			for q := p * p; q <= n; q += p {
+				isPrime[q] = false
+			}
+		}
+	}
+	primes := make([]int, 0)
+	for i := 2; i <= n; i++ {
+		if isPrime[i] {
+			primes = append(primes, i)
+		}
+	}
+	return primes
+}
+
+func expected(xs []int, queries [][2]int) []int64 {
+	maxR := 0
+	for _, q := range queries {
+		if q[1] > maxR {
+			maxR = q[1]
+		}
+	}
+	primes := sieve(maxR)
+	results := make([]int64, len(queries))
+	for idx, q := range queries {
+		l, r := q[0], q[1]
+		var sum int64
+		for _, p := range primes {
+			if p < l {
+				continue
+			}
+			if p > r {
+				break
+			}
+			cnt := 0
+			for _, v := range xs {
+				if v%p == 0 {
+					cnt++
+				}
+			}
+			sum += int64(cnt)
+		}
+		results[idx] = sum
+	}
+	return results
+}
+
+func generateCase(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(20) + 1
+	xs := make([]int, n)
+	for i := range xs {
+		xs[i] = rng.Intn(100) + 2
+	}
+	q := rng.Intn(5) + 1
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(50) + 2
+		r := l + rng.Intn(50)
+		queries[i] = [2]int{l, r}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range xs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for _, qr := range queries {
+		sb.WriteString(fmt.Sprintf("%d %d\n", qr[0], qr[1]))
+	}
+	return sb.String(), expected(xs, queries)
+}
+
+func runCase(bin, input string, expected []int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != len(expected) {
+		return fmt.Errorf("expected %d numbers got %d", len(expected), len(fields))
+	}
+	for i, f := range fields {
+		var val int64
+		if _, err := fmt.Sscan(f, &val); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if val != expected[i] {
+			return fmt.Errorf("expected %v got %v", expected, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/385/verifierD.go
+++ b/0-999/300-399/380-389/385/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int, l, r float64, px, py, a []float64) float64 {
+	cosA := make([]float64, n)
+	sinA := make([]float64, n)
+	for i := 0; i < n; i++ {
+		rad := a[i] * math.Pi / 180.0
+		cosA[i] = math.Cos(rad)
+		sinA[i] = math.Sin(rad)
+	}
+	size := 1 << uint(n)
+	dp := make([]float64, size)
+	for i := range dp {
+		dp[i] = l
+	}
+	for mask := 0; mask < size; mask++ {
+		base := dp[mask]
+		for i := 0; i < n; i++ {
+			if mask>>i&1 == 0 {
+				dx0 := base - px[i]
+				dy0 := -py[i]
+				dirX := dx0*cosA[i] - dy0*sinA[i]
+				dirY := dx0*sinA[i] + dy0*cosA[i]
+				np := r
+				if dirY < 0 {
+					t := -py[i] / dirY
+					np = px[i] + dirX*t
+					if np > r {
+						np = r
+					}
+				}
+				next := mask | (1 << i)
+				if np > dp[next] {
+					dp[next] = np
+				}
+			}
+		}
+	}
+	return dp[size-1] - l
+}
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	n := rng.Intn(4) + 1
+	l := rng.Float64()*20 - 10
+	r := l + rng.Float64()*10 + 1e-3
+	px := make([]float64, n)
+	py := make([]float64, n)
+	ang := make([]float64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %.6f %.6f\n", n, l, r))
+	for i := 0; i < n; i++ {
+		px[i] = rng.Float64()*20 - 10
+		py[i] = rng.Float64()*10 + 1
+		ang[i] = rng.Float64()*89 + 1
+		sb.WriteString(fmt.Sprintf("%.6f %.6f %.6f\n", px[i], py[i], ang[i]))
+	}
+	return sb.String(), expected(n, l, r, px, py, ang)
+}
+
+func runCase(bin, input string, expected float64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if math.Abs(got-expected) > 1e-6 {
+		return fmt.Errorf("expected %.6f got %.6f", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/385/verifierE.go
+++ b/0-999/300-399/380-389/385/verifierE.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func matMul(a, b [4][4]uint64, mod uint64) [4][4]uint64 {
+	var c [4][4]uint64
+	for i := 0; i < 4; i++ {
+		for k := 0; k < 4; k++ {
+			if a[i][k] == 0 {
+				continue
+			}
+			for j := 0; j < 4; j++ {
+				c[i][j] += a[i][k] * b[k][j]
+			}
+		}
+		for j := 0; j < 4; j++ {
+			c[i][j] %= mod
+		}
+	}
+	return c
+}
+
+func matPow(mat [4][4]uint64, p, mod uint64) [4][4]uint64 {
+	var res [4][4]uint64
+	for i := 0; i < 4; i++ {
+		res[i][i] = 1 % mod
+	}
+	for p > 0 {
+		if p&1 != 0 {
+			res = matMul(res, mat, mod)
+		}
+		mat = matMul(mat, mat, mod)
+		p >>= 1
+	}
+	return res
+}
+
+func expected(n, sx, sy, dx, dy, t int64) (int64, int64) {
+	if t == 0 {
+		return sx, sy
+	}
+	mod := uint64(n * 2)
+	X0 := uint64((sx - 1) % n)
+	Y0 := uint64((sy - 1) % n)
+	S0 := (X0 + Y0) % mod
+	DS0 := dx + dy
+	Sneg1 := (int64(S0) - DS0) % int64(mod)
+	if Sneg1 < 0 {
+		Sneg1 += int64(mod)
+	}
+	V0 := [4]uint64{uint64(S0), uint64(Sneg1), 0, 1}
+	M := [4][4]uint64{
+		{4 % mod, (mod - 1) % mod, 2 % mod, 4 % mod},
+		{1, 0, 0, 0},
+		{0, 0, 1, 1},
+		{0, 0, 0, 1},
+	}
+	Mt := matPow(M, uint64(t), mod)
+	var Vt [4]uint64
+	for i := 0; i < 4; i++ {
+		var acc uint64
+		for j := 0; j < 4; j++ {
+			acc += Mt[i][j] * V0[j]
+		}
+		Vt[i] = acc % mod
+	}
+	St := Vt[0]
+	diff0 := int64(X0) - int64(Y0)
+	delta := dx - dy
+	tmod := uint64(t % int64(mod))
+	deltaMod := (delta%int64(mod) + int64(mod)) % int64(mod)
+	diffT := (int64(diff0)%int64(mod) + (int64(tmod)*deltaMod)%int64(mod)) % int64(mod)
+	if diffT < 0 {
+		diffT += int64(mod)
+	}
+	d := uint64(diffT)
+	sumd := (St + d) % mod
+	Xt := (sumd / 2) % uint64(n)
+	diff := (St + mod - d) % mod
+	Yt := (diff / 2) % uint64(n)
+	return int64(Xt + 1), int64(Yt + 1)
+}
+
+func generateCase(rng *rand.Rand) (string, [2]int64) {
+	n := rng.Int63n(1000) + 1
+	sx := rng.Int63n(n) + 1
+	sy := rng.Int63n(n) + 1
+	dx := rng.Int63n(21) - 10
+	dy := rng.Int63n(21) - 10
+	t := rng.Int63n(10000)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d %d %d\n", n, sx, sy, dx, dy, t))
+	x, y := expected(n, sx, sy, dx, dy, t)
+	return sb.String(), [2]int64{x, y}
+}
+
+func runCase(bin, input string, expected [2]int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var x, y int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &x, &y); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if x != expected[0] || y != expected[1] {
+		return fmt.Errorf("expected %d %d got %d %d", expected[0], expected[1], x, y)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers `verifierA.go`–`verifierE.go` for contest 385
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ebf40cbe0832495443fa49ef7a757