### PR TITLE
Add Go solution verifiers for contest 377

### DIFF
--- a/0-999/300-399/370-379/377/verifierA.go
+++ b/0-999/300-399/370-379/377/verifierA.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type mazeCase struct {
+	n, m, k int
+	grid    [][]byte
+}
+
+func generateCase(rng *rand.Rand) (string, mazeCase) {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(6) + 1
+	total := n * m
+	open := rng.Intn(total) + 1
+	grid := make([][]byte, n)
+	for i := range grid {
+		grid[i] = make([]byte, m)
+		for j := range grid[i] {
+			grid[i][j] = '#'
+		}
+	}
+	sx, sy := rng.Intn(n), rng.Intn(m)
+	grid[sx][sy] = '.'
+	open--
+	cells := [][2]int{{sx, sy}}
+	for open > 0 {
+		c := cells[rng.Intn(len(cells))]
+		dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+		d := dirs[rng.Intn(4)]
+		nx, ny := c[0]+d[0], c[1]+d[1]
+		if nx < 0 || nx >= n || ny < 0 || ny >= m || grid[nx][ny] == '.' {
+			continue
+		}
+		grid[nx][ny] = '.'
+		cells = append(cells, [2]int{nx, ny})
+		open--
+	}
+	free := len(cells)
+	k := rng.Intn(free)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %d %d\n", n, m, k)
+	for i := 0; i < n; i++ {
+		b.Write(grid[i])
+		b.WriteByte('\n')
+	}
+	return b.String(), mazeCase{n: n, m: m, k: k, grid: grid}
+}
+
+func verify(tc mazeCase, out string) error {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	res := make([]string, 0, tc.n)
+	for scanner.Scan() && len(res) < tc.n {
+		line := scanner.Text()
+		if len(line) != tc.m {
+			return fmt.Errorf("expected %d columns", tc.m)
+		}
+		res = append(res, line)
+	}
+	if len(res) != tc.n {
+		return fmt.Errorf("expected %d rows", tc.n)
+	}
+	changed := 0
+	for i := 0; i < tc.n; i++ {
+		for j := 0; j < tc.m; j++ {
+			ch := res[i][j]
+			if tc.grid[i][j] == '#' {
+				if ch != '#' {
+					return fmt.Errorf("cannot modify walls")
+				}
+			} else {
+				if ch == '.' {
+				} else if ch == 'X' {
+					changed++
+				} else {
+					return fmt.Errorf("invalid char %c", ch)
+				}
+			}
+		}
+	}
+	if changed != tc.k {
+		return fmt.Errorf("expected %d X, got %d", tc.k, changed)
+	}
+	// connectivity
+	var q [][2]int
+	vis := make([][]bool, tc.n)
+	for i := range vis {
+		vis[i] = make([]bool, tc.m)
+	}
+	found := false
+	for i := 0; i < tc.n && !found; i++ {
+		for j := 0; j < tc.m; j++ {
+			if res[i][j] == '.' {
+				q = append(q, [2]int{i, j})
+				vis[i][j] = true
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		return fmt.Errorf("no free cells left")
+	}
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	idx := 0
+	for idx < len(q) {
+		x, y := q[idx][0], q[idx][1]
+		idx++
+		for _, d := range dirs {
+			nx, ny := x+d[0], y+d[1]
+			if nx < 0 || nx >= tc.n || ny < 0 || ny >= tc.m {
+				continue
+			}
+			if vis[nx][ny] || res[nx][ny] != '.' {
+				continue
+			}
+			vis[nx][ny] = true
+			q = append(q, [2]int{nx, ny})
+		}
+	}
+	total := 0
+	for i := 0; i < tc.n; i++ {
+		for j := 0; j < tc.m; j++ {
+			if res[i][j] == '.' {
+				total++
+			}
+		}
+	}
+	if total != len(q) {
+		return fmt.Errorf("cells not connected")
+	}
+	return nil
+}
+
+func runCase(bin string, input string, tc mazeCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return verify(tc, out.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		if err := runCase(bin, input, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/377/verifierB.go
+++ b/0-999/300-399/370-379/377/verifierB.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n, m  int
+	s     int64
+	bugs  []int
+	power []int
+	cost  []int
+}
+
+func generateCase(rng *rand.Rand) (string, testCaseB) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	bugs := make([]int, m)
+	for i := range bugs {
+		bugs[i] = rng.Intn(20) + 1
+	}
+	power := make([]int, n)
+	for i := range power {
+		power[i] = rng.Intn(20) + 1
+	}
+	cost := make([]int, n)
+	for i := range cost {
+		cost[i] = rng.Intn(20)
+	}
+	s := rng.Int63n(50)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %d %d\n", n, m, s)
+	for i, v := range bugs {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", v)
+	}
+	b.WriteByte('\n')
+	for i, v := range power {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", v)
+	}
+	b.WriteByte('\n')
+	for i, v := range cost {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", v)
+	}
+	b.WriteByte('\n')
+	tc := testCaseB{n: n, m: m, s: s, bugs: bugs, power: power, cost: cost}
+	return b.String(), tc
+}
+
+type req struct{ val, idx int }
+type shooter struct{ power, cost, idx int }
+
+type intHeap []int
+
+func (h intHeap) Len() int            { return len(h) }
+func (h intHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h intHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *intHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *intHeap) Pop() interface{}   { old := *h; x := old[len(old)-1]; *h = old[:len(old)-1]; return x }
+
+func minimalDays(tc testCaseB) (int, bool) {
+	reqs := make([]req, tc.m)
+	for i := 0; i < tc.m; i++ {
+		reqs[i] = req{val: tc.bugs[i], idx: i}
+	}
+	shooters := make([]shooter, tc.n)
+	for i := 0; i < tc.n; i++ {
+		shooters[i] = shooter{power: tc.power[i], cost: tc.cost[i], idx: i + 1}
+	}
+	sort.Slice(reqs, func(i, j int) bool { return reqs[i].val < reqs[j].val })
+	sort.Slice(shooters, func(i, j int) bool { return shooters[i].power < shooters[j].power })
+	chk := func(k int) bool {
+		var cst int64
+		h := &intHeap{}
+		heap.Init(h)
+		sp := tc.n - 1
+		for i := tc.m - 1; i >= 0; i -= k {
+			for sp >= 0 && shooters[sp].power >= reqs[i].val {
+				heap.Push(h, shooters[sp].cost)
+				sp--
+			}
+			if h.Len() == 0 {
+				return false
+			}
+			c := heap.Pop(h).(int)
+			cst += int64(c)
+			if cst > tc.s {
+				return false
+			}
+		}
+		return true
+	}
+	l, r := 1, tc.m+1
+	for l < r {
+		mid := (l + r) / 2
+		if chk(mid) {
+			r = mid
+		} else {
+			l = mid + 1
+		}
+	}
+	if r > tc.m {
+		return -1, false
+	}
+	return r, true
+}
+
+func runCase(bin string, input string, tc testCaseB) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	reader := bufio.NewReader(&out)
+	var first string
+	if _, err := fmt.Fscan(reader, &first); err != nil {
+		return fmt.Errorf("output parse")
+	}
+	minDays, possible := minimalDays(tc)
+	if first == "NO" {
+		if possible {
+			return fmt.Errorf("expected YES")
+		}
+		return nil
+	}
+	if first != "YES" {
+		return fmt.Errorf("expected YES/NO")
+	}
+	assign := make([]int, tc.m)
+	for i := 0; i < tc.m; i++ {
+		if _, err := fmt.Fscan(reader, &assign[i]); err != nil {
+			return fmt.Errorf("not enough numbers")
+		}
+	}
+	if !possible {
+		return fmt.Errorf("expected NO")
+	}
+	counts := make([]int, tc.n)
+	used := make([]bool, tc.n)
+	var costSum int64
+	maxCnt := 0
+	for i := 0; i < tc.m; i++ {
+		id := assign[i]
+		if id < 1 || id > tc.n {
+			return fmt.Errorf("invalid student")
+		}
+		if tc.power[id-1] < tc.bugs[i] {
+			return fmt.Errorf("student too weak")
+		}
+		counts[id-1]++
+		if counts[id-1] > maxCnt {
+			maxCnt = counts[id-1]
+		}
+		if !used[id-1] {
+			used[id-1] = true
+			costSum += int64(tc.cost[id-1])
+		}
+	}
+	if costSum > tc.s {
+		return fmt.Errorf("exceeds cost")
+	}
+	if maxCnt != minDays {
+		return fmt.Errorf("not minimal days")
+	}
+	for _, cnt := range counts {
+		if cnt > minDays {
+			return fmt.Errorf("too many assignments")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		if err := runCase(bin, input, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/377/verifierC.go
+++ b/0-999/300-399/370-379/377/verifierC.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	n         int
+	strengths []int64
+	m         int
+	isPick    []bool
+	team      []int
+}
+
+func generateCase(rng *rand.Rand) (string, testCaseC) {
+	n := rng.Intn(6) + 2
+	strengths := make([]int64, n)
+	for i := range strengths {
+		strengths[i] = int64(rng.Intn(50) + 1)
+	}
+	pickCount := rng.Intn(n/2) + 1
+	banCount := rng.Intn(n/2) + 1
+	for 2*(pickCount+banCount) > n {
+		pickCount = rng.Intn(n/2) + 1
+		banCount = rng.Intn(n/2) + 1
+	}
+	m := 2 * (pickCount + banCount)
+	var ops []struct {
+		pick bool
+		team int
+	}
+	for t := 1; t <= 2; t++ {
+		for i := 0; i < pickCount; i++ {
+			ops = append(ops, struct {
+				pick bool
+				team int
+			}{true, t})
+		}
+		for i := 0; i < banCount; i++ {
+			ops = append(ops, struct {
+				pick bool
+				team int
+			}{false, t})
+		}
+	}
+	rng.Shuffle(len(ops), func(i, j int) { ops[i], ops[j] = ops[j], ops[i] })
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i, v := range strengths {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", v)
+	}
+	b.WriteByte('\n')
+	fmt.Fprintf(&b, "%d\n", m)
+	isPick := make([]bool, m)
+	team := make([]int, m)
+	for i, op := range ops {
+		if op.pick {
+			b.WriteString("p ")
+		} else {
+			b.WriteString("b ")
+		}
+		b.WriteString(fmt.Sprint(op.team))
+		b.WriteByte('\n')
+		isPick[i] = op.pick
+		team[i] = op.team
+	}
+	tc := testCaseC{n: n, strengths: strengths, m: m, isPick: isPick, team: team}
+	return b.String(), tc
+}
+
+func expectedAnswer(tc testCaseC) int64 {
+	s := make([]int64, len(tc.strengths))
+	copy(s, tc.strengths)
+	sort.Slice(s, func(i, j int) bool { return s[i] > s[j] })
+	m := tc.m
+	if m > len(s) {
+		m = len(s)
+	}
+	a := make([]int64, m)
+	for i := 0; i < m; i++ {
+		a[i] = s[i]
+	}
+	total := 1 << m
+	dp := make([]int64, total)
+	for mask := total - 1; mask >= 0; mask-- {
+		k := bits.OnesCount(uint(mask))
+		if k >= m {
+			dp[mask] = 0
+			continue
+		}
+		pick := tc.isPick[k]
+		t := tc.team[k]
+		if t == 1 {
+			best := int64(-1 << 60)
+			for i := 0; i < m; i++ {
+				if mask&(1<<i) != 0 {
+					continue
+				}
+				val := dp[mask|1<<i]
+				if pick {
+					val += a[i]
+				}
+				if val > best {
+					best = val
+				}
+			}
+			dp[mask] = best
+		} else {
+			best := int64(1 << 60)
+			for i := 0; i < m; i++ {
+				if mask&(1<<i) != 0 {
+					continue
+				}
+				val := dp[mask|1<<i]
+				if pick {
+					val -= a[i]
+				}
+				if val < best {
+					best = val
+				}
+			}
+			dp[mask] = best
+		}
+	}
+	return dp[0]
+}
+
+func runCase(bin string, input string, tc testCaseC) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expected := fmt.Sprint(expectedAnswer(tc))
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		if err := runCase(bin, input, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/377/verifierD.go
+++ b/0-999/300-399/370-379/377/verifierD.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type seg struct{ l, x, r int }
+
+type testCaseD struct {
+	n    int
+	segs []seg
+}
+
+func generateCase(rng *rand.Rand) (string, testCaseD) {
+	n := rng.Intn(8) + 1
+	maxC := 20
+	segs := make([]seg, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(maxC-1) + 1
+		r := l + rng.Intn(maxC-l)
+		x := l + rng.Intn(r-l+1)
+		segs[i] = seg{l, x, r}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for _, s := range segs {
+		fmt.Fprintf(&b, "%d %d %d\n", s.l, s.x, s.r)
+	}
+	return b.String(), testCaseD{n, segs}
+}
+
+func brute(tc testCaseD) int {
+	maxC := 0
+	for _, s := range tc.segs {
+		if s.r > maxC {
+			maxC = s.r
+		}
+	}
+	best := 0
+	for L := 1; L <= maxC; L++ {
+		for R := L; R <= maxC; R++ {
+			cnt := 0
+			for _, s := range tc.segs {
+				if s.l <= L && s.x >= L && s.x <= R && s.r >= R {
+					cnt++
+				}
+			}
+			if cnt > best {
+				best = cnt
+			}
+		}
+	}
+	return best
+}
+
+func verify(tc testCaseD, out string) error {
+	reader := bufio.NewReader(strings.NewReader(out))
+	var ans int
+	if _, err := fmt.Fscan(reader, &ans); err != nil {
+		return fmt.Errorf("parse ans")
+	}
+	var ids []int
+	for {
+		var v int
+		if _, err := fmt.Fscan(reader, &v); err != nil {
+			break
+		}
+		ids = append(ids, v)
+	}
+	best := brute(tc)
+	if ans != best {
+		return fmt.Errorf("expected %d got %d", best, ans)
+	}
+	if len(ids) != ans {
+		return fmt.Errorf("expected %d ids", ans)
+	}
+	seen := make(map[int]bool)
+	Llow := 0
+	Lhigh := 1 << 30
+	Rlow := 0
+	Rhigh := 1 << 30
+	for _, id := range ids {
+		if id < 1 || id > tc.n {
+			return fmt.Errorf("bad id %d", id)
+		}
+		if seen[id] {
+			return fmt.Errorf("duplicate id %d", id)
+		}
+		seen[id] = true
+		s := tc.segs[id-1]
+		if s.l > Llow {
+			Llow = s.l
+		}
+		if s.x < Lhigh {
+			Lhigh = s.x
+		}
+		if s.x > Rlow {
+			Rlow = s.x
+		}
+		if s.r < Rhigh {
+			Rhigh = s.r
+		}
+	}
+	if Llow > Lhigh || Rlow > Rhigh || Llow > Rhigh {
+		return fmt.Errorf("infeasible interval")
+	}
+	return nil
+}
+
+func runCase(bin string, input string, tc testCaseD) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return verify(tc, out.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		if err := runCase(bin, input, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/377/verifierE.go
+++ b/0-999/300-399/370-379/377/verifierE.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type building struct {
+	v int
+	c int
+}
+
+type testCaseE struct {
+	n  int
+	s  int64
+	bs []building
+}
+
+func generateCase(rng *rand.Rand) (string, testCaseE) {
+	n := rng.Intn(6) + 1
+	s := int64(rng.Intn(100) + 1)
+	bs := make([]building, n)
+	for i := 0; i < n; i++ {
+		bs[i] = building{v: rng.Intn(10) + 1, c: rng.Intn(10)}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %d\n", n, s)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "%d %d\n", bs[i].v, bs[i].c)
+	}
+	return b.String(), testCaseE{n: n, s: s, bs: bs}
+}
+
+func expected(tc testCaseE) int64 {
+	best := make(map[int]int)
+	for _, b := range tc.bs {
+		if pc, ok := best[b.v]; !ok || b.c < pc {
+			best[b.v] = b.c
+		}
+	}
+	vs := make([]int, 0, len(best))
+	for v := range best {
+		vs = append(vs, v)
+	}
+	sort.Ints(vs)
+	filtered := make([]building, len(vs))
+	for i, v := range vs {
+		filtered[i] = building{v: v, c: best[v]}
+	}
+	const INF = 1e300
+	dp := make([]float64, len(filtered))
+	type line struct{ m, b float64 }
+	type hull struct {
+		lines []line
+		xs    []float64
+	}
+	addLine := func(h *hull, m, b float64) {
+		for len(h.lines) > 0 {
+			last := h.lines[len(h.lines)-1]
+			if m == last.m {
+				if b >= last.b {
+					return
+				}
+				h.lines = h.lines[:len(h.lines)-1]
+				h.xs = h.xs[:len(h.xs)-1]
+				continue
+			}
+			x := (last.b - b) / (m - last.m)
+			if len(h.xs) > 0 && x <= h.xs[len(h.xs)-1] {
+				h.lines = h.lines[:len(h.lines)-1]
+				h.xs = h.xs[:len(h.xs)-1]
+				continue
+			}
+			h.xs = append(h.xs, x)
+			break
+		}
+		if len(h.lines) == 0 {
+			h.xs = append(h.xs, -1e300)
+		}
+		h.lines = append(h.lines, line{m, b})
+	}
+	query := func(h hull, x float64) float64 {
+		l, r := 0, len(h.lines)-1
+		for l < r {
+			m := (l + r + 1) / 2
+			if h.xs[m] <= x {
+				l = m
+			} else {
+				r = m - 1
+			}
+		}
+		ln := h.lines[l]
+		return ln.m*x + ln.b
+	}
+	var h hull
+	for i, b := range filtered {
+		if b.c == 0 {
+			dp[i] = 0
+		} else if len(h.lines) == 0 {
+			dp[i] = INF
+		} else {
+			dp[i] = query(h, float64(b.c))
+		}
+		if dp[i] < INF {
+			addLine(&h, 1/float64(b.v), dp[i])
+		}
+	}
+	res := 1e300
+	for i, b := range filtered {
+		if dp[i] >= INF {
+			continue
+		}
+		t := dp[i] + float64(tc.s)/float64(b.v)
+		if t < res {
+			res = t
+		}
+	}
+	ans := int64(res)
+	if float64(ans) < res-1e-12 {
+		ans++
+	}
+	return ans
+}
+
+func runCase(bin string, input string, tc testCaseE) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expectedAns := fmt.Sprint(expected(tc))
+	if outStr != expectedAns {
+		return fmt.Errorf("expected %s got %s", expectedAns, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		if err := runCase(bin, input, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` .. `verifierE.go` for contest 377
- each verifier runs a submitted binary on 100 random cases
- checks outputs for validity using small reference implementations

## Testing
- `go run verifierA.go ./A.bin`
- `go run verifierB.go ./B.bin`
- `go run verifierC.go ./C.bin`
- `go run verifierD.go ./D.bin`
- `go run verifierE.go ./E.bin`


------
https://chatgpt.com/codex/tasks/task_e_687ebd10a2588324819a9b982b68b533