### PR TITLE
Add Go verifiers for contest 294

### DIFF
--- a/0-999/200-299/290-299/294/verifierA.go
+++ b/0-999/200-299/290-299/294/verifierA.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type op struct{ x, y int }
+
+func simulateA(n int, arr []int, ops []op) []int {
+	a := make([]int, n)
+	copy(a, arr)
+	for _, o := range ops {
+		x := o.x - 1
+		y := o.y
+		left := y - 1
+		right := a[x] - y
+		a[x] = 0
+		if x-1 >= 0 {
+			a[x-1] += left
+		}
+		if x+1 < n {
+			a[x+1] += right
+		}
+	}
+	return a
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(10) + 1
+	}
+	m := rng.Intn(5) + 1
+	ops := make([]op, 0, m)
+	tmp := make([]int, n)
+	copy(tmp, arr)
+	for i := 0; i < m; i++ {
+		for {
+			x := rng.Intn(n)
+			if tmp[x] > 0 {
+				y := rng.Intn(tmp[x]) + 1
+				ops = append(ops, op{x + 1, y})
+				left := y - 1
+				right := tmp[x] - y
+				tmp[x] = 0
+				if x-1 >= 0 {
+					tmp[x-1] += left
+				}
+				if x+1 < n {
+					tmp[x+1] += right
+				}
+				break
+			}
+		}
+	}
+	final := simulateA(n, arr, ops)
+	var in bytes.Buffer
+	fmt.Fprintf(&in, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			in.WriteByte(' ')
+		}
+		fmt.Fprintf(&in, "%d", v)
+	}
+	in.WriteByte('\n')
+	fmt.Fprintf(&in, "%d\n", len(ops))
+	for _, o := range ops {
+		fmt.Fprintf(&in, "%d %d\n", o.x, o.y)
+	}
+	var out bytes.Buffer
+	for _, v := range final {
+		fmt.Fprintf(&out, "%d\n", v)
+	}
+	return in.String(), out.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/294/verifierB.go
+++ b/0-999/200-299/290-299/294/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type book struct{ t, w int }
+
+func solveB(books []book) int {
+	n := len(books)
+	totalWidth := 0
+	for _, b := range books {
+		totalWidth += b.w
+	}
+	maxT := 2 * n
+	const negInf = -1000000000
+	dp := make([]int, maxT+1)
+	for t := 1; t <= maxT; t++ {
+		dp[t] = negInf
+	}
+	dp[0] = 0
+	for _, b := range books {
+		for t := maxT; t >= b.t; t-- {
+			if dp[t-b.t] >= 0 && dp[t-b.t]+b.w > dp[t] {
+				dp[t] = dp[t-b.t] + b.w
+			}
+		}
+	}
+	ans := maxT
+	for t := 0; t <= maxT; t++ {
+		if dp[t] >= 0 && dp[t]+t >= totalWidth {
+			ans = t
+			break
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	books := make([]book, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			books[i].t = 1
+		} else {
+			books[i].t = 2
+		}
+		books[i].w = rng.Intn(10) + 1
+	}
+	ans := solveB(books)
+	var in bytes.Buffer
+	fmt.Fprintf(&in, "%d\n", n)
+	for _, b := range books {
+		fmt.Fprintf(&in, "%d %d\n", b.t, b.w)
+	}
+	out := fmt.Sprintf("%d\n", ans)
+	return in.String(), out
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/294/verifierC.go
+++ b/0-999/200-299/290-299/294/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const modC = 1000000007
+
+func modpow(a, e int64) int64 {
+	res := int64(1)
+	a %= modC
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % modC
+		}
+		a = a * a % modC
+		e >>= 1
+	}
+	return res
+}
+
+func solveC(n int, pos []int) int64 {
+	sort.Ints(pos)
+	m := len(pos)
+	totalOff := n - m
+	fact := make([]int64, n+1)
+	invFact := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % modC
+	}
+	invFact[n] = modpow(fact[n], modC-2)
+	for i := n; i >= 1; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % modC
+	}
+	ans := fact[totalOff]
+	first := pos[0] - 1
+	ans = ans * invFact[first] % modC
+	for i := 1; i < m; i++ {
+		gap := pos[i] - pos[i-1] - 1
+		ans = ans * invFact[gap] % modC
+		if gap > 0 {
+			ans = ans * modpow(2, int64(gap-1)) % modC
+		}
+	}
+	last := n - pos[m-1]
+	ans = ans * invFact[last] % modC
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(n) + 1
+	posMap := make(map[int]struct{})
+	positions := make([]int, 0, m)
+	for len(positions) < m {
+		p := rng.Intn(n) + 1
+		if _, ok := posMap[p]; !ok {
+			posMap[p] = struct{}{}
+			positions = append(positions, p)
+		}
+	}
+	ans := solveC(n, append([]int(nil), positions...))
+	var in bytes.Buffer
+	fmt.Fprintf(&in, "%d %d\n", n, m)
+	for i, p := range positions {
+		if i > 0 {
+			in.WriteByte(' ')
+		}
+		fmt.Fprintf(&in, "%d", p)
+	}
+	in.WriteByte('\n')
+	out := fmt.Sprintf("%d\n", ans)
+	return in.String(), out
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/294/verifierD.go
+++ b/0-999/200-299/290-299/294/verifierD.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Fenwick struct {
+	n int
+	f []int
+}
+
+func NewFenwick(n int) *Fenwick { return &Fenwick{n, make([]int, n+1)} }
+func (ft *Fenwick) Update(i, v int) {
+	for x := i; x <= ft.n; x += x & -x {
+		ft.f[x] += v
+	}
+}
+func (ft *Fenwick) Query(i int) int {
+	if i > ft.n {
+		i = ft.n
+	}
+	if i < 1 {
+		return 0
+	}
+	s := 0
+	for x := i; x > 0; x -= x & -x {
+		s += ft.f[x]
+	}
+	return s
+}
+func (ft *Fenwick) Range(l, r int) int {
+	if l > r {
+		return 0
+	}
+	if l < 1 {
+		l = 1
+	}
+	if r > ft.n {
+		r = ft.n
+	}
+	return ft.Query(r) - ft.Query(l-1)
+}
+
+type Segment struct{ x, y, dx, dy, l int }
+
+func solveD(n, m, xs, ys int, dir string) string {
+	dx, dy := 0, 0
+	switch dir {
+	case "DR":
+		dx, dy = 1, 1
+	case "DL":
+		dx, dy = 1, -1
+	case "UR":
+		dx, dy = -1, 1
+	case "UL":
+		dx, dy = -1, -1
+	}
+	p := (xs + ys) & 1
+	total := int64(n) * int64(m)
+	var need int64
+	if p == 0 {
+		need = (total + 1) / 2
+	} else {
+		need = total / 2
+	}
+	var segs []Segment
+	x0, y0 := xs, ys
+	dx0, dy0 := dx, dy
+	for {
+		sx := n - x0
+		if dx < 0 {
+			sx = x0 - 1
+		}
+		sy := m - y0
+		if dy < 0 {
+			sy = y0 - 1
+		}
+		steps := sx
+		if sy < steps {
+			steps = sy
+		}
+		segs = append(segs, Segment{x0, y0, dx, dy, steps})
+		x1 := x0 + dx*steps
+		y1 := y0 + dy*steps
+		if x1 == n || x1 == 1 {
+			dx = -dx
+		}
+		if y1 == m || y1 == 1 {
+			dy = -dy
+		}
+		x0, y0 = x1, y1
+		if x0 == xs && y0 == ys && dx == dx0 && dy == dy0 {
+			break
+		}
+	}
+	maxD := n + m + 5
+	ftMinus := NewFenwick(maxD)
+	off := m + 2
+	maxV := n + m + 5
+	ftPlus := NewFenwick(maxV)
+	var unique int64 = 1
+	var stepsCount int64 = 1
+	if dx0*dy0 > 0 {
+		v0 := xs - ys
+		ftPlus.Update(v0+off, 1)
+	} else {
+		d0 := xs + ys
+		ftMinus.Update(d0, 1)
+	}
+	for _, s := range segs {
+		typ := 0
+		if s.dx*s.dy < 0 {
+			typ = 1
+		}
+		segLen := int64(s.l)
+		var inter int
+		if typ == 0 {
+			sum0 := s.x + s.y
+			if s.dy > 0 {
+				l := sum0 + 2
+				r := sum0 + 2*s.l
+				inter = ftMinus.Range(l, r)
+			} else {
+				l := sum0 - 2*s.l
+				r := sum0 - 2
+				inter = ftMinus.Range(l, r)
+			}
+		} else {
+			diff0 := s.x - s.y
+			if s.dx > 0 {
+				l := diff0 + 2
+				r := diff0 + 2*s.l
+				inter = ftPlus.Range(l+off, r+off)
+			} else {
+				l := diff0 - 2*s.l
+				r := diff0 - 2
+				inter = ftPlus.Range(l+off, r+off)
+			}
+		}
+		newAll := segLen - int64(inter)
+		if unique+newAll < need {
+			unique += newAll
+			stepsCount += segLen
+			if typ == 0 {
+				v := s.x - s.y
+				ftPlus.Update(v+off, 1)
+			} else {
+				d := s.x + s.y
+				ftMinus.Update(d, 1)
+			}
+			continue
+		}
+		needLeft := need - unique
+		lo, hi := int64(1), segLen
+		best := segLen
+		for lo <= hi {
+			mid := (lo + hi) / 2
+			var inter2 int
+			if typ == 0 {
+				sum0 := s.x + s.y
+				if s.dy > 0 {
+					r := sum0 + 2*int(mid)
+					inter2 = ftMinus.Range(sum0+2, r)
+				} else {
+					l := sum0 - 2*int(mid)
+					inter2 = ftMinus.Range(l, sum0-2)
+				}
+			} else {
+				diff0 := s.x - s.y
+				if s.dx > 0 {
+					r := diff0 + 2*int(mid)
+					inter2 = ftPlus.Range(diff0+2+off, r+off)
+				} else {
+					l := diff0 - 2*int(mid)
+					inter2 = ftPlus.Range(l+off, diff0-2+off)
+				}
+			}
+			visited := mid - int64(inter2)
+			if visited >= needLeft {
+				best = mid
+				hi = mid - 1
+			} else {
+				lo = mid + 1
+			}
+		}
+		return fmt.Sprintf("%d\n", stepsCount+best)
+	}
+	return "-1\n"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	m := rng.Intn(8) + 2
+	side := rng.Intn(4)
+	var xs, ys int
+	switch side {
+	case 0:
+		xs = 1
+		ys = rng.Intn(m) + 1
+	case 1:
+		xs = n
+		ys = rng.Intn(m) + 1
+	case 2:
+		ys = 1
+		xs = rng.Intn(n) + 1
+	default:
+		ys = m
+		xs = rng.Intn(n) + 1
+	}
+	dirs := []string{"UL", "UR", "DL", "DR"}
+	dir := dirs[rng.Intn(4)]
+	ans := solveD(n, m, xs, ys, dir)
+	in := fmt.Sprintf("%d %d\n%d %d %s\n", n, m, xs, ys, dir)
+	return in, ans
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/294/verifierE.go
+++ b/0-999/200-299/290-299/294/verifierE.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Structures and globals similar to 294E.go
+
+type edge struct{ to, w, id int }
+
+var (
+	adj       [][]edge
+	edges     [][3]int
+	visited   []bool
+	compNodes []int
+	sizeArr   []int
+	downSum   []int64
+	fullSum   []int64
+)
+
+func collect(u, skip int) {
+	visited[u] = true
+	compNodes = append(compNodes, u)
+	for _, e := range adj[u] {
+		if e.id == skip || visited[e.to] {
+			continue
+		}
+		collect(e.to, skip)
+	}
+}
+
+func dfs1(u, parent, skip int) {
+	sizeArr[u] = 1
+	downSum[u] = 0
+	for _, e := range adj[u] {
+		v := e.to
+		if e.id == skip || v == parent || !visited[v] {
+			continue
+		}
+		dfs1(v, u, skip)
+		sizeArr[u] += sizeArr[v]
+		downSum[u] += downSum[v] + int64(sizeArr[v])*int64(e.w)
+	}
+}
+
+func dfs2(u, parent, compSize, skip int, minPtr *int64) {
+	if fullSum[u] < *minPtr {
+		*minPtr = fullSum[u]
+	}
+	for _, e := range adj[u] {
+		v := e.to
+		if e.id == skip || v == parent || !visited[v] {
+			continue
+		}
+		fullSum[v] = fullSum[u] + int64(e.w)*int64(compSize-2*sizeArr[v])
+		dfs2(v, u, compSize, skip, minPtr)
+	}
+}
+
+func solveE(n int, edgesInput [][3]int) string {
+	adj = make([][]edge, n)
+	edges = edgesInput
+	for i, e := range edges {
+		a, b, w := e[0], e[1], e[2]
+		adj[a] = append(adj[a], edge{b, w, i})
+		adj[b] = append(adj[b], edge{a, w, i})
+	}
+	visited = make([]bool, n)
+	sizeArr = make([]int, n)
+	downSum = make([]int64, n)
+	fullSum = make([]int64, n)
+	for i := range visited {
+		visited[i] = true
+	}
+	dfs1(0, -1, -1)
+	fullSum[0] = downSum[0]
+	minTmp := fullSum[0]
+	dfs2(0, -1, n, -1, &minTmp)
+	var sumAll int64
+	for i := 0; i < n; i++ {
+		sumAll += fullSum[i]
+	}
+	sumAll /= 2
+	for i := range visited {
+		visited[i] = false
+	}
+	sizeArr = make([]int, n)
+	downSum = make([]int64, n)
+	fullSum = make([]int64, n)
+	bestDelta := int64(0)
+	for id, e := range edges {
+		u, v, _ := e[0], e[1], e[2]
+		compNodes = compNodes[:0]
+		collect(u, id)
+		compSizeB := len(compNodes)
+		dfs1(u, -1, id)
+		fullSum[u] = downSum[u]
+		minTmpB := fullSum[u]
+		dfs2(u, -1, compSizeB, id, &minTmpB)
+		sumBu := fullSum[u]
+		for _, x := range compNodes {
+			visited[x] = false
+		}
+		compNodes = compNodes[:0]
+		collect(v, id)
+		compSizeA := len(compNodes)
+		dfs1(v, -1, id)
+		fullSum[v] = downSum[v]
+		minTmpA := fullSum[v]
+		dfs2(v, -1, compSizeA, id, &minTmpA)
+		sumAv := fullSum[v]
+		for _, x := range compNodes {
+			visited[x] = false
+		}
+		a := int64(compSizeA)
+		b := int64(compSizeB)
+		delta := b*(minTmpA-sumAv) + a*(minTmpB-sumBu)
+		if id == 0 || delta < bestDelta {
+			bestDelta = delta
+		}
+	}
+	return fmt.Sprintf("%d\n", sumAll+bestDelta)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	edges := make([][3]int, n-1)
+	parents := make([]int, n)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		parents[i] = p
+		w := rng.Intn(10) + 1
+		edges[i-1] = [3]int{p, i, w}
+	}
+	ans := solveE(n, edges)
+	var in bytes.Buffer
+	fmt.Fprintf(&in, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&in, "%d %d %d\n", e[0]+1, e[1]+1, e[2])
+	}
+	return in.String(), ans
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go/B.go/C.go/D.go/E.go for contest 294
- each verifier randomly generates 100 test cases
- solutions from 294A–E implemented inside verifiers to compute expected output

## Testing
- `go build -o /tmp/verifierA 0-999/200-299/290-299/294/verifierA.go`
- `go build -o /tmp/verifierB 0-999/200-299/290-299/294/verifierB.go`
- `go build -o /tmp/verifierC 0-999/200-299/290-299/294/verifierC.go`
- `go build -o /tmp/verifierD 0-999/200-299/290-299/294/verifierD.go`
- `go build -o /tmp/verifierE 0-999/200-299/290-299/294/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ea65b916c83249e5a1c2ec1ca39b2