### PR TITLE
Add verifiers for Codeforces Round 251

### DIFF
--- a/0-999/200-299/250-259/251/verifierA.go
+++ b/0-999/200-299/250-259/251/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n   int
+	d   int64
+	xs  []int64
+	ans int64
+}
+
+func countTriples(xs []int64, d int64) int64 {
+	n := len(xs)
+	var res int64
+	r := 0
+	for l := 0; l < n; l++ {
+		if r < l {
+			r = l
+		}
+		for r+1 < n && xs[r+1]-xs[l] <= d {
+			r++
+		}
+		cnt := r - l
+		if cnt >= 2 {
+			res += int64(cnt*(cnt-1)) / 2
+		}
+	}
+	return res
+}
+
+func genCaseA() testCaseA {
+	rand.Seed(time.Now().UnixNano())
+	n := rand.Intn(10) + 3
+	d := rand.Int63n(20)
+	xs := make([]int64, n)
+	cur := rand.Int63n(10)
+	for i := 0; i < n; i++ {
+		xs[i] = cur
+		cur += rand.Int63n(5) + 1
+	}
+	return testCaseA{n, d, xs, countTriples(xs, d)}
+}
+
+func buildInputA(cases []testCaseA) string {
+	var sb strings.Builder
+	fmt.Fprintln(&sb, len(cases))
+	for _, c := range cases {
+		fmt.Fprintf(&sb, "%d %d\n", c.n, c.d)
+		for i, v := range c.xs {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := make([]testCaseA, 100)
+	for i := range cases {
+		cases[i] = genCaseA()
+	}
+	input := buildInputA(cases)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("runtime error:", err)
+		os.Exit(1)
+	}
+	outputs := strings.Fields(strings.TrimSpace(out.String()))
+	if len(outputs) != len(cases) {
+		fmt.Printf("expected %d lines got %d\n", len(cases), len(outputs))
+		os.Exit(1)
+	}
+	for i, s := range outputs {
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil || v != cases[i].ans {
+			fmt.Printf("mismatch on case %d: expected %d got %s\n", i+1, cases[i].ans, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/250-259/251/verifierB.go
+++ b/0-999/200-299/250-259/251/verifierB.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n   int
+	k   int
+	q   []int
+	s   []int
+	ans string
+}
+
+func identity(n int) []int {
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = i
+	}
+	return a
+}
+
+func compose(p, q []int) []int {
+	n := len(p)
+	r := make([]int, n)
+	for i := 0; i < n; i++ {
+		r[i] = p[q[i]]
+	}
+	return r
+}
+
+func inverse(p []int) []int {
+	n := len(p)
+	inv := make([]int, n)
+	for i, v := range p {
+		inv[v] = i
+	}
+	return inv
+}
+
+func equalPerm(a, b []int) bool {
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func minSteps(q, qinv [][]int, target []int, k int) int {
+	type node struct{ exp, dist int }
+	offset := k
+	vis := make([]bool, 2*k+1)
+	qnodes := []node{{0, 0}}
+	vis[offset] = true
+	for len(qnodes) > 0 {
+		cur := qnodes[0]
+		qnodes = qnodes[1:]
+		var perm []int
+		if cur.exp >= 0 {
+			perm = q[cur.exp]
+		} else {
+			perm = qinv[-cur.exp]
+		}
+		if equalPerm(perm, target) {
+			return cur.dist
+		}
+		if cur.dist == k {
+			continue
+		}
+		for _, next := range []int{cur.exp + 1, cur.exp - 1} {
+			if next < -k || next > k {
+				continue
+			}
+			idx := next + offset
+			if !vis[idx] {
+				vis[idx] = true
+				qnodes = append(qnodes, node{next, cur.dist + 1})
+			}
+		}
+	}
+	return -1
+}
+
+func computeB(n, k int, qperm, s []int) string {
+	qpow := make([][]int, k+1)
+	qpow[0] = identity(n)
+	for i := 1; i <= k; i++ {
+		qpow[i] = compose(qpow[i-1], qperm)
+	}
+	inv := inverse(qperm)
+	invpow := make([][]int, k+1)
+	invpow[0] = identity(n)
+	for i := 1; i <= k; i++ {
+		invpow[i] = compose(invpow[i-1], inv)
+	}
+	d := minSteps(qpow, invpow, s, k)
+	if d == k {
+		return "YES"
+	}
+	return "NO"
+}
+
+func genCaseB() testCaseB {
+	rand.Seed(time.Now().UnixNano())
+	n := rand.Intn(5) + 1
+	k := rand.Intn(10) + 1
+	q := rand.Perm(n)
+	s := rand.Perm(n)
+	ans := computeB(n, k, q, s)
+	// convert to 1-indexed for input
+	q1 := make([]int, n)
+	s1 := make([]int, n)
+	for i := 0; i < n; i++ {
+		q1[i] = q[i] + 1
+		s1[i] = s[i] + 1
+	}
+	return testCaseB{n, k, q1, s1, ans}
+}
+
+func buildInputB(cs []testCaseB) string {
+	var sb strings.Builder
+	fmt.Fprintln(&sb, len(cs))
+	for _, c := range cs {
+		fmt.Fprintf(&sb, "%d %d\n", c.n, c.k)
+		for i, v := range c.q {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		for i, v := range c.s {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := make([]testCaseB, 100)
+	for i := range cases {
+		cases[i] = genCaseB()
+	}
+	input := buildInputB(cases)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("runtime error:", err)
+		os.Exit(1)
+	}
+	outputs := strings.Fields(strings.TrimSpace(out.String()))
+	if len(outputs) != len(cases) {
+		fmt.Printf("expected %d lines got %d\n", len(cases), len(outputs))
+		os.Exit(1)
+	}
+	for i, s := range outputs {
+		if s != cases[i].ans {
+			fmt.Printf("mismatch on case %d: expected %s got %s\n", i+1, cases[i].ans, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/250-259/251/verifierC.go
+++ b/0-999/200-299/250-259/251/verifierC.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int) int {
+	return a / gcd(a, b) * b
+}
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func computeC(a, b int64, k int) int64 {
+	diff := a - b
+	if diff <= 0 {
+		return 0
+	}
+	L := 1
+	for x := 2; x <= k; x++ {
+		L = lcm(L, x)
+	}
+	bmod := make([]int64, k+1)
+	for x := 2; x <= k; x++ {
+		bmod[x] = b % int64(x)
+	}
+	maxI := L
+	if diff < int64(L) {
+		maxI = int(diff)
+	}
+	dp := make([]int64, maxI+1)
+	for i := 1; i <= maxI; i++ {
+		dp[i] = dp[i-1] + 1
+		for x := 2; x <= k; x++ {
+			r := (bmod[x] + int64(i%x)) % int64(x)
+			if r > 0 && int(r) <= i {
+				cand := dp[i-int(r)] + 1
+				if cand < dp[i] {
+					dp[i] = cand
+				}
+			}
+		}
+	}
+	if diff <= int64(maxI) {
+		return dp[diff]
+	}
+	chunks := diff / int64(L)
+	rem := diff % int64(L)
+	return chunks*dp[L] + dp[rem]
+}
+
+type testCaseC struct {
+	a, b int64
+	k    int
+	ans  int64
+}
+
+func genCaseC() testCaseC {
+	rand.Seed(time.Now().UnixNano())
+	b := rand.Int63n(50) + 1
+	diff := rand.Int63n(60)
+	a := b + diff
+	k := rand.Intn(14) + 2
+	return testCaseC{a, b, k, computeC(a, b, k)}
+}
+
+func buildInputC(cs []testCaseC) string {
+	var sb strings.Builder
+	fmt.Fprintln(&sb, len(cs))
+	for _, c := range cs {
+		fmt.Fprintf(&sb, "%d %d %d\n", c.a, c.b, c.k)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := make([]testCaseC, 100)
+	for i := range cases {
+		cases[i] = genCaseC()
+	}
+	input := buildInputC(cases)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("runtime error:", err)
+		os.Exit(1)
+	}
+	outputs := strings.Fields(strings.TrimSpace(out.String()))
+	if len(outputs) != len(cases) {
+		fmt.Printf("expected %d lines got %d\n", len(cases), len(outputs))
+		os.Exit(1)
+	}
+	for i, s := range outputs {
+		var val int64
+		fmt.Sscan(s, &val)
+		if val != cases[i].ans {
+			fmt.Printf("mismatch on case %d: expected %d got %s\n", i+1, cases[i].ans, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/250-259/251/verifierD.go
+++ b/0-999/200-299/250-259/251/verifierD.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseD struct {
+	nums []uint64
+	ans  []int
+}
+
+func bruteD(nums []uint64) []int {
+	n := len(nums)
+	bestVal := uint64(0)
+	bestX1 := uint64(0)
+	bestMask := 0
+	for mask := 0; mask < (1 << n); mask++ {
+		var x1, x2 uint64
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) != 0 {
+				x1 ^= nums[i]
+			} else {
+				x2 ^= nums[i]
+			}
+		}
+		val := x1 + x2
+		if val > bestVal || (val == bestVal && x1 < bestX1) {
+			bestVal = val
+			bestX1 = x1
+			bestMask = mask
+		}
+	}
+	res := make([]int, n)
+	for i := 0; i < n; i++ {
+		if bestMask&(1<<i) != 0 {
+			res[i] = 1
+		} else {
+			res[i] = 2
+		}
+	}
+	return res
+}
+
+func genCaseD() testCaseD {
+	rand.Seed(time.Now().UnixNano())
+	n := rand.Intn(10) + 1
+	nums := make([]uint64, n)
+	for i := range nums {
+		nums[i] = uint64(rand.Intn(30))
+	}
+	return testCaseD{nums, bruteD(nums)}
+}
+
+func buildInputD(cs []testCaseD) string {
+	var sb strings.Builder
+	fmt.Fprintln(&sb, len(cs))
+	for _, c := range cs {
+		fmt.Fprintln(&sb, len(c.nums))
+		for i, v := range c.nums {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func parseOutputD(out string, n int) ([]int, bool) {
+	fields := strings.Fields(out)
+	if len(fields) != n {
+		return nil, false
+	}
+	res := make([]int, n)
+	for i, f := range fields {
+		var v int
+		fmt.Sscan(f, &v)
+		if v != 1 && v != 2 {
+			return nil, false
+		}
+		res[i] = v
+	}
+	return res, true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := make([]testCaseD, 100)
+	for i := range cases {
+		cases[i] = genCaseD()
+	}
+	input := buildInputD(cases)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("runtime error:", err)
+		os.Exit(1)
+	}
+	outputs := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(outputs) != len(cases) {
+		fmt.Printf("expected %d lines got %d\n", len(cases), len(outputs))
+		os.Exit(1)
+	}
+	for i, line := range outputs {
+		res, ok := parseOutputD(line, len(cases[i].nums))
+		if !ok {
+			fmt.Printf("bad output format on case %d\n", i+1)
+			os.Exit(1)
+		}
+		expect := cases[i].ans
+		for j := range expect {
+			if res[j] != expect[j] {
+				fmt.Printf("mismatch on case %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/250-259/251/verifierE.go
+++ b/0-999/200-299/250-259/251/verifierE.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+func add(a, b int) int {
+	a += b
+	if a >= MOD {
+		a -= MOD
+	}
+	return a
+}
+
+func mul(a, b int) int {
+	return int((int64(a) * int64(b)) % MOD)
+}
+
+func solveE(n int, edges [][2]int) int {
+	m := 2 * n
+	adj := make([][]int, m)
+	deg := make([]int, m)
+	for _, e := range edges {
+		u := e[0]
+		v := e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+		deg[u]++
+		deg[v]++
+	}
+	if n == 1 {
+		return 2
+	}
+	parent := make([]int, m)
+	order := make([]int, 0, m)
+	parent[0] = -1
+	stack := []int{0}
+	for len(stack) > 0 {
+		u := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, u)
+		for _, v := range adj[u] {
+			if v == parent[u] {
+				continue
+			}
+			parent[v] = u
+			stack = append(stack, v)
+		}
+	}
+	dp0 := make([][8]int, m)
+	dp1 := make([][8]int, m)
+	for i := len(order) - 1; i >= 0; i-- {
+		u := order[i]
+		var children []int
+		for _, v := range adj[u] {
+			if v == parent[u] {
+				continue
+			}
+			children = append(children, v)
+		}
+		csz := len(children)
+		A := make([][8]int, csz+1)
+		B := make([][8]int, csz+1)
+		A[0][0] = 1
+		for j := 0; j < csz; j++ {
+			var tmp [8]int
+			for s1 := 0; s1 < 8; s1++ {
+				if A[j][s1] == 0 {
+					continue
+				}
+				b1 := s1 >> 2
+				k1 := s1 & 3
+				for s2 := 0; s2 < 8; s2++ {
+					v := dp0[children[j]][s2]
+					if v == 0 {
+						continue
+					}
+					b2 := s2 >> 2
+					k2 := s2 & 3
+					nb := b1 | b2
+					nk := k1 + k2
+					if nk > 3 {
+						nk = 3
+					}
+					idx := (nb << 2) | nk
+					tmp[idx] = (tmp[idx] + int((int64(A[j][s1])*int64(v))%MOD)) % MOD
+				}
+			}
+			A[j+1] = tmp
+		}
+		B[csz][0] = 1
+		for j := csz - 1; j >= 0; j-- {
+			var tmp [8]int
+			for s1 := 0; s1 < 8; s1++ {
+				if B[j+1][s1] == 0 {
+					continue
+				}
+				b1 := s1 >> 2
+				k1 := s1 & 3
+				for s2 := 0; s2 < 8; s2++ {
+					v := dp0[children[j]][s2]
+					if v == 0 {
+						continue
+					}
+					b2 := s2 >> 2
+					k2 := s2 & 3
+					nb := b1 | b2
+					nk := k1 + k2
+					if nk > 3 {
+						nk = 3
+					}
+					idx := (nb << 2) | nk
+					tmp[idx] = (tmp[idx] + int((int64(B[j+1][s1])*int64(v))%MOD)) % MOD
+				}
+			}
+			B[j] = tmp
+		}
+		dp1[u] = A[csz]
+		var res0 [8]int
+		for j, v := range children {
+			var others [8]int
+			for s1 := 0; s1 < 8; s1++ {
+				if A[j][s1] == 0 {
+					continue
+				}
+				b1 := s1 >> 2
+				k1 := s1 & 3
+				for s2 := 0; s2 < 8; s2++ {
+					c2 := B[j+1][s2]
+					if c2 == 0 {
+						continue
+					}
+					b2 := s2 >> 2
+					k2 := s2 & 3
+					nb := b1 | b2
+					nk := k1 + k2
+					if nk > 3 {
+						nk = 3
+					}
+					idx := (nb << 2) | nk
+					others[idx] = (others[idx] + int((int64(A[j][s1])*int64(c2))%MOD)) % MOD
+				}
+			}
+			ce := deg[u] + deg[v] - 2
+			for s := 0; s < 8; s++ {
+				if others[s] == 0 {
+					continue
+				}
+				b0 := s >> 2
+				k0 := s & 3
+				for s2 := 0; s2 < 8; s2++ {
+					cnt2 := dp1[v][s2]
+					if cnt2 == 0 {
+						continue
+					}
+					b2 := s2 >> 2
+					k2 := s2 & 3
+					nb := b0 | b2
+					nk := k0 + k2
+					if nk > 3 {
+						nk = 3
+					}
+					if ce == 0 {
+						nb = 1
+					} else if ce == 1 {
+						nk++
+						if nk > 3 {
+							nk = 3
+						}
+					}
+					idx := (nb << 2) | nk
+					res0[idx] = (res0[idx] + int((int64(others[s])*int64(cnt2))%MOD)) % MOD
+				}
+			}
+		}
+		dp0[u] = res0
+	}
+	ans := dp0[0][0*4+2]
+	ans = int((int64(ans) * 4) % MOD)
+	return ans
+}
+
+type testCaseE struct {
+	n     int
+	edges [][2]int
+	ans   int
+}
+
+func genCaseE() testCaseE {
+	rand.Seed(time.Now().UnixNano())
+	n := rand.Intn(4) + 1
+	m := 2 * n
+	if n == 1 {
+		return testCaseE{1, [][2]int{{0, 1}}, 2}
+	}
+	edges := make([][2]int, m-1)
+	for i := 1; i < m; i++ {
+		p := rand.Intn(i)
+		edges[i-1] = [2]int{i, p}
+	}
+	ans := solveE(n, edges)
+	return testCaseE{n, edges, ans}
+}
+
+func buildInputE(cs []testCaseE) string {
+	var sb strings.Builder
+	fmt.Fprintln(&sb, len(cs))
+	for _, c := range cs {
+		fmt.Fprintln(&sb, c.n)
+		for _, e := range c.edges {
+			fmt.Fprintf(&sb, "%d %d\n", e[0]+1, e[1]+1)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := make([]testCaseE, 100)
+	for i := range cases {
+		cases[i] = genCaseE()
+	}
+	input := buildInputE(cases)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("runtime error:", err)
+		os.Exit(1)
+	}
+	outputs := strings.Fields(strings.TrimSpace(out.String()))
+	if len(outputs) != len(cases) {
+		fmt.Printf("expected %d lines got %d\n", len(cases), len(outputs))
+		os.Exit(1)
+	}
+	for i, s := range outputs {
+		var val int
+		fmt.Sscan(s, &val)
+		if val != cases[i].ans {
+			fmt.Printf("mismatch on case %d: expected %d got %s\n", i+1, cases[i].ans, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 251
- each verifier creates 100 random tests and checks the binary output
- uses problem solutions to compute expected answers

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e9a96e8308324976009a16951d4d3