### PR TITLE
Add random verifiers for Codeforces contest 299

### DIFF
--- a/0-999/200-299/290-299/299/verifierA.go
+++ b/0-999/200-299/290-299/299/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Int63n(1000) + 1
+	}
+	g := arr[0]
+	for i := 1; i < n; i++ {
+		g = gcd(g, arr[i])
+	}
+	expected := int64(-1)
+	for _, v := range arr {
+		if v == g {
+			expected = g
+			break
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String(), fmt.Sprintf("%d", expected)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/299/verifierB.go
+++ b/0-999/200-299/290-299/299/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, k int, s string) string {
+	cnt := 0
+	for i := 0; i < n; i++ {
+		if s[i] == '#' {
+			cnt++
+			if cnt >= k {
+				return "NO"
+			}
+		} else {
+			cnt = 0
+		}
+	}
+	return "YES"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 2 // at least 2
+	k := rng.Intn(n) + 1
+	b := make([]byte, n)
+	b[0] = '.'
+	b[n-1] = '.'
+	for i := 1; i < n-1; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '.'
+		} else {
+			b[i] = '#'
+		}
+	}
+	s := string(b)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n%s\n", n, k, s)
+	return sb.String(), expected(n, k, s)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	got = strings.ToUpper(got)
+	expected = strings.ToUpper(expected)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A and B of contest 299
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`


------
https://chatgpt.com/codex/tasks/task_e_687ea7b9459c8324a74952b41344fae4