### PR TITLE
Add contest 369 solution verifiers

### DIFF
--- a/0-999/300-399/360-369/369/verifierA.go
+++ b/0-999/300-399/360-369/369/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type caseA struct {
+	n, m, k int
+	dishes  []int
+}
+
+func computeA(n, m, k int, dishes []int) int {
+	washes := 0
+	for _, d := range dishes {
+		switch d {
+		case 1:
+			if m > 0 {
+				m--
+			} else {
+				washes++
+			}
+		case 2:
+			if k > 0 {
+				k--
+			} else if m > 0 {
+				m--
+			} else {
+				washes++
+			}
+		}
+	}
+	return washes
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(10)
+	k := rng.Intn(10)
+	dishes := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		dishes[i] = rng.Intn(2) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", dishes[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), computeA(n, m, k, dishes)
+}
+
+func runCase(bin, input string, exp int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/369/verifierB.go
+++ b/0-999/300-399/360-369/369/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type caseB struct {
+	n, k, l, r, sAll, sK int
+	input                string
+}
+
+func generateCase(rng *rand.Rand) caseB {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n) + 1
+	l := rng.Intn(11) // 0..10
+	r := l + rng.Intn(11)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = l + rng.Intn(r-l+1)
+	}
+	sAll := 0
+	for _, v := range arr {
+		sAll += v
+	}
+	sorted := append([]int(nil), arr...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] > sorted[j] })
+	sK := 0
+	for i := 0; i < k; i++ {
+		sK += sorted[i]
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d %d %d\n", n, k, l, r, sAll, sK))
+	return caseB{n, k, l, r, sAll, sK, sb.String()}
+}
+
+func runCase(bin string, c caseB) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(c.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	reader := strings.NewReader(out.String())
+	arr := make([]int, c.n)
+	for i := 0; i < c.n; i++ {
+		if _, err := fmt.Fscan(reader, &arr[i]); err != nil {
+			return fmt.Errorf("failed to read number %d: %v\n%s", i+1, err, out.String())
+		}
+	}
+	for _, v := range arr {
+		if v < c.l || v > c.r {
+			return fmt.Errorf("value %d outside [%d,%d]", v, c.l, c.r)
+		}
+	}
+	sum := 0
+	for _, v := range arr {
+		sum += v
+	}
+	if sum != c.sAll {
+		return fmt.Errorf("sum %d != %d", sum, c.sAll)
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i] > arr[j] })
+	sK := 0
+	for i := 0; i < c.k; i++ {
+		sK += arr[i]
+	}
+	if sK != c.sK {
+		return fmt.Errorf("top %d sum %d != %d", c.k, sK, c.sK)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := generateCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/369/verifierC.go
+++ b/0-999/300-399/360-369/369/verifierC.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	to, t int
+}
+
+type caseC struct {
+	n      int
+	edges  [][3]int
+	input  string
+	expect []int
+}
+
+func computeSet(n int, edges [][3]int) []int {
+	adj := make([][]edge, n+1)
+	for _, e := range edges {
+		a, b, c := e[0], e[1], e[2]
+		adj[a] = append(adj[a], edge{b, c})
+		adj[b] = append(adj[b], edge{a, c})
+	}
+	ans := make([]int, 0)
+	var dfs func(u, p int) bool
+	dfs = func(u, p int) bool {
+		selected := false
+		for _, e := range adj[u] {
+			if e.to == p {
+				continue
+			}
+			child := dfs(e.to, u)
+			if e.t == 2 && !child {
+				ans = append(ans, e.to)
+				child = true
+			}
+			if child {
+				selected = true
+			}
+		}
+		return selected
+	}
+	dfs(1, 0)
+	sort.Ints(ans)
+	return ans
+}
+
+func generateCase(rng *rand.Rand) caseC {
+	n := rng.Intn(9) + 2 // at least 2
+	edges := make([][3]int, n-1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		t := rng.Intn(2) + 1
+		edges[i-2] = [3]int{p, i, t}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", p, i, t))
+	}
+	expect := computeSet(n, edges)
+	return caseC{n, edges, sb.String(), expect}
+}
+
+func runCase(bin string, c caseC) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(c.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	reader := strings.NewReader(out.String())
+	var k int
+	if _, err := fmt.Fscan(reader, &k); err != nil {
+		return fmt.Errorf("failed to read k: %v\n%s", err, out.String())
+	}
+	got := make([]int, k)
+	for i := 0; i < k; i++ {
+		if _, err := fmt.Fscan(reader, &got[i]); err != nil {
+			return fmt.Errorf("failed to read node %d: %v\n%s", i+1, err, out.String())
+		}
+	}
+	sort.Ints(got)
+	if k != len(c.expect) {
+		return fmt.Errorf("expected %d nodes got %d", len(c.expect), k)
+	}
+	for i := range got {
+		if got[i] != c.expect[i] {
+			return fmt.Errorf("mismatch at %d: expected %d got %d", i, c.expect[i], got[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := generateCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/369/verifierD.go
+++ b/0-999/300-399/360-369/369/verifierD.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type caseD struct {
+	n, k   int
+	p      []int
+	input  string
+	expect int
+}
+
+func computeD(n, k int, p []int) int {
+	sufPos := make([]bool, n+3)
+	sufSafe := make([]bool, n+3)
+	for i := n; i >= 1; i-- {
+		sufPos[i] = sufPos[i+1] || (p[i-1] > 0)
+		sufSafe[i] = sufSafe[i+1] && (p[i-1] < 100)
+	}
+	stride := k + 2
+	visited := make([]bool, (n+2)*stride)
+	type state struct{ i, d int }
+	curr := []state{{1, func() int {
+		if 2 > n+1 {
+			return n + 1
+		}
+		return 2
+	}() - 1}}
+	visited[1*stride+curr[0].d] = true
+	count := 1
+	for round := 0; round < k && len(curr) > 0; round++ {
+		next := []state{}
+		for _, st := range curr {
+			i := st.i
+			j := i + st.d
+			if i > n || j > n {
+				continue
+			}
+			kill1 := sufPos[j]
+			surv1 := sufSafe[j]
+			kill2 := p[i-1] > 0
+			surv2 := p[i-1] < 100
+			if kill1 && kill2 {
+				ni, nd := j+1, 1
+				idx := ni*stride + nd
+				if !visited[idx] {
+					visited[idx] = true
+					next = append(next, state{ni, nd})
+					count++
+				}
+			}
+			if kill1 && surv2 {
+				ni, nd := j, 1
+				idx := ni*stride + nd
+				if !visited[idx] {
+					visited[idx] = true
+					next = append(next, state{ni, nd})
+					count++
+				}
+			}
+			if surv1 && kill2 {
+				ni, nd := i, st.d+1
+				idx := ni*stride + nd
+				if !visited[idx] {
+					visited[idx] = true
+					next = append(next, state{ni, nd})
+					count++
+				}
+			}
+		}
+		curr = next
+	}
+	return count
+}
+
+func generateCase(rng *rand.Rand) caseD {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(5) + 1
+	p := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = rng.Intn(101)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", p[i]))
+	}
+	sb.WriteByte('\n')
+	exp := computeD(n, k, p)
+	return caseD{n, k, p, sb.String(), exp}
+}
+
+func runCase(bin string, c caseD) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(c.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v\n%s", err, out.String())
+	}
+	if got != c.expect {
+		return fmt.Errorf("expected %d got %d", c.expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := generateCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/369/verifierE.go
+++ b/0-999/300-399/360-369/369/verifierE.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Segment struct{ l, r int }
+
+func NewBIT(n int) *BIT { return &BIT{n: n, t: make([]int, n+2)} }
+
+type BIT struct {
+	n int
+	t []int
+}
+
+func (b *BIT) Add(i, v int) {
+	for i <= b.n {
+		b.t[i] += v
+		i += i & -i
+	}
+}
+
+func (b *BIT) Sum(i int) int {
+	if i > b.n {
+		i = b.n
+	}
+	s := 0
+	for i > 0 {
+		s += b.t[i]
+		i -= i & -i
+	}
+	return s
+}
+
+func computeE(n, m int, segs []Segment, queries [][]int) []int {
+	lArr := make([]int, n)
+	rArr := make([]int, n)
+	for i, s := range segs {
+		lArr[i] = s.l
+		rArr[i] = s.r
+	}
+	sort.Ints(lArr)
+	sort.Ints(rArr)
+	ansL := make([]int, m)
+	ansR := make([]int, m)
+	gapSum := make([]int, m)
+	type Gap struct{ x, y, idx int }
+	var gaps []Gap
+	for qi, pts := range queries {
+		sort.Ints(pts)
+		p1 := pts[0]
+		ansL[qi] = sort.SearchInts(rArr, p1)
+		pk := pts[len(pts)-1]
+		idxR := sort.Search(len(lArr), func(i int) bool { return lArr[i] > pk })
+		ansR[qi] = n - idxR
+		for i := 0; i+1 < len(pts); i++ {
+			gaps = append(gaps, Gap{pts[i], pts[i+1], qi})
+		}
+	}
+	sort.Slice(segs, func(i, j int) bool { return segs[i].l > segs[j].l })
+	sort.Slice(gaps, func(i, j int) bool { return gaps[i].x > gaps[j].x })
+	maxC := 1000
+	bit := NewBIT(maxC)
+	si := 0
+	for _, g := range gaps {
+		for si < n && segs[si].l > g.x {
+			r := segs[si].r
+			if r >= 1 && r <= maxC {
+				bit.Add(r, 1)
+			}
+			si++
+		}
+		lim := g.y - 1
+		if lim > 0 {
+			gapSum[g.idx] += bit.Sum(lim)
+		}
+	}
+	res := make([]int, m)
+	for i := 0; i < m; i++ {
+		res[i] = n - ansL[i] - ansR[i] - gapSum[i]
+	}
+	return res
+}
+
+type caseE struct {
+	n, m    int
+	segs    []Segment
+	queries [][]int
+	input   string
+	expect  []int
+}
+
+func generateCase(rng *rand.Rand) caseE {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	segs := make([]Segment, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		l := rng.Intn(20) + 1
+		r := l + rng.Intn(10)
+		segs[i] = Segment{l, r}
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	queries := make([][]int, m)
+	for qi := 0; qi < m; qi++ {
+		cnt := rng.Intn(3) + 1
+		pts := make([]int, cnt)
+		for i := 0; i < cnt; i++ {
+			pts[i] = rng.Intn(25)
+		}
+		queries[qi] = pts
+		sb.WriteString(fmt.Sprintf("%d", cnt))
+		for _, p := range pts {
+			sb.WriteString(fmt.Sprintf(" %d", p))
+		}
+		sb.WriteByte('\n')
+	}
+	expect := computeE(n, m, segs, queries)
+	return caseE{n, m, segs, queries, sb.String(), expect}
+}
+
+func runCase(bin string, c caseE) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(c.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	reader := strings.NewReader(out.String())
+	for i := 0; i < c.m; i++ {
+		var got int
+		if _, err := fmt.Fscan(reader, &got); err != nil {
+			return fmt.Errorf("failed to read answer %d: %v\n%s", i+1, err, out.String())
+		}
+		if got != c.expect[i] {
+			return fmt.Errorf("answer %d expected %d got %d", i+1, c.expect[i], got)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := generateCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 369
- each verifier generates 100 random test cases
- verify outputs of any binary solution by executing it

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ebae0348083249b35655a8d6fd4cf