### PR TITLE
Add solution verifiers for Codeforces contest 333

### DIFF
--- a/0-999/300-399/330-339/333/verifierA.go
+++ b/0-999/300-399/330-339/333/verifierA.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n uint64
+}
+
+func expected(n uint64) uint64 {
+	m := n
+	var p uint64
+	for m%3 == 0 {
+		m /= 3
+		p++
+	}
+	denom := uint64(1)
+	for i := uint64(0); i <= p; i++ {
+		denom *= 3
+	}
+	return (n + denom - 1) / denom
+}
+
+func runCase(bin string, n uint64) error {
+	input := fmt.Sprintf("%d\n", n)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got uint64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	exp := expected(n)
+	if got != exp {
+		return fmt.Errorf("for n=%d expected %d got %d", n, exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []uint64{1, 2, 3, 4, 27, 28, 81}
+	for i := 0; i < 100; i++ {
+		v := uint64(rng.Int63n(1e12) + 1)
+		cases = append(cases, v)
+	}
+
+	for i, n := range cases {
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/330-339/333/verifierB.go
+++ b/0-999/300-399/330-339/333/verifierB.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type cell struct{ x, y int }
+
+func solve(n int, banned []cell) int {
+	bannedRow := make([]bool, n+1)
+	bannedCol := make([]bool, n+1)
+	for _, c := range banned {
+		bannedRow[c.x] = true
+		bannedCol[c.y] = true
+	}
+	rowClear := make([]bool, n+1)
+	colClear := make([]bool, n+1)
+	for i := 2; i <= n-1; i++ {
+		rowClear[i] = !bannedRow[i]
+		colClear[i] = !bannedCol[i]
+	}
+	total := 0
+	seen := make([]bool, n+1)
+	for c := 2; c <= n-1; c++ {
+		if seen[c] {
+			continue
+		}
+		p := n + 1 - c
+		seen[c] = true
+		if p >= 2 && p <= n-1 {
+			seen[p] = true
+		}
+		type node struct {
+			kind byte
+			idx  int
+		}
+		var nodes []node
+		if colClear[c] {
+			nodes = append(nodes, node{'T', c}, node{'B', c})
+		}
+		if rowClear[c] {
+			nodes = append(nodes, node{'L', c}, node{'R', c})
+		}
+		if p != c && p >= 2 && p <= n-1 {
+			if colClear[p] {
+				nodes = append(nodes, node{'T', p}, node{'B', p})
+			}
+			if rowClear[p] {
+				nodes = append(nodes, node{'L', p}, node{'R', p})
+			}
+		}
+		K := len(nodes)
+		if K == 0 {
+			continue
+		}
+		conflict := make([][]bool, K)
+		for i := range conflict {
+			conflict[i] = make([]bool, K)
+		}
+		for i := 0; i < K; i++ {
+			for j := i + 1; j < K; j++ {
+				a, b := nodes[i], nodes[j]
+				c1, c2 := a.idx, b.idx
+				f := false
+				if (a.kind == 'T' || a.kind == 'B') && (b.kind == 'T' || b.kind == 'B') && c1 == c2 {
+					f = true
+				}
+				if (a.kind == 'L' || a.kind == 'R') && (b.kind == 'L' || b.kind == 'R') && c1 == c2 {
+					f = true
+				}
+				if (a.kind == 'T' || a.kind == 'B') && (b.kind == 'L' || b.kind == 'R') {
+					if a.kind == 'T' && b.kind == 'L' && c1 == c2 {
+						f = true
+					}
+					if a.kind == 'B' && b.kind == 'R' && c1 == c2 {
+						f = true
+					}
+					if a.kind == 'T' && b.kind == 'R' && c1+c2 == n+1 {
+						f = true
+					}
+					if a.kind == 'B' && b.kind == 'L' && c1+c2 == n+1 {
+						f = true
+					}
+				}
+				if !f && (a.kind == 'L' || a.kind == 'R') && (b.kind == 'T' || b.kind == 'B') {
+					if b.kind == 'T' && a.kind == 'L' && c1 == c2 {
+						f = true
+					}
+					if b.kind == 'B' && a.kind == 'R' && c1 == c2 {
+						f = true
+					}
+					if b.kind == 'T' && a.kind == 'R' && c1+c2 == n+1 {
+						f = true
+					}
+					if b.kind == 'B' && a.kind == 'L' && c1+c2 == n+1 {
+						f = true
+					}
+				}
+				conflict[i][j] = f
+				conflict[j][i] = f
+			}
+		}
+		best := 0
+		for mask := 0; mask < (1 << K); mask++ {
+			cnt := bitsOn(mask)
+			if cnt <= best {
+				continue
+			}
+			ok := true
+			for i := 0; i < K && ok; i++ {
+				if mask&(1<<i) == 0 {
+					continue
+				}
+				for j := i + 1; j < K; j++ {
+					if mask&(1<<j) != 0 && conflict[i][j] {
+						ok = false
+						break
+					}
+				}
+			}
+			if ok {
+				best = cnt
+			}
+		}
+		total += best
+	}
+	return total
+}
+
+func bitsOn(x int) int {
+	cnt := 0
+	for x > 0 {
+		cnt += x & 1
+		x >>= 1
+	}
+	return cnt
+}
+
+func runCase(bin string, n int, banned []cell) error {
+	input := fmt.Sprintf("%d %d\n", n, len(banned))
+	for _, c := range banned {
+		input += fmt.Sprintf("%d %d\n", c.x, c.y)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(bytes.NewReader(out.Bytes()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solve(n, banned)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (int, []cell) {
+	n := rng.Intn(8) + 2 // 2..9
+	m := rng.Intn(n)
+	used := make(map[cell]struct{})
+	banned := make([]cell, 0, m)
+	for len(banned) < m {
+		c := cell{rng.Intn(n) + 1, rng.Intn(n) + 1}
+		if _, ok := used[c]; ok {
+			continue
+		}
+		used[c] = struct{}{}
+		banned = append(banned, c)
+	}
+	return n, banned
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []struct {
+		n int
+		b []cell
+	}{{2, nil}, {3, []cell{{2, 2}}}}
+	for i := 0; i < 100; i++ {
+		n, b := genCase(rng)
+		cases = append(cases, struct {
+			n int
+			b []cell
+		}{n, b})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc.n, tc.b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/330-339/333/verifierC.go
+++ b/0-999/300-399/330-339/333/verifierC.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isKLucky(ticket string, k int) bool {
+	if len(ticket) != 8 {
+		return false
+	}
+	digits := make([]int, 8)
+	for i := 0; i < 8; i++ {
+		if ticket[i] < '0' || ticket[i] > '9' {
+			return false
+		}
+		digits[i] = int(ticket[i] - '0')
+	}
+	dp := make([][]map[int]struct{}, 9)
+	for i := range dp {
+		dp[i] = make([]map[int]struct{}, 9)
+	}
+	for i := 0; i < 8; i++ {
+		dp[i][i+1] = map[int]struct{}{digits[i]: {}}
+	}
+	for length := 2; length <= 8; length++ {
+		for l := 0; l+length <= 8; l++ {
+			r := l + length
+			m := make(map[int]struct{})
+			for mid := l + 1; mid < r; mid++ {
+				left := dp[l][mid]
+				right := dp[mid][r]
+				for a := range left {
+					for b := range right {
+						m[a+b] = struct{}{}
+						m[a-b] = struct{}{}
+						m[a*b] = struct{}{}
+					}
+				}
+			}
+			dp[l][r] = m
+		}
+	}
+	_, ok := dp[0][8][k]
+	return ok
+}
+
+func runCase(bin string, k, m int) error {
+	input := fmt.Sprintf("%d %d\n", k, m)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != m {
+		return fmt.Errorf("expected %d lines, got %d", m, len(lines))
+	}
+	seen := make(map[string]struct{})
+	for _, line := range lines {
+		t := strings.TrimSpace(line)
+		if _, ok := seen[t]; ok {
+			return fmt.Errorf("duplicate ticket %s", t)
+		}
+		seen[t] = struct{}{}
+		if !isKLucky(t, k) {
+			return fmt.Errorf("ticket %s is not %d-lucky", t, k)
+		}
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (int, int) {
+	k := rng.Intn(1000)
+	m := rng.Intn(3) + 1
+	return k, m
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := [][2]int{{0, 1}, {1, 1}}
+	for i := 0; i < 100; i++ {
+		k, m := genCase(rng)
+		cases = append(cases, [2]int{k, m})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc[0], tc[1]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/330-339/333/verifierD.go
+++ b/0-999/300-399/330-339/333/verifierD.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n, m int, grid [][]int) int {
+	lo, hi := 0, int(1e9)
+	rows := make([][]uint64, n)
+	W := (m + 63) >> 6
+	for i := range rows {
+		rows[i] = make([]uint64, W)
+	}
+	check := func(x int) bool {
+		good := make([]int, 0, n)
+		for i := 0; i < n; i++ {
+			cnt := 0
+			for j := 0; j < m; j++ {
+				if grid[i][j] >= x {
+					w := j >> 6
+					b := uint(j & 63)
+					rows[i][w] |= 1 << b
+					cnt++
+				}
+			}
+			if cnt >= 2 {
+				good = append(good, i)
+			}
+		}
+		if len(good) < 2 {
+			for i := 0; i < n; i++ {
+				for k := range rows[i] {
+					rows[i][k] = 0
+				}
+			}
+			return false
+		}
+		for ii := 0; ii < len(good); ii++ {
+			i := good[ii]
+			for jj := ii + 1; jj < len(good); jj++ {
+				k := good[jj]
+				found := 0
+				for w := 0; w < W; w++ {
+					common := rows[i][w] & rows[k][w]
+					if common == 0 {
+						continue
+					}
+					found += bitsOn64(common)
+					if found >= 2 {
+						for t := 0; t < n; t++ {
+							for u := range rows[t] {
+								rows[t][u] = 0
+							}
+						}
+						return true
+					}
+				}
+			}
+		}
+		for i := 0; i < n; i++ {
+			for k := range rows[i] {
+				rows[i][k] = 0
+			}
+		}
+		return false
+	}
+	for lo < hi {
+		mid := (lo + hi + 1) >> 1
+		if check(mid) {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return lo
+}
+
+func bitsOn64(x uint64) int { return int(strings.Count(fmt.Sprintf("%b", x), "1")) }
+
+func runCase(bin string, n, m int, grid [][]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			sb.WriteString(fmt.Sprintf("%d ", grid[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(bytes.NewReader(out.Bytes()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solve(n, m, grid)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (int, int, [][]int) {
+	n := rng.Intn(5) + 2
+	m := rng.Intn(5) + 2
+	grid := make([][]int, n)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			grid[i][j] = rng.Intn(100)
+		}
+	}
+	return n, m, grid
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []struct {
+		n, m int
+		g    [][]int
+	}
+	g1 := [][]int{{1, 2}, {3, 4}}
+	cases = append(cases, struct {
+		n, m int
+		g    [][]int
+	}{2, 2, g1})
+	for i := 0; i < 100; i++ {
+		n, m, g := genCase(rng)
+		cases = append(cases, struct {
+			n, m int
+			g    [][]int
+		}{n, m, g})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc.n, tc.m, tc.g); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/330-339/333/verifierE.go
+++ b/0-999/300-399/330-339/333/verifierE.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	d    int
+	u, v int
+}
+
+func solve(n int, xs, ys []int) float64 {
+	tot := n * (n - 1) / 2
+	edges := make([]edge, 0, tot)
+	for i := 0; i < n; i++ {
+		for j := 0; j < i; j++ {
+			dx := xs[i] - xs[j]
+			dy := ys[i] - ys[j]
+			d2 := dx*dx + dy*dy
+			edges = append(edges, edge{d: d2, u: i, v: j})
+		}
+	}
+	sort.Slice(edges, func(i, j int) bool { return edges[i].d > edges[j].d })
+	g := (n + 63) / 64
+	bits := make([][]uint64, n)
+	for i := range bits {
+		bits[i] = make([]uint64, g)
+	}
+	for _, e := range edges {
+		u, v := e.u, e.v
+		for k := 0; k < g; k++ {
+			if bits[u][k]&bits[v][k] != 0 {
+				return math.Sqrt(float64(e.d)) / 2.0
+			}
+		}
+		bits[u][v>>6] |= 1 << (uint(v) & 63)
+		bits[v][u>>6] |= 1 << (uint(u) & 63)
+	}
+	return 0.0
+}
+
+func runCase(bin string, n int, xs, ys []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", xs[i], ys[i]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(bytes.NewReader(out.Bytes()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solve(n, xs, ys)
+	if math.Abs(got-exp) > 1e-6 {
+		return fmt.Errorf("expected %.6f got %.6f", exp, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (int, []int, []int) {
+	n := rng.Intn(6) + 3
+	xs := make([]int, n)
+	ys := make([]int, n)
+	used := make(map[[2]int]struct{})
+	for i := 0; i < n; i++ {
+		for {
+			x := rng.Intn(21) - 10
+			y := rng.Intn(21) - 10
+			p := [2]int{x, y}
+			if _, ok := used[p]; !ok {
+				used[p] = struct{}{}
+				xs[i] = x
+				ys[i] = y
+				break
+			}
+		}
+	}
+	return n, xs, ys
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []struct {
+		n      int
+		xs, ys []int
+	}
+	xs1 := []int{0, 1, 2}
+	ys1 := []int{0, 0, 0}
+	cases = append(cases, struct {
+		n      int
+		xs, ys []int
+	}{3, xs1, ys1})
+	for i := 0; i < 100; i++ {
+		n, xs, ys := genCase(rng)
+		cases = append(cases, struct {
+			n      int
+			xs, ys []int
+		}{n, xs, ys})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc.n, tc.xs, tc.ys); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 333 problems A–E
- each verifier generates over 100 random tests and checks the program output

## Testing
- `go run verifierA.go ./333A`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687eb10690488324936adb11644c0f4d