### PR TITLE
Add verifiers for contest 290

### DIFF
--- a/0-999/200-299/290-299/290/verifierA.go
+++ b/0-999/200-299/290-299/290/verifierA.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"time"
+)
+
+func factorial(n int) string {
+	res := big.NewInt(1)
+	for i := 2; i <= n; i++ {
+		res.Mul(res, big.NewInt(int64(i)))
+	}
+	return res.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(40) + 1
+		expected := factorial(n)
+
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("%d\n", n))
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", i+1, err, string(out))
+			os.Exit(1)
+		}
+		got := string(bytes.TrimSpace(out))
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: input %d expected %s got %s\n", i+1, n, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/200-299/290-299/290/verifierB.go
+++ b/0-999/200-299/290-299/290/verifierB.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+func binom(n, k int) int64 {
+	if k > n {
+		return 0
+	}
+	if k > n-k {
+		k = n - k
+	}
+	res := int64(1)
+	for i := 1; i <= k; i++ {
+		res = res * int64(n-k+i) / int64(i)
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(30)
+		k := rand.Intn(n + 1)
+		expected := binom(n, k)
+
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("%d %d\n", n, k))
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", i+1, err, string(out))
+			os.Exit(1)
+		}
+		gotStr := string(bytes.TrimSpace(out))
+		got, err2 := strconv.ParseInt(gotStr, 10, 64)
+		if err2 != nil || got != expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: n=%d k=%d expected %d got %s\n", i+1, n, k, expected, gotStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/200-299/290-299/290/verifierC.go
+++ b/0-999/200-299/290-299/290/verifierC.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solve(arr []float64) float64 {
+	sum := 0.0
+	best := arr[0]
+	for i, v := range arr {
+		sum += v
+		avg := sum / float64(i+1)
+		if avg > best {
+			best = avg
+		}
+	}
+	return best
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		vals := make([]float64, n)
+		for j := 0; j < n; j++ {
+			vals[j] = float64(rand.Intn(100))
+		}
+		expected := solve(vals)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j, v := range vals {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", int(v))
+		}
+		sb.WriteByte('\n')
+
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewBufferString(sb.String())
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", i+1, err, string(out))
+			os.Exit(1)
+		}
+		outStr := strings.TrimSpace(string(out))
+		got, err2 := strconv.ParseFloat(outStr, 64)
+		if err2 != nil || mathAbs(got-expected) > 1e-4 {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d expected %.5f got %s\n", i+1, expected, outStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}
+
+func mathAbs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/0-999/200-299/290-299/290/verifierD.go
+++ b/0-999/200-299/290-299/290/verifierD.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func shift(s string, k int) string {
+	r := []rune(s)
+	for i, ch := range r {
+		switch {
+		case ch >= 'a' && ch <= 'z':
+			r[i] = 'a' + (ch-'a'+rune(k))%26
+		case ch >= 'A' && ch <= 'Z':
+			r[i] = 'A' + (ch-'A'+rune(k))%26
+		}
+	}
+	return string(r)
+}
+
+const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		s := randString(rand.Intn(20) + 1)
+		k := rand.Intn(27)
+		expected := shift(s, k)
+		input := fmt.Sprintf("%s\n%d\n", s, k)
+
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewBufferString(input)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", i+1, err, string(out))
+			os.Exit(1)
+		}
+		outStr := strings.TrimSpace(string(out))
+		if outStr != expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d expected %s got %s\n", i+1, expected, outStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/200-299/290-299/290/verifierE.go
+++ b/0-999/200-299/290-299/290/verifierE.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const charset = "HQ9abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func randStr(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func expected(s string) string {
+	for _, ch := range s {
+		if ch == 'H' || ch == 'Q' || ch == '9' {
+			return "Yes"
+		}
+	}
+	return "No"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		s := randStr(rand.Intn(40) + 1)
+		exp := expected(s)
+
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewBufferString(s + "\n")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", i+1, err, string(out))
+			os.Exit(1)
+		}
+		outStr := strings.TrimSpace(string(out))
+		if outStr != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d expected %s got %s\n", i+1, exp, outStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/200-299/290-299/290/verifierF.go
+++ b/0-999/200-299/290-299/290/verifierF.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solve(n int, edges [][2]int) (bool, []int) {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	total := 1 << n
+	dp := make([]bool, total*n)
+	prev := make([]int8, total*n)
+	for v := 0; v < n; v++ {
+		mask := 1 << v
+		dp[mask*n+v] = true
+		prev[mask*n+v] = -1
+	}
+	full := total - 1
+	found := false
+	endV := -1
+	for mask := 1; mask < total && !found; mask++ {
+		for v := 0; v < n && !found; v++ {
+			if !dp[mask*n+v] {
+				continue
+			}
+			if mask == full {
+				found = true
+				endV = v
+				break
+			}
+			for _, u := range adj[v] {
+				if mask&(1<<u) == 0 {
+					m2 := mask | (1 << u)
+					idx := m2*n + u
+					if !dp[idx] {
+						dp[idx] = true
+						prev[idx] = int8(v)
+					}
+				}
+			}
+		}
+	}
+	if !found {
+		return false, nil
+	}
+	path := make([]int, n)
+	mask := full
+	v := endV
+	for i := n - 1; i >= 0; i-- {
+		path[i] = v + 1
+		p := prev[mask*n+v]
+		mask ^= 1 << v
+		v = int(p)
+	}
+	return true, path
+}
+
+func genGraph() (int, [][2]int) {
+	n := rand.Intn(5) + 2 // 2..6
+	var edges [][2]int
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				edges = append(edges, [2]int{i, j})
+			}
+		}
+	}
+	return n, edges
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		n, edges := genGraph()
+		m := len(edges)
+		expOk, expPath := solve(n, edges)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for _, e := range edges {
+			fmt.Fprintf(&sb, "%d %d\n", e[0]+1, e[1]+1)
+		}
+
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewBufferString(sb.String())
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", i+1, err, string(out))
+			os.Exit(1)
+		}
+		lines := strings.Fields(strings.TrimSpace(string(out)))
+		if !expOk {
+			if len(lines) != 1 || lines[0] != "No" {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d expected No got %s\n", i+1, string(out))
+				os.Exit(1)
+			}
+			continue
+		}
+		if len(lines) != n+1 || lines[0] != "Yes" {
+			fmt.Fprintf(os.Stderr, "wrong format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		for j := 0; j < n; j++ {
+			val, err := strconv.Atoi(lines[j+1])
+			if err != nil || val != expPath[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("Accepted")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for contest 290 problems A–F
- each verifier runs 100 random test cases and checks output

## Testing
- `go build 0-999/200-299/290-299/290/verifierA.go`
- `go build 0-999/200-299/290-299/290/verifierB.go`
- `go build 0-999/200-299/290-299/290/verifierC.go`
- `go build 0-999/200-299/290-299/290/verifierD.go`
- `go build 0-999/200-299/290-299/290/verifierE.go`
- `go build 0-999/200-299/290-299/290/verifierF.go`
- `go run 0-999/200-299/290-299/290/verifierA.go ./290A_bin`
- `go run 0-999/200-299/290-299/290/verifierF.go ./290F_bin`

------
https://chatgpt.com/codex/tasks/task_e_687ea542e04c8324ac04c8b9ce949458