### PR TITLE
Add verifiers for contest 318

### DIFF
--- a/0-999/300-399/310-319/318/verifierA.go
+++ b/0-999/300-399/310-319/318/verifierA.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(n, k int64) int64 {
+	half := (n + 1) / 2
+	if k <= half {
+		return 2*k - 1
+	}
+	return 2 * (k - half)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// deterministic edge cases
+	fixed := [][2]int64{
+		{1, 1},
+		{2, 1},
+		{2, 2},
+		{5, 3},
+		{10, 10},
+		{1000000000000, 1},
+		{1000000000000, 1000000000000},
+		{999999999999, 500000000000},
+	}
+	idx := 0
+	for ; idx < len(fixed); idx++ {
+		n := fixed[idx][0]
+		k := fixed[idx][1]
+		input := fmt.Sprintf("%d %d\n", n, k)
+		expectedOut := strconv.FormatInt(expected(n, k), 10)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedOut {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", idx+1, expectedOut, got, input)
+			os.Exit(1)
+		}
+	}
+	// random cases to reach at least 100
+	for ; idx < 100; idx++ {
+		n := rng.Int63n(1000000000000) + 1 // up to 1e12
+		k := rng.Int63n(n) + 1
+		input := fmt.Sprintf("%d %d\n", n, k)
+		expectedOut := strconv.FormatInt(expected(n, k), 10)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedOut {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", idx+1, expectedOut, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}

--- a/0-999/300-399/310-319/318/verifierB.go
+++ b/0-999/300-399/310-319/318/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) int64 {
+	b := []byte(s)
+	var heavyCount int64
+	var result int64
+	n := len(b)
+	for i := 0; i+4 < n; i++ {
+		if b[i] == 'h' && b[i+1] == 'e' && b[i+2] == 'a' && b[i+3] == 'v' && b[i+4] == 'y' {
+			heavyCount++
+		} else if b[i] == 'm' && b[i+1] == 'e' && b[i+2] == 't' && b[i+3] == 'a' && b[i+4] == 'l' {
+			result += heavyCount
+		}
+	}
+	return result
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type test struct {
+	s string
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var tests []test
+	// fixed edge cases
+	fixed := []string{
+		"heavymetal",
+		"heavyheavymetal",
+		"heavymetalisheavymetal",
+		"heavymetalisheavymetalisheavy",
+		"metalheavy",
+		"heavy",
+		"metal",
+		"h",
+		"",
+		"heavymetalm",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(50) + 1 // up to 50 chars for simplicity
+		var b strings.Builder
+		letters := []byte("heavymlt") // letters from heavy+metal
+		for i := 0; i < n; i++ {
+			b.WriteByte(letters[rng.Intn(len(letters))])
+		}
+		tests = append(tests, test{b.String()})
+	}
+	for i, t := range tests {
+		input := t.s + "\n"
+		expectedOut := fmt.Sprint(expected(t.s))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedOut {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expectedOut, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 318 problems A and B
- support running against any binary or `.go` file
- include deterministic and random tests to reach 100 cases each

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go run verifierA.go ./318A_bin`
- `go run verifierB.go ./318B_bin`

------
https://chatgpt.com/codex/tasks/task_e_687eaced0b248324919df332c83f0c75