### PR TITLE
Add Go verifiers for contest 269

### DIFF
--- a/0-999/200-299/260-269/269/verifierA.go
+++ b/0-999/200-299/260-269/269/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(k []int, a []int64) string {
+	var ans int64
+	for i := range k {
+		cap := int64(1)
+		d := int64(0)
+		for cap < a[i] {
+			cap <<= 2
+			d++
+		}
+		if int64(k[i])+d > ans {
+			ans = int64(k[i]) + d
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	ks := make([]int, n)
+	as := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		ks[i] = rng.Intn(20)
+		as[i] = int64(rng.Intn(20) + 1)
+		sb.WriteString(fmt.Sprintf("%d %d\n", ks[i], as[i]))
+	}
+	expect := solveCase(ks, as)
+	return testCase{input: sb.String(), expected: expect}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{input: "1\n0 1\n", expected: "0"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/269/verifierB.go
+++ b/0-999/200-299/260-269/269/verifierB.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func fenwickQuery(bit []int, i int) int {
+	res := 0
+	for i > 0 {
+		if bit[i] > res {
+			res = bit[i]
+		}
+		i &= i - 1
+	}
+	return res
+}
+
+func fenwickUpdate(bit []int, i, val int) {
+	for i < len(bit) {
+		if val > bit[i] {
+			bit[i] = val
+		}
+		i += i & -i
+	}
+}
+
+func solveCase(species []int, m int) string {
+	bit := make([]int, m+2)
+	best := 0
+	for _, s := range species {
+		cur := fenwickQuery(bit, s) + 1
+		if cur > best {
+			best = cur
+		}
+		fenwickUpdate(bit, s, cur)
+	}
+	return fmt.Sprintf("%d", len(species)-best)
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(15) + 1
+	m := rng.Intn(n) + 1
+	species := make([]int, n)
+	positions := make([]float64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	pos := 0.0
+	// guarantee each species appears at least once
+	for i := 1; i <= m; i++ {
+		species[i-1] = i
+	}
+	for i := m; i < n; i++ {
+		species[i] = rng.Intn(m) + 1
+	}
+	rng.Shuffle(n, func(i, j int) { species[i], species[j] = species[j], species[i] })
+	for i := 0; i < n; i++ {
+		pos += rng.Float64()*10 + 0.1
+		positions[i] = pos
+		sb.WriteString(fmt.Sprintf("%d %.6f\n", species[i], positions[i]))
+	}
+	expect := solveCase(species, m)
+	return testCase{input: sb.String(), expected: expect}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{}
+	cases = append(cases, testCase{input: "1 1\n1 0.0\n", expected: "0"})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/269/verifierC.go
+++ b/0-999/200-299/260-269/269/verifierC.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input string
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "269C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges-(n-1)+1) + (n - 1)
+	// build tree to ensure connectivity
+	edges := make([][3]int, 0, m)
+	parent := rng.Perm(n - 1)
+	for i := 2; i <= n; i++ {
+		p := parent[i-2] + 1
+		w := rng.Intn(20) + 1
+		edges = append(edges, [3]int{p, i, w})
+	}
+	used := make(map[[2]int]bool)
+	for _, e := range edges {
+		if e[0] < e[1] {
+			used[[2]int{e[0], e[1]}] = true
+		} else {
+			used[[2]int{e[1], e[0]}] = true
+		}
+	}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		if used[[2]int{u, v}] {
+			continue
+		}
+		used[[2]int{u, v}] = true
+		w := rng.Intn(20) + 1
+		edges = append(edges, [3]int{u, v, w})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+	}
+	return testCase{input: sb.String()}
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(tc.input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 101)
+	for i := 0; i < 101; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/269/verifierD.go
+++ b/0-999/200-299/260-269/269/verifierD.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input string
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "269D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	t := rng.Intn(50) + 2
+	heights := rng.Perm(t - 1)[:n]
+	panels := make([][3]int, n)
+	for i := 0; i < n; i++ {
+		h := heights[i] + 1
+		l := rng.Intn(40) - 20
+		r := l + rng.Intn(20) + 1
+		panels[i] = [3]int{h, l, r}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, t))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", panels[i][0], panels[i][1], panels[i][2]))
+	}
+	return testCase{input: sb.String()}
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(tc.input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 101)
+	for i := 0; i < 101; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/269/verifierE.go
+++ b/0-999/200-299/260-269/269/verifierE.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input string
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "269E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	type side struct {
+		name  string
+		count int
+	}
+	sides := []side{{"L", n}, {"R", n}, {"T", m}, {"B", m}}
+	pins := make(map[string][]int)
+	for _, s := range sides {
+		arr := rng.Perm(s.count)
+		for i := range arr {
+			arr[i]++
+		}
+		pins[s.name] = arr
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	stringsUsed := 0
+	total := n + m
+	for stringsUsed < total {
+		// choose two different sides with available pins
+		side1 := sides[rng.Intn(len(sides))]
+		for len(pins[side1.name]) == 0 {
+			side1 = sides[rng.Intn(len(sides))]
+		}
+		side2 := sides[rng.Intn(len(sides))]
+		for side2.name == side1.name || len(pins[side2.name]) == 0 {
+			side2 = sides[rng.Intn(len(sides))]
+		}
+		p1 := pins[side1.name][len(pins[side1.name])-1]
+		pins[side1.name] = pins[side1.name][:len(pins[side1.name])-1]
+		p2 := pins[side2.name][len(pins[side2.name])-1]
+		pins[side2.name] = pins[side2.name][:len(pins[side2.name])-1]
+		sb.WriteString(fmt.Sprintf("%s %d %s %d\n", side1.name, p1, side2.name, p2))
+		stringsUsed++
+	}
+	return testCase{input: sb.String()}
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(tc.input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 101)
+	for i := 0; i < 101; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` using an internal solution
- implement `verifierB.go` with LIS logic
- add oracle‑based verifiers `verifierC.go`, `verifierD.go`, `verifierE.go`
- each verifier creates 100+ random tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e9f83ba148324bea4f30742bb113a