### PR TITLE
Add verifiers for Codeforces Round 337

### DIFF
--- a/0-999/300-399/330-339/337/verifierA.go
+++ b/0-999/300-399/330-339/337/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func solve(n, m int, puzzles []int) int {
+	sort.Ints(puzzles)
+	ans := puzzles[n-1] - puzzles[0]
+	for i := 1; i+n-1 < m; i++ {
+		diff := puzzles[i+n-1] - puzzles[i]
+		if diff < ans {
+			ans = diff
+		}
+	}
+	return ans
+}
+
+func generateTest(rng *rand.Rand) (string, int) {
+	m := rng.Intn(49) + 2  // 2..50
+	n := rng.Intn(m-1) + 2 // 2..m
+	puzzles := make([]int, m)
+	for i := range puzzles {
+		puzzles[i] = rng.Intn(997) + 4 // 4..1000
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i, v := range puzzles {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	expected := solve(n, m, puzzles)
+	return sb.String(), expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	const tests = 100
+	for t := 1; t <= tests; t++ {
+		inp, want := generateTest(rng)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(inp)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: runtime error: %v\n%s", t, err, out.String())
+			os.Exit(1)
+		}
+		gotStr := strings.TrimSpace(out.String())
+		var got int
+		if _, err := fmt.Sscan(gotStr, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: failed to parse output: %v\nOutput: %s\n", t, err, gotStr)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %d\nGot: %d\n", t, inp, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/330-339/337/verifierB.go
+++ b/0-999/300-399/330-339/337/verifierB.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solve(a, b, c, d int) (int, int) {
+	t1 := a * d
+	t2 := b * c
+	var p, q int
+	if t1 <= t2 {
+		p = b*c - a*d
+		q = b * c
+	} else {
+		p = a*d - b*c
+		q = a * d
+	}
+	if p == 0 {
+		return 0, 1
+	}
+	g := gcd(p, q)
+	return p / g, q / g
+}
+
+func generateTest(rng *rand.Rand) (string, string) {
+	a := rng.Intn(1000) + 1
+	b := rng.Intn(1000) + 1
+	c := rng.Intn(1000) + 1
+	d := rng.Intn(1000) + 1
+	p, q := solve(a, b, c, d)
+	inp := fmt.Sprintf("%d %d %d %d\n", a, b, c, d)
+	return inp, fmt.Sprintf("%d/%d", p, q)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	const tests = 100
+	for t := 1; t <= tests; t++ {
+		inp, want := generateTest(rng)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(inp)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: runtime error: %v\n%s", t, err, out.String())
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", t, inp, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/330-339/337/verifierC.go
+++ b/0-999/300-399/330-339/337/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const MOD int64 = 1000000009
+
+func modPow(x, e int64) int64 {
+	res := int64(1)
+	x %= MOD
+	for e > 0 {
+		if e&1 == 1 {
+			res = (res * x) % MOD
+		}
+		x = (x * x) % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func solve(n, m, k int64) int64 {
+	w := n - m
+	safeCap := (w + 1) * (k - 1)
+	if m <= safeCap {
+		return m % MOD
+	}
+	t := m - safeCap
+	b := (t + k - 1) / k
+	pow2b := modPow(2, b)
+	blocksScore := (2 * k) % MOD * ((pow2b - 1 + MOD) % MOD) % MOD
+	rem := (m - b*k) % MOD
+	if rem < 0 {
+		rem += MOD
+	}
+	ans := (blocksScore + rem) % MOD
+	return ans
+}
+
+func generateTest(rng *rand.Rand) (string, int64) {
+	n := int64(rng.Intn(1000000) + 2)
+	k := int64(rng.Intn(int(n-1)) + 2)
+	m := int64(rng.Intn(int(n + 1)))
+	inp := fmt.Sprintf("%d %d %d\n", n, m, k)
+	return inp, solve(n, m, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	const tests = 100
+	for t := 1; t <= tests; t++ {
+		inp, want := generateTest(rng)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(inp)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: runtime error: %v\n%s", t, err, out.String())
+			os.Exit(1)
+		}
+		gotStr := strings.TrimSpace(out.String())
+		var got int64
+		if _, err := fmt.Sscan(gotStr, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: failed to parse output: %v\nOutput: %s\n", t, err, gotStr)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %d\nGot: %d\n", t, inp, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/330-339/337/verifierD.go
+++ b/0-999/300-399/330-339/337/verifierD.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func bfs(n int, g [][]int, start int) []int {
+	dist := make([]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = -1
+	}
+	q := make([]int, 0, n)
+	q = append(q, start)
+	dist[start] = 0
+	for head := 0; head < len(q); head++ {
+		u := q[head]
+		for _, v := range g[u] {
+			if dist[v] == -1 {
+				dist[v] = dist[u] + 1
+				q = append(q, v)
+			}
+		}
+	}
+	return dist
+}
+
+func solve(n, m, d int, p []int, edges [][2]int) int {
+	g := make([][]int, n)
+	for _, e := range edges {
+		u := e[0]
+		v := e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	d0 := bfs(n, g, p[0])
+	a := p[0]
+	for _, x := range p {
+		if d0[x] > d0[a] {
+			a = x
+		}
+	}
+	da := bfs(n, g, a)
+	b := p[0]
+	for _, x := range p {
+		if da[x] > da[b] {
+			b = x
+		}
+	}
+	db := bfs(n, g, b)
+	cnt := 0
+	for i := 0; i < n; i++ {
+		if da[i] <= d && db[i] <= d {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func generateTest(rng *rand.Rand) (string, int) {
+	n := rng.Intn(50) + 1
+	m := rng.Intn(n) + 1
+	d := rng.Intn(n)
+	p := make([]int, m)
+	perm := rng.Perm(n)
+	for i := 0; i < m; i++ {
+		p[i] = perm[i]
+	}
+	edges := make([][2]int, n-1)
+	for i := 1; i < n; i++ {
+		parent := rng.Intn(i)
+		edges[i-1] = [2]int{parent, i}
+	}
+	inp := fmt.Sprintf("%d %d %d\n", n, m, d)
+	for i, x := range p {
+		if i > 0 {
+			inp += " "
+		}
+		inp += fmt.Sprintf("%d", x+1)
+	}
+	inp += "\n"
+	for _, e := range edges {
+		inp += fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1)
+	}
+	ans := solve(n, m, d, p, edges)
+	return inp, ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	const tests = 100
+	for t := 1; t <= tests; t++ {
+		inp, want := generateTest(rng)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(inp)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: runtime error: %v\n%s", t, err, out.String())
+			os.Exit(1)
+		}
+		gotStr := strings.TrimSpace(out.String())
+		var got int
+		if _, err := fmt.Sscan(gotStr, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: failed to parse output: %v\nOutput: %s\n", t, err, gotStr)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %d\nGot: %d\n", t, inp, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/330-339/337/verifierE.go
+++ b/0-999/300-399/330-339/337/verifierE.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func mulMod(a, b, mod uint64) uint64 {
+	res := new(big.Int).Mul(new(big.Int).SetUint64(a), new(big.Int).SetUint64(b))
+	res.Mod(res, new(big.Int).SetUint64(mod))
+	return res.Uint64()
+}
+
+func powMod(a, d, mod uint64) uint64 {
+	res := uint64(1)
+	for d > 0 {
+		if d&1 == 1 {
+			res = mulMod(res, a, mod)
+		}
+		a = mulMod(a, a, mod)
+		d >>= 1
+	}
+	return res
+}
+
+func isPrime(n uint64) bool {
+	if n < 2 {
+		return false
+	}
+	small := []uint64{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37}
+	for _, p := range small {
+		if n%p == 0 {
+			return n == p
+		}
+	}
+	d := n - 1
+	s := 0
+	for d&1 == 0 {
+		d >>= 1
+		s++
+	}
+	bases := []uint64{2, 325, 9375, 28178, 450775, 9780504, 1795265022}
+	for _, a := range bases {
+		if a%n == 0 {
+			continue
+		}
+		x := powMod(a%n, d, n)
+		if x == 1 || x == n-1 {
+			continue
+		}
+		skip := false
+		for r := 1; r < s; r++ {
+			x = mulMod(x, x, n)
+			if x == n-1 {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func gcd(a, b uint64) uint64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func pollardsRho(n uint64) uint64 {
+	if n%2 == 0 {
+		return 2
+	}
+	if n%3 == 0 {
+		return 3
+	}
+	for {
+		c := uint64(rand.Int63n(int64(n-1))) + 1
+		x := uint64(rand.Int63n(int64(n)))
+		y := x
+		d := uint64(1)
+		for d == 1 {
+			x = (mulMod(x, x, n) + c) % n
+			y = (mulMod(y, y, n) + c) % n
+			y = (mulMod(y, y, n) + c) % n
+			if x > y {
+				d = gcd(x-y, n)
+			} else {
+				d = gcd(y-x, n)
+			}
+			if d == n {
+				break
+			}
+		}
+		if d > 1 && d < n {
+			return d
+		}
+	}
+}
+
+func factor(n uint64, res *[]uint64) {
+	if n == 1 {
+		return
+	}
+	if isPrime(n) {
+		*res = append(*res, n)
+		return
+	}
+	d := pollardsRho(n)
+	factor(d, res)
+	factor(n/d, res)
+}
+
+func solve(a []uint64) int {
+	n := len(a)
+	omega := make([]int, n)
+	for i := 0; i < n; i++ {
+		var fs []uint64
+		factor(a[i], &fs)
+		omega[i] = len(fs)
+	}
+	isChildable := make([]bool, n)
+	for j := 0; j < n; j++ {
+		for i := 0; i < n; i++ {
+			if i != j && a[i]%a[j] == 0 {
+				isChildable[j] = true
+				break
+			}
+		}
+	}
+	B := make([]int, 0, n)
+	unCount := 0
+	for i := 0; i < n; i++ {
+		if isChildable[i] {
+			B = append(B, i)
+		} else {
+			unCount++
+		}
+	}
+	sumOmegaComp := 0
+	for i := 0; i < n; i++ {
+		if omega[i] > 1 {
+			sumOmegaComp += omega[i]
+		}
+	}
+	best := int(1e18)
+	m := len(B)
+	for mask := 0; mask < (1 << m); mask++ {
+		sumSel := 0
+		bits := 0
+		for k := 0; k < m; k++ {
+			if mask&(1<<k) != 0 {
+				sumSel += omega[B[k]]
+				bits++
+			}
+		}
+		roots := unCount + (m - bits)
+		penalty := 0
+		if roots > 1 {
+			penalty = 1
+		}
+		total := n + sumOmegaComp - sumSel + penalty
+		if total < best {
+			best = total
+		}
+	}
+	return best
+}
+
+func generateTest(rng *rand.Rand) (string, int) {
+	n := rng.Intn(8) + 1
+	a := make([]uint64, n)
+	for i := 0; i < n; i++ {
+		a[i] = uint64(rng.Intn(1000000) + 2)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	ans := solve(a)
+	return sb.String(), ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	rand.Seed(time.Now().UnixNano())
+	const tests = 100
+	for t := 1; t <= tests; t++ {
+		inp, want := generateTest(rng)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(inp)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: runtime error: %v\n%s", t, err, out.String())
+			os.Exit(1)
+		}
+		gotStr := strings.TrimSpace(out.String())
+		var got int
+		if _, err := fmt.Sscan(gotStr, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: failed to parse output: %v\nOutput: %s\n", t, err, gotStr)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %d\nGot: %d\n", t, inp, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- added Go verification programs for contest 337 problems A–E
- each verifier generates 100 random test cases and checks a provided binary

## Testing
- `go run verifierA.go ./337A` → `All tests passed`
- `go run verifierE.go ./337E` → `All tests passed`


------
https://chatgpt.com/codex/tasks/task_e_687eb21ee244832484a5ca323cdef81b