### PR TITLE
Add Go verifiers for contest 336

### DIFF
--- a/0-999/300-399/330-339/336/verifierA.go
+++ b/0-999/300-399/330-339/336/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswerA(x, y int64) string {
+	L := abs64(x) + abs64(y)
+	x1 := L
+	if x <= 0 {
+		x1 = -L
+	}
+	y1 := int64(0)
+	x2 := int64(0)
+	y2 := L
+	if y <= 0 {
+		y2 = -L
+	}
+	if x1 >= x2 {
+		x1, x2 = x2, x1
+		y1, y2 = y2, y1
+	}
+	return fmt.Sprintf("%d %d %d %d", x1, y1, x2, y2)
+}
+
+func abs64(a int64) int64 {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func generateCaseA(rng *rand.Rand) (int64, int64) {
+	x := rng.Int63n(2001) - 1000
+	for x == 0 {
+		x = rng.Int63n(2001) - 1000
+	}
+	y := rng.Int63n(2001) - 1000
+	for y == 0 {
+		y = rng.Int63n(2001) - 1000
+	}
+	return x, y
+}
+
+func runCaseA(bin string, x, y int64) error {
+	input := fmt.Sprintf("%d %d\n", x, y)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedAnswerA(x, y)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		x, y := generateCaseA(rng)
+		if err := runCaseA(bin, x, y); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %d\n", i+1, err, x, y)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/330-339/336/verifierB.go
+++ b/0-999/300-399/330-339/336/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func clc(q, r float64) float64 {
+	if q < 1.0 {
+		return 0.0
+	}
+	q1 := math.Min(1.0, q)
+	base := math.Sqrt(r*r + r*r)
+	rs := base*q1 + q1*q1*r
+	q -= q1
+	return rs + base*q*2.0 + q*q*r
+}
+
+func expectedAnswerB(m, R int) float64 {
+	n := float64(m)
+	r := float64(R)
+	rs := 0.0
+	for i := 1; i <= m; i++ {
+		rs += r + r
+		q1 := float64(i - 1)
+		rs += r*q1 + clc(q1, r)
+		q2 := n - float64(i)
+		rs += r*q2 + clc(q2, r)
+	}
+	rs /= n * n
+	return rs
+}
+
+func generateCaseB(rng *rand.Rand) (int, int) {
+	m := rng.Intn(8) + 1
+	R := rng.Intn(10) + 1
+	return m, R
+}
+
+func runCaseB(bin string, m, R int) error {
+	input := fmt.Sprintf("%d %d\n", m, R)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseFloat(gotStr, 64)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expected := expectedAnswerB(m, R)
+	if math.Abs(got-expected) > 1e-6 {
+		return fmt.Errorf("expected %.6f got %s", expected, gotStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		m, R := generateCaseB(rng)
+		if err := runCaseB(bin, m, R); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %d\n", i+1, err, m, R)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/330-339/336/verifierC.go
+++ b/0-999/300-399/330-339/336/verifierC.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedAnswerC(arr []int64) []int64 {
+	for j := 31; j >= 0; j-- {
+		var subset []int64
+		for _, v := range arr {
+			if (v>>uint(j))&1 == 1 {
+				subset = append(subset, v)
+			}
+		}
+		if len(subset) == 0 {
+			continue
+		}
+		common := subset[0]
+		for k := 1; k < len(subset); k++ {
+			common &= subset[k]
+		}
+		tz := 0
+		for common&1 == 0 {
+			tz++
+			common >>= 1
+		}
+		if tz == j {
+			return subset
+		}
+	}
+	return []int64{arr[0]}
+}
+
+func generateCaseC(rng *rand.Rand) []int64 {
+	n := rng.Intn(8) + 1
+	nums := make([]int64, n)
+	cur := int64(0)
+	for i := 0; i < n; i++ {
+		cur += int64(rng.Intn(20) + 1)
+		nums[i] = cur
+	}
+	return nums
+}
+
+func runCaseC(bin string, arr []int64) error {
+	input := fmt.Sprintf("%d\n", len(arr))
+	for i, v := range arr {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprint(v)
+	}
+	input += "\n"
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) < 1 {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("bad k: %v", err)
+	}
+	if k != len(fields)-1 {
+		return fmt.Errorf("expected %d numbers got %d", k, len(fields)-1)
+	}
+	expected := expectedAnswerC(arr)
+	if k != len(expected) {
+		return fmt.Errorf("expected length %d got %d", len(expected), k)
+	}
+	for i := 0; i < k; i++ {
+		val, err := strconv.ParseInt(fields[i+1], 10, 64)
+		if err != nil {
+			return fmt.Errorf("bad number: %v", err)
+		}
+		if val != expected[i] {
+			return fmt.Errorf("expected %v got %v", expected, fields[1:])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := generateCaseC(rng)
+		if err := runCaseC(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%v\n", i+1, err, arr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/330-339/336/verifierD.go
+++ b/0-999/300-399/330-339/336/verifierD.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const modD = 1000000007
+
+func modpow(a, e int64) int64 {
+	res := int64(1)
+	a %= modD
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % modD
+		}
+		a = a * a % modD
+		e >>= 1
+	}
+	return res
+}
+
+func expectedAnswerD(n, m, g int) int64 {
+	if m == 0 {
+		B := 0
+		if n%2 == 0 {
+			B = 1
+		}
+		if g == 1 {
+			return int64(B)
+		}
+		return int64((1 - B + modD) % modD)
+	}
+	N := n + m
+	fact := make([]int64, N+1)
+	invfact := make([]int64, N+1)
+	fact[0] = 1
+	for i := 1; i <= N; i++ {
+		fact[i] = fact[i-1] * int64(i) % modD
+	}
+	invfact[N] = modpow(fact[N], modD-2)
+	for i := N; i >= 1; i-- {
+		invfact[i-1] = invfact[i] * int64(i) % modD
+	}
+	comb := func(a, b int) int64 {
+		if b < 0 || b > a {
+			return 0
+		}
+		return fact[a] * invfact[b] % modD * invfact[a-b] % modD
+	}
+	B := make([]int64, n+1)
+	if m == 1 {
+		B[0] = 1
+	} else {
+		B[0] = 0
+	}
+	if n >= 1 {
+		if m >= 2 {
+			B[1] = 1
+		} else {
+			B[1] = 0
+		}
+	}
+	for i := 2; i <= n; i++ {
+		B[i] = (comb(i+m-2, i-1) + B[i-2]) % modD
+	}
+	total := comb(n+m, n)
+	Bn := B[n]
+	if g == 1 {
+		return Bn
+	}
+	return (total - Bn + modD) % modD
+}
+
+func generateCaseD(rng *rand.Rand) (int, int, int) {
+	n := rng.Intn(6)
+	m := rng.Intn(6)
+	g := rng.Intn(2)
+	if n+m == 0 {
+		n = 1
+	}
+	return n, m, g
+}
+
+func runCaseD(bin string, n, m, g int) error {
+	input := fmt.Sprintf("%d %d %d\n", n, m, g)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(gotStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expected := expectedAnswerD(n, m, g)
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, g := generateCaseD(rng)
+		if err := runCaseD(bin, n, m, g); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %d %d\n", i+1, err, n, m, g)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/330-339/336/verifierE.go
+++ b/0-999/300-399/330-339/336/verifierE.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const modE = 1000000007
+
+func modPowE(a, e int64) int64 {
+	res := int64(1)
+	a %= modE
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % modE
+		}
+		a = a * a % modE
+		e >>= 1
+	}
+	return res
+}
+
+func expectedAnswerE(n, k int64) int64 {
+	if n == 0 {
+		if k == 0 {
+			return 1
+		}
+		return 0
+	}
+	if k > 4 {
+		return 0
+	}
+	perm4 := int64(1)
+	for i := int64(0); i < k; i++ {
+		perm4 = perm4 * (4 - i) % modE
+	}
+	pw := modPowE(n+1, k)
+	return perm4 * pw % modE
+}
+
+func generateCaseE(rng *rand.Rand) (int64, int64) {
+	n := int64(rng.Intn(10))
+	k := int64(rng.Intn(6))
+	return n, k
+}
+
+func runCaseE(bin string, n, k int64) error {
+	input := fmt.Sprintf("%d %d\n", n, k)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(gotStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expected := expectedAnswerE(n, k)
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k := generateCaseE(rng)
+		if err := runCaseE(bin, n, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %d\n", i+1, err, n, k)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go`..`verifierE.go` for contest 336
- each verifier generates 100 random test cases and checks a given binary
- verifiers use same algorithms as the Go solutions

## Testing
- `go run 0-999/300-399/330-339/336/verifierA.go /tmp/336A`
- `go run 0-999/300-399/330-339/336/verifierB.go /tmp/336B`
- `go run 0-999/300-399/330-339/336/verifierC.go /tmp/336C`
- `go run 0-999/300-399/330-339/336/verifierD.go /tmp/336D`
- `go run 0-999/300-399/330-339/336/verifierE.go /tmp/336E`


------
https://chatgpt.com/codex/tasks/task_e_687eb1d90ebc832490687d8cc5b1c195