### PR TITLE
Add Go verifiers for Codeforces Round 366

### DIFF
--- a/0-999/300-399/360-369/366/verifierA.go
+++ b/0-999/300-399/360-369/366/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(r, &n); err != nil {
+		return ""
+	}
+	var g [4][4]int
+	for i := 0; i < 4; i++ {
+		fmt.Fscan(r, &g[i][0], &g[i][1], &g[i][2], &g[i][3])
+	}
+	for i := 0; i < 4; i++ {
+		m1 := g[i][0]
+		if g[i][1] < m1 {
+			m1 = g[i][1]
+		}
+		m2 := g[i][2]
+		if g[i][3] < m2 {
+			m2 = g[i][3]
+		}
+		if m1+m2 <= n {
+			return fmt.Sprintf("%d %d %d\n", i+1, m1, n-m1)
+		}
+	}
+	return "-1\n"
+}
+
+func genTest() (string, string) {
+	n := rand.Intn(200) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < 4; i++ {
+		a := rand.Intn(200) + 1
+		b := rand.Intn(200) + 1
+		c := rand.Intn(200) + 1
+		d := rand.Intn(200) + 1
+		fmt.Fprintf(&sb, "%d %d %d %d\n", a, b, c, d)
+	}
+	inp := sb.String()
+	out := solve(inp)
+	return inp, out
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genTest()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%sOutput:\n%s\n", i+1, err, in, got)
+			return
+		}
+		if got != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/366/verifierB.go
+++ b/0-999/300-399/360-369/366/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n, k int
+	if _, err := fmt.Fscan(r, &n, &k); err != nil {
+		return ""
+	}
+	sums := make([]int64, k)
+	for i := 0; i < n; i++ {
+		var a int64
+		fmt.Fscan(r, &a)
+		sums[i%k] += a
+	}
+	minSum := sums[0]
+	minR := 0
+	for r := 1; r < k; r++ {
+		if sums[r] < minSum {
+			minSum = sums[r]
+			minR = r
+		}
+	}
+	return fmt.Sprintf("%d\n", minR+1)
+}
+
+func genTest() (string, string) {
+	k := rand.Intn(9) + 1
+	q := rand.Intn(9) + 1
+	n := k * q
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", rand.Intn(1000))
+	}
+	sb.WriteByte('\n')
+	inp := sb.String()
+	out := solve(inp)
+	return inp, out
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genTest()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%sOutput:\n%s\n", i+1, err, in, got)
+			return
+		}
+		if got != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/366/verifierC.go
+++ b/0-999/300-399/360-369/366/verifierC.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n, k int
+	if _, err := fmt.Fscan(r, &n, &k); err != nil {
+		return ""
+	}
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &a[i])
+	}
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &b[i])
+	}
+	deltas := make([]int, n)
+	negSum, posSum := 0, 0
+	for i := 0; i < n; i++ {
+		del := a[i] - k*b[i]
+		deltas[i] = del
+		if del < 0 {
+			negSum += del
+		} else {
+			posSum += del
+		}
+	}
+	base := -negSum
+	size := posSum + base + 1
+	dp := make([]int, size)
+	for i := range dp {
+		dp[i] = -1
+	}
+	dp[base] = 0
+	for i := 0; i < n; i++ {
+		del := deltas[i]
+		ai := a[i]
+		if del >= 0 {
+			for j := size - 1 - del; j >= 0; j-- {
+				if dp[j] >= 0 {
+					nj := j + del
+					v := dp[j] + ai
+					if v > dp[nj] {
+						dp[nj] = v
+					}
+				}
+			}
+		} else {
+			for j := -del; j < size; j++ {
+				if dp[j] >= 0 {
+					nj := j + del
+					v := dp[j] + ai
+					if v > dp[nj] {
+						dp[nj] = v
+					}
+				}
+			}
+		}
+	}
+	res := dp[base]
+	if res > 0 {
+		return fmt.Sprintf("%d\n", res)
+	}
+	return "-1\n"
+}
+
+func genTest() (string, string) {
+	n := rand.Intn(7) + 1
+	k := rand.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", rand.Intn(20)+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", rand.Intn(20)+1)
+	}
+	sb.WriteByte('\n')
+	inp := sb.String()
+	out := solve(inp)
+	return inp, out
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genTest()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%sOutput:\n%s\n", i+1, err, in, got)
+			return
+		}
+		if got != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/366/verifierD.go
+++ b/0-999/300-399/360-369/366/verifierD.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to, rk int
+}
+
+type Item struct {
+	node, w int
+}
+
+type MaxHeap []Item
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i].w > h[j].w }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(Item)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	it := old[n-1]
+	*h = old[:n-1]
+	return it
+}
+
+func widestPath(n int, adj [][]Edge) int {
+	const INF = 1000000001
+	width := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		width[i] = 0
+	}
+	width[1] = INF
+	h := &MaxHeap{}
+	heap.Init(h)
+	heap.Push(h, Item{node: 1, w: INF})
+	for h.Len() > 0 {
+		it := heap.Pop(h).(Item)
+		u, w := it.node, it.w
+		if w < width[u] {
+			continue
+		}
+		if u == n {
+			break
+		}
+		for _, e := range adj[u] {
+			nw := w
+			if e.rk < nw {
+				nw = e.rk
+			}
+			if nw > width[e.to] {
+				width[e.to] = nw
+				heap.Push(h, Item{node: e.to, w: nw})
+			}
+		}
+	}
+	return width[n]
+}
+
+func solve(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n, m int
+	if _, err := fmt.Fscan(r, &n, &m); err != nil {
+		return ""
+	}
+	type E struct{ u, v, l, r int }
+	edges := make([]E, m)
+	ls := make([]int, 0, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(r, &edges[i].u, &edges[i].v, &edges[i].l, &edges[i].r)
+		ls = append(ls, edges[i].l)
+	}
+	if m == 0 {
+		return "Nice work, Dima!\n"
+	}
+	sort.Ints(ls)
+	us := ls[:0]
+	for i, v := range ls {
+		if i == 0 || v != ls[i-1] {
+			us = append(us, v)
+		}
+	}
+	answer := 0
+	globalMaxR := 0
+	for _, e := range edges {
+		if e.r > globalMaxR {
+			globalMaxR = e.r
+		}
+	}
+	for _, L := range us {
+		if globalMaxR-L+1 <= answer {
+			break
+		}
+		adj := make([][]Edge, n+1)
+		for _, e := range edges {
+			if e.l <= L {
+				adj[e.u] = append(adj[e.u], Edge{to: e.v, rk: e.r})
+				adj[e.v] = append(adj[e.v], Edge{to: e.u, rk: e.r})
+			}
+		}
+		W := widestPath(n, adj)
+		if W >= L {
+			loyalty := W - L + 1
+			if loyalty > answer {
+				answer = loyalty
+			}
+		}
+	}
+	if answer <= 0 {
+		return "Nice work, Dima!\n"
+	}
+	return fmt.Sprintf("%d\n", answer)
+}
+
+func genTest() (string, string) {
+	n := rand.Intn(4) + 2
+	m := rand.Intn(5)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		u := rand.Intn(n) + 1
+		v := rand.Intn(n) + 1
+		l := rand.Intn(10) + 1
+		r := l + rand.Intn(10)
+		fmt.Fprintf(&sb, "%d %d %d %d\n", u, v, l, r)
+	}
+	inp := sb.String()
+	out := solve(inp)
+	return inp, out
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genTest()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%sOutput:\n%s\n", i+1, err, in, got)
+			return
+		}
+		if got != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/366/verifierE.go
+++ b/0-999/300-399/360-369/366/verifierE.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n, m, k, s int
+	if _, err := fmt.Fscan(r, &n, &m, &k, &s); err != nil {
+		return ""
+	}
+	inf := int(1e9)
+	maxS := make([]int, k+1)
+	minS := make([]int, k+1)
+	maxD := make([]int, k+1)
+	minD := make([]int, k+1)
+	for t := 1; t <= k; t++ {
+		maxS[t] = -inf
+		minS[t] = inf
+		maxD[t] = -inf
+		minD[t] = inf
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			var t int
+			fmt.Fscan(r, &t)
+			S := i + j
+			D := i - j
+			if S > maxS[t] {
+				maxS[t] = S
+			}
+			if S < minS[t] {
+				minS[t] = S
+			}
+			if D > maxD[t] {
+				maxD[t] = D
+			}
+			if D < minD[t] {
+				minD[t] = D
+			}
+		}
+	}
+	Q := make([]int, s)
+	for i := 0; i < s; i++ {
+		fmt.Fscan(r, &Q[i])
+	}
+	dist := make([][]int, k+1)
+	for t := 0; t <= k; t++ {
+		dist[t] = make([]int, k+1)
+	}
+	for t1 := 1; t1 <= k; t1++ {
+		for t2 := 1; t2 <= k; t2++ {
+			var d int
+			if t1 == t2 {
+				d1 := maxS[t1] - minS[t1]
+				d2 := maxD[t1] - minD[t1]
+				if d2 > d1 {
+					d1 = d2
+				}
+				d = d1
+			} else {
+				d1 := maxS[t1] - minS[t2]
+				if maxS[t2]-minS[t1] > d1 {
+					d1 = maxS[t2] - minS[t1]
+				}
+				d2 := maxD[t1] - minD[t2]
+				if maxD[t2]-minD[t1] > d2 {
+					d2 = maxD[t2] - minD[t1]
+				}
+				if d2 > d1 {
+					d = d2
+				} else {
+					d = d1
+				}
+			}
+			dist[t1][t2] = d
+		}
+	}
+	ans := 0
+	for i := 0; i+1 < s; i++ {
+		t1 := Q[i]
+		t2 := Q[i+1]
+		if dist[t1][t2] > ans {
+			ans = dist[t1][t2]
+		}
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func genTest() (string, string) {
+	n := rand.Intn(4) + 1
+	m := rand.Intn(4) + 1
+	k := rand.Intn(3) + 1
+	s := rand.Intn(8) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", n, m, k, s)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			fmt.Fprintf(&sb, "%d ", rand.Intn(k)+1)
+		}
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < s; i++ {
+		fmt.Fprintf(&sb, "%d ", rand.Intn(k)+1)
+	}
+	sb.WriteByte('\n')
+	inp := sb.String()
+	out := solve(inp)
+	return inp, out
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genTest()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%sOutput:\n%s\n", i+1, err, in, got)
+			return
+		}
+		if got != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to test problem A solutions
- add verifierB.go to test problem B solutions
- add verifierC.go to test problem C solutions
- add verifierD.go to test problem D solutions
- add verifierE.go to test problem E solutions

All verifiers generate 100 random tests, compute the expected output and run a provided binary to check results.

## Testing
- `go run verifierA.go ./366A`
- `go run verifierB.go ./366B`
- `go run verifierC.go ./366C`
- `go run verifierD.go ./366D`
- `go run verifierE.go ./366E`


------
https://chatgpt.com/codex/tasks/task_e_687eba0e170c8324b4c8954515e152c0