### PR TITLE
Add contest 383 verifiers

### DIFF
--- a/0-999/300-399/380-389/383/verifierA.go
+++ b/0-999/300-399/380-389/383/verifierA.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n        int
+	arr      []int
+	expected string
+}
+
+func solveCase(tc testCaseA) string {
+	var ones int64
+	var ans int64
+	for _, x := range tc.arr {
+		if x == 1 {
+			ones++
+		} else {
+			ans += ones
+		}
+	}
+	return strconv.FormatInt(ans, 10)
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				arr[j] = 0
+			} else {
+				arr[j] = 1
+			}
+		}
+		tc := testCaseA{n: n, arr: arr}
+		expected := solveCase(tc)
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/383/verifierB.go
+++ b/0-999/300-399/380-389/383/verifierB.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type obstacle struct{ x, y int }
+
+type testCaseB struct {
+	n        int
+	obs      []obstacle
+	expected string
+}
+
+func solveCase(tc testCaseB) string {
+	n := tc.n
+	grid := make([][]bool, n+1)
+	for i := range grid {
+		grid[i] = make([]bool, n+1)
+	}
+	for _, o := range tc.obs {
+		if o.x >= 1 && o.x <= n && o.y >= 1 && o.y <= n {
+			grid[o.x][o.y] = true
+		}
+	}
+	dp := make([][]bool, n+1)
+	for i := range dp {
+		dp[i] = make([]bool, n+1)
+	}
+	dp[1][1] = !grid[1][1]
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= n; j++ {
+			if grid[i][j] {
+				dp[i][j] = false
+				continue
+			}
+			if i == 1 && j == 1 {
+				continue
+			}
+			if i > 1 && dp[i-1][j] {
+				dp[i][j] = true
+			}
+			if j > 1 && dp[i][j-1] {
+				dp[i][j] = true
+			}
+		}
+	}
+	if dp[n][n] {
+		return strconv.Itoa(2*n - 2)
+	}
+	return "-1"
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 2
+		maxObs := n * n / 3
+		m := rng.Intn(maxObs + 1)
+		obsSet := make(map[[2]int]struct{})
+		obs := make([]obstacle, 0, m)
+		for len(obs) < m {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(n) + 1
+			if x == 1 && y == 1 || x == n && y == n {
+				continue
+			}
+			key := [2]int{x, y}
+			if _, ok := obsSet[key]; ok {
+				continue
+			}
+			obsSet[key] = struct{}{}
+			obs = append(obs, obstacle{x, y})
+		}
+		tc := testCaseB{n: n, obs: obs}
+		expected := solveCase(tc)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, len(obs)))
+		for _, o := range obs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", o.x, o.y))
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/383/verifierC.go
+++ b/0-999/300-399/380-389/383/verifierC.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type opC struct {
+	t int
+	x int
+	v int64
+}
+
+type testCaseC struct {
+	n        int
+	m        int
+	values   []int64
+	edges    [][2]int
+	ops      []opC
+	expected []string
+}
+
+func buildTree(n int, edges [][2]int) [][]int {
+	g := make([][]int, n+1)
+	for _, e := range edges {
+		g[e[0]] = append(g[e[0]], e[1])
+		g[e[1]] = append(g[e[1]], e[0])
+	}
+	return g
+}
+
+func dfsOrder(g [][]int, n int) (parent []int, depth []int, subtree [][]int) {
+	parent = make([]int, n+1)
+	depth = make([]int, n+1)
+	subtree = make([][]int, n+1)
+	stack := []int{1}
+	order := []int{}
+	parent[1] = 0
+	depth[1] = 0
+	for len(stack) > 0 {
+		u := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, u)
+		for _, v := range g[u] {
+			if v == parent[u] {
+				continue
+			}
+			parent[v] = u
+			depth[v] = depth[u] + 1
+			stack = append(stack, v)
+		}
+	}
+	// build subtree lists reverse order
+	for i := len(order) - 1; i >= 0; i-- {
+		u := order[i]
+		subtree[u] = append(subtree[u], u)
+		for _, v := range g[u] {
+			if v == parent[u] {
+				continue
+			}
+			subtree[u] = append(subtree[u], subtree[v]...)
+		}
+	}
+	return
+}
+
+func solveCase(tc testCaseC) []string {
+	g := buildTree(tc.n, tc.edges)
+	_, depth, subtree := dfsOrder(g, tc.n)
+	vals := make([]int64, tc.n+1)
+	copy(vals[1:], tc.values)
+	res := make([]string, 0)
+	for _, op := range tc.ops {
+		if op.t == 1 {
+			x := op.x
+			v := op.v
+			for _, node := range subtree[x] {
+				if depth[node]%2 == depth[x]%2 {
+					vals[node] += v
+				} else {
+					vals[node] -= v
+				}
+			}
+		} else {
+			x := op.x
+			res = append(res, strconv.FormatInt(vals[x], 10))
+		}
+	}
+	return res
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(7) + 2
+		m := rng.Intn(5) + 1
+		values := make([]int64, n)
+		for j := 0; j < n; j++ {
+			values[j] = int64(rng.Intn(10))
+		}
+		edges := make([][2]int, n-1)
+		for j := 1; j < n; j++ {
+			p := rng.Intn(j) + 1
+			edges[j-1] = [2]int{p, j + 1}
+		}
+		ops := make([]opC, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				x := rng.Intn(n) + 1
+				v := int64(rng.Intn(5)) - 2
+				ops[j] = opC{t: 1, x: x, v: v}
+			} else {
+				x := rng.Intn(n) + 1
+				ops[j] = opC{t: 2, x: x}
+			}
+		}
+		tc := testCaseC{n: n, m: m, values: values, edges: edges, ops: ops}
+		expected := solveCase(tc)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(values[j], 10))
+		}
+		sb.WriteByte('\n')
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		for _, op := range ops {
+			if op.t == 1 {
+				sb.WriteString(fmt.Sprintf("1 %d %d\n", op.x, op.v))
+			} else {
+				sb.WriteString(fmt.Sprintf("2 %d\n", op.x))
+			}
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(got), "\n")
+		if len(lines) != len(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\n", i+1, len(expected), len(lines))
+			os.Exit(1)
+		}
+		for idx := range lines {
+			if strings.TrimSpace(lines[idx]) != expected[idx] {
+				fmt.Fprintf(os.Stderr, "case %d failed on line %d: expected %s got %s\n", i+1, idx+1, expected[idx], lines[idx])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/383/verifierD.go
+++ b/0-999/300-399/380-389/383/verifierD.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+type testCaseD struct {
+	n        int
+	arr      []int
+	expected string
+}
+
+func solveCase(tc testCaseD) string {
+	n := tc.n
+	a := tc.arr
+	total := 0
+	for _, v := range a {
+		total += v
+	}
+	offset := total
+	size := 2*total + 1
+	dpPrev := make([]int, size)
+	dpCurr := make([]int, size)
+	ans := 0
+	for i := 0; i < n; i++ {
+		ai := a[i]
+		for j := 0; j < size; j++ {
+			dpCurr[j] = 0
+		}
+		dpCurr[offset+ai] = (dpCurr[offset+ai] + 1) % MOD
+		dpCurr[offset-ai] = (dpCurr[offset-ai] + 1) % MOD
+		for j := 0; j < size; j++ {
+			v := dpPrev[j]
+			if v != 0 {
+				jp := j + ai
+				if jp < size {
+					dpCurr[jp] = (dpCurr[jp] + v) % MOD
+				}
+				jm := j - ai
+				if jm >= 0 {
+					dpCurr[jm] = (dpCurr[jm] + v) % MOD
+				}
+			}
+		}
+		ans = (ans + dpCurr[offset]) % MOD
+		dpPrev, dpCurr = dpCurr, dpPrev
+	}
+	return strconv.Itoa(ans)
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 2
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(5) + 1
+		}
+		tc := testCaseD{n: n, arr: arr}
+		expected := solveCase(tc)
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(arr[j]))
+		}
+		sb.WriteByte('\n')
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/383/verifierE.go
+++ b/0-999/300-399/380-389/383/verifierE.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseE struct {
+	n        int
+	words    []string
+	expected string
+}
+
+func solveCase(tc testCaseE) string {
+	n := tc.n
+	masks := make([]uint32, n)
+	used := make([]bool, 24)
+	for i, w := range tc.words {
+		var m uint32
+		for _, ch := range w {
+			idx := ch - 'a'
+			if idx < 0 || idx >= 24 {
+				continue
+			}
+			used[idx] = true
+			m |= 1 << idx
+		}
+		masks[i] = m
+	}
+	cntUsed := 0
+	for _, u := range used {
+		if u {
+			cntUsed++
+		}
+	}
+	if cntUsed < 24 {
+		return "0"
+	}
+	size := 1 << 24
+	f := make([]uint16, size)
+	for _, m := range masks {
+		f[m]++
+	}
+	for bit := 0; bit < 24; bit++ {
+		step := 1 << bit
+		for mask := 0; mask < size; mask++ {
+			if mask&step != 0 {
+				f[mask] += f[mask^step]
+			}
+		}
+	}
+	var res uint32
+	for mask := 0; mask < size; mask++ {
+		v := uint32(f[mask])
+		res ^= v * v
+	}
+	return strconv.FormatUint(uint64(res), 10)
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randWord(rng *rand.Rand) string {
+	b := []byte{byte(rng.Intn(24) + 'a'), byte(rng.Intn(24) + 'a'), byte(rng.Intn(24) + 'a')}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		words := make([]string, n)
+		for j := 0; j < n; j++ {
+			words[j] = randWord(rng)
+		}
+		tc := testCaseE{n: n, words: words}
+		expected := solveCase(tc)
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for _, w := range words {
+			sb.WriteString(w)
+			sb.WriteByte('\n')
+		}
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E

## Testing
- `go run verifierA.go ./A_bin`
- `go run verifierB.go ./B_bin`
- `go run verifierD.go ./D_bin`
- `go run verifierE.go ./E_bin`
- `go build verifierC.go`

------
https://chatgpt.com/codex/tasks/task_e_687ebeb4ba4c83248f052a9ae9a34d9e