### PR TITLE
Add Go verifiers for contest 324

### DIFF
--- a/0-999/300-399/320-329/324/324A.go
+++ b/0-999/300-399/320-329/324/324A.go
@@ -1,0 +1,3 @@
+package main
+
+func main() { panic("boom") }

--- a/0-999/300-399/320-329/324/verifierA.go
+++ b/0-999/300-399/320-329/324/verifierA.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	input string
+	a     []int64
+	sum   int64
+}
+
+func solveA(a []int64) int64 {
+	n := len(a) - 1 // 1-indexed for easier logic
+	posPref := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		posPref[i] = posPref[i-1]
+		if a[i] > 0 {
+			posPref[i] += a[i]
+		}
+	}
+	posMap := make(map[int64][]int)
+	for i := 1; i <= n; i++ {
+		v := a[i]
+		posMap[v] = append(posMap[v], i)
+	}
+	bestSum := int64(math.MinInt64)
+	var bestL, bestR int
+	for v, vec := range posMap {
+		if len(vec) < 2 {
+			continue
+		}
+		l := vec[0]
+		r := vec[len(vec)-1]
+		midSum := int64(0)
+		if r > l+1 {
+			midSum = posPref[r-1] - posPref[l]
+		}
+		total := int64(v) + int64(v) + midSum
+		if total > bestSum {
+			bestSum = total
+			bestL = l
+			bestR = r
+		}
+	}
+	// compute sum according to bestL,bestR
+	sum := a[bestL] + a[bestR]
+	for i := bestL + 1; i < bestR; i++ {
+		if a[i] > 0 {
+			sum += a[i]
+		}
+	}
+	return sum
+}
+
+func genCaseA(rng *rand.Rand) testCaseA {
+	n := rng.Intn(8) + 2
+	arr := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		arr[i] = int64(rng.Intn(21) - 10)
+	}
+	// ensure at least two equal numbers
+	if n >= 2 {
+		arr[2] = arr[1]
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	sum := solveA(arr)
+	return testCaseA{input: sb.String(), a: arr, sum: sum}
+}
+
+func runCaseA(bin string, tc testCaseA) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) < 2 {
+		return fmt.Errorf("bad output")
+	}
+	var gotSum int64
+	var k int
+	if _, err := fmt.Sscan(fields[0], &gotSum); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if _, err := fmt.Sscan(fields[1], &k); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if len(fields) != 2+k {
+		return fmt.Errorf("expected %d indices, got %d", k, len(fields)-2)
+	}
+	removed := make(map[int]bool)
+	for i := 0; i < k; i++ {
+		var idx int
+		if _, err := fmt.Sscan(fields[2+i], &idx); err != nil {
+			return fmt.Errorf("bad index: %v", err)
+		}
+		if idx < 1 || idx >= len(tc.a) {
+			return fmt.Errorf("index out of range: %d", idx)
+		}
+		if removed[idx] {
+			return fmt.Errorf("duplicate index %d", idx)
+		}
+		removed[idx] = true
+	}
+	sum := int64(0)
+	for i := 1; i < len(tc.a); i++ {
+		if !removed[i] {
+			sum += tc.a[i]
+		}
+	}
+	if sum != gotSum {
+		return fmt.Errorf("reported sum %d does not match computed sum %d", gotSum, sum)
+	}
+	if gotSum != tc.sum {
+		return fmt.Errorf("expected sum %d got %d", tc.sum, gotSum)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseA(rng)
+		if err := runCaseA(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/324/verifierB.go
+++ b/0-999/300-399/320-329/324/verifierB.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type queryB struct {
+	typ int
+	x   int
+	y   int
+}
+
+type testCaseB struct {
+	input    string
+	expected []int
+}
+
+func solveB(n int, a []int, queries []queryB) []int {
+	pos := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		pos[a[i]] = i
+	}
+	res := []int{}
+	for _, q := range queries {
+		if q.typ == 1 {
+			sessions := 1
+			for id := q.x; id < q.y; id++ {
+				if pos[id+1] < pos[id] {
+					sessions++
+				}
+			}
+			res = append(res, sessions)
+		} else {
+			v1 := a[q.x]
+			v2 := a[q.y]
+			a[q.x], a[q.y] = v2, v1
+			pos[v1], pos[v2] = q.y, q.x
+		}
+	}
+	return res
+}
+
+func genCaseB(rng *rand.Rand) testCaseB {
+	n := rng.Intn(5) + 1
+	perm := rng.Perm(n)
+	a := make([]int, n+1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 1; i <= n; i++ {
+		a[i] = perm[i-1] + 1
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteByte('\n')
+	qcnt := rng.Intn(10) + 1
+	fmt.Fprintf(&sb, "%d\n", qcnt)
+	queries := make([]queryB, qcnt)
+	for i := 0; i < qcnt; i++ {
+		typ := rng.Intn(2) + 1
+		x := rng.Intn(n) + 1
+		y := rng.Intn(n) + 1
+		if typ == 1 && x > y {
+			x, y = y, x
+		}
+		queries[i] = queryB{typ: typ, x: x, y: y}
+		fmt.Fprintf(&sb, "%d %d %d\n", typ, x, y)
+	}
+	expected := solveB(n, append([]int(nil), a...), queries)
+	return testCaseB{input: sb.String(), expected: expected}
+}
+
+func runCaseB(bin string, tc testCaseB) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != len(tc.expected) {
+		return fmt.Errorf("expected %d numbers got %d", len(tc.expected), len(fields))
+	}
+	for i, f := range fields {
+		var val int
+		if _, err := fmt.Sscan(f, &val); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if val != tc.expected[i] {
+			return fmt.Errorf("expected %v got %v", tc.expected, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseB(rng)
+		if err := runCaseB(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/324/verifierC.go
+++ b/0-999/300-399/320-329/324/verifierC.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	input    string
+	expected int
+}
+
+func solveC(n int) int {
+	dp := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		best := 1<<31 - 1
+		x := i
+		for x > 0 {
+			d := x % 10
+			x /= 10
+			if d > 0 {
+				if dp[i-d] < best {
+					best = dp[i-d]
+				}
+			}
+		}
+		dp[i] = best + 1
+	}
+	return dp[n]
+}
+
+func genCaseC(rng *rand.Rand) testCaseC {
+	n := rng.Intn(1000) + 1
+	expected := solveC(n)
+	return testCaseC{input: fmt.Sprintf("%d\n", n), expected: expected}
+}
+
+func runCaseC(bin string, tc testCaseC) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseC(rng)
+		if err := runCaseC(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/324/verifierD.go
+++ b/0-999/300-399/320-329/324/verifierD.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Segment struct {
+	vertical  bool
+	fixed     int64
+	low, high int64
+	headCoord int64
+	headDir   byte
+}
+
+type queryD struct {
+	x, y int64
+	dir  byte
+	t    int64
+}
+
+type testCaseD struct {
+	input    string
+	expected []string
+}
+
+func solveQueriesD(b int64, vert []Segment, hor []Segment, qs []queryD) []string {
+	res := make([]string, len(qs))
+	for i, q := range qs {
+		x, y := q.x, q.y
+		dir := q.dir
+		t := q.t
+		for t > 0 {
+			var dx, dy int64
+			switch dir {
+			case 'R':
+				dx = 1
+			case 'L':
+				dx = -1
+			case 'U':
+				dy = 1
+			case 'D':
+				dy = -1
+			}
+			distBound := int64(0)
+			if dx > 0 {
+				distBound = b - x
+			} else if dx < 0 {
+				distBound = x
+			} else if dy > 0 {
+				distBound = b - y
+			} else if dy < 0 {
+				distBound = y
+			}
+			bestDist := distBound + 1
+			var seg *Segment
+			if dx != 0 {
+				for j := range vert {
+					s := &vert[j]
+					if y < s.low || y > s.high {
+						continue
+					}
+					d := (s.fixed - x) * dx
+					if d > 0 && d < bestDist {
+						bestDist = d
+						seg = s
+					}
+				}
+			} else {
+				for j := range hor {
+					s := &hor[j]
+					if x < s.low || x > s.high {
+						continue
+					}
+					d := (s.fixed - y) * dy
+					if d > 0 && d < bestDist {
+						bestDist = d
+						seg = s
+					}
+				}
+			}
+			if seg == nil || bestDist > distBound {
+				move := t
+				if move > distBound {
+					move = distBound
+				}
+				x += dx * move
+				y += dy * move
+				break
+			}
+			if t < bestDist {
+				x += dx * t
+				y += dy * t
+				break
+			}
+			x += dx * bestDist
+			y += dy * bestDist
+			t -= bestDist
+			if seg.vertical {
+				dseg := seg.headCoord - y
+				sign := int64(1)
+				if dseg < 0 {
+					sign = -1
+				}
+				lenSeg := dseg * sign
+				if t < lenSeg {
+					y += sign * t
+					break
+				}
+				y = seg.headCoord
+				t -= lenSeg
+			} else {
+				dseg := seg.headCoord - x
+				sign := int64(1)
+				if dseg < 0 {
+					sign = -1
+				}
+				lenSeg := dseg * sign
+				if t < lenSeg {
+					x += sign * t
+					break
+				}
+				x = seg.headCoord
+				t -= lenSeg
+			}
+			dir = seg.headDir
+		}
+		res[i] = fmt.Sprintf("%d %d", x, y)
+	}
+	return res
+}
+
+func genCaseD(rng *rand.Rand) testCaseD {
+	b := int64(rng.Intn(10) + 5)
+	nSeg := rng.Intn(3)
+	var vert []Segment
+	var hor []Segment
+	usedX := make(map[int64]bool)
+	for i := 0; i < nSeg; i++ {
+		x := int64(rng.Intn(int(b-1)) + 1)
+		for usedX[x] {
+			x = int64(rng.Intn(int(b-1)) + 1)
+		}
+		usedX[x] = true
+		y0 := int64(rng.Intn(int(b + 1)))
+		y1 := int64(rng.Intn(int(b + 1)))
+		for y1 == y0 {
+			y1 = int64(rng.Intn(int(b + 1)))
+		}
+		s := Segment{vertical: true, fixed: x}
+		if y0 < y1 {
+			s.low = y0
+			s.high = y1
+			s.headCoord = y1
+			s.headDir = 'U'
+		} else {
+			s.low = y1
+			s.high = y0
+			s.headCoord = y1
+			s.headDir = 'D'
+		}
+		vert = append(vert, s)
+	}
+	qcnt := rng.Intn(5) + 1
+	var qs []queryD
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", nSeg, b)
+	for _, s := range vert {
+		if s.vertical {
+			if s.headDir == 'U' {
+				fmt.Fprintf(&sb, "%d %d %d %d\n", s.fixed, s.low, s.fixed, s.high)
+			} else {
+				fmt.Fprintf(&sb, "%d %d %d %d\n", s.fixed, s.high, s.fixed, s.low)
+			}
+		} else {
+			// not used
+		}
+	}
+	fmt.Fprintf(&sb, "%d\n", qcnt)
+	dirs := []byte{'U', 'D', 'L', 'R'}
+	for i := 0; i < qcnt; i++ {
+		x := int64(rng.Intn(int(b + 1)))
+		y := int64(rng.Intn(int(b + 1)))
+		dir := dirs[rng.Intn(len(dirs))]
+		t := int64(rng.Intn(10) + 1)
+		qs = append(qs, queryD{x: x, y: y, dir: dir, t: t})
+		fmt.Fprintf(&sb, "%d %d %c %d\n", x, y, dir, t)
+	}
+	expected := solveQueriesD(b, vert, hor, qs)
+	return testCaseD{input: sb.String(), expected: expected}
+}
+
+func runCaseD(bin string, tc testCaseD) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(gotLines) != len(tc.expected) {
+		return fmt.Errorf("expected %d lines got %d", len(tc.expected), len(gotLines))
+	}
+	for i, l := range gotLines {
+		if strings.TrimSpace(l) != tc.expected[i] {
+			return fmt.Errorf("expected %q got %q", tc.expected[i], l)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseD(rng)
+		if err := runCaseD(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/320-329/324/verifierE.go
+++ b/0-999/300-399/320-329/324/verifierE.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	x, y int
+}
+
+type testCaseE struct {
+	input    string
+	expected []int64
+}
+
+const modE = 1000000007
+
+func solveE(n int, edges []edge) []int64 {
+	adj := make([][]int, n)
+	for i := range adj {
+		adj[i] = make([]int, n)
+	}
+	for _, e := range edges {
+		adj[e.x-1][e.y-1] = 1
+	}
+	maxLen := 2 * n
+	dp := make([][]int64, maxLen)
+	for i := 0; i < maxLen; i++ {
+		dp[i] = make([]int64, n)
+	}
+	for u := 0; u < n; u++ {
+		dp[0][u] = 1
+	}
+	for s := 1; s < maxLen; s++ {
+		for u := 0; u < n; u++ {
+			var sum int64
+			for v := 0; v < n; v++ {
+				if adj[v][u] != 0 {
+					sum += dp[s-1][v]
+					if sum >= modE {
+						sum -= modE
+					}
+				}
+			}
+			dp[s][u] = sum
+		}
+	}
+	res := make([]int64, maxLen)
+	for L := 1; L <= maxLen; L++ {
+		if L == 1 {
+			res[L-1] = 0
+			continue
+		}
+		s := L - 1
+		var total int64
+		for u := 0; u < n; u++ {
+			total += dp[s][u]
+			if total >= modE {
+				total -= modE
+			}
+		}
+		res[L-1] = total
+	}
+	return res
+}
+
+func genCaseE(rng *rand.Rand) testCaseE {
+	n := rng.Intn(4) + 1
+	maxEdges := n * (n - 1)
+	m := rng.Intn(maxEdges + 1)
+	var edgesList []edge
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(n) + 1
+		for y == x {
+			y = rng.Intn(n) + 1
+		}
+		edgesList = append(edgesList, edge{x, y})
+		fmt.Fprintf(&sb, "%d %d 2 %d %d\n", x, y, x, y)
+	}
+	expected := solveE(n, edgesList)
+	return testCaseE{input: sb.String(), expected: expected}
+}
+
+func runCaseE(bin string, tc testCaseE) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != len(tc.expected) {
+		return fmt.Errorf("expected %d numbers got %d", len(tc.expected), len(fields))
+	}
+	for i, f := range fields {
+		var v int64
+		if _, err := fmt.Sscan(f, &v); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if v != tc.expected[i] {
+			return fmt.Errorf("expected %v got %v", tc.expected, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseE(rng)
+		if err := runCaseE(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add crashy `324A.go` for runtime error testing
- implement solution verifiers `verifierA.go`–`verifierE.go` for contest 324

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go 324A.go`

------
https://chatgpt.com/codex/tasks/task_e_687eae901c08832484cd2b051a2dff14