### PR TITLE
Add verifiers for contest 350

### DIFF
--- a/0-999/300-399/350-359/350/verifierA.go
+++ b/0-999/300-399/350-359/350/verifierA.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(a, b []int) int {
+	maxA := a[0]
+	minA := a[0]
+	for _, v := range a {
+		if v > maxA {
+			maxA = v
+		}
+		if v < minA {
+			minA = v
+		}
+	}
+	minB := b[0]
+	for _, v := range b {
+		if v < minB {
+			minB = v
+		}
+	}
+	v := maxA
+	if 2*minA > v {
+		v = 2 * minA
+	}
+	if v < minB {
+		return v
+	}
+	return -1
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(42))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		a := make([]int, n)
+		b := make([]int, m)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(100) + 1
+		}
+		for i := 0; i < m; i++ {
+			b[i] = rng.Intn(100) + 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		for i, v := range b {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		exp := fmt.Sprintf("%d", solve(a, b))
+		tests = append(tests, test{sb.String(), exp})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/300-399/350-359/350/verifierB.go
+++ b/0-999/300-399/350-359/350/verifierB.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solveB(n int, t, parent []int) []int {
+	depth := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		if t[i] != 1 || depth[i] != 0 {
+			continue
+		}
+		path := make([]int, 0)
+		u := i
+		for u != 0 && depth[u] == 0 {
+			path = append(path, u)
+			u = parent[u]
+		}
+		base := 0
+		if u != 0 {
+			base = depth[u]
+		}
+		for j := len(path) - 1; j >= 0; j-- {
+			base++
+			depth[path[j]] = base
+		}
+	}
+	best := 1
+	maxd := 0
+	for i := 1; i <= n; i++ {
+		if t[i] == 1 && depth[i] > maxd {
+			maxd = depth[i]
+			best = i
+		}
+	}
+	res := make([]int, 0, maxd)
+	u := best
+	for u != 0 {
+		res = append(res, u)
+		u = parent[u]
+	}
+	for i, j := 0, len(res)-1; i < j; i, j = i+1, j-1 {
+		res[i], res[j] = res[j], res[i]
+	}
+	return res
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(43))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		t := make([]int, n+1)
+		hasHotel := false
+		for i := 1; i <= n; i++ {
+			if rng.Intn(2) == 1 {
+				t[i] = 1
+				hasHotel = true
+			}
+		}
+		if !hasHotel {
+			t[1] = 1
+		}
+		parent := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			parent[i] = rng.Intn(i) // 0..i-1 ensures no cycles
+		}
+		path := solveB(n, t, parent)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 1; i <= n; i++ {
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(t[i]))
+		}
+		sb.WriteByte('\n')
+		for i := 1; i <= n; i++ {
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(parent[i]))
+		}
+		sb.WriteByte('\n')
+		var out strings.Builder
+		fmt.Fprintf(&out, "%d\n", len(path))
+		for i, v := range path {
+			if i > 0 {
+				out.WriteByte(' ')
+			}
+			out.WriteString(strconv.Itoa(v))
+		}
+		out.WriteByte('\n')
+		tests = append(tests, test{sb.String(), out.String()})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/300-399/350-359/350/verifierC.go
+++ b/0-999/300-399/350-359/350/verifierC.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type bomb struct {
+	x, y, d int
+}
+
+type test struct {
+	input    string
+	expected string
+}
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solveC(bs []bomb) string {
+	// copy algorithm from 350C.go
+	// sort by distance
+	sort.Slice(bs, func(i, j int) bool { return bs[i].d < bs[j].d })
+	var k int
+	for _, b := range bs {
+		if b.x != 0 {
+			k++
+		}
+		if b.y != 0 {
+			k++
+		}
+		k++ // pick
+		if b.y != 0 {
+			k++
+		}
+		if b.x != 0 {
+			k++
+		}
+		k++ // destroy
+	}
+	var out strings.Builder
+	fmt.Fprintf(&out, "%d\n", k)
+	for _, b := range bs {
+		if b.x > 0 {
+			fmt.Fprintf(&out, "1 %d R\n", b.x)
+		} else if b.x < 0 {
+			fmt.Fprintf(&out, "1 %d L\n", -b.x)
+		}
+		if b.y > 0 {
+			fmt.Fprintf(&out, "1 %d U\n", b.y)
+		} else if b.y < 0 {
+			fmt.Fprintf(&out, "1 %d D\n", -b.y)
+		}
+		fmt.Fprintln(&out, 2)
+		if b.y > 0 {
+			fmt.Fprintf(&out, "1 %d D\n", b.y)
+		} else if b.y < 0 {
+			fmt.Fprintf(&out, "1 %d U\n", -b.y)
+		}
+		if b.x > 0 {
+			fmt.Fprintf(&out, "1 %d L\n", b.x)
+		} else if b.x < 0 {
+			fmt.Fprintf(&out, "1 %d R\n", -b.x)
+		}
+		fmt.Fprintln(&out, 3)
+	}
+	return out.String()
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(44))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		seen := make(map[[2]int]bool)
+		bs := make([]bomb, 0, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for len(bs) < n {
+			x := rng.Intn(21) - 10
+			y := rng.Intn(21) - 10
+			if x == 0 && y == 0 {
+				continue
+			}
+			if seen[[2]int{x, y}] {
+				continue
+			}
+			seen[[2]int{x, y}] = true
+			bs = append(bs, bomb{x: x, y: y, d: abs(x) + abs(y)})
+			fmt.Fprintf(&sb, "%d %d\n", x, y)
+		}
+		expected := solveC(append([]bomb(nil), bs...))
+		tests = append(tests, test{sb.String(), expected})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/300-399/350-359/350/verifierD.go
+++ b/0-999/300-399/350-359/350/verifierD.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+type lineKey struct {
+	a, b, c int64
+}
+
+type lineGroup struct {
+	starts []int64
+	ends   []int64
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func gcd3(a, b, c int64) int64 {
+	return gcd(gcd(a, b), c)
+}
+
+func solveD(n, m int, segments [][4]int64, circles [][3]int64) string {
+	groups := make(map[lineKey]*lineGroup, n)
+	for _, s := range segments {
+		x1, y1, x2, y2 := s[0], s[1], s[2], s[3]
+		dx := x2 - x1
+		dy := y2 - y1
+		g := gcd(dx, dy)
+		dx /= g
+		dy /= g
+		if dx < 0 || (dx == 0 && dy < 0) {
+			dx = -dx
+			dy = -dy
+		}
+		a := -dy
+		b := dx
+		c2 := 2 * (a*x1 + b*y1)
+		g2 := gcd3(a, b, c2)
+		a /= g2
+		b /= g2
+		c2 /= g2
+		if a < 0 || (a == 0 && b < 0) {
+			a = -a
+			b = -b
+			c2 = -c2
+		}
+		key := lineKey{a, b, c2}
+		grp, ok := groups[key]
+		if !ok {
+			grp = &lineGroup{}
+			groups[key] = grp
+		}
+		t1 := 2 * (dx*x1 + dy*y1)
+		t2 := 2 * (dx*x2 + dy*y2)
+		if t1 <= t2 {
+			grp.starts = append(grp.starts, t1)
+			grp.ends = append(grp.ends, t2)
+		} else {
+			grp.starts = append(grp.starts, t2)
+			grp.ends = append(grp.ends, t1)
+		}
+	}
+	for _, grp := range groups {
+		sort.Slice(grp.starts, func(i, j int) bool { return grp.starts[i] < grp.starts[j] })
+		sort.Slice(grp.ends, func(i, j int) bool { return grp.ends[i] < grp.ends[j] })
+	}
+	type circle struct{ x, y, r int64 }
+	byRadius := make(map[int64][]circle)
+	for _, c := range circles {
+		x, y, r := c[0], c[1], c[2]
+		byRadius[r] = append(byRadius[r], circle{x, y, r})
+	}
+	var ans int64
+	for r, cs := range byRadius {
+		k := len(cs)
+		if k < 2 {
+			continue
+		}
+		lim := 4 * r * r
+		for i := 0; i < k; i++ {
+			xi, yi := cs[i].x, cs[i].y
+			for j := i + 1; j < k; j++ {
+				xj, yj := cs[j].x, cs[j].y
+				dx := xj - xi
+				dy := yj - yi
+				if dx*dx+dy*dy <= lim {
+					continue
+				}
+				dxd := -dy
+				dyd := dx
+				g := gcd(dxd, dyd)
+				dxd /= g
+				dyd /= g
+				if dxd < 0 || (dxd == 0 && dyd < 0) {
+					dxd = -dxd
+					dyd = -dyd
+				}
+				a := -dyd
+				b := dxd
+				c2 := a*(xi+xj) + b*(yi+yj)
+				g2 := gcd3(a, b, c2)
+				a /= g2
+				b /= g2
+				c2 /= g2
+				if a < 0 || (a == 0 && b < 0) {
+					a = -a
+					b = -b
+					c2 = -c2
+				}
+				key := lineKey{a, b, c2}
+				grp, ok := groups[key]
+				if !ok {
+					continue
+				}
+				tmid := dxd*(xi+xj) + dyd*(yi+yj)
+				sCnt := sort.Search(len(grp.starts), func(i int) bool { return grp.starts[i] > tmid })
+				eCnt := sort.Search(len(grp.ends), func(i int) bool { return grp.ends[i] >= tmid })
+				ans += int64(sCnt - eCnt)
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(45))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(3) + 1
+		m := rng.Intn(3) + 2
+		segs := make([][4]int64, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for i := 0; i < n; i++ {
+			x1 := int64(rng.Intn(11) - 5)
+			y1 := int64(rng.Intn(11) - 5)
+			x2 := int64(rng.Intn(11) - 5)
+			y2 := int64(rng.Intn(11) - 5)
+			for x1 == x2 && y1 == y2 {
+				x2 = int64(rng.Intn(11) - 5)
+				y2 = int64(rng.Intn(11) - 5)
+			}
+			segs[i] = [4]int64{x1, y1, x2, y2}
+			fmt.Fprintf(&sb, "%d %d %d %d\n", x1, y1, x2, y2)
+		}
+		cirs := make([][3]int64, m)
+		for i := 0; i < m; i++ {
+			x := int64(rng.Intn(11) - 5)
+			y := int64(rng.Intn(11) - 5)
+			r := int64(rng.Intn(5) + 1)
+			cirs[i] = [3]int64{x, y, r}
+			fmt.Fprintf(&sb, "%d %d %d\n", x, y, r)
+		}
+		expected := solveD(n, m, segs, cirs)
+		tests = append(tests, test{sb.String(), expected})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/300-399/350-359/350/verifierE.go
+++ b/0-999/300-399/350-359/350/verifierE.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solveE(n, m, k int, special []int) string {
+	vis := make([]int, n+1)
+	ss := special[0]
+	for i, x := range special {
+		vis[x] = 1
+		if i == 0 {
+			vis[x] = 2
+		}
+	}
+	a := make([]int, 0, n)
+	b := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		if vis[i] != 2 {
+			a = append(a, i)
+		}
+		if vis[i] == 0 {
+			b = append(b, i)
+		}
+	}
+	tot := (n - k) + ((n-1)*(n-2))/2
+	if m > tot || k == n {
+		return "-1"
+	}
+	var out strings.Builder
+	edgesLeft := m
+	for i := 0; i < len(a) && edgesLeft > 1; i++ {
+		for j := i + 1; j < len(a) && edgesLeft > 1; j++ {
+			fmt.Fprintf(&out, "%d %d\n", a[i], a[j])
+			edgesLeft--
+		}
+	}
+	for i := 0; i < edgesLeft; i++ {
+		fmt.Fprintf(&out, "%d %d\n", ss, b[i])
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(46))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(8) + 3
+		k := rng.Intn(n-1) + 2
+		special := make([]int, 0, k)
+		used := make(map[int]bool)
+		for len(special) < k {
+			x := rng.Intn(n) + 1
+			if !used[x] {
+				used[x] = true
+				special = append(special, x)
+			}
+		}
+		tot := (n - k) + ((n-1)*(n-2))/2
+		m := rng.Intn(tot + 1) // may trigger -1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+		for i, v := range special {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		expected := solveE(n, m, k, special)
+		tests = append(tests, test{sb.String(), expected})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–E of contest 350
- each verifier generates 100 random tests and runs a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687eb5ad6e188324862ea59a783f0942