### PR TITLE
Add Go verifiers for Codeforces contest 245

### DIFF
--- a/0-999/200-299/240-249/245/verifierA.go
+++ b/0-999/200-299/240-249/245/verifierA.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type command struct {
+	t int
+	x int
+	y int
+}
+
+func expected(commands []command) string {
+	succA, succB := 0, 0
+	cntA, cntB := 0, 0
+	for _, c := range commands {
+		if c.t == 1 {
+			succA += c.x
+			cntA += 10
+		} else {
+			succB += c.x
+			cntB += 10
+		}
+	}
+	var res strings.Builder
+	if succA*2 >= cntA {
+		res.WriteString("LIVE\n")
+	} else {
+		res.WriteString("DEAD\n")
+	}
+	if succB*2 >= cntB {
+		res.WriteString("LIVE")
+	} else {
+		res.WriteString("DEAD")
+	}
+	return res.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 2
+	cmds := make([]command, n)
+	hasA, hasB := false, false
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		t := 1 + rng.Intn(2)
+		x := rng.Intn(11)
+		y := 10 - x
+		cmds[i] = command{t, x, y}
+		if t == 1 {
+			hasA = true
+		} else {
+			hasB = true
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", t, x, y))
+	}
+	// ensure at least one of each type
+	if !hasA {
+		cmds[0].t = 1
+	}
+	if !hasB {
+		cmds[0].t = 2
+	}
+	if !hasA || !hasB {
+		sb.Reset()
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for _, c := range cmds {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", c.t, c.x, c.y))
+		}
+	}
+	return sb.String(), expected(cmds)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/245/verifierB.go
+++ b/0-999/200-299/240-249/245/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedURL(s string) string {
+	x := -1
+	for i := 1; i < len(s); i++ {
+		if s[i-1] == 'r' && s[i] == 'u' {
+			x = i - 1
+		}
+	}
+	var res strings.Builder
+	start := 0
+	if strings.HasPrefix(s, "http") {
+		res.WriteString("http://")
+		start = 4
+	} else {
+		res.WriteString("ftp://")
+		start = 3
+	}
+	if x > start {
+		res.WriteString(s[start:x])
+	}
+	res.WriteString(".ru")
+	if x+2 < len(s) {
+		res.WriteString("/")
+		res.WriteString(s[x+2:])
+	}
+	return res.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	protocol := "http"
+	if rng.Intn(2) == 0 {
+		protocol = "ftp"
+	}
+	domainLen := rng.Intn(10) + 1
+	contextLen := rng.Intn(5)
+	build := func(n int) string {
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			b[i] = byte('a' + rng.Intn(26))
+		}
+		return string(b)
+	}
+	domain := build(domainLen)
+	context := build(contextLen)
+	raw := protocol + domain + "ru" + context
+	return raw + "\n", expectedURL(raw)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/245/verifierC.go
+++ b/0-999/200-299/240-249/245/verifierC.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(a []int) int64 {
+	n := len(a) - 1
+	maxA := 0
+	for i := 1; i <= n; i++ {
+		if a[i] > maxA {
+			maxA = a[i]
+		}
+	}
+	MAX := maxA
+	m := (n - 1) / 2
+	const INF int64 = 1e18
+	f := make([][]int64, n+2)
+	for v := n; v >= 1; v-- {
+		c1 := 2 * v
+		c2 := 2*v + 1
+		var f1, f2 []int64
+		if c1 <= n {
+			f1 = f[c1]
+		}
+		if c2 <= n {
+			f2 = f[c2]
+		}
+		hasVar := v <= m
+		s := make([]int64, MAX+1)
+		for k := 0; k <= MAX; k++ {
+			if !hasVar && k > 0 {
+				s[k] = INF
+				continue
+			}
+			cost := int64(k)
+			if f1 != nil {
+				cost += f1[k]
+			}
+			if f2 != nil {
+				cost += f2[k]
+			}
+			s[k] = cost
+		}
+		for k := MAX - 1; k >= 0; k-- {
+			if s[k+1] < s[k] {
+				s[k] = s[k+1]
+			}
+		}
+		fv := make([]int64, MAX+1)
+		for p := 0; p <= MAX; p++ {
+			lb := a[v] - p
+			if lb < 0 {
+				lb = 0
+			}
+			if lb > MAX {
+				fv[p] = INF
+			} else {
+				fv[p] = s[lb]
+			}
+		}
+		f[v] = fv
+	}
+	res := f[1][0]
+	if res >= int64(1e17) {
+		return -1
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	a := make([]int, n+1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		a[i] = rng.Intn(5)
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+		if i < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	ans := solveC(a)
+	return sb.String(), fmt.Sprint(ans)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/245/verifierD.go
+++ b/0-999/200-299/240-249/245/verifierD.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(b [][]int) []int {
+	n := len(b)
+	a := make([]int, n)
+	for k := 0; k <= 30; k++ {
+		deg := make([]int, n)
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				if i != j && ((b[i][j]>>k)&1) == 1 {
+					deg[i]++
+				}
+			}
+		}
+		visited := make([]bool, n)
+		for i := 0; i < n; i++ {
+			if visited[i] || deg[i] == 0 {
+				continue
+			}
+			queue := []int{i}
+			comp := []int{i}
+			visited[i] = true
+			for head := 0; head < len(queue); head++ {
+				u := queue[head]
+				for v := 0; v < n; v++ {
+					if !visited[v] && ((b[u][v]>>k)&1) == 1 {
+						visited[v] = true
+						queue = append(queue, v)
+						comp = append(comp, v)
+					}
+				}
+			}
+			for _, u := range comp {
+				a[u] |= 1 << k
+			}
+		}
+	}
+	return a
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(1000)
+	}
+	b := make([][]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		b[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			if i == j {
+				b[i][j] = -1
+			} else {
+				b[i][j] = a[i] & a[j]
+			}
+			sb.WriteString(fmt.Sprintf("%d", b[i][j]))
+			if j+1 < n {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	ansArr := solveD(b)
+	var exp strings.Builder
+	for i, v := range ansArr {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(fmt.Sprint(v))
+	}
+	return sb.String(), exp.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/245/verifierE.go
+++ b/0-999/200-299/240-249/245/verifierE.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(s string) int {
+	cur := 0
+	maxPeople := 0
+	for _, c := range s {
+		if c == '+' {
+			cur++
+			if cur > maxPeople {
+				maxPeople = cur
+			}
+		} else if c == '-' {
+			if cur > 0 {
+				cur--
+			} else {
+				maxPeople++
+			}
+		}
+	}
+	return maxPeople
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	l := rng.Intn(50) + 1
+	b := make([]byte, l)
+	for i := 0; i < l; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '+'
+		} else {
+			b[i] = '-'
+		}
+	}
+	s := string(b)
+	return s + "\n", fmt.Sprint(solveE(s))
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/245/verifierF.go
+++ b/0-999/200-299/240-249/245/verifierF.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var daysBefore = [13]int{0, 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335}
+
+func parseTS(ts string) int {
+	month, _ := strconv.Atoi(ts[5:7])
+	day, _ := strconv.Atoi(ts[8:10])
+	hour, _ := strconv.Atoi(ts[11:13])
+	minute, _ := strconv.Atoi(ts[14:16])
+	second, _ := strconv.Atoi(ts[17:19])
+	days := daysBefore[month] + day - 1
+	return days*86400 + hour*3600 + minute*60 + second
+}
+
+func solveF(window, threshold int, lines []string) string {
+	var q []int
+	for _, rec := range lines {
+		ts := rec[:19]
+		cur := parseTS(ts)
+		q = append(q, cur)
+		limit := cur - window + 1
+		i := 0
+		for i < len(q) && q[i] < limit {
+			i++
+		}
+		if i > 0 {
+			q = q[i:]
+		}
+		if len(q) >= threshold {
+			return ts
+		}
+	}
+	return "-1"
+}
+
+func randomTS(base int) string {
+	sec := base
+	day := sec / 86400
+	sec %= 86400
+	hour := sec / 3600
+	sec %= 3600
+	minute := sec / 60
+	second := sec % 60
+	// convert day to month/day
+	md := []int{31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
+	month := 1
+	for day >= md[month-1] {
+		day -= md[month-1]
+		month++
+	}
+	return fmt.Sprintf("2012-%02d-%02d %02d:%02d:%02d", month, day+1, hour, minute, second)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	window := rng.Intn(50) + 1
+	threshold := rng.Intn(10) + 1
+	linesCount := rng.Intn(30) + threshold
+	base := 0
+	lines := make([]string, linesCount)
+	for i := 0; i < linesCount; i++ {
+		base += rng.Intn(5) + 1
+		ts := randomTS(base)
+		lines[i] = ts + ":A"
+	}
+	input := fmt.Sprintf("%d %d\n%s\n", window, threshold, strings.Join(lines, "\n"))
+	ans := solveF(window, threshold, lines)
+	return input, ans
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/245/verifierG.go
+++ b/0-999/200-299/240-249/245/verifierG.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func check(id int, adj [][]int) int {
+	N := len(adj)
+	a := make([]int, N)
+	for _, nei := range adj[id] {
+		a[nei] = 1
+	}
+	a[id] = 1
+	m := 0
+	for _, nei := range adj[id] {
+		for _, nn := range adj[nei] {
+			if a[nn]%2 == 0 {
+				a[nn] += 2
+				if a[nn] > m {
+					m = a[nn]
+				}
+			}
+		}
+	}
+	r := 0
+	for i := 0; i < N; i++ {
+		if a[i] == m {
+			r++
+		}
+	}
+	return r
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	N := rng.Intn(5) + 2
+	names := make([]string, N)
+	for i := 0; i < N; i++ {
+		names[i] = fmt.Sprintf("u%d", i)
+	}
+	edges := make(map[[2]int]bool)
+	adj := make([][]int, N)
+	// ensure each node has at least one friend
+	for i := 0; i < N-1; i++ {
+		edges[[2]int{i, i + 1}] = true
+	}
+	extra := rng.Intn(N)
+	for k := 0; k < extra; k++ {
+		a := rng.Intn(N)
+		b := rng.Intn(N)
+		if a == b {
+			b = (b + 1) % N
+		}
+		if a > b {
+			a, b = b, a
+		}
+		edges[[2]int{a, b}] = true
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(edges)))
+	for e := range edges {
+		a, b := e[0], e[1]
+		sb.WriteString(fmt.Sprintf("%s %s\n", names[a], names[b]))
+		adj[a] = append(adj[a], b)
+		adj[b] = append(adj[b], a)
+	}
+	// compute expected output
+	var keys []string
+	for _, n := range names {
+		keys = append(keys, n)
+	}
+	sort.Strings(keys)
+	var exp strings.Builder
+	exp.WriteString(fmt.Sprintf("%d\n", N))
+	for _, name := range keys {
+		id := -1
+		for i, nm := range names {
+			if nm == name {
+				id = i
+				break
+			}
+		}
+		val := check(id, adj)
+		exp.WriteString(fmt.Sprintf("%s %d\n", name, val))
+	}
+	return sb.String(), strings.TrimSpace(exp.String())
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/245/verifierH.go
+++ b/0-999/200-299/240-249/245/verifierH.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func precomputePal(s string) [][]bool {
+	n := len(s)
+	dp := make([][]bool, n)
+	for i := range dp {
+		dp[i] = make([]bool, n)
+	}
+	for i := 0; i < n; i++ {
+		dp[i][i] = true
+	}
+	for l := 2; l <= n; l++ {
+		for i := 0; i+l <= n; i++ {
+			j := i + l - 1
+			if s[i] == s[j] {
+				if l == 2 || dp[i+1][j-1] {
+					dp[i][j] = true
+				}
+			}
+		}
+	}
+	return dp
+}
+
+func countPal(dp [][]bool, l, r int) int {
+	cnt := 0
+	for i := l; i <= r; i++ {
+		for j := i; j <= r; j++ {
+			if dp[i][j] {
+				cnt++
+			}
+		}
+	}
+	return cnt
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	s := string(b)
+	q := rng.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		queries[i] = [2]int{l, r}
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	dp := precomputePal(s)
+	var exp strings.Builder
+	for i, qr := range queries {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		val := countPal(dp, qr[0]-1, qr[1]-1)
+		exp.WriteString(fmt.Sprint(val))
+	}
+	return sb.String(), exp.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–H of contest 245
- each verifier generates 100 random test cases and checks an arbitrary binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`

------
https://chatgpt.com/codex/tasks/task_e_687e98f2a7c083248cd67dfc66e4fa24