### PR TITLE
Add Go verifiers for contest 348

### DIFF
--- a/0-999/300-399/340-349/348/verifierA.go
+++ b/0-999/300-399/340-349/348/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(a []int64) int64 {
+	n := int64(len(a))
+	var sum int64
+	var maxa int64
+	for _, v := range a {
+		sum += v
+		if v > maxa {
+			maxa = v
+		}
+	}
+	rounds := (sum + n - 2) / (n - 1)
+	if rounds < maxa {
+		rounds = maxa
+	}
+	return rounds
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 3
+	a := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		a[i] = rng.Int63n(20) + 1
+		sb.WriteString(fmt.Sprintf("%d ", a[i]))
+	}
+	sb.WriteString("\n")
+	expect := fmt.Sprintf("%d", solveCase(a))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/348/verifierB.go
+++ b/0-999/300-399/340-349/348/verifierB.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int, weights []int64, edges []edge) int64 {
+	tree := make([][]int, n+1)
+	for _, e := range edges {
+		tree[e.u] = append(tree[e.u], e.v)
+		tree[e.v] = append(tree[e.v], e.u)
+	}
+	childs := make([][]int, n+1)
+	parent := make([]int, n+1)
+	parent[1] = 0
+	queue := []int{1}
+	for i := 0; i < len(queue); i++ {
+		v := queue[i]
+		for _, u := range tree[v] {
+			if u == parent[v] {
+				continue
+			}
+			parent[u] = v
+			childs[v] = append(childs[v], u)
+			queue = append(queue, u)
+		}
+	}
+	var dfs func(int) (int64, int64)
+	dfs = func(v int) (int64, int64) {
+		if len(childs[v]) == 0 {
+			return 0, weights[v]
+		}
+		var totalRem int64
+		var sumW int64
+		minW := int64(1<<62 - 1)
+		for _, u := range childs[v] {
+			r, w := dfs(u)
+			totalRem += r
+			sumW += w
+			if w < minW {
+				minW = w
+			}
+		}
+		cnt := int64(len(childs[v]))
+		totalRem += sumW - minW*cnt
+		return totalRem, minW * cnt
+	}
+	rem, _ := dfs(1)
+	return rem
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	edges := make([]edge, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = edge{p, i}
+	}
+	deg := make([]int, n+1)
+	for _, e := range edges {
+		deg[e.u]++
+		deg[e.v]++
+	}
+	weights := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		if deg[i] == 1 && i != 1 {
+			weights[i] = rng.Int63n(20) + 1
+		} else {
+			weights[i] = 0
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", weights[i]))
+	}
+	sb.WriteString("\n")
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	expect := fmt.Sprintf("%d", solveCase(n, weights, edges))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/348/verifierC.go
+++ b/0-999/300-399/340-349/348/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type query struct {
+	op int //0 query,1 add
+	k  int
+	x  int64
+}
+
+func solveCase(n int, a []int64, sets [][]int, qs []query) string {
+	arr := make([]int64, n)
+	copy(arr, a)
+	var sb strings.Builder
+	for _, q := range qs {
+		if q.op == 0 {
+			var sum int64
+			for _, idx := range sets[q.k] {
+				sum += arr[idx]
+			}
+			sb.WriteString(fmt.Sprintf("%d\n", sum))
+		} else {
+			for _, idx := range sets[q.k] {
+				arr[idx] += q.x
+			}
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	qn := rng.Intn(8) + 1
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = int64(rng.Intn(21) - 10)
+	}
+	sets := make([][]int, m)
+	for i := 0; i < m; i++ {
+		sz := rng.Intn(n) + 1
+		perm := rng.Perm(n)[:sz]
+		sets[i] = make([]int, sz)
+		copy(sets[i], perm)
+	}
+	qs := make([]query, qn)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, qn))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", a[i]))
+	}
+	sb.WriteString("\n")
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprintf("%d", len(sets[i])))
+		for _, idx := range sets[i] {
+			sb.WriteString(fmt.Sprintf(" %d", idx+1))
+		}
+		sb.WriteString("\n")
+	}
+	for i := 0; i < qn; i++ {
+		if rng.Intn(2) == 0 {
+			k := rng.Intn(m)
+			qs[i] = query{op: 0, k: k}
+			sb.WriteString(fmt.Sprintf("? %d\n", k+1))
+		} else {
+			k := rng.Intn(m)
+			x := int64(rng.Intn(21) - 10)
+			qs[i] = query{op: 1, k: k, x: x}
+			sb.WriteString(fmt.Sprintf("+ %d %d\n", k+1, x))
+		}
+	}
+	expect := solveCase(n, a, sets, qs)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/348/verifierD.go
+++ b/0-999/300-399/340-349/348/verifierD.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func computeDP(n, m int, grid [][]byte, sx, sy int) (int32, int32) {
+	t1x, t1y := n-2, m-1
+	t2x, t2y := n-1, m-2
+	dp := make([][]int32, n)
+	for i := range dp {
+		dp[i] = make([]int32, m)
+	}
+	if grid[sx][sy] == '#' {
+		return 0, 0
+	}
+	dp[sx][sy] = 1
+	for i := sx; i < n; i++ {
+		for j := sy; j < m; j++ {
+			if i == sx && j == sy {
+				continue
+			}
+			if grid[i][j] == '#' {
+				dp[i][j] = 0
+				continue
+			}
+			var v int32
+			if i > sx {
+				v += dp[i-1][j]
+			}
+			if j > sy {
+				v += dp[i][j-1]
+			}
+			if v >= mod {
+				v %= mod
+			}
+			dp[i][j] = v
+		}
+	}
+	var t1, t2 int32
+	if t1x >= sx && t1y >= sy {
+		t1 = dp[t1x][t1y]
+	}
+	if t2x >= sx && t2y >= sy {
+		t2 = dp[t2x][t2y]
+	}
+	return t1, t2
+}
+
+func solveCase(n, m int, grid [][]byte) int64 {
+	a11, a12 := computeDP(n, m, grid, 0, 1)
+	a21, a22 := computeDP(n, m, grid, 1, 0)
+	res := (int64(a11)*int64(a22) - int64(a12)*int64(a21)) % mod
+	if res < 0 {
+		res += mod
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	m := rng.Intn(5) + 2
+	grid := make([][]byte, n)
+	for i := range grid {
+		grid[i] = make([]byte, m)
+		for j := 0; j < m; j++ {
+			if (i == 0 && j == 0) || (i == n-1 && j == m-1) {
+				grid[i][j] = '.'
+			} else {
+				if rng.Intn(4) == 0 {
+					grid[i][j] = '#'
+				} else {
+					grid[i][j] = '.'
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			sb.WriteByte(grid[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	expect := fmt.Sprintf("%d", solveCase(n, m, grid))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/348/verifierE.go
+++ b/0-999/300-399/340-349/348/verifierE.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type e struct{ to, w int }
+
+func dijkstra(n, src, skip int, adj [][]e) []int64 {
+	const INF = int64(1 << 60)
+	dist := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = INF
+	}
+	if src == skip {
+		return dist
+	}
+	dist[src] = 0
+	h := &hp{{src, 0}}
+	heap.Init(h)
+	for h.Len() > 0 {
+		cur := heap.Pop(h).(pr)
+		if cur.d != dist[cur.u] {
+			continue
+		}
+		for _, ed := range adj[cur.u] {
+			if ed.to == skip || cur.u == skip {
+				continue
+			}
+			nd := cur.d + int64(ed.w)
+			if nd < dist[ed.to] {
+				dist[ed.to] = nd
+				heap.Push(h, pr{ed.to, nd})
+			}
+		}
+	}
+	return dist
+}
+
+type pr struct {
+	u int
+	d int64
+}
+type hp []pr
+
+func (h hp) Len() int            { return len(h) }
+func (h hp) Less(i, j int) bool  { return h[i].d < h[j].d }
+func (h hp) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *hp) Push(x interface{}) { *h = append(*h, x.(pr)) }
+func (h *hp) Pop() interface{}   { old := *h; x := old[len(old)-1]; *h = old[:len(old)-1]; return x }
+
+func solveCase(n, m int, spec []int, edges [][3]int) string {
+	adj := make([][]e, n+1)
+	for _, ed := range edges {
+		a, b, c := ed[0], ed[1], ed[2]
+		adj[a] = append(adj[a], e{b, c})
+		adj[b] = append(adj[b], e{a, c})
+	}
+	isSpec := make([]bool, n+1)
+	for _, s := range spec {
+		isSpec[s] = true
+	}
+	// all pairs distances
+	dist := make([][]int64, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = dijkstra(n, i, -1, adj)
+	}
+	far := make([][]int, n+1)
+	for _, s := range spec {
+		md := int64(-1)
+		for _, t := range spec {
+			if dist[s][t] > md {
+				md = dist[s][t]
+				far[s] = []int{t}
+			} else if dist[s][t] == md {
+				far[s] = append(far[s], t)
+			}
+		}
+	}
+	best := -1
+	ways := 0
+	for v := 1; v <= n; v++ {
+		if isSpec[v] {
+			continue
+		}
+		unhappy := 0
+		for _, s := range spec {
+			d := dijkstra(n, s, v, adj)
+			unreachable := true
+			for _, f := range far[s] {
+				if d[f] < int64(1<<60) {
+					unreachable = false
+					break
+				}
+			}
+			if unreachable {
+				unhappy++
+			}
+		}
+		if unhappy > best {
+			best = unhappy
+			ways = 1
+		} else if unhappy == best {
+			ways++
+		}
+	}
+	return fmt.Sprintf("%d %d", best, ways)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 3
+	m := rng.Intn(n-1) + 2
+	edges := make([][3]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		w := rng.Intn(10) + 1
+		edges[i-2] = [3]int{p, i, w}
+	}
+	perm := rng.Perm(n)
+	spec := perm[:m]
+	for i := 0; i < m; i++ {
+		spec[i]++
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, s := range spec {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", s))
+	}
+	sb.WriteByte('\n')
+	for _, ed := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", ed[0], ed[1], ed[2]))
+	}
+	expect := solveCase(n, m, spec, edges)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add random testcase verifiers for contest 348
- include verifiers for problems A through E
- each verifier runs 100 randomized checks

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_687eb5221da08324a9ddfe69cf37a992