### PR TITLE
Add Go verifiers for contest 305

### DIFF
--- a/0-999/300-399/300-309/305/verifierA.go
+++ b/0-999/300-399/300-309/305/verifierA.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var k int
+	fmt.Fscan(reader, &k)
+	arr := make([]int, k)
+	for i := 0; i < k; i++ {
+		fmt.Fscan(reader, &arr[i])
+	}
+	ans := make([]int, 0, k)
+	var y int
+	f, f1 := false, false
+	for _, x := range arr {
+		if x == 0 || x == 100 {
+			ans = append(ans, x)
+		} else if x < 10 && !f {
+			ans = append(ans, x)
+			f = true
+		} else if x%10 == 0 && !f1 {
+			ans = append(ans, x)
+			f1 = true
+		} else {
+			y = x
+		}
+	}
+	if !f && !f1 && y != 0 {
+		ans = append(ans, y)
+	}
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, len(ans))
+	for i, v := range ans {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprint(&buf, v)
+	}
+	buf.WriteByte('\n')
+	return strings.TrimSpace(buf.String())
+}
+
+func genTestA() string {
+	k := rand.Intn(100) + 1
+	used := make(map[int]bool)
+	arr := make([]int, 0, k)
+	for len(arr) < k {
+		x := rand.Intn(101)
+		if !used[x] {
+			used[x] = true
+			arr = append(arr, x)
+		}
+	}
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, k)
+	for i, v := range arr {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprint(&buf, v)
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		in := genTestA()
+		expected := solveA(in)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(in)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\noutput: %s\n", i, err, string(out))
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(string(out))
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/300-399/300-309/305/verifierB.go
+++ b/0-999/300-399/300-309/305/verifierB.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var pStr, qStr string
+	if _, err := fmt.Fscan(reader, &pStr, &qStr); err != nil {
+		return ""
+	}
+	p := new(big.Int)
+	p.SetString(pStr, 10)
+	q := new(big.Int)
+	q.SetString(qStr, 10)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return ""
+	}
+	a := make([]*big.Int, n)
+	for i := 0; i < n; i++ {
+		var aiStr string
+		fmt.Fscan(reader, &aiStr)
+		ai := new(big.Int)
+		ai.SetString(aiStr, 10)
+		a[i] = ai
+	}
+	num := new(big.Int).Set(a[n-1])
+	den := big.NewInt(1)
+	for i := n - 2; i >= 0; i-- {
+		newNum := new(big.Int).Mul(a[i], num)
+		newNum.Add(newNum, den)
+		newDen := new(big.Int).Set(num)
+		num, den = newNum, newDen
+	}
+	lhs := new(big.Int).Mul(p, den)
+	rhs := new(big.Int).Mul(q, num)
+	if lhs.Cmp(rhs) == 0 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func fractionFromA(a []*big.Int) (*big.Int, *big.Int) {
+	n := len(a)
+	num := new(big.Int).Set(a[n-1])
+	den := big.NewInt(1)
+	for i := n - 2; i >= 0; i-- {
+		newNum := new(big.Int).Mul(a[i], num)
+		newNum.Add(newNum, den)
+		newDen := new(big.Int).Set(num)
+		num, den = newNum, newDen
+	}
+	return num, den
+}
+
+func genTestB() string {
+	n := rand.Intn(10) + 1
+	a := make([]*big.Int, n)
+	for i := 0; i < n; i++ {
+		a[i] = big.NewInt(int64(rand.Intn(1000) + 1))
+	}
+	num, den := fractionFromA(a)
+	// decide if we want equal or not
+	equal := rand.Intn(2) == 0
+	p := new(big.Int).Set(num)
+	q := new(big.Int).Set(den)
+	if !equal {
+		// modify p slightly
+		p.Add(p, big.NewInt(int64(rand.Intn(5)+1)))
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%s %s\n", p.String(), q.String())
+	fmt.Fprintln(&buf, n)
+	for i, v := range a {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		buf.WriteString(v.String())
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		in := genTestB()
+		expected := solveB(in)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(in)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\noutput: %s\n", i, err, string(out))
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(string(out))
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/300-399/300-309/305/verifierC.go
+++ b/0-999/300-399/300-309/305/verifierC.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Heap struct{ data []int64 }
+
+func (h *Heap) Len() int { return len(h.data) }
+func (h *Heap) Push(x int64) {
+	h.data = append(h.data, x)
+	i := len(h.data) - 1
+	for i > 0 {
+		p := (i - 1) / 2
+		if h.data[p] <= h.data[i] {
+			break
+		}
+		h.data[p], h.data[i] = h.data[i], h.data[p]
+		i = p
+	}
+}
+func (h *Heap) Pop() int64 {
+	n := len(h.data)
+	if n == 0 {
+		return 0
+	}
+	ret := h.data[0]
+	last := h.data[n-1]
+	h.data = h.data[:n-1]
+	if n-1 > 0 {
+		h.data[0] = last
+		i := 0
+		for {
+			left := 2*i + 1
+			if left >= len(h.data) {
+				break
+			}
+			minChild := left
+			right := left + 1
+			if right < len(h.data) && h.data[right] < h.data[left] {
+				minChild = right
+			}
+			if h.data[minChild] >= h.data[i] {
+				break
+			}
+			h.data[i], h.data[minChild] = h.data[minChild], h.data[i]
+			i = minChild
+		}
+	}
+	return ret
+}
+
+func solveC(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return ""
+	}
+	cnt := make(map[int64]int64, n)
+	var ai int64
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &ai)
+		cnt[ai]++
+	}
+	h := &Heap{}
+	inHeap := make(map[int64]bool)
+	for k, v := range cnt {
+		if v >= 2 {
+			h.Push(k)
+			inHeap[k] = true
+		}
+	}
+	for h.Len() > 0 {
+		k := h.Pop()
+		inHeap[k] = false
+		v := cnt[k]
+		if v < 2 {
+			continue
+		}
+		carry := v >> 1
+		cnt[k] = v & 1
+		nk := k + 1
+		cnt[nk] += carry
+		if cnt[nk] >= 2 && !inHeap[nk] {
+			h.Push(nk)
+			inHeap[nk] = true
+		}
+	}
+	var H int64 = -1
+	var ones int64
+	for k, v := range cnt {
+		if v > 0 {
+			if k > H {
+				H = k
+			}
+			ones++
+		}
+	}
+	ans := (H + 1) - ones
+	return fmt.Sprint(ans)
+}
+
+func genTestC() string {
+	n := rand.Intn(20) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rand.Intn(20))
+	}
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, n)
+	for i, v := range arr {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprint(&buf, v)
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		in := genTestC()
+		expected := solveC(in)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(in)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\noutput: %s\n", i, err, string(out))
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(string(out))
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/300-399/300-309/305/verifierD.go
+++ b/0-999/300-399/300-309/305/verifierD.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+func solveD(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n, m, k int
+	if _, err := fmt.Fscan(in, &n, &m, &k); err != nil {
+		return ""
+	}
+	Spos := n - k - 1
+	jumps := make([]int, 0, m)
+	for i := 0; i < m; i++ {
+		var u, v int
+		fmt.Fscan(in, &u, &v)
+		d := v - u
+		if d == 1 {
+			continue
+		} else if d == k+1 {
+			jumps = append(jumps, u)
+		} else {
+			return "0"
+		}
+	}
+	sort.Ints(jumps)
+	P := len(jumps)
+	if Spos <= 0 {
+		if P == 0 {
+			return "1"
+		} else {
+			return "0"
+		}
+	}
+	maxN := Spos
+	if k+1 > maxN {
+		maxN = k + 1
+	}
+	pow2 := make([]int, maxN+2)
+	pow2[0] = 1
+	for i := 1; i <= maxN+1; i++ {
+		pow2[i] = pow2[i-1] * 2 % MOD
+	}
+	if P == 0 {
+		if Spos <= k {
+			return fmt.Sprint(pow2[Spos])
+		}
+		res := int64(Spos-k+1) * int64(pow2[k]) % MOD
+		return fmt.Sprint(res)
+	}
+	imin := jumps[0]
+	imax := jumps[P-1]
+	if imax-imin > k {
+		return "0"
+	}
+	low := imax - k
+	if low < 1 {
+		low = 1
+	}
+	high := imin
+	res := 0
+	for L0 := low; L0 <= high; L0++ {
+		R0 := L0 + k
+		if R0 > Spos {
+			R0 = Spos
+		}
+		wlen := R0 - L0 + 1
+		lo := sort.Search(len(jumps), func(i int) bool { return jumps[i] >= L0 })
+		hi := sort.Search(len(jumps), func(i int) bool { return jumps[i] > R0 }) - 1
+		inCnt := 0
+		if lo < len(jumps) && hi >= lo {
+			inCnt = hi - lo + 1
+		}
+		aSz := wlen - inCnt
+		var add int
+		if L0 == imin {
+			add = pow2[aSz]
+		} else {
+			if aSz-1 >= 0 {
+				add = pow2[aSz-1]
+			}
+		}
+		res = (res + add) % MOD
+	}
+	return fmt.Sprint(res)
+}
+
+func genTestD() string {
+	n := rand.Intn(8) + 2
+	k := rand.Intn(n-1) + 1
+	edges := make([][2]int, 0)
+	for u := 1; u <= n; u++ {
+		if u+1 <= n && rand.Intn(2) == 0 {
+			edges = append(edges, [2]int{u, u + 1})
+		}
+		if u+k+1 <= n && rand.Intn(2) == 0 {
+			edges = append(edges, [2]int{u, u + k + 1})
+		}
+	}
+	m := len(edges)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d %d %d\n", n, m, k)
+	for _, e := range edges {
+		fmt.Fprintf(&buf, "%d %d\n", e[0], e[1])
+	}
+	return buf.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		in := genTestD()
+		expected := solveD(in)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(in)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\noutput: %s\n", i, err, string(out))
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(string(out))
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/300-399/300-309/305/verifierE.go
+++ b/0-999/300-399/300-309/305/verifierE.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var s string
+	fmt.Fscan(reader, &s)
+	n := len(s)
+	rad := make([]int, n)
+	for i := 0; i < n; i++ {
+		l, r := i, i
+		for l-1 >= 0 && r+1 < n && s[l-1] == s[r+1] {
+			l--
+			r++
+		}
+		rad[i] = (r - l) / 2
+	}
+	dp := make([][]uint16, n)
+	for i := range dp {
+		dp[i] = make([]uint16, n)
+	}
+	const maxG = 512
+	seen := make([]int, maxG)
+	iter := 1
+	for length := 1; length <= n; length++ {
+		for l := 0; l+length-1 < n; l++ {
+			r := l + length - 1
+			var g uint16 = 0
+			if length >= 3 {
+				for k := l + 1; k <= r-1; k++ {
+					if rad[k] > 0 {
+						x := dp[l][k-1] ^ dp[k+1][r]
+						if int(x) < maxG {
+							seen[x] = iter
+						}
+					}
+				}
+				for j := 0; j < maxG; j++ {
+					if seen[j] != iter {
+						g = uint16(j)
+						break
+					}
+				}
+				iter++
+			}
+			dp[l][r] = g
+		}
+	}
+	full := dp[0][n-1]
+	if full == 0 {
+		return "Second"
+	}
+	var buf bytes.Buffer
+	buf.WriteString("First\n")
+	for i := 1; i+1 < n; i++ {
+		if rad[i] > 0 {
+			if dp[0][i-1]^dp[i+1][n-1] == 0 {
+				fmt.Fprintf(&buf, "%d", i+1)
+				break
+			}
+		}
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+func genTestE() string {
+	n := rand.Intn(20) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rand.Intn(26))
+	}
+	return string(b) + "\n"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		in := genTestE()
+		expected := solveE(in)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(in)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\noutput: %s\n", i, err, string(out))
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(string(out))
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for Codeforces contest 305
- verifiers run a reference solution on 100 random tests and check a given binary

## Testing
- `go build 0-999/300-399/300-309/305/verifierA.go`
- `go build 0-999/300-399/300-309/305/verifierB.go`
- `go build 0-999/300-399/300-309/305/verifierC.go`
- `go build 0-999/300-399/300-309/305/verifierD.go`
- `go build 0-999/300-399/300-309/305/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ea95d83408324a7493e42800a68cf