### PR TITLE
Add Go verifiers for contest 261

### DIFF
--- a/0-999/200-299/260-269/261/verifierA.go
+++ b/0-999/200-299/260-269/261/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	m   int
+	q   []int
+	n   int
+	arr []int
+}
+
+func expectedA(tc testCaseA) int64 {
+	minQ := tc.q[0]
+	for _, v := range tc.q {
+		if v < minQ {
+			minQ = v
+		}
+	}
+	sort.Slice(tc.arr, func(i, j int) bool { return tc.arr[i] > tc.arr[j] })
+	k := minQ + 2
+	var res int64
+	for i, v := range tc.arr {
+		if i%k < minQ {
+			res += int64(v)
+		}
+	}
+	return res
+}
+
+func genCaseA(rng *rand.Rand) (string, string) {
+	m := rng.Intn(5) + 1
+	q := make([]int, m)
+	for i := range q {
+		q[i] = rng.Intn(5) + 1
+	}
+	n := rng.Intn(6) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(20) + 1
+	}
+	tc := testCaseA{m, q, n, arr}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", m)
+	for i, v := range q {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	exp := fmt.Sprintf("%d\n", expectedA(tc))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", strings.TrimSpace(expected), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseA(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/261/verifierB.go
+++ b/0-999/200-299/260-269/261/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const LMT = 55
+
+func factorials() [LMT]float64 {
+	var fi [LMT]float64
+	fi[0] = 1
+	for i := 1; i < LMT; i++ {
+		fi[i] = float64(i) * fi[i-1]
+	}
+	return fi
+}
+
+func expectedB(n int, arr []int, p int) float64 {
+	var dp [LMT][LMT]float64
+	dp[0][0] = 1
+	for i := 0; i < n; i++ {
+		ai := arr[i]
+		for j := n; j >= 1; j-- {
+			for t := p; t >= ai; t-- {
+				dp[j][t] += dp[j-1][t-ai]
+			}
+		}
+	}
+	fi := factorials()
+	var ans float64
+	for i := 1; i <= n; i++ {
+		for t := 1; t <= p; t++ {
+			ans += dp[i][t] * fi[i] * fi[n-i]
+		}
+	}
+	return ans / fi[n]
+}
+
+func genCaseB(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(10) + 1
+	}
+	p := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", p)
+	exp := fmt.Sprintf("%.6f\n", expectedB(n, arr, p))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	// we compare as floats with tolerance
+	gv, err := strconv.ParseFloat(got, 64)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	ev, _ := strconv.ParseFloat(strings.TrimSpace(expected), 64)
+	if diff := gv - ev; diff < -1e-4 || diff > 1e-4 {
+		return fmt.Errorf("expected %.6f got %.6f", ev, gv)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseB(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/261/verifierC.go
+++ b/0-999/200-299/260-269/261/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MAX = 64
+
+var comb [MAX][MAX]uint64
+
+func initComb() {
+	for i := 0; i < MAX; i++ {
+		comb[i][0] = 1
+		for j := 1; j <= i; j++ {
+			comb[i][j] = comb[i-1][j-1] + comb[i-1][j]
+		}
+	}
+}
+
+func count(n uint64, t uint64) uint64 {
+	if t == 0 || t&(t-1) != 0 {
+		return 0
+	}
+	k := bits.TrailingZeros64(t)
+	Ln := 64 - bits.LeadingZeros64(n)
+	var ans uint64
+	for L := k + 1; L < Ln; L++ {
+		ans += comb[L-1][k]
+	}
+	zeros := 0
+	for i := Ln - 2; i >= 0; i-- {
+		if (n>>uint(i))&1 == 1 {
+			remZeros := k - (zeros + 1)
+			remBits := i
+			if remZeros >= 0 && remZeros <= remBits {
+				ans += comb[remBits][remZeros]
+			}
+		}
+		if (n>>uint(i))&1 == 0 {
+			zeros++
+		}
+	}
+	if zeros == k {
+		ans++
+	}
+	return ans
+}
+
+func genCaseC(rng *rand.Rand) (string, string) {
+	k := rng.Intn(6)
+	t := uint64(1) << k
+	n := uint64(rng.Int63n(1<<20) + int64(t))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, t)
+	exp := fmt.Sprintf("%d\n", count(n, t))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", strings.TrimSpace(expected), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	initComb()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseC(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/261/verifierD.go
+++ b/0-999/200-299/260-269/261/verifierD.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func lis(a []int) int {
+	d := make([]int, 0, len(a))
+	for _, v := range a {
+		i := sort.SearchInts(d, v)
+		if i == len(d) {
+			d = append(d, v)
+		} else {
+			d[i] = v
+		}
+	}
+	return len(d)
+}
+
+func expectedD(n int, arr []int, t int) int {
+	a := make([]int, 0, n*t)
+	for i := 0; i < t; i++ {
+		a = append(a, arr...)
+	}
+	return lis(a)
+}
+
+func genCaseD(rng *rand.Rand) (string, string) {
+	k := rng.Intn(3) + 1
+	n := rng.Intn(5) + 1
+	maxb := 20
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", k, n, maxb, t)
+	var out strings.Builder
+	for i := 0; i < k; i++ {
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(maxb) + 1
+		}
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		fmt.Fprintf(&out, "%d", expectedD(n, arr, t))
+		if i+1 < k {
+			out.WriteByte('\n')
+		}
+	}
+	out.WriteByte('\n')
+	return sb.String(), out.String()
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseD(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/261/verifierE.go
+++ b/0-999/200-299/260-269/261/verifierE.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func dfs(res map[int64]struct{}, lastB int64, remOps int, prod int64, l, r int64) {
+	for t := 0; t <= remOps-1; t++ {
+		if lastB == 0 && t < 1 {
+			continue
+		}
+		newB := lastB + int64(t)
+		if newB <= 0 {
+			continue
+		}
+		nextRem := remOps - t - 1
+		if prod > r/newB {
+			continue
+		}
+		newProd := prod * newB
+		if newProd > r {
+			continue
+		}
+		if newProd >= l {
+			res[newProd] = struct{}{}
+		}
+		if nextRem > 0 {
+			dfs(res, newB, nextRem, newProd, l, r)
+		}
+	}
+}
+
+func expectedE(l, r int64, p int) int {
+	res := make(map[int64]struct{})
+	dfs(res, 0, p, 1, l, r)
+	cnt := 0
+	for x := range res {
+		if x >= l && x <= r {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func genCaseE(rng *rand.Rand) (string, string) {
+	l := int64(rng.Intn(20) + 1)
+	r := l + int64(rng.Intn(20))
+	p := rng.Intn(6) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", l, r, p)
+	exp := fmt.Sprintf("%d\n", expectedE(l, r, p))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", strings.TrimSpace(expected), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseE(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new Go based verifiers for problems A–E of contest 261
- each verifier produces 100 random tests and checks a provided binary

## Testing
- `go build 0-999/200-299/260-269/261/verifierA.go`
- `go run 0-999/200-299/260-269/261/verifierA.go /tmp/261A_bin`
- `go build 0-999/200-299/260-269/261/verifierB.go`
- `go run 0-999/200-299/260-269/261/verifierB.go /tmp/261B_bin`
- `go build 0-999/200-299/260-269/261/verifierC.go`
- `go run 0-999/200-299/260-269/261/verifierC.go /tmp/261C_bin`
- `go build 0-999/200-299/260-269/261/verifierD.go`
- `go run 0-999/200-299/260-269/261/verifierD.go /tmp/261D_bin`
- `go build 0-999/200-299/260-269/261/verifierE.go`
- `go run 0-999/200-299/260-269/261/verifierE.go /tmp/261E_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e9d5382bc83249a4a3341720fe245