### PR TITLE
Add Go solution verifiers for contest 254

### DIFF
--- a/0-999/200-299/250-259/254/verifierA.go
+++ b/0-999/200-299/250-259/254/verifierA.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(10) + 1
+	nums := make([]int, 2*n)
+	for i := range nums {
+		nums[i] = rng.Intn(5) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), nums
+}
+
+func expectedPossible(nums []int) bool {
+	count := make(map[int]int)
+	for _, v := range nums {
+		count[v]++
+	}
+	for _, c := range count {
+		if c%2 == 1 {
+			return false
+		}
+	}
+	return true
+}
+
+func verifyOutput(out string, nums []int) error {
+	fields := strings.Fields(out)
+	if expectedPossible(nums) {
+		n := len(nums) / 2
+		if len(fields) != 2*n {
+			return fmt.Errorf("expected %d numbers, got %d", 2*n, len(fields))
+		}
+		used := make([]bool, len(nums))
+		for i := 0; i < n; i++ {
+			idx1, err1 := strconv.Atoi(fields[2*i])
+			idx2, err2 := strconv.Atoi(fields[2*i+1])
+			if err1 != nil || err2 != nil {
+				return fmt.Errorf("failed to parse integers")
+			}
+			if idx1 < 1 || idx1 > len(nums) || idx2 < 1 || idx2 > len(nums) {
+				return fmt.Errorf("index out of range")
+			}
+			if idx1 == idx2 {
+				return fmt.Errorf("pair uses same index")
+			}
+			if used[idx1-1] || used[idx2-1] {
+				return fmt.Errorf("index repeated")
+			}
+			used[idx1-1], used[idx2-1] = true, true
+			if nums[idx1-1] != nums[idx2-1] {
+				return fmt.Errorf("values mismatch for pair")
+			}
+		}
+		for _, u := range used {
+			if !u {
+				return fmt.Errorf("some indices not used")
+			}
+		}
+	} else {
+		if len(fields) != 1 || fields[0] != "-1" {
+			return fmt.Errorf("expected -1")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, nums := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := verifyOutput(out, nums); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/250-259/254/verifierB.go
+++ b/0-999/200-299/250-259/254/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+var monthDays = []int{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
+
+func expected(events [][4]int) int {
+	const offset = 500
+	const maxDays = 1000
+	load := make([]int, maxDays)
+	prefix := make([]int, 13)
+	for i := 1; i <= 12; i++ {
+		prefix[i] = prefix[i-1] + monthDays[i-1]
+	}
+	for _, e := range events {
+		m, d, p, t := e[0], e[1], e[2], e[3]
+		doy := prefix[m-1] + (d - 1)
+		start := doy - t + offset
+		end := doy - 1 + offset
+		if start < 0 {
+			start = 0
+		}
+		if end >= maxDays {
+			end = maxDays - 1
+		}
+		for i := start; i <= end; i++ {
+			load[i] += p
+		}
+	}
+	ans := 0
+	for _, v := range load {
+		if v > ans {
+			ans = v
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, [][4]int) {
+	n := rng.Intn(10) + 1
+	events := make([][4]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		m := rng.Intn(12) + 1
+		d := rng.Intn(monthDays[m-1]) + 1
+		p := rng.Intn(10) + 1
+		t := rng.Intn(10)
+		events[i] = [4]int{m, d, p, t}
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", m, d, p, t))
+	}
+	return sb.String(), events
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, events := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Fscan(strings.NewReader(out), &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed to parse output: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		exp := expected(events)
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%soutput:\n%s", i+1, exp, got, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/250-259/254/verifierC.go
+++ b/0-999/200-299/250-259/254/verifierC.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solve(s, t string) (int, string) {
+	n := len(s)
+	Cs := make([]int, 26)
+	Ct := make([]int, 26)
+	for i := 0; i < n; i++ {
+		Cs[s[i]-'A']++
+		Ct[t[i]-'A']++
+	}
+	best := 0
+	for c := 0; c < 26; c++ {
+		best += min(Cs[c], Ct[c])
+	}
+	remCt := make([]int, 26)
+	remCs := make([]int, 26)
+	copy(remCt, Ct)
+	copy(remCs, Cs)
+	matched := 0
+	u := make([]byte, n)
+	for i := 0; i < n; i++ {
+		si := int(s[i] - 'A')
+		for c := 0; c < 26; c++ {
+			if remCt[c] == 0 {
+				continue
+			}
+			inc := 0
+			if c == si {
+				inc = 1
+			}
+			sum := 0
+			for x := 0; x < 26; x++ {
+				rc := remCt[x]
+				rcs := remCs[x]
+				if x == c {
+					rc--
+				}
+				if x == si {
+					rcs--
+				}
+				if rc < 0 {
+					rc = 0
+				}
+				if rcs < 0 {
+					rcs = 0
+				}
+				sum += min(rc, rcs)
+			}
+			if matched+inc+sum >= best {
+				u[i] = byte('A' + c)
+				if c == si {
+					matched++
+				}
+				remCt[c]--
+				remCs[si]--
+				break
+			}
+		}
+	}
+	z := n - best
+	return z, string(u)
+}
+
+func generateCase(rng *rand.Rand) (string, string, string) {
+	n := rng.Intn(10) + 1
+	b1 := make([]byte, n)
+	b2 := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b1[i] = byte('A' + rng.Intn(26))
+		b2[i] = byte('A' + rng.Intn(26))
+	}
+	s := string(b1)
+	t := string(b2)
+	input := s + "\n" + t + "\n"
+	return input, s, t
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, s, t := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var z int
+		var u string
+		if _, err := fmt.Fscan(strings.NewReader(out), &z, &u); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed to parse output: %v\ninput:\n%soutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+		expZ, expU := solve(s, t)
+		if z != expZ || u != expU {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d %s got %d %s\ninput:\n%s", i+1, expZ, expU, z, u, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/250-259/254/verifierD.go
+++ b/0-999/200-299/250-259/254/verifierD.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type pt struct{ x, y, d int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func bfs(grid [][]byte, dist, sx, sy int) [][]bool {
+	n := len(grid)
+	m := len(grid[0])
+	vis := make([][]bool, n)
+	for i := range vis {
+		vis[i] = make([]bool, m)
+	}
+	if sx < 0 || sy < 0 || sx >= n || sy >= m || grid[sx][sy] == 'X' {
+		return vis
+	}
+	q := []pt{{sx, sy, 0}}
+	vis[sx][sy] = true
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for head := 0; head < len(q); head++ {
+		p := q[head]
+		if p.d == dist {
+			continue
+		}
+		nd := p.d + 1
+		for _, d := range dirs {
+			x := p.x + d[0]
+			y := p.y + d[1]
+			if x >= 0 && y >= 0 && x < n && y < m && grid[x][y] != 'X' && !vis[x][y] {
+				vis[x][y] = true
+				q = append(q, pt{x, y, nd})
+			}
+		}
+	}
+	return vis
+}
+
+func hasSolution(grid [][]byte, dist int) bool {
+	// use official solver to check
+	n := len(grid)
+	m := len(grid[0])
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n-2, m-2, dist))
+	for i := 1; i < n-1; i++ {
+		sb.WriteString(string(grid[i][1:m-1]) + "\n")
+	}
+	out, err := run("254D.go", sb.String())
+	if err != nil {
+		return false
+	}
+	out = strings.TrimSpace(out)
+	return out != "-1"
+}
+
+func verifyOut(grid [][]byte, dist int, out string, expectPossible bool) error {
+	out = strings.TrimSpace(out)
+	if !expectPossible {
+		if out != "-1" {
+			return fmt.Errorf("expected -1")
+		}
+		return nil
+	}
+	fields := strings.Fields(out)
+	if len(fields) != 4 {
+		return fmt.Errorf("expected four integers")
+	}
+	vals := make([]int, 4)
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("bad int")
+		}
+		vals[i] = v
+	}
+	n := len(grid)
+	m := len(grid[0])
+	x1, y1, x2, y2 := vals[0]-1, vals[1]-1, vals[2]-1, vals[3]-1
+	if x1 < 0 || x1 >= n-2 || y1 < 0 || y1 >= m-2 || x2 < 0 || x2 >= n-2 || y2 < 0 || y2 >= m-2 {
+		return fmt.Errorf("coords out of range")
+	}
+	if x1 == x2 && y1 == y2 {
+		return fmt.Errorf("same cell")
+	}
+	grid2 := make([][]byte, n-2)
+	for i := 1; i < n-1; i++ {
+		grid2[i-1] = grid[i][1 : m-1]
+	}
+	cover1 := bfs(grid2, dist, x1, y1)
+	cover2 := bfs(grid2, dist, x2, y2)
+	for i := 0; i < len(grid2); i++ {
+		for j := 0; j < len(grid2[0]); j++ {
+			if grid2[i][j] == 'R' && !cover1[i][j] && !cover2[i][j] {
+				return fmt.Errorf("rats remain")
+			}
+		}
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, [][]byte, int) {
+	n := rng.Intn(6) + 4
+	m := rng.Intn(6) + 4
+	dist := rng.Intn(3) + 1
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]byte, m)
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if i == 0 || j == 0 || i == n-1 || j == m-1 {
+				grid[i][j] = 'X'
+			} else {
+				r := rng.Intn(5)
+				switch r {
+				case 0:
+					grid[i][j] = 'R'
+				case 1:
+					grid[i][j] = 'X'
+				default:
+					grid[i][j] = '.'
+				}
+			}
+		}
+	}
+	// ensure at least one rat and two empty cells
+	rats := 0
+	empties := 0
+	for i := 1; i < n-1; i++ {
+		for j := 1; j < m-1; j++ {
+			if grid[i][j] == 'R' {
+				rats++
+			}
+			if grid[i][j] != 'X' {
+				empties++
+			}
+		}
+	}
+	if rats == 0 {
+		grid[1][1] = 'R'
+		rats = 1
+	}
+	if empties < 2 {
+		grid[1][2] = '.'
+		grid[2][1] = '.'
+		empties = 2
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n-2, m-2, dist))
+	for i := 1; i < n-1; i++ {
+		sb.WriteString(string(grid[i][1 : m-1]))
+		sb.WriteByte('\n')
+	}
+	return sb.String(), grid, dist
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, grid, dist := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		expect := hasSolution(grid, dist)
+		if e := verifyOut(grid, dist, out, expect); e != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, e, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/250-259/254/verifierE.go
+++ b/0-999/200-299/250-259/254/verifierE.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type friend struct{ l, r, f int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func expectedRating(input string) (int, error) {
+	out, err := run("254E.go", input)
+	if err != nil {
+		return 0, err
+	}
+	var rating int
+	if _, err := fmt.Fscan(strings.NewReader(out), &rating); err != nil {
+		return 0, err
+	}
+	return rating, nil
+}
+
+func simulate(n, v int, a []int, friends []friend, schedule [][]int) (int, error) {
+	carry := 0
+	rating := 0
+	for day := 0; day < n; day++ {
+		avail := a[day] + carry
+		used := make(map[int]bool)
+		for _, idx := range schedule[day] {
+			if idx < 1 || idx > len(friends) {
+				return 0, fmt.Errorf("bad friend index")
+			}
+			if used[idx] {
+				return 0, fmt.Errorf("duplicate friend")
+			}
+			used[idx] = true
+			f := friends[idx-1]
+			if day+1 < f.l || day+1 > f.r {
+				return 0, fmt.Errorf("feeding outside interval")
+			}
+			avail -= f.f
+			rating++
+		}
+		avail -= v
+		if avail < 0 {
+			return 0, fmt.Errorf("not enough food")
+		}
+		if avail > v {
+			avail = v
+		}
+		carry = avail
+	}
+	return rating, nil
+}
+
+func generateCase(rng *rand.Rand) (string, int, []int, []friend) {
+	n := rng.Intn(4) + 1
+	v := rng.Intn(5) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = v + rng.Intn(5)
+	}
+	m := rng.Intn(3) + 1
+	friends := make([]friend, m)
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		f := rng.Intn(v) + 1
+		friends[i] = friend{l, r, f}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, v))
+	for i, x := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", x))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for _, fr := range friends {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", fr.l, fr.r, fr.f))
+	}
+	return sb.String(), v, a, friends
+}
+
+func parseSchedule(out string, n int) (int, [][]int, error) {
+	tokens := strings.Fields(out)
+	if len(tokens) == 0 {
+		return 0, nil, fmt.Errorf("no output")
+	}
+	rating, err := strconv.Atoi(tokens[0])
+	if err != nil {
+		return 0, nil, fmt.Errorf("bad rating")
+	}
+	pos := 1
+	schedule := make([][]int, n)
+	for i := 0; i < n; i++ {
+		if pos >= len(tokens) {
+			return 0, nil, fmt.Errorf("missing day %d", i+1)
+		}
+		k, err := strconv.Atoi(tokens[pos])
+		if err != nil {
+			return 0, nil, fmt.Errorf("bad k")
+		}
+		pos++
+		if pos+k > len(tokens) {
+			return 0, nil, fmt.Errorf("missing indices")
+		}
+		day := make([]int, k)
+		for j := 0; j < k; j++ {
+			val, err := strconv.Atoi(tokens[pos])
+			if err != nil {
+				return 0, nil, fmt.Errorf("bad index")
+			}
+			day[j] = val
+			pos++
+		}
+		schedule[i] = day
+	}
+	if pos != len(tokens) {
+		return 0, nil, fmt.Errorf("extra tokens")
+	}
+	return rating, schedule, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, v, a, friends := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		rating, schedule, err := parseSchedule(out, len(a))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+		simRating, err := simulate(len(a), v, a, friends, schedule)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d invalid schedule: %v\ninput:\n%soutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+		if simRating != rating {
+			fmt.Fprintf(os.Stderr, "case %d rating mismatch: reported %d actual %d\ninput:\n%soutput:\n%s", i+1, rating, simRating, input, out)
+			os.Exit(1)
+		}
+		exp, err := expectedRating(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d internal solver error: %v", i+1, err)
+			os.Exit(1)
+		}
+		if rating != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected rating %d got %d\ninput:\n%soutput:\n%s", i+1, exp, rating, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to validate pairings output
- add verifierB.go to check maximum load calculation
- add verifierC.go for lexicographically minimal anagram
- add verifierD.go to verify grenade placements
- add verifierE.go to validate feeding schedule

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e9b695dd88324a4e8b0def0138f2f