### PR TITLE
Add Go verifiers for Codeforces contest 260

### DIFF
--- a/0-999/200-299/260-269/260/verifierA.go
+++ b/0-999/200-299/260-269/260/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "260A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCases() [][3]int {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([][3]int, 100)
+	for i := range cases {
+		a := rng.Intn(100000) + 1
+		b := rng.Intn(100000) + 1
+		n := rng.Intn(100000) + 1
+		cases[i] = [3]int{a, b, n}
+	}
+	return cases
+}
+
+func runCase(oracle, bin string, args [3]int) error {
+	input := fmt.Sprintf("%d %d %d\n", args[0], args[1], args[2])
+
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	cases := generateCases()
+	for i, c := range cases {
+		if err := runCase(oracle, bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/260/verifierB.go
+++ b/0-999/200-299/260-269/260/verifierB.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedDate(s string) string {
+	days := []int{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
+	count := make(map[string]int)
+	maxCount := 0
+	result := ""
+	n := len(s)
+	for i := 0; i+10 <= n; i++ {
+		if s[i+2] != '-' || s[i+5] != '-' {
+			continue
+		}
+		sub := s[i : i+10]
+		day, err1 := strconv.Atoi(sub[0:2])
+		month, err2 := strconv.Atoi(sub[3:5])
+		year, err3 := strconv.Atoi(sub[6:10])
+		if err1 != nil || err2 != nil || err3 != nil {
+			continue
+		}
+		if year < 2013 || year > 2015 {
+			continue
+		}
+		if month < 1 || month > 12 {
+			continue
+		}
+		if day < 1 || day > days[month-1] {
+			continue
+		}
+		count[sub]++
+		if count[sub] > maxCount {
+			maxCount = count[sub]
+			result = sub
+		}
+	}
+	return result
+}
+
+func randomDate(rng *rand.Rand) string {
+	year := rng.Intn(3) + 2013
+	month := rng.Intn(12) + 1
+	days := []int{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
+	day := rng.Intn(days[month-1]) + 1
+	return fmt.Sprintf("%02d-%02d-%04d", day, month, year)
+}
+
+func generateString(rng *rand.Rand) string {
+	baseLen := rng.Intn(50) + 10
+	var sb strings.Builder
+	for i := 0; i < baseLen; i++ {
+		if rng.Intn(5) == 0 {
+			sb.WriteByte('-')
+		} else {
+			sb.WriteByte(byte('0' + rng.Intn(10)))
+		}
+	}
+	date := randomDate(rng)
+	pos := rng.Intn(sb.Len() + 1)
+	str := sb.String()
+	return str[:pos] + date + str[pos:]
+}
+
+func runCase(bin string, s string) error {
+	input := s + "\n"
+	expected := expectedDate(s)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := generateString(rng)
+		if err := runCase(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/260/verifierC.go
+++ b/0-999/200-299/260-269/260/verifierC.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func simulateCase(rng *rand.Rand) (int, int, []int64) {
+	n := rng.Intn(20) + 2
+	orig := make([]int64, n)
+	for i := range orig {
+		orig[i] = int64(rng.Intn(10))
+	}
+	idx := rng.Intn(n)
+	orig[idx] += int64(rng.Intn(5) + 1) // ensure >0 balls removed
+	balls := orig[idx]
+	final := make([]int64, n)
+	copy(final, orig)
+	final[idx] = 0
+	pos := (idx + 1) % n
+	for t := int64(0); t < balls; t++ {
+		final[pos]++
+		pos = (pos + 1) % n
+	}
+	x := (idx+int(balls))%n + 1
+	return n, x, final
+}
+
+func expectedAnswer(n, x int, a []int64) []int64 {
+	m := a[0]
+	for i := 1; i < n; i++ {
+		if a[i] < m {
+			m = a[i]
+		}
+	}
+	ks := []int64{m}
+	if m > 0 {
+		ks = append(ks, m-1)
+	}
+	for _, k := range ks {
+		d := make([]int64, n)
+		ok := true
+		for i := 0; i < n; i++ {
+			d[i] = a[i] - k
+			if d[i] < 0 {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+		rCount := 0
+		pos := x - 1
+		for rCount < n && d[pos] > 0 {
+			rCount++
+			pos = (pos - 1 + n) % n
+		}
+		r := rCount % n
+		if k == 0 && r == 0 {
+			continue
+		}
+		i0 := ((x-1-r)%n + n) % n
+		seg := make([]bool, n)
+		for t := 1; t <= r; t++ {
+			j := (i0 + t) % n
+			seg[j] = true
+		}
+		init := make([]int64, n)
+		base := k*int64(n) + int64(r)
+		init[i0] = base
+		valid := base > 0
+		for j := 0; j < n && valid; j++ {
+			if j == i0 {
+				continue
+			}
+			if seg[j] {
+				init[j] = a[j] - k - 1
+			} else {
+				init[j] = a[j] - k
+			}
+			if init[j] < 0 {
+				valid = false
+			}
+		}
+		if valid {
+			return init
+		}
+	}
+	return nil
+}
+
+func runCase(bin string, n, x int, arr, expect []int64) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	var got []int64
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		for _, f := range fields {
+			var v int64
+			fmt.Sscan(f, &v)
+			got = append(got, v)
+		}
+	}
+	if len(got) != len(expect) {
+		return fmt.Errorf("expected %d numbers got %d", len(expect), len(got))
+	}
+	for i := range expect {
+		if got[i] != expect[i] {
+			return fmt.Errorf("mismatch at %d expected %d got %d", i+1, expect[i], got[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, x, arr := simulateCase(rng)
+		expect := expectedAnswer(n, x, arr)
+		if expect == nil {
+			fmt.Fprintf(os.Stderr, "case %d generation failed\n", i+1)
+			os.Exit(1)
+		}
+		if err := runCase(bin, n, x, arr, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/260/verifierD.go
+++ b/0-999/200-299/260-269/260/verifierD.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	u, v, w int
+}
+
+type dsu struct {
+	parent []int
+	rank   []int
+}
+
+func newDSU(n int) *dsu {
+	d := &dsu{parent: make([]int, n+1), rank: make([]int, n+1)}
+	for i := 1; i <= n; i++ {
+		d.parent[i] = i
+	}
+	return d
+}
+
+func (d *dsu) find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *dsu) union(x, y int) {
+	x = d.find(x)
+	y = d.find(y)
+	if x == y {
+		return
+	}
+	if d.rank[x] < d.rank[y] {
+		x, y = y, x
+	}
+	d.parent[y] = x
+	if d.rank[x] == d.rank[y] {
+		d.rank[x]++
+	}
+}
+
+func generateCase(rng *rand.Rand) (int, []int, []int) {
+	n := rng.Intn(10) + 2
+	edges := make([]edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		w := rng.Intn(20)
+		edges = append(edges, edge{u: i, v: p, w: w})
+	}
+	color := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		color[i] = 1 - color[edges[i-2].v]
+	}
+	sum := make([]int, n+1)
+	for _, e := range edges {
+		sum[e.u] += e.w
+		sum[e.v] += e.w
+	}
+	input := make([]int, 0, 2*n)
+	for i := 1; i <= n; i++ {
+		input = append(input, color[i], sum[i])
+	}
+	return n, color[1:], sum[1:]
+}
+
+func parseOutput(out string) ([]edge, error) {
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields)%3 != 0 {
+		return nil, fmt.Errorf("expected triples")
+	}
+	m := len(fields) / 3
+	res := make([]edge, m)
+	for i := 0; i < m; i++ {
+		u, err1 := strconv.Atoi(fields[3*i])
+		v, err2 := strconv.Atoi(fields[3*i+1])
+		w, err3 := strconv.Atoi(fields[3*i+2])
+		if err1 != nil || err2 != nil || err3 != nil {
+			return nil, fmt.Errorf("bad numbers")
+		}
+		res[i] = edge{u: u, v: v, w: w}
+	}
+	return res, nil
+}
+
+func verify(n int, color, sum []int, edges []edge) error {
+	if len(edges) != n-1 {
+		return fmt.Errorf("expected %d edges got %d", n-1, len(edges))
+	}
+	d := newDSU(n)
+	cur := make([]int, n+1)
+	for _, e := range edges {
+		if e.u < 1 || e.u > n || e.v < 1 || e.v > n || e.u == e.v || e.w < 0 {
+			return fmt.Errorf("invalid edge")
+		}
+		if color[e.u-1] == color[e.v-1] {
+			return fmt.Errorf("edge with same colors")
+		}
+		cur[e.u] += e.w
+		cur[e.v] += e.w
+		d.union(e.u, e.v)
+	}
+	root := d.find(1)
+	for i := 2; i <= n; i++ {
+		if d.find(i) != root {
+			return fmt.Errorf("graph not connected")
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if cur[i] != sum[i-1] {
+			return fmt.Errorf("sum mismatch at %d", i)
+		}
+	}
+	return nil
+}
+
+func runCase(bin string, n int, color, sum []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", color[i], sum[i]))
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	edges, err := parseOutput(out.String())
+	if err != nil {
+		return err
+	}
+	return verify(n, color, sum, edges)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, color, sum := generateCase(rng)
+		if err := runCase(bin, n, color, sum); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/260-269/260/verifierE.go
+++ b/0-999/200-299/260-269/260/verifierE.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int }
+
+func generateCase(rng *rand.Rand) (int, []point, [9]int, float64, float64, float64, float64) {
+	n := rng.Intn(40) + 9
+	pts := make([]point, n)
+	for i := range pts {
+		pts[i] = point{rng.Intn(21) - 10, rng.Intn(21) - 10}
+	}
+	x1 := float64(rng.Intn(19)-9) + 0.5
+	x2 := float64(rng.Intn(19)-9) + 0.5
+	for x2 == x1 {
+		x2 = float64(rng.Intn(19)-9) + 0.5
+	}
+	if x1 > x2 {
+		x1, x2 = x2, x1
+	}
+	y1 := float64(rng.Intn(19)-9) + 0.5
+	y2 := float64(rng.Intn(19)-9) + 0.5
+	for y2 == y1 {
+		y2 = float64(rng.Intn(19)-9) + 0.5
+	}
+	if y1 > y2 {
+		y1, y2 = y2, y1
+	}
+	var cnt [9]int
+	for _, p := range pts {
+		region := 0
+		if float64(p.x) < x1 {
+			if float64(p.y) < y1 {
+				region = 0
+			} else if float64(p.y) < y2 {
+				region = 3
+			} else {
+				region = 6
+			}
+		} else if float64(p.x) < x2 {
+			if float64(p.y) < y1 {
+				region = 1
+			} else if float64(p.y) < y2 {
+				region = 4
+			} else {
+				region = 7
+			}
+		} else {
+			if float64(p.y) < y1 {
+				region = 2
+			} else if float64(p.y) < y2 {
+				region = 5
+			} else {
+				region = 8
+			}
+		}
+		cnt[region]++
+	}
+	return n, pts, cnt, x1, x2, y1, y2
+}
+
+func checkOutput(x1, x2, y1, y2 float64, pts []point, want [9]int) error {
+	if math.Abs(x1-x2) <= 1e-6 || math.Abs(y1-y2) <= 1e-6 {
+		return fmt.Errorf("lines coincide")
+	}
+	if x1 > x2 {
+		x1, x2 = x2, x1
+	}
+	if y1 > y2 {
+		y1, y2 = y2, y1
+	}
+	var got [9]int
+	for _, p := range pts {
+		if math.Abs(float64(p.x)-x1) <= 1e-6 || math.Abs(float64(p.x)-x2) <= 1e-6 || math.Abs(float64(p.y)-y1) <= 1e-6 || math.Abs(float64(p.y)-y2) <= 1e-6 {
+			return fmt.Errorf("point on line")
+		}
+		region := 0
+		if float64(p.x) < x1 {
+			if float64(p.y) < y1 {
+				region = 0
+			} else if float64(p.y) < y2 {
+				region = 3
+			} else {
+				region = 6
+			}
+		} else if float64(p.x) < x2 {
+			if float64(p.y) < y1 {
+				region = 1
+			} else if float64(p.y) < y2 {
+				region = 4
+			} else {
+				region = 7
+			}
+		} else {
+			if float64(p.y) < y1 {
+				region = 2
+			} else if float64(p.y) < y2 {
+				region = 5
+			} else {
+				region = 8
+			}
+		}
+		got[region]++
+	}
+	for i := 0; i < 9; i++ {
+		if got[i] != want[i] {
+			return fmt.Errorf("region %d expected %d got %d", i+1, want[i], got[i])
+		}
+	}
+	return nil
+}
+
+func runCase(bin string, n int, pts []point, cnt [9]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, p := range pts {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.x, p.y))
+	}
+	for i := 0; i < 9; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(cnt[i]))
+	}
+	sb.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	parts := strings.Fields(strings.TrimSpace(out.String()))
+	if len(parts) != 4 {
+		return fmt.Errorf("expected 4 numbers")
+	}
+	x1, _ := strconv.ParseFloat(parts[0], 64)
+	x2, _ := strconv.ParseFloat(parts[1], 64)
+	y1, _ := strconv.ParseFloat(parts[2], 64)
+	y2, _ := strconv.ParseFloat(parts[3], 64)
+	return checkOutput(x1, x2, y1, y2, pts, cnt)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, pts, cnt, _, _, _, _ := generateCase(rng)
+		if err := runCase(bin, n, pts, cnt); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add automated Go verifiers for contest 260 problems A–E
- verifiers generate 100 random test cases each
- include checks against oracles or internally computed answers

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e9d0d9ce48324a778af84cb606919