### PR TITLE
Add Go verifiers for contest 263

### DIFF
--- a/0-999/200-299/260-269/263/verifierA.go
+++ b/0-999/200-299/260-269/263/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func generateCases() []testCase {
+	rand.Seed(1)
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		r := rand.Intn(5) + 1
+		c := rand.Intn(5) + 1
+		var buf bytes.Buffer
+		for row := 1; row <= 5; row++ {
+			for col := 1; col <= 5; col++ {
+				val := 0
+				if row == r && col == c {
+					val = 1
+				}
+				fmt.Fprintf(&buf, "%d", val)
+				if col < 5 {
+					buf.WriteByte(' ')
+				}
+			}
+			buf.WriteByte('\n')
+		}
+		exp := fmt.Sprintf("%d", abs(r-3)+abs(c-3))
+		cases[i] = testCase{input: buf.String(), expected: exp}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierA.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/263/verifierB.go
+++ b/0-999/200-299/260-269/263/verifierB.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func generateCases() []testCase {
+	rand.Seed(2)
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50) + 1
+		k := rand.Intn(50) + 1
+		vals := make([]int, 0, n)
+		used := make(map[int]bool)
+		for len(vals) < n {
+			v := rand.Intn(1000000) + 1
+			if !used[v] {
+				used[v] = true
+				vals = append(vals, v)
+			}
+		}
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "%d %d\n", n, k)
+		for j, v := range vals {
+			if j > 0 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprintf(&buf, "%d", v)
+		}
+		buf.WriteByte('\n')
+		sorted := append([]int(nil), vals...)
+		sort.Ints(sorted)
+		var exp string
+		if k > n {
+			exp = "-1"
+		} else {
+			exp = fmt.Sprintf("%d 0", sorted[n-k])
+		}
+		cases[i] = testCase{input: buf.String(), expected: exp}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierB.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/263/verifierC.go
+++ b/0-999/200-299/260-269/263/verifierC.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func solve(n int, edges [][2]int) string {
+	f := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		f[u] = append(f[u], v)
+		f[v] = append(f[v], u)
+	}
+	a := make([]int, n+1)
+	use := make([]bool, n+1)
+	a[1] = 1
+	var getRem func() bool
+	getRem = func() bool {
+		for i := 3; i <= n-1; i++ {
+			found := false
+			for _, u := range f[a[i-1]] {
+				if use[u] {
+					continue
+				}
+				ok := false
+				for _, v := range f[a[i-2]] {
+					if v == u {
+						ok = true
+						break
+					}
+				}
+				if !ok {
+					continue
+				}
+				use[u] = true
+				a[i] = u
+				found = true
+				break
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	}
+	check := func() bool {
+		t1, t2, t3, t4 := false, false, false, false
+		for _, v := range f[a[n]] {
+			if v == a[1] {
+				t1 = true
+			}
+			if v == a[2] {
+				t2 = true
+			}
+			if v == a[n-1] {
+				t3 = true
+			}
+			if v == a[n-2] {
+				t4 = true
+			}
+		}
+		return t1 && t2 && t3 && t4
+	}
+	for p := 0; p < len(f[1]); p++ {
+		for q := 0; q < len(f[1]); q++ {
+			if p == q {
+				continue
+			}
+			u := f[1][p]
+			v := f[1][q]
+			ok := false
+			for _, x := range f[u] {
+				if x == v {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				continue
+			}
+			for i := range use {
+				use[i] = false
+			}
+			use[1], use[u], use[v] = true, true, true
+			a[2] = v
+			a[n] = u
+			if getRem() && check() {
+				var out bytes.Buffer
+				for i := 1; i <= n; i++ {
+					if i > 1 {
+						out.WriteByte(' ')
+					}
+					fmt.Fprintf(&out, "%d", a[i])
+				}
+				return out.String()
+			}
+		}
+	}
+	return "-1"
+}
+
+func generateCases() []testCase {
+	rand.Seed(3)
+	cases := make([]testCase, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(6) + 5
+		perm := make([]int, n)
+		perm[0] = 1
+		p := rand.Perm(n - 1)
+		for i, v := range p {
+			perm[i+1] = v + 2
+		}
+		edgeMap := map[[2]int]bool{}
+		for i := 0; i < n; i++ {
+			a := perm[i]
+			b := perm[(i+1)%n]
+			if a > b {
+				a, b = b, a
+			}
+			edgeMap[[2]int{a, b}] = true
+			a2 := perm[i]
+			b2 := perm[(i+2)%n]
+			if a2 > b2 {
+				a2, b2 = b2, a2
+			}
+			edgeMap[[2]int{a2, b2}] = true
+		}
+		edges := make([][2]int, 0, len(edgeMap))
+		for e := range edgeMap {
+			edges = append(edges, e)
+		}
+		rand.Shuffle(len(edges), func(i, j int) { edges[i], edges[j] = edges[j], edges[i] })
+		var buf bytes.Buffer
+		fmt.Fprintln(&buf, n)
+		for _, e := range edges {
+			fmt.Fprintf(&buf, "%d %d\n", e[0], e[1])
+		}
+		expected := solve(n, edges)
+		cases[t] = testCase{input: buf.String(), expected: expected}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierC.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/263/verifierD.go
+++ b/0-999/200-299/260-269/263/verifierD.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func solve(n, m, k int, edges [][2]int) string {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	visited := make([]bool, n+1)
+	c := make([]int, n+2)
+	cnt := 1
+	cur := 1
+	visited[1] = true
+	c[1] = 1
+	for {
+		found := false
+		for _, nb := range adj[cur] {
+			if !visited[nb] {
+				visited[nb] = true
+				cnt++
+				c[cnt] = nb
+				cur = nb
+				found = true
+				break
+			}
+		}
+		if !found {
+			break
+		}
+	}
+	end := c[cnt]
+	for i := 1; i <= cnt; i++ {
+		for _, nb := range adj[c[i]] {
+			if nb == end {
+				length := cnt - i + 1
+				var out bytes.Buffer
+				fmt.Fprintln(&out, length)
+				for j := i; j <= cnt; j++ {
+					if j > i {
+						out.WriteByte(' ')
+					}
+					fmt.Fprintf(&out, "%d", c[j])
+				}
+				return strings.TrimSpace(out.String())
+			}
+		}
+	}
+	return ""
+}
+
+func generateCases() []testCase {
+	rand.Seed(4)
+	cases := make([]testCase, 100)
+	for t := 0; t < 100; t++ {
+		k := rand.Intn(3) + 2
+		n := k + rand.Intn(3) + 1
+		if n < k+1 {
+			n = k + 1
+		}
+		edges := make([][2]int, 0, n*(n-1)/2)
+		for i := 1; i <= n; i++ {
+			for j := i + 1; j <= n; j++ {
+				edges = append(edges, [2]int{i, j})
+			}
+		}
+		m := len(edges)
+		rand.Shuffle(len(edges), func(i, j int) { edges[i], edges[j] = edges[j], edges[i] })
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "%d %d %d\n", n, m, k)
+		for _, e := range edges {
+			fmt.Fprintf(&buf, "%d %d\n", e[0], e[1])
+		}
+		expected := solve(n, m, k, edges)
+		cases[t] = testCase{input: buf.String(), expected: expected}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierD.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/263/verifierE.go
+++ b/0-999/200-299/260-269/263/verifierE.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func solve(n, m, k int, g [][]int64) string {
+	size := n + m + 5
+	a := make([][]int64, size)
+	for i := range a {
+		a[i] = make([]int64, size)
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			v := g[i-1][j-1]
+			x := i + j
+			y := i - j + m
+			a[x][y] = v
+		}
+	}
+	limit := n + m
+	for i := 1; i <= limit; i++ {
+		row := a[i]
+		prev := a[i-1]
+		for j := 1; j <= limit; j++ {
+			row[j] += prev[j] + row[j-1] - prev[j-1]
+		}
+	}
+	sum := func(l, L, r, R int) int64 {
+		return a[r][R] - a[l-1][R] - a[r][L-1] + a[l-1][L-1]
+	}
+	var best int64 = -1
+	ansX, ansY := 0, 0
+	for i := k; i <= n-k+1; i++ {
+		for j := k; j <= m-k+1; j++ {
+			x := i + j
+			y := i - j + m
+			var s int64
+			for z := 0; z < k; z++ {
+				s += sum(x-z, y-z, x+z, y+z)
+			}
+			if s > best {
+				best = s
+				ansX, ansY = i, j
+			}
+		}
+	}
+	return fmt.Sprintf("%d %d", ansX, ansY)
+}
+
+func generateCases() []testCase {
+	rand.Seed(5)
+	cases := make([]testCase, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(4) + 1
+		m := rand.Intn(4) + 1
+		kMax := (min(n, m) + 1) / 2
+		if kMax == 0 {
+			kMax = 1
+		}
+		k := rand.Intn(kMax) + 1
+		g := make([][]int64, n)
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "%d %d %d\n", n, m, k)
+		for i := 0; i < n; i++ {
+			g[i] = make([]int64, m)
+			for j := 0; j < m; j++ {
+				val := int64(rand.Intn(11))
+				g[i][j] = val
+				if j > 0 {
+					buf.WriteByte(' ')
+				}
+				fmt.Fprintf(&buf, "%d", val)
+			}
+			buf.WriteByte('\n')
+		}
+		expected := solve(n, m, k, g)
+		cases[t] = testCase{input: buf.String(), expected: expected}
+	}
+	return cases
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierE.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go, verifierB.go, verifierC.go, verifierD.go, verifierE.go for contest 263
- each verifier generates at least 100 random test cases and checks a solution binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e9ddfa92483249b495f00b8ba66f3