### PR TITLE
Add Go verifiers for contest 346

### DIFF
--- a/0-999/300-399/340-349/346/verifierA.go
+++ b/0-999/300-399/340-349/346/verifierA.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func expectedAnswer(nums []int64) string {
+	g := nums[0]
+	maxV := nums[0]
+	for _, v := range nums[1:] {
+		g = gcd(g, v)
+		if v > maxV {
+			maxV = v
+		}
+	}
+	total := maxV / g
+	moves := total - int64(len(nums))
+	if moves%2 == 1 {
+		return "Alice"
+	}
+	return "Bob"
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(9) + 2 // 2..10
+	used := make(map[int64]bool)
+	nums := make([]int64, n)
+	for i := 0; i < n; i++ {
+		var v int64
+		for {
+			v = int64(rng.Intn(1000) + 1)
+			if !used[v] {
+				used[v] = true
+				break
+			}
+		}
+		nums[i] = v
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func parseNums(input string) []int64 {
+	parts := strings.Fields(input)
+	n := 0
+	fmt.Sscan(parts[0], &n)
+	nums := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Sscan(parts[i+1], &nums[i])
+	}
+	return nums
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{
+		"2\n2 3\n",
+		"3\n1 2 3\n",
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for idx, tc := range cases {
+		nums := parseNums(tc)
+		expect := expectedAnswer(nums)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/346/verifierB.go
+++ b/0-999/300-399/340-349/346/verifierB.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func prefixFunction(s string) []int {
+	pi := make([]int, len(s))
+	for i := 1; i < len(s); i++ {
+		j := pi[i-1]
+		for j > 0 && s[i] != s[j] {
+			j = pi[j-1]
+		}
+		if s[i] == s[j] {
+			j++
+		}
+		pi[i] = j
+	}
+	return pi
+}
+
+func buildAutomaton(virus string) [][]int {
+	n := len(virus)
+	pi := prefixFunction(virus)
+	next := make([][]int, n+1)
+	for k := 0; k <= n; k++ {
+		next[k] = make([]int, 26)
+		for c := 0; c < 26; c++ {
+			if k == n {
+				next[k][c] = n
+				continue
+			}
+			t := k
+			for t > 0 && byte('A'+c) != virus[t] {
+				t = pi[t-1]
+			}
+			if byte('A'+c) == virus[t] {
+				t++
+			}
+			next[k][c] = t
+		}
+	}
+	return next
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func expectedLength(s1, s2, virus string) int {
+	n1, n2, n3 := len(s1), len(s2), len(virus)
+	next := buildAutomaton(virus)
+	dp := make([][][]int, n1+1)
+	for i := range dp {
+		dp[i] = make([][]int, n2+1)
+		for j := range dp[i] {
+			dp[i][j] = make([]int, n3+1)
+			for k := range dp[i][j] {
+				dp[i][j][k] = -1
+			}
+		}
+	}
+	var f func(i, j, k int) int
+	f = func(i, j, k int) int {
+		if i == n1 || j == n2 {
+			return 0
+		}
+		if dp[i][j][k] != -1 {
+			return dp[i][j][k]
+		}
+		res := max(f(i+1, j, k), f(i, j+1, k))
+		if s1[i] == s2[j] {
+			c := s1[i] - 'A'
+			nk := next[k][c]
+			if nk < n3 {
+				res = max(res, 1+f(i+1, j+1, nk))
+			}
+		}
+		dp[i][j][k] = res
+		return res
+	}
+	return f(0, 0, 0)
+}
+
+func isSubsequence(s, sub string) bool {
+	j := 0
+	for i := 0; i < len(s) && j < len(sub); i++ {
+		if s[i] == sub[j] {
+			j++
+		}
+	}
+	return j == len(sub)
+}
+
+func generateString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('A' + rng.Intn(4))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n1 := rng.Intn(5) + 1
+	n2 := rng.Intn(5) + 1
+	n3 := rng.Intn(3) + 1
+	s1 := generateString(rng, n1)
+	s2 := generateString(rng, n2)
+	virus := generateString(rng, n3)
+	return fmt.Sprintf("%s\n%s\n%s\n", s1, s2, virus)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{
+		"ABC\nABCD\nBC\n",
+		"AAAA\nAAAA\nAA\n",
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for idx, tc := range cases {
+		lines := strings.Split(strings.TrimSpace(tc), "\n")
+		s1, s2, virus := lines[0], lines[1], lines[2]
+		expectLen := expectedLength(s1, s2, virus)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if expectLen == 0 {
+			if got != "0" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected 0 got %s\ninput:\n%s", idx+1, got, tc)
+				os.Exit(1)
+			}
+			continue
+		}
+		if len(got) != expectLen || !isSubsequence(s1, got) || !isSubsequence(s2, got) || strings.Contains(got, virus) {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid output %s\ninput:\n%s", idx+1, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/346/verifierC.go
+++ b/0-999/300-399/340-349/346/verifierC.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedMoves(x []int, a, b int) int {
+	if a == b {
+		return 0
+	}
+	L := a - b
+	const INF = int(1e9)
+	dist := make([]int, L+1)
+	for i := range dist {
+		dist[i] = INF
+	}
+	queue := []int{L}
+	dist[L] = 0
+	for len(queue) > 0 {
+		d := queue[0]
+		queue = queue[1:]
+		cur := dist[d]
+		if d == 0 {
+			return cur
+		}
+		if d > 0 && dist[d-1] > cur+1 {
+			dist[d-1] = cur + 1
+			queue = append(queue, d-1)
+		}
+		val := b + d
+		for _, xi := range x {
+			m := val - val%xi
+			if m < b {
+				continue
+			}
+			nd := m - b
+			if dist[nd] > cur+1 {
+				dist[nd] = cur + 1
+				queue = append(queue, nd)
+			}
+		}
+	}
+	return dist[0]
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	x := make([]int, n)
+	for i := 0; i < n; i++ {
+		x[i] = rng.Intn(9) + 2 // 2..10
+	}
+	a := rng.Intn(50) + 50 // 50..99
+	b := rng.Intn(a + 1)
+	if a-b > 30 {
+		b = a - 30
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range x {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	fmt.Fprintf(&sb, "\n%d %d\n", a, b)
+	return sb.String()
+}
+
+func parseCase(input string) ([]int, int, int) {
+	r := strings.NewReader(input)
+	var n int
+	fmt.Fscan(r, &n)
+	x := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &x[i])
+	}
+	var a, b int
+	fmt.Fscan(r, &a, &b)
+	return x, a, b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for idx, tc := range cases {
+		x, a, b := parseCase(tc)
+		expect := expectedMoves(x, a, b)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != fmt.Sprint(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", idx+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/346/verifierD.go
+++ b/0-999/300-399/340-349/346/verifierD.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const INF = 1000000007
+
+type Item struct{ v, f int }
+type PQ []Item
+
+func (pq PQ) Len() int            { return len(pq) }
+func (pq PQ) Less(i, j int) bool  { return pq[i].f < pq[j].f }
+func (pq PQ) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PQ) Push(x interface{}) { *pq = append(*pq, x.(Item)) }
+func (pq *PQ) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	x := old[n-1]
+	*pq = old[:n-1]
+	return x
+}
+
+func expectedOrders(n int, edges [][2]int, s, t int) int {
+	fwd := make([][]int, n+1)
+	rev := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		fwd[u] = append(fwd[u], v)
+		rev[v] = append(rev[v], u)
+	}
+	reachS := make([]bool, n+1)
+	q := []int{s}
+	reachS[s] = true
+	for qi := 0; qi < len(q); qi++ {
+		u := q[qi]
+		for _, v := range fwd[u] {
+			if !reachS[v] {
+				reachS[v] = true
+				q = append(q, v)
+			}
+		}
+	}
+	reachT := make([]bool, n+1)
+	q = []int{t}
+	reachT[t] = true
+	for qi := 0; qi < len(q); qi++ {
+		u := q[qi]
+		for _, v := range rev[u] {
+			if !reachT[v] {
+				reachT[v] = true
+				q = append(q, v)
+			}
+		}
+	}
+	if !reachS[t] {
+		return -1
+	}
+	good := make([]bool, n+1)
+	for i := 1; i <= n; i++ {
+		good[i] = reachS[i] && reachT[i]
+	}
+	deg := make([]int, n+1)
+	revGood := make([][]int, n+1)
+	for u := 1; u <= n; u++ {
+		if !good[u] {
+			continue
+		}
+		for _, v := range fwd[u] {
+			if good[v] {
+				deg[u]++
+				revGood[v] = append(revGood[v], u)
+			}
+		}
+	}
+
+	f := make([]int, n+1)
+	minF := make([]int, n+1)
+	maxF := make([]int, n+1)
+	cnt := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		f[i] = INF
+		minF[i] = INF
+	}
+	f[t] = 0
+	pq := &PQ{}
+	heap.Init(pq)
+	heap.Push(pq, Item{v: t, f: 0})
+	for pq.Len() > 0 {
+		it := heap.Pop(pq).(Item)
+		v := it.v
+		fv := it.f
+		if fv != f[v] {
+			continue
+		}
+		for _, u := range revGood[v] {
+			cnt[u]++
+			if fv < minF[u] {
+				minF[u] = fv
+			}
+			if fv > maxF[u] {
+				maxF[u] = fv
+			}
+			if cnt[u] == deg[u] {
+				noOrder := maxF[u]
+				order := minF[u] + 1
+				cand := noOrder
+				if order < cand {
+					cand = order
+				}
+				if cand < f[u] {
+					f[u] = cand
+					heap.Push(pq, Item{v: u, f: cand})
+				}
+			}
+		}
+	}
+	if f[s] >= INF {
+		return -1
+	}
+	return f[s]
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2 // 2..6
+	maxEdges := n * (n - 1)
+	m := rng.Intn(maxEdges + 1)
+	used := make(map[[2]int]bool)
+	edges := make([][2]int, 0, m)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		e := [2]int{u, v}
+		if used[e] {
+			continue
+		}
+		used[e] = true
+		edges = append(edges, e)
+	}
+	s := rng.Intn(n) + 1
+	t := rng.Intn(n) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, len(edges))
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	fmt.Fprintf(&sb, "%d %d\n", s, t)
+	return sb.String()
+}
+
+func parseCase(input string) (int, [][2]int, int, int) {
+	r := strings.NewReader(input)
+	var n, m int
+	fmt.Fscan(r, &n, &m)
+	edges := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(r, &edges[i][0], &edges[i][1])
+	}
+	var s, t int
+	fmt.Fscan(r, &s, &t)
+	return n, edges, s, t
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for idx, tc := range cases {
+		n, edges, s, t := parseCase(tc)
+		expect := expectedOrders(n, edges, s, t)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != fmt.Sprint(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", idx+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/346/verifierE.go
+++ b/0-999/300-399/340-349/346/verifierE.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func expectedAnswer(instances [][4]int64) []string {
+	res := make([]string, len(instances))
+	for idx, ins := range instances {
+		a, n, p, h := ins[0], ins[1], ins[2], ins[3]
+		if n <= 2000000 {
+			heights := make([]int64, n)
+			for i := int64(1); i <= n; i++ {
+				heights[i-1] = (a * i) % p
+			}
+			sort.Slice(heights, func(i, j int) bool { return heights[i] < heights[j] })
+			ok := true
+			if heights[0] > h {
+				ok = false
+			}
+			for i := 1; ok && i < int(n); i++ {
+				if heights[i]-heights[i-1] > h {
+					ok = false
+				}
+			}
+			if ok {
+				res[idx] = "YES"
+			} else {
+				res[idx] = "NO"
+			}
+		} else {
+			if (n+1)*h >= p {
+				res[idx] = "YES"
+			} else {
+				res[idx] = "NO"
+			}
+		}
+	}
+	return res
+}
+
+func generateInstance(rng *rand.Rand) [4]int64 {
+	var a, p int64
+	for {
+		a = int64(rng.Intn(20) + 1)
+		p = int64(rng.Intn(50) + 30)
+		if gcd(a, p) == 1 {
+			break
+		}
+	}
+	n := int64(rng.Intn(10) + 1)
+	h := int64(rng.Intn(20))
+	if n >= p {
+		n = p - 1
+	}
+	return [4]int64{a, n, p, h}
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	inst := make([][4]int64, t)
+	for i := 0; i < t; i++ {
+		inst[i] = generateInstance(rng)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		v := inst[i]
+		fmt.Fprintf(&sb, "%d %d %d %d\n", v[0], v[1], v[2], v[3])
+	}
+	return sb.String()
+}
+
+func parseCase(input string) [][4]int64 {
+	r := strings.NewReader(input)
+	var t int
+	fmt.Fscan(r, &t)
+	inst := make([][4]int64, t)
+	for i := 0; i < t; i++ {
+		fmt.Fscan(r, &inst[i][0], &inst[i][1], &inst[i][2], &inst[i][3])
+	}
+	return inst
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for idx, tc := range cases {
+		inst := parseCase(tc)
+		expect := expectedAnswer(inst)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc)
+			os.Exit(1)
+		}
+		outLines := strings.Split(strings.TrimSpace(got), "\n")
+		if len(outLines) != len(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", idx+1, len(expect), len(outLines), tc)
+			os.Exit(1)
+		}
+		for i := range expect {
+			if strings.TrimSpace(outLines[i]) != expect[i] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s (line %d)\ninput:\n%s", idx+1, expect[i], outLines[i], i+1, tc)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go, verifierB.go, verifierC.go, verifierD.go, verifierE.go for contest 346
- each verifier runs a provided binary against 100+ random tests

## Testing
- `go build 0-999/300-399/340-349/346/verifierA.go`
- `go build 0-999/300-399/340-349/346/verifierB.go`
- `go build 0-999/300-399/340-349/346/verifierC.go`
- `go build 0-999/300-399/340-349/346/verifierD.go`
- `go build 0-999/300-399/340-349/346/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687eb49551f88324912c90a0c71ab2e8