### PR TITLE
Add Go verifiers for contest 292

### DIFF
--- a/0-999/200-299/290-299/292/verifierA.go
+++ b/0-999/200-299/290-299/292/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1 // up to 10 tasks
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	type task struct{ t, c int64 }
+	tasks := make([]task, n)
+	var curT int64
+	for i := 0; i < n; i++ {
+		curT += int64(rng.Intn(5) + 1)
+		c := int64(rng.Intn(5) + 1)
+		tasks[i] = task{curT, c}
+		fmt.Fprintf(&sb, "%d %d\n", curT, c)
+	}
+	// compute expected
+	var curTime, queue, lastTime, maxQueue int64
+	for _, tt := range tasks {
+		dt := tt.t - curTime
+		processed := queue
+		if processed > dt {
+			processed = dt
+		}
+		if processed > 0 {
+			lastTime = curTime + processed
+			queue -= processed
+		}
+		curTime = tt.t
+		queue += tt.c
+		if queue > maxQueue {
+			maxQueue = queue
+		}
+	}
+	if queue > 0 {
+		lastTime = curTime + queue
+	}
+	expected := fmt.Sprintf("%d %d", lastTime, maxQueue)
+	return sb.String(), expected
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/292/verifierB.go
+++ b/0-999/200-299/290-299/292/verifierB.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func generateBus(rng *rand.Rand) (int, []edge) {
+	n := rng.Intn(6) + 2 // 2..7
+	edges := make([]edge, n-1)
+	for i := 1; i < n; i++ {
+		edges[i-1] = edge{i, i + 1}
+	}
+	return n, edges
+}
+
+func generateRing(rng *rand.Rand) (int, []edge) {
+	n := rng.Intn(6) + 3 // 3..8
+	edges := make([]edge, n)
+	for i := 1; i < n; i++ {
+		edges[i-1] = edge{i, i + 1}
+	}
+	edges[n-1] = edge{n, 1}
+	return n, edges
+}
+
+func generateStar(rng *rand.Rand) (int, []edge) {
+	n := rng.Intn(6) + 3 // 3..8
+	edges := make([]edge, n-1)
+	for i := 2; i <= n; i++ {
+		edges[i-2] = edge{1, i}
+	}
+	return n, edges
+}
+
+func generateUnknown(rng *rand.Rand) (int, []edge) {
+	// start from one topology and add extra edge
+	typ := rng.Intn(3)
+	var n int
+	var e []edge
+	switch typ {
+	case 0:
+		n, e = generateBus(rng)
+	case 1:
+		n, e = generateRing(rng)
+	default:
+		n, e = generateStar(rng)
+	}
+	// add extra edge to break topology
+	// choose random pair not already present
+	exist := make(map[[2]int]bool)
+	for _, ed := range e {
+		a, b := ed.u, ed.v
+		if a > b {
+			a, b = b, a
+		}
+		exist[[2]int{a, b}] = true
+	}
+	for {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		a, b := u, v
+		if a > b {
+			a, b = b, a
+		}
+		if !exist[[2]int{a, b}] {
+			e = append(e, edge{u, v})
+			break
+		}
+	}
+	return n, e
+}
+
+func topology(n int, edges []edge) string {
+	m := len(edges)
+	deg := make([]int, n+1)
+	for _, e := range edges {
+		deg[e.u]++
+		deg[e.v]++
+	}
+	cnt1, cnt2, cntn1 := 0, 0, 0
+	for i := 1; i <= n; i++ {
+		if deg[i] == 1 {
+			cnt1++
+		}
+		if deg[i] == 2 {
+			cnt2++
+		}
+		if deg[i] == n-1 {
+			cntn1++
+		}
+	}
+	switch {
+	case m == n-1 && cnt1 == 2 && cnt2 == n-2:
+		return "bus topology"
+	case m == n && cnt2 == n:
+		return "ring topology"
+	case m == n-1 && cntn1 == 1 && cnt1 == n-1:
+		return "star topology"
+	default:
+		return "unknown topology"
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	typ := rng.Intn(4)
+	var n int
+	var e []edge
+	var expected string
+	switch typ {
+	case 0:
+		n, e = generateBus(rng)
+	case 1:
+		n, e = generateRing(rng)
+	case 2:
+		n, e = generateStar(rng)
+	default:
+		n, e = generateUnknown(rng)
+	}
+	expected = topology(n, e)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, len(e))
+	for _, ed := range e {
+		fmt.Fprintf(&sb, "%d %d\n", ed.u, ed.v)
+	}
+	return sb.String(), expected
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/292/verifierC.go
+++ b/0-999/200-299/290-299/292/verifierC.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func enumerate(digits []int) []string {
+	must := 0
+	for _, d := range digits {
+		must |= 1 << d
+	}
+	var s [20]int
+	var cur [4]int
+	var ans []string
+	var length int
+
+	var part func(pos, cnt int)
+	part = func(pos, cnt int) {
+		if pos == length {
+			if cnt == 4 {
+				ans = append(ans, fmt.Sprintf("%d.%d.%d.%d", cur[0], cur[1], cur[2], cur[3]))
+			}
+			return
+		}
+		if cnt >= 4 {
+			return
+		}
+		curval := 0
+		for i := 0; i < 3; i++ {
+			if pos+i >= length {
+				break
+			}
+			curval = curval*10 + s[pos+i]
+			if curval > 255 {
+				break
+			}
+			if i > 0 && s[pos] == 0 {
+				break
+			}
+			cur[cnt] = curval
+			part(pos+i+1, cnt+1)
+		}
+	}
+
+	var goRec func(pos, mask int)
+	goRec = func(pos, mask int) {
+		if pos >= 2 && pos <= 6 && mask == must {
+			for iter := 0; iter < 2; iter++ {
+				length = 2*pos - iter
+				for i := 0; i < pos; i++ {
+					s[length-1-i] = s[i]
+				}
+				part(0, 0)
+			}
+		}
+		if pos == 6 {
+			return
+		}
+		for d := 0; d < 10; d++ {
+			if must&(1<<d) != 0 {
+				s[pos] = d
+				goRec(pos+1, mask|1<<d)
+			}
+		}
+	}
+
+	goRec(0, 0)
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	perm := rng.Perm(10)
+	digits := make([]int, n)
+	for i := 0; i < n; i++ {
+		digits[i] = perm[i]
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, d := range digits {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", d))
+	}
+	sb.WriteByte('\n')
+
+	ans := enumerate(digits)
+	var out strings.Builder
+	fmt.Fprintf(&out, "%d\n", len(ans))
+	for _, ip := range ans {
+		out.WriteString(ip)
+		out.WriteByte('\n')
+	}
+	return sb.String(), strings.TrimSpace(out.String())
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/292/verifierD.go
+++ b/0-999/200-299/290-299/292/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+type dsu struct{ p []int }
+
+func newDSU(n int) *dsu {
+	p := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = i
+	}
+	return &dsu{p}
+}
+func (d *dsu) find(x int) int {
+	for d.p[x] != x {
+		x = d.p[x]
+	}
+	return x
+}
+func (d *dsu) union(a, b int) {
+	ra, rb := d.find(a), d.find(b)
+	if ra != rb {
+		d.p[rb] = ra
+	}
+}
+
+func components(n int, edges []edge) int {
+	d := newDSU(n)
+	for _, e := range edges {
+		d.union(e.u, e.v)
+	}
+	seen := make(map[int]bool)
+	for i := 0; i < n; i++ {
+		seen[d.find(i)] = true
+	}
+	return len(seen)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2 // 2..6
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges) + 1
+	edges := make([]edge, 0, m)
+	exist := make(map[[2]int]bool)
+	for len(edges) < m {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		if u == v {
+			continue
+		}
+		a, b := u, v
+		if a > b {
+			a, b = b, a
+		}
+		if exist[[2]int{a, b}] {
+			continue
+		}
+		exist[[2]int{a, b}] = true
+		edges = append(edges, edge{u, v})
+	}
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u+1, e.v+1)
+	}
+	fmt.Fprintf(&sb, "%d\n", q)
+	var out strings.Builder
+	for i := 0; i < q; i++ {
+		l := rng.Intn(m) + 1
+		r := rng.Intn(m-l+1) + l
+		fmt.Fprintf(&sb, "%d %d\n", l, r)
+		var remaining []edge
+		for idx, e := range edges {
+			pos := idx + 1
+			if pos < l || pos > r {
+				remaining = append(remaining, e)
+			}
+		}
+		comp := components(n, remaining)
+		fmt.Fprintf(&out, "%d\n", comp)
+	}
+	return sb.String(), strings.TrimSpace(out.String())
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/292/verifierE.go
+++ b/0-999/200-299/290-299/292/verifierE.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1 // 1..8
+	m := rng.Intn(20) + 1
+	a := make([]int64, n+1)
+	b := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = int64(rng.Intn(41) - 20)
+	}
+	for i := 1; i <= n; i++ {
+		b[i] = int64(rng.Intn(41) - 20)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&sb, "%d", a[i])
+		if i < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&sb, "%d", b[i])
+		if i < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	var out strings.Builder
+	for i := 0; i < m; i++ {
+		t := rng.Intn(2) + 1
+		if t == 1 {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(n) + 1
+			maxk := n - max(x, y) + 1
+			if maxk <= 0 {
+				maxk = 1
+			}
+			k := rng.Intn(maxk) + 1
+			fmt.Fprintf(&sb, "1 %d %d %d\n", x, y, k)
+			for j := 0; j < k; j++ {
+				b[y+j] = a[x+j]
+			}
+		} else {
+			x := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "2 %d\n", x)
+			fmt.Fprintf(&out, "%d\n", b[x])
+		}
+	}
+	return sb.String(), strings.TrimSpace(out.String())
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 292 problems A–E
- each verifier runs 100 randomized tests against a provided binary

## Testing
- `go run verifierA.go ./A.bin`
- `go run verifierB.go ./B.bin`
- `go run verifierC.go ./C.bin`
- `go run verifierD.go ./D.bin`
- `go run verifierE.go ./E.bin`

------
https://chatgpt.com/codex/tasks/task_e_687ea5ceef50832491adcb8baf222817