### PR TITLE
Add solution verifiers for contest 276

### DIFF
--- a/0-999/200-299/270-279/276/verifierA.go
+++ b/0-999/200-299/270-279/276/verifierA.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n int
+	k int64
+	f []int64
+	t []int64
+}
+
+func generateCaseA(rng *rand.Rand) testCaseA {
+	n := rng.Intn(10) + 1
+	k := rng.Int63n(20)
+	f := make([]int64, n)
+	t := make([]int64, n)
+	for i := 0; i < n; i++ {
+		f[i] = rng.Int63n(50) + 1
+		t[i] = rng.Int63n(40) + 1
+	}
+	return testCaseA{n: n, k: k, f: f, t: t}
+}
+
+func buildInputA(tc testCaseA) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.k)
+	for i := 0; i < tc.n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", tc.f[i], tc.t[i])
+	}
+	return sb.String()
+}
+
+func expectedA(tc testCaseA) int64 {
+	maxJoy := int64(-1 << 60)
+	for i := 0; i < tc.n; i++ {
+		joy := tc.f[i]
+		if tc.t[i] > tc.k {
+			joy -= tc.t[i] - tc.k
+		}
+		if joy > maxJoy {
+			maxJoy = joy
+		}
+	}
+	return maxJoy
+}
+
+func runCaseA(bin string, tc testCaseA) error {
+	input := buildInputA(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	want := expectedA(tc)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseA(rng)
+		if err := runCaseA(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInputA(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/276/verifierB.go
+++ b/0-999/200-299/270-279/276/verifierB.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	s string
+}
+
+func generateCaseB(rng *rand.Rand) testCaseB {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return testCaseB{s: string(b)}
+}
+
+func expectedB(tc testCaseB) string {
+	counts := make(map[rune]int)
+	for _, ch := range tc.s {
+		counts[ch]++
+	}
+	odd := 0
+	for _, c := range counts {
+		if c%2 != 0 {
+			odd++
+		}
+	}
+	if odd == 0 || odd%2 == 1 {
+		return "First"
+	}
+	return "Second"
+}
+
+func runCaseB(bin string, tc testCaseB) error {
+	input := fmt.Sprintf("%s\n", tc.s)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := expectedB(tc)
+	if got != want {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseB(rng)
+		if err := runCaseB(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s\n", i+1, err, tc.s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/276/verifierC.go
+++ b/0-999/200-299/270-279/276/verifierC.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	n int
+	q int
+	a []int
+	L []int
+	R []int
+}
+
+func generateCaseC(rng *rand.Rand) testCaseC {
+	n := rng.Intn(10) + 1
+	q := rng.Intn(10) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(50)
+	}
+	L := make([]int, q)
+	R := make([]int, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		L[i] = l
+		R[i] = r
+	}
+	return testCaseC{n: n, q: q, a: a, L: L, R: R}
+}
+
+func buildInputC(tc testCaseC) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.q)
+	for i := 0; i < tc.n; i++ {
+		fmt.Fprintf(&sb, "%d ", tc.a[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < tc.q; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", tc.L[i], tc.R[i])
+	}
+	return sb.String()
+}
+
+func expectedC(tc testCaseC) int64 {
+	freqDiff := make([]int, tc.n+1)
+	for i := 0; i < tc.q; i++ {
+		freqDiff[tc.L[i]-1]++
+		freqDiff[tc.R[i]]--
+	}
+	freq := make([]int, tc.n)
+	cur := 0
+	for i := 0; i < tc.n; i++ {
+		cur += freqDiff[i]
+		freq[i] = cur
+	}
+	arr := append([]int(nil), tc.a...)
+	sort.Ints(arr)
+	sort.Ints(freq)
+	var ans int64
+	for i := 0; i < tc.n; i++ {
+		ans += int64(arr[i]) * int64(freq[i])
+	}
+	return ans
+}
+
+func runCaseC(bin string, tc testCaseC) error {
+	input := buildInputC(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	want := expectedC(tc)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseC(rng)
+		if err := runCaseC(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInputC(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/276/verifierD.go
+++ b/0-999/200-299/270-279/276/verifierD.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseD struct {
+	l uint64
+	r uint64
+}
+
+func generateCaseD(rng *rand.Rand) testCaseD {
+	l := rng.Uint64()%1000 + 1
+	r := l + rng.Uint64()%1000
+	return testCaseD{l: l, r: r}
+}
+
+func expectedD(tc testCaseD) uint64 {
+	x := tc.l ^ tc.r
+	var ans uint64
+	for x > 0 {
+		ans = (ans << 1) | 1
+		x >>= 1
+	}
+	return ans
+}
+
+func runCaseD(bin string, tc testCaseD) error {
+	input := fmt.Sprintf("%d %d\n", tc.l, tc.r)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got uint64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	want := expectedD(tc)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseD(rng)
+		if err := runCaseD(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%d %d\n", i+1, err, tc.l, tc.r)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/276/verifierE.go
+++ b/0-999/200-299/270-279/276/verifierE.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+type testCaseE struct {
+	n     int
+	edges []edge
+	q     int
+	ops   []opE
+}
+
+type opE struct {
+	typ int // 0 or 1
+	v   int
+	x   int
+	d   int
+}
+
+func generateTreeE(rng *rand.Rand, n int) []edge {
+	deg := make([]int, n+1)
+	var edges []edge
+	for i := 2; i <= n; i++ {
+		for {
+			p := rng.Intn(i-1) + 1
+			if p == 1 || deg[p] < 2 {
+				edges = append(edges, edge{p, i})
+				deg[p]++
+				deg[i]++
+				break
+			}
+		}
+	}
+	return edges
+}
+
+func generateCaseE(rng *rand.Rand) testCaseE {
+	n := rng.Intn(6) + 1
+	edges := generateTreeE(rng, n)
+	q := rng.Intn(10) + 1
+	ops := make([]opE, q)
+	for i := 0; i < q; i++ {
+		typ := rng.Intn(2)
+		if typ == 0 {
+			v := rng.Intn(n) + 1
+			x := rng.Intn(10)
+			d := rng.Intn(n)
+			ops[i] = opE{typ: 0, v: v, x: x, d: d}
+		} else {
+			v := rng.Intn(n) + 1
+			ops[i] = opE{typ: 1, v: v}
+		}
+	}
+	return testCaseE{n: n, edges: edges, q: q, ops: ops}
+}
+
+func buildInputE(tc testCaseE) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.q)
+	for _, e := range tc.edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+	}
+	for _, op := range tc.ops {
+		if op.typ == 0 {
+			fmt.Fprintf(&sb, "0 %d %d %d\n", op.v, op.x, op.d)
+		} else {
+			fmt.Fprintf(&sb, "1 %d\n", op.v)
+		}
+	}
+	return sb.String()
+}
+
+func expectedE(tc testCaseE) string {
+	adj := make([][]int, tc.n+1)
+	for _, e := range tc.edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	val := make([]int64, tc.n+1)
+	var out strings.Builder
+	for _, op := range tc.ops {
+		if op.typ == 0 {
+			// BFS
+			seen := make([]bool, tc.n+1)
+			queue := []struct{ v, d int }{{op.v, 0}}
+			seen[op.v] = true
+			for len(queue) > 0 {
+				cur := queue[0]
+				queue = queue[1:]
+				val[cur.v] += int64(op.x)
+				if cur.d == op.d {
+					continue
+				}
+				for _, nb := range adj[cur.v] {
+					if !seen[nb] {
+						seen[nb] = true
+						queue = append(queue, struct{ v, d int }{nb, cur.d + 1})
+					}
+				}
+			}
+		} else {
+			fmt.Fprintf(&out, "%d\n", val[op.v])
+		}
+	}
+	return strings.TrimSuffix(out.String(), "\n")
+}
+
+func runCaseE(bin string, tc testCaseE) error {
+	input := buildInputE(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := expectedE(tc)
+	if got != want {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseE(rng)
+		if err := runCaseE(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInputE(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–E of contest 276
- each verifier runs the target binary on 100 randomly generated tests
- verification covers runtime failures and wrong answers

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_687ea16e490c8324a042e49ecf06c676