### PR TITLE
Add verifiers for contest 325

### DIFF
--- a/0-999/300-399/320-329/325/verifierA.go
+++ b/0-999/300-399/320-329/325/verifierA.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Rect struct{ x1, y1, x2, y2 int }
+
+func expected(rects []Rect) string {
+	if len(rects) == 0 {
+		return "NO"
+	}
+	minX, minY := 1<<30, 1<<30
+	maxX, maxY := 0, 0
+	var sum int64
+	for _, r := range rects {
+		if r.x1 < minX {
+			minX = r.x1
+		}
+		if r.y1 < minY {
+			minY = r.y1
+		}
+		if r.x2 > maxX {
+			maxX = r.x2
+		}
+		if r.y2 > maxY {
+			maxY = r.y2
+		}
+		sum += int64(r.x2-r.x1) * int64(r.y2-r.y1)
+	}
+	dx := maxX - minX
+	dy := maxY - minY
+	if dx != dy {
+		return "NO"
+	}
+	if int64(dx)*int64(dy) != sum {
+		return "NO"
+	}
+	return "YES"
+}
+
+func genSquare(rng *rand.Rand, n int) []Rect {
+	L := rng.Intn(10) + 1
+	x0 := rng.Intn(10)
+	y0 := rng.Intn(10)
+	rects := []Rect{{x0, y0, x0 + L, y0 + L}}
+	for len(rects) < n {
+		idx := rng.Intn(len(rects))
+		r := rects[idx]
+		if rng.Intn(2) == 0 {
+			if r.x2-r.x1 < 2 {
+				continue
+			}
+			cut := rng.Intn(r.x2-r.x1-1) + r.x1 + 1
+			rects[idx] = Rect{r.x1, r.y1, cut, r.y2}
+			rects = append(rects, Rect{cut, r.y1, r.x2, r.y2})
+		} else {
+			if r.y2-r.y1 < 2 {
+				continue
+			}
+			cut := rng.Intn(r.y2-r.y1-1) + r.y1 + 1
+			rects[idx] = Rect{r.x1, r.y1, r.x2, cut}
+			rects = append(rects, Rect{r.x1, cut, r.x2, r.y2})
+		}
+	}
+	return rects
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	rects := genSquare(rng, n)
+	if rng.Intn(2) == 0 {
+		// make it NO by adding extra rectangle outside
+		r := rects[rng.Intn(len(rects))]
+		rects = append(rects, Rect{r.x2 + 1, r.y2 + 1, r.x2 + 2, r.y2 + 2})
+		n++
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		r := rects[i]
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", r.x1, r.y1, r.x2, r.y2))
+	}
+	return sb.String(), expected(rects[:n])
+}
+
+func runCase(bin string, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	ans := strings.TrimSpace(out.String())
+	if ans != exp {
+		return fmt.Errorf("expected %s got %s", exp, ans)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/325/verifierB.go
+++ b/0-999/300-399/320-329/325/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(n *big.Int) []uint64 {
+	two := big.NewInt(2)
+	eight := big.NewInt(8)
+	results := make(map[uint64]struct{})
+	for k := 0; k <= 60; k++ {
+		p := new(big.Int).Lsh(big.NewInt(1), uint(k))
+		B := new(big.Int).Lsh(big.NewInt(1), uint(k+1))
+		B.Sub(B, big.NewInt(3))
+		D := new(big.Int).Mul(B, B)
+		tmp := new(big.Int).Mul(eight, n)
+		D.Add(D, tmp)
+		sqrtD := new(big.Int).Sqrt(D)
+		if new(big.Int).Mul(sqrtD, sqrtD).Cmp(D) != 0 {
+			continue
+		}
+		r := new(big.Int).Sub(sqrtD, B)
+		if r.Sign() <= 0 || r.Bit(0) == 0 {
+			continue
+		}
+		r.Div(r, two)
+		if r.Sign() <= 0 {
+			continue
+		}
+		T := new(big.Int).Mul(r, p)
+		if T.BitLen() > 64 {
+			continue
+		}
+		t64 := T.Uint64()
+		if t64 > 0 {
+			results[t64] = struct{}{}
+		}
+	}
+	out := make([]uint64, 0, len(results))
+	for t := range results {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func generateCase(rng *rand.Rand) (string, []uint64) {
+	// generate n up to 1e12
+	n := rng.Int63n(1_000_000_000_000) + 1
+	nBig := big.NewInt(n)
+	out := expected(nBig)
+	return fmt.Sprintf("%d\n", n), out
+}
+
+func runCase(bin string, input string, exp []uint64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(exp) == 0 {
+		if len(fields) != 1 || fields[0] != "-1" {
+			return fmt.Errorf("expected -1 got %v", fields)
+		}
+		return nil
+	}
+	if len(fields) != len(exp) {
+		return fmt.Errorf("expected %d numbers got %d", len(exp), len(fields))
+	}
+	for i, f := range fields {
+		var val uint64
+		if _, err := fmt.Sscan(f, &val); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if val != exp[i] {
+			return fmt.Errorf("expected %v got %v", exp, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/325/verifierC.go
+++ b/0-999/300-399/320-329/325/verifierC.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	refBin := filepath.Join(os.TempDir(), "ref325C")
+	cmd := exec.Command("go", "build", "-o", refBin, "325C.go")
+	var out bytes.Buffer
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out.String())
+	}
+	return refBin, nil
+}
+
+func runRef(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("ref runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	m := rng.Intn(10) + 1
+	n := rng.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", m, n))
+	for i := 0; i < m; i++ {
+		mi := rng.Intn(n) + 1
+		li := rng.Intn(3) + 1
+		sb.WriteString(fmt.Sprintf("%d %d", mi, li))
+		hasDiam := false
+		for j := 0; j < li; j++ {
+			if rng.Intn(3) == 0 {
+				sb.WriteString(" -1")
+				hasDiam = true
+			} else {
+				sb.WriteString(fmt.Sprintf(" %d", rng.Intn(n)+1))
+			}
+		}
+		if !hasDiam {
+			sb.WriteString(" -1")
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(bin, refBin, input string) error {
+	exp, err := runRef(refBin, input)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\n got:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, refBin, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/325/verifierD.go
+++ b/0-999/300-399/320-329/325/verifierD.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	parent      []int
+	left, right []bool
+}
+
+func NewDSU(n int) *DSU {
+	d := &DSU{parent: make([]int, n), left: make([]bool, n), right: make([]bool, n)}
+	return d
+}
+
+func (d *DSU) Find(x int) int {
+	for d.parent[x] != x {
+		d.parent[x] = d.parent[d.parent[x]]
+		x = d.parent[x]
+	}
+	return x
+}
+
+func (d *DSU) Union(x, y int) {
+	rx := d.Find(x)
+	ry := d.Find(y)
+	if rx == ry {
+		return
+	}
+	d.parent[ry] = rx
+	d.left[rx] = d.left[rx] || d.left[ry]
+	d.right[rx] = d.right[rx] || d.right[ry]
+}
+
+func expected(r, c int, ops [][2]int) int {
+	rc := r * c
+	idx := make([]int, rc)
+	dsu := NewDSU(len(ops) + 5)
+	curID := 0
+	ans := 0
+	for _, op := range ops {
+		i := op[0] - 1
+		j := op[1] - 1
+		pos := i*c + j
+		newLeft := j == 0
+		newRight := j == c-1
+		orLeft, orRight := false, false
+		neigh := make([]int, 0, 4)
+		// up/down
+		for _, di := range []int{-1, 1} {
+			ni := i + di
+			if ni < 0 || ni >= r {
+				continue
+			}
+			nj := j
+			p2 := ni*c + nj
+			id2 := idx[p2]
+			if id2 == 0 {
+				continue
+			}
+			root := dsu.Find(id2)
+			dup := false
+			for _, v := range neigh {
+				if v == root {
+					dup = true
+					break
+				}
+			}
+			if dup {
+				continue
+			}
+			neigh = append(neigh, root)
+			if dsu.left[root] {
+				orLeft = true
+			}
+			if dsu.right[root] {
+				orRight = true
+			}
+		}
+		// left/right wrap
+		for _, dj := range []int{-1, 1} {
+			ni := i
+			nj := j + dj
+			if nj < 0 {
+				nj = c - 1
+			} else if nj >= c {
+				nj = 0
+			}
+			p2 := ni*c + nj
+			id2 := idx[p2]
+			if id2 == 0 {
+				continue
+			}
+			root := dsu.Find(id2)
+			dup := false
+			for _, v := range neigh {
+				if v == root {
+					dup = true
+					break
+				}
+			}
+			if dup {
+				continue
+			}
+			neigh = append(neigh, root)
+			if dsu.left[root] {
+				orLeft = true
+			}
+			if dsu.right[root] {
+				orRight = true
+			}
+		}
+		totalLeft := newLeft || orLeft
+		totalRight := newRight || orRight
+		if totalLeft && totalRight {
+			continue
+		}
+		curID++
+		ans++
+		id := curID
+		idx[pos] = id
+		dsu.parent[id] = id
+		dsu.left[id] = newLeft
+		dsu.right[id] = newRight
+		for _, v := range neigh {
+			dsu.Union(id, v)
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	r := rng.Intn(4) + 2
+	c := rng.Intn(4) + 2
+	n := rng.Intn(r*c) + 1
+	ops := make([][2]int, n)
+	for i := 0; i < n; i++ {
+		ops[i] = [2]int{rng.Intn(r) + 1, rng.Intn(c) + 1}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", r, c, n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", ops[i][0], ops[i][1]))
+	}
+	return sb.String(), expected(r, c, ops)
+}
+
+func runCase(bin, input string, exp int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/325/verifierE.go
+++ b/0-999/300-399/320-329/325/verifierE.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedSeq(n int) []int {
+	if n%2 == 1 {
+		return nil
+	}
+	a := make([]int, n+1)
+	vis := make([]bool, n)
+	a[n] = 0
+	a[n-1] = n / 2
+	vis[n/2] = true
+	for i := n - 1; i > 0; i-- {
+		x1 := a[i] / 2
+		x2 := (a[i] + n) / 2
+		if vis[x1] {
+			a[i-1] = x2
+			vis[x2] = true
+		} else if vis[x2] {
+			a[i-1] = x1
+			vis[x1] = true
+		} else if x1 > x2 {
+			a[i-1] = x1
+			vis[x1] = true
+		} else {
+			a[i-1] = x2
+			vis[x2] = true
+		}
+	}
+	return a
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := (rng.Intn(10) + 1) * 2
+	return fmt.Sprintf("%d\n", n), expectedSeq(n)
+}
+
+func runCase(bin string, input string, exp []int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != len(exp) {
+		return fmt.Errorf("expected %d numbers got %d", len(exp), len(fields))
+	}
+	for i, f := range fields {
+		var v int
+		if _, err := fmt.Sscan(f, &v); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if v != exp[i] {
+			return fmt.Errorf("expected %v got %v", exp, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 325

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687eaed63ffc8324ab4eba4a41c401f1