### PR TITLE
Add verifiers for CF Round 323

### DIFF
--- a/0-999/300-399/320-329/323/verifierA.go
+++ b/0-999/300-399/320-329/323/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func checkPainting(k int, out string) bool {
+	out = strings.TrimSpace(out)
+	if k%2 == 1 {
+		return out == "-1"
+	}
+	letters := make([]byte, 0, k*k*k)
+	for i := 0; i < len(out); i++ {
+		c := out[i]
+		if c == 'w' || c == 'b' {
+			letters = append(letters, c)
+		}
+	}
+	if len(letters) != k*k*k {
+		return false
+	}
+	idx := 0
+	cube := make([][][]byte, k)
+	for z := 0; z < k; z++ {
+		layer := make([][]byte, k)
+		for y := 0; y < k; y++ {
+			row := make([]byte, k)
+			copy(row, letters[idx:idx+k])
+			idx += k
+			layer[y] = row
+		}
+		cube[z] = layer
+	}
+	dirs := [][3]int{{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1}}
+	for x := 0; x < k; x++ {
+		for y := 0; y < k; y++ {
+			for z := 0; z < k; z++ {
+				c := cube[x][y][z]
+				cnt := 0
+				for _, d := range dirs {
+					nx, ny, nz := x+d[0], y+d[1], z+d[2]
+					if nx >= 0 && nx < k && ny >= 0 && ny < k && nz >= 0 && nz < k {
+						if cube[nx][ny][nz] == c {
+							cnt++
+						}
+					}
+				}
+				if cnt != 2 {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func runCase(binary string, k int) error {
+	in := fmt.Sprintf("%d\n", k)
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if !checkPainting(k, buf.String()) {
+		return fmt.Errorf("wrong answer")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for k := 1; k <= 100; k++ {
+		if err := runCase(bin, k); err != nil {
+			fmt.Printf("test %d failed: %v\n", k, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/300-399/320-329/323/verifierB.go
+++ b/0-999/300-399/320-329/323/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func validateTournament(n int, out string) bool {
+	out = strings.TrimSpace(out)
+	if n < 3 {
+		return out == "-1"
+	}
+	fields := strings.Fields(out)
+	if len(fields) != n*n {
+		return false
+	}
+	a := make([][]int, n)
+	idx := 0
+	for i := 0; i < n; i++ {
+		row := make([]int, n)
+		for j := 0; j < n; j++ {
+			v, err := strconv.Atoi(fields[idx])
+			if err != nil || (v != 0 && v != 1) {
+				return false
+			}
+			row[j] = v
+			idx++
+		}
+		a[i] = row
+	}
+	for i := 0; i < n; i++ {
+		if a[i][i] != 0 {
+			return false
+		}
+		for j := i + 1; j < n; j++ {
+			if a[i][j]+a[j][i] != 1 {
+				return false
+			}
+		}
+	}
+	for s := 0; s < n; s++ {
+		for t := 0; t < n; t++ {
+			if s == t {
+				continue
+			}
+			if a[s][t] == 1 {
+				continue
+			}
+			ok := false
+			for k := 0; k < n && !ok; k++ {
+				if a[s][k] == 1 && a[k][t] == 1 {
+					ok = true
+				}
+			}
+			if !ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func runCase(bin string, n int) error {
+	in := fmt.Sprintf("%d\n", n)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if !validateTournament(n, buf.String()) {
+		return fmt.Errorf("wrong answer")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for n := 1; n <= 100; n++ {
+		if err := runCase(bin, n); err != nil {
+			fmt.Printf("test %d failed: %v\n", n, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/300-399/320-329/323/verifierC.go
+++ b/0-999/300-399/320-329/323/verifierC.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase(seed int64) (string, []int) {
+	rand.Seed(seed)
+	n := 5 + rand.Intn(5) // 5..9
+	p := rand.Perm(n)
+	q := rand.Perm(n)
+	for i := 0; i < n; i++ {
+		p[i]++
+		q[i]++
+	}
+	m := 3 + rand.Intn(3) // 3..5
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", p[i])
+	}
+	b.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", q[i])
+	}
+	b.WriteByte('\n')
+	fmt.Fprintf(&b, "%d\n", m)
+	queries := make([][4]int, m)
+	for i := 0; i < m; i++ {
+		for j := 0; j < 4; j++ {
+			queries[i][j] = 1 + rand.Intn(n)
+		}
+		fmt.Fprintf(&b, "%d %d %d %d\n", queries[i][0], queries[i][1], queries[i][2], queries[i][3])
+	}
+	ans := solveCase(n, p, q, queries)
+	return b.String(), ans
+}
+
+func solveCase(n int, p, q []int, queries [][4]int) []int {
+	posP := make([]int, n+1)
+	posQ := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		posP[p[i]] = i + 1
+		posQ[q[i]] = i + 1
+	}
+	x := 0
+	res := make([]int, len(queries))
+	for qi, qu := range queries {
+		a, b, c, d := qu[0], qu[1], qu[2], qu[3]
+		f := func(z int) int { return ((z - 1 + x) % n) + 1 }
+		l1 := f(a)
+		r1 := f(b)
+		if l1 > r1 {
+			l1, r1 = r1, l1
+		}
+		l2 := f(c)
+		r2 := f(d)
+		if l2 > r2 {
+			l2, r2 = r2, l2
+		}
+		count := 0
+		for v := 1; v <= n; v++ {
+			if posP[v] >= l1 && posP[v] <= r1 && posQ[v] >= l2 && posQ[v] <= r2 {
+				count++
+			}
+		}
+		res[qi] = count
+		x = count + 1
+	}
+	return res
+}
+
+func runCase(bin string, seed int64) error {
+	input, ans := generateCase(seed)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	outLines := strings.Fields(buf.String())
+	if len(outLines) != len(ans) {
+		return fmt.Errorf("wrong answer")
+	}
+	for i, v := range outLines {
+		x, err := strconv.Atoi(v)
+		if err != nil || x != ans[i] {
+			return fmt.Errorf("wrong answer")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		if err := runCase(bin, int64(i)+time.Now().UnixNano()); err != nil {
+			fmt.Printf("test %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`, `verifierB.go`, `verifierC.go` for contest 323
- each verifier runs a given binary on 100 generated test cases
- verifiers check program output and report failures

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`


------
https://chatgpt.com/codex/tasks/task_e_687eae4b42208324883177fbc5f0ec00