### PR TITLE
Add verifiers for contest 275

### DIFF
--- a/0-999/200-299/270-279/275/verifierA.go
+++ b/0-999/200-299/270-279/275/verifierA.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+type grid [3][3]int
+
+func expected(g grid) [3][3]int {
+	dirs := [][2]int{{0, 0}, {1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	var res [3][3]int
+	for i := 0; i < 3; i++ {
+		for j := 0; j < 3; j++ {
+			sum := 0
+			for _, d := range dirs {
+				ni, nj := i+d[0], j+d[1]
+				if ni >= 0 && ni < 3 && nj >= 0 && nj < 3 {
+					sum += g[ni][nj]
+				}
+			}
+			if sum%2 == 0 {
+				res[i][j] = 1
+			} else {
+				res[i][j] = 0
+			}
+		}
+	}
+	return res
+}
+
+func gridToInput(g grid) string {
+	var sb strings.Builder
+	for i := 0; i < 3; i++ {
+		for j := 0; j < 3; j++ {
+			sb.WriteString(fmt.Sprintf("%d", g[i][j]))
+			if j+1 < 3 {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func outputToGrid(out string) ([3][3]int, error) {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 3 {
+		return [3][3]int{}, fmt.Errorf("expected 3 lines, got %d", len(lines))
+	}
+	var res [3][3]int
+	for i := 0; i < 3; i++ {
+		if len(lines[i]) < 3 {
+			return res, fmt.Errorf("line %d too short", i+1)
+		}
+		for j := 0; j < 3; j++ {
+			if lines[i][j] == '0' {
+				res[i][j] = 0
+			} else if lines[i][j] == '1' {
+				res[i][j] = 1
+			} else {
+				return res, fmt.Errorf("invalid char %q", lines[i][j])
+			}
+		}
+	}
+	return res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		var g grid
+		for r := 0; r < 3; r++ {
+			for c := 0; c < 3; c++ {
+				g[r][c] = rng.Intn(101) // 0..100
+			}
+		}
+		input := gridToInput(g)
+		expectedGrid := expected(g)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := outputToGrid(out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+		if got != expectedGrid {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %v got %v\ninput:\n%s", i+1, expectedGrid, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/275/verifierB.go
+++ b/0-999/200-299/270-279/275/verifierB.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func isConvex(grid [][]byte) bool {
+	n := len(grid)
+	m := len(grid[0])
+	rowPS := make([][]int, n)
+	for i := 0; i < n; i++ {
+		rowPS[i] = make([]int, m+1)
+		for j := 0; j < m; j++ {
+			rowPS[i][j+1] = rowPS[i][j]
+			if grid[i][j] == 'B' {
+				rowPS[i][j+1]++
+			}
+		}
+	}
+	colPS := make([][]int, m)
+	for j := 0; j < m; j++ {
+		colPS[j] = make([]int, n+1)
+		for i := 0; i < n; i++ {
+			colPS[j][i+1] = colPS[j][i]
+			if grid[i][j] == 'B' {
+				colPS[j][i+1]++
+			}
+		}
+	}
+	type cell struct{ r, c int }
+	blacks := make([]cell, 0)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 'B' {
+				blacks = append(blacks, cell{i, j})
+			}
+		}
+	}
+	k := len(blacks)
+	for a := 0; a < k; a++ {
+		for b := a + 1; b < k; b++ {
+			r1, c1 := blacks[a].r, blacks[a].c
+			r2, c2 := blacks[b].r, blacks[b].c
+			ok := false
+			if r1 == r2 {
+				cmin, cmax := c1, c2
+				if cmin > cmax {
+					cmin, cmax = cmax, cmin
+				}
+				if rowPS[r1][cmax+1]-rowPS[r1][cmin] == cmax-cmin+1 {
+					ok = true
+				}
+			}
+			if !ok && c1 == c2 {
+				rmin, rmax := r1, r2
+				if rmin > rmax {
+					rmin, rmax = rmax, rmin
+				}
+				if colPS[c1][rmax+1]-colPS[c1][rmin] == rmax-rmin+1 {
+					ok = true
+				}
+			}
+			if !ok {
+				cmin, cmax := c1, c2
+				if cmin > cmax {
+					cmin, cmax = cmax, cmin
+				}
+				rmin, rmax := r1, r2
+				if rmin > rmax {
+					rmin, rmax = rmax, rmin
+				}
+				seg1 := rowPS[r1][cmax+1]-rowPS[r1][cmin] == cmax-cmin+1
+				seg2 := colPS[c2][rmax+1]-colPS[c2][rmin] == rmax-rmin+1
+				if seg1 && seg2 {
+					ok = true
+				}
+			}
+			if !ok {
+				cmin, cmax := c1, c2
+				if cmin > cmax {
+					cmin, cmax = cmax, cmin
+				}
+				rmin, rmax := r1, r2
+				if rmin > rmax {
+					rmin, rmax = rmax, rmin
+				}
+				seg1 := colPS[c1][rmax+1]-colPS[c1][rmin] == rmax-rmin+1
+				seg2 := rowPS[r2][cmax+1]-rowPS[r2][cmin] == cmax-cmin+1
+				if seg1 && seg2 {
+					ok = true
+				}
+			}
+			if !ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		grid := make([][]byte, n)
+		bcount := 0
+		for r := 0; r < n; r++ {
+			row := make([]byte, m)
+			for c := 0; c < m; c++ {
+				if rng.Intn(2) == 0 {
+					row[c] = 'W'
+				} else {
+					row[c] = 'B'
+					bcount++
+				}
+			}
+			grid[r] = row
+		}
+		if bcount == 0 {
+			grid[0][0] = 'B'
+			bcount = 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for r := 0; r < n; r++ {
+			sb.WriteString(string(grid[r]))
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expected := "NO"
+		if isConvex(grid) {
+			expected = "YES"
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 275 problems A and B
- verifiers run 100 randomized testcases each and check output of any binary

## Testing
- `go run verifierA.go ./275A_bin`
- `go run verifierB.go ./275B_bin`


------
https://chatgpt.com/codex/tasks/task_e_687ea128629083249db6a86e565800c6