### PR TITLE
Add Go verifiers for contest 301

### DIFF
--- a/0-999/300-399/300-309/301/verifierA.go
+++ b/0-999/300-399/300-309/301/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type TestCaseA struct {
+	input    string
+	expected string
+}
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveLocal(n int, arr []int) int {
+	m := 2*n - 1
+	sumAbs := 0
+	neg := 0
+	minAbs := int(1e9)
+	for i := 0; i < m; i++ {
+		x := arr[i]
+		if x < 0 {
+			neg++
+		}
+		ax := x
+		if ax < 0 {
+			ax = -ax
+		}
+		sumAbs += ax
+		if ax < minAbs {
+			minAbs = ax
+		}
+	}
+	if n%2 == 1 || neg%2 == 0 {
+		return sumAbs
+	}
+	return sumAbs - 2*minAbs
+}
+
+func genTests() []TestCaseA {
+	rand.Seed(1)
+	tests := make([]TestCaseA, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(99) + 2 // 2..100
+		m := 2*n - 1
+		arr := make([]int, m)
+		for i := 0; i < m; i++ {
+			arr[i] = rand.Intn(2001) - 1000
+		}
+		expected := solveLocal(n, arr)
+		var b strings.Builder
+		fmt.Fprintln(&b, n)
+		for i, v := range arr {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", v)
+		}
+		b.WriteByte('\n')
+		tests = append(tests, TestCaseA{input: b.String(), expected: fmt.Sprint(expected)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	passed := 0
+	for i, tc := range tests {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			continue
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, tc.expected, out)
+		} else {
+			passed++
+		}
+	}
+	fmt.Printf("passed %d/%d tests\n", passed, len(tests))
+	if passed != len(tests) {
+		os.Exit(1)
+	}
+}

--- a/0-999/300-399/300-309/301/verifierB.go
+++ b/0-999/300-399/300-309/301/verifierB.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type TestCaseB struct {
+	input    string
+	expected string
+}
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func abs(a int64) int64 {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func canReach(n int, d int64, a, x, y []int64, initFuel int64) bool {
+	const INF = math.MaxInt64 / 4
+	best := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		best[i] = -INF
+	}
+	best[1] = initFuel
+	for it := 0; it < n-1; it++ {
+		updated := false
+		for i := 1; i <= n; i++ {
+			if best[i] < 0 {
+				continue
+			}
+			bi := best[i]
+			for j := 1; j <= n; j++ {
+				if i == j {
+					continue
+				}
+				cost := d * (abs(x[i]-x[j]) + abs(y[i]-y[j]))
+				if bi < cost {
+					continue
+				}
+				nf := bi - cost + a[j]
+				if nf > best[j] {
+					best[j] = nf
+					updated = true
+				}
+			}
+		}
+		if !updated {
+			break
+		}
+	}
+	if best[n] >= 0 {
+		return true
+	}
+	for i := 1; i <= n; i++ {
+		if best[i] < 0 {
+			continue
+		}
+		bi := best[i]
+		for j := 1; j <= n; j++ {
+			if i == j {
+				continue
+			}
+			cost := d * (abs(x[i]-x[j]) + abs(y[i]-y[j]))
+			if bi < cost {
+				continue
+			}
+			nf := bi - cost + a[j]
+			if nf > best[j] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func solveLocal(n int, d int64, a, x, y []int64) int64 {
+	dist := abs(x[1]-x[n]) + abs(y[1]-y[n])
+	high := d * dist
+	low := int64(0)
+	for low < high {
+		mid := (low + high) / 2
+		if canReach(n, d, a, x, y, mid) {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+	return low
+}
+
+func genTests() []TestCaseB {
+	rand.Seed(2)
+	tests := make([]TestCaseB, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(8) + 3 // 3..10 small for speed
+		d := int64(rand.Intn(1000) + 1000)
+		a := make([]int64, n+1)
+		for i := 2; i <= n-1; i++ {
+			a[i] = int64(rand.Intn(1000) + 1)
+		}
+		x := make([]int64, n+1)
+		y := make([]int64, n+1)
+		for i := 1; i <= n; i++ {
+			x[i] = int64(rand.Intn(201) - 100)
+			y[i] = int64(rand.Intn(201) - 100)
+		}
+		expected := solveLocal(n, d, a, x, y)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, d)
+		for i := 2; i <= n-1; i++ {
+			if i > 2 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", a[i])
+		}
+		sb.WriteByte('\n')
+		for i := 1; i <= n; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", x[i], y[i])
+		}
+		tests = append(tests, TestCaseB{input: sb.String(), expected: fmt.Sprint(expected)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	passed := 0
+	for i, tc := range tests {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			continue
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, tc.expected, out)
+		} else {
+			passed++
+		}
+	}
+	fmt.Printf("passed %d/%d tests\n", passed, len(tests))
+	if passed != len(tests) {
+		os.Exit(1)
+	}
+}

--- a/0-999/300-399/300-309/301/verifierC.go
+++ b/0-999/300-399/300-309/301/verifierC.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var expectedOutput = []string{
+	"0??<>1",
+	"1??<>2",
+	"2??<>3",
+	"3??<>4",
+	"4??<>5",
+	"5??<>6",
+	"6??<>7",
+	"7??<>8",
+	"8??<>9",
+	"9??>>??0",
+	"??<>1",
+	"?0>>0?",
+	"?1>>1?",
+	"?2>>2?",
+	"?3>>3?",
+	"?4>>4?",
+	"?5>>5?",
+	"?6>>6?",
+	"?7>>7?",
+	"?8>>8?",
+	"?9>>9?",
+	"?>>??",
+	">>?",
+}
+
+func runBinary(path string) (string, error) {
+	cmd := exec.Command(path)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	expected := strings.Join(expectedOutput, "\n")
+	passed := 0
+	for i := 0; i < 100; i++ { // run 100 times
+		out, err := runBinary(bin)
+		if err != nil {
+			fmt.Printf("run %d: runtime error: %v\n", i+1, err)
+			continue
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Printf("run %d failed: output mismatch\n", i+1)
+		} else {
+			passed++
+		}
+	}
+	fmt.Printf("passed %d/100 runs\n", passed)
+	if passed != 100 {
+		os.Exit(1)
+	}
+}

--- a/0-999/300-399/300-309/301/verifierD.go
+++ b/0-999/300-399/300-309/301/verifierD.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type TestCaseD struct {
+	input    string
+	expected string
+}
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+// --- Reference solution logic copied from 301D.go ---
+
+type BIT struct {
+	n    int
+	tree []int
+}
+
+func NewBIT(n int) *BIT {
+	return &BIT{n: n, tree: make([]int, n+1)}
+}
+
+func (b *BIT) Add(i, v int) {
+	for ; i <= b.n; i += i & -i {
+		b.tree[i] += v
+	}
+}
+
+func (b *BIT) Sum(i int) int {
+	if i <= 0 {
+		return 0
+	}
+	s := 0
+	for ; i > 0; i -= i & -i {
+		s += b.tree[i]
+	}
+	return s
+}
+
+type Query struct {
+	y     int
+	id    int
+	coeff int
+}
+
+func solveLocal(n, m int, p []int, L, R []int) []int64 {
+	pos := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		pos[p[i-1]] = i
+	}
+	edgesByU := make([][]int, n+1)
+	for v := 1; v <= n; v++ {
+		u := pos[v]
+		for k := v + v; k <= n; k += v {
+			edgesByU[u] = append(edgesByU[u], pos[k])
+		}
+	}
+	subsByX := make([][]Query, n+1)
+	for i := 0; i < m; i++ {
+		l, r := L[i], R[i]
+		subsByX[r] = append(subsByX[r], Query{y: r, id: i, coeff: 1})
+		if l > 0 {
+			subsByX[l-1] = append(subsByX[l-1], Query{y: r, id: i, coeff: -1})
+			subsByX[r] = append(subsByX[r], Query{y: l - 1, id: i, coeff: -1})
+			subsByX[l-1] = append(subsByX[l-1], Query{y: l - 1, id: i, coeff: 1})
+		}
+	}
+	bit := NewBIT(n)
+	ansEdges := make([]int64, m)
+	for x := 0; x <= n; x++ {
+		if x > 0 {
+			for _, y := range edgesByU[x] {
+				bit.Add(y, 1)
+			}
+		}
+		for _, q := range subsByX[x] {
+			cnt := bit.Sum(q.y)
+			ansEdges[q.id] += int64(q.coeff) * int64(cnt)
+		}
+	}
+	res := make([]int64, m)
+	for i := 0; i < m; i++ {
+		res[i] = ansEdges[i] + int64(R[i]-L[i]+1)
+	}
+	return res
+}
+
+func genTests() []TestCaseD {
+	rand.Seed(3)
+	tests := make([]TestCaseD, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(50) + 1
+		m := rand.Intn(50) + 1
+		perm := rand.Perm(n)
+		for i := range perm {
+			perm[i] += 1
+		}
+		L := make([]int, m)
+		R := make([]int, m)
+		for i := 0; i < m; i++ {
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			L[i], R[i] = l, r
+		}
+		ans := solveLocal(n, m, perm, L, R)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for i, v := range perm {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < m; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", L[i], R[i])
+		}
+		outLines := make([]string, m)
+		for i, v := range ans {
+			outLines[i] = strconv.FormatInt(v, 10)
+		}
+		tests = append(tests, TestCaseD{input: sb.String(), expected: strings.Join(outLines, "\n")})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	passed := 0
+	for i, tc := range tests {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			continue
+		}
+		cleaned := strings.TrimSpace(out)
+		if cleaned != tc.expected {
+			fmt.Printf("test %d failed\nexpected:\n%s\n\ngot:\n%s\n", i+1, tc.expected, cleaned)
+		} else {
+			passed++
+		}
+	}
+	fmt.Printf("passed %d/%d tests\n", passed, len(tests))
+	if passed != len(tests) {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 301 problems A–D
- each verifier generates 100 random test cases and checks a target binary
- verifier for problem C checks constant output

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`


------
https://chatgpt.com/codex/tasks/task_e_687ea84596e0832489558ce11f2f3f98