### PR TITLE
Add Go verifiers for contest 247

### DIFF
--- a/0-999/200-299/240-249/247/verifierA.go
+++ b/0-999/200-299/240-249/247/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// solveA implements the logic of 247A using the code from 247A.go
+func solveA(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(r, &n); err != nil {
+		return ""
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &a[i])
+	}
+	var sizes []int
+	currLen := 0
+	negCnt := 0
+	for _, v := range a {
+		if v < 0 {
+			if negCnt == 2 {
+				sizes = append(sizes, currLen)
+				currLen = 1
+				negCnt = 1
+			} else {
+				currLen++
+				negCnt++
+			}
+		} else {
+			currLen++
+		}
+	}
+	if currLen > 0 {
+		sizes = append(sizes, currLen)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(sizes)))
+	for i, sz := range sizes {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(sz))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func generateCaseA(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1 // 1..20
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rng.Intn(41) - 20 // -20..20
+		sb.WriteString(fmt.Sprint(val))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseA(rng)
+	}
+	for i, tc := range cases {
+		expect := solveA(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/247/verifierB.go
+++ b/0-999/200-299/240-249/247/verifierB.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expandIPv6(s string) string {
+	var blocks []string
+	if strings.Contains(s, "::") {
+		parts := strings.SplitN(s, "::", 2)
+		var left, right []string
+		if parts[0] != "" {
+			left = strings.Split(parts[0], ":")
+		}
+		if parts[1] != "" {
+			right = strings.Split(parts[1], ":")
+		}
+		missing := 8 - (len(left) + len(right))
+		blocks = make([]string, 0, 8)
+		blocks = append(blocks, left...)
+		for i := 0; i < missing; i++ {
+			blocks = append(blocks, "0")
+		}
+		blocks = append(blocks, right...)
+	} else {
+		blocks = strings.Split(s, ":")
+	}
+	for i, b := range blocks {
+		if len(b) < 4 {
+			blocks[i] = strings.Repeat("0", 4-len(b)) + b
+		}
+	}
+	return strings.Join(blocks, ":")
+}
+
+func solveB(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(r, &n); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		var s string
+		fmt.Fscan(r, &s)
+		sb.WriteString(expandIPv6(s))
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func generateCaseB(rng *rand.Rand) string {
+	num := rng.Intn(5) + 1 // 1..5 addresses
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", num))
+	for i := 0; i < num; i++ {
+		blocks := make([]uint16, 8)
+		for j := range blocks {
+			blocks[j] = uint16(rng.Intn(65536))
+		}
+		// choose run of zeros to compress with probability
+		start := -1
+		length := 0
+		if rng.Intn(2) == 0 {
+			// find longest run of zeros
+			l := 0
+			bestL := 0
+			bestStart := -1
+			for j := 0; j < 8; j++ {
+				if blocks[j] == 0 {
+					l++
+					if l > bestL {
+						bestL = l
+						bestStart = j - l + 1
+					}
+				} else {
+					l = 0
+				}
+			}
+			if bestL > 1 {
+				start = bestStart
+				length = bestL
+			}
+		}
+		var short []string
+		for j := 0; j < 8; {
+			if j == start {
+				short = append(short, "") // placeholder for ::
+				j += length
+				continue
+			}
+			block := fmt.Sprintf("%x", blocks[j])
+			short = append(short, strings.TrimLeft(block, "0"))
+			if short[len(short)-1] == "" {
+				short[len(short)-1] = "0"
+			}
+			j++
+		}
+		addr := strings.Join(short, ":")
+		if start != -1 {
+			if start == 0 {
+				addr = "::" + strings.Join(short[1:], ":")
+			} else if start+length >= 8 {
+				addr = strings.Join(short[:start], ":") + "::"
+			} else {
+				addr = strings.Join(short[:start], ":") + "::" + strings.Join(short[start+1:], ":")
+			}
+		}
+		// remove empty edges
+		addr = strings.ReplaceAll(addr, ":::", "::")
+		if strings.HasPrefix(addr, ":") && !strings.HasPrefix(addr, "::") {
+			addr = "0" + addr
+		}
+		if strings.HasSuffix(addr, ":") && !strings.HasSuffix(addr, "::") {
+			addr = addr + "0"
+		}
+		sb.WriteString(addr)
+		if i+1 < num {
+			sb.WriteByte('\n')
+		} else {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseB(rng)
+	}
+	for i, tc := range cases {
+		expect := solveB(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/247/verifierC.go
+++ b/0-999/200-299/240-249/247/verifierC.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n, k int
+	if _, err := fmt.Fscan(r, &n, &k); err != nil {
+		return ""
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &a[i])
+	}
+	totalStress := 0
+	removed := make([]int, k+1)
+	added := make([]int, k+1)
+	for i := 1; i < n; i++ {
+		if a[i] != a[i-1] {
+			totalStress++
+			removed[a[i]]++
+			removed[a[i-1]]++
+		}
+	}
+	for i := 0; i < n; {
+		j := i
+		for j+1 < n && a[j+1] == a[i] {
+			j++
+		}
+		g := a[i]
+		if i > 0 && j < n-1 {
+			left := a[i-1]
+			right := a[j+1]
+			if left != right {
+				added[g]++
+			}
+		}
+		i = j + 1
+	}
+	best := 1
+	minStress := totalStress - removed[1] + added[1]
+	for x := 2; x <= k; x++ {
+		stress := totalStress - removed[x] + added[x]
+		if stress < minStress {
+			minStress = stress
+			best = x
+		}
+	}
+	return fmt.Sprintf("%d\n", best)
+}
+
+func generateCaseC(rng *rand.Rand) string {
+	n := rng.Intn(20) + 2          // >=2
+	k := rng.Intn(min(5, n-1)) + 2 // 2..min(5,n)
+	if k > n {
+		k = n
+	}
+	genres := make([]int, n)
+	for i := 0; i < k; i++ {
+		genres[i] = i + 1
+	}
+	for i := k; i < n; i++ {
+		genres[i] = rng.Intn(k) + 1
+	}
+	rng.Shuffle(n, func(i, j int) { genres[i], genres[j] = genres[j], genres[i] })
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, g := range genres {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(g))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseC(rng)
+	}
+	for i, tc := range cases {
+		expect := solveC(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/247/verifierD.go
+++ b/0-999/200-299/240-249/247/verifierD.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n, m, a, b int
+	if _, err := fmt.Fscan(r, &n, &m, &a, &b); err != nil {
+		return ""
+	}
+	ys := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &ys[i])
+	}
+	yps := make([]int, m)
+	for j := 0; j < m; j++ {
+		fmt.Fscan(r, &yps[j])
+	}
+	ls := make([]int, m)
+	for j := 0; j < m; j++ {
+		fmt.Fscan(r, &ls[j])
+	}
+	D := make([]float64, n)
+	aa := float64(a)
+	for i := 0; i < n; i++ {
+		yi := float64(ys[i])
+		D[i] = math.Hypot(aa, yi)
+	}
+	deltaX := float64(b - a)
+	bestI := 0
+	bestJ := 0
+	minCost := math.Inf(1)
+	for j := 0; j < m; j++ {
+		yj := float64(yps[j])
+		for bestI+1 < n {
+			dy0 := float64(ys[bestI]) - yj
+			cost0 := D[bestI] + math.Hypot(deltaX, dy0)
+			dy1 := float64(ys[bestI+1]) - yj
+			cost1 := D[bestI+1] + math.Hypot(deltaX, dy1)
+			if cost1 <= cost0 {
+				bestI++
+			} else {
+				break
+			}
+		}
+		dy := float64(ys[bestI]) - yj
+		bridge := math.Hypot(deltaX, dy)
+		total := D[bestI] + bridge + float64(ls[j])
+		if total < minCost {
+			minCost = total
+			bestJ = j
+		}
+	}
+	return fmt.Sprintf("%d %d\n", bestI+1, bestJ+1)
+}
+
+func generateCaseD(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	a := rng.Intn(5) + 1
+	b := a + rng.Intn(5) + 1
+	ys := make([]int, n)
+	yps := make([]int, m)
+	for i := range ys {
+		if i == 0 {
+			ys[i] = rng.Intn(21) - 10
+		} else {
+			ys[i] = ys[i-1] + rng.Intn(3) + 1
+		}
+	}
+	for j := range yps {
+		if j == 0 {
+			yps[j] = rng.Intn(21) - 10
+		} else {
+			yps[j] = yps[j-1] + rng.Intn(3) + 1
+		}
+	}
+	ls := make([]int, m)
+	for j := range ls {
+		ls[j] = rng.Intn(10) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, a, b))
+	for i, v := range ys {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for j, v := range yps {
+		if j > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for j, v := range ls {
+		if j > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseD(rng)
+	}
+	for i, tc := range cases {
+		expect := solveD(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/247/verifierE.go
+++ b/0-999/200-299/240-249/247/verifierE.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return ""
+	}
+	floors := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		var line string
+		fmt.Fscan(reader, &line)
+		floors[n-1-i] = []byte(line)
+	}
+	visited := make([][2]int, m)
+	curVer := 1
+	floor := n - 1
+	pos := 0
+	dir := 1
+	var timeCount int64
+	reset := func() { curVer++ }
+	reset()
+	for {
+		if floor == 0 {
+			return fmt.Sprintf("%d\n", timeCount)
+		}
+		if floors[floor-1][pos] == '.' {
+			floor--
+			timeCount++
+			reset()
+			continue
+		}
+		next := pos + dir
+		var cell byte
+		if next < 0 || next >= m {
+			cell = '#'
+		} else {
+			cell = floors[floor][next]
+		}
+		if cell == '+' {
+			floors[floor][next] = '.'
+			dir = -dir
+			timeCount++
+			reset()
+			continue
+		}
+		if cell == '.' {
+			pos = next
+		} else if cell == '#' {
+			dir = -dir
+		}
+		timeCount++
+		di := 1
+		if dir < 0 {
+			di = 0
+		}
+		if visited[pos][di] == curVer {
+			return "Never\n"
+		}
+		visited[pos][di] = curVer
+	}
+}
+
+func generateCaseE(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	m := rng.Intn(10) + 1
+	floors := make([]string, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			ch := rng.Intn(3)
+			if ch == 0 {
+				row[j] = '.'
+			} else if ch == 1 {
+				row[j] = '+'
+			} else {
+				row[j] = '#'
+			}
+		}
+		floors[n-1-i] = string(row)
+	}
+	// ensure first cell of top floor is '.'
+	top := []byte(floors[n-1])
+	top[0] = '.'
+	floors[n-1] = string(top)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(floors[i])
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		cases[i] = generateCaseE(rng)
+	}
+	for i, tc := range cases {
+		expect := solveE(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:%sq\ngot:%sq\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` .. `verifierE.go` for contest 247
- each verifier runs a binary on 100 random tests
- verifiers reimplement the reference solutions to check output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `./verifierA ./247A_bin`
- `./verifierB ./247B_bin`
- `./verifierC ./247C_bin`
- `./verifierD ./247D_bin`
- `./verifierE ./247E_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e997ed50c8324b35e836c6b814906