### PR TITLE
Add verifiers for CF Round 384

### DIFF
--- a/0-999/300-399/380-389/384/verifierA.go
+++ b/0-999/300-399/380-389/384/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) string {
+	total := n * n / 2
+	if n*n%2 != 0 {
+		total++
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", total))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if (i+j)%2 == 0 {
+				sb.WriteByte('C')
+			} else {
+				sb.WriteByte('.')
+			}
+		}
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(1000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	return input, expected(n)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 || len(os.Args) > 3 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// deterministic edge cases
+	edge := []int{1, 2, 3, 4, 5, 10, 1000}
+	for i, n := range edge {
+		input := fmt.Sprintf("%d\n", n)
+		if err := runCase(bin, input, expected(n)); err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100-len(edge); i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/384/verifierB.go
+++ b/0-999/300-399/380-389/384/verifierB.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, m, k int) string {
+	total := m * (m - 1) / 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", total))
+	if k == 0 {
+		for i := 1; i <= m; i++ {
+			for j := i + 1; j <= m; j++ {
+				sb.WriteString(fmt.Sprintf("%d %d\n", i, j))
+			}
+		}
+	} else {
+		for i := 1; i <= m; i++ {
+			for j := i + 1; j <= m; j++ {
+				sb.WriteString(fmt.Sprintf("%d %d\n", j, i))
+			}
+		}
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(8) + 1
+	k := rng.Intn(2)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rng.Intn(1000000) + 1
+			sb.WriteString(fmt.Sprintf("%d", val))
+		}
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	input := sb.String()
+	return input, expected(n, m, k)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 || len(os.Args) > 3 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// deterministic edge cases
+	cases := []struct{ n, m, k int }{
+		{1, 1, 0}, {1, 2, 0}, {1, 2, 1}, {3, 3, 0}, {2, 5, 1},
+	}
+	for i, tc := range cases {
+		input := fmt.Sprintf("%d %d %d\n", tc.n, tc.m, tc.k)
+		for l := 0; l < tc.n; l++ {
+			for j := 0; j < tc.m; j++ {
+				input += "1"
+				if j+1 < tc.m {
+					input += " "
+				}
+			}
+			if l+1 < tc.n {
+				input += "\n"
+			}
+		}
+		if err := runCase(bin, input, expected(tc.n, tc.m, tc.k)); err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100-len(cases); i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest 384 problems A and B
- allow running a binary or `.go` source file
- include deterministic edge cases and 100 random tests

## Testing
- `go run verifierA.go /tmp/384A_bin`
- `go run verifierA.go -- 384A.go`
- `go run verifierB.go /tmp/384B_bin`
- `go run verifierB.go -- 384B.go`


------
https://chatgpt.com/codex/tasks/task_e_687ebefac13c8324b849c10ef9b25332