### PR TITLE
Add solution verifiers for Codeforces contest 374

### DIFF
--- a/0-999/300-399/370-379/374/verifierA.go
+++ b/0-999/300-399/370-379/374/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func expected(n, m, i, j, a, b int) string {
+	if (i == 1 || i == n) && (j == 1 || j == m) {
+		return "0"
+	}
+	if a > n-1 || b > m-1 {
+		return "Poor Inna and pony!"
+	}
+	inf := int(1e9)
+	ans := inf
+	corners := [][2]int{{1, 1}, {1, m}, {n, 1}, {n, m}}
+	for _, c := range corners {
+		x, y := c[0], c[1]
+		dx := abs(x - i)
+		dy := abs(y - j)
+		if dx%a != 0 || dy%b != 0 {
+			continue
+		}
+		u := dx / a
+		v := dy / b
+		if u%2 != v%2 {
+			continue
+		}
+		if k := max(u, v); k < ans {
+			ans = k
+		}
+	}
+	if ans == inf {
+		return "Poor Inna and pony!"
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		n := rng.Intn(20) + 1
+		m := rng.Intn(20) + 1
+		i := rng.Intn(n) + 1
+		j := rng.Intn(m) + 1
+		a := rng.Intn(20) + 1
+		b := rng.Intn(20) + 1
+		input := fmt.Sprintf("%d %d %d %d %d %d\n", n, m, i, j, a, b)
+		exp := expected(n, m, i, j, a, b)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/374/verifierB.go
+++ b/0-999/300-399/370-379/374/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) string {
+	ans := uint64(1)
+	n := len(s)
+	for i := 0; i < n; {
+		if s[i] == '9' {
+			i++
+			continue
+		}
+		if i+1 < n && int(s[i]-'0')+int(s[i+1]-'0') == 9 {
+			j := i
+			for j+1 < n && s[j] != '9' && int(s[j]-'0')+int(s[j+1]-'0') == 9 {
+				j++
+			}
+			length := j - i + 1
+			if length%2 == 1 {
+				ans *= uint64(length/2 + 1)
+			}
+			i = j + 1
+		} else {
+			i++
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	digits := []byte("123456789")
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		n := rng.Intn(50) + 1
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = digits[rng.Intn(len(digits))]
+		}
+		s := string(b)
+		input := s + "\n"
+		exp := expected(s)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/374/verifierC.go
+++ b/0-999/300-399/370-379/374/verifierC.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ x, y int }
+
+var dirs = [][2]int{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
+var nextCh = map[byte]byte{'D': 'I', 'I': 'M', 'M': 'A', 'A': 'D'}
+
+func expected(grid [][]byte) string {
+	n := len(grid)
+	m := len(grid[0])
+	dp := make([][]int, n)
+	vis := make([][]int, n)
+	for i := range dp {
+		dp[i] = make([]int, m)
+		vis[i] = make([]int, m)
+	}
+	infinite := false
+	var dfs func(int, int) int
+	dfs = func(i, j int) int {
+		if infinite {
+			return 0
+		}
+		if vis[i][j] == 1 {
+			infinite = true
+			return 0
+		}
+		if vis[i][j] == 2 {
+			return dp[i][j]
+		}
+		vis[i][j] = 1
+		best := 1
+		cur := grid[i][j]
+		nxt, ok := nextCh[cur]
+		if ok {
+			for _, d := range dirs {
+				ni, nj := i+d[0], j+d[1]
+				if ni >= 0 && ni < n && nj >= 0 && nj < m && grid[ni][nj] == nxt {
+					v := dfs(ni, nj)
+					if infinite {
+						return 0
+					}
+					if v+1 > best {
+						best = v + 1
+					}
+				}
+			}
+		}
+		vis[i][j] = 2
+		dp[i][j] = best
+		return best
+	}
+	maxLen := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 'D' {
+				v := dfs(i, j)
+				if infinite {
+					return "Poor Inna!"
+				}
+				if v > maxLen {
+					maxLen = v
+				}
+			}
+		}
+	}
+	if maxLen < 4 {
+		return "Poor Dima!"
+	}
+	return fmt.Sprintf("%d", maxLen/4)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	letters := []byte{'D', 'I', 'M', 'A'}
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(6) + 1
+		grid := make([][]byte, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			row := make([]byte, m)
+			for j := 0; j < m; j++ {
+				row[j] = letters[rng.Intn(4)]
+			}
+			grid[i] = row
+			sb.WriteString(string(row))
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		exp := expected(grid)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/374/verifierD.go
+++ b/0-999/300-399/370-379/374/verifierD.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(n, m int, a []int, events []int) string {
+	seq := make([]byte, 0)
+	for _, ev := range events {
+		if ev >= 0 {
+			if ev == 0 {
+				seq = append(seq, '0')
+			} else {
+				seq = append(seq, '1')
+			}
+		} else {
+			L := len(seq)
+			k := sort.SearchInts(a, L+1)
+			for j := 0; j < k; j++ {
+				idx := a[j] - 1 - j
+				if idx < 0 || idx >= len(seq) {
+					continue
+				}
+				seq = append(seq[:idx], seq[idx+1:]...)
+			}
+		}
+	}
+	if len(seq) == 0 {
+		return "Poor stack!"
+	}
+	return string(seq)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		n := rng.Intn(20) + 1
+		m := rng.Intn(4) + 1
+		a := make([]int, m)
+		for i := 0; i < m; i++ {
+			a[i] = i + 1 + rng.Intn(3)
+		}
+		sort.Ints(a)
+		events := make([]int, n)
+		for i := 0; i < n; i++ {
+			events[i] = []int{-1, 0, 1}[rng.Intn(3)]
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for _, ev := range events {
+			sb.WriteString(fmt.Sprintf("%d\n", ev))
+		}
+		input := sb.String()
+		exp := expected(n, m, a, events)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/370-379/374/verifierE.go
+++ b/0-999/300-399/370-379/374/verifierE.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pt struct{ x, y int }
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+// expected uses the reference solution 374E.go to compute the answer
+func expected(input string) (string, error) {
+	return runProg("./374E.go", input)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		n := rng.Intn(3) + 2
+		m := rng.Intn(3) + 2
+		blue := make([]pt, n)
+		red := make([]pt, m)
+		for i := 0; i < n; i++ {
+			blue[i] = pt{rng.Intn(7) - 3, rng.Intn(7) - 3}
+		}
+		for i := 0; i < m; i++ {
+			red[i] = pt{rng.Intn(7) - 3, rng.Intn(7) - 3}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for _, p := range blue {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p.x, p.y))
+		}
+		for _, p := range red {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p.x, p.y))
+		}
+		input := sb.String()
+		exp, err := expected(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` through `verifierE.go` under contest 374
- each verifier runs 100 random tests and checks output
- problem E uses the reference solution `374E.go` for validation

## Testing
- `go run verifierA.go ./A_bin`
- `go run verifierB.go ./B_bin`
- `go run verifierC.go ./C_bin`
- `go run verifierD.go ./D_bin`
- `go run verifierE.go ./E_bin`

------
https://chatgpt.com/codex/tasks/task_e_687ebc3e7e04832488544577071a1420