### PR TITLE
Add verifiers for Codeforces contest 380

### DIFF
--- a/0-999/300-399/380-389/380/verifierA.go
+++ b/0-999/300-399/380-389/380/verifierA.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	input  string
+	output string
+}
+
+func findValueA(pos int64, tp []int, x, l, lenArr []int64) int64 {
+	for {
+		idx := sort.Search(len(lenArr), func(i int) bool { return lenArr[i] >= pos })
+		if tp[idx] == 1 {
+			return x[idx]
+		}
+		prevLen := int64(0)
+		if idx > 0 {
+			prevLen = lenArr[idx-1]
+		}
+		pos = (pos-prevLen-1)%l[idx] + 1
+	}
+}
+
+func solveA(r io.Reader) string {
+	reader := bufio.NewReader(r)
+	var m int
+	if _, err := fmt.Fscan(reader, &m); err != nil {
+		return ""
+	}
+	tp := make([]int, m)
+	x := make([]int64, m)
+	l := make([]int64, m)
+	c := make([]int64, m)
+	lenArr := make([]int64, m)
+	var curLen int64
+	for i := 0; i < m; i++ {
+		fmt.Fscan(reader, &tp[i])
+		if tp[i] == 1 {
+			fmt.Fscan(reader, &x[i])
+			curLen++
+		} else {
+			fmt.Fscan(reader, &l[i], &c[i])
+			curLen += l[i] * c[i]
+		}
+		lenArr[i] = curLen
+	}
+	var q int
+	fmt.Fscan(reader, &q)
+	queries := make([]int64, q)
+	for i := 0; i < q; i++ {
+		fmt.Fscan(reader, &queries[i])
+	}
+	var sb strings.Builder
+	for i, pos := range queries {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, findValueA(pos, tp, x, l, lenArr))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCaseA(bin string, in string, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expect) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expect), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func genCaseA(rng *rand.Rand) string {
+	m := rng.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	seqLen := 0
+	for i := 0; i < m; i++ {
+		tp := rng.Intn(2) + 1
+		if tp == 1 || seqLen == 0 {
+			val := rng.Intn(100) + 1
+			sb.WriteString(fmt.Sprintf("1 %d\n", val))
+			seqLen++
+		} else {
+			l := rng.Intn(seqLen) + 1
+			c := rng.Intn(2) + 1
+			if seqLen+l*c > 1000 {
+				if l > 0 {
+					c = (1000 - seqLen) / l
+				}
+				if c <= 0 {
+					val := rng.Intn(100) + 1
+					sb.WriteString(fmt.Sprintf("1 %d\n", val))
+					seqLen++
+					continue
+				}
+			}
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", l, c))
+			seqLen += l * c
+		}
+	}
+	q := rng.Intn(min(seqLen, 10)) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	positions := make([]int, q)
+	for i := 0; i < q; i++ {
+		positions[i] = rng.Intn(seqLen) + 1
+	}
+	sort.Ints(positions)
+	for i, p := range positions {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(p))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCaseA(rng)
+		expect := solveA(strings.NewReader(in))
+		if err := runCaseA(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/380/verifierB.go
+++ b/0-999/300-399/380-389/380/verifierB.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Op struct {
+	level, l, r int
+}
+
+func solveB(r io.Reader) string {
+	reader := bufio.NewReader(r)
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return ""
+	}
+	opsByX := make(map[int][]Op)
+	var sb strings.Builder
+	for i := 0; i < m; i++ {
+		var tp int
+		fmt.Fscan(reader, &tp)
+		if tp == 1 {
+			var t, l, r, x int
+			fmt.Fscan(reader, &t, &l, &r, &x)
+			opsByX[x] = append(opsByX[x], Op{level: t, l: l, r: r})
+		} else {
+			var t0, v0 int
+			fmt.Fscan(reader, &t0, &v0)
+			cnt := 0
+			for _, ops := range opsByX {
+				for _, op := range ops {
+					if op.level < t0 {
+						continue
+					}
+					maxPos := v0 + (op.level - t0)
+					if op.l <= maxPos && op.r >= v0 {
+						cnt++
+						break
+					}
+				}
+			}
+			fmt.Fprintln(&sb, cnt)
+		}
+	}
+	return sb.String()
+}
+
+func runCaseB(bin string, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expect) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expect), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func genCaseB(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			t := rng.Intn(n) + 1
+			l := rng.Intn(3) + 1
+			r := l + rng.Intn(3)
+			x := rng.Intn(10) + 1
+			sb.WriteString(fmt.Sprintf("1 %d %d %d %d\n", t, l, r, x))
+		} else {
+			t := rng.Intn(n) + 1
+			v := rng.Intn(3) + 1
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", t, v))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCaseB(rng)
+		expect := solveB(strings.NewReader(in))
+		if err := runCaseB(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/380/verifierC.go
+++ b/0-999/300-399/380-389/380/verifierC.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Node struct {
+	pairs int
+	open  int
+	close int
+}
+
+func merge(a, b Node) Node {
+	match := a.open
+	if b.close < match {
+		match = b.close
+	}
+	return Node{pairs: a.pairs + b.pairs + match, open: a.open + b.open - match, close: a.close + b.close - match}
+}
+
+func solveC(r io.Reader) string {
+	reader := bufio.NewReader(r)
+	var s string
+	if _, err := fmt.Fscan(reader, &s); err != nil {
+		return ""
+	}
+	n := len(s)
+	N := 1
+	for N < n {
+		N <<= 1
+	}
+	tree := make([]Node, 2*N)
+	for i := 0; i < n; i++ {
+		idx := N + i
+		if s[i] == '(' {
+			tree[idx] = Node{open: 1}
+		} else {
+			tree[idx] = Node{close: 1}
+		}
+	}
+	for i := N - 1; i > 0; i-- {
+		tree[i] = merge(tree[2*i], tree[2*i+1])
+	}
+	var m int
+	fmt.Fscan(reader, &m)
+	var sb strings.Builder
+	for q := 0; q < m; q++ {
+		var l, r int
+		fmt.Fscan(reader, &l, &r)
+		l--
+		r--
+		l += N
+		r += N
+		resL := Node{}
+		resR := Node{}
+		for l <= r {
+			if l&1 == 1 {
+				resL = merge(resL, tree[l])
+				l++
+			}
+			if r&1 == 0 {
+				resR = merge(tree[r], resR)
+				r--
+			}
+			l >>= 1
+			r >>= 1
+		}
+		res := merge(resL, resR)
+		fmt.Fprintln(&sb, res.pairs*2)
+	}
+	return sb.String()
+}
+
+func runCaseC(bin string, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expect) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expect), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func genCaseC(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('(')
+		} else {
+			sb.WriteByte(')')
+		}
+	}
+	sb.WriteByte('\n')
+	m := rng.Intn(20) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n) + 1
+		if l > r {
+			l, r = r, l
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCaseC(rng)
+		expect := solveC(strings.NewReader(in))
+		if err := runCaseC(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/380/verifierD.go
+++ b/0-999/300-399/380-389/380/verifierD.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+type testCaseD struct {
+	input  string
+	output string
+}
+
+func solveD(r io.Reader) string {
+	reader := bufio.NewReader(r)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return ""
+	}
+	a := make([]int, n+2)
+	pred := make([]int, n+2)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(reader, &a[i])
+		if a[i] > 0 {
+			pred[a[i]] = i
+		}
+	}
+	taken := make([]bool, n+2)
+	avail := make(map[int]struct{})
+	freeUnfixed := make(map[int]struct{})
+	for i := 1; i <= n; i++ {
+		avail[i] = struct{}{}
+		if a[i] == 0 {
+			freeUnfixed[i] = struct{}{}
+		}
+	}
+	ans := 1
+	for t := 1; t <= n; t++ {
+		if pos := pred[t]; pos > 0 {
+			if _, ok := avail[pos]; !ok {
+				return "0\n"
+			}
+			removeD(pos, n, taken, avail, freeUnfixed)
+		} else {
+			k := len(freeUnfixed)
+			if k == 0 {
+				return "0\n"
+			}
+			ans = int(int64(ans) * int64(k) % MOD)
+			var pos int
+			for idx := range freeUnfixed {
+				pos = idx
+				break
+			}
+			removeD(pos, n, taken, avail, freeUnfixed)
+		}
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func removeD(i, n int, taken []bool, avail, freeUnfixed map[int]struct{}) {
+	taken[i] = true
+	delete(avail, i)
+	if _, ok := freeUnfixed[i]; ok {
+		delete(freeUnfixed, i)
+	}
+	for _, j := range []int{i - 1, i + 1} {
+		if j < 1 || j > n || taken[j] {
+			continue
+		}
+		leftTaken := j-1 >= 1 && taken[j-1]
+		rightTaken := j+1 <= n && taken[j+1]
+		if leftTaken && rightTaken {
+			delete(avail, j)
+			delete(freeUnfixed, j)
+		}
+	}
+}
+
+func runCaseD(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expect) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expect), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func genCaseD(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	perm := rng.Perm(n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	used := make([]bool, n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			val := perm[i] + 1
+			sb.WriteString(fmt.Sprint(val))
+			used[val-1] = true
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCaseD(rng)
+		expect := solveD(strings.NewReader(in))
+		if err := runCaseD(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/380-389/380/verifierE.go
+++ b/0-999/300-399/380-389/380/verifierE.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const K = 45
+
+type pair struct {
+	val, idx int
+}
+
+func solveE(r io.Reader) string {
+	reader := bufio.NewReader(r)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return ""
+	}
+	a := make([]int, n+2)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	p2 := make([]float64, K)
+	p2[0] = 1.0
+	for i := 1; i < K; i++ {
+		p2[i] = p2[i-1] * 2.0
+	}
+	v := make([]pair, n)
+	for i := 1; i <= n; i++ {
+		v[i-1] = pair{a[i], i}
+	}
+	sort.Slice(v, func(i, j int) bool { return v[i].val < v[j].val })
+	tlft := make([]int, n+2)
+	trgt := make([]int, n+2)
+	for i := 0; i <= n+1; i++ {
+		tlft[i] = i - 1
+		trgt[i] = i + 1
+	}
+	tlft[0] = 0
+	trgt[n] = n + 1
+	ans := 0.0
+	for _, pr := range v {
+		i := pr.idx
+		tl := 0.0
+		tr := 0.0
+		pl := i
+		prr := i
+		for j := 0; j < K; j++ {
+			if pl != 0 {
+				dist := float64(pl - tlft[pl])
+				tl += dist / p2[j]
+				pl = tlft[pl]
+			}
+			if prr <= n {
+				dist := float64(trgt[prr] - prr)
+				tr += dist / p2[j]
+				prr = trgt[prr]
+			}
+		}
+		left := tlft[i]
+		right := trgt[i]
+		trgt[left] = right
+		tlft[right] = left
+		ans += tl * tr * float64(a[i]) * 0.5
+	}
+	result := ans / (float64(n) * float64(n))
+	return fmt.Sprintf("%.12f\n", result)
+}
+
+func runCaseE(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expect)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func genCaseE(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(100) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCaseE(rng)
+		expect := solveE(strings.NewReader(in))
+		if err := runCaseE(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems 380A through 380E
- each verifier runs 100 random test cases against a given binary

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_687ebde2bad88324937a4a55d90468d1