### PR TITLE
Add verifiers for contest 317

### DIFF
--- a/0-999/300-399/310-319/317/verifierA.go
+++ b/0-999/300-399/310-319/317/verifierA.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	cmd := exec.Command("go", "run", "317A.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		x := rand.Int63n(200) - 100
+		y := rand.Int63n(200) - 100
+		m := rand.Int63n(200) - 100
+		input := fmt.Sprintf("%d %d %d\n", x, y, m)
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference run error:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary run error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != got {
+			fmt.Printf("mismatch on test %d\ninput: %sexpected: %s\n got: %s\n", i+1, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/300-399/310-319/317/verifierB.go
+++ b/0-999/300-399/310-319/317/verifierB.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	cmd := exec.Command("go", "run", "317B.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(2)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50)
+		q := rand.Intn(5) + 1
+		input := fmt.Sprintf("%d %d\n", n, q)
+		for j := 0; j < q; j++ {
+			x := rand.Intn(11) - 5
+			y := rand.Intn(11) - 5
+			input += fmt.Sprintf("%d %d\n", x, y)
+		}
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference run error:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary run error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != got {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:\n%s\n got:\n%s\n", i+1, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/300-399/310-319/317/verifierC.go
+++ b/0-999/300-399/310-319/317/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	cmd := exec.Command("go", "run", "317C.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(4) + 2
+		v := rand.Intn(10) + 1
+		maxEdges := n * (n - 1) / 2
+		m := rand.Intn(maxEdges + 1)
+		a := make([]int, n)
+		b := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rand.Intn(v + 1)
+		}
+		for j := 0; j < n; j++ {
+			b[j] = rand.Intn(v + 1)
+		}
+		edges := make([][2]int, 0, m)
+		used := make(map[[2]int]bool)
+		for len(edges) < m {
+			x := rand.Intn(n) + 1
+			y := rand.Intn(n) + 1
+			if x == y {
+				continue
+			}
+			pair := [2]int{x, y}
+			if x > y {
+				pair = [2]int{y, x}
+			}
+			if used[pair] {
+				continue
+			}
+			used[pair] = true
+			edges = append(edges, pair)
+		}
+		input := fmt.Sprintf("%d %d %d\n", n, v, m)
+		for j := 0; j < n; j++ {
+			input += fmt.Sprintf("%d ", a[j])
+		}
+		input = strings.TrimSpace(input) + "\n"
+		for j := 0; j < n; j++ {
+			input += fmt.Sprintf("%d ", b[j])
+		}
+		input = strings.TrimSpace(input) + "\n"
+		for _, e := range edges {
+			input += fmt.Sprintf("%d %d\n", e[0], e[1])
+		}
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference run error:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary run error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != got {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:\n%s\n got:\n%s\n", i+1, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/300-399/310-319/317/verifierD.go
+++ b/0-999/300-399/310-319/317/verifierD.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	cmd := exec.Command("go", "run", "317D.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(4)
+	for i := 0; i < 100; i++ {
+		n := rand.Int63n(1000) + 1
+		input := fmt.Sprintf("%d\n", n)
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference run error:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary run error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != got {
+			fmt.Printf("mismatch on test %d\ninput: %sexpected: %s\n got: %s\n", i+1, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/300-399/310-319/317/verifierE.go
+++ b/0-999/300-399/310-319/317/verifierE.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	cmd := exec.Command("go", "run", "317E.go")
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	for i := 0; i < 100; i++ {
+		vx := rand.Intn(7) - 3
+		vy := rand.Intn(7) - 3
+		sx := rand.Intn(7) - 3
+		sy := rand.Intn(7) - 3
+		for vx == sx && vy == sy {
+			sx = rand.Intn(7) - 3
+			sy = rand.Intn(7) - 3
+		}
+		m := rand.Intn(5)
+		trees := make(map[[2]int]bool)
+		for len(trees) < m {
+			tx := rand.Intn(7) - 3
+			ty := rand.Intn(7) - 3
+			if (tx == vx && ty == vy) || (tx == sx && ty == sy) {
+				continue
+			}
+			trees[[2]int{tx, ty}] = true
+		}
+		input := fmt.Sprintf("%d %d %d %d %d\n", vx, vy, sx, sy, m)
+		for t := range trees {
+			input += fmt.Sprintf("%d %d\n", t[0], t[1])
+		}
+		exp, err := runRef(input)
+		if err != nil {
+			fmt.Println("reference run error:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary run error on test %d: %v\n", i+1, err)
+			return
+		}
+		if exp != got {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:\n%s\n got:\n%s\n", i+1, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 317 (problems A-E)
- each verifier runs 100 randomized tests against the reference solution

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687eaca5d20483248280163187293fab