### PR TITLE
Add verifiers for contest 316

### DIFF
--- a/0-999/300-399/310-319/316/verifierA.go
+++ b/0-999/300-399/310-319/316/verifierA.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	s string
+}
+
+func expected(s string) int64 {
+	seen := make([]bool, 10)
+	k := 0
+	for _, c := range s {
+		if c >= 'A' && c <= 'J' {
+			idx := c - 'A'
+			if !seen[idx] {
+				seen[idx] = true
+				k++
+			}
+		}
+	}
+	var letterMapping int64 = 1
+	first := s[0]
+	if first >= 'A' && first <= 'J' {
+		letterMapping = 9
+		rem := k - 1
+		for i := 0; i < rem; i++ {
+			letterMapping *= int64(9 - i)
+		}
+	} else {
+		for i := 0; i < k; i++ {
+			letterMapping *= int64(10 - i)
+		}
+	}
+	multiplier := int64(1)
+	for i, c := range s {
+		if c == '?' {
+			if i == 0 {
+				multiplier *= 9
+			} else {
+				multiplier *= 10
+			}
+		}
+	}
+	return letterMapping * multiplier
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	length := rng.Intn(10) + 1
+	firstChoices := []byte("123456789?ABCDEFGHIJ")
+	otherChoices := []byte("0123456789?ABCDEFGHIJ")
+	bs := make([]byte, length)
+	bs[0] = firstChoices[rng.Intn(len(firstChoices))]
+	for i := 1; i < length; i++ {
+		bs[i] = otherChoices[rng.Intn(len(otherChoices))]
+	}
+	s := string(bs)
+	input := fmt.Sprintf("%s\n", s)
+	output := fmt.Sprintf("%d\n", expected(s))
+	return input, output
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/310-319/316/verifierB.go
+++ b/0-999/300-399/310-319/316/verifierB.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int
+	x int
+	a []int
+}
+
+func solve(n, x int, a []int) []int {
+	next := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		if a[i] != 0 {
+			next[a[i]] = i
+		}
+	}
+	var other []int
+	sumOther := 0
+	posInChain := 0
+	for i := 1; i <= n; i++ {
+		if a[i] != 0 {
+			continue
+		}
+		cur := i
+		size := 0
+		containsX := false
+		for cur != 0 {
+			if cur == x {
+				containsX = true
+				posInChain = size
+			}
+			size++
+			cur = next[cur]
+		}
+		if !containsX {
+			other = append(other, size)
+			sumOther += size
+		}
+	}
+	dp := make([]bool, sumOther+1)
+	dp[0] = true
+	for _, sz := range other {
+		for s := sumOther; s >= sz; s-- {
+			if dp[s-sz] {
+				dp[s] = true
+			}
+		}
+	}
+	var res []int
+	for s := 0; s <= sumOther; s++ {
+		if dp[s] {
+			res = append(res, s+posInChain+1)
+		}
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(7) + 3 // up to 9/10
+	ids := rng.Perm(n)
+	a := make([]int, n+1)
+	start := true
+	for i, id := range ids {
+		if start || rng.Float64() < 0.3 {
+			a[id+1] = 0
+			start = false
+		} else {
+			a[id+1] = ids[i-1] + 1
+		}
+	}
+	x := ids[rng.Intn(n)] + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, x)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteByte('\n')
+	ans := solve(n, x, a)
+	var out strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprintf(&out, "%d", v)
+	}
+	out.WriteByte('\n')
+	return sb.String(), out.String()
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/310-319/316/verifierC.go
+++ b/0-999/300-399/310-319/316/verifierC.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n, m int, grid [][]int) int {
+	N := n * m
+	K := N / 2
+	pos := make([][2]int, K)
+	cnt := make([]int, K)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			x := grid[i][j] - 1
+			idx := i*m + j
+			if cnt[x] < 2 {
+				pos[x][cnt[x]] = idx
+			}
+			cnt[x]++
+		}
+	}
+	edges := make([][2]int, 0)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			u := i*m + j
+			if j+1 < m {
+				edges = append(edges, [2]int{u, u + 1})
+			}
+			if i+1 < n {
+				edges = append(edges, [2]int{u, u + m})
+			}
+		}
+	}
+	E := len(edges)
+	costMat := make([][]int, K)
+	cand := make([][]int, K)
+	for k := 0; k < K; k++ {
+		costMat[k] = make([]int, E)
+		for e := 0; e < E; e++ {
+			u, v := edges[e][0], edges[e][1]
+			p0, p1 := pos[k][0], pos[k][1]
+			c1 := 0
+			if p0 != u {
+				c1++
+			}
+			if p1 != v {
+				c1++
+			}
+			c2 := 0
+			if p0 != v {
+				c2++
+			}
+			if p1 != u {
+				c2++
+			}
+			if c2 < c1 {
+				costMat[k][e] = c2
+			} else {
+				costMat[k][e] = c1
+			}
+		}
+		idxs := make([]int, E)
+		for e := 0; e < E; e++ {
+			idxs[e] = e
+		}
+		for i := 1; i < E; i++ {
+			v := idxs[i]
+			j := i
+			for j > 0 && costMat[k][idxs[j-1]] > costMat[k][v] {
+				idxs[j] = idxs[j-1]
+				j--
+			}
+			idxs[j] = v
+		}
+		cand[k] = idxs
+	}
+	order := make([]int, K)
+	for i := 0; i < K; i++ {
+		order[i] = i
+	}
+	type od struct{ k, c0, c1 int }
+	ods := make([]od, K)
+	for _, k := range order {
+		c0, c1 := 0, 0
+		for _, e := range cand[k] {
+			if costMat[k][e] == 0 {
+				c0++
+			} else if costMat[k][e] == 1 {
+				c1++
+			} else {
+				break
+			}
+		}
+		ods[k] = od{k: k, c0: c0, c1: c1}
+	}
+	for i := 1; i < K; i++ {
+		tmp := ods[i]
+		j := i
+		for j > 0 {
+			o := ods[j-1]
+			if tmp.c0 < o.c0 || (tmp.c0 == o.c0 && tmp.c1 < o.c1) {
+				ods[j] = o
+				j--
+			} else {
+				break
+			}
+		}
+		ods[j] = tmp
+	}
+	for i := 0; i < K; i++ {
+		order[i] = ods[i].k
+	}
+	lbSum := make([]int, K+1)
+	lb := make([]int, K)
+	for i := 0; i < K; i++ {
+		k := order[i]
+		mc := costMat[k][cand[k][0]]
+		lb[i] = mc
+	}
+	lbSum[K] = 0
+	for i := K - 1; i >= 0; i-- {
+		lbSum[i] = lbSum[i+1] + lb[i]
+	}
+	best := 2 * K
+	var dfs func(idx int, used uint64, cur int)
+	dfs = func(idx int, used uint64, cur int) {
+		if cur+lbSum[idx] >= best {
+			return
+		}
+		if idx == K {
+			if cur < best {
+				best = cur
+			}
+			return
+		}
+		k := order[idx]
+		for _, e := range cand[k] {
+			c := costMat[k][e]
+			if cur+c >= best {
+				continue
+			}
+			u, v := edges[e][0], edges[e][1]
+			bit := (uint64(1) << u) | (uint64(1) << v)
+			if used&bit != 0 {
+				continue
+			}
+			dfs(idx+1, used|bit, cur+c)
+		}
+	}
+	dfs(0, 0, 0)
+	return best
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 2
+	m := rng.Intn(3) + 2
+	K := n * m / 2
+	nums := make([]int, 2*K)
+	for i := 0; i < K; i++ {
+		nums[2*i] = i + 1
+		nums[2*i+1] = i + 1
+	}
+	rng.Shuffle(len(nums), func(i, j int) { nums[i], nums[j] = nums[j], nums[i] })
+	grid := make([][]int, n)
+	idx := 0
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			grid[i][j] = nums[idx]
+			idx++
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", grid[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	ans := solveCase(n, m, grid)
+	return sb.String(), fmt.Sprintf("%d\n", ans)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/310-319/316/verifierD.go
+++ b/0-999/300-399/310-319/316/verifierD.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func nextPerm(a []int) bool {
+	n := len(a)
+	i := n - 2
+	for i >= 0 && a[i] >= a[i+1] {
+		i--
+	}
+	if i < 0 {
+		return false
+	}
+	j := n - 1
+	for a[j] <= a[i] {
+		j--
+	}
+	a[i], a[j] = a[j], a[i]
+	for l, r := i+1, n-1; l < r; l, r = l+1, r-1 {
+		a[l], a[r] = a[r], a[l]
+	}
+	return true
+}
+
+func validPerm(p, cap []int) bool {
+	n := len(p)
+	vis := make([]bool, n)
+	for i := 0; i < n; i++ {
+		if vis[i] {
+			continue
+		}
+		cur := i
+		cycle := []int{}
+		for !vis[cur] {
+			vis[cur] = true
+			cycle = append(cycle, cur)
+			cur = p[cur]
+		}
+		k := len(cycle)
+		if k <= 1 {
+			continue
+		}
+		b0, b1, b2 := 0, 0, 0
+		for _, v := range cycle {
+			if cap[v] <= 0 {
+				b0++
+			} else if cap[v] == 1 {
+				b1++
+			} else {
+				b2++
+			}
+		}
+		if b0 > 0 {
+			return false
+		}
+		if b1 > 2 {
+			return false
+		}
+		if k >= 3 && b2 < k-2 {
+			return false
+		}
+	}
+	return true
+}
+
+func solveCase(caps []int) int64 {
+	n := len(caps)
+	p := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = i
+	}
+	var cnt int64 = 0
+	for {
+		if validPerm(p, caps) {
+			cnt++
+		}
+		if !nextPerm(p) {
+			break
+		}
+	}
+	return cnt % mod
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	caps := make([]int, n)
+	for i := 0; i < n; i++ {
+		caps[i] = rng.Intn(3)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", caps[i])
+	}
+	sb.WriteByte('\n')
+	ans := solveCase(caps)
+	return sb.String(), fmt.Sprintf("%d\n", ans)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/310-319/316/verifierE.go
+++ b/0-999/300-399/310-319/316/verifierE.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000000
+
+func solveCase(n int, a []int, ops [][]int) string {
+	f := make([]int, n+1)
+	if n >= 0 {
+		f[0] = 1
+	}
+	if n >= 1 {
+		f[1] = 1
+	}
+	for i := 2; i <= n; i++ {
+		f[i] = f[i-1] + f[i-2]
+		if f[i] >= mod {
+			f[i] -= mod
+		}
+	}
+	var out strings.Builder
+	for _, op := range ops {
+		t := op[0]
+		switch t {
+		case 1:
+			x, v := op[1], op[2]
+			if x >= 1 && x <= n {
+				a[x] = v
+			}
+		case 2:
+			l, r := op[1], op[2]
+			sum := 0
+			for x := l; x <= r; x++ {
+				idx := x - l
+				sum += f[idx] * a[x]
+				if sum >= mod {
+					sum %= mod
+				}
+			}
+			fmt.Fprintf(&out, "%d\n", sum%mod)
+		}
+	}
+	return out.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = rng.Intn(5)
+	}
+	ops := make([][]int, m)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			x := rng.Intn(n) + 1
+			v := rng.Intn(5)
+			ops[i] = []int{1, x, v}
+			fmt.Fprintf(&sb, "1 %d %d\n", x, v)
+		} else {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			ops[i] = []int{2, l, r}
+			fmt.Fprintf(&sb, "2 %d %d\n", l, r)
+		}
+	}
+	expected := solveCase(n, append([]int(nil), a...), ops)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/310-319/316/verifierF.go
+++ b/0-999/300-399/310-319/316/verifierF.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int }
+
+func solveCase(h, w int, grid [][]int) string {
+	visited := make([][]bool, h)
+	for i := range visited {
+		visited[i] = make([]bool, w)
+	}
+	var rayCounts []int
+	dirs := [8][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}, {1, 1}, {1, -1}, {-1, 1}, {-1, -1}}
+	for i := 0; i < h; i++ {
+		for j := 0; j < w; j++ {
+			if grid[i][j] == 1 && !visited[i][j] {
+				var q []point
+				q = append(q, point{i, j})
+				visited[i][j] = true
+				comp := make([]point, 0, 256)
+				for qi := 0; qi < len(q); qi++ {
+					p := q[qi]
+					comp = append(comp, p)
+					for _, d := range dirs {
+						nx, ny := p.x+d[0], p.y+d[1]
+						if nx >= 0 && nx < h && ny >= 0 && ny < w && grid[nx][ny] == 1 && !visited[nx][ny] {
+							visited[nx][ny] = true
+							q = append(q, point{nx, ny})
+						}
+					}
+				}
+				var sx, sy float64
+				for _, p := range comp {
+					sx += float64(p.x)
+					sy += float64(p.y)
+				}
+				cnt := float64(len(comp))
+				cx := sx / cnt
+				cy := sy / cnt
+				hist := make(map[int]int)
+				for _, p := range comp {
+					dx := float64(p.x) - cx
+					dy := float64(p.y) - cy
+					d := math.Hypot(dx, dy)
+					r := int(d + 0.5)
+					hist[r]++
+				}
+				r0, maxc := 0, 0
+				for r, c := range hist {
+					if c > maxc {
+						maxc = c
+						r0 = r
+					}
+				}
+				cutoff := r0 + 2
+				var rays []point
+				for _, p := range comp {
+					dx := float64(p.x) - cx
+					dy := float64(p.y) - cy
+					d := math.Hypot(dx, dy)
+					if int(d+0.5) > cutoff {
+						rays = append(rays, p)
+					}
+				}
+				if len(rays) == 0 {
+					rayCounts = append(rayCounts, 0)
+					continue
+				}
+				minx, miny := rays[0].x, rays[0].y
+				maxx, maxy := minx, miny
+				for _, p := range rays {
+					if p.x < minx {
+						minx = p.x
+					}
+					if p.x > maxx {
+						maxx = p.x
+					}
+					if p.y < miny {
+						miny = p.y
+					}
+					if p.y > maxy {
+						maxy = p.y
+					}
+				}
+				hh := maxx - minx + 1
+				ww := maxy - miny + 1
+				mask := make([][]bool, hh)
+				vis2 := make([][]bool, hh)
+				for ii := 0; ii < hh; ii++ {
+					mask[ii] = make([]bool, ww)
+					vis2[ii] = make([]bool, ww)
+				}
+				for _, p := range rays {
+					mask[p.x-minx][p.y-miny] = true
+				}
+				rc := 0
+				for ii := 0; ii < hh; ii++ {
+					for jj := 0; jj < ww; jj++ {
+						if mask[ii][jj] && !vis2[ii][jj] {
+							rc++
+							var q2 []point
+							q2 = append(q2, point{ii, jj})
+							vis2[ii][jj] = true
+							for qi := 0; qi < len(q2); qi++ {
+								pp := q2[qi]
+								for _, d := range dirs {
+									nx, ny := pp.x+d[0], pp.y+d[1]
+									if nx >= 0 && nx < hh && ny >= 0 && ny < ww && mask[nx][ny] && !vis2[nx][ny] {
+										vis2[nx][ny] = true
+										q2 = append(q2, point{nx, ny})
+									}
+								}
+							}
+						}
+					}
+				}
+				rayCounts = append(rayCounts, rc)
+			}
+		}
+	}
+	sort.Ints(rayCounts)
+	var out strings.Builder
+	fmt.Fprintf(&out, "%d\n", len(rayCounts))
+	for i, v := range rayCounts {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		fmt.Fprintf(&out, "%d", v)
+	}
+	out.WriteByte('\n')
+	return out.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	h := rng.Intn(3) + 2
+	w := rng.Intn(3) + 2
+	grid := make([][]int, h)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", h, w)
+	for i := 0; i < h; i++ {
+		grid[i] = make([]int, w)
+		for j := 0; j < w; j++ {
+			v := rng.Intn(2)
+			grid[i][j] = v
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	expected := solveCase(h, w, grid)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/310-319/316/verifierG1.go
+++ b/0-999/300-399/310-319/316/verifierG1.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type SAM struct {
+	next []map[byte]int
+	link []int
+	len  []int
+	cnt  []int64
+	last int
+	sz   int
+}
+
+func NewSAM(maxLen int) *SAM {
+	size := 2*maxLen + 1
+	sam := &SAM{
+		next: make([]map[byte]int, size),
+		link: make([]int, size),
+		len:  make([]int, size),
+		cnt:  make([]int64, size),
+		last: 0,
+		sz:   1,
+	}
+	sam.next[0] = make(map[byte]int)
+	sam.link[0] = -1
+	return sam
+}
+
+func (sam *SAM) Extend(c byte) {
+	p := sam.last
+	cur := sam.sz
+	sam.sz++
+	sam.len[cur] = sam.len[p] + 1
+	sam.next[cur] = make(map[byte]int)
+	sam.cnt[cur] = 1
+	for p >= 0 && sam.next[p][c] == 0 {
+		sam.next[p][c] = cur
+		p = sam.link[p]
+	}
+	if p == -1 {
+		sam.link[cur] = 0
+	} else {
+		q := sam.next[p][c]
+		if sam.len[p]+1 == sam.len[q] {
+			sam.link[cur] = q
+		} else {
+			clone := sam.sz
+			sam.sz++
+			sam.len[clone] = sam.len[p] + 1
+			sam.next[clone] = make(map[byte]int)
+			for k, v := range sam.next[q] {
+				sam.next[clone][k] = v
+			}
+			sam.link[clone] = sam.link[q]
+			sam.cnt[clone] = 0
+			for p >= 0 && sam.next[p][c] == q {
+				sam.next[p][c] = clone
+				p = sam.link[p]
+			}
+			sam.link[q] = clone
+			sam.link[cur] = clone
+		}
+	}
+	sam.last = cur
+}
+
+func BuildSAM(s string) *SAM {
+	sam := NewSAM(len(s))
+	for i := 0; i < len(s); i++ {
+		sam.Extend(s[i])
+	}
+	maxLen := 0
+	for i := 0; i < sam.sz; i++ {
+		if sam.len[i] > maxLen {
+			maxLen = sam.len[i]
+		}
+	}
+	bucket := make([]int, maxLen+1)
+	for i := 0; i < sam.sz; i++ {
+		bucket[sam.len[i]]++
+	}
+	for i := 1; i <= maxLen; i++ {
+		bucket[i] += bucket[i-1]
+	}
+	order := make([]int, sam.sz)
+	for i := sam.sz - 1; i >= 0; i-- {
+		l := sam.len[i]
+		bucket[l]--
+		order[bucket[l]] = i
+	}
+	for i := sam.sz - 1; i > 0; i-- {
+		v := order[i]
+		p := sam.link[v]
+		if p >= 0 {
+			sam.cnt[p] += sam.cnt[v]
+		}
+	}
+	return sam
+}
+
+type Rule struct {
+	sam *SAM
+	l   int64
+	r   int64
+}
+
+func solveCase(s string, rules []Rule) string {
+	good := make(map[string]struct{})
+	for i := 0; i < len(s); i++ {
+		cur := make([]int, len(rules))
+		for k := range cur {
+			cur[k] = 0
+		}
+		for j := i; j < len(s); j++ {
+			c := s[j]
+			ok := true
+			for k := 0; k < len(rules); k++ {
+				if cur[k] >= 0 {
+					nxt, has := rules[k].sam.next[cur[k]][c]
+					if !has {
+						cur[k] = -1
+					} else {
+						cur[k] = nxt
+					}
+				}
+				var occ int64
+				if cur[k] >= 0 {
+					occ = rules[k].sam.cnt[cur[k]]
+				} else {
+					occ = 0
+				}
+				if occ < rules[k].l || occ > rules[k].r {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				sub := s[i : j+1]
+				good[sub] = struct{}{}
+			}
+		}
+	}
+	return fmt.Sprintf("%d\n", len(good))
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	L := rng.Intn(5) + 1
+	var letters = []byte("abc")
+	bs := make([]byte, L)
+	for i := 0; i < L; i++ {
+		bs[i] = letters[rng.Intn(len(letters))]
+	}
+	s := string(bs)
+	n := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s %d\n", s, n)
+	rules := make([]Rule, n)
+	for i := 0; i < n; i++ {
+		lp := rng.Intn(3) + 1
+		pb := make([]byte, lp)
+		for j := 0; j < lp; j++ {
+			pb[j] = letters[rng.Intn(len(letters))]
+		}
+		p := string(pb)
+		l := rng.Intn(3)
+		r := l + rng.Intn(3)
+		fmt.Fprintf(&sb, "%s %d %d\n", p, l, r)
+		rules[i] = Rule{sam: BuildSAM(p), l: int64(l), r: int64(r)}
+	}
+	expected := solveCase(s, rules)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for all problems of contest 316

## Testing
- `go build 0-999/300-399/310-319/316/verifierA.go`
- `go build 0-999/300-399/310-319/316/verifierB.go`
- `go build 0-999/300-399/310-319/316/verifierC.go`
- `go build 0-999/300-399/310-319/316/verifierD.go`
- `go build 0-999/300-399/310-319/316/verifierE.go`
- `go build 0-999/300-399/310-319/316/verifierF.go`
- `go build 0-999/300-399/310-319/316/verifierG1.go`


------
https://chatgpt.com/codex/tasks/task_e_687eac5ff68c8324a0999ffa5d565410