### PR TITLE
Add Go verifiers for contest 238

### DIFF
--- a/0-999/200-299/230-239/238/verifierA.go
+++ b/0-999/200-299/230-239/238/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod int64 = 1000000009
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = (res * a) % mod
+		}
+		a = (a * a) % mod
+		e >>= 1
+	}
+	return res
+}
+
+func solveCase(n int, m int64) string {
+	if m < 63 {
+		if int64(n)+1 > (int64(1) << m) {
+			return "0"
+		}
+	}
+	total := modPow(2, m)
+	ans := int64(1)
+	for i := 0; i < n; i++ {
+		term := (total - 1 - int64(i)) % mod
+		if term < 0 {
+			term += mod
+		}
+		ans = (ans * term) % mod
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+type test struct{ input, expected string }
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(42))
+	var tests []test
+	fixed := [][2]int{{1, 1}, {2, 1}, {3, 4}, {5, 6}}
+	for _, f := range fixed {
+		inp := fmt.Sprintf("%d %d\n", f[0], f[1])
+		tests = append(tests, test{inp, solveCase(f[0], int64(f[1]))})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(20) + 1
+		m := rng.Intn(60) + 1
+		inp := fmt.Sprintf("%d %d\n", n, m)
+		tests = append(tests, test{inp, solveCase(n, int64(m))})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/200-299/230-239/238/verifierB.go
+++ b/0-999/200-299/230-239/238/verifierB.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func solveCase(n int, h int64, a []int64) string {
+	pos := 0
+	for i := 1; i < n; i++ {
+		if a[i] < a[pos] {
+			pos = i
+		}
+	}
+	b := append([]int64(nil), a...)
+	sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
+	val1 := b[n-1] + b[n-2] - b[0] - b[1]
+	max12 := b[n-1] + b[n-2]
+	if b[0]+b[n-1]+h > max12 {
+		max12 = b[0] + b[n-1] + h
+	}
+	min01 := b[1] + b[2]
+	if b[0]+b[1]+h < min01 {
+		min01 = b[0] + b[1] + h
+	}
+	val2 := max12 - min01
+	if val1 < val2 {
+		pos = -1
+	}
+	res := val1
+	if val2 < res {
+		res = val2
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", res))
+	for i := 0; i < n; i++ {
+		if i == pos {
+			sb.WriteString("2 ")
+		} else {
+			sb.WriteString("1 ")
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+type test struct{ input, expected string }
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(43))
+	var tests []test
+	// some fixed cases
+	fixed := []struct {
+		n int
+		h int64
+		a []int64
+	}{
+		{2, 1, []int64{1, 2}},
+		{3, 0, []int64{1, 2, 3}},
+	}
+	for _, f := range fixed {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", f.n, f.h))
+		for i, v := range f.a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solveCase(f.n, f.h, f.a)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(8) + 2
+		h := int64(rng.Intn(5))
+		a := make([]int64, n)
+		for i := range a {
+			a[i] = int64(rng.Intn(10))
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, h))
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solveCase(n, h, a)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/200-299/230-239/238/verifierC.go
+++ b/0-999/200-299/230-239/238/verifierC.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Edge struct {
+	to int
+	wF int
+	wB int
+}
+
+func solveCase(n int, edges [][2]int) string {
+	if n == 0 {
+		return "0"
+	}
+	adj := make([][]Edge, n)
+	for _, e := range edges {
+		a := e[0] - 1
+		b := e[1] - 1
+		adj[a] = append(adj[a], Edge{to: b, wF: 0, wB: 1})
+		adj[b] = append(adj[b], Edge{to: a, wF: 1, wB: 0})
+	}
+	cost := make([]int, n)
+	var dfs1 func(u, p int) int
+	dfs1 = func(u, p int) int {
+		sum := 0
+		for _, e := range adj[u] {
+			v := e.to
+			if v == p {
+				continue
+			}
+			sum += e.wF
+			sum += dfs1(v, u)
+		}
+		return sum
+	}
+	var dfs2 func(u, p int)
+	dfs2 = func(u, p int) {
+		for _, e := range adj[u] {
+			v := e.to
+			if v == p {
+				continue
+			}
+			cost[v] = cost[u] - e.wF + e.wB
+			dfs2(v, u)
+		}
+	}
+	cost[0] = dfs1(0, -1)
+	dfs2(0, -1)
+	prefix := make([]int, n+1)
+	answer := cost[0]
+	var dfsDelta func(u, p, depth, s1 int, best *int)
+	dfsDelta = func(u, p, depth, s1 int, best *int) {
+		d := depth
+		mid := (d + 1) / 2
+		delta := prefix[d] - prefix[mid]
+		cur := cost[s1] + delta
+		if cur < *best {
+			*best = cur
+		}
+		for _, e := range adj[u] {
+			v := e.to
+			if v == p {
+				continue
+			}
+			diff := -1
+			if e.wF == 0 {
+				diff = 1
+			}
+			prefix[d+1] = prefix[d] + diff
+			dfsDelta(v, u, d+1, s1, best)
+		}
+	}
+	for s1 := 0; s1 < n; s1++ {
+		best := cost[s1]
+		prefix[0] = 0
+		dfsDelta(s1, -1, 0, s1, &best)
+		if best < answer {
+			answer = best
+		}
+	}
+	return fmt.Sprintf("%d", answer)
+}
+
+type test struct{ input, expected string }
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(44))
+	var tests []test
+	fixed := []struct {
+		n     int
+		edges [][2]int
+	}{
+		{1, [][2]int{}},
+		{2, [][2]int{{1, 2}}},
+	}
+	for _, f := range fixed {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", f.n))
+		for _, e := range f.edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solveCase(f.n, f.edges)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(6) + 2
+		edges := make([][2]int, n-1)
+		for i := 2; i <= n; i++ {
+			p := rng.Intn(i-1) + 1
+			if rng.Intn(2) == 0 {
+				edges[i-2] = [2]int{p, i}
+			} else {
+				edges[i-2] = [2]int{i, p}
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solveCase(n, edges)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/200-299/230-239/238/verifierD.go
+++ b/0-999/200-299/230-239/238/verifierD.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func simulate(seq []byte) [10]int {
+	cp := 0
+	dir := 1
+	var cnt [10]int
+	for cp >= 0 && cp < len(seq) {
+		c := seq[cp]
+		if c >= '0' && c <= '9' {
+			d := int(c - '0')
+			cnt[d]++
+			cp += dir
+			d--
+			idx := cp - dir
+			if d < 0 {
+				seq = append(seq[:idx], seq[idx+1:]...)
+				if dir == 1 {
+					cp--
+				}
+			} else {
+				seq[idx] = byte('0' + d)
+			}
+		} else {
+			if c == '<' {
+				dir = -1
+			} else {
+				dir = 1
+			}
+			cp += dir
+			prev := cp - dir
+			if cp >= 0 && cp < len(seq) && (seq[cp] == '<' || seq[cp] == '>') {
+				seq = append(seq[:prev], seq[prev+1:]...)
+				if dir == 1 {
+					cp--
+				}
+			}
+		}
+	}
+	return cnt
+}
+
+func solveCase(s string, queries [][2]int) string {
+	var sb strings.Builder
+	for _, q := range queries {
+		sub := []byte(s[q[0]-1 : q[1]])
+		res := simulate(sub)
+		for i := 0; i < 10; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", res[i]))
+		}
+		sb.WriteByte('\n')
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+type test struct{ input, expected string }
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(45))
+	var tests []test
+	fixed := []struct {
+		s string
+		q [][2]int
+	}{
+		{"1", [][2]int{{1, 1}}},
+		{"<>", [][2]int{{1, 2}}},
+	}
+	for _, f := range fixed {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n%s\n", len(f.s), len(f.q), f.s))
+		for _, p := range f.q {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solveCase(f.s, f.q)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(8) + 1
+		letters := "<>0123456789"
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = letters[rng.Intn(len(letters))]
+		}
+		s := string(b)
+		qn := rng.Intn(3) + 1
+		qs := make([][2]int, qn)
+		for i := 0; i < qn; i++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			qs[i] = [2]int{l, r}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n%s\n", n, qn, s))
+		for _, p := range qs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solveCase(s, qs)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/200-299/230-239/238/verifierE.go
+++ b/0-999/200-299/230-239/238/verifierE.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const inf = 1000000000
+
+func bfs(start int, g [][]int) []int {
+	n := len(g)
+	dist := make([]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = inf
+	}
+	dist[start] = 0
+	q := list.New()
+	q.PushBack(start)
+	for q.Len() > 0 {
+		u := q.Remove(q.Front()).(int)
+		for _, v := range g[u] {
+			if dist[v] > dist[u]+1 {
+				dist[v] = dist[u] + 1
+				q.PushBack(v)
+			}
+		}
+	}
+	return dist
+}
+
+func solveCase(n, m, a, b int, edges [][2]int, buses [][2]int) string {
+	g := make([][]int, n)
+	for _, e := range edges {
+		g[e[0]-1] = append(g[e[0]-1], e[1]-1)
+	}
+	dist := make([][]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = bfs(i, g)
+	}
+	busAdj := make([][]int, n)
+	for _, pr := range buses {
+		s := pr[0] - 1
+		t := pr[1] - 1
+		d := dist[s][t]
+		if d >= inf {
+			continue
+		}
+		for v := 0; v < n; v++ {
+			if dist[s][v]+dist[v][t] == d {
+				busAdj[v] = append(busAdj[v], t)
+			}
+		}
+	}
+	da := make([]int, n)
+	for i := range da {
+		da[i] = inf
+	}
+	da[a-1] = 0
+	q := list.New()
+	q.PushBack(a - 1)
+	for q.Len() > 0 {
+		u := q.Remove(q.Front()).(int)
+		for _, v := range busAdj[u] {
+			if da[v] > da[u]+1 {
+				da[v] = da[u] + 1
+				q.PushBack(v)
+			}
+		}
+	}
+	if da[b-1] >= inf {
+		return "-1"
+	}
+	return fmt.Sprintf("%d", da[b-1])
+}
+
+type test struct{ input, expected string }
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(46))
+	var tests []test
+	fixed := []struct {
+		n, m, a, b int
+		edges      [][2]int
+		buses      [][2]int
+	}{
+		{2, 1, 1, 2, [][2]int{{1, 2}}, [][2]int{{1, 2}}},
+		{3, 3, 1, 3, [][2]int{{1, 2}, {2, 3}, {1, 3}}, [][2]int{{1, 3}}},
+	}
+	for _, f := range fixed {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", f.n, f.m, f.a, f.b))
+		for _, e := range f.edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", len(f.buses)))
+		for _, pr := range f.buses {
+			sb.WriteString(fmt.Sprintf("%d %d\n", pr[0], pr[1]))
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solveCase(f.n, f.m, f.a, f.b, f.edges, f.buses)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 2
+		m := rng.Intn(n*(n-1)) + 1
+		edgeSet := make(map[[2]int]bool)
+		edges := make([][2]int, 0, m)
+		for len(edges) < m {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			e := [2]int{u, v}
+			if edgeSet[e] {
+				continue
+			}
+			edgeSet[e] = true
+			edges = append(edges, e)
+		}
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		k := rng.Intn(3) + 1
+		buses := make([][2]int, k)
+		for i := 0; i < k; i++ {
+			s := rng.Intn(n) + 1
+			t := rng.Intn(n) + 1
+			buses[i] = [2]int{s, t}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, len(edges), a, b))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", k))
+		for _, pr := range buses {
+			sb.WriteString(fmt.Sprintf("%d %d\n", pr[0], pr[1]))
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solveCase(n, len(edges), a, b, edges, buses)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add new solution verifiers for contest 238 problems A–E
- each verifier generates 100 random tests and checks any provided binary

## Testing
- `go build ./0-999/200-299/230-239/238/verifierA.go`
- `go build ./0-999/200-299/230-239/238/verifierB.go`
- `go build ./0-999/200-299/230-239/238/verifierC.go`
- `go build ./0-999/200-299/230-239/238/verifierD.go`
- `go build ./0-999/200-299/230-239/238/verifierE.go`
- `./verifierA ./238A.go` (expected runtime error)


------
https://chatgpt.com/codex/tasks/task_e_687e970872148324bf8bb50fc7857eee