### PR TITLE
Add verifiers for contest 246

### DIFF
--- a/0-999/200-299/240-249/246/verifierA.go
+++ b/0-999/200-299/240-249/246/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// runOnePassSort applies Valera's buggy algorithm
+func runOnePassSort(a []int) []int {
+	b := make([]int, len(a))
+	copy(b, a)
+	for i := 0; i+1 < len(b); i++ {
+		if b[i] > b[i+1] {
+			b[i], b[i+1] = b[i+1], b[i]
+		}
+	}
+	return b
+}
+
+func isSorted(a []int) bool {
+	for i := 1; i < len(a); i++ {
+		if a[i-1] > a[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func checkOutput(n int, out string) error {
+	out = strings.TrimSpace(out)
+	if n < 3 {
+		if out != "-1" {
+			return fmt.Errorf("expected -1, got %q", out)
+		}
+		return nil
+	}
+	parts := strings.Fields(out)
+	if len(parts) != n {
+		return fmt.Errorf("expected %d numbers, got %d", n, len(parts))
+	}
+	arr := make([]int, n)
+	for i, p := range parts {
+		v, err := strconv.Atoi(p)
+		if err != nil {
+			return fmt.Errorf("not an integer: %q", p)
+		}
+		if v < 1 || v > 100 {
+			return fmt.Errorf("value %d out of range", v)
+		}
+		arr[i] = v
+	}
+	b := runOnePassSort(arr)
+	if isSorted(b) {
+		return fmt.Errorf("array still sorted after algorithm")
+	}
+	return nil
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("%d\n", n)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return checkOutput(n, out.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(50) + 1
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (n=%d)\n", i+1, err, n)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/246/verifierB.go
+++ b/0-999/200-299/240-249/246/verifierB.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(a []int) int {
+	sum := 0
+	for _, v := range a {
+		sum += v
+	}
+	n := len(a)
+	if sum%n == 0 {
+		return n
+	}
+	return n - 1
+}
+
+func runCase(bin string, arr []int) error {
+	var sb strings.Builder
+	n := len(arr)
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(gotStr)
+	if err != nil {
+		return fmt.Errorf("non-integer output %q", gotStr)
+	}
+	if got != expected(arr) {
+		return fmt.Errorf("expected %d got %d", expected(arr), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(50) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(101)
+		}
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/246/verifierC.go
+++ b/0-999/200-299/240-249/246/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedOutput(n int, k int64, arr []int) string {
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = arr[i-1]
+	}
+	sort.Slice(a[1:], func(i, j int) bool { return a[i+1] < a[j+1] })
+	var sb strings.Builder
+	for i := 0; i <= n; i++ {
+		for j := 1; j <= n-i; j++ {
+			if k <= 0 {
+				return strings.TrimSpace(sb.String())
+			}
+			k--
+			sb.WriteString(strconv.Itoa(i + 1))
+			for p := n - i + 1; p <= n; p++ {
+				sb.WriteByte(' ')
+				sb.WriteString(strconv.Itoa(a[p]))
+			}
+			sb.WriteByte(' ')
+			sb.WriteString(strconv.Itoa(a[j]))
+			sb.WriteByte('\n')
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func runCase(bin string, n int, k int64, arr []int) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprint(v))
+	}
+	input.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := expectedOutput(n, k, arr)
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 1
+		maxK := n * (n + 1) / 2
+		k := int64(rng.Intn(maxK) + 1)
+		arr := rand.Perm(n)
+		for j := range arr {
+			arr[j] = arr[j] + 1 + rng.Intn(9)*10 + j // ensure distinct
+		}
+		if err := runCase(bin, n, k, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/246/verifierD.go
+++ b/0-999/200-299/240-249/246/verifierD.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func expectedColor(n int, colors []int, edges []edge) int {
+	neigh := make(map[int]map[int]struct{})
+	present := make(map[int]struct{})
+	for _, c := range colors {
+		present[c] = struct{}{}
+	}
+	for _, e := range edges {
+		cu := colors[e.u-1]
+		cv := colors[e.v-1]
+		if cu == cv {
+			continue
+		}
+		if neigh[cu] == nil {
+			neigh[cu] = make(map[int]struct{})
+		}
+		if neigh[cv] == nil {
+			neigh[cv] = make(map[int]struct{})
+		}
+		neigh[cu][cv] = struct{}{}
+		neigh[cv][cu] = struct{}{}
+	}
+	bestColor := 0
+	bestCount := -1
+	colorsList := make([]int, 0, len(present))
+	for c := range present {
+		colorsList = append(colorsList, c)
+	}
+	sort.Ints(colorsList)
+	for _, c := range colorsList {
+		cnt := len(neigh[c])
+		if cnt > bestCount {
+			bestCount = cnt
+			bestColor = c
+		}
+	}
+	return bestColor
+}
+
+func runCase(bin string, n int, colors []int, edges []edge) error {
+	var sb strings.Builder
+	m := len(edges)
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, c := range colors {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(c))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(gotStr)
+	if err != nil {
+		return fmt.Errorf("non-integer output %q", gotStr)
+	}
+	expect := expectedColor(n, colors, edges)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		colors := make([]int, n)
+		for j := range colors {
+			colors[j] = rng.Intn(5) + 1
+		}
+		maxEdges := n * (n - 1) / 2
+		m := rng.Intn(maxEdges + 1)
+		used := make(map[[2]int]struct{})
+		edges := make([]edge, 0, m)
+		for len(edges) < m {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			if u > v {
+				u, v = v, u
+			}
+			key := [2]int{u, v}
+			if _, ok := used[key]; ok {
+				continue
+			}
+			used[key] = struct{}{}
+			edges = append(edges, edge{u, v})
+		}
+		if err := runCase(bin, n, colors, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/246/verifierE.go
+++ b/0-999/200-299/240-249/246/verifierE.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Fenwick tree for sum queries and point updates
+type Fenwick struct {
+	n int
+	t []int
+}
+
+func NewFenwick(n int) *Fenwick { return &Fenwick{n: n, t: make([]int, n+1)} }
+func (f *Fenwick) Add(i, v int) {
+	for ; i <= f.n; i += i & -i {
+		f.t[i] += v
+	}
+}
+func (f *Fenwick) Sum(i int) int {
+	s := 0
+	for ; i > 0; i -= i & -i {
+		s += f.t[i]
+	}
+	return s
+}
+func (f *Fenwick) RangeSum(l, r int) int {
+	if r < l {
+		return 0
+	}
+	return f.Sum(r) - f.Sum(l-1)
+}
+
+type person struct {
+	name   string
+	parent int
+}
+
+type Query struct{ v, k int }
+
+func expected(n int, people []person, queries []Query) []int {
+	nameMap := make(map[string]int)
+	nextID := 1
+	nameID := make([]int, n+1)
+	children := make([][]int, n+1)
+	for i := 1; i <= n; i++ {
+		p := people[i-1]
+		if p.parent != 0 {
+			children[p.parent] = append(children[p.parent], i)
+		}
+		id, ok := nameMap[p.name]
+		if !ok {
+			id = nextID
+			nameMap[p.name] = id
+			nextID++
+		}
+		nameID[i] = id
+	}
+	depth := make([]int, n+1)
+	tin := make([]int, n+1)
+	tout := make([]int, n+1)
+	tins := make([][]int, n+2)
+	namesAtDepth := make([][]int, n+2)
+	timev := 1
+	type Frame struct{ u, idx int }
+	stack := make([]Frame, 0, n)
+	for i := 1; i <= n; i++ {
+		if people[i-1].parent != 0 {
+			continue
+		}
+		depth[i] = 0
+		stack = append(stack, Frame{i, -1})
+		for len(stack) > 0 {
+			top := &stack[len(stack)-1]
+			u := top.u
+			if top.idx == -1 {
+				tin[u] = timev
+				timev++
+				d := depth[u]
+				tins[d] = append(tins[d], tin[u])
+				namesAtDepth[d] = append(namesAtDepth[d], nameID[u])
+				top.idx = 0
+			} else if top.idx < len(children[u]) {
+				v := children[u][top.idx]
+				top.idx++
+				depth[v] = depth[u] + 1
+				stack = append(stack, Frame{v, -1})
+			} else {
+				tout[u] = timev - 1
+				stack = stack[:len(stack)-1]
+			}
+		}
+	}
+	queriesByDepth := make([][]struct{ l, r, id int }, n+2)
+	ans := make([]int, len(queries))
+	for qi, q := range queries {
+		td := depth[q.v] + q.k
+		if td >= len(tins) || len(tins[td]) == 0 {
+			ans[qi] = 0
+			continue
+		}
+		arr := tins[td]
+		l := lowerBound(arr, tin[q.v])
+		r := upperBound(arr, tout[q.v]) - 1
+		if l > r {
+			ans[qi] = 0
+		} else {
+			queriesByDepth[td] = append(queriesByDepth[td], struct{ l, r, id int }{l + 1, r + 1, qi})
+		}
+	}
+	maxNameID := nextID
+	for d, qs := range queriesByDepth {
+		if len(qs) == 0 {
+			continue
+		}
+		sort.Slice(qs, func(i, j int) bool { return qs[i].r < qs[j].r })
+		cnt := len(namesAtDepth[d])
+		bit := NewFenwick(cnt)
+		last := make([]int, maxNameID)
+		qi := 0
+		for i := 1; i <= cnt; i++ {
+			id := namesAtDepth[d][i-1]
+			if last[id] != 0 {
+				bit.Add(last[id], -1)
+			}
+			bit.Add(i, 1)
+			last[id] = i
+			for qi < len(qs) && qs[qi].r == i {
+				l := qs[qi].l
+				r := qs[qi].r
+				ans[qs[qi].id] = bit.RangeSum(l, r)
+				qi++
+			}
+		}
+	}
+	return ans
+}
+
+func lowerBound(a []int, x int) int {
+	l, r := 0, len(a)
+	for l < r {
+		m := l + (r-l)/2
+		if a[m] < x {
+			l = m + 1
+		} else {
+			r = m
+		}
+	}
+	return l
+}
+func upperBound(a []int, x int) int {
+	l, r := 0, len(a)
+	for l < r {
+		m := l + (r-l)/2
+		if a[m] <= x {
+			l = m + 1
+		} else {
+			r = m
+		}
+	}
+	return l
+}
+
+func runCase(bin string, n int, people []person, qs []Query) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, p := range people {
+		sb.WriteString(p.name)
+		sb.WriteByte(' ')
+		sb.WriteString(fmt.Sprint(p.parent))
+		if i+1 < len(people) {
+			sb.WriteByte('\n')
+		}
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", len(qs)))
+	for i, q := range qs {
+		sb.WriteString(fmt.Sprintf("%d %d", q.v, q.k))
+		if i+1 < len(qs) {
+			sb.WriteByte('\n')
+		}
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expect := expected(n, people, qs)
+	gotFields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(gotFields) != len(expect) {
+		return fmt.Errorf("expected %d numbers got %d", len(expect), len(gotFields))
+	}
+	for i, f := range gotFields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("non-int output %q", f)
+		}
+		if v != expect[i] {
+			return fmt.Errorf("at %d expected %d got %d", i, expect[i], v)
+		}
+	}
+	return nil
+}
+
+func randName(rng *rand.Rand) string {
+	l := rng.Intn(5) + 1
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(15) + 1
+		people := make([]person, n)
+		for j := 0; j < n; j++ {
+			name := randName(rng)
+			parent := 0
+			if j > 0 {
+				parent = rng.Intn(j) + 1
+			}
+			people[j] = person{name, parent}
+		}
+		m := rng.Intn(15) + 1
+		queries := make([]Query, m)
+		for j := 0; j < m; j++ {
+			v := rng.Intn(n) + 1
+			k := rng.Intn(n)
+			queries[j] = Query{v, k}
+		}
+		if err := runCase(bin, n, people, queries); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 246
- each verifier generates 100 random test cases and checks candidate binaries
- verifiers cover buggy sorting, array equality, unique detachments, colored graph analysis, and family tree queries

## Testing
- `go build 0-999/200-299/240-249/246/verifierA.go`
- `go build 0-999/200-299/240-249/246/verifierB.go`
- `go build 0-999/200-299/240-249/246/verifierC.go`
- `go build 0-999/200-299/240-249/246/verifierD.go`
- `go build 0-999/200-299/240-249/246/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e9938ce648324b047b4af9fed2cd4