### PR TITLE
Add Go verifiers for contest 297 problems

### DIFF
--- a/0-999/200-299/290-299/297/verifierA.go
+++ b/0-999/200-299/290-299/297/verifierA.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func canTransform(a, b string) bool {
+	n, m := len(a), len(b)
+	if a == b {
+		return true
+	}
+	const B uint64 = 91138233
+	pow := make([]uint64, m)
+	if m > 0 {
+		pow[0] = 1
+		for i := 1; i < m; i++ {
+			pow[i] = pow[i-1] * B
+		}
+	}
+	var hb uint64
+	for i := 0; i < m; i++ {
+		if b[i] == '1' {
+			hb += pow[m-1-i]
+		}
+	}
+	for k := 0; k < n; k++ {
+		s := make([]byte, m)
+		if n-k >= m {
+			copy(s, a[k:k+m])
+		} else {
+			copy(s, a[k:])
+			s = s[:n-k]
+			parity := byte(0)
+			for _, c := range s {
+				parity ^= c - '0'
+			}
+			for len(s) < m {
+				s = append(s, '0'+parity)
+				parity = 0
+			}
+		}
+		var hs uint64
+		var par byte
+		for i := 0; i < m; i++ {
+			if s[i] == '1' {
+				hs += pow[m-1-i]
+				par ^= 1
+			}
+		}
+		for t := 0; t <= m; t++ {
+			if hs == hb && string(s) == b {
+				return true
+			}
+			if t == m {
+				break
+			}
+			p := par
+			front := s[0] - '0'
+			hs = (hs - uint64(front)*pow[m-1]) * B
+			if p == 1 {
+				hs += 1
+			}
+			copy(s[0:m-1], s[1:m])
+			s[m-1] = '0' + p
+			par = front
+		}
+	}
+	return false
+}
+
+func randBits(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		if rng.Intn(2) == 1 {
+			b[i] = '1'
+		} else {
+			b[i] = '0'
+		}
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 200; i++ {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		a := randBits(rng, n)
+		b := randBits(rng, m)
+		input := fmt.Sprintf("%s\n%s\n", a, b)
+		expect := "NO"
+		if canTransform(a, b) {
+			expect = "YES"
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		res := strings.ToUpper(strings.TrimSpace(out))
+		if res != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/297/verifierB.go
+++ b/0-999/200-299/290-299/297/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func aliceGreater(a, b []int) bool {
+	diff := make(map[int]int)
+	for _, x := range a {
+		diff[x]++
+	}
+	for _, x := range b {
+		diff[x]--
+	}
+	keys := make([]int, 0, len(diff))
+	for k := range diff {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	suffix := 0
+	for i := len(keys) - 1; i >= 0; i-- {
+		suffix += diff[keys[i]]
+		if suffix > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func randArray(rng *rand.Rand, n int, k int) []int {
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(k) + 1
+	}
+	return arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 200; i++ {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		k := rng.Intn(10) + 1
+		a := randArray(rng, n, k)
+		b := randArray(rng, m, k)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+		for j, v := range a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for j, v := range b {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := "NO"
+		if aliceGreater(a, b) {
+			expect = "YES"
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		res := strings.ToUpper(strings.TrimSpace(out))
+		if res != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/297/verifierC.go
+++ b/0-999/200-299/290-299/297/verifierC.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randUnique(rng *rand.Rand, n int) []int {
+	m := make(map[int]struct{})
+	res := make([]int, 0, n)
+	for len(res) < n {
+		v := rng.Intn(50)
+		if _, ok := m[v]; ok {
+			continue
+		}
+		m[v] = struct{}{}
+		res = append(res, v)
+	}
+	return res
+}
+
+func dupCount(arr []int) int {
+	freq := make(map[int]int)
+	rem := 0
+	for _, v := range arr {
+		freq[v]++
+	}
+	for _, f := range freq {
+		if f > 1 {
+			rem += f - 1
+		}
+	}
+	return rem
+}
+
+func verifyOutput(s []int, out string) error {
+	tokens := strings.Fields(out)
+	if len(tokens) < 1 {
+		return fmt.Errorf("no output")
+	}
+	if strings.ToUpper(tokens[0]) != "YES" {
+		return fmt.Errorf("first token should be YES")
+	}
+	if len(tokens) < 1+2*len(s) {
+		return fmt.Errorf("not enough numbers")
+	}
+	a := make([]int, len(s))
+	b := make([]int, len(s))
+	idx := 1
+	for i := 0; i < len(s); i++ {
+		fmt.Sscan(tokens[idx], &a[i])
+		idx++
+	}
+	for i := 0; i < len(s); i++ {
+		fmt.Sscan(tokens[idx], &b[i])
+		idx++
+	}
+	for i := 0; i < len(s); i++ {
+		if a[i] < 0 || b[i] < 0 {
+			return fmt.Errorf("negative value")
+		}
+		if a[i]+b[i] != s[i] {
+			return fmt.Errorf("sum mismatch at %d", i)
+		}
+	}
+	limit := (len(s) + 2) / 3
+	if dupCount(a) > limit || dupCount(b) > limit {
+		return fmt.Errorf("not almost unique")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 200; i++ {
+		n := rng.Intn(8) + 1
+		s := randUnique(rng, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range s {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := verifyOutput(s, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/297/verifierD.go
+++ b/0-999/200-299/290-299/297/verifierD.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func bruteForce(h, w, k int, row []string, col []string) (int, bool) {
+	total := h*(w-1) + w*(h-1)
+	best := 0
+	cells := h * w
+	assign := make([]int, cells)
+	var dfs func(pos int)
+	dfs = func(pos int) {
+		if pos == cells {
+			sat := 0
+			for i := 0; i < h; i++ {
+				for j := 0; j < w-1; j++ {
+					a := assign[i*w+j]
+					b := assign[i*w+j+1]
+					if row[i][j] == 'E' && a == b || row[i][j] == 'N' && a != b {
+						sat++
+					}
+				}
+			}
+			for i := 0; i < h-1; i++ {
+				for j := 0; j < w; j++ {
+					a := assign[i*w+j]
+					b := assign[(i+1)*w+j]
+					if col[i][j] == 'E' && a == b || col[i][j] == 'N' && a != b {
+						sat++
+					}
+				}
+			}
+			if sat > best {
+				best = sat
+			}
+			return
+		}
+		for c := 1; c <= k; c++ {
+			assign[pos] = c
+			dfs(pos + 1)
+		}
+	}
+	dfs(0)
+	return best, best*4 >= 3*total
+}
+
+func satisfaction(h, w int, row []string, col []string, board []int) int {
+	sat := 0
+	for i := 0; i < h; i++ {
+		for j := 0; j < w-1; j++ {
+			a := board[i*w+j]
+			b := board[i*w+j+1]
+			if row[i][j] == 'E' && a == b || row[i][j] == 'N' && a != b {
+				sat++
+			}
+		}
+	}
+	for i := 0; i < h-1; i++ {
+		for j := 0; j < w; j++ {
+			a := board[i*w+j]
+			b := board[(i+1)*w+j]
+			if col[i][j] == 'E' && a == b || col[i][j] == 'N' && a != b {
+				sat++
+			}
+		}
+	}
+	return sat
+}
+
+func parseBoard(tokens []string, idx int, h, w, k int) ([]int, error) {
+	if len(tokens) < idx+h*w {
+		return nil, fmt.Errorf("not enough numbers")
+	}
+	board := make([]int, h*w)
+	for i := 0; i < h*w; i++ {
+		var v int
+		fmt.Sscan(tokens[idx+i], &v)
+		if v < 1 || v > k {
+			return nil, fmt.Errorf("color out of range")
+		}
+		board[i] = v
+	}
+	return board, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 200; caseNum++ {
+		h := rng.Intn(2) + 2
+		w := rng.Intn(2) + 2
+		k := rng.Intn(3) + 1
+		row := make([]string, h)
+		col := make([]string, h-1)
+		for i := 0; i < h; i++ {
+			if w-1 > 0 {
+				b := make([]byte, w-1)
+				for j := range b {
+					if rng.Intn(2) == 0 {
+						b[j] = 'E'
+					} else {
+						b[j] = 'N'
+					}
+				}
+				row[i] = string(b)
+			} else {
+				row[i] = ""
+			}
+			if i < h-1 {
+				b := make([]byte, w)
+				for j := range b {
+					if rng.Intn(2) == 0 {
+						b[j] = 'E'
+					} else {
+						b[j] = 'N'
+					}
+				}
+				col[i] = string(b)
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", h, w, k))
+		for i := 0; i < 2*h-1; i++ {
+			if i%2 == 0 {
+				sb.WriteString(row[i/2])
+			} else {
+				sb.WriteString(col[i/2])
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		_, possible := bruteForce(h, w, k, row, col)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		tokens := strings.Fields(out)
+		if len(tokens) == 0 {
+			fmt.Fprintf(os.Stderr, "case %d failed: no output\n", caseNum+1)
+			os.Exit(1)
+		}
+		ans := strings.ToUpper(tokens[0])
+		if ans == "NO" {
+			if possible {
+				fmt.Fprintf(os.Stderr, "case %d failed: answer should be YES\ninput:\n%s", caseNum+1, input)
+				os.Exit(1)
+			}
+			continue
+		}
+		if ans != "YES" {
+			fmt.Fprintf(os.Stderr, "case %d failed: first token should be YES or NO\n", caseNum+1)
+			os.Exit(1)
+		}
+		board, err := parseBoard(tokens, 1, h, w, k)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		sat := satisfaction(h, w, row, col, board)
+		total := h*(w-1) + w*(h-1)
+		if sat*4 < 3*total {
+			fmt.Fprintf(os.Stderr, "case %d failed: satisfaction too low\ninput:\n%soutput:\n%s", caseNum+1, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/297/verifierE.go
+++ b/0-999/200-299/290-299/297/verifierE.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func checkValid(a []int) bool {
+	for rot := 0; rot < 6; rot++ {
+		ok1 := true
+		for i := 0; i < 3; i++ {
+			if a[(rot+2*i)%6] != a[(rot+2*i+1)%6] {
+				ok1 = false
+				break
+			}
+		}
+		if ok1 {
+			return true
+		}
+		ok2 := true
+		for i := 0; i < 3; i++ {
+			if a[(rot+i)%6] != a[(rot+i+3)%6] {
+				ok2 = false
+				break
+			}
+		}
+		if ok2 {
+			return true
+		}
+	}
+	return false
+}
+
+func countWays(n int, l, r []int) int64 {
+	pos := make([]int, 2*n)
+	for i := 0; i < n; i++ {
+		a := l[i] - 1
+		b := r[i] - 1
+		pos[a] = i + 1
+		pos[b] = -(i + 1)
+	}
+	var res int64
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			for k := j + 1; k < n; k++ {
+				seq := make([]int, 0, 6)
+				for t := 0; t < 2*n; t++ {
+					x := pos[t]
+					if x == i+1 || x == -(i+1) || x == j+1 || x == -(j+1) || x == k+1 || x == -(k+1) {
+						if x < 0 {
+							x = -x
+						}
+						if x == i+1 {
+							seq = append(seq, 1)
+						} else if x == j+1 {
+							seq = append(seq, 2)
+						} else {
+							seq = append(seq, 3)
+						}
+					}
+				}
+				if checkValid(seq) {
+					res++
+				}
+			}
+		}
+	}
+	return res
+}
+
+func randomMatching(rng *rand.Rand, n int) ([]int, []int) {
+	arr := rng.Perm(2 * n)
+	l := make([]int, n)
+	r := make([]int, n)
+	for i := 0; i < n; i++ {
+		a := arr[2*i] + 1
+		b := arr[2*i+1] + 1
+		if a < b {
+			l[i] = a
+			r[i] = b
+		} else {
+			l[i] = b
+			r[i] = a
+		}
+	}
+	return l, r
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 200; i++ {
+		n := rng.Intn(5) + 3
+		l, r := randomMatching(rng, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", l[j], r[j]))
+		}
+		input := sb.String()
+		expected := countWays(n, l, r)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid output\ninput:\n%soutput:\n%s", i+1, input, out)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add randomized solution verifiers for contest 297 problems A-E
- each verifier runs 200 tests against a provided solution binary
- verifiers check correctness for unique and constructive outputs

## Testing
- `go build 0-999/200-299/290-299/297/verifierA.go`
- `go build 0-999/200-299/290-299/297/verifierB.go`
- `go build 0-999/200-299/290-299/297/verifierC.go`
- `go build 0-999/200-299/290-299/297/verifierD.go`
- `go build 0-999/200-299/290-299/297/verifierE.go`
- `go build -o solA 0-999/200-299/290-299/297/297A.go && go run 0-999/200-299/290-299/297/verifierA.go ./solA`

------
https://chatgpt.com/codex/tasks/task_e_687ea72d4178832485def386156835f4