### PR TITLE
Add verifiers for Codeforces contest 327

### DIFF
--- a/0-999/300-399/320-329/327/verifierA.go
+++ b/0-999/300-399/320-329/327/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(arr []int) int {
+	ones := 0
+	b := make([]int, len(arr))
+	for i, x := range arr {
+		if x == 1 {
+			ones++
+			b[i] = -1
+		} else {
+			b[i] = 1
+		}
+	}
+	best := b[0]
+	curr := b[0]
+	for i := 1; i < len(b); i++ {
+		if curr < 0 {
+			curr = b[i]
+		} else {
+			curr += b[i]
+		}
+		if curr > best {
+			best = curr
+		}
+	}
+	return ones + best
+}
+
+func generateCase(rng *rand.Rand) []int {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(2)
+	}
+	return arr
+}
+
+func runCase(bin string, arr []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := fmt.Sprint(expected(arr))
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := generateCase(rng)
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %v\n", i+1, err, arr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/327/verifierB.go
+++ b/0-999/300-399/320-329/327/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) int {
+	return rng.Intn(20) + 1
+}
+
+func checkSequence(n int, nums []int) error {
+	if len(nums) != n {
+		return fmt.Errorf("expected %d numbers, got %d", n, len(nums))
+	}
+	prev := 0
+	for i, x := range nums {
+		if x < 1 || x > 10000000 {
+			return fmt.Errorf("number out of range: %d", x)
+		}
+		if i > 0 && x <= prev {
+			return fmt.Errorf("sequence not strictly increasing")
+		}
+		prev = x
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if nums[j]%nums[i] == 0 {
+				return fmt.Errorf("%d divides %d", nums[i], nums[j])
+			}
+		}
+	}
+	return nil
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("%d\n", n)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	scanner.Split(bufio.ScanWords)
+	var nums []int
+	for scanner.Scan() {
+		v, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("invalid integer %q", scanner.Text())
+		}
+		nums = append(nums, v)
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if err := checkSequence(n, nums); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := generateCase(rng)
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/327/verifierC.go
+++ b/0-999/300-399/320-329/327/verifierC.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const modC = 1000000007
+
+func modPow(x, e int64) int64 {
+	res := int64(1)
+	x %= modC
+	for e > 0 {
+		if e&1 == 1 {
+			res = (res * x) % modC
+		}
+		x = (x * x) % modC
+		e >>= 1
+	}
+	return res
+}
+
+func modInv(x int64) int64 {
+	return modPow(x, modC-2)
+}
+
+func expectedAnswer(a string, k int64) int64 {
+	m := int64(len(a))
+	var sumP int64
+	var pow2 int64 = 1
+	for i := int64(0); i < m; i++ {
+		c := a[i]
+		if c == '0' || c == '5' {
+			sumP = (sumP + pow2) % modC
+		}
+		pow2 = (pow2 * 2) % modC
+	}
+	twoPowM := pow2
+	var GS int64
+	if twoPowM == 1 {
+		GS = k % modC
+	} else {
+		numerator := (modPow(twoPowM, k) - 1 + modC) % modC
+		denom := (twoPowM - 1 + modC) % modC
+		GS = numerator * modInv(denom) % modC
+	}
+	return GS * sumP % modC
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(6) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('0' + rng.Intn(10))
+	}
+	k := int64(rng.Intn(20) + 1)
+	return string(b), k
+}
+
+func runCase(bin string, a string, k int64) error {
+	input := fmt.Sprintf("%s\n%d\n", a, k)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(gotStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid output %q", gotStr)
+	}
+	expect := expectedAnswer(a, k)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		a, k := generateCase(rng)
+		if err := runCase(bin, a, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/327/verifierD.go
+++ b/0-999/300-399/320-329/327/verifierD.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Point struct{ x, y int }
+type Op struct {
+	opt  byte
+	x, y int
+}
+
+func solve(grid [][]byte, n, m int) []Op {
+	mark := make([][]bool, n+2)
+	vis := make([][]bool, n+2)
+	for i := 0; i < n+2; i++ {
+		mark[i] = make([]bool, m+2)
+		vis[i] = make([]bool, m+2)
+	}
+	ans := make([]Op, 0, n*m*2)
+	stack := make([]Point, 0, n*m)
+	dx := [4]int{0, 0, 1, -1}
+	dy := [4]int{1, -1, 0, 0}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			if mark[i][j] || grid[i][j] == '#' {
+				continue
+			}
+			mark[i][j] = true
+			stack = append(stack, Point{i, j})
+			for len(stack) > 0 {
+				a := stack[len(stack)-1]
+				if vis[a.x][a.y] {
+					stack = stack[:len(stack)-1]
+					if len(stack) > 0 {
+						ans = append(ans, Op{'D', a.x, a.y})
+						ans = append(ans, Op{'R', a.x, a.y})
+					}
+				} else {
+					vis[a.x][a.y] = true
+					ans = append(ans, Op{'B', a.x, a.y})
+					found := false
+					for p := 0; p < 4; p++ {
+						x := a.x + dx[p]
+						y := a.y + dy[p]
+						if x < 1 || x > n || y < 1 || y > m || mark[x][y] || grid[x][y] == '#' {
+							continue
+						}
+						mark[x][y] = true
+						stack = append(stack, Point{x, y})
+						found = true
+					}
+					if !found {
+						stack = stack[:len(stack)-1]
+						if len(stack) > 0 {
+							ans[len(ans)-1].opt = 'R'
+						}
+					}
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (int, int, [][]byte) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	grid := make([][]byte, n+1)
+	empty := false
+	for i := 1; i <= n; i++ {
+		row := make([]byte, m+1)
+		for j := 1; j <= m; j++ {
+			if rng.Intn(3) == 0 {
+				row[j] = '#'
+			} else {
+				row[j] = '.'
+				empty = true
+			}
+		}
+		grid[i] = row
+	}
+	if !empty {
+		grid[1][1] = '.'
+	}
+	return n, m, grid
+}
+
+func gridToStrings(grid [][]byte, n, m int) []string {
+	lines := make([]string, n)
+	for i := 1; i <= n; i++ {
+		lines[i-1] = string(grid[i][1 : m+1])
+	}
+	return lines
+}
+
+func runCase(bin string, n, m int, grid [][]byte) error {
+	lines := gridToStrings(grid, n, m)
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d %d\n", n, m)
+	for _, line := range lines {
+		input.WriteString(line)
+		input.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(strings.TrimSpace(scanner.Text()))
+	if err != nil {
+		return fmt.Errorf("bad k line")
+	}
+	var ops []Op
+	for i := 0; i < k; i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("missing op %d", i+1)
+		}
+		f := strings.Fields(scanner.Text())
+		if len(f) != 3 {
+			return fmt.Errorf("bad op line %d", i+1)
+		}
+		opt := f[0][0]
+		x, _ := strconv.Atoi(f[1])
+		y, _ := strconv.Atoi(f[2])
+		ops = append(ops, Op{opt, x, y})
+	}
+	if scanner.Err() != nil {
+		return scanner.Err()
+	}
+	exp := solve(grid, n, m)
+	if len(exp) != len(ops) {
+		return fmt.Errorf("expected %d ops got %d", len(exp), len(ops))
+	}
+	for i := range exp {
+		if exp[i] != ops[i] {
+			return fmt.Errorf("op %d expected %c %d %d got %c %d %d", i+1, exp[i].opt, exp[i].x, exp[i].y, ops[i].opt, ops[i].x, ops[i].y)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, grid := generateCase(rng)
+		if err := runCase(bin, n, m, grid); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/327/verifierE.go
+++ b/0-999/300-399/320-329/327/verifierE.go
@@ -1,0 +1,298 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const modE = 1000000007
+
+func addE(a, b int64) int64 {
+	a += b
+	if a >= modE {
+		a -= modE
+	}
+	return a
+}
+func mulE(a, b int64) int64 { return (a * b) % modE }
+
+func solveE(n int, a []int64, k int, bad []int64) int64 {
+	fac := make([]int64, n+1)
+	fac[0] = 1
+	for i := 1; i <= n; i++ {
+		fac[i] = fac[i-1] * int64(i) % modE
+	}
+	total := fac[n]
+	if k == 0 {
+		return total
+	}
+	n1 := n / 2
+	n2 := n - n1
+	aL := a[:n1]
+	aR := a[n1:]
+	mapL := make(map[int64]map[int]int)
+	for mask := 0; mask < (1 << n1); mask++ {
+		var sum int64
+		sz := bits.OnesCount(uint(mask))
+		for j := 0; j < n1; j++ {
+			if mask&(1<<j) != 0 {
+				sum += aL[j]
+			}
+		}
+		msz, ok := mapL[sum]
+		if !ok {
+			msz = make(map[int]int)
+			mapL[sum] = msz
+		}
+		msz[sz]++
+	}
+	mapR := make(map[int64]map[int]int)
+	for mask := 0; mask < (1 << n2); mask++ {
+		var sum int64
+		sz := bits.OnesCount(uint(mask))
+		for j := 0; j < n2; j++ {
+			if mask&(1<<j) != 0 {
+				sum += aR[j]
+			}
+		}
+		msz, ok := mapR[sum]
+		if !ok {
+			msz = make(map[int]int)
+			mapR[sum] = msz
+		}
+		msz[sz]++
+	}
+	computeF := func(x int64) int64 {
+		var res int64
+		for sumL, cntL := range mapL {
+			sumR := x - sumL
+			cntR, ok := mapR[sumR]
+			if !ok {
+				continue
+			}
+			for sL, cL := range cntL {
+				for sR, cR := range cntR {
+					s := sL + sR
+					ways := fac[s] * fac[n-s] % modE
+					res = (res + ways*int64(cL)*int64(cR)) % modE
+				}
+			}
+		}
+		return res
+	}
+	f := make([]int64, k)
+	for i := 0; i < k; i++ {
+		f[i] = computeF(bad[i])
+	}
+	var fxy int64
+	if k == 2 {
+		x, y := bad[0], bad[1]
+		if x > y {
+			x, y = y, x
+		}
+		cntL := 1 << n1
+		sumFullL := make([]int64, cntL)
+		pcL := make([]int, cntL)
+		for mask := 1; mask < cntL; mask++ {
+			lsb := mask & -mask
+			j := bits.TrailingZeros(uint(lsb))
+			prev := mask ^ lsb
+			sumFullL[mask] = sumFullL[prev] + aL[j]
+			pcL[mask] = pcL[prev] + 1
+		}
+		cntR := 1 << n2
+		sumFullR := make([]int64, cntR)
+		pcR := make([]int, cntR)
+		for mask := 1; mask < cntR; mask++ {
+			lsb := mask & -mask
+			j := bits.TrailingZeros(uint(lsb))
+			prev := mask ^ lsb
+			sumFullR[mask] = sumFullR[prev] + aR[j]
+			pcR[mask] = pcR[prev] + 1
+		}
+		dpL := make([]map[int64]map[int]int, cntL)
+		dpL[0] = map[int64]map[int]int{0: {0: 1}}
+		for mask := 1; mask < cntL; mask++ {
+			lsb := mask & -mask
+			j := bits.TrailingZeros(uint(lsb))
+			prev := mask ^ lsb
+			prevMap := dpL[prev]
+			cur := make(map[int64]map[int]int, len(prevMap)+1)
+			for sum, msz := range prevMap {
+				nm := make(map[int]int, len(msz))
+				for s, c := range msz {
+					nm[s] = c
+				}
+				cur[sum] = nm
+			}
+			ai := aL[j]
+			for sum, msz := range prevMap {
+				nsum := sum + ai
+				inn, ok := cur[nsum]
+				if !ok {
+					inn = make(map[int]int)
+					cur[nsum] = inn
+				}
+				for s, c := range msz {
+					inn[s+1] += c
+				}
+			}
+			dpL[mask] = cur
+		}
+		dpR := make([]map[int64]map[int]int, cntR)
+		dpR[0] = map[int64]map[int]int{0: {0: 1}}
+		for mask := 1; mask < cntR; mask++ {
+			lsb := mask & -mask
+			j := bits.TrailingZeros(uint(lsb))
+			prev := mask ^ lsb
+			prevMap := dpR[prev]
+			cur := make(map[int64]map[int]int, len(prevMap)+1)
+			for sum, msz := range prevMap {
+				nm := make(map[int]int, len(msz))
+				for s, c := range msz {
+					nm[s] = c
+				}
+				cur[sum] = nm
+			}
+			ai := aR[j]
+			for sum, msz := range prevMap {
+				nsum := sum + ai
+				inn, ok := cur[nsum]
+				if !ok {
+					inn = make(map[int]int)
+					cur[nsum] = inn
+				}
+				for s, c := range msz {
+					inn[s+1] += c
+				}
+			}
+			dpR[mask] = cur
+		}
+		masksR := make(map[int64][]int)
+		for mask := 0; mask < cntR; mask++ {
+			s := sumFullR[mask]
+			if s > y {
+				continue
+			}
+			masksR[s] = append(masksR[s], mask)
+		}
+		for maskL, sumL := range sumFullL {
+			if sumL > y {
+				continue
+			}
+			sumRNeeded := y - sumL
+			listR, ok := masksR[sumRNeeded]
+			if !ok {
+				continue
+			}
+			tL := pcL[maskL]
+			dpLM := dpL[maskL]
+			for _, maskR := range listR {
+				t := tL + pcR[maskR]
+				dpRM := dpR[maskR]
+				for sumSL, mszL := range dpLM {
+					sumSR := x - sumSL
+					mszR, ok2 := dpRM[sumSR]
+					if !ok2 {
+						continue
+					}
+					for szL, cL := range mszL {
+						for szR, cR := range mszR {
+							s := szL + szR
+							ways := fac[s] * fac[t-s] % modE * fac[n-t] % modE
+							fxy = (fxy + ways*int64(cL)*int64(cR)) % modE
+						}
+					}
+				}
+			}
+		}
+	}
+	ans := total
+	for i := 0; i < k; i++ {
+		ans = (ans - f[i] + modE) % modE
+	}
+	if k == 2 {
+		ans = (ans + fxy) % modE
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (int, []int64, int, []int64) {
+	n := rng.Intn(6) + 1
+	a := make([]int64, n)
+	sum := int64(0)
+	for i := range a {
+		a[i] = int64(rng.Intn(10) + 1)
+		sum += a[i]
+	}
+	k := rng.Intn(3) // 0..2
+	bad := make([]int64, k)
+	for i := 0; i < k; i++ {
+		bad[i] = int64(rng.Intn(int(sum)) + 1)
+	}
+	return n, a, k, bad
+}
+
+func runCase(bin string, n int, a []int64, k int, bad []int64) error {
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprint(v))
+	}
+	input.WriteByte('\n')
+	fmt.Fprintf(&input, "%d\n", k)
+	if k > 0 {
+		for i, v := range bad {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(fmt.Sprint(v))
+		}
+		input.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(outStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("bad output %q", outStr)
+	}
+	expect := solveE(n, a, k, bad)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, a, k, bad := generateCase(rng)
+		if err := runCase(bin, n, a, k, bad); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 327 problems A–E
- each verifier generates 100 random test cases and checks the candidate binary

## Testing
- `go build 0-999/300-399/320-329/327/verifierA.go`
- `go build 0-999/300-399/320-329/327/verifierB.go`
- `go build 0-999/300-399/320-329/327/verifierC.go`
- `go build 0-999/300-399/320-329/327/verifierD.go`
- `go build 0-999/300-399/320-329/327/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687eaf623f908324a82b6ae9e5081b36