### PR TITLE
Add verifiers for Codeforces contest 253

### DIFF
--- a/0-999/200-299/250-259/253/verifierA.go
+++ b/0-999/200-299/250-259/253/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func transitions(s string) int {
+	t := 0
+	for i := 0; i+1 < len(s); i++ {
+		if s[i] != s[i+1] {
+			t++
+		}
+	}
+	return t
+}
+
+func maxTransitions(n, m int) int {
+	if n == m {
+		return 2*n - 1
+	}
+	if n < m {
+		n, m = m, n
+	}
+	// now n > m
+	return 2 * m
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tc := 1; tc <= 100; tc++ {
+		n := rng.Intn(100) + 1
+		m := rng.Intn(100) + 1
+		input := fmt.Sprintf("%d %d\n", n, m)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tc, err, input)
+			os.Exit(1)
+		}
+		s := strings.TrimSpace(out)
+		if len(s) != n+m {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected length %d got %d\ninput:\n%s", tc, n+m, len(s), input)
+			os.Exit(1)
+		}
+		countB := strings.Count(s, "B")
+		countG := strings.Count(s, "G")
+		if countB != n || countG != m || countB+countG != len(s) {
+			fmt.Fprintf(os.Stderr, "case %d failed: wrong counts B=%d G=%d output=%s\ninput:\n%s", tc, countB, countG, s, input)
+			os.Exit(1)
+		}
+		texp := maxTransitions(n, m)
+		if transitions(s) != texp {
+			fmt.Fprintf(os.Stderr, "case %d failed: transitions %d expected %d output=%s\ninput:\n%s", tc, transitions(s), texp, s, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/250-259/253/verifierB.go
+++ b/0-999/200-299/250-259/253/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(nums []int) int {
+	sort.Ints(nums)
+	n := len(nums)
+	maxKeep := 0
+	j := 0
+	for i := 0; i < n; i++ {
+		for j < n && nums[j] <= 2*nums[i] {
+			j++
+		}
+		if j-i > maxKeep {
+			maxKeep = j - i
+		}
+	}
+	return n - maxKeep
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tc := 1; tc <= 100; tc++ {
+		n := rng.Intn(100) + 1
+		nums := make([]int, n)
+		for i := 0; i < n; i++ {
+			nums[i] = rng.Intn(5000) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range nums {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := fmt.Sprintf("%d", solveB(append([]int(nil), nums...)))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tc, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", tc, expect, strings.TrimSpace(out), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/250-259/253/verifierC.go
+++ b/0-999/200-299/250-259/253/verifierC.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type edge struct{ to, w int }
+
+type item struct{ v, d int }
+
+// priority queue for Dijkstra
+type pq []item
+
+func (p pq) Len() int            { return len(p) }
+func (p pq) Less(i, j int) bool  { return p[i].d < p[j].d }
+func (p pq) Swap(i, j int)       { p[i], p[j] = p[j], p[i] }
+func (p *pq) Push(x interface{}) { *p = append(*p, x.(item)) }
+func (p *pq) Pop() interface{} {
+	old := *p
+	v := old[len(old)-1]
+	*p = old[:len(old)-1]
+	return v
+}
+
+func solveC(a []int, r1, c1, r2, c2 int) int {
+	n := len(a)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		b[i] = a[i] + 1
+	}
+	cols := []int{c1, c2}
+	for _, v := range b {
+		cols = append(cols, v)
+	}
+	sort.Ints(cols)
+	uniq := cols[:0]
+	for i, v := range cols {
+		if i == 0 || v != cols[i-1] {
+			uniq = append(uniq, v)
+		}
+	}
+	cols = uniq
+	m := len(cols)
+	idx := make(map[int]int, m)
+	for i, v := range cols {
+		idx[v] = i
+	}
+	valid := make([][]int, n)
+	for i := 0; i < n; i++ {
+		for j, v := range cols {
+			if v <= b[i] {
+				valid[i] = append(valid[i], j)
+			} else {
+				break
+			}
+		}
+	}
+	N := n * m
+	adj := make([][]edge, N)
+	id := func(r, c int) int { return r*m + c }
+	for i := 0; i < n; i++ {
+		vs := valid[i]
+		for k := 1; k < len(vs); k++ {
+			u := vs[k-1]
+			v := vs[k]
+			w := cols[v] - cols[u]
+			ui := id(i, u)
+			vi := id(i, v)
+			adj[ui] = append(adj[ui], edge{vi, w})
+			adj[vi] = append(adj[vi], edge{ui, w})
+		}
+	}
+	for i := 0; i < n; i++ {
+		for _, u := range valid[i] {
+			cu := cols[u]
+			ui := id(i, u)
+			if i > 0 {
+				tc := cu
+				if tc > b[i-1] {
+					tc = b[i-1]
+				}
+				if v, ok := idx[tc]; ok {
+					adj[ui] = append(adj[ui], edge{id(i-1, v), 1})
+				}
+			}
+			if i+1 < n {
+				tc := cu
+				if tc > b[i+1] {
+					tc = b[i+1]
+				}
+				if v, ok := idx[tc]; ok {
+					adj[ui] = append(adj[ui], edge{id(i+1, v), 1})
+				}
+			}
+		}
+	}
+	const INF = int(1e9)
+	dist := make([]int, N)
+	for i := range dist {
+		dist[i] = INF
+	}
+	si := id(r1, idx[c1])
+	ti := id(r2, idx[c2])
+	dist[si] = 0
+	pq := &pq{{si, 0}}
+	heap.Init(pq)
+	for pq.Len() > 0 {
+		it := heap.Pop(pq).(item)
+		v, d := it.v, it.d
+		if d != dist[v] {
+			continue
+		}
+		if v == ti {
+			break
+		}
+		for _, e := range adj[v] {
+			nd := d + e.w
+			if nd < dist[e.to] {
+				dist[e.to] = nd
+				heap.Push(pq, item{e.to, nd})
+			}
+		}
+	}
+	return dist[ti]
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tc := 1; tc <= 100; tc++ {
+		n := rng.Intn(10) + 1
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(10)
+		}
+		r1 := rng.Intn(n) + 1
+		r2 := rng.Intn(n) + 1
+		c1 := rng.Intn(a[r1-1]+1) + 1
+		c2 := rng.Intn(a[r2-1]+1) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteString(fmt.Sprintf("\n%d %d %d %d\n", r1, c1, r2, c2))
+		input := sb.String()
+		expect := fmt.Sprintf("%d", solveC(append([]int(nil), a...), r1-1, c1, r2-1, c2))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tc, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", tc, expect, strings.TrimSpace(out), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/250-259/253/verifierD.go
+++ b/0-999/200-299/250-259/253/verifierD.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveD(n, m, k int, grid []string) int64 {
+	psa := make([][]int, n+1)
+	for i := range psa {
+		psa[i] = make([]int, m+1)
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			psa[i][j] = psa[i-1][j] + psa[i][j-1] - psa[i-1][j-1]
+			if grid[i-1][j-1] == 'a' {
+				psa[i][j]++
+			}
+		}
+	}
+	var ans int64
+	for x1 := 1; x1 < n; x1++ {
+		for x2 := x1 + 1; x2 <= n; x2++ {
+			var pos [26][]int
+			for y := 1; y <= m; y++ {
+				c1 := grid[x1-1][y-1]
+				c2 := grid[x2-1][y-1]
+				if c1 == c2 {
+					pos[c1-'a'] = append(pos[c1-'a'], y)
+				}
+			}
+			for c := 0; c < 26; c++ {
+				P := pos[c]
+				t := len(P)
+				if t < 2 {
+					continue
+				}
+				r := 1
+				for l := 0; l < t-1; l++ {
+					if r < l+1 {
+						r = l + 1
+					}
+					for r < t {
+						y1 := P[l]
+						y2 := P[r]
+						cnt := psa[x2][y2] - psa[x1-1][y2] - psa[x2][y1-1] + psa[x1-1][y1-1]
+						if cnt <= k {
+							r++
+						} else {
+							break
+						}
+					}
+					ans += int64(r - l - 1)
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func randLetter(rng *rand.Rand) byte {
+	return byte('a' + rng.Intn(3))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tc := 1; tc <= 100; tc++ {
+		n := rng.Intn(4) + 2
+		m := rng.Intn(4) + 2
+		k := rng.Intn(n*m + 1)
+		grid := make([]string, n)
+		for i := 0; i < n; i++ {
+			b := make([]byte, m)
+			for j := range b {
+				b[j] = randLetter(rng)
+			}
+			grid[i] = string(b)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+		for i := 0; i < n; i++ {
+			sb.WriteString(grid[i])
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expect := fmt.Sprintf("%d", solveD(n, m, k, grid))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tc, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", tc, expect, strings.TrimSpace(out), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/250-259/253/verifierE.go
+++ b/0-999/200-299/250-259/253/verifierE.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type task struct {
+	t, s, p int
+}
+
+type info struct {
+	x, y int
+}
+
+type maxHeap []info
+
+func (h maxHeap) Len() int            { return len(h) }
+func (h maxHeap) Less(i, j int) bool  { return h[i].x > h[j].x }
+func (h maxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *maxHeap) Push(x interface{}) { *h = append(*h, x.(info)) }
+func (h *maxHeap) Pop() interface{} {
+	old := *h
+	x := old[len(old)-1]
+	*h = old[:len(old)-1]
+	return x
+}
+
+func calcOverlap(s1, t1, s2, t2 int64) int64 {
+	if s2 > s1 {
+		s1 = s2
+	}
+	if t2 < t1 {
+		t1 = t2
+	}
+	res := t1 - s1 + 1
+	if res > 0 {
+		return res
+	}
+	return 0
+}
+
+func simulate(tasks []task, order []info, w int, T int64, updateUsed bool, used, last []int64) {
+	var cur int64
+	h := &maxHeap{}
+	heap.Init(h)
+	need := make([]int, len(tasks))
+	for i := 0; i < len(tasks); i++ {
+		heap.Push(h, info{tasks[order[i].y].p, order[i].y})
+		need[order[i].y] = tasks[order[i].y].s
+		if cur < int64(order[i].x) {
+			cur = int64(order[i].x)
+		}
+		for (i == len(tasks)-1 || cur < int64(order[i+1].x)) && h.Len() > 0 {
+			top := (*h)[0]
+			x := top.y
+			var d int
+			if i == len(tasks)-1 {
+				d = need[x]
+			} else {
+				avail := int(int64(order[i+1].x) - cur)
+				if need[x] < avail {
+					d = need[x]
+				} else {
+					d = avail
+				}
+			}
+			added := calcOverlap(int64(tasks[w].t), T-1, cur, cur+int64(d)-1)
+			if updateUsed {
+				used[x] += added
+			}
+			cur += int64(d)
+			need[x] -= d
+			if need[x] == 0 {
+				last[x] = cur
+				heap.Pop(h)
+			}
+		}
+	}
+}
+
+func solveE(n int, tasks []task, T int64, w int) (int, []int64) {
+	order := make([]info, n)
+	for i := 0; i < n; i++ {
+		order[i] = info{tasks[i].t, i}
+	}
+	sort.Slice(order, func(i, j int) bool { return order[i].x < order[j].x })
+	used := make([]int64, n)
+	last := make([]int64, n)
+	simulate(tasks, order, w, T, true, used, last)
+	g := make([]info, n)
+	for i := 0; i < n; i++ {
+		g[i] = info{tasks[i].p, i}
+	}
+	sort.Slice(g, func(i, j int) bool { return g[i].x < g[j].x })
+	var sum int64
+	j := 0
+	for sum < int64(tasks[w].s) {
+		sum += used[g[j].y]
+		j++
+	}
+	j--
+	newP := g[j].x + 1
+	if newP < 1 {
+		newP = 1
+	}
+	for j+1 < n && g[j+1].x == newP {
+		newP++
+		j++
+	}
+	tasks[w].p = newP
+	simulate(tasks, order, w, T, false, used, last)
+	return newP, last
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	tasks := make([]task, n)
+	usedPriorities := map[int]bool{}
+	for i := 0; i < n; i++ {
+		tasks[i].t = rng.Intn(20)
+		tasks[i].s = rng.Intn(5) + 1
+		p := rng.Intn(30) + 1
+		for usedPriorities[p] {
+			p = rng.Intn(30) + 1
+		}
+		tasks[i].p = p
+		usedPriorities[p] = true
+	}
+	w := rng.Intn(n)
+	order := make([]info, n)
+	for i := 0; i < n; i++ {
+		order[i] = info{tasks[i].t, i}
+	}
+	sort.Slice(order, func(i, j int) bool { return order[i].x < order[j].x })
+	used := make([]int64, n)
+	last := make([]int64, n)
+	simulate(tasks, order, w, 1<<60, false, used, last)
+	T := last[w]
+	tasks[w].p = -1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", tasks[i].t, tasks[i].s, tasks[i].p))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", T))
+	input := sb.String()
+	expectP, expectLast := solveE(n, append([]task(nil), tasks...), T, w)
+	expectStr := fmt.Sprintf("%d\n", expectP)
+	for i := 0; i < n; i++ {
+		expectStr += fmt.Sprintf("%d ", expectLast[i])
+	}
+	expectStr = strings.TrimSpace(expectStr)
+	return input, expectStr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tc := 1; tc <= 100; tc++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tc, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", tc, exp, strings.TrimSpace(out), in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for all problems of contest 253
- each verifier generates 100 random tests and runs any binary
- reused existing solutions for expected results

## Testing
- `go run verifierA.go ./253A.bin`
- `go run verifierB.go ./253B.bin`
- `go run verifierC.go ./253C.bin`
- `go run verifierD.go ./253D.bin`
- `go run verifierE.go ./253E.bin`

------
https://chatgpt.com/codex/tasks/task_e_687e9b2315388324b98e9a37c5b7076f