### PR TITLE
Add Go verifiers for CF302

### DIFF
--- a/0-999/300-399/300-309/302/verifierA.go
+++ b/0-999/300-399/300-309/302/verifierA.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type query struct{ l, r int }
+
+func expected(arr []int, qs []query) string {
+	cnt1 := 0
+	for _, v := range arr {
+		if v == 1 {
+			cnt1++
+		}
+	}
+	cntNeg := len(arr) - cnt1
+	var sb strings.Builder
+	for i, q := range qs {
+		length := q.r - q.l + 1
+		res := 0
+		if length%2 == 0 && cnt1 >= length/2 && cntNeg >= length/2 {
+			res = 1
+		}
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(strconv.Itoa(res))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			if rng.Intn(2) == 0 {
+				arr[j] = -1
+			} else {
+				arr[j] = 1
+			}
+		}
+		m := rng.Intn(20) + 1
+		qs := make([]query, m)
+		for j := 0; j < m; j++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n) + 1
+			if l > r {
+				l, r = r, l
+			}
+			qs[j] = query{l, r}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		for _, q := range qs {
+			fmt.Fprintf(&sb, "%d %d\n", q.l, q.r)
+		}
+		input := sb.String()
+		expect := expected(arr, qs)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\n got:\n%s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/300-309/302/verifierB.go
+++ b/0-999/300-399/300-309/302/verifierB.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type pair struct{ c, t int64 }
+
+func expected(pl []pair, qs []int64) string {
+	prefix := make([]int64, len(pl))
+	var sum int64
+	for i, p := range pl {
+		sum += p.c * p.t
+		prefix[i] = sum
+	}
+	var sb strings.Builder
+	for i, v := range qs {
+		idx := sort.Search(len(prefix), func(j int) bool {
+			return prefix[j] >= v
+		})
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(idx + 1))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		pl := make([]pair, n)
+		var total int64
+		for j := 0; j < n; j++ {
+			c := rng.Int63n(5) + 1
+			t := rng.Int63n(5) + 1
+			pl[j] = pair{c, t}
+			total += c * t
+		}
+		maxM := 10
+		if int64(maxM) > total {
+			maxM = int(total)
+		}
+		if maxM == 0 {
+			maxM = 1
+		}
+		m := rng.Intn(maxM) + 1
+		vals := make(map[int64]struct{})
+		for len(vals) < m {
+			v := rng.Int63n(total) + 1
+			vals[v] = struct{}{}
+		}
+		qs := make([]int64, 0, m)
+		for v := range vals {
+			qs = append(qs, v)
+		}
+		sort.Slice(qs, func(a, b int) bool { return qs[a] < qs[b] })
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d %d\n", pl[j].c, pl[j].t)
+		}
+		for j, v := range qs {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(v, 10))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := expected(pl, qs)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\n got:\n%s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` for problem A of contest 302
- add `verifierB.go` for problem B of contest 302
- each verifier generates 100 random testcases and checks any binary

## Testing
- `go run 0-999/300-399/300-309/302/verifierA.go ./302A`
- `go run 0-999/300-399/300-309/302/verifierB.go ./302B`


------
https://chatgpt.com/codex/tasks/task_e_687ea88bfaf48324ae2d5f673d5de699