### PR TITLE
Add Go verifiers for contest 329

### DIFF
--- a/0-999/300-399/320-329/329/verifierA.go
+++ b/0-999/300-399/320-329/329/verifierA.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testA struct {
+	input  string
+	output string
+}
+
+func solveA(n int, grid []string) string {
+	rowAns := make([][2]int, n)
+	okRow := true
+	for i := 0; i < n; i++ {
+		pos := -1
+		for j := 0; j < n; j++ {
+			if grid[i][j] == '.' {
+				pos = j
+				break
+			}
+		}
+		if pos == -1 {
+			okRow = false
+			break
+		}
+		rowAns[i] = [2]int{i + 1, pos + 1}
+	}
+	if okRow {
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", rowAns[i][0], rowAns[i][1])
+		}
+		return strings.TrimSpace(sb.String())
+	}
+	colAns := make([][2]int, n)
+	okCol := true
+	for j := 0; j < n; j++ {
+		pos := -1
+		for i := 0; i < n; i++ {
+			if grid[i][j] == '.' {
+				pos = i
+				break
+			}
+		}
+		if pos == -1 {
+			okCol = false
+			break
+		}
+		colAns[j] = [2]int{pos + 1, j + 1}
+	}
+	if okCol {
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", colAns[i][0], colAns[i][1])
+		}
+		return strings.TrimSpace(sb.String())
+	}
+	return "-1"
+}
+
+func generateCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	grid := make([]string, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		row := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = '.'
+			} else {
+				row[j] = 'E'
+			}
+		}
+		grid[i] = string(row)
+		sb.WriteString(grid[i])
+		sb.WriteByte('\n')
+	}
+	out := solveA(n, grid)
+	return sb.String(), out
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseA(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/329/verifierB.go
+++ b/0-999/300-399/320-329/329/verifierB.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(r, c int, grid []string) string {
+	var si, sj, ei, ej int
+	for i := 0; i < r; i++ {
+		for j := 0; j < c; j++ {
+			ch := grid[i][j]
+			if ch == 'S' {
+				si, sj = i, j
+			} else if ch == 'E' {
+				ei, ej = i, j
+			}
+		}
+	}
+	n := r * c
+	dist := make([]int, n)
+	for i := range dist {
+		dist[i] = -1
+	}
+	idx0 := ei*c + ej
+	dist[idx0] = 0
+	q := list.New()
+	q.PushBack(idx0)
+	dirs := [][2]int{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
+	for q.Len() > 0 {
+		v := q.Remove(q.Front()).(int)
+		x := v / c
+		y := v % c
+		d := dist[v]
+		for _, dir := range dirs {
+			ni := x + dir[0]
+			nj := y + dir[1]
+			if ni < 0 || ni >= r || nj < 0 || nj >= c {
+				continue
+			}
+			ch := grid[ni][nj]
+			if ch == 'T' {
+				continue
+			}
+			idx := ni*c + nj
+			if dist[idx] == -1 {
+				dist[idx] = d + 1
+				q.PushBack(idx)
+			}
+		}
+	}
+	startDist := dist[si*c+sj]
+	total := 0
+	for i := 0; i < r; i++ {
+		for j := 0; j < c; j++ {
+			ch := grid[i][j]
+			if ch >= '0' && ch <= '9' {
+				d := dist[i*c+j]
+				if d != -1 && d <= startDist {
+					total += int(ch - '0')
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+func generateCaseB(rng *rand.Rand) (string, string) {
+	r := rng.Intn(5) + 1
+	c := rng.Intn(5) + 1
+	grid := make([]string, r)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", r, c))
+	si := rng.Intn(r)
+	sj := rng.Intn(c)
+	ei := rng.Intn(r)
+	ej := rng.Intn(c)
+	for ei == si && ej == sj {
+		ei = rng.Intn(r)
+		ej = rng.Intn(c)
+	}
+	for i := 0; i < r; i++ {
+		row := make([]byte, c)
+		for j := 0; j < c; j++ {
+			if i == si && j == sj {
+				row[j] = 'S'
+			} else if i == ei && j == ej {
+				row[j] = 'E'
+			} else {
+				if rng.Intn(4) == 0 {
+					row[j] = byte('0' + rng.Intn(10))
+				} else {
+					row[j] = '.'
+				}
+			}
+		}
+		grid[i] = string(row)
+		sb.WriteString(grid[i])
+		sb.WriteByte('\n')
+	}
+	out := solveB(r, c, grid)
+	return sb.String(), out
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseB(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/329/verifierC.go
+++ b/0-999/300-399/320-329/329/verifierC.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// We reuse the algorithm from 329C.go
+
+func solveC(n, m int, edges [][2]int) string {
+	b := make([][]int, n+1)
+	cl := make([]int, n)
+	leftCnt := make([]int, n+1)
+	bns := make([][2]int, m)
+	ans := make([][2]int, m)
+	for _, e := range edges {
+		u := e[0]
+		v := e[1]
+		b[u] = append(b[u], v)
+		b[v] = append(b[v], u)
+	}
+	for i := 0; i < n; i++ {
+		cl[i] = i + 1
+	}
+	var flagOK bool
+	var f func(x, y, z int) bool
+	f = func(x, y, z int) bool {
+		for _, v := range b[x] {
+			if v == y || v == z {
+				return true
+			}
+		}
+		for _, v := range b[z] {
+			if v == y {
+				return true
+			}
+		}
+		return false
+	}
+	var btrk func(int, int, int, int, int)
+	btrk = func(ln, lm, loc, p, q int) {
+		if loc == lm {
+			flagOK = true
+			return
+		}
+		if p == ln {
+			return
+		}
+		if p == q {
+			btrk(ln, lm, loc, p+1, 0)
+			return
+		}
+		u := cl[p]
+		v := cl[q]
+		if u > 0 && v > 0 && u != v && leftCnt[u] < 2 && leftCnt[v] < 2 {
+			ok := true
+			for _, w := range b[u] {
+				if w == v {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				bns[loc][0] = u
+				bns[loc][1] = v
+				leftCnt[u]++
+				leftCnt[v]++
+				btrk(ln, lm, loc+1, p, q+1)
+				leftCnt[u]--
+				leftCnt[v]--
+				if flagOK {
+					return
+				}
+			}
+		}
+		btrk(ln, lm, loc, p, q+1)
+	}
+	if n <= 7 {
+		btrk(n, m, 0, 0, 0)
+		if !flagOK {
+			return "-1"
+		}
+		var sb strings.Builder
+		for i := 0; i < m; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", bns[i][0], bns[i][1])
+		}
+		return strings.TrimSpace(sb.String())
+	}
+	var i int
+	for i = 0; i < n-7; i += 3 {
+		var jj, kk, ll int
+		found := false
+		for j := 0; j < 7 && !found; j++ {
+			for k := 0; k < j && !found; k++ {
+				for l := 0; l < k; l++ {
+					if !f(cl[n-i-1-j], cl[n-i-1-k], cl[n-i-1-l]) {
+						jj, kk, ll = j, k, l
+						found = true
+						break
+					}
+				}
+			}
+		}
+		ans[i][0] = cl[n-i-1-jj]
+		ans[i][1] = cl[n-i-1-kk]
+		ans[i+1][0] = cl[n-i-1-jj]
+		ans[i+1][1] = cl[n-i-1-ll]
+		ans[i+2][0] = cl[n-i-1-kk]
+		ans[i+2][1] = cl[n-i-1-ll]
+		cl[n-i-1-jj] = 0
+		cl[n-i-1-kk] = 0
+		cl[n-i-1-ll] = 0
+		for t := 0; t < 3; t++ {
+			idx := n - i - 1 - t
+			if cl[idx] != 0 {
+				pos := n - i - 4
+				for pos >= 0 && cl[pos] != 0 {
+					pos--
+				}
+				if pos >= 0 {
+					cl[pos] = cl[idx]
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	if i >= m {
+		for j := 0; j < m; j++ {
+			fmt.Fprintf(&sb, "%d %d\n", ans[j][0], ans[j][1])
+		}
+		return strings.TrimSpace(sb.String())
+	}
+	for j := 0; j < i; j++ {
+		fmt.Fprintf(&sb, "%d %d\n", ans[j][0], ans[j][1])
+	}
+	btrk(n-i, m-i, 0, 0, 0)
+	if !flagOK {
+		return "-1"
+	}
+	for j := 0; j < m-i; j++ {
+		fmt.Fprintf(&sb, "%d %d\n", bns[j][0], bns[j][1])
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCaseC(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(n) + 1
+	deg := make([]int, n+1)
+	edges := make([][2]int, 0, m)
+	used := make(map[[2]int]bool)
+	attempts := 0
+	for len(edges) < m && attempts < 1000 {
+		attempts++
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v || deg[u] >= 2 || deg[v] >= 2 {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		p := [2]int{u, v}
+		if used[p] {
+			continue
+		}
+		used[p] = true
+		deg[u]++
+		deg[v]++
+		edges = append(edges, [2]int{u, v})
+	}
+	m = len(edges)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	out := solveC(n, m, edges)
+	return sb.String(), out
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseC(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/329/verifierD.go
+++ b/0-999/300-399/320-329/329/verifierD.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(n, x int) string {
+	var sb strings.Builder
+	if n == 5 {
+		sb.WriteString(">...v\n")
+		sb.WriteString("v.<..\n")
+		sb.WriteString("..^..\n")
+		sb.WriteString(">....\n")
+		sb.WriteString("..^.<\n")
+		sb.WriteString("1 1")
+		return sb.String()
+	}
+	if n == 3 {
+		sb.WriteString(">vv\n")
+		sb.WriteString("^<.\n")
+		sb.WriteString("^.<\n")
+		sb.WriteString("1 3")
+		return sb.String()
+	}
+	mp := make([][]rune, n)
+	for i := 0; i < n; i++ {
+		mp[i] = make([]rune, n)
+		for j := 0; j < n; j++ {
+			mp[i][j] = '.'
+		}
+	}
+	for i := 0; i < n; i++ {
+		mp[i][0] = '^'
+	}
+	mp[0][0] = '>'
+	for i := 0; i < n; i += 2 {
+		for j := 1; j < n-1; j++ {
+			if j < n/2 || j%2 == 1 {
+				mp[i][j] = '>'
+			}
+		}
+		mp[i][n-1] = 'v'
+	}
+	for i := 1; i < n; i += 2 {
+		for j := n - 1; j > 0; j-- {
+			if (n-j) < n/2 || j%2 == 1 {
+				mp[i][j] = '<'
+			}
+		}
+		mp[i][1] = 'v'
+	}
+	mp[n-1][1] = '<'
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(mp[i]))
+		sb.WriteByte('\n')
+	}
+	sb.WriteString("1 1")
+	return sb.String()
+}
+
+func generateCaseD(rng *rand.Rand) (string, string) {
+	cases := [][2]int{{5, 5}, {3, 2}, {100, 105}}
+	pick := cases[rng.Intn(len(cases))]
+	n, x := pick[0], pick[1]
+	in := fmt.Sprintf("%d %d\n", n, x)
+	out := solveD(n, x)
+	return in, out
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseD(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/329/verifierE.go
+++ b/0-999/300-399/320-329/329/verifierE.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type vec struct{ dx, dy int64 }
+
+func solveE(n int, xs, ys []int64) string {
+	calc := func(order []int) int64 {
+		var best int64
+		for t := 0; t < 2; t++ {
+			seq := make([]int, 0, n)
+			l, r := 0, n-1
+			for i := 0; i < n; i++ {
+				if (i%2 == 0) == (t == 0) {
+					seq = append(seq, order[l])
+					l++
+				} else {
+					seq = append(seq, order[r])
+					r--
+				}
+			}
+			var sum int64
+			for i := 0; i < n; i++ {
+				j := seq[i]
+				k := seq[(i+1)%n]
+				dx := xs[j] - xs[k]
+				if dx < 0 {
+					dx = -dx
+				}
+				dy := ys[j] - ys[k]
+				if dy < 0 {
+					dy = -dy
+				}
+				sum += dx + dy
+			}
+			if sum > best {
+				best = sum
+			}
+		}
+		return best
+	}
+	dirs := []vec{{1, 0}, {0, 1}, {1, 1}, {1, -1}, {-1, 1}, {-1, -1}}
+	idx := make([]int, n)
+	var ans int64
+	for _, v := range dirs {
+		for i := range idx {
+			idx[i] = i
+		}
+		sort.Slice(idx, func(i, j int) bool {
+			return v.dx*xs[idx[i]]+v.dy*ys[idx[i]] < v.dx*xs[idx[j]]+v.dy*ys[idx[j]]
+		})
+		if val := calc(idx); val > ans {
+			ans = val
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCaseE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 3
+	xs := make([]int64, n)
+	ys := make([]int64, n)
+	used := make(map[[2]int64]bool)
+	for i := 0; i < n; i++ {
+		for {
+			x := rng.Int63n(50)
+			y := rng.Int63n(50)
+			if !used[[2]int64{x, y}] {
+				used[[2]int64{x, y}] = true
+				xs[i] = x
+				ys[i] = y
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", xs[i], ys[i]))
+	}
+	out := solveE(n, xs, ys)
+	return sb.String(), out
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseE(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for contest 329
- verifiers A–E produce 100 random tests each and compare the output of a binary with the reference solution

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687eafef62208324966716d1fbcceff6