### PR TITLE
Add verifiers for contest 364

### DIFF
--- a/0-999/300-399/360-369/364/verifierA.go
+++ b/0-999/300-399/360-369/364/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(a int64, s string) int64 {
+	n := len(s)
+	ps := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		ps[i+1] = ps[i] + int64(s[i]-'0')
+	}
+	maxSum := ps[n]
+	freq := make([]int64, maxSum+1)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j <= n; j++ {
+			sum := ps[j] - ps[i]
+			freq[sum]++
+		}
+	}
+	total := int64(n) * int64(n+1) / 2
+	var ans int64
+	if a == 0 {
+		f0 := freq[0]
+		ans = 2*f0*total - f0*f0
+	} else {
+		for d := int64(1); d*d <= a; d++ {
+			if a%d != 0 {
+				continue
+			}
+			p := d
+			q := a / d
+			if p <= maxSum && q <= maxSum {
+				if p == q {
+					ans += freq[p] * freq[q]
+				} else {
+					ans += freq[p] * freq[q] * 2
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	a := int64(rng.Intn(100))
+	n := rng.Intn(10) + 1
+	digits := make([]byte, n)
+	for i := range digits {
+		digits[i] = byte('0' + rng.Intn(10))
+	}
+	s := string(digits)
+	input := fmt.Sprintf("%d\n%s\n", a, s)
+	exp := fmt.Sprintf("%d", expected(a, s))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/364/verifierB.go
+++ b/0-999/300-399/360-369/364/verifierB.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(n, d int, c []int) string {
+	sort.Ints(c)
+	prefix := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		prefix[i] = prefix[i-1] + c[i-1]
+	}
+	const INF = int(1e9)
+	dp := make([]int, n+1)
+	for i := range dp {
+		dp[i] = INF
+	}
+	dp[0] = 0
+	for i := 1; i <= n; i++ {
+		for j := 0; j < i; j++ {
+			if dp[j] < INF && 2*prefix[j]+d >= prefix[i] {
+				if dp[j]+1 < dp[i] {
+					dp[i] = dp[j] + 1
+				}
+			}
+		}
+	}
+	bestSum, bestDays := 0, 0
+	for i := 0; i <= n; i++ {
+		if dp[i] < INF {
+			if prefix[i] > bestSum {
+				bestSum = prefix[i]
+				bestDays = dp[i]
+			} else if prefix[i] == bestSum && dp[i] < bestDays {
+				bestDays = dp[i]
+			}
+		}
+	}
+	return fmt.Sprintf("%d %d", bestSum, bestDays)
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	d := rng.Intn(5) + 1
+	c := make([]int, n)
+	for i := 0; i < n; i++ {
+		c[i] = rng.Intn(20) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, d)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", c[i])
+	}
+	sb.WriteByte('\n')
+	exp := expected(n, d, c)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/364/verifierC.go
+++ b/0-999/300-399/360-369/364/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+var primes = []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47}
+
+func genSeq(n int) []int {
+	t := 2 * n * n
+	A := make([]int, n)
+	AA := make([]int, n)
+	A[0] = 1
+	m := 1
+	for k := 0; m < n && k < len(primes); k++ {
+		p := primes[k]
+		mm := 0
+		d := p
+		l := m
+		cnt := 0
+		for mm < n && d <= t {
+			var i int
+			for i = 0; i < l && mm < n; i++ {
+				if d*A[i] <= t {
+					AA[mm] = A[i] * d
+					mm++
+					if d > 1 {
+						cnt++
+					}
+				} else {
+					break
+				}
+			}
+			if d == p {
+				l = i
+			}
+			if d == p {
+				d = 1
+			} else if d == 1 {
+				d = p * p
+			} else {
+				d *= p
+			}
+		}
+		for cnt >= (mm+2)/2 && l < m && mm < n {
+			AA[mm] = A[l]
+			mm++
+			l++
+		}
+		if mm == m {
+			break
+		}
+		m = mm
+		for i := 0; i < m; i++ {
+			A[i] = AA[i]
+		}
+		sort.Ints(A[:m])
+	}
+	return A[:n]
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	seq := genSeq(n)
+	var exp strings.Builder
+	for i, v := range seq {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(fmt.Sprintf("%d", v))
+	}
+	input := fmt.Sprintf("%d\n", n)
+	return input, exp.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/364/verifierD.go
+++ b/0-999/300-399/360-369/364/verifierD.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func divisors(x int64) []int64 {
+	var d []int64
+	for i := int64(1); i*i <= x; i++ {
+		if x%i == 0 {
+			d = append(d, i)
+			if i*i != x {
+				d = append(d, x/i)
+			}
+		}
+	}
+	return d
+}
+
+func expected(arr []int64) int64 {
+	n := len(arr)
+	half := (n + 1) / 2
+	cnt := make(map[int64]int)
+	for _, v := range arr {
+		for _, d := range divisors(v) {
+			cnt[d]++
+		}
+	}
+	best := int64(1)
+	for d, c := range cnt {
+		if c >= half && d > best {
+			best = d
+		}
+	}
+	return best
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(100) + 1)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	exp := fmt.Sprintf("%d", expected(arr))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/364/verifierE.go
+++ b/0-999/300-399/360-369/364/verifierE.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n, m, k int, grid [][]byte) int64 {
+	res := int64(0)
+	arr := make([]int, m)
+	for top := 0; top < n; top++ {
+		for j := 0; j < m; j++ {
+			arr[j] = 0
+		}
+		for bottom := top; bottom < n; bottom++ {
+			for c := 0; c < m; c++ {
+				if grid[bottom][c] == '1' {
+					arr[c]++
+				}
+			}
+			cnt := map[int]int{0: 1}
+			sum := 0
+			for c := 0; c < m; c++ {
+				sum += arr[c]
+				if sum >= k {
+					if v, ok := cnt[sum-k]; ok {
+						res += int64(v)
+					}
+				}
+				cnt[sum]++
+			}
+		}
+	}
+	return res
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	k := rng.Intn(n*m + 1)
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 1 {
+				row[j] = '1'
+			} else {
+				row[j] = '0'
+			}
+		}
+		grid[i] = row
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		sb.WriteByte('\n')
+	}
+	exp := fmt.Sprintf("%d", solve(n, m, k, grid))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go based solution verifiers for contest 364 problems A–E
- each verifier generates 100 random tests and runs a candidate binary or Go file
- verifiers compute expected output using reference algorithms and report mismatches

## Testing
- `go build 0-999/300-399/360-369/364/verifierA.go`
- `go build 0-999/300-399/360-369/364/verifierB.go`
- `go build 0-999/300-399/360-369/364/verifierC.go`
- `go build 0-999/300-399/360-369/364/verifierD.go`
- `go build 0-999/300-399/360-369/364/verifierE.go`
- `./verifierA ./0-999/300-399/360-369/364/364A.go`
- `./verifierB ./0-999/300-399/360-369/364/364B.go`
- `./verifierC ./0-999/300-399/360-369/364/364C.go`
- `./verifierD ./0-999/300-399/360-369/364/364D.go`
- `./verifierE ./0-999/300-399/360-369/364/364E.go`


------
https://chatgpt.com/codex/tasks/task_e_687eb98205088324b6c782616c49564b