### PR TITLE
Add Go verifiers for Codeforces contest 283

### DIFF
--- a/0-999/200-299/280-289/283/verifierA.go
+++ b/0-999/200-299/280-289/283/verifierA.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type op struct {
+	t int
+	a int
+	x int
+}
+
+func solveOps(ops []op) []float64 {
+	seq := []int{0}
+	res := make([]float64, len(ops))
+	for i, o := range ops {
+		switch o.t {
+		case 1:
+			for j := 0; j < o.a && j < len(seq); j++ {
+				seq[j] += o.x
+			}
+		case 2:
+			seq = append(seq, o.x)
+		case 3:
+			if len(seq) > 1 {
+				seq = seq[:len(seq)-1]
+			}
+		}
+		sum := 0
+		for _, v := range seq {
+			sum += v
+		}
+		res[i] = float64(sum) / float64(len(seq))
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(30) + 1
+	ops := make([]op, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	seqLen := 1
+	for i := 0; i < n; i++ {
+		t := rng.Intn(3) + 1
+		if seqLen == 1 && t == 3 {
+			t = rng.Intn(2) + 1 // avoid deletion when size 1
+		}
+		ops[i].t = t
+		switch t {
+		case 1:
+			ops[i].a = rng.Intn(seqLen) + 1
+			ops[i].x = rng.Intn(201) - 100
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", ops[i].a, ops[i].x))
+		case 2:
+			ops[i].x = rng.Intn(201) - 100
+			sb.WriteString(fmt.Sprintf("2 %d\n", ops[i].x))
+			seqLen++
+		case 3:
+			sb.WriteString("3\n")
+			seqLen--
+		}
+	}
+	expect := solveOps(ops)
+	var out strings.Builder
+	for _, v := range expect {
+		out.WriteString(fmt.Sprintf("%.8f\n", v))
+	}
+	return sb.String(), strings.Split(strings.TrimSuffix(out.String(), "\n"), "\n")
+}
+
+func runCase(bin string, input string, exp []string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, line := range lines {
+		var val float64
+		if _, err := fmt.Sscan(line, &val); err != nil {
+			return fmt.Errorf("bad float on line %d: %v", i+1, err)
+		}
+		var expVal float64
+		fmt.Sscan(exp[i], &expVal)
+		if diff := val - expVal; diff < -1e-6 || diff > 1e-6 {
+			return fmt.Errorf("line %d expected %.8f got %.8f", i+1, expVal, val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expLines := generateCase(rng)
+		if err := runCase(bin, in, expLines); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/283/verifierB.go
+++ b/0-999/200-299/280-289/283/verifierB.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(n int, a []int64) []int64 {
+	m := (n - 1) * 2
+	const UNVIS = int64(-2)
+	const INF = int64(-1)
+	dp := make([]int64, m)
+	rev := make([][]int, m)
+	for i := range dp {
+		dp[i] = UNVIS
+	}
+	q := make([]int, 0, m)
+	for pos := 2; pos <= n; pos++ {
+		idx := (pos - 2) * 2
+		for dir := 0; dir < 2; dir++ {
+			u := idx + dir
+			var vpos int64
+			if dir == 0 {
+				vpos = int64(pos) + a[pos]
+			} else {
+				vpos = int64(pos) - a[pos]
+			}
+			vdir := dir ^ 1
+			if vpos >= 2 && vpos <= int64(n) {
+				vidx := (int(vpos) - 2) * 2
+				v := vidx + vdir
+				rev[v] = append(rev[v], u)
+			} else if vpos <= 0 || vpos > int64(n) {
+				dp[u] = a[pos]
+				q = append(q, u)
+			}
+		}
+	}
+	for head := 0; head < len(q); head++ {
+		v := q[head]
+		for _, u := range rev[v] {
+			if dp[u] != UNVIS {
+				continue
+			}
+			pos := u/2 + 2
+			if dp[v] == INF {
+				dp[u] = INF
+			} else {
+				dp[u] = a[pos] + dp[v]
+			}
+			q = append(q, u)
+		}
+	}
+	for i := 0; i < m; i++ {
+		if dp[i] == UNVIS {
+			dp[i] = INF
+		}
+	}
+	ans := make([]int64, n-1)
+	for i := 1; i <= n-1; i++ {
+		pos1 := 1 + i
+		u := (pos1-2)*2 + 1
+		if dp[u] == INF {
+			ans[i-1] = -1
+		} else {
+			ans[i-1] = dp[u] + int64(i)
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(18) + 2
+	a := make([]int64, n+1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		a[i] = int64(rng.Intn(10) + 1)
+		if i > 2 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteString("\n")
+	ans := solveB(n, a)
+	expLines := make([]string, len(ans))
+	for i, v := range ans {
+		expLines[i] = fmt.Sprint(v)
+	}
+	return sb.String(), ans
+}
+
+func runCase(bin, input string, exp []int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, line := range lines {
+		var val int64
+		if _, err := fmt.Sscan(strings.TrimSpace(line), &val); err != nil {
+			return fmt.Errorf("bad int on line %d: %v", i+1, err)
+		}
+		if val != exp[i] {
+			return fmt.Errorf("line %d expected %d got %d", i+1, exp[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/283/verifierC.go
+++ b/0-999/200-299/280-289/283/verifierC.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func solveC(n, q, t int, arr []int, pairs [][2]int) int {
+	indegree := make([]int, n)
+	out := make([]int, n)
+	nxt := make([]int, n)
+	for i := range nxt {
+		nxt[i] = -1
+	}
+	prev := make([]int, n)
+	for i := range prev {
+		prev[i] = -1
+	}
+	for _, p := range pairs {
+		b := p[0]
+		c := p[1]
+		out[b]++
+		indegree[c]++
+		if out[b] > 1 || indegree[c] > 1 {
+			return 0
+		}
+		nxt[b] = c
+		prev[c] = b
+	}
+	visited := make([]bool, n)
+	weights := make([]int, 0, n)
+	C := 0
+	for i := 0; i < n; i++ {
+		if indegree[i] == 0 {
+			path := []int{}
+			cur := i
+			for cur != -1 {
+				path = append(path, cur)
+				visited[cur] = true
+				cur = nxt[cur]
+			}
+			k := len(path)
+			prefix := make([]int, k)
+			sum := 0
+			for j, v := range path {
+				sum += arr[v]
+				prefix[j] = sum
+			}
+			weights = append(weights, prefix...)
+			for j, v := range path {
+				C += (k - 1 - j) * arr[v]
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		if !visited[i] {
+			return 0
+		}
+	}
+	T := t - C
+	if T < 0 {
+		return 0
+	}
+	dp := make([]int, T+1)
+	dp[0] = 1
+	for _, w := range weights {
+		for s := w; s <= T; s++ {
+			dp[s] += dp[s-w]
+			if dp[s] >= mod {
+				dp[s] -= mod
+			}
+		}
+	}
+	return dp[T]
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(6) + 1
+	q := rng.Intn(n + 1)
+	t := rng.Intn(50) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(10) + 1
+	}
+	usedB := make(map[int]bool)
+	usedC := make(map[int]bool)
+	pairs := make([][2]int, 0, q)
+	for len(pairs) < q {
+		b := rng.Intn(n)
+		c := rng.Intn(n)
+		if b == c || usedB[b] || usedC[c] {
+			continue
+		}
+		usedB[b] = true
+		usedC[c] = true
+		pairs = append(pairs, [2]int{b, c})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, q, t))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	for _, p := range pairs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p[0]+1, p[1]+1))
+	}
+	ans := solveC(n, q, t, arr, pairs)
+	return sb.String(), ans
+}
+
+func runCase(bin, input string, exp int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var val int
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &val); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if val != exp {
+		return fmt.Errorf("expected %d got %d", exp, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/283/verifierD.go
+++ b/0-999/200-299/280-289/283/verifierD.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveD(a []int64) int {
+	n := len(a)
+	bad := make([]bool, n)
+	for i := 0; i < n-1; i++ {
+		x := a[i]
+		y := a[i+1]
+		var d int64
+		if y%2 == 1 {
+			d = 0
+		} else {
+			d = y / 2
+		}
+		if (x-d)%y != 0 {
+			bad[i] = true
+		}
+	}
+	dp0 := make([]int, n+1)
+	dp1 := make([]int, n+1)
+	dp0[1] = 0
+	dp1[1] = 1
+	for i := 2; i <= n; i++ {
+		if bad[i-2] {
+			dp0[i] = max(dp0[i-1], dp1[i-1])
+			dp1[i] = 1 + dp0[i-1]
+		} else {
+			mx := max(dp0[i-1], dp1[i-1])
+			dp0[i] = mx
+			dp1[i] = 1 + mx
+		}
+	}
+	best := max(dp0[n], dp1[n])
+	return n - best
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(20) + 2
+	a := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(30) + 1)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteString("\n")
+	ans := solveD(a)
+	return sb.String(), ans
+}
+
+func runCase(bin, input string, exp int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var val int
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &val); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if val != exp {
+		return fmt.Errorf("expected %d got %d", exp, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/283/verifierE.go
+++ b/0-999/200-299/280-289/283/verifierE.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveE(n, k int, skills []int, flips [][2]int) int64 {
+	sorted := make([]int, n)
+	copy(sorted, skills)
+	sort.Ints(sorted)
+	dt := make([]int64, n+3)
+	dsum := make([]int64, n+3)
+	for _, f := range flips {
+		a := f[0]
+		b := f[1]
+		l0 := sort.Search(n, func(i int) bool { return sorted[i] >= a })
+		r0 := sort.Search(n, func(i int) bool { return sorted[i] > b }) - 1
+		if l0 <= r0 {
+			l := int64(l0 + 1)
+			r := int64(r0 + 1)
+			dt[l]++
+			dt[r+1]--
+			dsum[l] += l + r
+			dsum[r+1] -= l + r
+		}
+	}
+	t := make([]int64, n+2)
+	sumlr := make([]int64, n+2)
+	var ct, cs int64
+	for u := 1; u <= n; u++ {
+		ct += dt[u]
+		cs += dsum[u]
+		t[u] = ct
+		sumlr[u] = cs
+	}
+	var trans int64
+	for u := 1; u <= n; u++ {
+		out := int64(u-1) + sumlr[u] - 2*int64(u)*t[u]
+		if out > 1 {
+			trans += out * (out - 1) / 2
+		}
+	}
+	nn := int64(n)
+	total := nn * (nn - 1) * (nn - 2) / 6
+	return total - trans
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(10) + 3
+	k := rng.Intn(10)
+	skills := make([]int, n)
+	used := make(map[int]bool)
+	for i := 0; i < n; i++ {
+		val := rng.Intn(100) + 1
+		for used[val] {
+			val = rng.Intn(100) + 1
+		}
+		used[val] = true
+		skills[i] = val
+	}
+	flips := make([][2]int, k)
+	for i := 0; i < k; i++ {
+		a := rng.Intn(100) + 1
+		b := a + rng.Intn(100)
+		if a > b {
+			a, b = b, a
+		}
+		flips[i] = [2]int{a, b}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range skills {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	for _, f := range flips {
+		sb.WriteString(fmt.Sprintf("%d %d\n", f[0], f[1]))
+	}
+	ans := solveE(n, k, skills, flips)
+	return sb.String(), ans
+}
+
+func runCase(bin, input string, exp int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var val int64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &val); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if val != exp {
+		return fmt.Errorf("expected %d got %d", exp, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement verifierA.go..verifierE.go for contest 283
- each verifier runs 100 randomized tests on a candidate binary

## Testing
- `go run verifierA.go ./a_bin`
- `go run verifierB.go ./b_bin`
- `go run verifierC.go ./c_bin`
- `go run verifierD.go ./d_bin`
- `go run verifierE.go ./e_bin`


------
https://chatgpt.com/codex/tasks/task_e_687ea358f4448324843509d17da94925