### PR TITLE
Add Go verifiers for Codeforces contest 361

### DIFF
--- a/0-999/300-399/360-369/361/verifierA.go
+++ b/0-999/300-399/360-369/361/verifierA.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runTest(binary string, n, k int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binary)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("stdin pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start: %v", err)
+	}
+	fmt.Fprintf(stdin, "%d %d\n", n, k)
+	stdin.Close()
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("program error: %v", err)
+	}
+
+	outLines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(outLines) != n {
+		return fmt.Errorf("expected %d lines, got %d", n, len(outLines))
+	}
+	table := make([][]int, n)
+	for i := 0; i < n; i++ {
+		fields := strings.Fields(outLines[i])
+		if len(fields) != n {
+			return fmt.Errorf("line %d: expected %d numbers, got %d", i+1, n, len(fields))
+		}
+		row := make([]int, n)
+		for j, f := range fields {
+			v, err := strconv.Atoi(f)
+			if err != nil {
+				return fmt.Errorf("line %d col %d: not integer", i+1, j+1)
+			}
+			if v < -1000 || v > 1000 {
+				return fmt.Errorf("line %d col %d: value %d out of range", i+1, j+1, v)
+			}
+			row[j] = v
+		}
+		table[i] = row
+	}
+
+	// check sums
+	for i := 0; i < n; i++ {
+		sum := 0
+		for j := 0; j < n; j++ {
+			sum += table[i][j]
+		}
+		if sum != k {
+			return fmt.Errorf("row %d sum %d != %d", i+1, sum, k)
+		}
+	}
+	for j := 0; j < n; j++ {
+		sum := 0
+		for i := 0; i < n; i++ {
+			sum += table[i][j]
+		}
+		if sum != k {
+			return fmt.Errorf("column %d sum %d != %d", j+1, sum, k)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierA <binary>")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := [][2]int{}
+	for n := 1; n <= 10; n++ {
+		for k := 1; k <= 10; k++ {
+			tests = append(tests, [2]int{n, k})
+		}
+	}
+	for idx, t := range tests {
+		if err := runTest(binary, t[0], t[1]); err != nil {
+			fmt.Printf("test %d (n=%d k=%d) failed: %v\n", idx+1, t[0], t[1], err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/0-999/300-399/360-369/361/verifierB.go
+++ b/0-999/300-399/360-369/361/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func runTest(binary string, n, k int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binary)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("stdin pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start: %v", err)
+	}
+	fmt.Fprintf(stdin, "%d %d\n", n, k)
+	stdin.Close()
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("program error: %v", err)
+	}
+
+	out := strings.TrimSpace(stdout.String())
+	tokens := strings.Fields(out)
+	if n == k {
+		if len(tokens) != 1 || tokens[0] != "-1" {
+			return fmt.Errorf("expected -1 for n=k=%d", n)
+		}
+		return nil
+	}
+
+	if len(tokens) != n {
+		return fmt.Errorf("expected %d numbers, got %d", n, len(tokens))
+	}
+	seen := make([]bool, n+1)
+	perm := make([]int, n)
+	for i, t := range tokens {
+		v, err := strconv.Atoi(t)
+		if err != nil {
+			return fmt.Errorf("token %d not integer", i+1)
+		}
+		if v < 1 || v > n {
+			return fmt.Errorf("value %d out of range 1..%d", v, n)
+		}
+		if seen[v] {
+			return fmt.Errorf("duplicate value %d", v)
+		}
+		seen[v] = true
+		perm[i] = v
+	}
+	good := 0
+	for i, v := range perm {
+		if gcd(i+1, v) > 1 {
+			good++
+		}
+	}
+	if good != k {
+		return fmt.Errorf("good elements %d != %d", good, k)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierB <binary>")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := [][2]int{}
+	for n := 1; n <= 14; n++ {
+		for k := 0; k <= n; k++ {
+			tests = append(tests, [2]int{n, k})
+		}
+	}
+	for idx, t := range tests {
+		if err := runTest(binary, t[0], t[1]); err != nil {
+			fmt.Printf("test %d (n=%d k=%d) failed: %v\n", idx+1, t[0], t[1], err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` and `verifierB.go` for contest 361 problems A and B
- each verifier runs a provided binary on >=100 test cases
- checks correctness of the output according to the problem statements

## Testing
- `go vet ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687eb8afe8548324a4b7c8ee863be9bc