### PR TITLE
Add Go verifiers for contest 289

### DIFF
--- a/0-999/200-299/280-289/289/verifierA.go
+++ b/0-999/200-299/280-289/289/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type segment struct {
+	l, r int
+}
+
+func expectedAnswer(n int, k int, segs []segment) int64 {
+	var sum int64
+	for _, s := range segs {
+		sum += int64(s.r - s.l + 1)
+	}
+	rem := sum % int64(k)
+	if rem == 0 {
+		return 0
+	}
+	return int64(k) - rem
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(100) + 1
+	segs := make([]segment, n)
+	start := rng.Intn(200) - 100
+	for i := 0; i < n; i++ {
+		length := rng.Intn(20) + 1
+		end := start + length - 1
+		segs[i] = segment{l: start, r: end}
+		start = end + rng.Intn(20) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for _, s := range segs {
+		fmt.Fprintf(&sb, "%d %d\n", s.l, s.r)
+	}
+	expected := expectedAnswer(n, k, segs)
+	return sb.String(), expected
+}
+
+func runCase(exe string, input string, expected int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	var got int64
+	if _, err := fmt.Sscan(outStr, &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v\n%s", err, outStr)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// a couple of deterministic cases
+	cases := []struct {
+		input    string
+		expected int64
+	}{
+		{"1 5\n0 0\n", 5 - (1 % 5)},
+		{"2 3\n0 0\n5 7\n", (3 - (4 % 3))},
+	}
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		cases = append(cases, struct {
+			input    string
+			expected int64
+		}{in, exp})
+	}
+	for i, tc := range cases {
+		if err := runCase(exe, tc.input, tc.expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/289/verifierB.go
+++ b/0-999/200-299/280-289/289/verifierB.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expectedAnswer(n, m, d int, grid []int) int64 {
+	mod := grid[0] % d
+	for _, v := range grid {
+		if v%d != mod {
+			return -1
+		}
+	}
+	vals := make([]int, len(grid))
+	for i, v := range grid {
+		vals[i] = v / d
+	}
+	sort.Ints(vals)
+	median := vals[len(vals)/2]
+	var moves int64
+	for _, v := range vals {
+		if v > median {
+			moves += int64(v - median)
+		} else {
+			moves += int64(median - v)
+		}
+	}
+	return moves
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	d := rng.Intn(9) + 1
+	total := n * m
+	grid := make([]int, total)
+	base := rng.Intn(50)
+	base = base - base%d
+	mod := base % d
+	valid := rng.Intn(2) == 0
+	for i := 0; i < total; i++ {
+		val := rng.Intn(50)
+		val = val - val%d + mod
+		grid[i] = val
+	}
+	if !valid {
+		idx := rng.Intn(total)
+		grid[idx]++ // break mod
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, d)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			fmt.Fprintf(&sb, "%d", grid[i*m+j])
+			if j+1 < m {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	expected := expectedAnswer(n, m, d, grid)
+	return sb.String(), expected
+}
+
+func runCase(exe string, input string, expected int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	var got int64
+	if _, err := fmt.Sscan(outStr, &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v\n%s", err, outStr)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []struct {
+		input    string
+		expected int64
+	}{
+		{"1 1 1\n5\n", 0},
+		{"2 2 3\n1 4\n7 10\n", 4},
+	}
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		cases = append(cases, struct {
+			input    string
+			expected int64
+		}{in, exp})
+	}
+	for i, tc := range cases {
+		if err := runCase(exe, tc.input, tc.expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go and verifierB.go for contest 289
- each verifier generates 100+ tests and checks runtime and answer for a solution binary
- supports verifying Go source or compiled binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go run verifierA.go ./solA` (after compiling 289A.go) -> `All tests passed`
- `go run verifierB.go ./solB` (after compiling 289B.go) -> `All tests passed`


------
https://chatgpt.com/codex/tasks/task_e_687ea4fd2344832487f050d130dcdb1f