### PR TITLE
Add Go verifiers for Codeforces contest 280

### DIFF
--- a/0-999/200-299/280-289/280/verifierA.go
+++ b/0-999/200-299/280-289/280/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(w, h, deg int) float64 {
+	x := float64(w)
+	y := float64(h)
+	if x < y {
+		x, y = y, x
+	}
+	a := float64(deg) / 180 * math.Pi
+	if a > math.Pi/2 {
+		a = math.Pi - a
+	}
+	diag := math.Sqrt(x*x + y*y)
+	maxAngle := math.Asin(y/diag) * 2
+	halfA := a / 2
+	var ans float64
+	if a >= maxAngle && a <= math.Pi-maxAngle {
+		l := y / math.Sin(halfA)
+		hh := l / 2 * math.Tan(halfA)
+		ans = l * hh
+	} else {
+		l := y * math.Sin(halfA)
+		ans = l * l / math.Tan(halfA)
+		g := math.Cos(a) + math.Sin(a) + 1
+		gg := math.Cos(a) - math.Sin(a) + 1
+		xv := 0.0
+		if gg != 0 {
+			xv = (x - (x+y)/g*math.Sin(a)) / gg
+		}
+		yv := 0.0
+		if g != 0 {
+			yv = (x+y)/g - xv
+		}
+		s1 := xv * math.Sin(halfA) * xv * math.Cos(halfA) * 2
+		s2 := yv * math.Sin(halfA) * yv * math.Cos(halfA) * 2
+		s3 := yv * math.Cos(halfA) * 2 * xv * math.Cos(halfA) * 2
+		ans = s1 + s2 + s3
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	w := rng.Intn(1_000_000) + 1
+	h := rng.Intn(1_000_000) + 1
+	a := rng.Intn(181)
+	input := fmt.Sprintf("%d %d %d\n", w, h, a)
+	return input, expected(w, h, a)
+}
+
+func runCase(bin, input string, expected float64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	diff := math.Abs(got - expected)
+	tol := 1e-6 * math.Max(1, math.Abs(expected))
+	if diff > tol {
+		return fmt.Errorf("expected %.7f got %.7f", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/280/verifierB.go
+++ b/0-999/200-299/280-289/280/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(arr []int) int {
+	stack := make([]int, 0, len(arr))
+	ans := 0
+	for _, v := range arr {
+		for len(stack) > 0 {
+			top := stack[len(stack)-1]
+			xor := top ^ v
+			if xor > ans {
+				ans = xor
+			}
+			if top > v {
+				break
+			}
+			stack = stack[:len(stack)-1]
+		}
+		stack = append(stack, v)
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(1_000_000_000)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(arr)
+}
+
+func runCase(bin, input string, exp int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/280/verifierC.go
+++ b/0-999/200-299/280-289/280/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int, edges [][2]int) float64 {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		x, y := e[0], e[1]
+		adj[x] = append(adj[x], y)
+		adj[y] = append(adj[y], x)
+	}
+	parent := make([]int, n+1)
+	depth := make([]int, n+1)
+	q := []int{1}
+	depth[1] = 1
+	for i := 0; i < len(q); i++ {
+		u := q[i]
+		for _, v := range adj[u] {
+			if v != parent[u] {
+				parent[v] = u
+				depth[v] = depth[u] + 1
+				q = append(q, v)
+			}
+		}
+	}
+	ans := 0.0
+	for i := 1; i <= n; i++ {
+		ans += 1.0 / float64(depth[i])
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	n := rng.Intn(15) + 1
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{i, p}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String(), expected(n, edges)
+}
+
+func runCase(bin, input string, exp float64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	diff := got - exp
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > 1e-6*exp+1e-6 {
+		return fmt.Errorf("expected %.10f got %.10f", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/280/verifierD.go
+++ b/0-999/200-299/280-289/280/verifierD.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func maxK(arr []int, k int) int {
+	n := len(arr)
+	dp := make([][]int, n+1)
+	for i := range dp {
+		dp[i] = make([]int, k+1)
+		for j := range dp[i] {
+			dp[i][j] = math.MinInt32
+		}
+	}
+	dp[0][0] = 0
+	prefix := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i] + arr[i]
+	}
+	for i := 1; i <= n; i++ {
+		for j := 0; j <= k; j++ {
+			if dp[i-1][j] > dp[i][j] {
+				dp[i][j] = dp[i-1][j]
+			}
+		}
+		for j := 1; j <= k; j++ {
+			for t := 0; t < i; t++ {
+				if dp[t][j-1] == math.MinInt32 {
+					continue
+				}
+				sum := prefix[i] - prefix[t]
+				if val := dp[t][j-1] + sum; val > dp[i][j] {
+					dp[i][j] = val
+				}
+			}
+		}
+	}
+	ans := 0
+	for j := 1; j <= k; j++ {
+		if dp[n][j] > ans {
+			ans = dp[n][j]
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(21) - 10
+	}
+	m := rng.Intn(15) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	expOutputs := []string{}
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			pos := rng.Intn(n) + 1
+			val := rng.Intn(21) - 10
+			arr[pos-1] = val
+			sb.WriteString(fmt.Sprintf("0 %d %d\n", pos, val))
+		} else {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			k := rng.Intn(3) + 1
+			ans := maxK(arr[l-1:r], k)
+			sb.WriteString(fmt.Sprintf("1 %d %d %d\n", l, r, k))
+			expOutputs = append(expOutputs, fmt.Sprintf("%d", ans))
+		}
+	}
+	sbInput := sb.String()
+	exp := strings.Join(expOutputs, "\n")
+	if len(expOutputs) > 0 {
+		exp += "\n"
+	}
+	return sbInput, exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expStr := strings.TrimSpace(expected)
+	if outStr != expStr {
+		return fmt.Errorf("expected %q got %q", expStr, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/280-289/280/verifierE.go
+++ b/0-999/200-299/280-289/280/verifierE.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func clamp(x, lo, hi float64) float64 {
+	if x < lo {
+		return lo
+	}
+	if x > hi {
+		return hi
+	}
+	return x
+}
+
+func solve(xs []float64, q, a, b float64) ([]float64, float64) {
+	n := len(xs)
+	y := make([]float64, n)
+	L := make([]float64, n)
+	U := make([]float64, n)
+	for i := 0; i < n; i++ {
+		L[i] = 1 + float64(i)*a
+		U[i] = q - float64(n-1-i)*a
+	}
+	for i := 0; i < n; i++ {
+		y[i] = clamp(xs[i], L[i], U[i])
+	}
+	for it := 0; it < 200; it++ {
+		maxd := 0.0
+		for i := 0; i+1 < n; i++ {
+			lo := y[i] + a
+			hi := y[i] + b
+			old := y[i+1]
+			y[i+1] = clamp(y[i+1], lo, hi)
+			if d := math.Abs(y[i+1] - old); d > maxd {
+				maxd = d
+			}
+		}
+		for i := n - 1; i > 0; i-- {
+			hi := y[i] - a
+			lo := y[i] - b
+			old := y[i-1]
+			y[i-1] = clamp(y[i-1], math.Max(lo, L[i-1]), math.Min(hi, U[i-1]))
+			if d := math.Abs(y[i-1] - old); d > maxd {
+				maxd = d
+			}
+		}
+		if maxd < 1e-9 {
+			break
+		}
+	}
+	cost := 0.0
+	for i := 0; i < n; i++ {
+		d := y[i] - xs[i]
+		cost += d * d
+	}
+	return y, cost
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	q := rng.Float64()*20 + 5
+	a := rng.Float64() * 2
+	b := a + rng.Float64()*2
+	xs := make([]float64, n)
+	for i := range xs {
+		xs[i] = rng.Float64() * q
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %.6f %.6f %.6f\n", n, q, a, b))
+	for i, v := range xs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%.6f", v))
+	}
+	sb.WriteByte('\n')
+	ys, cost := solve(xs, q, a, b)
+	var exp strings.Builder
+	for i, v := range ys {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(fmt.Sprintf("%.9f", v))
+	}
+	exp.WriteByte('\n')
+	exp.WriteString(fmt.Sprintf("%.9f", cost))
+	exp.WriteByte('\n')
+	return sb.String(), exp.String()
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expStr := strings.TrimSpace(expected)
+	if outStr != expStr {
+		return fmt.Errorf("expected %q got %q", expStr, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go..verifierE.go under contest 280
- each verifier runs 100 random tests against any solution binary

## Testing
- `go build 0-999/200-299/280-289/280/verifierA.go`
- `go build 0-999/200-299/280-289/280/verifierB.go`
- `go build 0-999/200-299/280-289/280/verifierC.go`
- `go build 0-999/200-299/280-289/280/verifierD.go`
- `go build 0-999/200-299/280-289/280/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687ea2865920832498d8a4eabc04c5ac