### PR TITLE
Add verifiers for contest 267

### DIFF
--- a/0-999/200-299/260-269/267/verifierA.go
+++ b/0-999/200-299/260-269/267/verifierA.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func ops(a, b int64) int64 {
+	var res int64
+	for a > 0 && b > 0 {
+		if a >= b {
+			res += a / b
+			a %= b
+		} else {
+			res += b / a
+			b %= a
+		}
+	}
+	return res
+}
+
+func generate() (string, string) {
+	const T = 150
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", T)
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < T; i++ {
+		a := rng.Int63n(1_000_000_000) + 1
+		b := rng.Int63n(1_000_000_000) + 1
+		fmt.Fprintf(&in, "%d %d\n", a, b)
+		fmt.Fprintf(&out, "%d\n", ops(a, b))
+	}
+	return in.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	in, exp := generate()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("error running binary:", err)
+		os.Exit(1)
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		fmt.Println("wrong answer")
+		fmt.Println("expected:\n" + exp)
+		fmt.Println("got:\n" + buf.String())
+		os.Exit(1)
+	}
+	fmt.Println("ok")
+}

--- a/0-999/200-299/260-269/267/verifierB.go
+++ b/0-999/200-299/260-269/267/verifierB.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveDomino(x, y []int) string {
+	n := len(x)
+	var a [7][7]int
+	deg := [7]int{}
+	for i := 0; i < n; i++ {
+		a[x[i]][y[i]]++
+		a[y[i]][x[i]]++
+		deg[x[i]]++
+		deg[y[i]]++
+	}
+	start := x[0]
+	odd := 0
+	for i := 0; i <= 6; i++ {
+		if deg[i]%2 != 0 {
+			odd++
+			start = i
+		}
+	}
+	if odd > 2 {
+		return "No solution"
+	}
+	ans := make([]int, 0, n+1)
+	var dfs func(int)
+	dfs = func(u int) {
+		for v := 0; v <= 6; v++ {
+			for a[u][v] > 0 {
+				a[u][v]--
+				a[v][u]--
+				dfs(v)
+			}
+		}
+		ans = append(ans, u)
+	}
+	dfs(start)
+	if len(ans) != n+1 {
+		return "No solution"
+	}
+	for i, j := 0, len(ans)-1; i < j; i, j = i+1, j-1 {
+		ans[i], ans[j] = ans[j], ans[i]
+	}
+	used := make([]bool, n)
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		u, v := ans[i], ans[i+1]
+		found := false
+		for j := 0; j < n; j++ {
+			if used[j] {
+				continue
+			}
+			if u == x[j] && v == y[j] {
+				fmt.Fprintf(&sb, "%d +\n", j+1)
+				used[j] = true
+				found = true
+				break
+			} else if u == y[j] && v == x[j] {
+				fmt.Fprintf(&sb, "%d -\n", j+1)
+				used[j] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return "No solution"
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func buildCase(dominoes [][2]int) testCase {
+	n := len(dominoes)
+	var in strings.Builder
+	x := make([]int, n)
+	y := make([]int, n)
+	fmt.Fprintf(&in, "%d\n", n)
+	for i, d := range dominoes {
+		x[i] = d[0]
+		y[i] = d[1]
+		fmt.Fprintf(&in, "%d %d\n", d[0], d[1])
+	}
+	exp := solveDomino(x, y)
+	if exp != "No solution" {
+		exp += "\n"
+	}
+	return testCase{in.String(), exp}
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(2))
+	cases := make([]testCase, 0, 120)
+	cases = append(cases, buildCase([][2]int{{1, 1}}))
+	cases = append(cases, buildCase([][2]int{{1, 2}, {2, 1}}))
+	for i := 0; i < 118; i++ {
+		n := rng.Intn(8) + 1
+		dom := make([][2]int, n)
+		for j := 0; j < n; j++ {
+			dom[j] = [2]int{rng.Intn(7), rng.Intn(7)}
+		}
+		cases = append(cases, buildCase(dom))
+	}
+	return cases
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(tc.expected) {
+		return fmt.Errorf("expected:\n%s\n got:\n%s", tc.expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/200-299/260-269/267/verifierC.go
+++ b/0-999/200-299/260-269/267/verifierC.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	u, v int
+	t    float64
+}
+
+type testCase struct {
+	input string
+	ans   []float64
+}
+
+func solve(n int, edges []edge) []float64 {
+	l := len(edges)
+	v := make([][]int, n)
+	d := make([][]float64, n)
+	s := make([]int, l)
+	e := make([]int, l)
+	for k, ed := range edges {
+		i := ed.u
+		j := ed.v
+		t := ed.t
+		s[k] = i
+		e[k] = j
+		v[i] = append(v[i], j)
+		v[j] = append(v[j], i)
+		d[i] = append(d[i], t)
+		d[j] = append(d[j], t)
+	}
+	a := make([][]float64, n)
+	for i := 0; i < n; i++ {
+		a[i] = make([]float64, n)
+	}
+	u := make([]bool, n)
+	var dfs func(int)
+	dfs = func(i int) {
+		u[i] = true
+		for idx, j := range v[i] {
+			a[i][j]++
+			a[i][i]--
+			if !u[j] {
+				dfs(j)
+			}
+			_ = idx
+		}
+	}
+	dfs(0)
+	a[0][0]--
+	rows := n - 1
+	m := make([][]float64, rows)
+	for i := 0; i < rows; i++ {
+		m[i] = make([]float64, n)
+		for j := 0; j < rows; j++ {
+			m[i][j] = a[i][j+1]
+		}
+		m[i][n-1] = -a[i][0]
+	}
+	y := make([]int, rows)
+	eps := 1e-9
+	singular := false
+	for i := 0; i < rows; i++ {
+		if !u[i] {
+			continue
+		}
+		pivot := -1
+		maxAbs := 0.0
+		for t := 0; t < n; t++ {
+			if abs := math.Abs(m[i][t]); abs > maxAbs {
+				maxAbs = abs
+				pivot = t
+			}
+		}
+		if maxAbs < eps {
+			singular = true
+			break
+		}
+		y[i] = pivot
+		for k := 0; k < rows; k++ {
+			if k == i {
+				continue
+			}
+			factor := m[k][pivot] / m[i][pivot]
+			if factor == 0 {
+				continue
+			}
+			for t := 0; t < n; t++ {
+				m[k][t] -= m[i][t] * factor
+			}
+		}
+	}
+	res := make([]float64, 1+l)
+	if singular {
+		return res
+	}
+	x := make([]float64, n)
+	x[0] = 1.0
+	for i := 0; i < rows; i++ {
+		if !u[i] {
+			continue
+		}
+		pivot := y[i]
+		x[pivot+1] = m[i][n-1] / m[i][pivot]
+	}
+	b := 1e20
+	for i := 0; i < n; i++ {
+		if !u[i] {
+			continue
+		}
+		for idx, j := range v[i] {
+			z := math.Abs(x[j] - x[i])
+			if z > eps {
+				val := d[i][idx] / z
+				if val < b {
+					b = val
+				}
+			}
+		}
+	}
+	res[0] = b
+	for k := 0; k < l; k++ {
+		delta := (x[e[k]] - x[s[k]]) * b
+		res[k+1] = delta
+	}
+	return res
+}
+
+func buildCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 2
+	l := rng.Intn(5) + 1
+	edges := make([]edge, l)
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d %d\n", n, l)
+	for i := 0; i < l; i++ {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		for v == u {
+			v = rng.Intn(n)
+		}
+		t := rng.Float64()*9 + 1
+		fmt.Fprintf(&in, "%d %d %.6f\n", u+1, v+1, t)
+		edges[i] = edge{u, v, t}
+	}
+	ans := solve(n, edges)
+	return testCase{in.String(), ans}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != len(tc.ans) {
+		return fmt.Errorf("expected %d numbers got %d", len(tc.ans), len(fields))
+	}
+	for i, f := range fields {
+		var val float64
+		if _, err := fmt.Sscan(f, &val); err != nil {
+			return fmt.Errorf("bad float: %v", err)
+		}
+		if math.Abs(val-tc.ans[i]) > 1e-6 {
+			return fmt.Errorf("mismatch at %d: expected %.6f got %.6f", i, tc.ans[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = buildCase(rng)
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add Go verifier for 267A with 150 deterministic random test pairs
- add Go verifier for 267B with 120 domino cases
- add Go verifier for 267C generating 100 random graphs

## Testing
- `go build 0-999/200-299/260-269/267/verifierA.go`
- `go build 0-999/200-299/260-269/267/verifierB.go`
- `go build 0-999/200-299/260-269/267/verifierC.go`


------
https://chatgpt.com/codex/tasks/task_e_687e9ef7b00c8324977a66995321c3af