### PR TITLE
Add verifiers for Codeforces contest 340

### DIFF
--- a/0-999/300-399/340-349/340/verifierA.go
+++ b/0-999/300-399/340-349/340/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func expectedAnswer(x, y, a, b int64) int64 {
+	g := gcd(x, y)
+	lcm := x / g * y
+	if lcm > b {
+		return 0
+	}
+	high := b / lcm
+	low := (a - 1) / lcm
+	return high - low
+}
+
+func generateCase(rng *rand.Rand) (int64, int64, int64, int64) {
+	x := int64(rng.Intn(1000) + 1)
+	y := int64(rng.Intn(1000) + 1)
+	a := rng.Int63n(2_000_000_000) + 1
+	b := rng.Int63n(2_000_000_000) + 1
+	if a > b {
+		a, b = b, a
+	}
+	return x, y, a, b
+}
+
+func runCase(bin string, x, y, a, b int64) error {
+	input := fmt.Sprintf("%d %d %d %d\n", x, y, a, b)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := strconv.FormatInt(expectedAnswer(x, y, a, b), 10)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		x, y, a, b := generateCase(rng)
+		if err := runCase(bin, x, y, a, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %d %d %d\n", i+1, err, x, y, a, b)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/340/verifierB.go
+++ b/0-999/300-399/340-349/340/verifierB.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y float64 }
+
+func cross(a, b, c point) float64 {
+	return (b.x-a.x)*(c.y-a.y) - (b.y-a.y)*(c.x-a.x)
+}
+
+func areaPoly(p []point) float64 {
+	s := 0.0
+	n := len(p)
+	for i := 1; i < n-1; i++ {
+		s += cross(p[0], p[i], p[i+1])
+	}
+	return math.Abs(s) * 0.5
+}
+
+func areaTri(p1, p2, p3 point) float64 {
+	return math.Abs(cross(p1, p2, p3)) * 0.5
+}
+
+func convexHull(pts []point) []point {
+	n := len(pts)
+	if n <= 1 {
+		return append([]point(nil), pts...)
+	}
+	sort.Slice(pts, func(i, j int) bool {
+		if math.Abs(pts[i].y-pts[j].y) > 1e-9 {
+			return pts[i].y < pts[j].y
+		}
+		return pts[i].x < pts[j].x
+	})
+	lower := make([]point, 0, n)
+	for _, p := range pts {
+		for len(lower) >= 2 && cross(lower[len(lower)-2], lower[len(lower)-1], p) <= 0 {
+			lower = lower[:len(lower)-1]
+		}
+		lower = append(lower, p)
+	}
+	upper := make([]point, 0, n)
+	for i := n - 1; i >= 0; i-- {
+		p := pts[i]
+		for len(upper) >= 2 && cross(upper[len(upper)-2], upper[len(upper)-1], p) <= 0 {
+			upper = upper[:len(upper)-1]
+		}
+		upper = append(upper, p)
+	}
+	hull := make([]point, 0, len(lower)+len(upper)-2)
+	hull = append(hull, lower...)
+	if len(upper) > 1 {
+		hull = append(hull, upper[1:len(upper)-1]...)
+	}
+	return hull
+}
+
+func expectedAnswer(n int, pts []point) float64 {
+	hull := convexHull(append([]point(nil), pts...))
+	c := len(hull)
+	baseArea := areaPoly(hull)
+	vis := make([]bool, n)
+	for _, hp := range hull {
+		for i, p := range pts {
+			if math.Abs(p.x-hp.x) < 1e-9 && math.Abs(p.y-hp.y) < 1e-9 {
+				vis[i] = true
+			}
+		}
+	}
+	ans := -1.0
+	if c < 4 {
+		for i, p := range pts {
+			if vis[i] {
+				continue
+			}
+			minA := math.Inf(1)
+			for j := 0; j < c; j++ {
+				k := (j + 1) % c
+				a := areaTri(p, hull[j], hull[k])
+				if a < minA {
+					minA = a
+				}
+			}
+			if baseArea-minA > ans {
+				ans = baseArea - minA
+			}
+		}
+	} else {
+		for i := 0; i < c-3; i++ {
+			for j := i + 1; j < c-2; j++ {
+				for k := j + 1; k < c-1; k++ {
+					for l := k + 1; l < c; l++ {
+						quad := []point{hull[i], hull[j], hull[k], hull[l]}
+						a := areaPoly(quad)
+						if a > ans {
+							ans = a
+						}
+					}
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (int, []point) {
+	n := rng.Intn(10) + 4 // small for runtime
+	pts := make([]point, 0, n)
+	for len(pts) < n {
+		x := float64(rng.Intn(2001) - 1000)
+		y := float64(rng.Intn(2001) - 1000)
+		ok := true
+		for _, p := range pts {
+			if p.x == x && p.y == y {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+		// check no three collinear
+		collinear := false
+		for i := 0; i < len(pts) && !collinear; i++ {
+			for j := i + 1; j < len(pts) && !collinear; j++ {
+				if math.Abs(cross(pts[i], pts[j], point{x, y})) < 1e-9 {
+					collinear = true
+				}
+			}
+		}
+		if collinear {
+			continue
+		}
+		pts = append(pts, point{x, y})
+	}
+	return n, pts
+}
+
+func runCase(bin string, n int, pts []point) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, p := range pts {
+		sb.WriteString(fmt.Sprintf("%.0f %.0f\n", p.x, p.y))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := fmt.Sprintf("%.9f", expectedAnswer(n, pts))
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, pts := generateCase(rng)
+		if err := runCase(bin, n, pts); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/340/verifierC.go
+++ b/0-999/300-399/340-349/340/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func expectedAnswer(a []int64) (int64, int64) {
+	n := len(a)
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	var sumA int64
+	for _, v := range a {
+		sumA += v
+	}
+	var prefix int64
+	var sumPairs int64
+	for i, v := range a {
+		sumPairs += v*int64(i) - prefix
+		prefix += v
+	}
+	num := sumA + 2*sumPairs
+	den := int64(n)
+	g := gcd(num, den)
+	return num / g, den / g
+}
+
+func generateCase(rng *rand.Rand) []int64 {
+	n := rng.Intn(50) + 1
+	vals := make([]int64, 0, n)
+	used := make(map[int64]bool)
+	for len(vals) < n {
+		v := int64(rng.Intn(2000))
+		if !used[v] {
+			used[v] = true
+			vals = append(vals, v)
+		}
+	}
+	return vals
+}
+
+func runCase(bin string, arr []int64) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	num, den := expectedAnswer(append([]int64(nil), arr...))
+	expected := fmt.Sprintf("%d %d", num, den)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := generateCase(rng)
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/340/verifierD.go
+++ b/0-999/300-399/340-349/340/verifierD.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedAnswer(a []int) int {
+	dp := make([]int, 0, len(a))
+	for _, x := range a {
+		i := sort.Search(len(dp), func(i int) bool { return dp[i] >= x })
+		if i == len(dp) {
+			dp = append(dp, x)
+		} else {
+			dp[i] = x
+		}
+	}
+	return len(dp)
+}
+
+func generateCase(rng *rand.Rand) []int {
+	n := rng.Intn(100) + 1
+	perm := rand.Perm(n)
+	for i := range perm {
+		perm[i]++ // 1..n
+	}
+	return perm
+}
+
+func runCase(bin string, arr []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := strconv.Itoa(expectedAnswer(arr))
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := generateCase(rng)
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/340-349/340/verifierE.go
+++ b/0-999/300-399/340-349/340/verifierE.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func modpow(a, e int) int {
+	res := 1
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func expectedAnswer(a []int) int {
+	n := len(a)
+	used := make([]bool, n+1)
+	for _, v := range a {
+		if v != -1 {
+			used[v] = true
+		}
+	}
+	m, k := 0, 0
+	for i := 1; i <= n; i++ {
+		if a[i-1] == -1 {
+			m++
+			if !used[i] {
+				k++
+			}
+		}
+	}
+	fact := make([]int, n+1)
+	invfact := make([]int, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * i % mod
+	}
+	invfact[n] = modpow(fact[n], mod-2)
+	for i := n; i > 0; i-- {
+		invfact[i-1] = invfact[i] * i % mod
+	}
+	ans := 0
+	for i := 0; i <= k; i++ {
+		comb := fact[k] * invfact[i] % mod * invfact[k-i] % mod
+		ways := fact[m-i]
+		term := comb * ways % mod
+		if i%2 == 1 {
+			ans = (ans - term + mod) % mod
+		} else {
+			ans = (ans + term) % mod
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) []int {
+	n := rng.Intn(50) + 2
+	perm := rand.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	arr := make([]int, n)
+	for i, v := range perm {
+		arr[i] = v
+	}
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			arr[i] = -1
+		}
+	}
+	return arr
+}
+
+func runCase(bin string, arr []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := strconv.Itoa(expectedAnswer(arr))
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := generateCase(rng)
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go based verifiers for contest 340
- `verifierA.go` through `verifierE.go` each run 100 random tests
- verifiers compute expected answers directly and compare with the target binary

## Testing
- `go run verifierA.go ./340A`

------
https://chatgpt.com/codex/tasks/task_e_687eb2f0fa508324a0b35256bbc97c57