### PR TITLE
Add Go verifiers for CF contest 359

### DIFF
--- a/0-999/300-399/350-359/359/verifierA.go
+++ b/0-999/300-399/350-359/359/verifierA.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+// solveCase computes the minimal operations using the algorithm from 359A.go
+func solveCase(n, m int, grid [][]int) int {
+	type rect struct {
+		m1, m2 int
+		r1, r2 int
+		c1, c2 int
+		bits   []uint64
+	}
+	nm := n * m
+	words := (nm + 63) >> 6
+	full := make([]uint64, words)
+	for idx := 0; idx < nm; idx++ {
+		full[idx>>6] |= 1 << (uint(idx) & 63)
+	}
+	rects := make([][]rect, 4)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] != 1 {
+				continue
+			}
+			// corner (1,1)
+			{
+				r := rect{m1: i + 1, m2: j + 1, r1: 0, r2: i, c1: 0, c2: j}
+				r.bits = make([]uint64, words)
+				for x := r.r1; x <= r.r2; x++ {
+					for y := r.c1; y <= r.c2; y++ {
+						idx := x*m + y
+						r.bits[idx>>6] |= 1 << (uint(idx) & 63)
+					}
+				}
+				rects[0] = append(rects[0], r)
+			}
+			// corner (1,m)
+			{
+				r := rect{m1: i + 1, m2: m - j, r1: 0, r2: i, c1: j, c2: m - 1}
+				r.bits = make([]uint64, words)
+				for x := r.r1; x <= r.r2; x++ {
+					for y := r.c1; y <= r.c2; y++ {
+						idx := x*m + y
+						r.bits[idx>>6] |= 1 << (uint(idx) & 63)
+					}
+				}
+				rects[1] = append(rects[1], r)
+			}
+			// corner (n,1)
+			{
+				r := rect{m1: n - i, m2: j + 1, r1: i, r2: n - 1, c1: 0, c2: j}
+				r.bits = make([]uint64, words)
+				for x := r.r1; x <= r.r2; x++ {
+					for y := r.c1; y <= r.c2; y++ {
+						idx := x*m + y
+						r.bits[idx>>6] |= 1 << (uint(idx) & 63)
+					}
+				}
+				rects[2] = append(rects[2], r)
+			}
+			// corner (n,m)
+			{
+				r := rect{m1: n - i, m2: m - j, r1: i, r2: n - 1, c1: j, c2: m - 1}
+				r.bits = make([]uint64, words)
+				for x := r.r1; x <= r.r2; x++ {
+					for y := r.c1; y <= r.c2; y++ {
+						idx := x*m + y
+						r.bits[idx>>6] |= 1 << (uint(idx) & 63)
+					}
+				}
+				rects[3] = append(rects[3], r)
+			}
+		}
+	}
+	for c := 0; c < 4; c++ {
+		arr := rects[c]
+		sort.Slice(arr, func(i, j int) bool {
+			if arr[i].m1 != arr[j].m1 {
+				return arr[i].m1 > arr[j].m1
+			}
+			return arr[i].m2 > arr[j].m2
+		})
+		filtered := make([]rect, 0, len(arr))
+		best2 := -1
+		for _, r := range arr {
+			if r.m2 > best2 {
+				filtered = append(filtered, r)
+				best2 = r.m2
+			}
+		}
+		rects[c] = filtered
+	}
+	// k=1
+	for c := 0; c < 4; c++ {
+		for _, r := range rects[c] {
+			ok := true
+			for w := 0; w < words; w++ {
+				if r.bits[w] != full[w] {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				return 1
+			}
+		}
+	}
+	// k=2
+	for c1 := 0; c1 < 4; c1++ {
+		for c2 := c1 + 1; c2 < 4; c2++ {
+			for _, r1 := range rects[c1] {
+				for _, r2 := range rects[c2] {
+					ok := true
+					for w := 0; w < words; w++ {
+						if (r1.bits[w] | r2.bits[w]) != full[w] {
+							ok = false
+							break
+						}
+					}
+					if ok {
+						return 2
+					}
+				}
+			}
+		}
+	}
+	// k=3
+	for c1 := 0; c1 < 4; c1++ {
+		for c2 := c1 + 1; c2 < 4; c2++ {
+			for c3 := c2 + 1; c3 < 4; c3++ {
+				for _, r1 := range rects[c1] {
+					for _, r2 := range rects[c2] {
+						for _, r3 := range rects[c3] {
+							ok := true
+							for w := 0; w < words; w++ {
+								if (r1.bits[w] | r2.bits[w] | r3.bits[w]) != full[w] {
+									ok = false
+									break
+								}
+							}
+							if ok {
+								return 3
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return 4
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 3
+	m := rng.Intn(8) + 3
+	grid := make([][]int, n)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]int, m)
+	}
+	// ensure at least one good cell not on a corner
+	x := rng.Intn(n-2) + 1
+	y := rng.Intn(m-2) + 1
+	grid[x][y] = 1
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if i == 0 || j == 0 || i == n-1 || j == m-1 {
+				continue
+			}
+			if i == x && j == y {
+				continue
+			}
+			if rng.Intn(2) == 1 {
+				grid[i][j] = 1
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", grid[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	exp := fmt.Sprintf("%d", solveCase(n, m, grid))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/359/verifierB.go
+++ b/0-999/300-399/350-359/359/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func checkOutput(n, k int, output string) error {
+	fields := strings.Fields(strings.TrimSpace(output))
+	if len(fields) != 2*n {
+		return fmt.Errorf("expected %d numbers got %d", 2*n, len(fields))
+	}
+	used := make([]bool, 2*n+1)
+	a := make([]int, 2*n)
+	for i, f := range fields {
+		val, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("bad number %q", f)
+		}
+		if val < 1 || val > 2*n {
+			return fmt.Errorf("value out of range: %d", val)
+		}
+		if used[val] {
+			return fmt.Errorf("duplicate value: %d", val)
+		}
+		used[val] = true
+		a[i] = val
+	}
+	sumPair := 0
+	sumDiff := 0
+	for i := 0; i < n; i++ {
+		sumPair += abs(a[2*i] - a[2*i+1])
+		sumDiff += a[2*i] - a[2*i+1]
+	}
+	if sumPair-abs(sumDiff) != 2*k {
+		return fmt.Errorf("equation not satisfied")
+	}
+	return nil
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func generateCase(rng *rand.Rand) (string, int, int) {
+	n := rng.Intn(30) + 1
+	k := rng.Intn(n/2 + 1)
+	input := fmt.Sprintf("%d %d\n", n, k)
+	return input, n, k
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n, k := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if err := checkOutput(n, k, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/359/verifierC.go
+++ b/0-999/300-399/350-359/359/verifierC.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const mod = 1000000007
+
+func modExp(base, exp int64) int64 {
+	res := int64(1)
+	base %= mod
+	for exp > 0 {
+		if exp&1 == 1 {
+			res = (res * base) % mod
+		}
+		base = (base * base) % mod
+		exp >>= 1
+	}
+	return res
+}
+
+func solveCase(n int, x int64, a []int64) int64 {
+	var sumA int64
+	for _, v := range a {
+		sumA += v
+	}
+	maxA := a[n-1]
+	cnt := make(map[int64]int64, n)
+	for _, v := range a {
+		d := maxA - v
+		cnt[d]++
+	}
+	var carry int64
+	var vT int64
+	for j := int64(0); ; j++ {
+		total := carry
+		if c, ok := cnt[j]; ok {
+			total += c
+		}
+		if total%x != 0 {
+			vT = j
+			break
+		}
+		carry = total / x
+	}
+	exp := (sumA - maxA) + vT
+	if exp > sumA {
+		exp = sumA
+	}
+	return modExp(x, exp)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	x := int64(rng.Intn(10) + 2)
+	a := make([]int64, n)
+	base := int64(rng.Intn(5))
+	a[0] = base
+	for i := 1; i < n; i++ {
+		base += int64(rng.Intn(3))
+		a[i] = base
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	exp := fmt.Sprintf("%d", solveCase(n, x, a))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/359/verifierD.go
+++ b/0-999/300-399/350-359/359/verifierD.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveCase(n int, a []int) ([]int, int) {
+	logs := make([]int, n+2)
+	logs[1] = 0
+	for i := 2; i <= n; i++ {
+		logs[i] = logs[i/2] + 1
+	}
+	kmax := logs[n] + 1
+	st := make([][]int, kmax)
+	st[0] = make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		st[0][i] = a[i-1]
+	}
+	for k := 1; k < kmax; k++ {
+		step := 1 << (k - 1)
+		st[k] = make([]int, n+1)
+		for i := 1; i+(1<<k)-1 <= n; i++ {
+			st[k][i] = gcd(st[k-1][i], st[k-1][i+step])
+		}
+	}
+	query := func(l, r int) int {
+		length := r - l + 1
+		k := logs[length]
+		j := r - (1 << k) + 1
+		return gcd(st[k][l], st[k][j])
+	}
+	maxd := 0
+	lvals := make([]int, 0, 16)
+	for j := 1; j <= n; j++ {
+		aj := a[j-1]
+		low, high := 1, j
+		for low < high {
+			mid := (low + high) >> 1
+			if query(mid, j) == aj {
+				high = mid
+			} else {
+				low = mid + 1
+			}
+		}
+		lj := low
+		low, high = j, n+1
+		for low < high {
+			mid := (low + high) >> 1
+			if mid <= n && query(j, mid) == aj {
+				low = mid + 1
+			} else {
+				high = mid
+			}
+		}
+		rj := low - 1
+		d := rj - lj
+		if d > maxd {
+			maxd = d
+			lvals = lvals[:0]
+			lvals = append(lvals, lj)
+		} else if d == maxd {
+			lvals = append(lvals, lj)
+		}
+	}
+	sort.Ints(lvals)
+	uniq := make([]int, 0, len(lvals))
+	for i, v := range lvals {
+		if i == 0 || v != lvals[i-1] {
+			uniq = append(uniq, v)
+		}
+	}
+	return uniq, maxd
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	lvals, d := solveCase(n, a)
+	var exp strings.Builder
+	exp.WriteString(fmt.Sprintf("%d %d\n", len(lvals), d))
+	for i, v := range lvals {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(fmt.Sprintf("%d", v))
+	}
+	exp.WriteByte('\n')
+	return sb.String(), exp.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/359/verifierE.go
+++ b/0-999/300-399/350-359/359/verifierE.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+var dx = map[byte]int{'U': -1, 'D': 1, 'L': 0, 'R': 0}
+var dy = map[byte]int{'U': 0, 'D': 0, 'L': -1, 'R': 1}
+
+func validMove(n int, grid [][]int, x, y int, dir byte) bool {
+	nx := x + dx[dir]
+	ny := y + dy[dir]
+	if nx < 1 || nx > n || ny < 1 || ny > n {
+		return false
+	}
+	tx := nx
+	ty := ny
+	for tx >= 1 && tx <= n && ty >= 1 && ty <= n {
+		if grid[tx][ty] == 1 {
+			return true
+		}
+		tx += dx[dir]
+		ty += dy[dir]
+	}
+	return false
+}
+
+func simulate(n, x0, y0 int, grid [][]int, actions string) error {
+	if len(actions) > 3000000 {
+		return fmt.Errorf("too many actions")
+	}
+	x, y := x0, y0
+	for i := 0; i < len(actions); i++ {
+		ch := actions[i]
+		switch ch {
+		case '1':
+			if grid[x][y] == 1 {
+				return fmt.Errorf("turn on when already on")
+			}
+			grid[x][y] = 1
+		case '2':
+			if grid[x][y] == 0 {
+				return fmt.Errorf("turn off when already off")
+			}
+			grid[x][y] = 0
+		case 'L', 'R', 'U', 'D':
+			if !validMove(n, grid, x, y, ch) {
+				return fmt.Errorf("invalid move %c", ch)
+			}
+			x += dx[ch]
+			y += dy[ch]
+		default:
+			return fmt.Errorf("invalid character %c", ch)
+		}
+	}
+	if x != x0 || y != y0 {
+		return fmt.Errorf("did not return to start")
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= n; j++ {
+			if grid[i][j] != 0 {
+				return fmt.Errorf("light not off at %d %d", i, j)
+			}
+		}
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, int, int, [][]int) {
+	n := rng.Intn(5) + 2
+	x0 := rng.Intn(n) + 1
+	y0 := rng.Intn(n) + 1
+	grid := make([][]int, n+1)
+	for i := 1; i <= n; i++ {
+		grid[i] = make([]int, n+1)
+		for j := 1; j <= n; j++ {
+			if rng.Intn(3) == 0 {
+				grid[i][j] = 1
+			}
+		}
+	}
+	grid[x0][y0] = 0
+	has := false
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= n; j++ {
+			if grid[i][j] == 1 {
+				has = true
+			}
+		}
+	}
+	if !has {
+		grid[rng.Intn(n)+1][rng.Intn(n)+1] = 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x0, y0))
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= n; j++ {
+			if j > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", grid[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), x0, y0, grid
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, x0, y0, grid := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) == 0 {
+			fmt.Fprintf(os.Stderr, "case %d failed: empty output\ninput:\n%s", i+1, in)
+			os.Exit(1)
+		}
+		ans := strings.TrimSpace(lines[0])
+		if ans == "NO" {
+			continue
+		}
+		if ans != "YES" {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected YES or NO\ninput:\n%soutput:\n%s", i+1, in, out)
+			os.Exit(1)
+		}
+		actions := ""
+		if len(lines) > 1 {
+			actions = strings.TrimSpace(lines[1])
+		}
+		gcopy := make([][]int, len(grid))
+		for i := range grid {
+			gcopy[i] = append([]int(nil), grid[i]...)
+		}
+		if err := simulate(len(grid)-1, x0, y0, gcopy, actions); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` through `verifierE.go` for contest 359
- each verifier generates 100 random tests and checks a candidate binary

## Testing
- `go build verifierA.go && ./verifierA ./359A.go`
- `go build verifierB.go && ./verifierB ./359B.go`
- `go build verifierC.go && ./verifierC ./359C.go`
- `go build verifierD.go && ./verifierD ./359D.go`
- `go build verifierE.go && ./verifierE ./359E.go`


------
https://chatgpt.com/codex/tasks/task_e_687eb823c680832488e6b9e6f51fc185