### PR TITLE
Add Go verifiers for Codeforces contest 272

### DIFF
--- a/0-999/200-299/270-279/272/verifierA.go
+++ b/0-999/200-299/270-279/272/verifierA.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	r := strings.NewReader(strings.TrimSpace(input))
+	var n int
+	fmt.Fscan(r, &n)
+	arr := make([]int, n)
+	sum := 0
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &arr[i])
+		sum += arr[i]
+	}
+	cnt := 0
+	total := n + 1
+	for k := 1; k <= 5; k++ {
+		if (sum+k)%total != 1 {
+			cnt++
+		}
+	}
+	return fmt.Sprintf("%d\n", cnt)
+}
+
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	fixed := []struct {
+		n   int
+		arr []int
+	}{
+		{1, []int{1}},
+		{2, []int{1, 2}},
+		{3, []int{5, 5, 5}},
+		{4, []int{1, 1, 1, 1}},
+		{5, []int{1, 2, 3, 4, 5}},
+	}
+	for _, f := range fixed {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", f.n))
+		for i, v := range f.arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(100) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(5)+1))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/200-299/270-279/272/verifierB.go
+++ b/0-999/200-299/270-279/272/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	r := strings.NewReader(strings.TrimSpace(input))
+	var n int
+	fmt.Fscan(r, &n)
+	counts := make([]int64, 33)
+	for i := 0; i < n; i++ {
+		var x uint
+		fmt.Fscan(r, &x)
+		counts[bits.OnesCount(x)]++
+	}
+	var ans int64
+	for _, c := range counts {
+		ans += c * (c - 1) / 2
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func generateTests() []test {
+	rand.Seed(43)
+	var tests []test
+	fixed := []struct {
+		arr []uint
+	}{
+		{[]uint{1, 2, 3}},
+		{[]uint{1, 1}},
+		{[]uint{0}},
+		{[]uint{7, 7, 7}},
+		{[]uint{5, 10, 5, 10}},
+	}
+	for _, f := range fixed {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(f.arr)))
+		for i, v := range f.arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Uint32()%1000))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/200-299/270-279/272/verifierC.go
+++ b/0-999/200-299/270-279/272/verifierC.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	r := strings.NewReader(strings.TrimSpace(input))
+	var n int
+	fmt.Fscan(r, &n)
+	a := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(r, &a[i])
+	}
+	var m int
+	fmt.Fscan(r, &m)
+	cur := int64(0)
+	var out strings.Builder
+	for i := 0; i < m; i++ {
+		var w int
+		var h int64
+		fmt.Fscan(r, &w, &h)
+		if a[w] > cur {
+			cur = a[w]
+		}
+		out.WriteString(fmt.Sprintf("%d\n", cur))
+		cur += h
+	}
+	return out.String()
+}
+
+func generateTests() []test {
+	rand.Seed(44)
+	var tests []test
+	fixed := []struct {
+		n       int
+		a       []int64
+		queries [][2]int64
+	}{
+		{1, []int64{5}, [][2]int64{{1, 2}, {1, 3}}},
+		{2, []int64{1, 2}, [][2]int64{{1, 1}, {2, 2}, {1, 3}}},
+	}
+	for _, f := range fixed {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", f.n))
+		for i, v := range f.a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteString("\n")
+		sb.WriteString(fmt.Sprintf("%d\n", len(f.queries)))
+		for _, q := range f.queries {
+			sb.WriteString(fmt.Sprintf("%d %d\n", q[0], q[1]))
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		a := make([]int64, n+1)
+		cur := int64(0)
+		for i := 1; i <= n; i++ {
+			cur += int64(rand.Intn(5) + 1)
+			a[i] = cur
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteString("\n")
+		m := rand.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+		for i := 0; i < m; i++ {
+			w := rand.Intn(n) + 1
+			h := rand.Intn(5) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", w, h))
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/200-299/270-279/272/verifierD.go
+++ b/0-999/200-299/270-279/272/verifierD.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	r := strings.NewReader(strings.TrimSpace(input))
+	var n int
+	fmt.Fscan(r, &n)
+	xs := make([]int, 2*n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &xs[i])
+	}
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &xs[n+i])
+	}
+	var m int
+	fmt.Fscan(r, &m)
+	sort.Ints(xs)
+	fact := make([]int, 2*n+1)
+	fact[0] = 1 % m
+	for i := 1; i <= 2*n; i++ {
+		fact[i] = int((int64(fact[i-1]) * int64(i)) % int64(m))
+	}
+	ans := 1 % m
+	for i := 0; i < 2*n; {
+		j := i + 1
+		for j < 2*n && xs[j] == xs[i] {
+			j++
+		}
+		cnt := j - i
+		ans = int((int64(ans) * int64(fact[cnt])) % int64(m))
+		i = j
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func generateTests() []test {
+	rand.Seed(45)
+	var tests []test
+	fixed := []struct {
+		a   []int
+		b   []int
+		mod int
+	}{
+		{[]int{1}, []int{1}, 2},
+		{[]int{1, 2}, []int{2, 1}, 10},
+		{[]int{1, 1}, []int{1, 1}, 7},
+	}
+	for _, f := range fixed {
+		var sb strings.Builder
+		n := len(f.a)
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range f.a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteString("\n")
+		for i, v := range f.b {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteString("\n")
+		sb.WriteString(fmt.Sprintf("%d\n", f.mod))
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		a := make([]int, n)
+		b := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rand.Intn(5)
+			b[i] = rand.Intn(5)
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteString("\n")
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", b[i]))
+		}
+		sb.WriteString("\n")
+		mod := rand.Intn(100) + 2
+		sb.WriteString(fmt.Sprintf("%d\n", mod))
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/200-299/270-279/272/verifierE.go
+++ b/0-999/200-299/270-279/272/verifierE.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	r := strings.NewReader(strings.TrimSpace(input))
+	var n, m int
+	fmt.Fscan(r, &n, &m)
+	adj := make([][]int, n)
+	for i := 0; i < m; i++ {
+		var a, b int
+		fmt.Fscan(r, &a, &b)
+		a--
+		b--
+		adj[a] = append(adj[a], b)
+		adj[b] = append(adj[b], a)
+	}
+	col := make([]byte, n)
+	same := make([]int, n)
+	q := []int{}
+	for i := 0; i < n; i++ {
+		same[i] = len(adj[i])
+		if same[i] >= 2 {
+			q = append(q, i)
+		}
+	}
+	for qi := 0; qi < len(q); qi++ {
+		v := q[qi]
+		if same[v] < 2 {
+			continue
+		}
+		old := col[v]
+		col[v] ^= 1
+		k := same[v]
+		d := len(adj[v])
+		same[v] = d - k
+		for _, u := range adj[v] {
+			if col[u] == old {
+				same[u]--
+			}
+			if col[u] == col[v] {
+				same[u]++
+			}
+			if same[u] == 2 {
+				q = append(q, u)
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		if same[i] >= 2 {
+			return "-1\n"
+		}
+	}
+	out := make([]byte, n+1)
+	for i := 0; i < n; i++ {
+		out[i] = '0' + col[i]
+	}
+	out[n] = '\n'
+	return string(out)
+}
+
+func generateTests() []test {
+	rand.Seed(46)
+	var tests []test
+	fixed := []struct {
+		n     int
+		edges [][2]int
+	}{
+		{1, nil},
+		{2, [][2]int{{1, 2}}},
+		{3, [][2]int{{1, 2}, {2, 3}}},
+	}
+	for _, f := range fixed {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", f.n, len(f.edges)))
+		for _, e := range f.edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(6) + 1
+		deg := make([]int, n)
+		edges := [][2]int{}
+		for i := 0; i < n; i++ {
+			for j := i + 1; j < n; j++ {
+				if deg[i] >= 3 || deg[j] >= 3 {
+					continue
+				}
+				if rand.Intn(3) == 0 {
+					edges = append(edges, [2]int{i + 1, j + 1})
+					deg[i]++
+					deg[j]++
+				}
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add verifiers for problems A–E of contest 272
- verifiers accept a compiled binary and run at least 100 random tests
- each verifier implements the reference solution in Go for expected output
- tested by building `272A.go` and running `verifierA.go`

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build -o solA 0-999/200-299/270-279/272/272A.go`
- `go run verifierA.go ./solA`

------
https://chatgpt.com/codex/tasks/task_e_687ea055e7148324bed1114bfa510e07