### PR TITLE
Add solution verifiers for contest 379

### DIFF
--- a/0-999/300-399/370-379/379/verifierA.go
+++ b/0-999/300-399/370-379/379/verifierA.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(a, b int) int {
+	candles := a
+	leftover := 0
+	hours := 0
+	for candles > 0 {
+		hours += candles
+		leftover += candles
+		candles = leftover / b
+		leftover %= b
+	}
+	return hours
+}
+
+func runCase(exe string, a, b int) error {
+	input := fmt.Sprintf("%d %d\n", a, b)
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	exp := expected(a, b)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	cases := [][2]int{{1, 2}, {4, 2}, {9, 3}, {10, 2}, {1000, 2}, {1000, 1000}}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		a := rng.Intn(1000) + 1
+		b := rng.Intn(999) + 2
+		cases = append(cases, [2]int{a, b})
+	}
+	for idx, c := range cases {
+		if err := runCase(exe, c[0], c[1]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/379/verifierB.go
+++ b/0-999/300-399/370-379/379/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCase(exe string, n int, a []int) error {
+	input := fmt.Sprintf("%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	instr := strings.TrimSpace(out.String())
+	if len(instr) > 1000000 {
+		return fmt.Errorf("instruction length > 1e6")
+	}
+	pos := 0
+	coins := make([]int, n)
+	lastP := false
+	for i := 0; i < len(instr); i++ {
+		c := instr[i]
+		switch c {
+		case 'L':
+			if pos == 0 {
+				return fmt.Errorf("move left from position 1")
+			}
+			pos--
+			lastP = false
+		case 'R':
+			if pos == n-1 {
+				return fmt.Errorf("move right from position n")
+			}
+			pos++
+			lastP = false
+		case 'P':
+			if lastP {
+				return fmt.Errorf("two consecutive P")
+			}
+			coins[pos]++
+			lastP = true
+		default:
+			return fmt.Errorf("invalid char %c", c)
+		}
+	}
+	for i := 0; i < n; i++ {
+		if coins[i] != a[i] {
+			return fmt.Errorf("wallet %d expected %d got %d", i+1, a[i], coins[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := [][]int{{1, 0, 2}, {0, 3}, {5, 0, 0, 1}}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 2
+		arr := make([]int, n)
+		pos := rng.Intn(n)
+		arr[pos] = rng.Intn(5) + 1
+		for j := 0; j < n; j++ {
+			if j != pos {
+				arr[j] = rng.Intn(5)
+			}
+		}
+		cases = append(cases, arr)
+	}
+	for idx, arr := range cases {
+		if err := runCase(exe, len(arr), arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/379/verifierC.go
+++ b/0-999/300-399/370-379/379/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type pair struct {
+	val int
+	idx int
+}
+
+func minimal(a []int) ([]int64, int64) {
+	n := len(a)
+	P := make([]pair, n)
+	for i := 0; i < n; i++ {
+		P[i] = pair{a[i], i}
+	}
+	sort.Slice(P, func(i, j int) bool { return P[i].val < P[j].val })
+	res := make([]int64, n)
+	var curr int64
+	var sum int64
+	for _, p := range P {
+		ai := int64(p.val)
+		if ai > curr {
+			curr = ai
+		} else {
+			curr++
+		}
+		res[p.idx] = curr
+		sum += curr
+	}
+	return res, sum
+}
+
+func runCase(exe string, a []int) error {
+	n := len(a)
+	input := fmt.Sprintf("%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != n {
+		return fmt.Errorf("expected %d numbers got %d", n, len(fields))
+	}
+	res := make([]int64, n)
+	for i, f := range fields {
+		var v int64
+		if _, err := fmt.Sscan(f, &v); err != nil {
+			return fmt.Errorf("parse error: %v", err)
+		}
+		res[i] = v
+	}
+	_, expSum := minimal(a)
+	seen := make(map[int64]bool)
+	var sum int64
+	for i := 0; i < n; i++ {
+		if res[i] < int64(a[i]) {
+			return fmt.Errorf("value %d less than a[i]", res[i])
+		}
+		if seen[res[i]] {
+			return fmt.Errorf("values not distinct")
+		}
+		seen[res[i]] = true
+		sum += res[i]
+	}
+	if sum != expSum {
+		return fmt.Errorf("sum not minimal")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := [][]int{{1, 1}, {5, 3, 3}, {1, 2, 3}}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(10) + 1
+		}
+		cases = append(cases, arr)
+	}
+	for idx, arr := range cases {
+		if err := runCase(exe, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/379/verifierD.go
+++ b/0-999/300-399/370-379/379/verifierD.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func countAC(s string) int {
+	cnt := 0
+	for i := 0; i+1 < len(s); i++ {
+		if s[i] == 'A' && s[i+1] == 'C' {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func gen(k, x, n, m int) (string, string, bool) {
+	letters := []byte{'A', 'X', 'C'}
+	for fs1 := 0; fs1 < 3; fs1++ {
+		for ls1 := 0; ls1 < 3; ls1++ {
+			for fs2 := 0; fs2 < 3; fs2++ {
+				for ls2 := 0; ls2 < 3; ls2++ {
+					for num1 := 0; num1 <= n/2; num1++ {
+						for num2 := 0; num2 <= m/2; num2++ {
+							if n == 1 && fs1 != ls1 {
+								continue
+							}
+							if m == 1 && fs2 != ls2 {
+								continue
+							}
+							if n > 1 && n%2 == 0 && num1 == n/2 && (fs1 != 0 || ls1 != 2) {
+								continue
+							}
+							if m > 1 && m%2 == 0 && num2 == m/2 && (fs2 != 0 || ls2 != 2) {
+								continue
+							}
+							if n > 1 && n%2 == 1 && num1 == n/2 && (fs1 != 0 && ls1 != 2) {
+								continue
+							}
+							if m > 1 && m%2 == 1 && num2 == m/2 && (fs2 != 0 && ls2 != 2) {
+								continue
+							}
+							if n == 2 && fs1 == 0 && ls1 == 2 && num1 != 1 {
+								continue
+							}
+							if m == 2 && fs2 == 0 && ls2 == 2 && num2 != 1 {
+								continue
+							}
+							// simulate counts
+							c1 := num1
+							c2 := num2
+							of, ol := fs1, ls1
+							nf, nl := fs2, ls2
+							ok := true
+							if k == 1 {
+								if c1 != x {
+									ok = false
+								}
+							} else if k == 2 {
+								if c2 != x {
+									ok = false
+								}
+							} else {
+								for it := 2; it < k && ok; it++ {
+									next := c1 + c2
+									if ol == 0 && nf == 2 {
+										next++
+									}
+									c1, c2 = c2, next
+									of, ol, nf, nl = nf, nl, of, nl
+									if c2 > x {
+										ok = false
+									}
+								}
+								if ok && c2 != x {
+									ok = false
+								}
+							}
+							if ok {
+								// build strings
+								var sb1, sb2 strings.Builder
+								sb1.WriteByte(letters[fs1])
+								rem := num1
+								for i := 1; i < n-1; i++ {
+									if rem > 0 && sb1.String()[i-1] == 'A' {
+										sb1.WriteByte('C')
+										rem--
+									} else {
+										sb1.WriteByte('A')
+									}
+								}
+								if n > 1 {
+									sb1.WriteByte(letters[ls1])
+								}
+								rem = num2
+								sb2.WriteByte(letters[fs2])
+								for i := 1; i < m-1; i++ {
+									if rem > 0 && sb2.String()[i-1] == 'A' {
+										sb2.WriteByte('C')
+										rem--
+									} else {
+										sb2.WriteByte('A')
+									}
+								}
+								if m > 1 {
+									sb2.WriteByte(letters[ls2])
+								}
+								return sb1.String(), sb2.String(), true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return "", "", false
+}
+
+func expectedValid(k, x, n, m int, s1, s2 string) bool {
+	if len(s1) != n || len(s2) != m {
+		return false
+	}
+	c1 := countAC(s1)
+	c2 := countAC(s2)
+	of, ol := s1[0], s1[len(s1)-1]
+	nf, nl := s2[0], s2[len(s2)-1]
+	for it := 2; it < k; it++ {
+		next := c1 + c2
+		if ol == 'A' && nf == 'C' {
+			next++
+		}
+		c1, c2 = c2, next
+		of, ol, nf, nl = nf, nl, of, nl
+		if c2 > x {
+			return false
+		}
+	}
+	return c2 == x
+}
+
+func runCase(exe string, k, x, n, m int) error {
+	input := fmt.Sprintf("%d %d %d %d\n", k, x, n, m)
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) == 1 && strings.TrimSpace(lines[0]) == "Happy new year!" {
+		if _, _, ok := gen(k, x, n, m); ok {
+			return fmt.Errorf("solution claims impossible but there is a pair")
+		}
+		return nil
+	}
+	if len(lines) != 2 {
+		return fmt.Errorf("expected two lines, got %d", len(lines))
+	}
+	s1 := strings.TrimSpace(lines[0])
+	s2 := strings.TrimSpace(lines[1])
+	if !expectedValid(k, x, n, m, s1, s2) {
+		return fmt.Errorf("output strings do not form valid solution")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	params := [][4]int{{3, 0, 1, 1}, {3, 1, 2, 2}, {4, 2, 3, 3}}
+	for i := 0; i < 100; i++ {
+		k := rng.Intn(5) + 3
+		x := rng.Intn(5)
+		n := rng.Intn(3) + 1
+		m := rng.Intn(3) + 1
+		params = append(params, [4]int{k, x, n, m})
+	}
+	for idx, p := range params {
+		if err := runCase(exe, p[0], p[1], p[2], p[3]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/379/verifierE.go
+++ b/0-999/300-399/370-379/379/verifierE.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Line struct {
+	a, b   int
+	x0, x1 float64
+}
+
+func eval(a, b int, x float64) float64 { return float64(a)*x + float64(b) }
+func P(a, b int, x0, x1 float64) float64 {
+	return (eval(a, b, x0) + eval(a, b, x1)) * (x1 - x0) / 2.0
+}
+func lowerBound(lines []Line, a int) int {
+	return sort.Search(len(lines), func(i int) bool { return lines[i].a >= a })
+}
+func removeAt(lines []Line, idx int) []Line { return append(lines[:idx], lines[idx+1:]...) }
+func insertAt(lines []Line, idx int, ln Line) []Line {
+	lines = append(lines, Line{})
+	copy(lines[idx+1:], lines[idx:])
+	lines[idx] = ln
+	return lines
+}
+func minF(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+func maxF(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveCase(n, k int, vals [][]int) []float64 {
+	S := make([][]Line, k)
+	res := make([]float64, n)
+	for i := 0; i < n; i++ {
+		y0 := vals[i][0]
+		area := 0.0
+		for j := 0; j < k; j++ {
+			y1 := vals[i][j+1]
+			a := y1 - y0
+			b := y0
+			segs := S[j]
+			if len(segs) == 0 {
+				segs = []Line{{a: a, b: b, x0: 0, x1: 1}}
+				area += P(a, b, 0, 1)
+				S[j] = segs
+				y0 = y1
+				continue
+			}
+			left, right := 1e18, -1e18
+			idx := lowerBound(segs, a)
+			for idx < len(segs) {
+				l := segs[idx]
+				if eval(a, b, l.x0) >= eval(l.a, l.b, l.x0) && eval(a, b, l.x1) >= eval(l.a, l.b, l.x1) {
+					area += P(a, b, l.x0, l.x1) - P(l.a, l.b, l.x0, l.x1)
+					left = minF(left, l.x0)
+					right = maxF(right, l.x1)
+					segs = removeAt(segs, idx)
+					continue
+				}
+				if eval(a, b, l.x0) > eval(l.a, l.b, l.x0) {
+					xsr := float64(b-l.b) / float64(l.a-a)
+					area += P(a, b, l.x0, xsr) - P(l.a, l.b, l.x0, xsr)
+					left = minF(left, l.x0)
+					right = maxF(right, xsr)
+					segs[idx] = Line{a: l.a, b: l.b, x0: xsr, x1: l.x1}
+				}
+				break
+			}
+			idx = lowerBound(segs, a)
+			if idx > 0 {
+				idx--
+				for idx >= 0 {
+					l := segs[idx]
+					if eval(a, b, l.x0) >= eval(l.a, l.b, l.x0) && eval(a, b, l.x1) >= eval(l.a, l.b, l.x1) {
+						area += P(a, b, l.x0, l.x1) - P(l.a, l.b, l.x0, l.x1)
+						left = minF(left, l.x0)
+						right = maxF(right, l.x1)
+						segs = removeAt(segs, idx)
+						idx--
+						continue
+					}
+					if eval(a, b, l.x1) > eval(l.a, l.b, l.x1) {
+						xsr := float64(b-l.b) / float64(l.a-a)
+						area += P(a, b, xsr, l.x1) - P(l.a, l.b, xsr, l.x1)
+						left = minF(left, xsr)
+						right = maxF(right, l.x1)
+						segs[idx] = Line{a: l.a, b: l.b, x0: l.x0, x1: xsr}
+					}
+					break
+				}
+			}
+			if left <= right {
+				insertPos := lowerBound(segs, a)
+				segs = insertAt(segs, insertPos, Line{a: a, b: b, x0: left, x1: right})
+			}
+			S[j] = segs
+			y0 = y1
+		}
+		res[i] = area
+	}
+	return res
+}
+
+func runCase(exe string, n, k int, vals [][]int) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		for j := 0; j <= k; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", vals[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != n {
+		return fmt.Errorf("expected %d numbers got %d", n, len(fields))
+	}
+	expected := solveCase(n, k, vals)
+	for i := 0; i < n; i++ {
+		var v float64
+		if _, err := fmt.Sscan(fields[i], &v); err != nil {
+			return fmt.Errorf("parse output: %v", err)
+		}
+		diff := v - expected[i]
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > 1e-4 {
+			return fmt.Errorf("value %d mismatch: expected %.5f got %.5f", i+1, expected[i], v)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []struct {
+		n, k int
+		vals [][]int
+	}{}
+	cases = append(cases, struct {
+		n, k int
+		vals [][]int
+	}{2, 2, [][]int{{1, 1, 1}, {2, 2, 2}}})
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(3) + 1
+		k := rng.Intn(3) + 1
+		vals := make([][]int, n)
+		for j := 0; j < n; j++ {
+			vals[j] = make([]int, k+1)
+			for t := 0; t <= k; t++ {
+				vals[j][t] = rng.Intn(5) + 1
+			}
+		}
+		cases = append(cases, struct {
+			n, k int
+			vals [][]int
+		}{n, k, vals})
+	}
+	for idx, c := range cases {
+		if err := runCase(exe, c.n, c.k, c.vals); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/379/verifierF.go
+++ b/0-999/300-399/370-379/379/verifierF.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func bfs(adj [][]int, start int) (int, []int) {
+	n := len(adj)
+	dist := make([]int, n)
+	for i := range dist {
+		dist[i] = -1
+	}
+	q := []int{start}
+	dist[start] = 0
+	var far int
+	for len(q) > 0 {
+		v := q[0]
+		q = q[1:]
+		far = v
+		for _, to := range adj[v] {
+			if dist[to] == -1 {
+				dist[to] = dist[v] + 1
+				q = append(q, to)
+			}
+		}
+	}
+	return far, dist
+}
+
+func solveF(ops []int) []int {
+	n := 4
+	adj := make([][]int, 2*len(ops)+5)
+	for i := 2; i <= 4; i++ {
+		adj[1] = append(adj[1], i)
+		adj[i] = append(adj[i], 1)
+	}
+	res := make([]int, len(ops))
+	for i, v := range ops {
+		n++
+		u := n
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+		n++
+		w := n
+		adj[w] = append(adj[w], v)
+		adj[v] = append(adj[v], w)
+		// compute diameter by two BFS
+		far, _ := bfs(adj[:n+1], 1)
+		far2, dist := bfs(adj[:n+1], far)
+		res[i] = dist[far2]
+	}
+	return res
+}
+
+func runCase(exe string, ops []int) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(ops))
+	for _, v := range ops {
+		fmt.Fprintf(&sb, "%d\n", v)
+	}
+	input := sb.String()
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != len(ops) {
+		return fmt.Errorf("expected %d numbers got %d", len(ops), len(fields))
+	}
+	expect := solveF(ops)
+	for i, f := range fields {
+		var v int
+		if _, err := fmt.Sscan(f, &v); err != nil {
+			return fmt.Errorf("parse error: %v", err)
+		}
+		if v != expect[i] {
+			return fmt.Errorf("at %d expected %d got %d", i+1, expect[i], v)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := [][]int{{1}, {2, 3}, {1, 1, 1}}
+	for i := 0; i < 100; i++ {
+		q := rng.Intn(5) + 1
+		ops := make([]int, q)
+		for j := 0; j < q; j++ {
+			ops[j] = rng.Intn(j+4) + 1
+		}
+		cases = append(cases, ops)
+	}
+	for idx, ops := range cases {
+		if err := runCase(exe, ops); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/379/verifierG.go
+++ b/0-999/300-399/370-379/379/verifierG.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct{ u, v int }
+
+func brute(n int, edges []Edge) []int {
+	best := make([]int, n+1)
+	adj := make([][]int, n)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	totalMask := 1 << n
+	for maskA := 0; maskA < totalMask; maskA++ {
+		countA := bits.OnesCount(uint(maskA))
+		for maskB := 0; maskB < totalMask; maskB++ {
+			if maskA&maskB != 0 {
+				continue
+			}
+			ok := true
+			for _, e := range edges {
+				uInA := maskA>>e.u&1 == 1
+				vInA := maskA>>e.v&1 == 1
+				uInB := maskB>>e.u&1 == 1
+				vInB := maskB>>e.v&1 == 1
+				if (uInA && vInB) || (vInA && uInB) {
+					ok = false
+					break
+				}
+			}
+			if !ok {
+				continue
+			}
+			countB := bits.OnesCount(uint(maskB))
+			if countB > best[countA] {
+				best[countA] = countB
+			}
+		}
+	}
+	return best
+}
+
+func runCase(exe string, n int, edges []Edge) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, len(edges))
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u+1, e.v+1)
+	}
+	input := sb.String()
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	expect := brute(n, edges)
+	if len(fields) != n+1 {
+		return fmt.Errorf("expected %d numbers got %d", n+1, len(fields))
+	}
+	for i := 0; i <= n; i++ {
+		var v int
+		if _, err := fmt.Sscan(fields[i], &v); err != nil {
+			return fmt.Errorf("parse error: %v", err)
+		}
+		if v != expect[i] {
+			return fmt.Errorf("index %d expected %d got %d", i, expect[i], v)
+		}
+	}
+	return nil
+}
+
+func genTree(rng *rand.Rand, n int) []Edge {
+	edges := make([]Edge, 0, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges = append(edges, Edge{p, i})
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []struct {
+		n     int
+		edges []Edge
+	}{
+		{1, []Edge{}},
+		{2, []Edge{{0, 1}}},
+	}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		edges := genTree(rng, n)
+		cases = append(cases, struct {
+			n     int
+			edges []Edge
+		}{n, edges})
+	}
+	for idx, c := range cases {
+		if err := runCase(exe, c.n, c.edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–G of Codeforces contest 379
- each verifier generates 100+ random test cases and checks a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_687ebd9cc17483248738db431fdd427f