### PR TITLE
Add verifiers for contest 353

### DIFF
--- a/0-999/300-399/350-359/353/verifierA.go
+++ b/0-999/300-399/350-359/353/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func expected(n int, dominos [][2]int) int {
+	sumUp, sumDown := 0, 0
+	swapPossible := false
+	for _, d := range dominos {
+		sumUp += d[0]
+		sumDown += d[1]
+		if d[0]%2 != d[1]%2 {
+			swapPossible = true
+		}
+	}
+	if sumUp%2 == 0 && sumDown%2 == 0 {
+		return 0
+	} else if sumUp%2 == 1 && sumDown%2 == 1 && swapPossible {
+		return 1
+	} else {
+		return -1
+	}
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 1
+	dom := make([][2]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		x := rng.Intn(6) + 1
+		y := rng.Intn(6) + 1
+		dom[i] = [2]int{x, y}
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	ans := expected(n, dom)
+	return testCase{input: sb.String(), expect: fmt.Sprintf("%d\n", ans)}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if out != strings.TrimSpace(tc.expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, strings.TrimSpace(tc.expect), out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/353/verifierB.go
+++ b/0-999/300-399/350-359/353/verifierB.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input           string
+	expectedProduct int
+	expectedAssign  []int
+}
+
+func expected(arr []int) (int, []int) {
+	n := len(arr) / 2
+	cnt := make([]int, 90)
+	for _, v := range arr {
+		cnt[v-10]++
+	}
+	assignCnt := make([]int, 90)
+	t, g1, g2 := 0, 0, 0
+	for i := 0; i < 90; i++ {
+		if cnt[i] == 1 {
+			if t == 0 {
+				assignCnt[i] = 1
+				g1++
+			} else {
+				g2++
+			}
+			cnt[i] = 0
+			t = (t + 1) % 2
+		}
+	}
+	for i := 0; i < 90; i++ {
+		if cnt[i] > 1 {
+			assignCnt[i] = cnt[i] / 2
+			g1++
+			g2++
+			if cnt[i]%2 == 1 {
+				if t == 0 {
+					assignCnt[i]++
+				}
+				t = (t + 1) % 2
+			}
+		}
+	}
+	assign := make([]int, 2*n)
+	for i, v := range arr {
+		idx := v - 10
+		if assignCnt[idx] > 0 {
+			assign[i] = 1
+			assignCnt[idx]--
+		} else {
+			assign[i] = 2
+		}
+	}
+	return g1 * g2, assign
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 1
+	arr := make([]int, 2*n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < 2*n; i++ {
+		arr[i] = rng.Intn(90) + 10
+		fmt.Fprintf(&sb, "%d ", arr[i])
+	}
+	sb.WriteByte('\n')
+	prod, assign := expected(arr)
+	return testCase{input: sb.String(), expectedProduct: prod, expectedAssign: assign}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != 1+len(tc.expectedAssign) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\ninput:\n%s", i+1, 1+len(tc.expectedAssign), len(fields), tc.input)
+			os.Exit(1)
+		}
+		var prod int
+		if _, err := fmt.Sscan(fields[0], &prod); err != nil || prod != tc.expectedProduct {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected product %d got %s\ninput:\n%s", i+1, tc.expectedProduct, fields[0], tc.input)
+			os.Exit(1)
+		}
+		for j, f := range fields[1:] {
+			var v int
+			if _, err := fmt.Sscan(f, &v); err != nil || v != tc.expectedAssign[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed at position %d: expected %d got %s\ninput:\n%s", i+1, j+1, tc.expectedAssign[j], f, tc.input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/353/verifierC.go
+++ b/0-999/300-399/350-359/353/verifierC.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect int64
+}
+
+func expected(a []int64, s string) int64 {
+	n := len(a)
+	pre := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		pre[i] = pre[i-1] + a[i-1]
+	}
+	suf := make([]int64, n+1)
+	for i := n - 1; i >= 0; i-- {
+		suf[i] = suf[i+1]
+		if s[i] == '1' {
+			suf[i] += a[i]
+		}
+	}
+	ans := suf[0]
+	for i := n - 1; i >= 0; i-- {
+		if s[i] == '1' {
+			cand := suf[i+1] + pre[i]
+			if cand > ans {
+				ans = cand
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 1
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(1000))
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", a[i])
+	}
+	sb.WriteByte('\n')
+	bits := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 1 {
+			bits[i] = '1'
+		} else {
+			bits[i] = '0'
+		}
+	}
+	s := string(bits)
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	ans := expected(a, s)
+	return testCase{input: sb.String(), expect: ans}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		var val int64
+		if _, err := fmt.Sscan(out, &val); err != nil || val != tc.expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i+1, tc.expect, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/353/verifierD.go
+++ b/0-999/300-399/350-359/353/verifierD.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect int64
+}
+
+func expected(s string) int64 {
+	var m, t int64
+	for i := 0; i < len(s); i++ {
+		if s[i] == 'M' {
+			m++
+		} else {
+			if m > 0 {
+				if t+1 > m {
+					t++
+				} else {
+					t = m
+				}
+			}
+		}
+	}
+	return t
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 1
+	bytes := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			bytes[i] = 'M'
+		} else {
+			bytes[i] = 'F'
+		}
+	}
+	s := string(bytes)
+	return testCase{input: s + "\n", expect: expected(s)}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		var val int64
+		if _, err := fmt.Sscan(out, &val); err != nil || val != tc.expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", i+1, tc.expect, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/350-359/353/verifierE.go
+++ b/0-999/300-399/350-359/353/verifierE.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect int
+}
+
+func expected(s string) int {
+	n := len(s)
+	hasIncoming := make([]bool, n)
+	for i := 0; i < n; i++ {
+		if s[i] == '0' {
+			j := i + 1
+			if j == n {
+				j = 0
+			}
+			hasIncoming[j] = true
+		} else {
+			hasIncoming[i] = true
+		}
+	}
+	cnt := 0
+	for i := 0; i < n; i++ {
+		if !hasIncoming[i] {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 2
+	bytes := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			bytes[i] = '0'
+		} else {
+			bytes[i] = '1'
+		}
+	}
+	s := string(bytes)
+	return testCase{input: s + "\n", expect: expected(s)}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		var val int
+		if _, err := fmt.Sscan(out, &val); err != nil || val != tc.expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", i+1, tc.expect, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 353 (problems A–E)
- each verifier generates 100 random test cases and checks a given binary

## Testing
- `go vet 0-999/300-399/350-359/353/verifierA.go`
- `go vet 0-999/300-399/350-359/353/verifierB.go`
- `go vet 0-999/300-399/350-359/353/verifierC.go`
- `go vet 0-999/300-399/350-359/353/verifierD.go`
- `go vet 0-999/300-399/350-359/353/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687eb67f7e3083249d23f38abd51a3a0