### PR TITLE
Add solution verifiers for contest 375

### DIFF
--- a/0-999/300-399/370-379/375/verifierA.go
+++ b/0-999/300-399/370-379/375/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct{ input string }
+
+func solveCase(in string) string {
+	in = strings.TrimSpace(in)
+	cnt := [10]int{}
+	for i := 0; i < len(in); i++ {
+		d := in[i] - '0'
+		cnt[d]++
+	}
+	cnt[1]--
+	cnt[6]--
+	cnt[8]--
+	cnt[9]--
+	perms := []string{"1869", "6198", "1896", "1689", "1986", "1968", "1698"}
+	m := 0
+	var sb strings.Builder
+	for d := 9; d >= 1; d-- {
+		for cnt[d] > 0 {
+			m = (m*10 + d) % 7
+			sb.WriteByte(byte('0' + d))
+			cnt[d]--
+		}
+	}
+	sb.WriteString(perms[m])
+	for cnt[0] > 0 {
+		sb.WriteByte('0')
+		cnt[0]--
+	}
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCase(tc.input)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 4
+	digits := []byte{'1', '6', '8', '9'}
+	for len(digits) < n {
+		digits = append(digits, byte('0'+rng.Intn(10)))
+	}
+	rng.Shuffle(len(digits), func(i, j int) { digits[i], digits[j] = digits[j], digits[i] })
+	return testCase{input: string(digits)}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{input: "1689"}, {input: "1869"}, {input: "196889"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %s\n", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/375/verifierB.go
+++ b/0-999/300-399/370-379/375/verifierB.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct{ input string }
+
+func solveCase(in string) string {
+	fields := strings.Fields(in)
+	if len(fields) < 2 {
+		return "0"
+	}
+	var n, m int
+	fmt.Sscan(fields[0], &n)
+	fmt.Sscan(fields[1], &m)
+	lines := strings.Split(strings.TrimSpace(in), "\n")
+	grid := lines[1 : 1+n]
+	colCount := make([]int, m)
+	for i := 0; i < n; i++ {
+		row := grid[i]
+		for j := 0; j < m; j++ {
+			if row[j] == '1' {
+				colCount[j]++
+			}
+		}
+	}
+	freq := make([]int, n+1)
+	for _, c := range colCount {
+		if c >= 0 && c <= n {
+			freq[c]++
+		}
+	}
+	eligible := 0
+	maxArea := 0
+	for h := n; h >= 1; h-- {
+		eligible += freq[h]
+		area := h * eligible
+		if area > maxArea {
+			maxArea = area
+		}
+	}
+	return fmt.Sprint(maxArea)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCase(tc.input)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = '0'
+			} else {
+				row[j] = '1'
+			}
+		}
+		sb.Write(row)
+		sb.WriteByte('\n')
+	}
+	return testCase{input: sb.String()}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 105)
+	cases = append(cases, testCase{input: "1 1\n1\n"}, testCase{input: "2 2\n01\n10\n"})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/375/verifierC.go
+++ b/0-999/300-399/370-379/375/verifierC.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct{ input string }
+
+type state struct{ i, j, mask int }
+
+func solveCase(in string) string {
+	rdr := strings.NewReader(in)
+	var n, m int
+	fmt.Fscan(rdr, &n, &m)
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(rdr, &grid[i])
+	}
+	var si, sj int
+	maxDigit := '0'
+	bombCount := 0
+	for i := 0; i < n; i++ {
+		for j, c := range grid[i] {
+			if c == 'S' {
+				si = i
+				sj = j
+			}
+			if c >= '1' && c <= '8' {
+				if c > maxDigit {
+					maxDigit = c
+				}
+			}
+			if c == 'B' {
+				bombCount++
+			}
+		}
+	}
+	t := int(maxDigit - '0')
+	treasureVals := make([]int, t)
+	for i := 0; i < t; i++ {
+		fmt.Fscan(rdr, &treasureVals[i])
+	}
+	o := t + bombCount
+	xs := make([]int, o)
+	ys := make([]int, o)
+	vals := make([]int, o)
+	bombMask := 0
+	for i := 0; i < n; i++ {
+		for j, c := range grid[i] {
+			if c >= '1' && c <= '8' {
+				tid := int(c - '1')
+				xs[tid] = j
+				ys[tid] = i
+				vals[tid] = treasureVals[tid]
+			}
+		}
+	}
+	bi := t
+	for i := 0; i < n; i++ {
+		for j, c := range grid[i] {
+			if c == 'B' {
+				xs[bi] = j
+				ys[bi] = i
+				vals[bi] = 0
+				bombMask |= 1 << bi
+				bi++
+			}
+		}
+	}
+	maxMask := 1 << o
+	const INF = -1
+	dist := make([][][]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = make([][]int, m)
+		for j := 0; j < m; j++ {
+			dist[i][j] = make([]int, maxMask)
+			for k := 0; k < maxMask; k++ {
+				dist[i][j][k] = INF
+			}
+		}
+	}
+	q := []state{{si, sj, 0}}
+	dist[si][sj][0] = 0
+	dirs := [][2]int{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
+	for head := 0; head < len(q); head++ {
+		cur := q[head]
+		d := dist[cur.i][cur.j][cur.mask]
+		for _, dir := range dirs {
+			ni := cur.i + dir[0]
+			nj := cur.j + dir[1]
+			if ni < 0 || ni >= n || nj < 0 || nj >= m {
+				continue
+			}
+			c := grid[ni][nj]
+			if c == '#' || c == 'B' || (c >= '1' && c <= '8') {
+				continue
+			}
+			newMask := cur.mask
+			if cur.j == nj {
+				x := cur.j
+				y1, y2 := cur.i, ni
+				if y1 > y2 {
+					y1, y2 = y2, y1
+				}
+				for k := 0; k < o; k++ {
+					if xs[k] < x && ys[k] >= y1 && ys[k] < y2 {
+						newMask ^= 1 << k
+					}
+				}
+			}
+			if dist[ni][nj][newMask] == INF {
+				dist[ni][nj][newMask] = d + 1
+				q = append(q, state{ni, nj, newMask})
+			}
+		}
+	}
+	ans := 0
+	for mask := 0; mask < maxMask; mask++ {
+		k := dist[si][sj][mask]
+		if k <= 0 {
+			continue
+		}
+		if mask&bombMask != 0 {
+			continue
+		}
+		sum := 0
+		for i := 0; i < o; i++ {
+			if mask&(1<<i) != 0 {
+				sum += vals[i]
+			}
+		}
+		profit := sum - k
+		if profit > ans {
+			ans = profit
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCase(tc.input)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]byte, m)
+		for j := 0; j < m; j++ {
+			grid[i][j] = '.'
+		}
+	}
+	si := rng.Intn(n)
+	sj := rng.Intn(m)
+	grid[si][sj] = 'S'
+	objCount := rng.Intn(3) + 1
+	digit := byte('1')
+	bombs := 0
+	for i := 0; i < objCount; i++ {
+		if rng.Intn(2) == 0 {
+			// treasure
+			for {
+				x := rng.Intn(n)
+				y := rng.Intn(m)
+				if grid[x][y] == '.' {
+					grid[x][y] = digit
+					digit++
+					break
+				}
+			}
+		} else {
+			// bomb
+			for {
+				x := rng.Intn(n)
+				y := rng.Intn(m)
+				if grid[x][y] == '.' {
+					grid[x][y] = 'B'
+					bombs++
+					break
+				}
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '.' && rng.Intn(5) == 0 {
+				grid[i][j] = '#'
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		sb.WriteByte('\n')
+	}
+	treasures := int(digit - '1')
+	for i := 0; i < treasures; i++ {
+		val := rng.Intn(401) - 200
+		sb.WriteString(fmt.Sprintf("%d\n", val))
+	}
+	return testCase{input: sb.String()}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 105)
+	cases = append(cases, randomCase(rng))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/375/verifierD.go
+++ b/0-999/300-399/370-379/375/verifierD.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct{ input string }
+
+func solveCase(in string) string {
+	rdr := strings.NewReader(in)
+	var n, m int
+	fmt.Fscan(rdr, &n, &m)
+	colors := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(rdr, &colors[i])
+	}
+	adj := make([][]int, n+1)
+	for i := 0; i < n-1; i++ {
+		var u, v int
+		fmt.Fscan(rdr, &u, &v)
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	// build parent and subtree list
+	parent := make([]int, n+1)
+	order := make([]int, 0, n)
+	stack := []int{1}
+	parent[1] = 0
+	for len(stack) > 0 {
+		u := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, u)
+		for _, v := range adj[u] {
+			if v != parent[u] {
+				parent[v] = u
+				stack = append(stack, v)
+			}
+		}
+	}
+	// compute children
+	children := make([][]int, n+1)
+	for _, u := range order {
+		if u == 1 {
+			continue
+		}
+		children[parent[u]] = append(children[parent[u]], u)
+	}
+	// gather subtree nodes
+	var collect func(int, []int) []int
+	collect = func(u int, arr []int) []int {
+		arr = append(arr, u)
+		for _, v := range children[u] {
+			arr = collect(v, arr)
+		}
+		return arr
+	}
+	var sb strings.Builder
+	for i := 0; i < m; i++ {
+		var v, k int
+		fmt.Fscan(rdr, &v, &k)
+		nodes := collect(v, nil)
+		freq := map[int]int{}
+		for _, x := range nodes {
+			freq[colors[x]]++
+		}
+		ans := 0
+		for _, c := range freq {
+			if c >= k {
+				ans++
+			}
+		}
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fmt.Sprint(ans))
+	}
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCase(tc.input)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 1; i <= n; i++ {
+		color := rng.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d ", color))
+	}
+	sb.WriteByte('\n')
+	edges := randomTree(rng, n)
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	for i := 0; i < m; i++ {
+		v := rng.Intn(n) + 1
+		k := rng.Intn(n) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", v, k))
+	}
+	return testCase{input: sb.String()}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 105)
+	cases = append(cases, randomCase(rng))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/375/verifierE.go
+++ b/0-999/300-399/370-379/375/verifierE.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct{ input string }
+
+type edge struct {
+	to int
+	w  int64
+}
+
+func solveCase(in string) string {
+	rdr := strings.NewReader(in)
+	var n int
+	var x int64
+	if _, err := fmt.Fscan(rdr, &n, &x); err != nil {
+		return ""
+	}
+	colors := make([]int, n)
+	bcnt := 0
+	for i := 0; i < n; i++ {
+		fmt.Fscan(rdr, &colors[i])
+		if colors[i] == 1 {
+			bcnt++
+		}
+	}
+	adj := make([][]edge, n)
+	for i := 0; i < n-1; i++ {
+		var u, v int
+		var w int64
+		fmt.Fscan(rdr, &u, &v, &w)
+		u--
+		v--
+		adj[u] = append(adj[u], edge{v, w})
+		adj[v] = append(adj[v], edge{u, w})
+	}
+	if bcnt == 0 {
+		return "-1"
+	}
+	dpRoot := dfs(0, -1, x, colors, adj)
+	best := -1
+	if m, ok := dpRoot[bcnt]; ok {
+		for _, v := range m {
+			if v > best {
+				best = v
+			}
+		}
+	}
+	if best < 0 {
+		return "-1"
+	}
+	return fmt.Sprint(bcnt - best)
+}
+
+func dfs(u, p int, x int64, color []int, adj [][]edge) map[int]map[int64]int {
+	dp0 := map[int]map[int64]int{0: {0: 0}}
+	initInter := 0
+	if color[u] == 1 {
+		initInter = 1
+	}
+	dp1 := map[int]map[int64]int{1: {-1: initInter}}
+	for _, e := range adj[u] {
+		v, w := e.to, e.w
+		if v == p {
+			continue
+		}
+		dpv := dfs(v, u, x, color, adj)
+		new0 := make(map[int]map[int64]int)
+		new1 := make(map[int]map[int64]int)
+		for k1, m1 := range dp0 {
+			for d1, inter1 := range m1 {
+				for k2, m2 := range dpv {
+					for d2, inter2 := range m2 {
+						k := k1 + k2
+						var dEff int64
+						if d2 < 0 {
+							dEff = d1
+						} else {
+							d2w := d2 + w
+							if d2w < d1 {
+								dEff = d1
+							} else {
+								dEff = d2w
+							}
+						}
+						if dEff <= x {
+							inter := inter1 + inter2
+							mm := new0[k]
+							if mm == nil {
+								mm = make(map[int64]int)
+								new0[k] = mm
+							}
+							if prev, ok := mm[dEff]; !ok || inter > prev {
+								mm[dEff] = inter
+							}
+						}
+					}
+				}
+			}
+		}
+		for k1, m1 := range dp1 {
+			for d1, inter1 := range m1 {
+				for k2, m2 := range dpv {
+					for d2, inter2 := range m2 {
+						k := k1 + k2
+						var dEff int64
+						if d2 < 0 {
+							dEff = d1
+						} else {
+							d2w := d2 + w
+							if d2w <= x {
+								dEff = d1
+							} else {
+								if d2w < d1 {
+									dEff = d1
+								} else {
+									dEff = d2w
+								}
+							}
+						}
+						if dEff <= x {
+							inter := inter1 + inter2
+							mm := new1[k]
+							if mm == nil {
+								mm = make(map[int64]int)
+								new1[k] = mm
+							}
+							if prev, ok := mm[dEff]; !ok || inter > prev {
+								mm[dEff] = inter
+							}
+						}
+					}
+				}
+			}
+		}
+		dp0 = prune(new0)
+		dp1 = prune(new1)
+	}
+	dp := make(map[int]map[int64]int)
+	for k, m := range dp0 {
+		for d, inter := range m {
+			mm := dp[k]
+			if mm == nil {
+				mm = make(map[int64]int)
+				dp[k] = mm
+			}
+			if prev, ok := mm[d]; !ok || inter > prev {
+				mm[d] = inter
+			}
+		}
+	}
+	for k, m := range dp1 {
+		for d, inter := range m {
+			mm := dp[k]
+			if mm == nil {
+				mm = make(map[int64]int)
+				dp[k] = mm
+			}
+			if prev, ok := mm[d]; !ok || inter > prev {
+				mm[d] = inter
+			}
+		}
+	}
+	return prune(dp)
+}
+
+func prune(dp map[int]map[int64]int) map[int]map[int64]int {
+	res := make(map[int]map[int64]int)
+	type pair struct {
+		d     int64
+		inter int
+	}
+	for k, m := range dp {
+		ps := make([]pair, 0, len(m))
+		for d, inter := range m {
+			ps = append(ps, pair{d, int(inter)})
+		}
+		for i := 1; i < len(ps); i++ {
+			for j := i; j > 0 && (ps[j].d < ps[j-1].d || (ps[j].d == ps[j-1].d && ps[j].inter > ps[j-1].inter)); j-- {
+				ps[j], ps[j-1] = ps[j-1], ps[j]
+			}
+		}
+		mm := make(map[int64]int)
+		maxInter := -1
+		for _, pr := range ps {
+			if pr.inter > maxInter {
+				mm[pr.d] = pr.inter
+				maxInter = pr.inter
+			}
+		}
+		res[k] = mm
+	}
+	return res
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCase(tc.input)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 1
+	x := int64(rng.Intn(10) + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteString("0 ")
+		} else {
+			sb.WriteString("1 ")
+		}
+	}
+	sb.WriteByte('\n')
+	edges := randomTree(rng, n)
+	for _, e := range edges {
+		w := rng.Int63n(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], w))
+	}
+	return testCase{input: sb.String()}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 105)
+	cases = append(cases, randomCase(rng))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 375 problems (A–E)
- each verifier generates 100+ random cases and checks a candidate binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ebc8486348324ac56652fe2e74890