### PR TITLE
Add verifiers for Codeforces contest 382

### DIFF
--- a/0-999/300-399/380-389/382/verifierA.go
+++ b/0-999/300-399/380-389/382/verifierA.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	in  string
+	out string
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func computeAnswer(s1, s2 string) string {
+	parts := strings.Split(s1, "|")
+	if len(parts) != 2 {
+		return "Impossible"
+	}
+	left := parts[0]
+	right := parts[1]
+	a, b, c := len(left), len(right), len(s2)
+	if (a+b+c)%2 != 0 || abs(a-b) > c {
+		return "Impossible"
+	}
+	diff := abs(a - b)
+	idx := 0
+	if a < b {
+		left += s2[idx : idx+diff]
+	} else {
+		right += s2[idx : idx+diff]
+	}
+	idx += diff
+	rem := s2[idx:]
+	half := len(rem) / 2
+	left += rem[:half]
+	right += rem[half:]
+	return left + "|" + right
+}
+
+func genCase(r *rand.Rand) Test {
+	letters := r.Perm(26)
+	l1 := r.Intn(6)
+	l2 := r.Intn(6)
+	rem := r.Intn(6)
+	if l1+l2+rem > 26 {
+		rem = 26 - l1 - l2
+	}
+	idx := 0
+	lb := make([]byte, l1)
+	for i := 0; i < l1; i++ {
+		lb[i] = byte('A' + letters[idx])
+		idx++
+	}
+	rb := make([]byte, l2)
+	for i := 0; i < l2; i++ {
+		rb[i] = byte('A' + letters[idx])
+		idx++
+	}
+	mb := make([]byte, rem)
+	for i := 0; i < rem; i++ {
+		mb[i] = byte('A' + letters[idx])
+		idx++
+	}
+	s1 := string(lb) + "|" + string(rb)
+	s2 := string(mb)
+	input := s1 + "\n" + s2 + "\n"
+	out := computeAnswer(s1, s2)
+	return Test{input, out}
+}
+
+func runCase(bin string, t Test) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(t.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(t.out)
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 25; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/382/verifierB.go
+++ b/0-999/300-399/380-389/382/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	in  string
+	out string
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func compute(a, b, w, x, c int64) int64 {
+	if c <= a {
+		return 0
+	}
+	D := c - a
+	g := gcd(w, x)
+	L := w / g
+	wrap := make([]int64, L)
+	var S int64
+	for i := int64(0); i < L; i++ {
+		bi := (b - (i*x)%w + w) % w
+		if bi < x {
+			wrap[i] = 1
+			S++
+		}
+	}
+	noWrap := L - S
+	k := D / noWrap
+	rem := D - k*noWrap
+	if rem == 0 {
+		rem = noWrap
+		k--
+	}
+	prefix := make([]int64, L+1)
+	for i := int64(0); i < L; i++ {
+		prefix[i+1] = prefix[i] + wrap[i]
+	}
+	var r int64
+	for i := int64(1); i <= L; i++ {
+		if i-prefix[i] >= rem {
+			r = i
+			break
+		}
+	}
+	return k*L + r
+}
+
+func genCase(r *rand.Rand) Test {
+	w := int64(r.Intn(10) + 2)
+	x := int64(r.Intn(int(w-1)) + 1)
+	a := int64(r.Intn(20) + 1)
+	b := int64(r.Intn(int(w)))
+	c := a + int64(r.Intn(20))
+	input := fmt.Sprintf("%d %d %d %d %d\n", a, b, w, x, c)
+	out := fmt.Sprintf("%d", compute(a, b, w, x, c))
+	return Test{input, out}
+}
+
+func runCase(bin string, t Test) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(t.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(t.out)
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < 25; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/382/verifierC.go
+++ b/0-999/300-399/380-389/382/verifierC.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type Test struct {
+	in  string
+	out string
+}
+
+func compute(a []int64) string {
+	n := len(a)
+	if n == 1 {
+		return "-1"
+	}
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	if n == 2 {
+		x, y := a[0], a[1]
+		d := y - x
+		if d == 0 {
+			return fmt.Sprintf("1\n%d", x)
+		} else if d%2 == 0 {
+			mid := x + d/2
+			res := []int64{x - d, mid, y + d}
+			sort.Slice(res, func(i, j int) bool { return res[i] < res[j] })
+			return fmt.Sprintf("%d\n%d %d %d", len(res), res[0], res[1], res[2])
+		}
+		return fmt.Sprintf("2\n%d %d", x-d, y+d)
+	}
+	diffs := make([]int64, n-1)
+	for i := 1; i < n; i++ {
+		diffs[i-1] = a[i] - a[i-1]
+	}
+	dmin := diffs[0]
+	for _, d := range diffs {
+		if d < dmin {
+			dmin = d
+		}
+	}
+	cntMin, cntOther := 0, 0
+	var otherD int64
+	pos := -1
+	for i, d := range diffs {
+		if d == dmin {
+			cntMin++
+		} else {
+			cntOther++
+			otherD = d
+			pos = i
+		}
+	}
+	if cntOther == 0 {
+		if dmin == 0 {
+			return fmt.Sprintf("1\n%d", a[0])
+		}
+		return fmt.Sprintf("2\n%d %d", a[0]-dmin, a[n-1]+dmin)
+	}
+	if cntOther == 1 && otherD == 2*dmin {
+		x := a[pos] + dmin
+		return fmt.Sprintf("1\n%d", x)
+	}
+	return "0"
+}
+
+func genCase(r *rand.Rand) Test {
+	n := r.Intn(6) + 2
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = int64(r.Intn(20))
+	}
+	var sb strings.Builder
+	fmt.Fprintln(&sb, n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	out := compute(append([]int64(nil), arr...))
+	return Test{sb.String(), out}
+}
+
+func runCase(bin string, t Test) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(t.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(t.out)
+	if got != expect {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(3))
+	for i := 0; i < 25; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/382/verifierD.go
+++ b/0-999/300-399/380-389/382/verifierD.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	in  string
+	out string
+}
+
+func compute(grid [][]byte) int {
+	n := len(grid)
+	m := len(grid[0])
+	size := n * m
+	dist := make([]int, size)
+	queue := make([]int, 0, size)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			u := grid[i][j]
+			if u == '<' || u == '>' || u == '^' || u == 'v' {
+				var ni, nj int
+				switch u {
+				case '<':
+					ni, nj = i, j-1
+				case '>':
+					ni, nj = i, j+1
+				case '^':
+					ni, nj = i-1, j
+				case 'v':
+					ni, nj = i+1, j
+				}
+				if grid[ni][nj] == '#' {
+					idx := i*m + j
+					dist[idx] = 1
+					queue = append(queue, idx)
+				}
+			}
+		}
+	}
+	head := 0
+	for head < len(queue) {
+		v := queue[head]
+		head++
+		vi := v / m
+		vj := v % m
+		if vi > 0 {
+			ui, uj := vi-1, vj
+			if grid[ui][uj] == 'v' {
+				u := ui*m + uj
+				if dist[u] == 0 {
+					dist[u] = dist[v] + 1
+					queue = append(queue, u)
+				}
+			}
+		}
+		if vi+1 < n {
+			ui, uj := vi+1, vj
+			if grid[ui][uj] == '^' {
+				u := ui*m + uj
+				if dist[u] == 0 {
+					dist[u] = dist[v] + 1
+					queue = append(queue, u)
+				}
+			}
+		}
+		if vj > 0 {
+			ui, uj := vi, vj-1
+			if grid[ui][uj] == '>' {
+				u := ui*m + uj
+				if dist[u] == 0 {
+					dist[u] = dist[v] + 1
+					queue = append(queue, u)
+				}
+			}
+		}
+		if vj+1 < m {
+			ui, uj := vi, vj+1
+			if grid[ui][uj] == '<' {
+				u := ui*m + uj
+				if dist[u] == 0 {
+					dist[u] = dist[v] + 1
+					queue = append(queue, u)
+				}
+			}
+		}
+	}
+	max1, max2 := 0, 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			c := grid[i][j]
+			if c == '<' || c == '>' || c == '^' || c == 'v' {
+				d := dist[i*m+j]
+				if d == 0 {
+					return -1
+				}
+				if d > max1 {
+					max2 = max1
+					max1 = d
+				} else if d > max2 {
+					max2 = d
+				}
+			}
+		}
+	}
+	return max1 + max2
+}
+
+func genCase(r *rand.Rand) Test {
+	n := r.Intn(4) + 3
+	m := r.Intn(4) + 3
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if i == 0 || j == 0 || i == n-1 || j == m-1 {
+				row[j] = '#'
+			} else {
+				opts := []byte{'<', '>', '^', 'v', '#'}
+				row[j] = opts[r.Intn(len(opts))]
+			}
+		}
+		grid[i] = row
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		sb.WriteByte('\n')
+	}
+	out := fmt.Sprintf("%d", compute(grid))
+	return Test{sb.String(), out}
+}
+
+func runCase(bin string, t Test) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(t.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(t.out)
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(4))
+	for i := 0; i < 25; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/382/verifierE.go
+++ b/0-999/300-399/380-389/382/verifierE.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const MOD int64 = 1000000007
+
+type Test struct {
+	in  string
+	out string
+}
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	a %= MOD
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func modInv(a int64) int64 { return modPow(a, MOD-2) }
+
+func compute(n, K int) int64 {
+	maxN := n
+	fac := make([]int64, maxN+1)
+	ifac := make([]int64, maxN+1)
+	fac[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fac[i] = fac[i-1] * int64(i) % MOD
+	}
+	ifac[maxN] = modInv(fac[maxN])
+	for i := maxN; i > 0; i-- {
+		ifac[i-1] = ifac[i] * int64(i) % MOD
+	}
+	C := func(n, k int) int64 {
+		if k < 0 || k > n {
+			return 0
+		}
+		return fac[n] * ifac[k] % MOD * ifac[n-k] % MOD
+	}
+	inv2 := modInv(2)
+	maxM := (n + 1) / 2
+	dp := make([][][]int64, n+1)
+	for i := range dp {
+		dp[i] = make([][]int64, maxM+2)
+		for j := range dp[i] {
+			dp[i][j] = make([]int64, maxM+2)
+		}
+	}
+	dp[1][0][0] = 1
+	for sz := 2; sz <= n; sz++ {
+		i := sz - 1
+		coeff1 := C(sz-1, i) * int64(i) % MOD
+		for g0 := 0; g0 <= i/2; g0++ {
+			for g1 := 0; g1 <= g0; g1++ {
+				cnt := dp[i][g0][g1]
+				if cnt == 0 {
+					continue
+				}
+				parentG1 := g0
+				mg0 := g0
+				if 1+g1 > mg0 {
+					mg0 = 1 + g1
+				}
+				dp[sz][mg0][parentG1] = (dp[sz][mg0][parentG1] + cnt*coeff1) % MOD
+			}
+		}
+		for i = 1; i <= sz-2; i++ {
+			j := sz - 1 - i
+			comb := C(sz-1, i)
+			var labelCoeff int64
+			if i != j {
+				labelCoeff = comb * int64(i) % MOD * int64(j) % MOD
+			} else {
+				labelCoeff = comb * int64(i) % MOD * int64(j) % MOD * inv2 % MOD
+			}
+			for g0_1 := 0; g0_1 <= i/2; g0_1++ {
+				for g1_1 := 0; g1_1 <= g0_1; g1_1++ {
+					cnt1 := dp[i][g0_1][g1_1]
+					if cnt1 == 0 {
+						continue
+					}
+					for g0_2 := 0; g0_2 <= j/2; g0_2++ {
+						for g1_2 := 0; g1_2 <= g0_2; g1_2++ {
+							cnt2 := dp[j][g0_2][g1_2]
+							if cnt2 == 0 {
+								continue
+							}
+							pairCount := cnt1 * cnt2 % MOD
+							ways := pairCount * labelCoeff % MOD
+							parentG1 := g0_1 + g0_2
+							match1a := 1 + g1_1 + g0_2
+							match1b := 1 + g0_1 + g1_2
+							mg0 := parentG1
+							if match1a > mg0 {
+								mg0 = match1a
+							}
+							if match1b > mg0 {
+								mg0 = match1b
+							}
+							dp[sz][mg0][parentG1] = (dp[sz][mg0][parentG1] + ways) % MOD
+						}
+					}
+				}
+			}
+		}
+	}
+	var ans int64
+	if K <= maxM {
+		for g1 := 0; g1 <= K; g1++ {
+			ans = (ans + dp[n][K][g1]) % MOD
+		}
+	}
+	return ans
+}
+
+func genCase(r *rand.Rand) Test {
+	n := r.Intn(6) + 1
+	K := r.Intn((n+1)/2 + 1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, K)
+	out := fmt.Sprintf("%d", compute(n, K))
+	return Test{sb.String(), out}
+}
+
+func runCase(bin string, t Test) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(t.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(t.out)
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(5))
+	for i := 0; i < 25; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 382
- each verifier generates deterministic random tests and checks a provided binary

## Testing
- `go run verifierA.go ./382Abin`
- `go run verifierB.go ./382Bbin`
- `go run verifierC.go ./382Cbin`
- `go run verifierD.go ./382Dbin`
- `go run verifierE.go ./382Ebin`

------
https://chatgpt.com/codex/tasks/task_e_687ebe6eda7c8324b1e65d5198184e3e