### PR TITLE
Add verifiers for contest 300

### DIFF
--- a/0-999/300-399/300-309/300/verifierA.go
+++ b/0-999/300-399/300-309/300/verifierA.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type test struct {
+	n   int
+	arr []int
+}
+
+func genTests() []test {
+	rand.Seed(1)
+	tests := make([]test, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(97) + 3 // 3..99
+		m := map[int]bool{}
+		arr := make([]int, 0, n)
+		// ensure one negative
+		for {
+			x := -rand.Intn(1000) - 1
+			if !m[x] {
+				m[x] = true
+				arr = append(arr, x)
+				break
+			}
+		}
+		// ensure one positive
+		for {
+			x := rand.Intn(1000) + 1
+			if !m[x] {
+				m[x] = true
+				arr = append(arr, x)
+				break
+			}
+		}
+		// ensure one zero
+		if !m[0] {
+			m[0] = true
+			arr = append(arr, 0)
+		}
+		for len(arr) < n {
+			x := rand.Intn(2001) - 1000
+			if !m[x] {
+				m[x] = true
+				arr = append(arr, x)
+			}
+		}
+		rand.Shuffle(n, func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+		tests = append(tests, test{n, arr})
+	}
+	return tests
+}
+
+func buildInput(t test) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t.n))
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", path)
+	} else {
+		cmd = exec.CommandContext(ctx, path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func signProduct(nums []int) int {
+	sign := 1
+	for _, v := range nums {
+		if v == 0 {
+			return 0
+		}
+		if v < 0 {
+			sign = -sign
+		}
+	}
+	return sign
+}
+
+func verifyOutput(out string, t test) bool {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	scanner.Split(bufio.ScanWords)
+	vals := []int{}
+	for scanner.Scan() {
+		v, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return false
+		}
+		vals = append(vals, v)
+	}
+	if len(vals) == 0 {
+		return false
+	}
+	idx := 0
+	if idx >= len(vals) {
+		return false
+	}
+	n1 := vals[idx]
+	idx++
+	if idx+n1 > len(vals) {
+		return false
+	}
+	s1 := vals[idx : idx+n1]
+	idx += n1
+	if idx >= len(vals) {
+		return false
+	}
+	n2 := vals[idx]
+	idx++
+	if idx+n2 > len(vals) {
+		return false
+	}
+	s2 := vals[idx : idx+n2]
+	idx += n2
+	if idx >= len(vals) {
+		return false
+	}
+	n3 := vals[idx]
+	idx++
+	if idx+n3 > len(vals) {
+		return false
+	}
+	s3 := vals[idx : idx+n3]
+	idx += n3
+	if idx != len(vals) {
+		return false
+	}
+	if n1+n2+n3 != t.n {
+		return false
+	}
+	counts := make(map[int]int)
+	for _, v := range s1 {
+		counts[v]++
+	}
+	for _, v := range s2 {
+		counts[v]++
+	}
+	for _, v := range s3 {
+		counts[v]++
+	}
+	if len(counts) != t.n {
+		return false
+	}
+	for _, v := range t.arr {
+		if counts[v] != 1 {
+			return false
+		}
+	}
+	if signProduct(s1) >= 0 {
+		return false
+	}
+	if signProduct(s2) <= 0 {
+		return false
+	}
+	if signProduct(s3) != 0 {
+		return false
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := buildInput(t)
+		out, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: error running candidate: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !verifyOutput(out, t) {
+			fmt.Printf("test %d failed. input:\n%s\noutput:\n%s\n", i+1, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/300-309/300/verifierB.go
+++ b/0-999/300-399/300-309/300/verifierB.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edge struct{ a, b int }
+type test struct {
+	n     int
+	edges []edge
+}
+
+func genTests() []test {
+	rand.Seed(2)
+	tests := make([]test, 0, 100)
+	for len(tests) < 100 {
+		n := (rand.Intn(5) + 1) * 3 // 3..15
+		students := rand.Perm(n)
+		groups := make([][]int, n/3)
+		for i := 0; i < n/3; i++ {
+			groups[i] = []int{students[3*i] + 1, students[3*i+1] + 1, students[3*i+2] + 1}
+		}
+		var edges []edge
+		for _, g := range groups {
+			for i := 0; i < 3; i++ {
+				for j := i + 1; j < 3; j++ {
+					if rand.Intn(2) == 0 {
+						edges = append(edges, edge{g[i], g[j]})
+					}
+				}
+			}
+		}
+		tests = append(tests, test{n, edges})
+	}
+	return tests
+}
+
+func buildInput(t test) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, len(t.edges)))
+	for _, e := range t.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.a, e.b))
+	}
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", path)
+	} else {
+		cmd = exec.CommandContext(ctx, path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func verifyOutput(out string, t test) bool {
+	out = strings.TrimSpace(out)
+	if out == "-1" {
+		return false // we always generate solvable cases
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	groups := [][]int{}
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 3 {
+			return false
+		}
+		g := make([]int, 3)
+		for i, p := range parts {
+			v, err := strconv.Atoi(p)
+			if err != nil || v < 1 || v > t.n {
+				return false
+			}
+			g[i] = v
+		}
+		groups = append(groups, g)
+	}
+	if len(groups) != t.n/3 {
+		return false
+	}
+	count := make([]int, t.n+1)
+	for _, g := range groups {
+		for _, v := range g {
+			count[v]++
+		}
+	}
+	for i := 1; i <= t.n; i++ {
+		if count[i] != 1 {
+			return false
+		}
+	}
+	groupOf := make([]int, t.n+1)
+	for i, g := range groups {
+		for _, v := range g {
+			groupOf[v] = i
+		}
+	}
+	for _, e := range t.edges {
+		if groupOf[e.a] != groupOf[e.b] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := buildInput(t)
+		out, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Printf("test %d: run error %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !verifyOutput(out, t) {
+			fmt.Printf("test %d failed. input:\n%soutput:\n%s\n", i+1, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/300-309/300/verifierC.go
+++ b/0-999/300-399/300-309/300/verifierC.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+type test struct{ a, b, n int }
+
+func modPow(x, p int64) int64 {
+	res := int64(1)
+	x %= mod
+	for p > 0 {
+		if p&1 == 1 {
+			res = res * x % mod
+		}
+		x = x * x % mod
+		p >>= 1
+	}
+	return res
+}
+
+func countExcellent(a, b, n int) int64 {
+	fact := make([]int64, n+1)
+	invFact := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invFact[n] = modPow(fact[n], mod-2)
+	for i := n; i > 0; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % mod
+	}
+	var res int64
+	for k := 0; k <= n; k++ {
+		sum := k*a + (n-k)*b
+		x := sum
+		good := true
+		for x > 0 {
+			d := x % 10
+			if d != a && d != b {
+				good = false
+				break
+			}
+			x /= 10
+		}
+		if !good {
+			continue
+		}
+		comb := fact[n] * invFact[k] % mod * invFact[n-k] % mod
+		res = (res + comb) % mod
+	}
+	return res
+}
+
+func genTests() []test {
+	rand.Seed(3)
+	tests := make([]test, 0, 100)
+	for len(tests) < 100 {
+		a := rand.Intn(8) + 1
+		b := rand.Intn(9-a) + a + 1
+		n := rand.Intn(30) + 1
+		tests = append(tests, test{a, b, n})
+	}
+	return tests
+}
+
+func buildInput(t test) string {
+	return fmt.Sprintf("%d %d %d\n", t.a, t.b, t.n)
+}
+
+func runBinary(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", path)
+	} else {
+		cmd = exec.CommandContext(ctx, path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func verifyOutput(out string, t test) bool {
+	out = strings.TrimSpace(out)
+	val, err := strconv.ParseInt(out, 10, 64)
+	if err != nil {
+		return false
+	}
+	expected := countExcellent(t.a, t.b, t.n)
+	return val%mod == expected%mod
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := buildInput(t)
+		out, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Printf("test %d: run error %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !verifyOutput(out, t) {
+			fmt.Printf("test %d failed. input:%soutput:%s\n", i+1, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/300-309/300/verifierD.go
+++ b/0-999/300-399/300-309/300/verifierD.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type query struct {
+	n int64
+	k int
+}
+type test struct {
+	q  int
+	qs []query
+}
+
+func genTests() []test {
+	rand.Seed(4)
+	tests := make([]test, 0, 100)
+	for len(tests) < 100 {
+		q := rand.Intn(3) + 1
+		qs := make([]query, q)
+		for i := 0; i < q; i++ {
+			n := int64(rand.Intn(100) + 1)
+			k := rand.Intn(4)
+			qs[i] = query{n, k}
+		}
+		tests = append(tests, test{q, qs})
+	}
+	return tests
+}
+
+func buildInput(t test) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t.q))
+	for _, qu := range t.qs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", qu.n, qu.k))
+	}
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", path)
+	} else {
+		cmd = exec.CommandContext(ctx, path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	// build reference binary
+	refBin := filepath.Join(os.TempDir(), "ref300D")
+	build := exec.Command("go", "build", "-o", refBin, "300D.go")
+	build.Dir = filepath.Dir(os.Args[0])
+	if err := build.Run(); err != nil {
+		fmt.Println("failed to build reference", err)
+		os.Exit(1)
+	}
+
+	tests := genTests()
+	for i, t := range tests {
+		input := buildInput(t)
+		candOut, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Printf("test %d: run error %v\n", i+1, err)
+			os.Exit(1)
+		}
+		refOut, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Printf("test %d: reference error %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Printf("test %d failed. input:\n%sExpected:\n%sGot:\n%s\n", i+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/300-399/300-309/300/verifierE.go
+++ b/0-999/300-399/300-309/300/verifierE.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type test struct {
+	k int
+	a []int
+}
+
+func genTests() []test {
+	rand.Seed(5)
+	tests := make([]test, 0, 100)
+	for len(tests) < 100 {
+		k := rand.Intn(5) + 1
+		a := make([]int, k)
+		for i := 0; i < k; i++ {
+			a[i] = rand.Intn(20) + 1
+		}
+		tests = append(tests, test{k, a})
+	}
+	return tests
+}
+
+func buildInput(t test) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t.k))
+	for i, v := range t.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", path)
+	} else {
+		cmd = exec.CommandContext(ctx, path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func sieve(max int) []int {
+	isComp := make([]bool, max+1)
+	primes := []int{}
+	for i := 2; i <= max; i++ {
+		if !isComp[i] {
+			primes = append(primes, i)
+			if i <= max/i {
+				for j := i * i; j <= max; j += i {
+					isComp[j] = true
+				}
+			}
+		}
+	}
+	return primes
+}
+
+func requiredN(a []int) int64 {
+	maxa := 0
+	var sumA int64
+	for _, v := range a {
+		if v > maxa {
+			maxa = v
+		}
+		sumA += int64(v)
+	}
+	freq := make([]int, maxa+2)
+	for _, v := range a {
+		freq[v]++
+	}
+	suf := make([]int, maxa+2)
+	for v := maxa; v >= 0; v-- {
+		suf[v] = freq[v] + suf[v+1]
+	}
+	primes := sieve(maxa)
+	B := make([]int64, len(primes))
+	for idx, p := range primes {
+		var bp int64
+		pPow := p
+		for pPow <= maxa {
+			var fx int64
+			for j := pPow; j <= maxa; j += pPow {
+				fx += int64(suf[j])
+			}
+			bp += fx
+			if pPow > maxa/p {
+				break
+			}
+			pPow *= p
+		}
+		B[idx] = bp
+	}
+	lo, hi := int64(1), sumA
+	ans := sumA
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		ok := true
+		for idx, p := range primes {
+			need := B[idx]
+			if need == 0 {
+				continue
+			}
+			var have int64
+			n := mid
+			for n > 0 && have < need {
+				n /= int64(p)
+				have += n
+			}
+			if have < need {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			ans = mid
+			hi = mid - 1
+		} else {
+			lo = mid + 1
+		}
+	}
+	return ans
+}
+
+func verifyOutput(out string, t test) bool {
+	val, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+	if err != nil {
+		return false
+	}
+	expected := requiredN(t.a)
+	return val == expected
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := buildInput(t)
+		out, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Printf("test %d: run error %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !verifyOutput(out, t) {
+			fmt.Printf("test %d failed. input:\n%soutput:\n%s\n", i+1, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for problems A–E in contest 300
- verifiers generate over 100 random tests and check candidate binaries
- reference algorithms or constraints are embedded to validate outputs

## Testing
- `go build 0-999/300-399/300-309/300/verifierA.go`
- `go build 0-999/300-399/300-309/300/verifierB.go`
- `go build 0-999/300-399/300-309/300/verifierC.go`
- `go build 0-999/300-399/300-309/300/verifierD.go`
- `go build 0-999/300-399/300-309/300/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ea7ffe0ac8324ac6221865f0dd280