### PR TITLE
Add contest 306 Go verifiers

### DIFF
--- a/0-999/300-399/300-309/306/verifierA.go
+++ b/0-999/300-399/300-309/306/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m int
+}
+
+func runCase(bin string, tc testCase) ([]int, error) {
+	input := fmt.Sprintf("%d %d\n", tc.n, tc.m)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != tc.m {
+		return nil, fmt.Errorf("expected %d numbers, got %d", tc.m, len(fields))
+	}
+	res := make([]int, tc.m)
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, fmt.Errorf("invalid integer %q", f)
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func verifyCase(tc testCase, arr []int) error {
+	if len(arr) != tc.m {
+		return fmt.Errorf("expected %d numbers, got %d", tc.m, len(arr))
+	}
+	sum := 0
+	minv := arr[0]
+	maxv := arr[0]
+	for _, v := range arr {
+		if v <= 0 {
+			return fmt.Errorf("non-positive value %d", v)
+		}
+		sum += v
+		if v < minv {
+			minv = v
+		}
+		if v > maxv {
+			maxv = v
+		}
+	}
+	if sum != tc.n {
+		return fmt.Errorf("sum mismatch: expected %d got %d", tc.n, sum)
+	}
+	diff := maxv - minv
+	expectDiff := 0
+	if tc.n%tc.m != 0 {
+		expectDiff = 1
+	}
+	if diff != expectDiff {
+		return fmt.Errorf("expected max-min difference %d, got %d", expectDiff, diff)
+	}
+	return nil
+}
+
+func generateCases() []testCase {
+	cases := []testCase{{1, 1}, {2, 1}, {2, 2}, {3, 2}, {100, 1}, {100, 100}, {7, 3}, {10, 10}, {99, 50}}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(cases) < 100 {
+		n := rng.Intn(100) + 1
+		m := rng.Intn(n) + 1
+		cases = append(cases, testCase{n, m})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		arr, err := runCase(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (n=%d m=%d)\n", i+1, err, tc.n, tc.m)
+			os.Exit(1)
+		}
+		if err := verifyCase(tc, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (n=%d m=%d)\n", i+1, err, tc.n, tc.m)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/300-309/306/verifierB.go
+++ b/0-999/300-399/300-309/306/verifierB.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type interval struct {
+	x, l int
+}
+
+type testCase struct {
+	n    int
+	segs []interval
+}
+
+func runCase(bin string, tc testCase) ([]int, error) {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, len(tc.segs)))
+	for _, s := range tc.segs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", s.x, s.l))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid k: %v", err)
+	}
+	if k < 0 || k > len(tc.segs) {
+		return nil, fmt.Errorf("invalid k %d", k)
+	}
+	if len(fields[1:]) != k {
+		return nil, fmt.Errorf("expected %d indices, got %d", k, len(fields)-1)
+	}
+	rem := make([]int, k)
+	for i, f := range fields[1:] {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, fmt.Errorf("invalid index %q", f)
+		}
+		if v < 1 || v > len(tc.segs) {
+			return nil, fmt.Errorf("index out of range: %d", v)
+		}
+		rem[i] = v
+	}
+	return rem, nil
+}
+
+func union(n int, segs []interval) []bool {
+	arr := make([]bool, n+1)
+	for _, s := range segs {
+		end := s.x + s.l - 1
+		for i := s.x; i <= end && i <= n; i++ {
+			arr[i] = true
+		}
+	}
+	return arr
+}
+
+func checkRemoval(n int, segs []interval, rem []int) error {
+	removed := make([]bool, len(segs)+1)
+	for _, id := range rem {
+		if removed[id] {
+			return fmt.Errorf("duplicate index %d", id)
+		}
+		removed[id] = true
+	}
+	kept := make([]interval, 0, len(segs))
+	for i, s := range segs {
+		if !removed[i+1] {
+			kept = append(kept, s)
+		}
+	}
+	want := union(n, segs)
+	got := union(n, kept)
+	for i := 1; i <= n; i++ {
+		if want[i] != got[i] {
+			return fmt.Errorf("coverage mismatch at cell %d", i)
+		}
+	}
+	return nil
+}
+
+func minimalKeep(segs []interval) int {
+	type iv struct{ x, end int }
+	arr := make([]iv, len(segs))
+	for i, s := range segs {
+		arr[i] = iv{s.x, s.x + s.l - 1}
+	}
+	sort.Slice(arr, func(i, j int) bool {
+		if arr[i].x != arr[j].x {
+			return arr[i].x < arr[j].x
+		}
+		return arr[i].end > arr[j].end
+	})
+	pre, now, keep := -1, -1, 0
+	for _, iv := range arr {
+		if iv.x <= pre+1 {
+			if now < iv.end {
+				now = iv.end
+			}
+		} else {
+			if now > pre {
+				pre = now
+				keep++
+				now = iv.end
+			} else {
+				pre = iv.end
+				keep++
+				now = -1
+			}
+		}
+	}
+	if now > pre {
+		keep++
+	}
+	return keep
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 100)
+	cases = append(cases, testCase{n: 1, segs: []interval{{1, 1}}})
+	for len(cases) < 100 {
+		n := rng.Intn(200) + 1
+		m := rng.Intn(20) + 1
+		if m > n {
+			m = n
+		}
+		segs := make([]interval, m)
+		for i := 0; i < m; i++ {
+			x := rng.Intn(n) + 1
+			maxL := n - x + 1
+			l := rng.Intn(maxL) + 1
+			segs[i] = interval{x, l}
+		}
+		cases = append(cases, testCase{n: n, segs: segs})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		rem, err := runCase(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := checkRemoval(tc.n, tc.segs, rem); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		keepMin := minimalKeep(tc.segs)
+		if len(tc.segs)-len(rem) != keepMin {
+			fmt.Fprintf(os.Stderr, "case %d failed: not maximal removal\n", i+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/300-309/306/verifierC.go
+++ b/0-999/300-399/300-309/306/verifierC.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000009
+const maxN = 4005
+
+var fac [maxN]int64
+var invFac [maxN]int64
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func initFac() {
+	fac[0] = 1
+	for i := 1; i < maxN; i++ {
+		fac[i] = fac[i-1] * int64(i) % mod
+	}
+	invFac[maxN-1] = modPow(fac[maxN-1], mod-2)
+	for i := maxN - 1; i > 0; i-- {
+		invFac[i-1] = invFac[i] * int64(i) % mod
+	}
+}
+
+func comb(n, k int) int64 {
+	if k < 0 || k > n {
+		return 0
+	}
+	return fac[n] * (invFac[k] * invFac[n-k] % mod) % mod
+}
+
+func expected(n, w, b int) int64 {
+	wf := fac[w]
+	bf := fac[b]
+	var sum int64
+	for t := 2; t <= n-1; t++ {
+		y := n - t
+		if y < 1 {
+			continue
+		}
+		waysStripes := int64(t - 1)
+		c1 := comb(w-1, t-1)
+		c2 := comb(b-1, y-1)
+		if c1 == 0 || c2 == 0 {
+			continue
+		}
+		sum = (sum + waysStripes*c1%mod*c2) % mod
+	}
+	return wf * bf % mod * sum % mod
+}
+
+type testCase struct{ n, w, b int }
+
+func runCase(bin string, tc testCase) (int64, error) {
+	input := fmt.Sprintf("%d %d %d\n", tc.n, tc.w, tc.b)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return 0, fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	s := strings.TrimSpace(out.String())
+	val, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer output: %q", s)
+	}
+	return val % mod, nil
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{3, 2, 1}, {4, 3, 1}, {5, 3, 2}, {10, 7, 3}}
+	for len(cases) < 100 {
+		n := rng.Intn(20) + 3
+		w := rng.Intn(20) + 2
+		b := rng.Intn(20) + 1
+		if w+b < n {
+			continue
+		}
+		cases = append(cases, testCase{n, w, b})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	initFac()
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		got, err := runCase(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		exp := expected(tc.n, tc.w, tc.b)
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/300-309/306/verifierD.go
+++ b/0-999/300-399/300-309/306/verifierD.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct{ n int }
+
+func runCase(bin string, n int) ([]string, error) {
+	input := fmt.Sprintf("%d\n", n)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	return lines, nil
+}
+
+func parseCoords(lines []string, n int) ([][2]float64, error) {
+	if len(lines) != n {
+		return nil, fmt.Errorf("expected %d lines, got %d", n, len(lines))
+	}
+	pts := make([][2]float64, n)
+	for i, line := range lines {
+		var x, y float64
+		if _, err := fmt.Sscan(line, &x, &y); err != nil {
+			return nil, fmt.Errorf("parse line %d: %v", i+1, err)
+		}
+		if math.Abs(x) > 1e6 || math.Abs(y) > 1e6 {
+			return nil, fmt.Errorf("coordinate out of bounds")
+		}
+		pts[i] = [2]float64{x, y}
+	}
+	return pts, nil
+}
+
+func checkPolygon(n int, pts [][2]float64) error {
+	edges := make([][2]float64, n)
+	lens := make([]float64, n)
+	for i := 0; i < n; i++ {
+		j := (i + 1) % n
+		dx := pts[j][0] - pts[i][0]
+		dy := pts[j][1] - pts[i][1]
+		edges[i] = [2]float64{dx, dy}
+		lens[i] = math.Hypot(dx, dy)
+		if lens[i] < 1-1e-3 || lens[i] > 1000+1e-3 {
+			return fmt.Errorf("side length out of range")
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if math.Abs(lens[i]-lens[j]) < 1e-3 {
+				return fmt.Errorf("side lengths must differ")
+			}
+		}
+	}
+	expectCos := math.Cos(2 * math.Pi / float64(n))
+	for i := 0; i < n; i++ {
+		j := (i + 1) % n
+		k := (i + 2) % n
+		v1 := edges[j]
+		v2 := edges[k]
+		dot := v1[0]*v2[0] + v1[1]*v2[1]
+		cos := dot / (lens[j] * lens[k])
+		if math.Abs(cos-expectCos) > 1e-3 {
+			return fmt.Errorf("angles not equal")
+		}
+		cross := v1[0]*v2[1] - v1[1]*v2[0]
+		if cross <= 0 {
+			return fmt.Errorf("polygon not convex ccw")
+		}
+	}
+	return nil
+}
+
+func generateCases() []testCase {
+	cases := []testCase{{3}, {4}}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(cases) < 100 {
+		n := rng.Intn(98) + 3
+		cases = append(cases, testCase{n})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		lines, err := runCase(bin, tc.n)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if tc.n < 5 {
+			if len(lines) != 1 || strings.TrimSpace(lines[0]) != "No solution" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected 'No solution'\n", i+1)
+				os.Exit(1)
+			}
+			continue
+		}
+		pts, err := parseCoords(lines, tc.n)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := checkPolygon(tc.n, pts); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–D of contest 306
- each verifier runs 100+ test cases
- verifiers check outputs against expected logic and report failures

## Testing
- `go run verifierA.go ./306A_bin`
- `go run verifierB.go ./306B_bin`
- `go run verifierC.go ./306C_bin`
- `go run verifierD.go ./306D_bin`

------
https://chatgpt.com/codex/tasks/task_e_687ea9a3f9948324b42fe8280a2b1ca0