### PR TITLE
Add verifiers for Codeforces Round 344

### DIFF
--- a/0-999/300-399/340-349/344/verifierA.go
+++ b/0-999/300-399/340-349/344/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswer(magnets []string) string {
+	if len(magnets) == 0 {
+		return "0"
+	}
+	count := 1
+	prev := magnets[0]
+	for _, m := range magnets[1:] {
+		if m != prev {
+			count++
+		}
+		prev = m
+	}
+	return fmt.Sprint(count)
+}
+
+func generateCase(rng *rand.Rand) []string {
+	n := rng.Intn(100) + 1 // 1..100 magnets
+	mags := make([]string, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			mags[i] = "01"
+		} else {
+			mags[i] = "10"
+		}
+	}
+	return mags
+}
+
+func runCase(bin string, mags []string) error {
+	input := fmt.Sprintf("%d\n%s\n", len(mags), strings.Join(mags, "\n"))
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedAnswer(mags)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		mags := generateCase(rng)
+		if err := runCase(bin, mags); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d\n%s\n", i+1, err, len(mags), strings.Join(mags, "\n"))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/344/verifierB.go
+++ b/0-999/300-399/340-349/344/verifierB.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswerB(a, b, c int64) string {
+	sumABc := a + b - c
+	sumBCa := b + c - a
+	sumACb := a + c - b
+	if sumABc < 0 || sumBCa < 0 || sumACb < 0 || sumABc%2 != 0 || sumBCa%2 != 0 || sumACb%2 != 0 {
+		return "Impossible"
+	}
+	x := sumABc / 2
+	y := sumBCa / 2
+	z := sumACb / 2
+	if x < 0 || y < 0 || z < 0 {
+		return "Impossible"
+	}
+	return fmt.Sprintf("%d %d %d", x, y, z)
+}
+
+func generateCaseB(rng *rand.Rand) (int64, int64, int64) {
+	a := rng.Int63n(1000000) + 1
+	b := rng.Int63n(1000000) + 1
+	c := rng.Int63n(1000000) + 1
+	return a, b, c
+}
+
+func runCase(bin string, a, b, c int64) error {
+	input := fmt.Sprintf("%d %d %d\n", a, b, c)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedAnswerB(a, b, c)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		a, b, c := generateCaseB(rng)
+		if err := runCase(bin, a, b, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%d %d %d\n", i+1, err, a, b, c)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` to automatically test solutions for problem A
- add `verifierB.go` for problem B

Both verifiers run 100 randomly generated tests against any supplied binary.

## Testing
- `go run verifierA.go ./344A`
- `go run verifierB.go ./344B`


------
https://chatgpt.com/codex/tasks/task_e_687eb40920ac8324b4d201bebc580d29