### PR TITLE
Add Go verifiers for contest 242

### DIFF
--- a/0-999/200-299/240-249/242/verifierA.go
+++ b/0-999/200-299/240-249/242/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	x, y, a, b int
+}
+
+func solveCase(tc testCase) string {
+	var pairs [][2]int
+	for c := tc.a; c <= tc.x; c++ {
+		for d := tc.b; d <= tc.y && d < c; d++ {
+			pairs = append(pairs, [2]int{c, d})
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(pairs))
+	for _, p := range pairs {
+		fmt.Fprintf(&sb, "%d %d\n", p[0], p[1])
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	tc := testCase{}
+	tc.x = rng.Intn(10) + 1
+	tc.y = rng.Intn(10) + 1
+	tc.a = rng.Intn(tc.x) + 1
+	tc.b = rng.Intn(tc.y) + 1
+	in := fmt.Sprintf("%d %d %d %d\n", tc.x, tc.y, tc.a, tc.b)
+	out := solveCase(tc)
+	return in, out
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/242/verifierB.go
+++ b/0-999/200-299/240-249/242/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type segment struct{ l, r int64 }
+
+func solveCase(segs []segment) string {
+	minL := int64(1<<63 - 1)
+	maxR := int64(-1 << 63)
+	for _, s := range segs {
+		if s.l < minL {
+			minL = s.l
+		}
+		if s.r > maxR {
+			maxR = s.r
+		}
+	}
+	res := -1
+	for i, s := range segs {
+		if s.l == minL && s.r == maxR {
+			res = i + 1
+			break
+		}
+	}
+	return fmt.Sprintf("%d\n", res)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	segs := make([]segment, n)
+	cover := rng.Intn(2) == 0
+	var coverL, coverR int64
+	if cover {
+		coverL = int64(rng.Intn(20) + 1)
+		coverR = coverL + int64(rng.Intn(10)+1)
+		segs[0] = segment{coverL, coverR}
+		for i := 1; i < n; i++ {
+			l := coverL + int64(rng.Intn(int(coverR-coverL+1)))
+			r := l + int64(rng.Intn(int(coverR-l+1)))
+			segs[i] = segment{l, r}
+		}
+	} else {
+		used := make(map[[2]int64]bool)
+		for i := 0; i < n; i++ {
+			for {
+				l := int64(rng.Intn(30) + 1)
+				r := l + int64(rng.Intn(10))
+				if !used[[2]int64{l, r}] {
+					segs[i] = segment{l, r}
+					used[[2]int64{l, r}] = true
+					break
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, s := range segs {
+		fmt.Fprintf(&sb, "%d %d\n", s.l, s.r)
+	}
+	return sb.String(), solveCase(segs)
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	if strings.TrimSpace(buf.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, buf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/242/verifierC.go
+++ b/0-999/200-299/240-249/242/verifierC.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type seg struct{ r, a, b int }
+
+type point struct{ x, y int }
+
+func solve(x0, y0, x1, y1 int, segs []seg) string {
+	allowed := make(map[point]bool)
+	for _, s := range segs {
+		for c := s.a; c <= s.b; c++ {
+			allowed[point{s.r, c}] = true
+		}
+	}
+	start := point{x0, y0}
+	goal := point{x1, y1}
+	dirs := [][2]int{{-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 1}, {1, -1}, {1, 0}, {1, 1}}
+	dist := map[point]int{start: 0}
+	q := []point{start}
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		if cur == goal {
+			return fmt.Sprintf("%d\n", dist[cur])
+		}
+		for _, d := range dirs {
+			nx, ny := cur.x+d[0], cur.y+d[1]
+			np := point{nx, ny}
+			if !allowed[np] {
+				continue
+			}
+			if _, ok := dist[np]; !ok {
+				dist[np] = dist[cur] + 1
+				q = append(q, np)
+			}
+		}
+	}
+	return "-1\n"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	rows := rng.Intn(4) + 2
+	cols := rng.Intn(4) + 2
+	n := rows
+	segs := make([]seg, 0, n)
+	allowed := make([]point, 0, rows*cols)
+	for i := 1; i <= rows; i++ {
+		a := rng.Intn(cols) + 1
+		b := a + rng.Intn(cols-a+1)
+		segs = append(segs, seg{i, a, b})
+		for c := a; c <= b; c++ {
+			allowed = append(allowed, point{i, c})
+		}
+	}
+	if len(allowed) < 2 {
+		return genCase(rng)
+	}
+	p1 := allowed[rng.Intn(len(allowed))]
+	p2 := allowed[rng.Intn(len(allowed))]
+	for p2 == p1 {
+		p2 = allowed[rng.Intn(len(allowed))]
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", p1.x, p1.y, p2.x, p2.y)
+	fmt.Fprintf(&sb, "%d\n", len(segs))
+	for _, s := range segs {
+		fmt.Fprintf(&sb, "%d %d %d\n", s.r, s.a, s.b)
+	}
+	out := solve(p1.x, p1.y, p2.x, p2.y, segs)
+	return sb.String(), out
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	if strings.TrimSpace(buf.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, buf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/242/verifierD.go
+++ b/0-999/200-299/240-249/242/verifierD.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func solve(n int, edges []edge, a []int) string {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	pt := make([]int, n)
+	queue := make([]int, 0, n)
+	res := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		if pt[i] == a[i] {
+			pt[i]++
+			queue = append(queue, i)
+			res = append(res, i)
+		}
+	}
+	for qi := 0; qi < len(queue); qi++ {
+		v := queue[qi]
+		for _, u := range adj[v] {
+			pt[u]++
+			if pt[u] == a[u] {
+				pt[u]++
+				queue = append(queue, u)
+				res = append(res, u)
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(res))
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	// generate simple undirected graph
+	possible := make([]edge, 0)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			possible = append(possible, edge{i, j})
+		}
+	}
+	m := rng.Intn(len(possible) + 1)
+	rng.Shuffle(len(possible), func(i, j int) { possible[i], possible[j] = possible[j], possible[i] })
+	edges := possible[:m]
+	a := make([]int, n)
+	deg := make([]int, n)
+	for _, e := range edges {
+		deg[e.u]++
+		deg[e.v]++
+	}
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(deg[i] + 1)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u+1, e.v+1)
+	}
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	out := solve(n, edges, a)
+	return sb.String(), out
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	if strings.TrimSpace(buf.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, buf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/240-249/242/verifierE.go
+++ b/0-999/200-299/240-249/242/verifierE.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n int, arr []int, ops [][]int) string {
+	a := make([]int, n)
+	copy(a, arr)
+	var sb strings.Builder
+	for _, op := range ops {
+		t := op[0]
+		l := op[1]
+		r := op[2]
+		if t == 1 {
+			sum := 0
+			for i := l - 1; i < r; i++ {
+				sum += a[i]
+			}
+			fmt.Fprintf(&sb, "%d\n", sum)
+		} else {
+			x := op[3]
+			for i := l - 1; i < r; i++ {
+				a[i] ^= x
+			}
+		}
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(20)
+	}
+	m := rng.Intn(10) + 1
+	ops := make([][]int, m)
+	for i := 0; i < m; i++ {
+		t := rng.Intn(2) + 1
+		l := rng.Intn(n) + 1
+		r := l + rng.Intn(n-l+1)
+		if t == 1 {
+			ops[i] = []int{t, l, r, 0}
+		} else {
+			x := rng.Intn(50) + 1
+			ops[i] = []int{t, l, r, x}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", m)
+	for _, op := range ops {
+		if op[0] == 1 {
+			fmt.Fprintf(&sb, "1 %d %d\n", op[1], op[2])
+		} else {
+			fmt.Fprintf(&sb, "2 %d %d %d\n", op[1], op[2], op[3])
+		}
+	}
+	out := solveCase(n, arr, ops)
+	return sb.String(), out
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	if strings.TrimSpace(buf.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, buf.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 242 problems A–E
- each verifier runs 100 random tests against a provided binary

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e98208e0483249423a5ee9194bbcd