### PR TITLE
Add verifiers for contest 285 problems

### DIFF
--- a/0-999/200-299/280-289/285/verifierA.go
+++ b/0-999/200-299/280-289/285/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, k int) string {
+	res := make([]string, 0, n)
+	for i := n; i > n-k; i-- {
+		res = append(res, fmt.Sprintf("%d", i))
+	}
+	for i := 1; i <= n-k; i++ {
+		res = append(res, fmt.Sprintf("%d", i))
+	}
+	return strings.Join(res, " ")
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(1000) + 1
+	k := rng.Intn(n)
+	input := fmt.Sprintf("%d %d\n", n, k)
+	expect := expected(n, k)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// Deterministic edge cases
+	cases := []struct{ n, k int }{
+		{1, 0}, {2, 0}, {2, 1}, {5, 2}, {10, 0},
+	}
+	for _, c := range cases {
+		in := fmt.Sprintf("%d %d\n", c.n, c.k)
+		exp := expected(c.n, c.k)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "edge case failed: %v\ninput:\n%s", err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "edge case failed: expected %s got %s\ninput:\n%s", exp, out, in)
+			os.Exit(1)
+		}
+	}
+
+	// Random cases
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/285/verifierB.go
+++ b/0-999/200-299/280-289/285/verifierB.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, s, t int, p []int) string {
+	if s == t {
+		return "0"
+	}
+	curr := s
+	steps := 0
+	for {
+		curr = p[curr]
+		steps++
+		if curr == t {
+			return fmt.Sprintf("%d", steps)
+		}
+		if curr == s || steps > n+5 {
+			return "-1"
+		}
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	perm := rng.Perm(n)
+	p := make([]int, n+1)
+	for i, v := range perm {
+		p[i+1] = v + 1
+	}
+	s := rng.Intn(n) + 1
+	t := rng.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, s, t))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", p[i]))
+	}
+	sb.WriteByte('\n')
+	expect := expected(n, s, t, p)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// some deterministic edge cases
+	cases := []struct {
+		n    int
+		p    []int
+		s, t int
+		exp  string
+	}{
+		{1, []int{0, 1}, 1, 1, "0"},
+		{3, []int{0, 2, 3, 1}, 1, 1, "0"},
+		{3, []int{0, 2, 3, 1}, 1, 2, "1"},
+		{3, []int{0, 2, 3, 1}, 1, 3, "2"},
+		{3, []int{0, 1, 2, 3}, 1, 2, "-1"},
+	}
+	for _, c := range cases {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", c.n, c.s, c.t))
+		for i := 1; i <= c.n; i++ {
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", c.p[i]))
+		}
+		sb.WriteByte('\n')
+		out, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "edge case failed: %v\ninput:\n%s", err, sb.String())
+			os.Exit(1)
+		}
+		if out != c.exp {
+			fmt.Fprintf(os.Stderr, "edge case failed: expected %s got %s\ninput:\n%s", c.exp, out, sb.String())
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/285/verifierC.go
+++ b/0-999/200-299/280-289/285/verifierC.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(a []int64) string {
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	var sum int64
+	for i, v := range a {
+		idx := int64(i + 1)
+		if v > idx {
+			sum += v - idx
+		} else {
+			sum += idx - v
+		}
+	}
+	return fmt.Sprintf("%d", sum)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = rng.Int63n(2000) - 1000
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	expect := expected(append([]int64(nil), arr...))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	edgeCases := [][]int64{
+		{1},
+		{1, 2, 3},
+		{3, 2, 1},
+		{-5, 5, 0},
+		{10, -10},
+	}
+	for _, arr := range edgeCases {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		exp := expected(append([]int64(nil), arr...))
+		out, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "edge case failed: %v\ninput:\n%s", err, sb.String())
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "edge case failed: expected %s got %s\ninput:\n%s", exp, out, sb.String())
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/285/verifierD.go
+++ b/0-999/200-299/280-289/285/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const mod = 1000000007
+
+var g = map[int]int64{
+	1:  1,
+	2:  0,
+	3:  3,
+	4:  0,
+	5:  15,
+	6:  0,
+	7:  133,
+	8:  0,
+	9:  2025,
+	10: 0,
+	11: 37851,
+	12: 0,
+	13: 942073,
+	14: 0,
+	15: 31601835,
+	16: 0,
+}
+
+func expected(n int) string {
+	fact := int64(1)
+	for i := 2; i <= n; i++ {
+		fact = fact * int64(i) % mod
+	}
+	ans := fact * g[n] % mod
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(16) + 1
+	input := fmt.Sprintf("%d\n", n)
+	expect := expected(n)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// run for every n once
+	for n := 1; n <= 16; n++ {
+		in := fmt.Sprintf("%d\n", n)
+		exp := expected(n)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "n=%d failed: %v\n", n, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "n=%d expected %s got %s\n", n, exp, out)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/285/verifierE.go
+++ b/0-999/200-299/280-289/285/verifierE.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const MOD = 1000000007
+
+func add(a, b int) int {
+	a += b
+	if a >= MOD {
+		a -= MOD
+	}
+	return a
+}
+
+func sub(a, b int) int {
+	a -= b
+	if a < 0 {
+		a += MOD
+	}
+	return a
+}
+
+func mul(a, b int) int {
+	return int((int64(a) * int64(b)) % MOD)
+}
+
+func powmod(a, e int) int {
+	res := 1
+	x := a
+	for e > 0 {
+		if e&1 == 1 {
+			res = mul(res, x)
+		}
+		x = mul(x, x)
+		e >>= 1
+	}
+	return res
+}
+
+func expected(n, k int) string {
+	dpCurr := make([][2][2]int, n+1)
+	dpCurr[0][0][0] = 1
+	for pos := 1; pos <= n; pos++ {
+		dpNext := make([][2][2]int, n+1)
+		for s := 0; s <= n; s++ {
+			for prevA := 0; prevA < 2; prevA++ {
+				for prev2A := 0; prev2A < 2; prev2A++ {
+					v := dpCurr[s][prevA][prev2A]
+					if v == 0 {
+						continue
+					}
+					dpNext[s][0][prevA] = add(dpNext[s][0][prevA], v)
+					if pos < n {
+						dpNext[s+1][1][prevA] = add(dpNext[s+1][1][prevA], v)
+					}
+					if pos > 1 && prev2A == 0 {
+						dpNext[s+1][0][prevA] = add(dpNext[s+1][0][prevA], v)
+					}
+				}
+			}
+		}
+		dpCurr = dpNext
+	}
+	dpEvents := make([]int, n+1)
+	for s := 0; s <= n; s++ {
+		total := 0
+		for prevA := 0; prevA < 2; prevA++ {
+			for prev2A := 0; prev2A < 2; prev2A++ {
+				total = add(total, dpCurr[s][prevA][prev2A])
+			}
+		}
+		dpEvents[s] = total
+	}
+	fact := make([]int, n+1)
+	invFact := make([]int, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = mul(fact[i-1], i)
+	}
+	invFact[n] = powmod(fact[n], MOD-2)
+	for i := n; i > 0; i-- {
+		invFact[i-1] = mul(invFact[i], i)
+	}
+	res := 0
+	for s := k; s <= n; s++ {
+		ds := dpEvents[s]
+		if ds == 0 {
+			continue
+		}
+		comb := mul(fact[s], mul(invFact[k], invFact[s-k]))
+		term := mul(ds, comb)
+		term = mul(term, fact[n-s])
+		if (s-k)&1 == 1 {
+			res = sub(res, term)
+		} else {
+			res = add(res, term)
+		}
+	}
+	return fmt.Sprintf("%d", res)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 1
+	k := rng.Intn(n + 1)
+	input := fmt.Sprintf("%d %d\n", n, k)
+	expect := expected(n, k)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := [][2]int{{1, 0}, {2, 0}, {3, 1}, {4, 2}, {5, 3}}
+	for _, c := range cases {
+		in := fmt.Sprintf("%d %d\n", c[0], c[1])
+		exp := expected(c[0], c[1])
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "edge case failed: %v\ninput:\n%s", err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "edge case failed: expected %s got %s\ninput:\n%s", exp, out, in)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for Codeforces contest 285 problems A–E
- each verifier generates over 100 test cases and checks an arbitrary binary

## Testing
- `go build 0-999/200-299/280-289/285/verifierA.go`
- `go build 0-999/200-299/280-289/285/verifierB.go`
- `go build 0-999/200-299/280-289/285/verifierC.go`
- `go build 0-999/200-299/280-289/285/verifierD.go`
- `go build 0-999/200-299/280-289/285/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ea3e4d9cc83248192a0ef8b6483f4