### PR TITLE
Add Go verifiers for contest 326

### DIFF
--- a/0-999/300-399/320-329/326/verifierA.go
+++ b/0-999/300-399/320-329/326/verifierA.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedAnswer(s string, n int) (int, string, bool) {
+	freq := make([]int, 26)
+	maxf := 0
+	distinct := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i] - 'a'
+		if freq[c] == 0 {
+			distinct++
+		}
+		freq[c]++
+		if freq[c] > maxf {
+			maxf = freq[c]
+		}
+	}
+	if distinct > n {
+		return -1, "", false
+	}
+	ans := -1
+	for k := 1; k <= maxf; k++ {
+		need := 0
+		for _, f := range freq {
+			if f > 0 {
+				need += (f + k - 1) / k
+			}
+		}
+		if need <= n {
+			ans = k
+			break
+		}
+	}
+	if ans == -1 {
+		return -1, "", false
+	}
+	sheet := make([]byte, 0, n)
+	used := 0
+	for i, f := range freq {
+		if f > 0 {
+			cnt := (f + ans - 1) / ans
+			for j := 0; j < cnt; j++ {
+				sheet = append(sheet, byte('a'+i))
+			}
+			used += cnt
+		}
+	}
+	for used < n {
+		sheet = append(sheet, 'a')
+		used++
+	}
+	return ans, string(sheet), true
+}
+
+func runCase(bin, s string, n int) error {
+	input := fmt.Sprintf("%s\n%d\n", s, n)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	expK, expT, ok := expectedAnswer(s, n)
+	if !ok {
+		if len(lines) != 1 || strings.TrimSpace(lines[0]) != "-1" {
+			return fmt.Errorf("expected -1 got %q", out.String())
+		}
+		return nil
+	}
+	if len(lines) != 2 {
+		return fmt.Errorf("expected two lines, got %d", len(lines))
+	}
+	gotK, err := strconv.Atoi(strings.TrimSpace(lines[0]))
+	if err != nil {
+		return fmt.Errorf("failed to parse k: %v", err)
+	}
+	gotT := strings.TrimSpace(lines[1])
+	if gotK != expK || gotT != expT {
+		return fmt.Errorf("expected %d %s got %d %s", expK, expT, gotK, gotT)
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	slen := rng.Intn(10) + 1
+	n := rng.Intn(10) + 1
+	b := make([]byte, slen)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b), n
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// predefined cases
+	predefined := []struct {
+		s string
+		n int
+	}{
+		{"abc", 2},
+		{"aaa", 1},
+		{"ab", 1},
+		{"a", 5},
+	}
+	for i, tc := range predefined {
+		if err := runCase(bin, tc.s, tc.n); err != nil {
+			fmt.Fprintf(os.Stderr, "predefined case %d failed: %v\ninput:\n%s\n%d\n", i+1, err, tc.s, tc.n)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		s, n := generateCase(rng)
+		if err := runCase(bin, s, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n%d\n", i+1, err, s, n)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/326/verifierB.go
+++ b/0-999/300-399/320-329/326/verifierB.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isPalindrome(t string) bool {
+	i, j := 0, len(t)-1
+	for i < j {
+		if t[i] != t[j] {
+			return false
+		}
+		i++
+		j--
+	}
+	return true
+}
+
+func isSubsequence(s, t string) bool {
+	j := 0
+	for i := 0; i < len(s) && j < len(t); i++ {
+		if s[i] == t[j] {
+			j++
+		}
+	}
+	return j == len(t)
+}
+
+func lpsString(s string) string {
+	n := len(s)
+	dp := make([][]int, n)
+	for i := range dp {
+		dp[i] = make([]int, n)
+	}
+	for i := n - 1; i >= 0; i-- {
+		dp[i][i] = 1
+		for j := i + 1; j < n; j++ {
+			if s[i] == s[j] {
+				dp[i][j] = dp[i+1][j-1] + 2
+			} else {
+				if dp[i+1][j] >= dp[i][j-1] {
+					dp[i][j] = dp[i+1][j]
+				} else {
+					dp[i][j] = dp[i][j-1]
+				}
+			}
+		}
+	}
+	// reconstruct
+	i, j := 0, n-1
+	left := make([]byte, 0, dp[0][n-1])
+	right := make([]byte, 0, dp[0][n-1])
+	for i <= j {
+		if i == j {
+			left = append(left, s[i])
+			break
+		}
+		if s[i] == s[j] {
+			left = append(left, s[i])
+			right = append(right, s[j])
+			i++
+			j--
+		} else if dp[i+1][j] >= dp[i][j-1] {
+			i++
+		} else {
+			j--
+		}
+	}
+	for k := len(right) - 1; k >= 0; k-- {
+		left = append(left, right[k])
+	}
+	return string(left)
+}
+
+func expectedLength(s string) int {
+	cnt := [26]int{}
+	for i := 0; i < len(s); i++ {
+		cnt[s[i]-'a']++
+	}
+	for _, c := range cnt {
+		if c >= 100 {
+			return 100
+		}
+	}
+	if len(s) == 0 {
+		return 0
+	}
+	lps := lpsString(s)
+	if len(lps) > 100 {
+		return 100
+	}
+	return len(lps)
+}
+
+func runCase(bin string, s string) error {
+	input := fmt.Sprintf("%s\n", s)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expLen := expectedLength(s)
+	if len(got) != expLen {
+		return fmt.Errorf("expected length %d got %d", expLen, len(got))
+	}
+	if !isPalindrome(got) {
+		return fmt.Errorf("output is not a palindrome: %s", got)
+	}
+	if !isSubsequence(s, got) {
+		return fmt.Errorf("output is not a subsequence: %s", got)
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	if rng.Intn(5) == 0 {
+		// case with many 'a'
+		n := 120
+		return strings.Repeat("a", n)
+	}
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		s := generateCase(rng)
+		if err := runCase(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/326/verifierC.go
+++ b/0-999/300-399/320-329/326/verifierC.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedResult(r int, reclaimed [][2]int) string {
+	avail := make([][3]bool, r+2)
+	for i := 1; i <= r; i++ {
+		avail[i][1], avail[i][2] = true, true
+	}
+	rec := make([][3]bool, r+2)
+	for _, rc := range reclaimed {
+		rec[rc[0]][rc[1]] = true
+	}
+	for i := 1; i <= r; i++ {
+		for c := 1; c <= 2; c++ {
+			if rec[i][c] {
+				avail[i][c] = false
+				oc := 3 - c
+				for d := -1; d <= 1; d++ {
+					j := i + d
+					if j >= 1 && j <= r {
+						avail[j][oc] = false
+					}
+				}
+			}
+		}
+	}
+	maxr := r
+	g := make([][][3]int, maxr+1)
+	for i := 0; i <= maxr; i++ {
+		g[i] = make([][3]int, 3)
+	}
+	for length := 1; length <= maxr; length++ {
+		for tb := 0; tb < 3; tb++ {
+			for bb := 0; bb < 3; bb++ {
+				used := make([]bool, length*2+5)
+				for i := 1; i <= length; i++ {
+					for c := 1; c <= 2; c++ {
+						if (i == 1 && tb == c) || (i == length && bb == c) {
+							continue
+						}
+						var g1 int
+						if i > 1 {
+							bb1 := 3 - c
+							g1 = g[i-1][tb][bb1]
+						}
+						var g2 int
+						if i < length {
+							tb2 := 3 - c
+							g2 = g[length-i][tb2][bb]
+						}
+						x := g1 ^ g2
+						if x < len(used) {
+							used[x] = true
+						}
+					}
+				}
+				mex := 0
+				for mex < len(used) && used[mex] {
+					mex++
+				}
+				g[length][tb][bb] = mex
+			}
+		}
+	}
+	total := 0
+	segStart := 0
+	segTB := 0
+	inSeg := false
+	for i := 1; i <= r; i++ {
+		if !avail[i][1] && !avail[i][2] {
+			if inSeg {
+				length := i - segStart
+				bb := 0
+				if !avail[i-1][1] {
+					bb = 1
+				}
+				if !avail[i-1][2] {
+					bb = 2
+				}
+				total ^= g[length][segTB][bb]
+			}
+			inSeg = false
+		} else {
+			if !inSeg {
+				inSeg = true
+				segStart = i
+				segTB = 0
+				if !avail[i][1] {
+					segTB = 1
+				}
+				if !avail[i][2] {
+					segTB = 2
+				}
+			}
+		}
+	}
+	if inSeg {
+		length := r - segStart + 1
+		bb := 0
+		if !avail[r][1] {
+			bb = 1
+		}
+		if !avail[r][2] {
+			bb = 2
+		}
+		total ^= g[length][segTB][bb]
+	}
+	if total != 0 {
+		return "WIN"
+	}
+	return "LOSE"
+}
+
+func runCase(bin string, r int, cells [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", r, len(cells)))
+	for _, c := range cells {
+		sb.WriteString(fmt.Sprintf("%d %d\n", c[0], c[1]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedResult(r, cells)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (int, [][2]int) {
+	r := rng.Intn(6) + 1
+	n := rng.Intn(r + 1)
+	board := make([][3]bool, r+2)
+	cells := make([][2]int, 0, n)
+	for len(cells) < n {
+		row := rng.Intn(r) + 1
+		col := rng.Intn(2) + 1
+		if board[row][col] {
+			continue
+		}
+		oc := 3 - col
+		if board[row][oc] || board[row-1][oc] || board[row+1][oc] {
+			continue
+		}
+		board[row][col] = true
+		cells = append(cells, [2]int{row, col})
+	}
+	return r, cells
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		r, cells := generateCase(rng)
+		if err := runCase(bin, r, cells); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/326/verifierD.go
+++ b/0-999/300-399/320-329/326/verifierD.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	p, r []int
+}
+
+func newDSU(n int) *DSU {
+	p := make([]int, n)
+	r := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = i
+	}
+	return &DSU{p: p, r: r}
+}
+
+func (d *DSU) find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *DSU) union(x, y int) {
+	rx := d.find(x)
+	ry := d.find(y)
+	if rx == ry {
+		return
+	}
+	if d.r[rx] < d.r[ry] {
+		d.p[rx] = ry
+	} else if d.r[ry] < d.r[rx] {
+		d.p[ry] = rx
+	} else {
+		d.p[ry] = rx
+		d.r[rx]++
+	}
+}
+
+type Edge struct{ low, high, id int }
+
+func expected(rects [][4]int) (bool, []int) {
+	n := len(rects)
+	left := make(map[int][]Edge)
+	right := make(map[int][]Edge)
+	bottom := make(map[int][]Edge)
+	top := make(map[int][]Edge)
+	for i, r := range rects {
+		x1, y1, x2, y2 := r[0], r[1], r[2], r[3]
+		left[x1] = append(left[x1], Edge{y1, y2, i})
+		right[x2] = append(right[x2], Edge{y1, y2, i})
+		bottom[y1] = append(bottom[y1], Edge{x1, x2, i})
+		top[y2] = append(top[y2], Edge{x1, x2, i})
+	}
+	dsu := newDSU(n)
+	process := func(a, b map[int][]Edge) {
+		for coord, edgesA := range a {
+			edgesB, ok := b[coord]
+			if !ok {
+				continue
+			}
+			sort.Slice(edgesA, func(i, j int) bool { return edgesA[i].low < edgesA[j].low })
+			sort.Slice(edgesB, func(i, j int) bool { return edgesB[i].low < edgesB[j].low })
+			j := 0
+			for _, ea := range edgesA {
+				for j < len(edgesB) && edgesB[j].high <= ea.low {
+					j++
+				}
+				for k := j; k < len(edgesB) && edgesB[k].low < ea.high; k++ {
+					dsu.union(ea.id, edgesB[k].id)
+				}
+			}
+		}
+	}
+	process(left, right)
+	process(right, left)
+	process(bottom, top)
+	process(top, bottom)
+
+	minX := make([]int, n)
+	maxX := make([]int, n)
+	minY := make([]int, n)
+	maxY := make([]int, n)
+	area := make([]int, n)
+	for i := 0; i < n; i++ {
+		minX[i] = 1 << 30
+		minY[i] = 1 << 30
+	}
+	for i, r := range rects {
+		f := dsu.find(i)
+		x1, y1, x2, y2 := r[0], r[1], r[2], r[3]
+		if x1 < minX[f] {
+			minX[f] = x1
+		}
+		if y1 < minY[f] {
+			minY[f] = y1
+		}
+		if x2 > maxX[f] {
+			maxX[f] = x2
+		}
+		if y2 > maxY[f] {
+			maxY[f] = y2
+		}
+		area[f] += (x2 - x1) * (y2 - y1)
+	}
+	for i := 0; i < n; i++ {
+		if dsu.find(i) != i {
+			continue
+		}
+		dx := maxX[i] - minX[i]
+		dy := maxY[i] - minY[i]
+		if dx > 0 && dx == dy && area[i] == dx*dy {
+			res := []int{}
+			for j := 0; j < n; j++ {
+				if dsu.find(j) == i {
+					res = append(res, j+1)
+				}
+			}
+			return true, res
+		}
+	}
+	return false, nil
+}
+
+func runCase(bin string, rects [][4]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(rects)))
+	for _, r := range rects {
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", r[0], r[1], r[2], r[3]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	ok, subset := expected(rects)
+	if !ok {
+		if len(gotLines) != 1 || strings.TrimSpace(gotLines[0]) != "NO" {
+			return fmt.Errorf("expected NO got %q", out.String())
+		}
+		return nil
+	}
+	if len(gotLines) < 2 {
+		return fmt.Errorf("expected YES")
+	}
+	if strings.TrimSpace(gotLines[0]) != "YES" {
+		return fmt.Errorf("expected YES got %s", gotLines[0])
+	}
+	m, err := fmt.Sscanf(strings.TrimSpace(gotLines[1]), "%d", new(int))
+	_ = m
+	_ = err
+	// parse second line using fmt.Fscan to get m. Better: using fmt.Sscan.
+	var count int
+	_, err = fmt.Sscan(strings.TrimSpace(gotLines[1]), &count)
+	if err != nil {
+		return fmt.Errorf("can't parse count: %v", err)
+	}
+	if len(gotLines) != 2 {
+		arr := strings.Fields(strings.Join(gotLines[1:], " "))
+		if len(arr) != 1+count {
+			// there may be spaces after numbers etc
+		}
+	}
+	// Flatten all numbers from remaining lines
+	vals := []int{}
+	for _, ln := range gotLines[2:] {
+		fields := strings.Fields(ln)
+		for _, f := range fields {
+			var x int
+			if _, err := fmt.Sscan(f, &x); err == nil {
+				vals = append(vals, x)
+			}
+		}
+	}
+	// Some solutions may print numbers on same second line separated by spaces
+	if len(vals) == 0 {
+		fields := strings.Fields(strings.TrimSpace(gotLines[1]))
+		if len(fields) > 1 {
+			fmtvals := fields[1:]
+			vals = make([]int, len(fmtvals))
+			for i, f := range fmtvals {
+				fmt.Sscan(f, &vals[i])
+			}
+		}
+	}
+	if len(vals) != count {
+		return fmt.Errorf("expected %d ids got %d", count, len(vals))
+	}
+	if count != len(subset) {
+		return fmt.Errorf("expected subset size %d got %d", len(subset), count)
+	}
+	// compare as sets
+	sort.Ints(vals)
+	sort.Ints(subset)
+	for i := range vals {
+		if vals[i] != subset[i] {
+			return fmt.Errorf("expected ids %v got %v", subset, vals)
+		}
+	}
+	return nil
+}
+
+func generateRectangles(rng *rand.Rand) [][4]int {
+	n := rng.Intn(4) + 1
+	rects := make([][4]int, 0, n)
+	occupied := map[[2]int]bool{}
+	for len(rects) < n {
+		x1 := rng.Intn(5)
+		y1 := rng.Intn(5)
+		x2 := x1 + rng.Intn(3) + 1
+		y2 := y1 + rng.Intn(3) + 1
+		if x2 > 9 {
+			x2 = 9
+		}
+		if y2 > 9 {
+			y2 = 9
+		}
+		overlap := false
+		for x := x1; x < x2; x++ {
+			for y := y1; y < y2; y++ {
+				if occupied[[2]int{x, y}] {
+					overlap = true
+					break
+				}
+			}
+			if overlap {
+				break
+			}
+		}
+		if overlap {
+			continue
+		}
+		for x := x1; x < x2; x++ {
+			for y := y1; y < y2; y++ {
+				occupied[[2]int{x, y}] = true
+			}
+		}
+		rects = append(rects, [4]int{x1, y1, x2, y2})
+	}
+	return rects
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// simple positive case
+	rects := [][4]int{{0, 0, 1, 2}, {1, 0, 2, 1}, {1, 1, 2, 2}, {0, 1, 1, 2}}
+	if err := runCase(bin, rects); err != nil {
+		fmt.Fprintf(os.Stderr, "predefined case failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		rc := generateRectangles(rng)
+		if err := runCase(bin, rc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/326/verifierE.go
+++ b/0-999/300-399/320-329/326/verifierE.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(name string, n int64, h int) float64 {
+	offset := int64((1 << (h + 1)) - 2)
+	if name == "Alice" {
+		return float64(n + offset)
+	}
+	return float64(n - offset)
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func runCase(bin, name string, n int64, h int) error {
+	input := fmt.Sprintf("%s\n%d %d\n", name, n, h)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var val float64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &val); err != nil {
+		return fmt.Errorf("unable to parse output: %v", err)
+	}
+	exp := expected(name, n, h)
+	if abs(val-exp) > 1e-6 {
+		return fmt.Errorf("expected %.6f got %.6f", exp, val)
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, int64, int) {
+	name := "Alice"
+	if rng.Intn(2) == 0 {
+		name = "Bob"
+	}
+	return name, rng.Int63n(1000), rng.Intn(10)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		name, n, h := generateCase(rng)
+		if err := runCase(bin, name, n, h); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/326/verifierF.go
+++ b/0-999/300-399/320-329/326/verifierF.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(pies []int) int64 {
+	sort.Ints(pies)
+	n := len(pies)
+	k := 0
+	i, j := 0, 0
+	for j < n && i < n {
+		if pies[j] > pies[i] {
+			k++
+			i++
+			j++
+		} else {
+			j++
+		}
+	}
+	if k > n-k {
+		k = n - k
+	}
+	var total, free int64
+	for _, v := range pies {
+		total += int64(v)
+	}
+	for idx := 0; idx < k; idx++ {
+		free += int64(pies[idx])
+	}
+	return total - free
+}
+
+func runCase(bin string, pies []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(pies)))
+	for i, p := range pies {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", p))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var val int64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &val); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	exp := expected(append([]int(nil), pies...))
+	if val != exp {
+		return fmt.Errorf("expected %d got %d", exp, val)
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) []int {
+	n := rng.Intn(10) + 1
+	pies := make([]int, n)
+	for i := range pies {
+		pies[i] = rng.Intn(1000) + 1
+	}
+	return pies
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		pies := generateCase(rng)
+		if err := runCase(bin, pies); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 326 problems A–F
- each verifier generates at least 100 random tests
- verifiers run any binary and check expected output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_687eaf1c3c208324a1eaf1866c95572c