### PR TITLE
Add Go solution verifiers for contest 356

### DIFF
--- a/0-999/300-399/350-359/356/verifierA.go
+++ b/0-999/300-399/350-359/356/verifierA.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveA(in string) string {
+	reader := bufio.NewReader(strings.NewReader(in))
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return ""
+	}
+	ans := make([]int, n+2)
+	parent := make([]int, n+2)
+	for i := 1; i <= n+1; i++ {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		for parent[x] != x {
+			parent[x] = parent[parent[x]]
+			x = parent[x]
+		}
+		return x
+	}
+	union := func(a, b int) {
+		pa := find(a)
+		pb := find(b)
+		parent[pa] = pb
+	}
+	for i := 0; i < m; i++ {
+		var l, r, x int
+		fmt.Fscan(reader, &l, &r, &x)
+		j := find(l)
+		for j <= r {
+			if j == x {
+				j = find(j + 1)
+				continue
+			}
+			ans[j] = x
+			union(j, j+1)
+			j = find(j)
+		}
+	}
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(ans[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func genTest(r *rand.Rand) string {
+	n := r.Intn(9) + 2
+	m := r.Intn(2*n) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		l := r.Intn(n-1) + 1
+		rgt := l + r.Intn(n-l) + 1
+		x := l + r.Intn(rgt-l+1)
+		fmt.Fprintf(&sb, "%d %d %d\n", l, rgt, x)
+	}
+	return sb.String()
+}
+
+func runBinary(path, in string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: verifierA <path-to-binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(1))
+	const tests = 100
+	for i := 0; i < tests; i++ {
+		in := genTest(r)
+		expect := strings.TrimSpace(solveA(in))
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/356/verifierB.go
+++ b/0-999/300-399/350-359/356/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveB(in string) string {
+	reader := bufio.NewReader(strings.NewReader(in))
+	var n, m int64
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return ""
+	}
+	var x, y string
+	fmt.Fscan(reader, &x)
+	fmt.Fscan(reader, &y)
+	px, py := len(x), len(y)
+	g := gcd(px, py)
+	ty := int64(py / g)
+	fullCycles := n / ty
+	var totalPairsPerCycle int64
+	for r := 0; r < g; r++ {
+		var cntX [26]int64
+		for i := r; i < px; i += g {
+			cntX[x[i]-'a']++
+		}
+		var cntY [26]int64
+		for j := r; j < py; j += g {
+			cntY[y[j]-'a']++
+		}
+		for c := 0; c < 26; c++ {
+			totalPairsPerCycle += cntX[c] * cntY[c]
+		}
+	}
+	totalMatches := totalPairsPerCycle * fullCycles
+	totalPositions := n * int64(px)
+	result := totalPositions - totalMatches
+	return fmt.Sprintln(result)
+}
+
+func genTest(r *rand.Rand) string {
+	px := r.Intn(3) + 1
+	py := r.Intn(3) + 1
+	g := gcd(px, py)
+	l := px * py / g
+	k := r.Intn(3) + 1
+	n := int64(k * l / px)
+	m := int64(k * l / py)
+	var xb, yb strings.Builder
+	for i := 0; i < px; i++ {
+		xb.WriteByte(byte('a' + r.Intn(26)))
+	}
+	for i := 0; i < py; i++ {
+		yb.WriteByte(byte('a' + r.Intn(26)))
+	}
+	return fmt.Sprintf("%d %d\n%s\n%s\n", n, m, xb.String(), yb.String())
+}
+
+func runBinary(path, in string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: verifierB <path-to-binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(2))
+	const tests = 100
+	for i := 0; i < tests; i++ {
+		in := genTest(r)
+		expect := strings.TrimSpace(solveB(in))
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/356/verifierC.go
+++ b/0-999/300-399/350-359/356/verifierC.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveC(in string) string {
+	reader := bufio.NewReader(strings.NewReader(in))
+	var n int64
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return ""
+	}
+	cnt := make([]int64, 5)
+	var ai int
+	var S int64
+	for i := int64(0); i < n; i++ {
+		fmt.Fscan(reader, &ai)
+		cnt[ai]++
+		S += int64(ai)
+	}
+	cost3 := []int64{3, 2, 1, 0, 0}
+	cost4 := []int64{4, 3, 2, 1, 0}
+	var best int64 = -1
+	c4min := int64(0)
+	if S > 3*n {
+		c4min = S - 3*n
+	}
+	c4max := S / 4
+	if c4max > n {
+		c4max = n
+	}
+	for c4 := c4min; c4 <= c4max; c4++ {
+		remS := S - 4*c4
+		if remS < 0 || remS%3 != 0 {
+			continue
+		}
+		c3 := remS / 3
+		if c3 < 0 || c4+c3 > n {
+			continue
+		}
+		need4 := c4
+		used4 := make([]int64, 5)
+		for ai := 4; ai >= 0 && need4 > 0; ai-- {
+			take := cnt[ai]
+			if take > need4 {
+				take = need4
+			}
+			used4[ai] = take
+			need4 -= take
+		}
+		if need4 > 0 {
+			continue
+		}
+		need3 := c3
+		used3 := make([]int64, 5)
+		for _, ai := range []int{3, 4, 2, 1, 0} {
+			if need3 <= 0 {
+				break
+			}
+			avail := cnt[ai] - used4[ai]
+			if avail <= 0 {
+				continue
+			}
+			take := avail
+			if take > need3 {
+				take = need3
+			}
+			used3[ai] = take
+			need3 -= take
+		}
+		if need3 > 0 {
+			continue
+		}
+		var cost int64
+		for ai := 0; ai <= 4; ai++ {
+			cost += used4[ai] * cost4[ai]
+			cost += used3[ai] * cost3[ai]
+		}
+		if best < 0 || cost < best {
+			best = cost
+		}
+	}
+	return fmt.Sprintln(best)
+}
+
+func genTest(r *rand.Rand) string {
+	n := r.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	cntPos := 0
+	for i := 0; i < n; i++ {
+		val := r.Intn(5)
+		if val > 0 {
+			cntPos++
+		}
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(val))
+	}
+	if cntPos == 0 {
+		sb.Reset()
+		sb.WriteString("1\n1")
+	} else {
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runBinary(path, in string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: verifierC <path-to-binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(3))
+	const tests = 100
+	for i := 0; i < tests; i++ {
+		in := genTest(r)
+		expect := strings.TrimSpace(solveC(in))
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/356/verifierD.go
+++ b/0-999/300-399/350-359/356/verifierD.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Bitset []uint64
+
+func newBitset(words int) Bitset { return make(Bitset, words) }
+func (b Bitset) clone() Bitset   { nb := make(Bitset, len(b)); copy(nb, b); return nb }
+func (b Bitset) set(i int)       { b[i>>6] |= 1 << uint(i&63) }
+func (b Bitset) get(i int) bool  { return (b[i>>6] & (1 << uint(i&63))) != 0 }
+func (b Bitset) orShift(shift, words int) {
+	w := shift >> 6
+	off := uint(shift & 63)
+	for i := words - 1; i >= 0; i-- {
+		j := i - w
+		if j < 0 {
+			continue
+		}
+		v := b[j] << off
+		if off != 0 && j-1 >= 0 {
+			v |= b[j-1] >> (64 - off)
+		}
+		b[i] |= v
+	}
+}
+
+func solveD(in string) string {
+	reader := bufio.NewReader(strings.NewReader(in))
+	var n, s int
+	if _, err := fmt.Fscan(reader, &n, &s); err != nil {
+		return ""
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	p := 0
+	for i := 1; i < n; i++ {
+		if a[i] > a[p] {
+			p = i
+		}
+	}
+	if s < a[p] {
+		return fmt.Sprintln(-1)
+	}
+	const S = 7
+	m := (n + S - 1) / S
+	bits := s + 1
+	words := (bits + 63) >> 6
+	f := make([]Bitset, m+1)
+	f[0] = newBitset(words)
+	f[0].set(0)
+	flag := make([]bool, n)
+	for i := 0; i < m; i++ {
+		cur := f[i].clone()
+		for j := 0; j < S; j++ {
+			k := i*S + j
+			if k >= n || k == p {
+				continue
+			}
+			shift := a[k]
+			if shift <= s {
+				cur.orShift(shift, words)
+			}
+		}
+		f[i+1] = cur
+	}
+	t := s - a[p]
+	if t < 0 || t > s || !f[m].get(t) {
+		return fmt.Sprintln(-1)
+	}
+	for i := m; i > 0; i-- {
+		base := i * S
+		for mask := 0; mask < 1<<S; mask++ {
+			val := 0
+			ok := true
+			for j := 0; j < S; j++ {
+				if mask>>j&1 == 1 {
+					k := base - S + j
+					if k < 0 || k >= n || k == p {
+						ok = false
+						break
+					}
+					val += a[k]
+				}
+			}
+			if !ok || val > t {
+				continue
+			}
+			if f[i-1].get(t - val) {
+				for j := 0; j < S; j++ {
+					if mask>>j&1 == 1 {
+						k := base - S + j
+						flag[k] = true
+					}
+				}
+				t -= val
+				break
+			}
+		}
+	}
+	flag[p] = true
+	c := make([]int, n)
+	adj := make([][]int, n)
+	pool := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		if !flag[i] {
+			pool = append(pool, i)
+		} else {
+			c[i] = a[i]
+		}
+	}
+	sort.Slice(pool, func(i, j int) bool { return a[pool[i]] < a[pool[j]] })
+	pool = append(pool, p)
+	for i, x := range pool {
+		c[x] = a[x]
+		if i > 0 {
+			par := pool[i-1]
+			adj[x] = append(adj[x], par)
+			c[x] -= a[par]
+		}
+	}
+	sumC := 0
+	for i := 0; i < n; i++ {
+		sumC += c[i]
+	}
+	if sumC != s {
+		return fmt.Sprintln(-1)
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if len(adj[i]) == 0 {
+			fmt.Fprintf(&sb, "%d %d\n", c[i], 0)
+		} else {
+			fmt.Fprintf(&sb, "%d %d", c[i], len(adj[i]))
+			for _, v := range adj[i] {
+				fmt.Fprintf(&sb, " %d", v+1)
+			}
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func genTest(r *rand.Rand) string {
+	n := r.Intn(5) + 1
+	a := make([]int, n)
+	sum := 0
+	for i := 0; i < n; i++ {
+		a[i] = r.Intn(5) + 1
+		sum += a[i]
+	}
+	s := r.Intn(sum) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, s)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(a[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runBinary(path, in string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: verifierD <path-to-binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(4))
+	const tests = 100
+	for i := 0; i < tests; i++ {
+		in := genTest(r)
+		expect := strings.TrimSpace(solveD(in))
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/356/verifierE.go
+++ b/0-999/300-399/350-359/356/verifierE.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func manacher(s []byte) []int {
+	n := len(s)
+	d := make([]int, n)
+	l, r := 0, -1
+	for i := 0; i < n; i++ {
+		var k int
+		if i > r {
+			k = 1
+		} else {
+			k = min(d[l+r-i], r-i) + 1
+		}
+		for i-k >= 0 && i+k < n && s[i-k] == s[i+k] {
+			k++
+		}
+		d[i] = k - 1
+		if i+k-1 > r {
+			l = i - k + 1
+			r = i + k - 1
+		}
+	}
+	return d
+}
+
+func solveE(in string) string {
+	reader := bufio.NewReader(strings.NewReader(in))
+	var t string
+	fmt.Fscan(reader, &t)
+	s := []byte(t)
+	n := len(s)
+	pal := manacher(s)
+	const K = 26
+	prev := make([]int, n)
+	last := make([]int, K)
+	for i := range last {
+		last[i] = -1
+	}
+	for i := 0; i < n; i++ {
+		c := int(s[i] - 'a')
+		prev[i] = last[c]
+		last[c] = i
+	}
+	next := make([]int, n)
+	for i := range last {
+		last[i] = n
+	}
+	for i := n - 1; i >= 0; i-- {
+		c := int(s[i] - 'a')
+		next[i] = last[c]
+		last[c] = i
+	}
+	uniq := make([]int, n)
+	for i := 0; i < n; i++ {
+		ldist := n
+		if prev[i] >= 0 {
+			ldist = i - prev[i]
+		}
+		rdist := n
+		if next[i] < n {
+			rdist = next[i] - i
+		}
+		tmp := min(ldist, rdist) - 1
+		if tmp < 0 {
+			tmp = 0
+		}
+		uniq[i] = tmp
+	}
+	maxH := 0
+	for h := 1; ; h++ {
+		if (1<<h)-1 > n {
+			break
+		}
+		maxH = h
+	}
+	d := make([]int, maxH+1)
+	off := make([]int, maxH+1)
+	for h := 1; h <= maxH; h++ {
+		if h == 1 {
+			d[h] = 0
+			off[h] = 0
+		} else {
+			d[h] = (1 << (h - 1)) - 1
+			off[h] = 1 << (h - 2)
+		}
+	}
+	good := make([][]bool, n)
+	dp := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		good[i] = make([]bool, maxH+1)
+		dp[i] = make([]bool, maxH+1)
+		good[i][1] = true
+		dp[i][1] = true
+	}
+	for h := 2; h <= maxH; h++ {
+		dh := d[h]
+		oh := off[h]
+		for k := 0; k < n; k++ {
+			if k-oh >= 0 && k+oh < n && pal[k] >= dh && good[k][h-1] && good[k-oh][h-1] {
+				good[k][h] = true
+				if uniq[k] >= dh {
+					dp[k][h] = true
+				}
+			}
+		}
+	}
+	lenh := make([]int64, maxH+1)
+	sqh := make([]int64, maxH+1)
+	for h := 1; h <= maxH; h++ {
+		l := int64((1 << h) - 1)
+		lenh[h] = l
+		sqh[h] = l * l
+	}
+	var origSum int64
+	bestDelta := int64(0)
+	for k := 0; k < n; k++ {
+		Hk := 0
+		Gk := 0
+		for h := 1; h <= maxH; h++ {
+			if dp[k][h] {
+				origSum += sqh[h]
+				Hk = h
+			}
+			if good[k][h] {
+				Gk = h
+			}
+		}
+		if Gk > Hk {
+			var delta int64
+			for h := Hk + 1; h <= Gk; h++ {
+				delta += sqh[h]
+			}
+			if delta > bestDelta {
+				bestDelta = delta
+			}
+		}
+	}
+	return fmt.Sprintln(origSum + bestDelta)
+}
+
+func genTest(r *rand.Rand) string {
+	n := r.Intn(10) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('a' + r.Intn(26)))
+	}
+	return sb.String() + "\n"
+}
+
+func runBinary(path, in string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: verifierE <path-to-binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(5))
+	const tests = 100
+	for i := 0; i < tests; i++ {
+		in := genTest(r)
+		expect := strings.TrimSpace(solveE(in))
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E

These verifiers run a provided binary against 100 random tests each and compare the results with the reference implementation.

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687eb751adf48324a8d3383676e02f44