### PR TITLE
Add Go verifiers for contest 311

### DIFF
--- a/0-999/300-399/310-319/311/verifierA.go
+++ b/0-999/300-399/310-319/311/verifierA.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(n int, k int64) string {
+	r := int64(n) * int64(n-1) / 2
+	if r <= k {
+		return "no solution"
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "0 %d\n", i)
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(9) + 2
+	maxPairs := int64(n*(n-1)) / 2
+	k := randInt63(rng, maxPairs+5)
+	input := fmt.Sprintf("%d %d\n", n, k)
+	expected := solveA(n, k)
+	return input, expected
+}
+
+func randInt63(rng *rand.Rand, n int64) int64 {
+	if n <= 0 {
+		return 0
+	}
+	return rng.Int63n(n)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseA(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/310-319/311/verifierB.go
+++ b/0-999/300-399/310-319/311/verifierB.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const INF int64 = 1 << 62
+
+func solveB(n, m, p int, d []int64, h []int, t []int64) string {
+	pos := make([]int64, n+1)
+	for i := 2; i <= n; i++ {
+		pos[i] = pos[i-1] + d[i-2]
+	}
+	ski := make([]int64, m+1)
+	for i := 1; i <= m; i++ {
+		ski[i] = t[i-1] - pos[h[i-1]]
+	}
+	sort.Slice(ski[1:], func(i, j int) bool { return ski[i+1] < ski[j+1] })
+	S := make([]int64, m+1)
+	for i := 1; i <= m; i++ {
+		S[i] = S[i-1] + ski[i]
+	}
+	dpPrev := make([]int64, m+1)
+	for i := 1; i <= m; i++ {
+		dpPrev[i] = INF
+	}
+	dpPrev[0] = 0
+	cost := func(k, i int) int64 {
+		return int64(i-k)*ski[i] - (S[i] - S[k])
+	}
+	for step := 1; step <= p; step++ {
+		dpCur := make([]int64, m+1)
+		dpCur[0] = 0
+		for i := 1; i <= m; i++ {
+			best := INF
+			for k := 0; k < i; k++ {
+				v := dpPrev[k] + cost(k, i)
+				if v < best {
+					best = v
+				}
+			}
+			dpCur[i] = best
+		}
+		dpPrev = dpCur
+	}
+	return fmt.Sprintf("%d", dpPrev[m])
+}
+
+func generateCaseB(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 2
+	m := rng.Intn(5) + 1
+	if m < 1 {
+		m = 1
+	}
+	p := rng.Intn(m) + 1
+	d := make([]int64, n-1)
+	for i := range d {
+		d[i] = int64(rng.Intn(5) + 1)
+	}
+	h := make([]int, m)
+	tarr := make([]int64, m)
+	for i := 0; i < m; i++ {
+		h[i] = rng.Intn(n) + 1
+		tarr[i] = int64(rng.Intn(30))
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, p)
+	for i := 0; i < n-1; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", d[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", h[i], tarr[i])
+	}
+	expected := solveB(n, m, p, d, h, tarr)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseB(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/310-319/311/verifierC.go
+++ b/0-999/300-399/310-319/311/verifierC.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func recomputeReach(methods []int, maxPos int) []bool {
+	reachable := make([]bool, maxPos+1)
+	queue := []int{0}
+	reachable[0] = true
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, step := range methods {
+			next := cur + step
+			if next <= maxPos && !reachable[next] {
+				reachable[next] = true
+				queue = append(queue, next)
+			}
+		}
+	}
+	return reachable
+}
+
+type Operation struct {
+	typ int
+	x   int
+	y   int64
+}
+
+func solveC(h int, n, m, k0 int, pos []int, c []int64, ops []Operation) string {
+	methods := []int{k0}
+	exists := make([]bool, n)
+	for i := range exists {
+		exists[i] = true
+	}
+	maxPos := h
+	for _, p := range pos {
+		if p > maxPos {
+			maxPos = p
+		}
+	}
+	var sb strings.Builder
+	for _, op := range ops {
+		if op.typ == 1 {
+			methods = append(methods, op.x)
+		} else if op.typ == 2 {
+			idx := op.x - 1
+			c[idx] -= op.y
+		}
+		reachable := recomputeReach(methods, maxPos)
+		if op.typ == 3 {
+			bestVal := int64(0)
+			bestIdx := -1
+			for i := 0; i < n; i++ {
+				if exists[i] && pos[i]-1 <= maxPos && reachable[pos[i]-1] {
+					if c[i] > bestVal || (c[i] == bestVal && (bestIdx == -1 || i < bestIdx)) {
+						bestVal = c[i]
+						bestIdx = i
+					}
+				}
+			}
+			if bestIdx == -1 {
+				sb.WriteString("0\n")
+			} else {
+				sb.WriteString(fmt.Sprintf("%d\n", bestVal))
+				exists[bestIdx] = false
+			}
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCaseC(rng *rand.Rand) (string, string) {
+	h := rng.Intn(50) + 10
+	n := rng.Intn(5) + 1
+	m := rng.Intn(10) + 1
+	k0 := rng.Intn(5) + 1
+	pos := make([]int, n)
+	used := map[int]bool{}
+	for i := 0; i < n; i++ {
+		for {
+			p := rng.Intn(h) + 1
+			if !used[p] {
+				used[p] = true
+				pos[i] = p
+				break
+			}
+		}
+	}
+	c := make([]int64, n)
+	for i := range c {
+		c[i] = int64(rng.Intn(50) + 1)
+	}
+	ops := make([]Operation, 0, m)
+	queryCount := 0
+	for i := 0; i < m; i++ {
+		typ := rng.Intn(3) + 1
+		if typ == 1 {
+			x := rng.Intn(5) + 1
+			ops = append(ops, Operation{typ: 1, x: x})
+		} else if typ == 2 {
+			x := rng.Intn(n) + 1
+			y := int64(rng.Intn(10) + 1)
+			ops = append(ops, Operation{typ: 2, x: x, y: y})
+		} else {
+			ops = append(ops, Operation{typ: 3})
+			queryCount++
+		}
+	}
+	if queryCount == 0 {
+		ops = append(ops, Operation{typ: 3})
+		m++
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", h, n, m, k0)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", pos[i], c[i])
+	}
+	for _, op := range ops {
+		if op.typ == 1 {
+			fmt.Fprintf(&sb, "1 %d\n", op.x)
+		} else if op.typ == 2 {
+			fmt.Fprintf(&sb, "2 %d %d\n", op.x, op.y)
+		} else {
+			fmt.Fprintf(&sb, "3\n")
+		}
+	}
+	expected := solveC(h, n, m, k0, pos, c, ops)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseC(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/310-319/311/verifierD.go
+++ b/0-999/300-399/310-319/311/verifierD.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 95542721
+
+func cube(x int) int {
+	return int((int64(x) * int64(x) % mod * int64(x)) % mod)
+}
+
+type Query struct {
+	t int
+	l int
+	r int
+}
+
+func solveD(n int, arr []int, queries []Query) string {
+	a := append([]int(nil), arr...)
+	var sb strings.Builder
+	for _, q := range queries {
+		if q.t == 1 {
+			sum := 0
+			for i := q.l - 1; i < q.r; i++ {
+				sum += a[i]
+				if sum >= mod {
+					sum %= mod
+				}
+			}
+			fmt.Fprintf(&sb, "%d\n", sum%mod)
+		} else {
+			for i := q.l - 1; i < q.r; i++ {
+				a[i] = cube(a[i])
+			}
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCaseD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(20)
+	}
+	q := rng.Intn(10) + 1
+	queries := make([]Query, q)
+	for i := 0; i < q; i++ {
+		t := rng.Intn(2) + 1
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		queries[i] = Query{t, l, r}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", q)
+	for _, qu := range queries {
+		fmt.Fprintf(&sb, "%d %d %d\n", qu.t, qu.l, qu.r)
+	}
+	expected := solveD(n, arr, queries)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseD(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/310-319/311/verifierE.go
+++ b/0-999/300-399/310-319/311/verifierE.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Bet struct {
+	t   int
+	w   int64
+	idx []int
+	fr  int
+}
+
+type InputE struct {
+	n    int
+	m    int
+	g    int64
+	s    []int
+	v    []int64
+	bets []Bet
+}
+
+func solveE(inp InputE) string {
+	n := inp.n
+	maxMask := 1 << uint(n)
+	best := int64(-1 << 63)
+	for mask := 0; mask < maxMask; mask++ {
+		profit := int64(0)
+		genders := make([]int, n)
+		for i := 0; i < n; i++ {
+			genders[i] = inp.s[i]
+			if mask&(1<<uint(i)) != 0 {
+				genders[i] ^= 1
+				profit -= inp.v[i]
+			}
+		}
+		for _, b := range inp.bets {
+			ok := true
+			for _, id := range b.idx {
+				if genders[id] != b.t {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				profit += b.w
+			} else if b.fr == 1 {
+				profit -= inp.g
+			}
+		}
+		if profit > best {
+			best = profit
+		}
+	}
+	return fmt.Sprintf("%d", best)
+}
+
+func generateCaseE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(3)
+	g := int64(rng.Intn(5))
+	s := make([]int, n)
+	v := make([]int64, n)
+	for i := 0; i < n; i++ {
+		s[i] = rng.Intn(2)
+		v[i] = int64(rng.Intn(5))
+	}
+	bets := make([]Bet, m)
+	for i := 0; i < m; i++ {
+		t := rng.Intn(2)
+		w := int64(rng.Intn(6))
+		k := rng.Intn(n) + 1
+		perm := rng.Perm(n)[:k]
+		fr := rng.Intn(2)
+		idx := make([]int, k)
+		for j := 0; j < k; j++ {
+			idx[j] = perm[j]
+		}
+		bets[i] = Bet{t: t, w: w, idx: idx, fr: fr}
+	}
+	inp := InputE{n: n, m: m, g: g, s: s, v: v, bets: bets}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, g)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", s[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		b := bets[i]
+		fmt.Fprintf(&sb, "%d %d %d", b.t, b.w, len(b.idx))
+		for _, id := range b.idx {
+			fmt.Fprintf(&sb, " %d", id+1)
+		}
+		fmt.Fprintf(&sb, " %d\n", b.fr)
+	}
+	expected := solveE(inp)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseE(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`, `verifierB.go`, `verifierC.go`, `verifierD.go`, and `verifierE.go`
- each verifier runs 100 randomized tests and checks a provided binary's output

## Testing
- `go build 0-999/300-399/310-319/311/verifierA.go`
- `go build 0-999/300-399/310-319/311/verifierB.go`
- `go build 0-999/300-399/310-319/311/verifierC.go`
- `go build 0-999/300-399/310-319/311/verifierD.go`
- `go build 0-999/300-399/310-319/311/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687eab02302883248d2792125d0df869