### PR TITLE
Add Go verifiers for contest 371

### DIFF
--- a/0-999/300-399/370-379/371/verifierA.go
+++ b/0-999/300-399/370-379/371/verifierA.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n, k int
+	if _, err := fmt.Fscan(reader, &n, &k); err != nil {
+		return ""
+	}
+	a := make([]int, n)
+	for i := range a {
+		fmt.Fscan(reader, &a[i])
+	}
+	changes := 0
+	for i := 0; i < k; i++ {
+		cnt1, cnt2 := 0, 0
+		for j := i; j < n; j += k {
+			if a[j] == 1 {
+				cnt1++
+			} else {
+				cnt2++
+			}
+		}
+		groupSize := cnt1 + cnt2
+		if cnt1 > cnt2 {
+			changes += groupSize - cnt1
+		} else {
+			changes += groupSize - cnt2
+		}
+	}
+	return fmt.Sprintf("%d", changes)
+}
+
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	fixed := []struct {
+		n   int
+		k   int
+		arr []int
+	}{
+		{1, 1, []int{1}},
+		{3, 1, []int{1, 2, 1}},
+		{4, 2, []int{1, 2, 1, 2}},
+	}
+	for _, f := range fixed {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", f.n, f.k)
+		for i, v := range f.arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(n) + 1
+		arr := make([]int, n)
+		for i := range arr {
+			arr[i] = rand.Intn(2) + 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\n got:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/300-399/370-379/371/verifierB.go
+++ b/0-999/300-399/370-379/371/verifierB.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func factor(x int64) (e2, e3, e5 int, rem int64) {
+	rem = x
+	for rem%2 == 0 {
+		rem /= 2
+		e2++
+	}
+	for rem%3 == 0 {
+		rem /= 3
+		e3++
+	}
+	for rem%5 == 0 {
+		rem /= 5
+		e5++
+	}
+	return
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var a, b int64
+	if _, err := fmt.Fscan(reader, &a, &b); err != nil {
+		return ""
+	}
+	a2, a3, a5, ra := factor(a)
+	b2, b3, b5, rb := factor(b)
+	if ra != rb {
+		return "-1"
+	}
+	ops := abs(a2-b2) + abs(a3-b3) + abs(a5-b5)
+	return fmt.Sprintf("%d", ops)
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func generateTests() []test {
+	rand.Seed(43)
+	var tests []test
+	fixed := []struct{ a, b int64 }{
+		{1, 1}, {10, 10}, {10, 1}, {100, 250}, {45, 75},
+	}
+	for _, f := range fixed {
+		inp := fmt.Sprintf("%d %d\n", f.a, f.b)
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	for len(tests) < 100 {
+		a := rand.Int63n(1000000) + 1
+		b := rand.Int63n(1000000) + 1
+		inp := fmt.Sprintf("%d %d\n", a, b)
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\n got:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/300-399/370-379/371/verifierC.go
+++ b/0-999/300-399/370-379/371/verifierC.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var recipe string
+	if _, err := fmt.Fscan(reader, &recipe); err != nil {
+		return ""
+	}
+	var nb, ns, nc int64
+	fmt.Fscan(reader, &nb, &ns, &nc)
+	var pb, ps, pc int64
+	fmt.Fscan(reader, &pb, &ps, &pc)
+	var r int64
+	fmt.Fscan(reader, &r)
+	var needB, needS, needC int64
+	for _, ch := range recipe {
+		switch ch {
+		case 'B':
+			needB++
+		case 'S':
+			needS++
+		case 'C':
+			needC++
+		}
+	}
+	can := func(x int64) bool {
+		cost := int64(0)
+		if req := needB*x - nb; req > 0 {
+			cost += req * pb
+		}
+		if req := needS*x - ns; req > 0 {
+			cost += req * ps
+		}
+		if req := needC*x - nc; req > 0 {
+			cost += req * pc
+		}
+		return cost <= r
+	}
+	lo, hi := int64(0), int64(1e13)
+	ans := int64(0)
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		if can(mid) {
+			ans = mid
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+	rand.Seed(44)
+	var tests []test
+	fixed := []string{
+		"BSC\n1 1 1\n1 1 1\n0\n",
+		"BB\n0 0 0\n1 1 1\n10\n",
+	}
+	for _, in := range fixed {
+		tests = append(tests, test{in, solve(in)})
+	}
+	for len(tests) < 100 {
+		l := rand.Intn(5) + 1
+		var sb strings.Builder
+		for i := 0; i < l; i++ {
+			ch := "BSC"[rand.Intn(3)]
+			sb.WriteByte(ch)
+		}
+		recipe := sb.String()
+		nb := rand.Int63n(10)
+		ns := rand.Int63n(10)
+		nc := rand.Int63n(10)
+		pb := rand.Int63n(10) + 1
+		ps := rand.Int63n(10) + 1
+		pc := rand.Int63n(10) + 1
+		r := rand.Int63n(1000)
+		inp := fmt.Sprintf("%s\n%d %d %d\n%d %d %d\n%d\n", recipe, nb, ns, nc, pb, ps, pc, r)
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\n got:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/300-399/370-379/371/verifierD.go
+++ b/0-999/300-399/370-379/371/verifierD.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n int
+	fmt.Fscan(reader, &n)
+	capv := make([]int64, n+2)
+	curr := make([]int64, n+2)
+	parent := make([]int, n+2)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(reader, &capv[i])
+		parent[i] = i
+	}
+	parent[n+1] = n + 1
+	find := func(x int) int {
+		for parent[x] != x {
+			parent[x] = parent[parent[x]]
+			x = parent[x]
+		}
+		return x
+	}
+	union := func(x, y int) { parent[find(x)] = find(y) }
+	var m int
+	fmt.Fscan(reader, &m)
+	var out bytes.Buffer
+	for i := 0; i < m; i++ {
+		var tp int
+		fmt.Fscan(reader, &tp)
+		if tp == 1 {
+			var p int
+			var x int64
+			fmt.Fscan(reader, &p, &x)
+			idx := find(p)
+			for idx <= n && x > 0 {
+				space := capv[idx] - curr[idx]
+				if space > x {
+					curr[idx] += x
+					x = 0
+					break
+				}
+				curr[idx] = capv[idx]
+				x -= space
+				union(idx, idx+1)
+				idx = find(idx)
+			}
+		} else {
+			var k int
+			fmt.Fscan(reader, &k)
+			fmt.Fprintln(&out, curr[k])
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateTests() []test {
+	rand.Seed(45)
+	var tests []test
+	for len(tests) < 100 {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(10) + 1
+		capv := make([]int64, n)
+		for i := range capv {
+			capv[i] = int64(rand.Intn(5) + 1)
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i, v := range capv {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		fmt.Fprintf(&sb, "%d\n", m)
+		for j := 0; j < m; j++ {
+			if rand.Intn(2) == 0 {
+				p := rand.Intn(n) + 1
+				x := rand.Intn(5) + 1
+				fmt.Fprintf(&sb, "1 %d %d\n", p, x)
+			} else {
+				k := rand.Intn(n) + 1
+				fmt.Fprintf(&sb, "2 %d\n", k)
+			}
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\n got:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/300-399/370-379/371/verifierE.go
+++ b/0-999/300-399/370-379/371/verifierE.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n, k int
+	fmt.Fscan(reader, &n)
+	stations := make([]struct {
+		x   int
+		idx int
+	}, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &stations[i].x)
+		stations[i].idx = i + 1
+	}
+	fmt.Fscan(reader, &k)
+	sort.Slice(stations, func(i, j int) bool { return stations[i].x < stations[j].x })
+	var sumX int64
+	var S int64
+	for t := 0; t < k; t++ {
+		xi := int64(stations[t].x)
+		sumX += xi
+		S += xi * int64(2*t-k+1)
+	}
+	best := S
+	bestL := 0
+	for l := 0; l+k < n; l++ {
+		leftX := int64(stations[l].x)
+		rightX := int64(stations[l+k].x)
+		S = S + int64(k+1)*leftX - 2*sumX + int64(k-1)*rightX
+		sumX = sumX - leftX + rightX
+		if S < best {
+			best = S
+			bestL = l + 1
+		}
+	}
+	var out bytes.Buffer
+	for t := 0; t < k; t++ {
+		if t > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprint(&out, stations[bestL+t].idx)
+	}
+	return out.String()
+}
+
+func generateTests() []test {
+	rand.Seed(46)
+	var tests []test
+	fixed := []string{
+		"3\n1 2 3\n2\n",
+		"4\n10 20 30 40\n1\n",
+	}
+	for _, in := range fixed {
+		tests = append(tests, test{in, solve(in)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(8) + 2
+		k := rand.Intn(n-1) + 1
+		xs := make([]int, n)
+		for i := 0; i < n; i++ {
+			xs[i] = rand.Intn(50)
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i, v := range xs {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		fmt.Fprintf(&sb, "%d\n", k)
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\n got:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest 371 problems A–E
- each verifier generates at least 100 random tests and checks any binary or Go file

## Testing
- `go build 0-999/300-399/370-379/371/verifierA.go`
- `go build 0-999/300-399/370-379/371/verifierB.go`
- `go build 0-999/300-399/370-379/371/verifierC.go`
- `go build 0-999/300-399/370-379/371/verifierD.go`
- `go build 0-999/300-399/370-379/371/verifierE.go`
- `./verifierA 371A.go`

------
https://chatgpt.com/codex/tasks/task_e_687ebb6c70688324bd2b293d54a77985