### PR TITLE
Add verifiers for Codeforces contest 274

### DIFF
--- a/0-999/200-299/270-279/274/verifierA.go
+++ b/0-999/200-299/270-279/274/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedA(n int, k int64, arr []int64) int {
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	used := make(map[int64]bool, n)
+	cnt := 0
+	for _, v := range arr {
+		if k != 0 && v%k == 0 {
+			if used[v/k] {
+				continue
+			}
+		}
+		used[v] = true
+		cnt++
+	}
+	return cnt
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 1
+	k := int64(rng.Intn(5) + 1)
+	vals := make([]int64, 0, n)
+	used := map[int64]bool{}
+	for len(vals) < n {
+		v := int64(rng.Intn(30) + 1)
+		if !used[v] {
+			used[v] = true
+			vals = append(vals, v)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	exp := expectedA(n, k, append([]int64(nil), vals...))
+	return sb.String(), fmt.Sprintf("%d\n", exp)
+}
+
+func runCase(exe string, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/274/verifierB.go
+++ b/0-999/200-299/270-279/274/verifierB.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func expectedB(n int, edges []edge, vals []int64) int64 {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	var dfs func(int, int) (int64, int64)
+	dfs = func(u, p int) (int64, int64) {
+		var inc, dec int64
+		for _, v := range adj[u] {
+			if v == p {
+				continue
+			}
+			ci, cd := dfs(v, u)
+			if ci > inc {
+				inc = ci
+			}
+			if cd > dec {
+				dec = cd
+			}
+		}
+		cur := vals[u] + inc - dec
+		if cur > 0 {
+			dec += cur
+		} else {
+			inc += -cur
+		}
+		return inc, dec
+	}
+	inc, dec := dfs(1, 0)
+	return inc + dec
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	edges := make([]edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, edge{p, i})
+	}
+	vals := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		vals[i] = int64(rng.Intn(11) - 5) // -5..5
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n) + "\n")
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(vals[i], 10))
+	}
+	sb.WriteByte('\n')
+	exp := expectedB(n, edges, vals)
+	return sb.String(), fmt.Sprintf("%d\n", exp)
+}
+
+func runCase(exe string, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/274/verifierC.go
+++ b/0-999/200-299/270-279/274/verifierC.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type pnt struct{ x, y float64 }
+
+const ep = 1e-9
+
+func (a pnt) sub(b pnt) pnt       { return pnt{a.x - b.x, a.y - b.y} }
+func (a pnt) add(b pnt) pnt       { return pnt{a.x + b.x, a.y + b.y} }
+func (a pnt) mul(s float64) pnt   { return pnt{a.x * s, a.y * s} }
+func (a pnt) div(s float64) pnt   { return pnt{a.x / s, a.y / s} }
+func (a pnt) dot(b pnt) float64   { return a.x*b.x + a.y*b.y }
+func (a pnt) cross(b pnt) float64 { return a.x*b.y - a.y*b.x }
+func (a pnt) dist() float64       { return math.Hypot(a.x, a.y) }
+
+func outercenter(a, b, c pnt) pnt {
+	c1 := (a.dot(a) - b.dot(b)) / 2
+	c2 := (a.dot(a) - c.dot(c)) / 2
+	d1 := a.sub(b).cross(a.sub(c))
+	x0 := (c1*(a.y-c.y) - c2*(a.y-b.y)) / d1
+	y0 := (c1*(a.x-c.x) - c2*(a.x-b.x)) / -d1
+	return pnt{x0, y0}
+}
+
+func chk(a, b, c pnt, pts []pnt, i, j, k int) bool {
+	r := b.sub(c).dist() / 2
+	o := b.add(c).div(2)
+	bf := false
+	for t := range pts {
+		if t == i || t == j || t == k {
+			continue
+		}
+		if (pts[t].sub(c).cross(b.sub(c)) * (a.sub(c).cross(b.sub(c)))) < -ep {
+			if pts[t].sub(b).dist() < 2*r && pts[t].sub(c).dist() < 2*r {
+				bf = true
+			}
+		}
+		if o.sub(pts[t]).dist() < r-ep {
+			return false
+		}
+	}
+	return bf
+}
+
+func solveC(n int, pts []pnt) float64 {
+	ans := -1.0
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			for k := j + 1; k < n; k++ {
+				fijk := pts[i].sub(pts[j]).dot(pts[k].sub(pts[j]))
+				fikj := pts[i].sub(pts[k]).dot(pts[j].sub(pts[k]))
+				fjik := pts[j].sub(pts[i]).dot(pts[k].sub(pts[i]))
+				if fijk < -ep || fikj < -ep || fjik < -ep {
+					continue
+				}
+				if math.Abs(fijk) < ep {
+					a, b, c := pts[j], pts[i], pts[k]
+					if chk(a, b, c, pts, i, j, k) {
+						r := b.sub(c).dist() / 2
+						if r > ans {
+							ans = r
+						}
+					}
+				} else if math.Abs(fikj) < ep {
+					a, b, c := pts[k], pts[i], pts[j]
+					if chk(a, b, c, pts, i, j, k) {
+						r := b.sub(c).dist() / 2
+						if r > ans {
+							ans = r
+						}
+					}
+				} else if math.Abs(fjik) < ep {
+					a, b, c := pts[i], pts[j], pts[k]
+					if chk(a, b, c, pts, i, j, k) {
+						r := b.sub(c).dist() / 2
+						if r > ans {
+							ans = r
+						}
+					}
+				} else {
+					area := math.Abs(pts[i].sub(pts[j]).cross(pts[k].sub(pts[j])))
+					r := pts[i].sub(pts[j]).dist() * pts[i].sub(pts[k]).dist() * pts[j].sub(pts[k]).dist() / area / 2
+					o := outercenter(pts[i], pts[j], pts[k])
+					ok := true
+					for t := range pts {
+						if t == i || t == j || t == k {
+							continue
+						}
+						if o.sub(pts[t]).dist() < r-ep {
+							ok = false
+							break
+						}
+					}
+					if ok && r > ans {
+						ans = r
+					}
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	pts := make([]pnt, 0, n)
+	used := map[[2]int]bool{}
+	for len(pts) < n {
+		x := rng.Intn(11) - 5
+		y := rng.Intn(11) - 5
+		if !used[[2]int{x, y}] {
+			used[[2]int{x, y}] = true
+			pts = append(pts, pnt{float64(x), float64(y)})
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n) + "\n")
+	for _, p := range pts {
+		sb.WriteString(fmt.Sprintf("%d %d\n", int(p.x), int(p.y)))
+	}
+	ans := solveC(n, pts)
+	if ans < -ep {
+		return sb.String(), "-1\n"
+	}
+	return sb.String(), fmt.Sprintf("%.12f\n", ans)
+}
+
+func runCase(exe string, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/274/verifierD.go
+++ b/0-999/200-299/270-279/274/verifierD.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type node struct{ val, no int }
+
+func solveD(n, m int, mat [][]int) []int {
+	rec := make([]node, m)
+	maxNodes := m*2 + n*2 + 5
+	join := make([]int, maxNodes)
+	v := make([][]int, maxNodes)
+	cnt := 0
+	ans := make([]int, 0, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			rec[j].val = mat[i][j]
+			rec[j].no = j
+		}
+		sort.Slice(rec, func(a, b int) bool { return rec[a].val < rec[b].val })
+		for j := 0; j < m; j++ {
+			if rec[j].val < 0 {
+				continue
+			}
+			if j == 0 || rec[j].val != rec[j-1].val {
+				cnt++
+			}
+			end := m + cnt + 1
+			v[rec[j].no] = append(v[rec[j].no], end)
+			join[end]++
+			start := m + cnt
+			v[start] = append(v[start], rec[j].no)
+			join[rec[j].no]++
+		}
+		cnt++
+	}
+	totalNodes := m + cnt + 3
+	q := make([]int, 0, totalNodes)
+	for i := 0; i < totalNodes && i < len(join); i++ {
+		if join[i] == 0 {
+			q = append(q, i)
+		}
+	}
+	head := 0
+	for head < len(q) {
+		t := q[head]
+		head++
+		if t < m {
+			ans = append(ans, t)
+		}
+		for _, to := range v[t] {
+			join[to]--
+			if join[to] == 0 {
+				q = append(q, to)
+			}
+		}
+	}
+	if len(ans) < m {
+		return nil
+	}
+	for i := 0; i < m; i++ {
+		ans[i]++
+	}
+	return ans[:m]
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	mat := make([][]int, n)
+	for i := 0; i < n; i++ {
+		row := make([]int, m)
+		for j := 0; j < m; j++ {
+			if rng.Float64() < 0.3 {
+				row[j] = -1
+			} else {
+				row[j] = rng.Intn(10)
+			}
+		}
+		mat[i] = row
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(mat[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	res := solveD(n, m, mat)
+	if res == nil {
+		return sb.String(), "-1\n"
+	}
+	var out strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		out.WriteString(strconv.Itoa(v))
+	}
+	out.WriteByte('\n')
+	return sb.String(), out.String()
+}
+
+func runCase(exe string, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/270-279/274/verifierE.go
+++ b/0-999/200-299/270-279/274/verifierE.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int }
+
+func simulate(n, m int, blocks map[point]bool, xs, ys int, dx, dy int) int {
+	visitedCells := map[point]bool{{xs, ys}: true}
+	ans := 1
+	states := map[[4]int]bool{}
+	x, y := xs, ys
+	for {
+		key := [4]int{x, y, dx, dy}
+		if states[key] {
+			break
+		}
+		states[key] = true
+		tx := n - x
+		if dx < 0 {
+			tx = x - 1
+		}
+		ty := m - y
+		if dy < 0 {
+			ty = y - 1
+		}
+		steps := tx
+		if ty < steps {
+			steps = ty
+		}
+		tObs := steps + 1
+		for s := 1; s <= steps; s++ {
+			nx := x + dx*s
+			ny := y + dy*s
+			if blocks[point{nx, ny}] {
+				tObs = s
+				break
+			}
+		}
+		t := steps
+		hitObs := false
+		if tObs <= steps {
+			t = tObs
+			hitObs = true
+		}
+		for s := 1; s <= t; s++ {
+			if hitObs && s == t {
+				break
+			}
+			nx := x + dx*s
+			ny := y + dy*s
+			p := point{nx, ny}
+			if !visitedCells[p] {
+				visitedCells[p] = true
+				ans++
+			}
+		}
+		x += dx * t
+		y += dy * t
+		if hitObs {
+			dx = -dx
+			dy = -dy
+		} else {
+			if tx < ty {
+				dx = -dx
+			} else if ty < tx {
+				dy = -dy
+			} else {
+				dx = -dx
+				dy = -dy
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	maxCells := n*m - 1
+	k := 0
+	if maxCells > 0 {
+		k = rng.Intn(min(maxCells, 4) + 1)
+	}
+	blocks := map[point]bool{}
+	for len(blocks) < k {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(m) + 1
+		blocks[point{x, y}] = true
+	}
+	xs := rng.Intn(n) + 1
+	ys := rng.Intn(m) + 1
+	for blocks[point{xs, ys}] {
+		xs = rng.Intn(n) + 1
+		ys = rng.Intn(m) + 1
+	}
+	dirs := []string{"NE", "NW", "SE", "SW"}
+	dir := dirs[rng.Intn(4)]
+	dx, dy := 0, 0
+	switch dir {
+	case "NE":
+		dx = -1
+		dy = 1
+	case "NW":
+		dx = -1
+		dy = -1
+	case "SE":
+		dx = 1
+		dy = 1
+	case "SW":
+		dx = 1
+		dy = -1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for p := range blocks {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.x, p.y))
+	}
+	sb.WriteString(fmt.Sprintf("%d %d %s\n", xs, ys, dir))
+	res := simulate(n, m, blocks, xs, ys, dx, dy)
+	return sb.String(), fmt.Sprintf("%d\n", res)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func runCase(exe string, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 274
- each verifier generates 100 random test cases and checks a solution binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687ea0e20ad4832494e141e492cc3179