### PR TITLE
Add Go verifiers for contest 362

### DIFF
--- a/0-999/300-399/360-369/362/verifierA.go
+++ b/0-999/300-399/360-369/362/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleA"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/300-399/360-369/362/362A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for b := 0; b < t; b++ {
+		r1, c1 := rng.Intn(8), rng.Intn(8)
+		r2, c2 := rng.Intn(8), rng.Intn(8)
+		for r1 == r2 && c1 == c2 {
+			r2, c2 = rng.Intn(8), rng.Intn(8)
+		}
+		board := make([][]byte, 8)
+		for i := 0; i < 8; i++ {
+			row := make([]byte, 8)
+			for j := 0; j < 8; j++ {
+				if rng.Intn(5) == 0 {
+					row[j] = '#'
+				} else {
+					row[j] = '.'
+				}
+			}
+			board[i] = row
+		}
+		board[r1][c1] = 'K'
+		board[r2][c2] = 'K'
+		for i := 0; i < 8; i++ {
+			sb.Write(board[i])
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\n got:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/362/verifierB.go
+++ b/0-999/300-399/360-369/362/verifierB.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleB"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/300-399/360-369/362/362B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(n + 1)
+	if m > 10 {
+		m = 10
+	}
+	dirty := make([]int, 0, m)
+	used := make(map[int]bool)
+	for len(dirty) < m {
+		d := rng.Intn(n) + 1
+		if !used[d] {
+			used[d] = true
+			dirty = append(dirty, d)
+		}
+	}
+	sort.Ints(dirty)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i, d := range dirty {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", d)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/362/verifierC.go
+++ b/0-999/300-399/360-369/362/verifierC.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleC"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/300-399/360-369/362/362C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 2
+	perm := rng.Perm(n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/362/verifierD.go
+++ b/0-999/300-399/360-369/362/verifierD.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleD"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/300-399/360-369/362/362D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	if m > 10 {
+		m = 10
+	}
+	p := rng.Intn(5)
+	qInput := rng.Intn(n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", n, m, p, qInput)
+	for i := 0; i < m; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		for b == a {
+			b = rng.Intn(n) + 1
+		}
+		d := rng.Intn(10) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", a, b, d)
+	}
+	return sb.String()
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\n got:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/360-369/362/verifierE.go
+++ b/0-999/300-399/360-369/362/verifierE.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleE"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/300-399/360-369/362/362E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	k := rng.Intn(10)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			val := 0
+			if i != j {
+				val = rng.Intn(5)
+			}
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", val)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 362 (problems A-E)
- each verifier builds the official solution, generates at least 100 random test cases and compares results with a target binary

## Testing
- `go build 0-999/300-399/360-369/362/verifierA.go`
- `go build 0-999/300-399/360-369/362/verifierB.go`
- `go build 0-999/300-399/360-369/362/verifierC.go`
- `go build 0-999/300-399/360-369/362/verifierD.go`
- `go build 0-999/300-399/360-369/362/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687eb8f5ec148324ba5a56a8da5012f1