### PR TITLE
Add Go verifiers for contest 291

### DIFF
--- a/0-999/200-299/290-299/291/verifierA.go
+++ b/0-999/200-299/290-299/291/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(ids []int) string {
+	freq := map[int]int{}
+	for _, id := range ids {
+		if id != 0 {
+			freq[id]++
+		}
+	}
+	pairs := 0
+	for _, c := range freq {
+		if c > 2 {
+			return "-1\n"
+		}
+		if c == 2 {
+			pairs++
+		}
+	}
+	return fmt.Sprintf("%d\n", pairs)
+}
+
+func genCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 1
+	ids := make([]int, n)
+	for i := range ids {
+		if rng.Intn(4) == 0 {
+			ids[i] = 0
+		} else {
+			ids[i] = rng.Intn(6)
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range ids {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveA(ids)
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseA(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/291/verifierB.go
+++ b/0-999/200-299/290-299/291/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(s string) string {
+	var lex []string
+	n := len(s)
+	for i := 0; i < n; {
+		if s[i] == ' ' {
+			i++
+			continue
+		}
+		if s[i] == '"' {
+			j := i + 1
+			for j < n && s[j] != '"' {
+				j++
+			}
+			lex = append(lex, s[i+1:j])
+			i = j + 1
+		} else {
+			j := i
+			for j < n && s[j] != ' ' {
+				j++
+			}
+			lex = append(lex, s[i:j])
+			i = j
+		}
+	}
+	var sb strings.Builder
+	for _, t := range lex {
+		sb.WriteByte('<')
+		sb.WriteString(t)
+		sb.WriteString("\n>")
+	}
+	return strings.ReplaceAll(sb.String(), "\n>", ">\n")
+}
+
+var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,?!")
+
+func randomWord(rng *rand.Rand, l int) string {
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func genCaseB(rng *rand.Rand) (string, string) {
+	m := rng.Intn(5) + 1
+	parts := make([]string, m)
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			l := rng.Intn(5) + 1
+			parts[i] = randomWord(rng, l)
+		} else {
+			l := rng.Intn(4)
+			var sb strings.Builder
+			for j := 0; j < l; j++ {
+				if j > 0 && rng.Intn(3) == 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteByte(letters[rng.Intn(len(letters))])
+			}
+			parts[i] = "\"" + sb.String() + "\""
+		}
+	}
+	cmd := strings.Join(parts, " ")
+	return cmd + "\n", solveB(cmd)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseB(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/291/verifierC.go
+++ b/0-999/200-299/290-299/291/verifierC.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveC(n, k int, ips []uint32) string {
+	arr := append([]uint32(nil), ips...)
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	for t := 1; t <= 31; t++ {
+		shift := 32 - t
+		cnt := 0
+		var last uint32 = 0xffffffff
+		for i, ip := range arr {
+			v := ip >> shift
+			if i == 0 || v != last {
+				cnt++
+				last = v
+			}
+			if cnt > k {
+				break
+			}
+		}
+		if cnt == k {
+			mask := ^uint32(0) << shift
+			return fmt.Sprintf("%d.%d.%d.%d\n", (mask>>24)&0xff, (mask>>16)&0xff, (mask>>8)&0xff, mask&0xff)
+		}
+	}
+	return "-1\n"
+}
+
+func genValidCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	t := rng.Intn(30) + 1
+	if t > 31 {
+		t = 31
+	}
+	kMax := 1 << t
+	if kMax > n {
+		kMax = n
+	}
+	k := rng.Intn(kMax) + 1
+	groups := rng.Perm(1 << t)[:k]
+	ips := make([]uint32, n)
+	for i := 0; i < n; i++ {
+		g := groups[rng.Intn(k)]
+		suffix := rng.Uint32() & ((1 << (32 - t)) - 1)
+		ips[i] = uint32(g)<<(32-t) | suffix
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for _, ip := range ips {
+		fmt.Fprintf(&sb, "%d.%d.%d.%d\n", ip>>24, (ip>>16)&0xff, (ip>>8)&0xff, ip&0xff)
+	}
+	return sb.String(), solveC(n, k, ips)
+}
+
+func genRandomCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n) + 1
+	ips := make([]uint32, n)
+	for i := 0; i < n; i++ {
+		ips[i] = rng.Uint32()
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for _, ip := range ips {
+		fmt.Fprintf(&sb, "%d.%d.%d.%d\n", ip>>24, (ip>>16)&0xff, (ip>>8)&0xff, ip&0xff)
+	}
+	return sb.String(), solveC(n, k, ips)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		var in, expect string
+		if rand.Intn(2) == 0 {
+			in, expect = genValidCase(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		} else {
+			in, expect = genRandomCase(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/291/verifierD.go
+++ b/0-999/200-299/290-299/291/verifierD.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(n, k int) string {
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = 1
+	}
+	a[n] = 0
+	mx := 1
+	var out strings.Builder
+	for step := 0; step < k; step++ {
+		for i := 1; i <= n; i++ {
+			if a[i] == n-i {
+				fmt.Fprintf(&out, "%d ", n)
+			} else if a[i]+mx >= n-i {
+				fmt.Fprintf(&out, "%d ", i+a[i])
+				a[i] = n - i
+			} else {
+				fmt.Fprintf(&out, "1 ")
+				a[i] += mx
+			}
+		}
+		out.WriteByte('\n')
+		mx *= 2
+	}
+	return out.String()
+}
+
+func genCaseD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(5) + 1
+	input := fmt.Sprintf("%d %d\n", n, k)
+	return input, solveD(n, k)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseD(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/290-299/291/verifierE.go
+++ b/0-999/200-299/290-299/291/verifierE.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(n int, edges []struct {
+	p int
+	s string
+}, t string) string {
+	children := make([][]int, n+1)
+	strs := make([][]byte, n+1)
+	for i, e := range edges {
+		v := i + 2
+		children[e.p] = append(children[e.p], v)
+		strs[v] = []byte(e.s)
+	}
+	tb := []byte(t)
+	m := len(tb)
+	pi := make([]int, m)
+	for i := 1; i < m; i++ {
+		j := pi[i-1]
+		for j > 0 && tb[j] != tb[i] {
+			j = pi[j-1]
+		}
+		if tb[j] == tb[i] {
+			j++
+		}
+		pi[i] = j
+	}
+	var ans int64
+	type frame struct {
+		u                        int
+		curBefore, curAfter, idx int
+	}
+	stack := []frame{{u: 1, idx: -1}}
+	for len(stack) > 0 {
+		fr := &stack[len(stack)-1]
+		if fr.idx == -1 {
+			cur := fr.curBefore
+			if fr.u > 1 {
+				for _, c := range strs[fr.u] {
+					for cur > 0 && (cur == m || tb[cur] != c) {
+						cur = pi[cur-1]
+					}
+					if cur < m && tb[cur] == c {
+						cur++
+					}
+					if cur == m {
+						ans++
+					}
+				}
+			}
+			fr.curAfter = cur
+			fr.idx = 0
+		} else if fr.idx < len(children[fr.u]) {
+			v := children[fr.u][fr.idx]
+			fr.idx++
+			stack = append(stack, frame{u: v, curBefore: fr.curAfter, idx: -1})
+		} else {
+			stack = stack[:len(stack)-1]
+		}
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func randString(rng *rand.Rand, l int) string {
+	letters := []byte("abc")
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func genCaseE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	edges := make([]struct {
+		p int
+		s string
+	}, n-1)
+	for i := 0; i < n-1; i++ {
+		edges[i].p = rng.Intn(i+1) + 1
+		edges[i].s = randString(rng, rng.Intn(3)+1)
+	}
+	t := randString(rng, rng.Intn(3)+1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %s\n", e.p, e.s)
+	}
+	fmt.Fprintf(&sb, "%s\n", t)
+	input := sb.String()
+	return input, solveE(n, edges, t)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseE(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–E of contest 291
- each verifier generates 100 random tests and checks any given binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ea5893b008324b241662578863df2