### PR TITLE
Add Go verifiers for contest 284

### DIFF
--- a/0-999/200-299/280-289/284/verifierA.go
+++ b/0-999/200-299/280-289/284/verifierA.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// totient computes Euler's totient of n
+func totient(n int) int {
+	result := n
+	m := n
+	for i := 2; i*i <= m; i++ {
+		if m%i == 0 {
+			for m%i == 0 {
+				m /= i
+			}
+			result = result / i * (i - 1)
+		}
+	}
+	if m > 1 {
+		result = result / m * (m - 1)
+	}
+	return result
+}
+
+func isPrime(x int) bool {
+	if x < 2 {
+		return false
+	}
+	for i := 2; i*i <= x; i++ {
+		if x%i == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	// collect primes < 2000
+	primes := []int{}
+	for i := 2; i < 2000; i++ {
+		if isPrime(i) {
+			primes = append(primes, i)
+		}
+	}
+
+	for idx, p := range primes {
+		input := fmt.Sprintf("%d\n", p)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d (p=%d) runtime error: %v\n%s", idx+1, p, err, out.String())
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d (p=%d) bad output: %v\n", idx+1, p, err)
+			os.Exit(1)
+		}
+		expected := totient(p - 1)
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d (p=%d) expected %d got %d\n", idx+1, p, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/284/verifierB.go
+++ b/0-999/200-299/280-289/284/verifierB.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedResult(s string) int {
+	cntI := 0
+	cntF := 0
+	for _, c := range s {
+		if c == 'I' {
+			cntI++
+		} else if c == 'F' {
+			cntF++
+		}
+	}
+	if cntI == 0 {
+		return len(s) - cntF
+	}
+	if cntI == 1 {
+		return 1
+	}
+	return 0
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 2 // n >= 2
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		v := rng.Intn(3)
+		switch v {
+		case 0:
+			sb.WriteByte('A')
+		case 1:
+			sb.WriteByte('I')
+		default:
+			sb.WriteByte('F')
+		}
+	}
+	s := sb.String()
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	return input, expectedResult(s)
+}
+
+func runCase(bin, input string, expected int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` that checks solutions for problem A on all primes <2000
- add `verifierB.go` that runs 100 random cases for problem B

## Testing
- `go build 0-999/200-299/280-289/284/verifierA.go`
- `go build 0-999/200-299/280-289/284/verifierB.go`
- `go vet 0-999/200-299/280-289/284/verifierA.go`
- `go vet 0-999/200-299/280-289/284/verifierB.go`


------
https://chatgpt.com/codex/tasks/task_e_687ea39e6978832483f9477b9fedc3f3