### PR TITLE
Add Go verifiers for contest 279

### DIFF
--- a/0-999/200-299/270-279/279/verifierA.go
+++ b/0-999/200-299/270-279/279/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(x, y int) string {
+	if x == 0 && y == 0 {
+		return "0"
+	}
+	dirs := [4][2]int{{1, 0}, {0, 1}, {-1, 0}, {0, -1}}
+	cx, cy := 0, 0
+	d := 0
+	turns := 0
+	first := true
+	for k := 1; ; k++ {
+		for rep := 0; rep < 2; rep++ {
+			if first {
+				first = false
+			} else {
+				d = (d + 1) % 4
+				turns++
+			}
+			dx, dy := dirs[d][0], dirs[d][1]
+			for step := 0; step < k; step++ {
+				cx += dx
+				cy += dy
+				if cx == x && cy == y {
+					return fmt.Sprintf("%d", turns)
+				}
+			}
+		}
+	}
+}
+
+func generateCaseA(rng *rand.Rand) (string, string) {
+	x := rng.Intn(201) - 100
+	y := rng.Intn(201) - 100
+	input := fmt.Sprintf("%d %d\n", x, y)
+	expected := solveA(x, y)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseA(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/279/verifierB.go
+++ b/0-999/200-299/270-279/279/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(n int, t int64, a []int64) string {
+	var sum int64
+	ans := 0
+	l := 0
+	for r := 0; r < n; r++ {
+		sum += a[r]
+		for sum > t {
+			sum -= a[l]
+			l++
+		}
+		if r-l+1 > ans {
+			ans = r - l + 1
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCaseB(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	t := int64(rng.Intn(500) + 1)
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = int64(rng.Intn(100) + 1)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, t)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expected := solveB(n, t, a)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseB(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/279/verifierC.go
+++ b/0-999/200-299/270-279/279/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(n, m int, a []int, queries [][2]int) string {
+	p := make([]int, n)
+	p[n-1] = n - 1
+	for i := n - 2; i >= 0; i-- {
+		if a[i] <= a[i+1] {
+			p[i] = p[i+1]
+		} else {
+			p[i] = i
+		}
+	}
+	q := make([]int, n)
+	q[n-1] = n - 1
+	for i := n - 2; i >= 0; i-- {
+		if a[i] >= a[i+1] {
+			q[i] = q[i+1]
+		} else {
+			q[i] = i
+		}
+	}
+	var sb strings.Builder
+	for idx, qr := range queries {
+		l, r := qr[0]-1, qr[1]-1
+		x := p[l]
+		if x >= r || q[x] >= r {
+			sb.WriteString("Yes")
+		} else {
+			sb.WriteString("No")
+		}
+		if idx+1 < len(queries) {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func generateCaseC(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 1
+	m := rng.Intn(15) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(20)
+	}
+	queries := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		queries[i] = [2]int{l, r}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for _, qr := range queries {
+		fmt.Fprintf(&sb, "%d %d\n", qr[0], qr[1])
+	}
+	input := sb.String()
+	expected := solveC(n, m, a, queries)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseC(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/279/verifierD.go
+++ b/0-999/200-299/270-279/279/verifierD.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(a []int) string {
+	n := len(a) - 1
+	P := make([][][2]int, n+1)
+	for k := 2; k <= n; k++ {
+		for i := 1; i < k; i++ {
+			for j := i; j < k; j++ {
+				if a[i]+a[j] == a[k] {
+					P[k] = append(P[k], [2]int{i, j})
+				}
+			}
+		}
+		if len(P[k]) == 0 {
+			return "-1"
+		}
+	}
+	var dfs func(int, []int, int) bool
+	dfs = func(k int, lastUse []int, M int) bool {
+		if k > n {
+			return true
+		}
+		for _, pair := range P[k] {
+			i, j := pair[0], pair[1]
+			oldI, oldJ := lastUse[i], lastUse[j]
+			lastUse[i], lastUse[j] = k, k
+			cnt := 0
+			for t := 1; t < k; t++ {
+				if lastUse[t] >= k {
+					cnt++
+				}
+			}
+			if cnt <= M {
+				if dfs(k+1, lastUse, M) {
+					return true
+				}
+			}
+			lastUse[i], lastUse[j] = oldI, oldJ
+		}
+		return false
+	}
+	for m := 1; m <= n; m++ {
+		last := make([]int, n+1)
+		if dfs(2, last, m) {
+			return fmt.Sprintf("%d", m)
+		}
+	}
+	return "-1"
+}
+
+func generateCaseD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = rng.Intn(20) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expected := solveD(a)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseD(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/279/verifierE.go
+++ b/0-999/200-299/270-279/279/verifierE.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(s string) string {
+	N := len(s)
+	b := make([]byte, N+2)
+	for i := 0; i < N; i++ {
+		b[N-1-i] = s[i] - '0'
+	}
+	var carry int
+	var ans int64
+	for i := 0; i < N+1; i++ {
+		bit := int(b[i]) + carry
+		if bit&1 == 0 {
+			if bit == 2 {
+				carry = 1
+			} else {
+				carry = 0
+			}
+		} else {
+			if b[i+1] == 1 {
+				carry = 1
+			} else {
+				carry = 0
+			}
+			ans++
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCaseE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := range b {
+		if rng.Intn(2) == 1 {
+			b[i] = '1'
+		} else {
+			b[i] = '0'
+		}
+	}
+	s := string(b)
+	input := s + "\n"
+	expected := solveE(s)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseE(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go..verifierE.go for problems 279A-279E
- each verifier generates 100 random tests and runs a target binary

## Testing
- `GO111MODULE=off go vet ./0-999/200-299/270-279/279`
- `gofmt -w 0-999/200-299/270-279/279/verifierA.go 0-999/200-299/270-279/279/verifierB.go 0-999/200-299/270-279/279/verifierC.go 0-999/200-299/270-279/279/verifierD.go 0-999/200-299/270-279/279/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687ea24060b083249b9a50d246c2a43a