### PR TITLE
Add Go verifiers for CF contest 367

### DIFF
--- a/0-999/300-399/360-369/367/verifierA.go
+++ b/0-999/300-399/360-369/367/verifierA.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type query struct{ l, r int }
+
+func solveA(s string, qs []query) []string {
+	n := len(s)
+	px := make([]int, n+1)
+	py := make([]int, n+1)
+	pz := make([]int, n+1)
+	for i, ch := range s {
+		px[i+1] = px[i]
+		py[i+1] = py[i]
+		pz[i+1] = pz[i]
+		switch ch {
+		case 'x':
+			px[i+1]++
+		case 'y':
+			py[i+1]++
+		case 'z':
+			pz[i+1]++
+		}
+	}
+	res := make([]string, len(qs))
+	for i, q := range qs {
+		l, r := q.l, q.r
+		length := r - l + 1
+		if length < 3 {
+			res[i] = "YES"
+			continue
+		}
+		cx := px[r] - px[l-1]
+		cy := py[r] - py[l-1]
+		cz := pz[r] - pz[l-1]
+		mx := cx
+		if cy > mx {
+			mx = cy
+		}
+		if cz > mx {
+			mx = cz
+		}
+		mn := cx
+		if cy < mn {
+			mn = cy
+		}
+		if cz < mn {
+			mn = cz
+		}
+		if mx-mn > 1 {
+			res[i] = "NO"
+		} else {
+			res[i] = "YES"
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	sb := strings.Builder{}
+	letters := []byte{'x', 'y', 'z'}
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rng.Intn(3)])
+	}
+	s := sb.String()
+	m := rng.Intn(20) + 1
+	qs := make([]query, m)
+	input := fmt.Sprintf("%s\n%d\n", s, m)
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		qs[i] = query{l, r}
+		input += fmt.Sprintf("%d %d\n", l, r)
+	}
+	ans := solveA(s, qs)
+	expected := strings.Join(ans, "\n")
+	return input, expected
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/367/verifierB.go
+++ b/0-999/300-399/360-369/367/verifierB.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func multisetEqual(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ma := make(map[int]int)
+	mb := make(map[int]int)
+	for _, v := range a {
+		ma[v]++
+	}
+	for _, v := range b {
+		mb[v]++
+	}
+	if len(ma) != len(mb) {
+		return false
+	}
+	for k, v := range ma {
+		if mb[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func solveB(n, m, p int, a, b []int) []int {
+	var res []int
+	for q := 0; q+(m-1)*p < n; q++ {
+		sub := make([]int, m)
+		for i := 0; i < m; i++ {
+			sub[i] = a[q+i*p]
+		}
+		if multisetEqual(sub, b) {
+			res = append(res, q+1)
+		}
+	}
+	sort.Ints(res)
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(min(10, n)) + 1
+	p := rng.Intn(n) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(10) + 1
+	}
+	b := make([]int, m)
+	for i := 0; i < m; i++ {
+		b[i] = rng.Intn(10) + 1
+	}
+	input := fmt.Sprintf("%d %d %d\n", n, m, p)
+	for i, v := range a {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	for i, v := range b {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	ans := solveB(n, m, p, a, b)
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("%d", len(ans)))
+	if len(ans) > 0 {
+		sb.WriteByte('\n')
+		for i, v := range ans {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+	}
+	expected := sb.String()
+	return input, expected
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/367/verifierC.go
+++ b/0-999/300-399/360-369/367/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveC(n int64, weights []int64) int64 {
+	m := int64(len(weights))
+	lim := n - 1
+	s := int64(math.Sqrt(float64(1 + 8*lim)))
+	k := (1 + s) / 2
+	for k*(k-1)/2 > lim {
+		k--
+	}
+	if m < k {
+		k = m
+	}
+	sort.Slice(weights, func(i, j int) bool { return weights[i] > weights[j] })
+	var total int64
+	for i := int64(0); i < k; i++ {
+		total += weights[i]
+	}
+	return total
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(100) + 1)
+	m := rng.Intn(6) + 1
+	weights := make([]int64, m)
+	qs := make([]int, m)
+	used := map[int]bool{}
+	for i := 0; i < m; i++ {
+		w := int64(rng.Intn(100) + 1)
+		weights[i] = w
+		q := rng.Intn(1000) + 1
+		for used[q] {
+			q = rng.Intn(1000) + 1
+		}
+		used[q] = true
+		qs[i] = q
+	}
+	input := fmt.Sprintf("%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		input += fmt.Sprintf("%d %d\n", qs[i], weights[i])
+	}
+	ans := solveC(n, weights)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/367/verifierD.go
+++ b/0-999/300-399/360-369/367/verifierD.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func checkSubset(mask int, sets [][]int, n, d int) bool {
+	var arr []int
+	for i, set := range sets {
+		if mask&(1<<uint(i)) != 0 {
+			arr = append(arr, set...)
+		}
+	}
+	if len(arr) == 0 {
+		return false
+	}
+	sort.Ints(arr)
+	if arr[0] > d {
+		return false
+	}
+	for i := 0; i < len(arr)-1; i++ {
+		if arr[i+1]-arr[i] > d {
+			return false
+		}
+	}
+	if arr[len(arr)-1] < n-d+1 {
+		return false
+	}
+	return true
+}
+
+func solveD(n, m, d int, sets [][]int) int {
+	best := m + 1
+	total := 1 << uint(m)
+	for mask := 1; mask < total; mask++ {
+		if checkSubset(mask, sets, n, d) {
+			c := bitsCount(mask)
+			if c < best {
+				best = c
+			}
+		}
+	}
+	if best == m+1 {
+		best = m
+	}
+	return best
+}
+
+func bitsCount(x int) int {
+	c := 0
+	for x > 0 {
+		x &= x - 1
+		c++
+	}
+	return c
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(min(5, n)) + 1
+	d := rng.Intn(n) + 1
+	// assign each number 1..n to one of m sets randomly
+	sets := make([][]int, m)
+	for v := 1; v <= n; v++ {
+		idx := rng.Intn(m)
+		sets[idx] = append(sets[idx], v)
+	}
+	input := fmt.Sprintf("%d %d %d\n", n, m, d)
+	for i := 0; i < m; i++ {
+		sort.Ints(sets[i])
+		input += fmt.Sprintf("%d", len(sets[i]))
+		for _, v := range sets[i] {
+			input += fmt.Sprintf(" %d", v)
+		}
+		input += "\n"
+	}
+	ans := solveD(n, m, d, sets)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/367/verifierE.go
+++ b/0-999/300-399/360-369/367/verifierE.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func computeS(n, m, x int, skipX bool) int64 {
+	dp := make([][]int64, n+1)
+	for i := range dp {
+		dp[i] = make([]int64, m+1)
+	}
+	dp[0][0] = 1
+	for l := 1; l <= m; l++ {
+		dp2 := make([][]int64, n+1)
+		for i := 0; i <= n; i++ {
+			row := make([]int64, m+1)
+			copy(row, dp[i])
+			dp2[i] = row
+		}
+		if !(skipX && l == x) {
+			for i := 0; i < n; i++ {
+				pre := make([]int64, m+1)
+				pre[0] = dp[i][0]
+				for r := 1; r <= m; r++ {
+					pre[r] = pre[r-1] + dp[i][r]
+					if pre[r] >= mod {
+						pre[r] -= mod
+					}
+				}
+				for r := l; r <= m; r++ {
+					dp2[i+1][r] = (dp2[i+1][r] + pre[r-1]) % mod
+				}
+			}
+		}
+		dp = dp2
+	}
+	var total int64
+	for r := 1; r <= m; r++ {
+		total = (total + dp[n][r]) % mod
+	}
+	return total
+}
+
+func solveE(n, m, x int) int64 {
+	fact := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	total := computeS(n, m, x, false)
+	bad := computeS(n, m, x, true)
+	ways := (total - bad + mod) % mod
+	return ways * fact[n] % mod
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(6) + 1
+	for n*m > 20 {
+		n = rng.Intn(4) + 1
+		m = rng.Intn(6) + 1
+	}
+	x := rng.Intn(m) + 1
+	input := fmt.Sprintf("%d %d %d\n", n, m, x)
+	ans := solveE(n, m, x)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add random test verifiers for contest 367 problems A–E
- each verifier checks 100 random cases against an embedded correct solution

## Testing
- `go build 0-999/300-399/360-369/367/verifierA.go`
- `go build 0-999/300-399/360-369/367/verifierB.go`
- `go build 0-999/300-399/360-369/367/verifierC.go`
- `go build 0-999/300-399/360-369/367/verifierD.go`
- `go build 0-999/300-399/360-369/367/verifierE.go`
- `./verifierA ./367A.go`

------
https://chatgpt.com/codex/tasks/task_e_687eba543e9c8324b5a5a3a1ac33abb1