### PR TITLE
Add verifiers for Codeforces contest 288

### DIFF
--- a/0-999/200-299/280-289/288/verifierA.go
+++ b/0-999/200-299/280-289/288/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, k int) string {
+	if k > n || (k == 1 && n > 1) {
+		return "-1"
+	}
+	if n == 1 {
+		return "a"
+	}
+	res := make([]byte, n)
+	altLen := n - (k - 2)
+	for i := 0; i < altLen; i++ {
+		if i%2 == 0 {
+			res[i] = 'a'
+		} else {
+			res[i] = 'b'
+		}
+	}
+	for j := 0; j < k-2; j++ {
+		res[altLen+j] = byte('c' + j)
+	}
+	return string(res)
+}
+
+func runCase(bin string, n, k int) error {
+	input := fmt.Sprintf("%d %d\n", n, k)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := expected(n, k)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q (n=%d k=%d)", exp, got, n, k)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	cases := []struct{ n, k int }{
+		{1, 1},
+		{2, 1},
+		{5, 3},
+		{3, 2},
+		{4, 4},
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(cases) < 100 {
+		n := rng.Intn(50) + 1
+		k := rng.Intn(26) + 1
+		cases = append(cases, struct{ n, k int }{n, k})
+	}
+
+	for i, c := range cases {
+		if err := runCase(bin, c.n, c.k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/288/verifierB.go
+++ b/0-999/200-299/280-289/288/verifierB.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+
+func modpow(a, e int64) int64 {
+	if e == 0 {
+		return 1
+	}
+	if e < 0 {
+		return modpow(modpow(a, -e), MOD-2)
+	}
+	res := int64(1)
+	a %= MOD
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func expected(n, k int) int64 {
+	fact := make([]int64, k+1)
+	invfact := make([]int64, k+1)
+	fact[0] = 1
+	for i := 1; i <= k; i++ {
+		fact[i] = fact[i-1] * int64(i) % MOD
+	}
+	for i := 0; i <= k; i++ {
+		invfact[i] = modpow(fact[i], MOD-2)
+	}
+	var sum int64
+	for m := 1; m <= k; m++ {
+		cyc := fact[k-1] * invfact[k-m] % MOD
+		var trees int64
+		if m < k {
+			trees = int64(m) * modpow(int64(k), int64(k-m-1)) % MOD
+		} else {
+			trees = 1
+		}
+		sum = (sum + cyc*trees) % MOD
+	}
+	rem := modpow(int64(n-k), int64(n-k))
+	ans := sum * rem % MOD
+	return ans
+}
+
+func runCase(bin string, n, k int) error {
+	input := fmt.Sprintf("%d %d\n", n, k)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	var got int64
+	if _, err := fmt.Sscan(gotStr, &got); err != nil {
+		return fmt.Errorf("cannot parse output %q", gotStr)
+	}
+	exp := expected(n, k)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d (n=%d k=%d)", exp, got, n, k)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := []struct{ n, k int }{
+		{1, 1},
+		{2, 2},
+		{3, 1},
+		{8, 3},
+		{10, 5},
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(cases) < 100 {
+		n := rng.Intn(30) + 1
+		k := rng.Intn(8) + 1
+		if k > n {
+			k = n
+		}
+		cases = append(cases, struct{ n, k int }{n, k})
+	}
+	for i, c := range cases {
+		if err := runCase(bin, c.n, c.k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/288/verifierC.go
+++ b/0-999/200-299/280-289/288/verifierC.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) (int64, []int) {
+	p := make([]int, n+1)
+	for i := range p {
+		p[i] = -1
+	}
+	for i := n; i >= 0; i-- {
+		if p[i] != -1 {
+			continue
+		}
+		if i == 0 {
+			p[0] = 0
+			break
+		}
+		k := bits.Len(uint(i)) - 1
+		b := (1 << (k + 1)) - 1
+		j := b - i
+		if j >= 0 && j <= n && p[j] == -1 {
+			p[i] = j
+			p[j] = i
+		} else {
+			p[i] = i
+		}
+	}
+	var sum int64
+	for i := 0; i <= n; i++ {
+		sum += int64(i ^ p[i])
+	}
+	return sum, p
+}
+
+func parseOutput(out string, n int) (int64, []int, error) {
+	lines := strings.Fields(out)
+	if len(lines) < n+2 {
+		return 0, nil, fmt.Errorf("expected at least %d numbers", n+2)
+	}
+	var m int64
+	if _, err := fmt.Sscan(lines[0], &m); err != nil {
+		return 0, nil, fmt.Errorf("cannot parse m: %v", err)
+	}
+	perm := make([]int, n+1)
+	for i := 0; i <= n; i++ {
+		if _, err := fmt.Sscan(lines[i+1], &perm[i]); err != nil {
+			return 0, nil, fmt.Errorf("cannot parse permutation: %v", err)
+		}
+	}
+	return m, perm, nil
+}
+
+func verifyPerm(p []int) bool {
+	seen := make([]bool, len(p))
+	for _, v := range p {
+		if v < 0 || v >= len(p) || seen[v] {
+			return false
+		}
+		seen[v] = true
+	}
+	for _, ok := range seen {
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("%d\n", n)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotM, gotPerm, err := parseOutput(out.String(), n)
+	if err != nil {
+		return err
+	}
+	expM, expPerm := expected(n)
+	if gotM != expM {
+		return fmt.Errorf("expected beauty %d got %d", expM, gotM)
+	}
+	if len(gotPerm) != len(expPerm) || !verifyPerm(gotPerm) {
+		return fmt.Errorf("invalid permutation")
+	}
+	var sum int64
+	for i := 0; i <= n; i++ {
+		sum += int64(i ^ gotPerm[i])
+	}
+	if sum != expM {
+		return fmt.Errorf("permutation produces beauty %d want %d", sum, expM)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := []int{0, 1, 2, 5, 10}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(cases) < 100 {
+		cases = append(cases, rng.Intn(50))
+	}
+	for i, n := range cases {
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d (n=%d) failed: %v\n", i+1, n, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/288/verifierD.go
+++ b/0-999/200-299/280-289/288/verifierD.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func shortestPath(n int, adj [][]int, a, b int) []int {
+	prev := make([]int, n+1)
+	for i := range prev {
+		prev[i] = -1
+	}
+	q := []int{a}
+	prev[a] = 0
+	for len(q) > 0 {
+		v := q[0]
+		q = q[1:]
+		if v == b {
+			break
+		}
+		for _, u := range adj[v] {
+			if prev[u] != -1 {
+				continue
+			}
+			prev[u] = v
+			q = append(q, u)
+		}
+	}
+	if prev[b] == -1 {
+		return nil
+	}
+	path := []int{b}
+	for b != a {
+		b = prev[b]
+		path = append(path, b)
+	}
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+	return path
+}
+
+func countPairs(n int, edges [][2]int) int64 {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	paths := make(map[[2]int][]int)
+	for a := 1; a <= n; a++ {
+		for b := a + 1; b <= n; b++ {
+			paths[[2]int{a, b}] = shortestPath(n, adj, a, b)
+		}
+	}
+	var count int64
+	for a := 1; a <= n; a++ {
+		for b := a + 1; b <= n; b++ {
+			p1 := paths[[2]int{a, b}]
+			set1 := make(map[int]bool)
+			for _, x := range p1 {
+				set1[x] = true
+			}
+			for c := 1; c <= n; c++ {
+				for d := c + 1; d <= n; d++ {
+					p2 := paths[[2]int{c, d}]
+					ok := true
+					for _, x := range p2 {
+						if set1[x] {
+							ok = false
+							break
+						}
+					}
+					if ok {
+						count++
+					}
+				}
+			}
+		}
+	}
+	return count
+}
+
+func buildCase(n int, rng *rand.Rand) string {
+	edges := make([][2]int, n-1)
+	for i := 0; i < n-1; i++ {
+		u := i + 2
+		v := rng.Intn(i+1) + 1
+		edges[i] = [2]int{u, v}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func parseEdges(n int, s string) [][2]int {
+	parts := strings.Fields(s)
+	idx := 0
+	edges := make([][2]int, n-1)
+	for i := 0; i < n-1; i++ {
+		u := toInt(parts[idx])
+		v := toInt(parts[idx+1])
+		idx += 2
+		edges[i] = [2]int{u, v}
+	}
+	return edges
+}
+
+func toInt(str string) int {
+	var x int
+	fmt.Sscan(str, &x)
+	return x
+}
+
+func runCase(bin string, input string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	var got int64
+	if _, err := fmt.Sscan(gotStr, &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	lines := strings.Fields(input)
+	n := toInt(lines[0])
+	edges := parseEdges(n, strings.Join(lines[1:], " "))
+	exp := countPairs(n, edges)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{
+		"2\n1 2\n",
+		"3\n1 2\n2 3\n",
+	}
+	for len(cases) < 100 {
+		n := rng.Intn(6) + 2
+		cases = append(cases, buildCase(n, rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/288/verifierE.go
+++ b/0-999/200-299/280-289/288/verifierE.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func isLucky(x int64) bool {
+	if x == 0 {
+		return false
+	}
+	for x > 0 {
+		d := x % 10
+		if d != 4 && d != 7 {
+			return false
+		}
+		x /= 10
+	}
+	return true
+}
+
+func genLucky(l, r int64) []int64 {
+	res := []int64{}
+	for i := l; i <= r; i++ {
+		if isLucky(i) {
+			res = append(res, i)
+		}
+	}
+	return res
+}
+
+func expected(l, r int64) int64 {
+	arr := genLucky(l, r)
+	var sum int64
+	for i := 0; i+1 < len(arr); i++ {
+		sum = (sum + (arr[i]%mod)*(arr[i+1]%mod)) % mod
+	}
+	return sum % mod
+}
+
+func runCase(bin string, l, r int64) error {
+	input := fmt.Sprintf("%d\n%d\n", l, r)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	var got int64
+	if _, err := fmt.Sscan(gotStr, &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	exp := expected(l, r)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d (l=%d r=%d)", exp, got, l, r)
+	}
+	return nil
+}
+
+func randLucky(rng *rand.Rand) int64 {
+	digits := rng.Intn(5) + 1
+	var sb strings.Builder
+	for i := 0; i < digits; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('4')
+		} else {
+			sb.WriteByte('7')
+		}
+	}
+	v, _ := strconv.ParseInt(sb.String(), 10, 64)
+	return v
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := [][2]int64{
+		{4, 7},
+		{44, 77},
+		{4, 4},
+		{7, 44},
+	}
+	for len(cases) < 100 {
+		a := randLucky(rng)
+		b := randLucky(rng)
+		if a > b {
+			a, b = b, a
+		}
+		if a == b {
+			b += 4
+		}
+		cases = append(cases, [2]int64{a, b})
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc[0], tc[1]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 288 problems A–E
- each verifier accepts a solution binary and runs over 100 tests
- random tests included for thorough checking

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ea4b6ff748324ab9d02db71652bb2