### PR TITLE
Add Go verifiers for Codeforces contest 363

### DIFF
--- a/0-999/300-399/360-369/363/verifierA.go
+++ b/0-999/300-399/360-369/363/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int) string {
+	var digits []int
+	if n == 0 {
+		digits = append(digits, 0)
+	} else {
+		for n > 0 {
+			digits = append(digits, n%10)
+			n /= 10
+		}
+	}
+	var sb strings.Builder
+	for i, d := range digits {
+		if d >= 5 {
+			sb.WriteString("-O|")
+		} else {
+			sb.WriteString("O-|")
+		}
+		x := d % 5
+		for j := 0; j < x; j++ {
+			sb.WriteByte('O')
+		}
+		sb.WriteByte('-')
+		for j := 0; j < 4-x; j++ {
+			sb.WriteByte('O')
+		}
+		if i+1 < len(digits) {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) int {
+	return rng.Intn(1000000000)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := generateCase(rng)
+		input := fmt.Sprintf("%d\n", n)
+		want := expected(n)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\n\ngot\n%s\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/363/verifierB.go
+++ b/0-999/300-399/360-369/363/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, k int, h []int) int {
+	sum := 0
+	for i := 0; i < k; i++ {
+		sum += h[i]
+	}
+	minSum := sum
+	minPos := 0
+	for i := k; i < n; i++ {
+		sum += h[i] - h[i-k]
+		if sum < minSum {
+			minSum = sum
+			minPos = i - k + 1
+		}
+	}
+	return minPos + 1
+}
+
+func generateCase(rng *rand.Rand) (int, int, []int) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	h := make([]int, n)
+	for i := range h {
+		h[i] = rng.Intn(100) + 1
+	}
+	return n, k, h
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, h := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for j, v := range h {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		want := fmt.Sprint(expected(n, k, h))
+		got, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/363/verifierC.go
+++ b/0-999/300-399/360-369/363/verifierC.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(s string) string {
+	n := len(s)
+	ans := make([]byte, 0, n)
+	for i := 0; i < n; i++ {
+		c := s[i]
+		m := len(ans)
+		if m >= 2 && ans[m-1] == c && ans[m-2] == c {
+			continue
+		}
+		if m >= 3 && ans[m-3] == ans[m-2] && ans[m-1] == c {
+			continue
+		}
+		ans = append(ans, c)
+	}
+	return string(ans)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := generateCase(rng)
+		input := fmt.Sprintf("%s\n", s)
+		want := expected(s)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/363/verifierD.go
+++ b/0-999/300-399/360-369/363/verifierD.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m int, a int64, b, p []int64) (int, int64) {
+	sort.Slice(b, func(i, j int) bool { return b[i] > b[j] })
+	sort.Slice(p, func(i, j int) bool { return p[i] < p[j] })
+	maxk := n
+	if m < n {
+		maxk = m
+	}
+	B := make([]int64, maxk+1)
+	for i := 1; i <= maxk; i++ {
+		B[i] = B[i-1] + b[i-1]
+	}
+	P := make([]int64, maxk+1)
+	for i := 1; i <= maxk; i++ {
+		P[i] = P[i-1] + p[i-1]
+	}
+	best := 0
+	var spend int64 = 0
+	for r := 1; r <= maxk; r++ {
+		need := P[r] - a
+		if need < 0 {
+			need = 0
+		}
+		if B[r] >= need {
+			best = r
+			spend = need
+		}
+	}
+	return best, spend
+}
+
+func generateCase(rng *rand.Rand) (int, int, int64, []int64, []int64) {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(6) + 1
+	a := rng.Int63n(100)
+	b := make([]int64, n)
+	for i := range b {
+		b[i] = rng.Int63n(100) + 1
+	}
+	p := make([]int64, m)
+	for i := range p {
+		p[i] = rng.Int63n(100) + 1
+	}
+	return n, m, a, b, p
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, a, b, p := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, a))
+		for j, v := range b {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		for j, v := range p {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		wantR, wantS := expected(n, m, a, append([]int64(nil), b...), append([]int64(nil), p...))
+		want := fmt.Sprintf("%d %d", wantR, wantS)
+		got, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/363/verifierE.go
+++ b/0-999/300-399/360-369/363/verifierE.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func oracle(input string) (string, error) {
+	cmd := exec.Command("go", "run", "363E.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("oracle error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (int, int, int, [][]int) {
+	n := rng.Intn(4) + 3
+	m := rng.Intn(4) + 3
+	maxR := (n - 1) / 2
+	if (m-1)/2 < maxR {
+		maxR = (m - 1) / 2
+	}
+	r := rng.Intn(maxR + 1)
+	grid := make([][]int, n)
+	for i := range grid {
+		grid[i] = make([]int, m)
+		for j := range grid[i] {
+			grid[i][j] = rng.Intn(10) + 1
+		}
+	}
+	return n, m, r, grid
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, r, grid := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, r))
+		for ii := 0; ii < n; ii++ {
+			for jj := 0; jj < m; jj++ {
+				if jj > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprint(grid[ii][jj]))
+			}
+			sb.WriteByte('\n')
+		}
+		want, err := oracle(sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for problems A–E of contest 363
- verifiers generate at least 100 random test cases each
- verifier for problem E uses the official solution as an oracle

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go run verifierA.go ./A.bin`
- `go run verifierB.go ./B.bin`
- `go run verifierC.go ./C.bin`
- `go run verifierD.go ./D.bin`
- `go run verifierE.go ./E.bin`


------
https://chatgpt.com/codex/tasks/task_e_687eb93bf368832490e498cc9687e3b6