### PR TITLE
Add verifiers for Codeforces contest 343

### DIFF
--- a/0-999/300-399/340-349/343/verifierA.go
+++ b/0-999/300-399/340-349/343/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	a, b uint64
+}
+
+func gcd(a, b uint64) uint64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func expected(a, b uint64) uint64 {
+	var cnt uint64
+	for a != 1 || b != 1 {
+		if a > b {
+			k := (a - 1) / b
+			cnt += k
+			a -= k * b
+		} else {
+			k := (b - 1) / a
+			cnt += k
+			b -= k * a
+		}
+	}
+	return cnt + 1
+}
+
+func runCase(bin string, tc testCase) error {
+	input := fmt.Sprintf("%d %d\n", tc.a, tc.b)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got uint64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := expected(tc.a, tc.b)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func generateCases(rng *rand.Rand) []testCase {
+	cases := []testCase{{1, 1}, {3, 2}, {1, 2}}
+	for len(cases) < 100 {
+		a := rng.Uint64()%1000000000000000000 + 1
+		b := rng.Uint64()%1000000000000000000 + 1
+		if gcd(a, b) != 1 {
+			continue
+		}
+		cases = append(cases, testCase{a, b})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := generateCases(rng)
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %d %d\n", i+1, err, tc.a, tc.b)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/343/verifierB.go
+++ b/0-999/300-399/340-349/343/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) string {
+	stack := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if len(stack) > 0 && stack[len(stack)-1] == ch {
+			stack = stack[:len(stack)-1]
+		} else {
+			stack = append(stack, ch)
+		}
+	}
+	if len(stack) == 0 {
+		return "Yes"
+	}
+	return "No"
+}
+
+type testCase struct {
+	s string
+}
+
+func runCase(bin string, tc testCase) error {
+	input := tc.s + "\n"
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := expected(tc.s)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func generateCases(rng *rand.Rand) []testCase {
+	cases := []testCase{{"++"}, {"+-"}, {"++--"}}
+	for len(cases) < 100 {
+		n := rng.Intn(50) + 1
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('+')
+			} else {
+				sb.WriteByte('-')
+			}
+		}
+		cases = append(cases, testCase{sb.String()})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := generateCases(rng)
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, tc.s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/343/verifierC.go
+++ b/0-999/300-399/340-349/343/verifierC.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m int
+	h    []int64
+	p    []int64
+}
+
+func canCover(h, p []int64, T int64) bool {
+	n, m := len(h), len(p)
+	j := 0
+	for i := 0; i < n && j < m; i++ {
+		hi := h[i]
+		if p[j] > hi {
+			limit := hi + T
+			t := sort.Search(m, func(x int) bool { return p[x] > limit })
+			j = t
+		} else {
+			l := p[j]
+			if hi-l > T {
+				return false
+			}
+			k := sort.Search(m, func(x int) bool { return p[x] > hi }) - 1
+			tMax := k
+			t1lim := T + 2*l - hi
+			if t1lim >= l {
+				idx := sort.Search(m, func(x int) bool { return p[x] > t1lim }) - 1
+				if idx > tMax {
+					tMax = idx
+				}
+			}
+			rem := T - (hi - l)
+			if rem >= 0 {
+				t2lim := hi + rem/2
+				idx2 := sort.Search(m, func(x int) bool { return p[x] > t2lim }) - 1
+				if idx2 > tMax {
+					tMax = idx2
+				}
+			}
+			j = tMax + 1
+		}
+	}
+	return j >= m
+}
+
+func expected(tc testCase) int64 {
+	lo, hi := int64(0), int64(40000000000)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if canCover(tc.h, tc.p, mid) {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return lo
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+	for i := 0; i < tc.n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", tc.h[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < tc.m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", tc.p[i])
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := expected(tc)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func generateCases(rng *rand.Rand) []testCase {
+	cases := []testCase{}
+	for len(cases) < 100 {
+		n := rng.Intn(4) + 1
+		m := rng.Intn(4) + 1
+		hs := make([]int64, n)
+		ps := make([]int64, m)
+		vals := rand.Perm(50)
+		for i := 0; i < n; i++ {
+			hs[i] = int64(vals[i] + 1)
+		}
+		vals2 := rand.Perm(50)
+		for i := 0; i < m; i++ {
+			ps[i] = int64(vals2[i] + 1)
+		}
+		sort.Slice(hs, func(i, j int) bool { return hs[i] < hs[j] })
+		sort.Slice(ps, func(i, j int) bool { return ps[i] < ps[j] })
+		cases = append(cases, testCase{n, m, hs, ps})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := generateCases(rng)
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/343/verifierD.go
+++ b/0-999/300-399/340-349/343/verifierD.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type op struct {
+	t int
+	v int
+}
+
+type testCase struct {
+	n     int
+	edges [][2]int
+	ops   []op
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", tc.n)
+	for _, e := range tc.edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	fmt.Fprintf(&sb, "%d\n", len(tc.ops))
+	for _, op := range tc.ops {
+		fmt.Fprintf(&sb, "%d %d\n", op.t, op.v)
+	}
+	input := sb.String()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outputLines := strings.Fields(strings.TrimSpace(out.String()))
+	expLines := expected(tc)
+	if len(outputLines) != len(expLines) {
+		return fmt.Errorf("expected %d lines got %d", len(expLines), len(outputLines))
+	}
+	for i := range expLines {
+		if outputLines[i] != expLines[i] {
+			return fmt.Errorf("line %d: expected %s got %s", i+1, expLines[i], outputLines[i])
+		}
+	}
+	return nil
+}
+
+func expected(tc testCase) []string {
+	n := tc.n
+	adj := make([][]int, n+1)
+	for _, e := range tc.edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	parent := make([]int, n+1)
+	order := []int{1}
+	parent[1] = 0
+	for i := 0; i < len(order); i++ {
+		v := order[i]
+		for _, to := range adj[v] {
+			if to != parent[v] {
+				parent[to] = v
+				order = append(order, to)
+			}
+		}
+	}
+	filled := make([]bool, n+1)
+	var res []string
+	for _, op := range tc.ops {
+		v := op.v
+		switch op.t {
+		case 1:
+			// fill subtree of v
+			stack := []int{v}
+			for len(stack) > 0 {
+				x := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				if filled[x] {
+					// already filled but continue to explore
+				}
+				filled[x] = true
+				for _, to := range adj[x] {
+					if to != parent[x] {
+						stack = append(stack, to)
+					}
+				}
+			}
+		case 2:
+			// empty path to root
+			for x := v; x != 0; x = parent[x] {
+				filled[x] = false
+			}
+		case 3:
+			if filled[v] {
+				res = append(res, "1")
+			} else {
+				res = append(res, "0")
+			}
+		}
+	}
+	return res
+}
+
+func generateCases(rng *rand.Rand) []testCase {
+	cases := []testCase{}
+	for len(cases) < 100 {
+		n := rng.Intn(7) + 2
+		edges := make([][2]int, n-1)
+		for i := 2; i <= n; i++ {
+			p := rng.Intn(i-1) + 1
+			edges[i-2] = [2]int{p, i}
+		}
+		q := rng.Intn(15) + 1
+		ops := make([]op, q)
+		for i := 0; i < q; i++ {
+			t := rng.Intn(3) + 1
+			v := rng.Intn(n) + 1
+			ops[i] = op{t, v}
+		}
+		cases = append(cases, testCase{n, edges, ops})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := generateCases(rng)
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/343/verifierE.go
+++ b/0-999/300-399/340-349/343/verifierE.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	u, v, c int
+}
+
+type testCase struct {
+	n     int
+	edges []edge
+}
+
+func addEdge(g [][]edgeImpl, u, v, c int) {
+	g[u] = append(g[u], edgeImpl{v, len(g[v]), c})
+	g[v] = append(g[v], edgeImpl{u, len(g[u]) - 1, c})
+}
+
+type edgeImpl struct {
+	to, rev, cap int
+}
+
+func maxFlow(n int, edges []edge, s, t int) int {
+	g := make([][]edgeImpl, n+1)
+	for _, e := range edges {
+		addEdge(g, e.u, e.v, e.c)
+	}
+	flow := 0
+	for {
+		q := []int{s}
+		parent := make([]int, n+1)
+		pe := make([]int, n+1)
+		for i := range parent {
+			parent[i] = -1
+		}
+		parent[s] = s
+		for len(q) > 0 && parent[t] == -1 {
+			v := q[0]
+			q = q[1:]
+			for i, e := range g[v] {
+				if e.cap > 0 && parent[e.to] == -1 {
+					parent[e.to] = v
+					pe[e.to] = i
+					q = append(q, e.to)
+					if e.to == t {
+						break
+					}
+				}
+			}
+		}
+		if parent[t] == -1 {
+			break
+		}
+		aug := 1<<31 - 1
+		for v := t; v != s; v = parent[v] {
+			e := &g[parent[v]][pe[v]]
+			if e.cap < aug {
+				aug = e.cap
+			}
+		}
+		for v := t; v != s; v = parent[v] {
+			e := &g[parent[v]][pe[v]]
+			e.cap -= aug
+			rev := e.rev
+			g[v][rev].cap += aug
+		}
+		flow += aug
+	}
+	return flow
+}
+
+func bestSalary(n int, edges []edge) (int, []int) {
+	flows := make([][]int, n+1)
+	for i := range flows {
+		flows[i] = make([]int, n+1)
+	}
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			flows[i][j] = maxFlow(n, edges, i, j)
+			flows[j][i] = flows[i][j]
+		}
+	}
+	perm := make([]int, n)
+	for i := 0; i < n; i++ {
+		perm[i] = i + 1
+	}
+	best := -1
+	bestPerm := make([]int, n)
+	var dfs func(int)
+	dfs = func(idx int) {
+		if idx == n {
+			sum := 0
+			for i := 0; i < n-1; i++ {
+				sum += flows[perm[i]][perm[i+1]]
+			}
+			if sum > best {
+				best = sum
+				copy(bestPerm, perm)
+			}
+			return
+		}
+		for i := idx; i < n; i++ {
+			perm[idx], perm[i] = perm[i], perm[idx]
+			dfs(idx + 1)
+			perm[idx], perm[i] = perm[i], perm[idx]
+		}
+	}
+	dfs(0)
+	return best, bestPerm
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, len(tc.edges))
+	for _, e := range tc.edges {
+		fmt.Fprintf(&sb, "%d %d %d\n", e.u, e.v, e.c)
+	}
+	input := sb.String()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) < 1+tc.n {
+		return fmt.Errorf("not enough output lines")
+	}
+	var salary int
+	if _, err := fmt.Sscan(fields[0], &salary); err != nil {
+		return fmt.Errorf("bad salary: %v", err)
+	}
+	perm := make([]int, tc.n)
+	for i := 0; i < tc.n; i++ {
+		if _, err := fmt.Sscan(fields[i+1], &perm[i]); err != nil {
+			return fmt.Errorf("bad permutation value: %v", err)
+		}
+	}
+	expSalary, _ := bestSalary(tc.n, tc.edges)
+	if salary != expSalary {
+		return fmt.Errorf("expected salary %d got %d", expSalary, salary)
+	}
+	used := make([]bool, tc.n+1)
+	for _, v := range perm {
+		if v < 1 || v > tc.n || used[v] {
+			return fmt.Errorf("invalid permutation")
+		}
+		used[v] = true
+	}
+	return nil
+}
+
+func generateCases(rng *rand.Rand) []testCase {
+	cases := []testCase{}
+	for len(cases) < 100 {
+		n := rng.Intn(5) + 2
+		maxEdges := n * (n - 1) / 2
+		m := rng.Intn(maxEdges-n+1) + n - 1
+		// start with a tree to ensure connectivity
+		edges := make([]edge, 0, m)
+		for i := 2; i <= n; i++ {
+			p := rng.Intn(i-1) + 1
+			c := rng.Intn(10) + 1
+			edges = append(edges, edge{p, i, c})
+		}
+		added := n - 1
+		for added < m {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			exists := false
+			for _, e := range edges {
+				if e.u == u && e.v == v || e.u == v && e.v == u {
+					exists = true
+					break
+				}
+			}
+			if exists {
+				continue
+			}
+			c := rng.Intn(10) + 1
+			edges = append(edges, edge{u, v, c})
+			added++
+		}
+		cases = append(cases, testCase{n, edges})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := generateCases(rng)
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–E of contest 343
- each verifier runs random tests and checks a candidate binary

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687eb3c317948324ae09612f72b14ef5