### PR TITLE
Add verifiers for Codeforces contest 372

### DIFF
--- a/0-999/300-399/370-379/372/verifierA.go
+++ b/0-999/300-399/370-379/372/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expectedVisible(sizes []int) int {
+	sort.Ints(sizes)
+	n := len(sizes)
+	mid := n / 2
+	i, j, count := 0, mid, 0
+	for i < mid && j < n {
+		if sizes[j] >= 2*sizes[i] {
+			count++
+			i++
+			j++
+		} else {
+			j++
+		}
+	}
+	return n - count
+}
+
+func runCase(bin string, n int, arr []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := fmt.Sprintf("%d", expectedVisible(append([]int(nil), arr...)))
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const tests = 100
+	for i := 0; i < tests; i++ {
+		n := rng.Intn(10) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(100) + 1
+		}
+		if err := runCase(bin, n, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", tests)
+}

--- a/0-999/300-399/370-379/372/verifierB.go
+++ b/0-999/300-399/370-379/372/verifierB.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type query struct{ a, b, c, d int }
+
+func bruteCount(grid [][]byte, q query) int {
+	a, b, c, d := q.a, q.b, q.c, q.d
+	count := 0
+	for x1 := a; x1 <= c; x1++ {
+		for y1 := b; y1 <= d; y1++ {
+			for x2 := x1; x2 <= c; x2++ {
+				for y2 := y1; y2 <= d; y2++ {
+					ok := true
+					for x := x1; x <= x2 && ok; x++ {
+						for y := y1; y <= y2; y++ {
+							if grid[x][y] == '1' {
+								ok = false
+								break
+							}
+						}
+					}
+					if ok {
+						count++
+					}
+				}
+			}
+		}
+	}
+	return count
+}
+
+func solveCase(n, m int, grid [][]byte, qs []query) []int {
+	ans := make([]int, len(qs))
+	for i, q := range qs {
+		ans[i] = bruteCount(grid, q)
+	}
+	return ans
+}
+
+func runCase(bin string, n, m, qCount int, grid [][]byte, qs []query) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, qCount))
+	for i := 0; i < n; i++ {
+		sb.Write(grid[i])
+		sb.WriteByte('\n')
+	}
+	for _, qq := range qs {
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", qq.a+1, qq.b+1, qq.c+1, qq.d+1))
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := solveCase(n, m, grid, qs)
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != len(expected) {
+		return fmt.Errorf("expected %d numbers got %d", len(expected), len(fields))
+	}
+	for i, f := range fields {
+		var val int
+		fmt.Sscan(f, &val)
+		if val != expected[i] {
+			return fmt.Errorf("expected %v got %v", expected, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rng.Intn(4) + 1
+		m := rng.Intn(4) + 1
+		qCount := rng.Intn(3) + 1
+		grid := make([][]byte, n)
+		for i := 0; i < n; i++ {
+			row := make([]byte, m)
+			for j := 0; j < m; j++ {
+				if rng.Intn(2) == 0 {
+					row[j] = '0'
+				} else {
+					row[j] = '1'
+				}
+			}
+			grid[i] = row
+		}
+		qs := make([]query, qCount)
+		for i := 0; i < qCount; i++ {
+			a := rng.Intn(n)
+			c := rng.Intn(n)
+			if a > c {
+				a, c = c, a
+			}
+			b := rng.Intn(m)
+			d := rng.Intn(m)
+			if b > d {
+				b, d = d, b
+			}
+			qs[i] = query{a, b, c, d}
+		}
+		if err := runCase(bin, n, m, qCount, grid, qs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", tests)
+}

--- a/0-999/300-399/370-379/372/verifierC.go
+++ b/0-999/300-399/370-379/372/verifierC.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func absInt(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solveCase(n, m, d int, a, b, tVals []int) int64 {
+	dp := make([]int64, n)
+	dp2 := make([]int64, n)
+	for x := 0; x < n; x++ {
+		dp[x] = int64(b[0] - absInt(a[0]-x))
+	}
+	for i := 1; i < m; i++ {
+		dist := (tVals[i] - tVals[i-1]) * d
+		if dist >= n {
+			var best int64 = math.MinInt64
+			for x := 0; x < n; x++ {
+				if dp[x] > best {
+					best = dp[x]
+				}
+			}
+			for x := 0; x < n; x++ {
+				dp2[x] = best + int64(b[i]-absInt(a[i]-x))
+			}
+		} else {
+			head, tail := 0, 0
+			deque := make([]int, n)
+			r := -1
+			for x := 0; x < n; x++ {
+				newR := x + dist
+				if newR >= n {
+					newR = n - 1
+				}
+				for r < newR {
+					r++
+					for tail > head && dp[deque[tail-1]] <= dp[r] {
+						tail--
+					}
+					deque[tail] = r
+					tail++
+				}
+				l := x - dist
+				if l < 0 {
+					l = 0
+				}
+				for head < tail && deque[head] < l {
+					head++
+				}
+				best := dp[deque[head]]
+				dp2[x] = best + int64(b[i]-absInt(a[i]-x))
+			}
+		}
+		dp, dp2 = dp2, dp
+	}
+	var ans int64 = math.MinInt64
+	for x := 0; x < n; x++ {
+		if dp[x] > ans {
+			ans = dp[x]
+		}
+	}
+	return ans
+}
+
+func runCase(bin string, n, m, d int, a, b, tVals []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, d))
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", a[i]+1, b[i], tVals[i]))
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := solveCase(n, m, d, a, b, tVals)
+	var got int64
+	fmt.Sscan(strings.TrimSpace(out.String()), &got)
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const tests = 100
+	for i := 0; i < tests; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(3) + 1
+		d := rng.Intn(3) + 1
+		a := make([]int, m)
+		b := make([]int, m)
+		tVals := make([]int, m)
+		curTime := 0
+		for j := 0; j < m; j++ {
+			a[j] = rng.Intn(n)
+			b[j] = rng.Intn(10)
+			curTime += rng.Intn(5) + 1
+			tVals[j] = curTime
+		}
+		if err := runCase(bin, n, m, d, a, b, tVals); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", tests)
+}

--- a/0-999/300-399/370-379/372/verifierD.go
+++ b/0-999/300-399/370-379/372/verifierD.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func connected(mask int, n int, edges []edge) bool {
+	var start int = -1
+	for i := 0; i < n; i++ {
+		if mask&(1<<i) != 0 {
+			start = i
+			break
+		}
+	}
+	if start == -1 {
+		return false
+	}
+	visited := 0
+	queue := []int{start}
+	visited |= 1 << start
+	for len(queue) > 0 {
+		u := queue[0]
+		queue = queue[1:]
+		for _, e := range edges {
+			a, b := e.u, e.v
+			if a == u && mask&(1<<b) != 0 && visited&(1<<b) == 0 {
+				visited |= 1 << b
+				queue = append(queue, b)
+			} else if b == u && mask&(1<<a) != 0 && visited&(1<<a) == 0 {
+				visited |= 1 << a
+				queue = append(queue, a)
+			}
+		}
+	}
+	return visited == mask
+}
+
+func consecutiveLen(mask int, n int) int {
+	best := 0
+	for l := 0; l < n; l++ {
+		for r := l; r < n; r++ {
+			if r-l+1 <= best {
+				continue
+			}
+			ok := true
+			for x := l; x <= r; x++ {
+				if mask&(1<<x) == 0 {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				best = r - l + 1
+			}
+		}
+	}
+	return best
+}
+
+func brute(n, k int, edges []edge) int {
+	best := 0
+	total := 1 << n
+	for mask := 1; mask < total; mask++ {
+		if bits.OnesCount(uint(mask)) > k {
+			continue
+		}
+		if !connected(mask, n, edges) {
+			continue
+		}
+		clen := consecutiveLen(mask, n)
+		if clen > best {
+			best = clen
+		}
+	}
+	return best
+}
+
+func runCase(bin string, n, k int, edges []edge) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u+1, e.v+1))
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := brute(n, k, edges)
+	var got int
+	fmt.Sscan(strings.TrimSpace(out.String()), &got)
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const tests = 100
+	for i := 0; i < tests; i++ {
+		n := rng.Intn(6) + 2
+		k := rng.Intn(n) + 1
+		edges := make([]edge, n-1)
+		for v := 1; v < n; v++ {
+			p := rng.Intn(v)
+			edges[v-1] = edge{u: p, v: v}
+		}
+		if err := runCase(bin, n, k, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", tests)
+}

--- a/0-999/300-399/370-379/372/verifierE.go
+++ b/0-999/300-399/370-379/372/verifierE.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+type point struct{ a, b, c, d int }
+
+type pair struct{ dot, cross int64 }
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solveCase(pts []point) int64 {
+	n := len(pts)
+	xs := make([]int64, n)
+	ys := make([]int64, n)
+	for i, p := range pts {
+		xs[i] = int64(p.a) * int64(p.d)
+		ys[i] = int64(p.c) * int64(p.b)
+	}
+	counts := make(map[pair]int)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			dot := xs[i]*xs[j] - ys[i]*ys[j]
+			cross := xs[i]*ys[j] + ys[i]*xs[j]
+			g := gcd(dot, cross)
+			if g != 0 {
+				dot /= g
+				cross /= g
+			}
+			counts[pair{dot, cross}]++
+		}
+	}
+	var ans int64
+	for _, m := range counts {
+		if m >= 2 {
+			add := modPow(2, int64(m)) - 1 - int64(m)
+			add %= mod
+			if add < 0 {
+				add += mod
+			}
+			ans = (ans + add) % mod
+		}
+	}
+	return ans
+}
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	a %= mod
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func runCase(bin string, pts []point) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(pts)))
+	for _, p := range pts {
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", p.a, p.b, p.c, p.d))
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := solveCase(pts)
+	var got int64
+	fmt.Sscan(strings.TrimSpace(out.String()), &got)
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const tests = 100
+	for i := 0; i < tests; i++ {
+		n := rng.Intn(5) + 2
+		pts := make([]point, n)
+		for j := 0; j < n; j++ {
+			for {
+				a := rng.Intn(5) - 2
+				c := rng.Intn(5) - 2
+				if a != 0 || c != 0 {
+					pts[j].a = a
+					pts[j].b = rng.Intn(3) + 1
+					pts[j].c = c
+					pts[j].d = rng.Intn(3) + 1
+					break
+				}
+			}
+		}
+		if err := runCase(bin, pts); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", tests)
+}


### PR DESCRIPTION
## Summary
- add Go based verifiers for problems A–E of contest 372
- each verifier generates at least 100 random tests and checks a binary's output

## Testing
- `go run 0-999/300-399/370-379/372/verifierA.go ./candidateA`


------
https://chatgpt.com/codex/tasks/task_e_687ebbb25c6c8324bd3259171998165c