### PR TITLE
Add verifiers for contest 308

### DIFF
--- a/0-999/300-399/300-309/308/verifierA.go
+++ b/0-999/300-399/300-309/308/verifierA.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	input  string
+	expect string
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedA(n int, l, t int64, a []int64) string {
+	t *= 2
+	full := t / l
+	left := t % l
+	var res int64
+	j := 0
+	phase := false
+	for i := 0; i < n; i++ {
+		if left+a[i] >= l {
+			phase = true
+			j = 0
+			left -= l
+		}
+		for j < n && a[j] <= left+a[i] {
+			j++
+		}
+		if !phase {
+			res += (full+1)*int64(j-i-1) + full*int64(n-j+i)
+		} else {
+			res += (full+1)*int64(n+j-i-1) + full*int64(i-j)
+		}
+	}
+	ans := float64(res) / 4.0
+	return fmt.Sprintf("%.6f", ans)
+}
+
+func genCase(rng *rand.Rand) TestCase {
+	n := rng.Intn(5) + 2
+	l := int64(rng.Intn(50) + int(n) + 5)
+	t := int64(rng.Intn(50) + 1)
+	vals := rng.Perm(int(l))[:n]
+	sort.Ints(vals)
+	a := make([]int64, n)
+	for i, v := range vals {
+		a[i] = int64(v)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, l, t)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteByte('\n')
+	expect := expectedA(n, l, t, a)
+	return TestCase{sb.String(), expect}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		out, err := runCandidate(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if out != tc.expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expect, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/300-309/308/verifierB.go
+++ b/0-999/300-399/300-309/308/verifierB.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedB(n, r, c int, text string) string {
+	words := strings.Fields(text)
+	if len(words) > n {
+		words = words[:n]
+	}
+	lens := make([]int, len(words))
+	for i, w := range words {
+		lens[i] = len(w)
+	}
+	N := len(words)
+	nxt := make([]uint32, N+1)
+	sum := 0
+	j := 0
+	for i := 0; i < N; i++ {
+		if j < i {
+			j = i
+			sum = 0
+		}
+		for j < N && sum+lens[j]+(j-i) <= c {
+			sum += lens[j]
+			j++
+		}
+		nxt[i] = uint32(j)
+		sum -= lens[i]
+	}
+	nxt[N] = uint32(N)
+	maxB := 0
+	tmp := r
+	for tmp > 0 {
+		maxB++
+		tmp >>= 1
+	}
+	dp := make([][]uint32, maxB)
+	dp[0] = nxt
+	for b := 1; b < maxB; b++ {
+		dp[b] = make([]uint32, N+1)
+		prev := dp[b-1]
+		cur := dp[b]
+		for i := 0; i <= N; i++ {
+			cur[i] = prev[prev[i]]
+		}
+	}
+	bestLen := 0
+	bestStart := 0
+	var bestEnd uint32
+	for i := 0; i < N; i++ {
+		pos := uint32(i)
+		rem := r
+		b := 0
+		for rem > 0 {
+			if rem&1 != 0 {
+				pos = dp[b][pos]
+			}
+			rem >>= 1
+			b++
+		}
+		length := int(pos) - i
+		if length > bestLen {
+			bestLen = length
+			bestStart = i
+			bestEnd = pos
+		}
+		if bestLen == N {
+			break
+		}
+	}
+	var outBuf bytes.Buffer
+	cur := uint32(bestStart)
+	lines := 0
+	for lines < r && cur < bestEnd {
+		nxtPos := nxt[cur]
+		if nxtPos > bestEnd {
+			nxtPos = bestEnd
+		}
+		for k := cur; k < nxtPos; k++ {
+			if k > cur {
+				outBuf.WriteByte(' ')
+			}
+			outBuf.WriteString(words[k])
+		}
+		if lines+1 < r && nxtPos < bestEnd {
+			outBuf.WriteByte('\n')
+		}
+		cur = nxtPos
+		lines++
+	}
+	return strings.TrimSpace(outBuf.String())
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	r := rng.Intn(5) + 1
+	c := rng.Intn(15) + 5
+	wordCount := n
+	words := make([]string, wordCount)
+	for i := 0; i < wordCount; i++ {
+		l := rng.Intn(5) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('a' + rng.Intn(26))
+		}
+		words[i] = string(b)
+	}
+	text := strings.Join(words, " ")
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, r, c)
+	sb.WriteString(text)
+	if !strings.HasSuffix(text, "\n") {
+		sb.WriteByte('\n')
+	}
+	expect := expectedB(n, r, c, text)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/300-309/308/verifierC.go
+++ b/0-999/300-399/300-309/308/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedC(n, m int, a []int, b []int) string {
+	const maxExp = 30
+	cnt := make([]int, maxExp+1)
+	for _, x := range b {
+		if x >= 0 && x <= maxExp {
+			cnt[x]++
+		}
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(a)))
+	ans := 0
+	for _, cap := range a {
+		rem := cap
+		for exp := maxExp; exp >= 0; exp-- {
+			size := 1 << exp
+			if rem < size || cnt[exp] == 0 {
+				continue
+			}
+			maxk := rem >> exp
+			if cnt[exp] <= maxk {
+				ans += cnt[exp]
+				rem -= cnt[exp] * size
+				cnt[exp] = 0
+			} else {
+				ans += maxk
+				cnt[exp] -= maxk
+				rem -= maxk * size
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(50) + 1
+	}
+	b := make([]int, m)
+	for i := 0; i < m; i++ {
+		b[i] = rng.Intn(5)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", b[i]))
+	}
+	sb.WriteByte('\n')
+	expect := expectedC(n, m, a, b)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/300-309/308/verifierD.go
+++ b/0-999/300-399/300-309/308/verifierD.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedD(n, m int) string {
+	N := n + 1
+	low := m + 1
+	high := n - m
+	if low > high {
+		return "0"
+	}
+	var sumP, sumQ, sumR int64
+	for a := low; a <= high; a++ {
+		for b := low; b <= high; b++ {
+			C := int64(2*N-2*a-b)*int64(N-2*a) + int64(3*b*N)
+			denom := int64(2*N - 2*a + 5*b)
+			if denom <= 0 {
+				continue
+			}
+			threshold := C / denom
+			kmin := threshold + 1
+			if int(kmin) < low {
+				kmin = int64(low)
+			}
+			if int(kmin) <= high {
+				sumP += int64(high) - kmin + 1
+			}
+		}
+	}
+	for b := low; b <= high; b++ {
+		for c := low; c <= high; c++ {
+			C := int64(2*N-2*b-c)*int64(N-2*b) + int64(3*c*N)
+			denom := int64(2*N - 2*b + 5*c)
+			if denom <= 0 {
+				continue
+			}
+			threshold := C / denom
+			amin := threshold + 1
+			if int(amin) < low {
+				amin = int64(low)
+			}
+			if int(amin) <= high {
+				sumQ += int64(high) - amin + 1
+			}
+		}
+	}
+	for c := low; c <= high; c++ {
+		for a := low; a <= high; a++ {
+			C := int64(2*N-2*c-a)*int64(N-2*c) + int64(3*a*N)
+			denom := int64(2*N - 2*c + 5*a)
+			if denom <= 0 {
+				continue
+			}
+			threshold := C / denom
+			bmin := threshold + 1
+			if int(bmin) < low {
+				bmin = int64(low)
+			}
+			if int(bmin) <= high {
+				sumR += int64(high) - bmin + 1
+			}
+		}
+	}
+	return fmt.Sprintf("%d", sumP+sumQ+sumR)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 3
+	m := rng.Intn(n/2 + 1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	exp := expectedD(n, m)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/300-309/308/verifierE.go
+++ b/0-999/300-399/300-309/308/verifierE.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Sheep struct {
+	l, r, idx int
+}
+
+func okCheck(n, med int, print bool, v []Sheep, T [][]bool, buf *bytes.Buffer) bool {
+	ogr := make([]int, n)
+	cnt := make([]int, n)
+	pos := make([]int, n)
+	on := make([]int, n)
+	for i := 0; i < n; i++ {
+		ogr[i] = n - 1
+		cnt[i] = 0
+		pos[i] = -1
+	}
+	cnt[n-1] = n
+	for i := 0; i < n; i++ {
+		sum := 0
+		for j := 0; j < n; j++ {
+			sum += cnt[j]
+			if sum > j+1 {
+				return false
+			}
+			if sum == j+1 && j >= i {
+				break
+			}
+		}
+		cur := -1
+		for j := 0; j < n; j++ {
+			if ogr[j] <= sum-1 && pos[j] == -1 {
+				cur = j
+				break
+			}
+		}
+		cnt[ogr[cur]]--
+		cnt[i]++
+		ogr[cur] = i
+		pos[cur] = i
+		on[i] = cur
+		for j := 0; j < n; j++ {
+			if T[cur][j] {
+				if i+med < ogr[j] {
+					cnt[ogr[j]]--
+					ogr[j] = i + med
+					cnt[ogr[j]]++
+				}
+			}
+		}
+	}
+	if print {
+		for i := 0; i < n; i++ {
+			buf.WriteString(strconv.Itoa(v[on[i]].idx + 1))
+			if i+1 < n {
+				buf.WriteByte(' ')
+			}
+		}
+	}
+	return true
+}
+
+func expectedE(n int, intervals []Sheep) string {
+	v := make([]Sheep, n)
+	copy(v, intervals)
+	sort.Slice(v, func(i, j int) bool { return v[i].r < v[j].r })
+	T := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		T[i] = make([]bool, n)
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if v[i].l > v[j].r || v[j].l > v[i].r {
+				T[i][j] = false
+			} else {
+				T[i][j] = true
+			}
+		}
+	}
+	beg, end := 0, n
+	for beg < end {
+		med := (beg + end) / 2
+		if okCheck(n, med, false, v, T, nil) {
+			end = med
+		} else {
+			beg = med + 1
+		}
+	}
+	var buf bytes.Buffer
+	okCheck(n, beg, true, v, T, &buf)
+	return strings.TrimSpace(buf.String())
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	intervals := make([]Sheep, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(10)
+		r := l + rng.Intn(10)
+		intervals[i] = Sheep{l, r, i}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", intervals[i].l, intervals[i].r)
+	}
+	expect := expectedE(n, intervals)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for Codeforces Round 308 problems A–E
- each verifier generates 100 random test cases and checks a candidate binary
- verifiers support running either a compiled binary or a `.go` file via `go run`
- fix generator edge case in verifierA

## Testing
- `go build verifierA.go`
- `go run verifierA.go ./binTest` *(using compiled 308A.go)*
- `go build verifierB.go`
- `go run verifierB.go ./binB`
- `go build verifierC.go`
- `go run verifierC.go ./binC`
- `go build verifierD.go`
- `go run verifierD.go ./binD`
- `go build verifierE.go`
- `go run verifierE.go ./binE`

------
https://chatgpt.com/codex/tasks/task_e_687eaa2f956c8324bbdbf41083c4f88e