### PR TITLE
Add Go verifiers for Codeforces contest 345

### DIFF
--- a/0-999/300-399/340-349/345/verifierA.go
+++ b/0-999/300-399/340-349/345/verifierA.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedValue(s string, p float64) float64 {
+	count1 := 0
+	countQ := 0
+	for _, ch := range s {
+		if ch == '1' {
+			count1++
+		} else if ch == '?' {
+			countQ++
+		}
+	}
+	n := float64(len(s))
+	return (float64(count1) + float64(countQ)*p) / n
+}
+
+func runCase(bin string, s string, p float64) error {
+	input := fmt.Sprintf("%s\n%f\n", s, p)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	val, err := strconv.ParseFloat(out, 64)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := expectedValue(s, p)
+	if math.Abs(val-exp) > 1e-5 {
+		return fmt.Errorf("expected %.5f got %.5f", exp, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(50) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			r := rng.Intn(3)
+			switch r {
+			case 0:
+				sb.WriteByte('0')
+			case 1:
+				sb.WriteByte('1')
+			default:
+				sb.WriteByte('?')
+			}
+		}
+		p := rng.Float64()
+		if err := runCase(bin, sb.String(), p); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (s=%s p=%f)\n", i+1, err, sb.String(), p)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/345/verifierB.go
+++ b/0-999/300-399/340-349/345/verifierB.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func countBadBases(n int) int {
+	if strings.Contains(strconv.Itoa(n), "13") {
+		return -1
+	}
+	cnt := 0
+	for b := 2; b <= n; b++ {
+		x := n
+		var digits []int
+		for x > 0 {
+			digits = append(digits, x%b)
+			x /= b
+		}
+		var sb strings.Builder
+		for i := len(digits) - 1; i >= 0; i-- {
+			sb.WriteString(strconv.Itoa(digits[i]))
+		}
+		if strings.Contains(sb.String(), "13") {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("%d\n", n)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := countBadBases(n)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(1000) + 1
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (n=%d)\n", i+1, err, n)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/345/verifierC.go
+++ b/0-999/300-399/340-349/345/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func countFriday13(dates []string) int {
+	cnt := 0
+	for _, s := range dates {
+		if len(s) >= 10 && s[8:10] == "13" {
+			t, err := time.Parse("2006-01-02", s)
+			if err == nil && t.Weekday() == time.Friday {
+				cnt++
+			}
+		}
+	}
+	return cnt
+}
+
+func runCase(bin string, dates []string) error {
+	input := fmt.Sprintf("%d\n%s\n", len(dates), strings.Join(dates, "\n"))
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := countFriday13(dates)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func randomDate(rng *rand.Rand) string {
+	year := 1974 + rng.Intn(57) // up to 2030
+	month := rng.Intn(12) + 1
+	day := rng.Intn(28) + 1
+	return fmt.Sprintf("%04d-%02d-%02d", year, month, day)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		dates := make([]string, n)
+		for j := 0; j < n; j++ {
+			dates[j] = randomDate(rng)
+		}
+		if err := runCase(bin, dates); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/345/verifierD.go
+++ b/0-999/300-399/340-349/345/verifierD.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func bfsCount(f []string) int {
+	n := len(f)
+	visited := make([]bool, n)
+	queue := []int{0}
+	visited[0] = true
+	count := make([]int, n)
+	for head := 0; head < len(queue); head++ {
+		u := queue[head]
+		for v := 0; v < n; v++ {
+			if f[u][v] == '1' {
+				count[v]++
+				if v != n-1 && !visited[v] {
+					visited[v] = true
+					queue = append(queue, v)
+				}
+			}
+		}
+	}
+	return count[n-1]
+}
+
+func runCase(bin string, f []string) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(f)))
+	for _, row := range f {
+		sb.WriteString(row)
+		sb.WriteByte('\n')
+	}
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := bfsCount(f)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func randomMatrix(rng *rand.Rand, n int) []string {
+	rows := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if i == j {
+				b[j] = '0'
+			} else {
+				if rng.Intn(2) == 0 {
+					b[j] = '0'
+				} else {
+					b[j] = '1'
+				}
+			}
+		}
+		rows[i] = string(b)
+	}
+	// ensure symmetry
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if rows[i][j] != rows[j][i] {
+				if rng.Intn(2) == 0 {
+					rows[i] = rows[i][:j] + string(rows[j][i]) + rows[i][j+1:]
+				} else {
+					rows[j] = rows[j][:i] + string(rows[i][j]) + rows[j][i+1:]
+				}
+			}
+		}
+	}
+	return rows
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 2 // between 2 and 7
+		f := randomMatrix(rng, n)
+		if err := runCase(bin, f); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/345/verifierE.go
+++ b/0-999/300-399/340-349/345/verifierE.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func intersects(a, v, u int, x, y float64) bool {
+	af := float64(a)
+	vf := float64(v)
+	uf := float64(u)
+	alpha := 1.0 - (uf*uf)/(vf*vf)
+	eps := 1e-12
+	xif := x
+	yif := y
+	f := func(t float64) float64 {
+		return alpha*t*t - 2*xif*t + xif*xif + yif*yif
+	}
+	if v == u {
+		if x > 0 {
+			return f(af) <= eps
+		}
+		return f(0) <= eps
+	}
+	if alpha > 0 {
+		x0 := xif / alpha
+		if x0 < 0 {
+			x0 = 0
+		} else if x0 > af {
+			x0 = af
+		}
+		return f(x0) <= eps
+	}
+	return f(0) <= eps || f(af) <= eps
+}
+
+func countCats(a, v, u int, cats [][2]int) int {
+	cnt := 0
+	for _, c := range cats {
+		x := float64(c[0])
+		y := float64(c[1])
+		if intersects(a, v, u, x, y) {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func runCase(bin string, a, v, u int, cats [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", a, v, u, len(cats)))
+	for _, c := range cats {
+		sb.WriteString(fmt.Sprintf("%d %d\n", c[0], c[1]))
+	}
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := countCats(a, v, u, cats)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		a := rng.Intn(50) + 1
+		v := rng.Intn(100) + 1
+		u := rng.Intn(100) + 1
+		n := rng.Intn(5) + 1
+		cats := make([][2]int, n)
+		for j := 0; j < n; j++ {
+			cats[j][0] = rng.Intn(201) - 100
+			cats[j][1] = rng.Intn(201) - 100
+		}
+		if err := runCase(bin, a, v, u, cats); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/345/verifierF.go
+++ b/0-999/300-399/340-349/345/verifierF.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func normalize(s string) string {
+	fields := strings.Fields(s)
+	for i, w := range fields {
+		fields[i] = strings.ToLower(w)
+	}
+	return strings.Join(fields, " ")
+}
+
+func solveCase(countries [][]string) []string {
+	counts := make(map[string]int)
+	for _, list := range countries {
+		set := make(map[string]bool)
+		for _, sup := range list {
+			set[normalize(sup)] = true
+		}
+		for s := range set {
+			counts[s]++
+		}
+	}
+	maxCount := 0
+	for _, c := range counts {
+		if c > maxCount {
+			maxCount = c
+		}
+	}
+	var best []string
+	for s, c := range counts {
+		if c == maxCount {
+			best = append(best, s)
+		}
+	}
+	sort.Strings(best)
+	return best
+}
+
+func runCase(bin string, countries [][]string) error {
+	var sb strings.Builder
+	for idx, list := range countries {
+		if idx > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fmt.Sprintf("Country%d\n", idx))
+		for _, s := range list {
+			sb.WriteString("* ")
+			sb.WriteString(s)
+			sb.WriteByte('\n')
+		}
+	}
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	gotLines := strings.Split(strings.TrimSpace(out), "\n")
+	expected := solveCase(countries)
+	if len(gotLines) != len(expected) {
+		return fmt.Errorf("expected %d lines got %d", len(expected), len(gotLines))
+	}
+	for i := range expected {
+		if strings.TrimSpace(gotLines[i]) != expected[i] {
+			return fmt.Errorf("line %d expected %q got %q", i+1, expected[i], strings.TrimSpace(gotLines[i]))
+		}
+	}
+	return nil
+}
+
+func randomSup(rng *rand.Rand) string {
+	words := rng.Intn(3) + 1
+	var parts []string
+	for i := 0; i < words; i++ {
+		l := rng.Intn(5) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('a' + rng.Intn(26))
+		}
+		parts = append(parts, string(b))
+	}
+	return strings.Join(parts, " ")
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := rng.Intn(3) + 1
+		countries := make([][]string, c)
+		for j := 0; j < c; j++ {
+			n := rng.Intn(3) + 1
+			countries[j] = make([]string, n)
+			for k := 0; k < n; k++ {
+				countries[j][k] = randomSup(rng)
+			}
+		}
+		if err := runCase(bin, countries); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/345/verifierG.go
+++ b/0-999/300-399/340-349/345/verifierG.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Node struct {
+	children map[byte]*Node
+	count    int
+}
+
+func insert(root *Node, s string) int {
+	cur := root
+	for i := len(s) - 1; i >= 0; i-- {
+		c := s[i]
+		if cur.children == nil {
+			cur.children = make(map[byte]*Node)
+		}
+		if cur.children[c] == nil {
+			cur.children[c] = &Node{}
+		}
+		cur = cur.children[c]
+		cur.count++
+	}
+	return cur.count
+}
+
+func solveCase(stringsIn []string) int {
+	root := &Node{}
+	ans := 0
+	for _, s := range stringsIn {
+		cnt := insert(root, s)
+		if cnt > ans {
+			ans = cnt
+		}
+	}
+	return ans
+}
+
+func runCase(bin string, arr []string) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for _, s := range arr {
+		sb.WriteString(s)
+		sb.WriteByte('\n')
+	}
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solveCase(arr)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func randomString(rng *rand.Rand) string {
+	l := rng.Intn(10) + 1
+	b := make([]byte, l)
+	for i := 0; i < l; i++ {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		arr := make([]string, n)
+		for j := 0; j < n; j++ {
+			arr[j] = randomString(rng)
+		}
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go solution verifiers for contest 345 (problems A–G)
- each verifier generates 100 random test cases
- verifiers run a provided binary (or Go source) and check outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_687eb44f2d108324a7ffd33bccda175a