### PR TITLE
Add verifiers for contest 354

### DIFF
--- a/0-999/300-399/350-359/354/verifierA.go
+++ b/0-999/300-399/350-359/354/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(n int, l, r, Ql, Qr int64, w []int64) int64 {
+	pre := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		pre[i+1] = pre[i] + w[i]
+	}
+	total := pre[n]
+	ans := int64(1<<63 - 1)
+	for L := 0; L <= n; L++ {
+		leftCost := pre[L] * l
+		rightCost := (total - pre[L]) * r
+		R := n - L
+		var penalty int64
+		if L > R {
+			diff := int64(L - R - 1)
+			if diff > 0 {
+				penalty = diff * Ql
+			}
+		} else if R > L {
+			diff := int64(R - L - 1)
+			if diff > 0 {
+				penalty = diff * Qr
+			}
+		}
+		cost := leftCost + rightCost + penalty
+		if cost < ans {
+			ans = cost
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(30) + 1
+		l := rng.Int63n(100) + 1
+		r := rng.Int63n(100) + 1
+		Ql := rng.Int63n(20) + 1
+		Qr := rng.Int63n(20) + 1
+		w := make([]int64, n)
+		for j := 0; j < n; j++ {
+			w[j] = rng.Int63n(100) + 1
+		}
+
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d %d %d %d %d\n", n, l, r, Ql, Qr))
+		for j, val := range w {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(strconv.FormatInt(val, 10))
+		}
+		input.WriteByte('\n')
+
+		expectedOut := strconv.FormatInt(expected(n, l, r, Ql, Qr, w), 10)
+		got, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input.String())
+			os.Exit(1)
+		}
+		if got != expectedOut {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expectedOut, got, input.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/354/verifierB.go
+++ b/0-999/300-399/350-359/354/verifierB.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ r, c int }
+
+func expected(T [][]byte, n int) string {
+	maxD := 2 * n
+	pos := make([][]pair, maxD+2)
+	for d := 2; d <= maxD; d++ {
+		for r := 1; r <= n; r++ {
+			c := d - r
+			if c >= 1 && c <= n {
+				pos[d] = append(pos[d], pair{r, c})
+			}
+		}
+	}
+	succ := make([][][]int, maxD+2)
+	for d := 2; d < maxD; d++ {
+		m := len(pos[d])
+		succ[d] = make([][]int, m)
+		nextMap := make(map[int]map[int]int)
+		for j, p := range pos[d+1] {
+			if nextMap[p.r] == nil {
+				nextMap[p.r] = make(map[int]int)
+			}
+			nextMap[p.r][p.c] = j
+		}
+		for i, p := range pos[d] {
+			if p.r+1 <= n {
+				if idx, ok := nextMap[p.r+1][p.c]; ok {
+					succ[d][i] = append(succ[d][i], idx)
+				}
+			}
+			if p.c+1 <= n {
+				if idx, ok := nextMap[p.r][p.c+1]; ok {
+					succ[d][i] = append(succ[d][i], idx)
+				}
+			}
+		}
+	}
+	if n == 1 {
+		if T[1][1] == 'a' {
+			return "FIRST"
+		} else if T[1][1] == 'b' {
+			return "SECOND"
+		} else {
+			return "DRAW"
+		}
+	}
+
+	dp := make([]map[int]int, maxD+2)
+	for d := 0; d <= maxD+1; d++ {
+		dp[d] = make(map[int]int)
+	}
+	var solve func(d, mask int) int
+	solve = func(d, mask int) int {
+		if d > maxD-1 {
+			return 0
+		}
+		if v, ok := dp[d][mask]; ok {
+			return v
+		}
+		turnFirst := (d % 2) == 0
+		best := -1000000000
+		if !turnFirst {
+			best = 1000000000
+		}
+		for ch := 'a'; ch <= 'z'; ch++ {
+			mask2 := 0
+			for i := 0; i < len(pos[d]); i++ {
+				if mask&(1<<i) != 0 {
+					p := pos[d][i]
+					if T[p.r][p.c] == byte(ch) {
+						mask2 |= 1 << i
+					}
+				}
+			}
+			if mask2 == 0 {
+				continue
+			}
+			nextMask := 0
+			for i := 0; i < len(pos[d]); i++ {
+				if mask2&(1<<i) != 0 {
+					for _, j := range succ[d][i] {
+						nextMask |= 1 << j
+					}
+				}
+			}
+			score := 0
+			if ch == 'a' {
+				score = 1
+			} else if ch == 'b' {
+				score = -1
+			}
+			val := score + solve(d+1, nextMask)
+			if turnFirst {
+				if val > best {
+					best = val
+				}
+			} else {
+				if val < best {
+					best = val
+				}
+			}
+		}
+		dp[d][mask] = best
+		return best
+	}
+	startScore := 0
+	if T[1][1] == 'a' {
+		startScore = 1
+	} else if T[1][1] == 'b' {
+		startScore = -1
+	}
+	initialMask := 0
+	for _, j := range succ[2][0] {
+		initialMask |= 1 << j
+	}
+	res := startScore + solve(3, initialMask)
+	if res > 0 {
+		return "FIRST"
+	} else if res < 0 {
+		return "SECOND"
+	} else {
+		return "DRAW"
+	}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		T := make([][]byte, n+1)
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", n))
+		for r := 1; r <= n; r++ {
+			row := make([]byte, n+1)
+			for c := 1; c <= n; c++ {
+				row[c] = byte('a' + rng.Intn(3))
+			}
+			T[r] = row
+			for c := 1; c <= n; c++ {
+				input.WriteByte(row[c])
+			}
+			if r < n {
+				input.WriteByte('\n')
+			} else {
+				input.WriteByte('\n')
+			}
+		}
+		expect := expected(T, n)
+		got, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input.String())
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/354/verifierC.go
+++ b/0-999/300-399/350-359/354/verifierC.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(n, k int, a []int) int {
+	maxA := 0
+	minA := int(1e9)
+	for _, v := range a {
+		if v > maxA {
+			maxA = v
+		}
+		if v < minA {
+			minA = v
+		}
+	}
+	cnt := make([]int, maxA+1)
+	for _, v := range a {
+		cnt[v]++
+	}
+	ps := make([]int, maxA+1)
+	for i := 1; i <= maxA; i++ {
+		ps[i] = ps[i-1] + cnt[i]
+	}
+	ans := 1
+	for d := 2; d <= minA; d++ {
+		ok := true
+		for m := 0; m <= maxA; m += d {
+			low := m + k + 1
+			if low > maxA {
+				break
+			}
+			high := m + d - 1
+			if high > maxA {
+				high = maxA
+			}
+			if low <= high && ps[high]-ps[low-1] > 0 {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			ans = d
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(20) + 1
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rng.Intn(50) + 1
+		}
+
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for j, v := range a {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(strconv.Itoa(v))
+		}
+		input.WriteByte('\n')
+
+		expect := strconv.Itoa(expected(n, k, a))
+		got, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input.String())
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/354/verifierD.go
+++ b/0-999/300-399/350-359/354/verifierD.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(n int, pts [][2]int) int64 {
+	k := len(pts)
+	rowCols := make(map[int][]int, k)
+	exist := make(map[int]map[int]bool, k)
+	for _, p := range pts {
+		r, c := p[0], p[1]
+		if exist[r] == nil {
+			exist[r] = make(map[int]bool)
+		}
+		exist[r][c] = true
+		rowCols[r] = append(rowCols[r], c)
+	}
+	rows := make([]int, 0, len(rowCols))
+	for r, cols := range rowCols {
+		sort.Ints(cols)
+		rowCols[r] = cols
+		rows = append(rows, r)
+	}
+	sort.Ints(rows)
+	dpRow := make(map[int]map[int]int, len(rows))
+	for i := len(rows) - 1; i >= 0; i-- {
+		r := rows[i]
+		dpRow[r] = make(map[int]int, len(rowCols[r]))
+		next := dpRow[r+1]
+		for _, c := range rowCols[r] {
+			d1, d2 := 0, 0
+			if next != nil {
+				d1 = next[c]
+				d2 = next[c+1]
+			}
+			m := d1
+			if d2 < m {
+				m = d2
+			}
+			dpRow[r][c] = m + 1
+		}
+	}
+	type cand struct{ dp, r, c int }
+	cands := make([]cand, 0, k)
+	for _, p := range pts {
+		r, c := p[0], p[1]
+		d := dpRow[r][c]
+		if d > 0 {
+			cands = append(cands, cand{d, r, c})
+		}
+	}
+	sort.Slice(cands, func(i, j int) bool { return cands[i].dp > cands[j].dp })
+	covered := make(map[int]map[int]bool, len(rowCols))
+	for r := range rowCols {
+		covered[r] = make(map[int]bool, len(rowCols[r]))
+	}
+	rem := k
+	var cost int64 = 0
+	for _, cd := range cands {
+		if rem <= 0 {
+			break
+		}
+		r, c, d := cd.r, cd.c, cd.dp
+		if covered[r][c] {
+			continue
+		}
+		h := d - 1
+		tsize := d * (d + 1) / 2
+		cost += int64(tsize + 2)
+		for p := 0; p <= h; p++ {
+			rr := r + p
+			cols := rowCols[rr]
+			if cols == nil {
+				continue
+			}
+			l := sort.Search(len(cols), func(i int) bool { return cols[i] >= c })
+			for idx := l; idx < len(cols) && cols[idx] <= c+p; idx++ {
+				cc := cols[idx]
+				if !covered[rr][cc] {
+					covered[rr][cc] = true
+					rem--
+				}
+			}
+		}
+	}
+	if rem > 0 {
+		cost += int64(rem * 3)
+	}
+	return cost
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		k := rng.Intn(n) + 1
+		pts := make([][2]int, k)
+		for j := 0; j < k; j++ {
+			r := rng.Intn(n) + 1
+			c := rng.Intn(r) + 1
+			pts[j] = [2]int{r, c}
+		}
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for _, p := range pts {
+			input.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+		}
+		expect := strconv.FormatInt(expected(n, pts), 10)
+		got, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input.String())
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/354/verifierE.go
+++ b/0-999/300-399/350-359/354/verifierE.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	PERMS  = 28
+	DIGITS = 19
+)
+
+var p [PERMS][7]int
+var bucket [10][]int
+var pow10 [DIGITS]int64
+var a [6]int64
+
+func nextDigit(i int) int {
+	if i == 0 {
+		return 4
+	} else if i == 4 {
+		return 7
+	}
+	return 8
+}
+
+func initPrecomp() {
+	pid := 0
+	for i := 0; i <= 7; i = nextDigit(i) {
+		for j := i; j <= 7; j = nextDigit(j) {
+			for k := j; k <= 7; k = nextDigit(k) {
+				for l := k; l <= 7; l = nextDigit(l) {
+					for m := l; m <= 7; m = nextDigit(m) {
+						for n2 := m; n2 <= 7; n2 = nextDigit(n2) {
+							sum := i + j + k + l + m + n2
+							p[pid][0], p[pid][1], p[pid][2] = i, j, k
+							p[pid][3], p[pid][4], p[pid][5] = l, m, n2
+							p[pid][6] = sum
+							bucket[sum%10] = append(bucket[sum%10], pid)
+							pid++
+						}
+					}
+				}
+			}
+		}
+	}
+	pow10[0] = 1
+	for i := 1; i < DIGITS; i++ {
+		pow10[i] = pow10[i-1] * 10
+	}
+}
+
+func search(n int64, dig int) bool {
+	if n == 0 {
+		return true
+	}
+	if dig >= DIGITS {
+		return false
+	}
+	d := int((n / pow10[dig]) % 10)
+	for _, idx := range bucket[d] {
+		sumDigit := int64(p[idx][6])
+		if n < sumDigit*pow10[dig] {
+			continue
+		}
+		for j := 0; j < 6; j++ {
+			a[j] += int64(p[idx][j]) * pow10[dig]
+		}
+		if search(n-sumDigit*pow10[dig], dig+1) {
+			return true
+		}
+		for j := 0; j < 6; j++ {
+			a[j] -= int64(p[idx][j]) * pow10[dig]
+		}
+	}
+	return false
+}
+
+func expected(nums []int64) []string {
+	res := make([]string, len(nums))
+	for idx, n := range nums {
+		for i := 0; i < 6; i++ {
+			a[i] = 0
+		}
+		if search(n, 0) {
+			parts := make([]string, 6)
+			for i := 0; i < 6; i++ {
+				parts[i] = strconv.FormatInt(a[i], 10)
+			}
+			res[idx] = strings.Join(parts, " ")
+		} else {
+			res[idx] = "-1"
+		}
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	initPrecomp()
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		t := rng.Intn(5) + 1
+		nums := make([]int64, t)
+		for j := 0; j < t; j++ {
+			nums[j] = rng.Int63n(1e12) + 1
+		}
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", t))
+		for _, v := range nums {
+			input.WriteString(fmt.Sprintf("%d\n", v))
+		}
+		expLines := expected(nums)
+		got, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input.String())
+			os.Exit(1)
+		}
+		gotLines := strings.Split(strings.TrimSpace(got), "\n")
+		if len(gotLines) != len(expLines) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", i+1, len(expLines), len(gotLines), input.String())
+			os.Exit(1)
+		}
+		for j, line := range expLines {
+			if strings.TrimSpace(gotLines[j]) != line {
+				fmt.Fprintf(os.Stderr, "case %d failed on line %d: expected %s got %s\ninput:\n%s", i+1, j+1, line, gotLines[j], input.String())
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 354 problems A–E
- each verifier runs 100 randomized tests on any binary

## Testing
- `go run verifierA.go ./354A.go`
- `go run verifierB.go ./354B.go`
- `go run verifierC.go ./354C.go`
- `go run verifierD.go ./354D.go`
- `go run verifierE.go ./354E.go`


------
https://chatgpt.com/codex/tasks/task_e_687eb6c583a48324928a7c0517192b39