### PR TITLE
Add solution verifiers for CF 237

### DIFF
--- a/0-999/200-299/230-239/237/verifierA.go
+++ b/0-999/200-299/230-239/237/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 1
+	counts := make(map[[2]int]int)
+	maxC := 0
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		h := rng.Intn(24)
+		m := rng.Intn(60)
+		sb.WriteString(fmt.Sprintf("%d %d\n", h, m))
+		key := [2]int{h, m}
+		counts[key]++
+		if counts[key] > maxC {
+			maxC = counts[key]
+		}
+	}
+	return testCase{input: sb.String(), expected: maxC}
+}
+
+func runCase(bin string, tc testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	// deterministic simple cases
+	cases = append(cases, testCase{input: "1\n0 0\n", expected: 1})
+	cases = append(cases, testCase{input: "3\n1 2\n1 2\n1 3\n", expected: 2})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/230-239/237/verifierB.go
+++ b/0-999/200-299/230-239/237/verifierB.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input   string
+	c       []int
+	initial [][]int
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	c := make([]int, n)
+	c[0] = rng.Intn(4) + 1
+	for i := 1; i < n; i++ {
+		c[i] = rng.Intn(c[i-1]) + 1
+	}
+	s := 0
+	for _, v := range c {
+		s += v
+	}
+	nums := rng.Perm(s)
+	arr := make([][]int, n)
+	idx := 0
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		arr[i] = make([]int, c[i])
+		for j := 0; j < c[i]; j++ {
+			val := nums[idx] + 1
+			idx++
+			arr[i][j] = val
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", val))
+		}
+		sb.WriteByte('\n')
+	}
+	return testCase{input: sb.String(), c: c, initial: arr}
+}
+
+func runCase(bin string, tc testCase) error {
+	// make copy
+	arr := make([][]int, len(tc.initial))
+	for i := range arr {
+		arr[i] = append([]int(nil), tc.initial[i]...)
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return fmt.Errorf("missing number of swaps")
+	}
+	m, err := strconv.Atoi(scanner.Text())
+	if err != nil {
+		return fmt.Errorf("invalid number of swaps")
+	}
+	s := 0
+	for _, v := range tc.c {
+		s += v
+	}
+	if m < 0 || m > s {
+		return fmt.Errorf("invalid swaps count")
+	}
+	for i := 0; i < m; i++ {
+		vals := make([]int, 4)
+		for j := 0; j < 4; j++ {
+			if !scanner.Scan() {
+				return fmt.Errorf("not enough values for swap %d", i+1)
+			}
+			v, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				return fmt.Errorf("invalid integer in swap")
+			}
+			vals[j] = v
+		}
+		x, y, p, q := vals[0]-1, vals[1]-1, vals[2]-1, vals[3]-1
+		if x < 0 || x >= len(arr) || p < 0 || p >= len(arr) ||
+			y < 0 || y >= len(arr[x]) || q < 0 || q >= len(arr[p]) {
+			return fmt.Errorf("indices out of range")
+		}
+		arr[x][y], arr[p][q] = arr[p][q], arr[x][y]
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	// verify numbers
+	seen := make(map[int]bool)
+	total := 0
+	for i := range arr {
+		for j := range arr[i] {
+			val := arr[i][j]
+			if val <= 0 || val > s {
+				return fmt.Errorf("invalid value")
+			}
+			if seen[val] {
+				return fmt.Errorf("duplicate value")
+			}
+			seen[val] = true
+			total++
+		}
+	}
+	if total != s {
+		return fmt.Errorf("missing values")
+	}
+	// row condition
+	for i := range arr {
+		for j := 1; j < len(arr[i]); j++ {
+			if arr[i][j] <= arr[i][j-1] {
+				return fmt.Errorf("row not strictly increasing")
+			}
+		}
+	}
+	// column condition
+	for i := 1; i < len(arr); i++ {
+		for j := 0; j < len(arr[i]); j++ {
+			if arr[i][j] <= arr[i-1][j] {
+				return fmt.Errorf("column not strictly increasing")
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	// simple deterministic case
+	cases = append(cases, generateCase(rand.New(rand.NewSource(1))))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/230-239/237/verifierC.go
+++ b/0-999/200-299/230-239/237/verifierC.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int
+}
+
+func isPrimeSieve(limit int) []bool {
+	isPrime := make([]bool, limit+1)
+	for i := 2; i <= limit; i++ {
+		isPrime[i] = true
+	}
+	for i := 2; i*i <= limit; i++ {
+		if isPrime[i] {
+			for j := i * i; j <= limit; j += i {
+				isPrime[j] = false
+			}
+		}
+	}
+	return isPrime
+}
+
+func prefixPrimes(isPrime []bool) []int {
+	pre := make([]int, len(isPrime))
+	for i := 1; i < len(isPrime); i++ {
+		pre[i] = pre[i-1]
+		if isPrime[i] {
+			pre[i]++
+		}
+	}
+	return pre
+}
+
+func ok(a, b, k, l int, pre []int) bool {
+	for x := a; x <= b-l+1; x++ {
+		cnt := pre[x+l-1] - pre[x-1]
+		if cnt < k {
+			return false
+		}
+	}
+	return true
+}
+
+func solve(a, b, k int) int {
+	n := b - a + 1
+	isPrime := isPrimeSieve(b)
+	pre := prefixPrimes(isPrime)
+	lo, hi := k, n
+	ans := -1
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		if ok(a, b, k, mid, pre) {
+			ans = mid
+			hi = mid - 1
+		} else {
+			lo = mid + 1
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	a := rng.Intn(1000) + 1
+	b := a + rng.Intn(1000)
+	k := rng.Intn(b-a+1) + 1
+	l := solve(a, b, k)
+	input := fmt.Sprintf("%d %d %d\n", a, b, k)
+	return testCase{input: input, expected: l}
+}
+
+func runCase(bin string, tc testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, testCase{input: "1 1 1\n", expected: 1})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/230-239/237/verifierD.go
+++ b/0-999/200-299/230-239/237/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solve(n int, edges [][2]int) string {
+	c := make([]int, n+1)
+	for i, e := range edges {
+		x, y := e[0], e[1]
+		if c[x] == 0 {
+			c[x] = i + 1
+		}
+		if c[y] == 0 {
+			c[y] = i + 1
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("2 %d %d\n", e[0], e[1]))
+	}
+	for i, e := range edges {
+		u, v := e[0], e[1]
+		idx := i + 1
+		if idx != c[u] {
+			sb.WriteString(fmt.Sprintf("%d %d\n", idx, c[u]))
+		}
+		if idx != c[v] {
+			sb.WriteString(fmt.Sprintf("%d %d\n", idx, c[v]))
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 2
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	exp := solve(n, edges)
+	return testCase{input: sb.String(), expected: exp}
+}
+
+func runCase(bin string, tc testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(tc.expected)
+	if got != expect {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, generateCase(rand.New(rand.NewSource(1))))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/230-239/237/verifierE.go
+++ b/0-999/200-299/230-239/237/verifierE.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to, rev, cap int
+	cost         int
+}
+
+type Graph [][]*Edge
+
+func (g Graph) AddEdge(u, v, cap, cost int) {
+	g[u] = append(g[u], &Edge{to: v, rev: len(g[v]), cap: cap, cost: cost})
+	g[v] = append(g[v], &Edge{to: u, rev: len(g[u]) - 1, cap: 0, cost: -cost})
+}
+
+type Item struct {
+	v    int
+	dist int
+}
+
+type PriorityQueue []Item
+
+func (pq PriorityQueue) Len() int            { return len(pq) }
+func (pq PriorityQueue) Less(i, j int) bool  { return pq[i].dist < pq[j].dist }
+func (pq PriorityQueue) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PriorityQueue) Push(x interface{}) { *pq = append(*pq, x.(Item)) }
+func (pq *PriorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	it := old[n-1]
+	*pq = old[0 : n-1]
+	return it
+}
+
+func minCostFlow(g Graph, s, t, maxf int) (int, int) {
+	n := len(g)
+	h := make([]int, n)
+	prevv := make([]int, n)
+	preve := make([]int, n)
+	flow, cost := 0, 0
+	const INF = int(1 << 60)
+	for flow < maxf {
+		dist := make([]int, n)
+		for i := range dist {
+			dist[i] = INF
+		}
+		dist[s] = 0
+		pq := &PriorityQueue{}
+		heap.Init(pq)
+		heap.Push(pq, Item{v: s, dist: 0})
+		for pq.Len() > 0 {
+			it := heap.Pop(pq).(Item)
+			v := it.v
+			if dist[v] < it.dist {
+				continue
+			}
+			for i, e := range g[v] {
+				if e.cap > 0 && dist[e.to] > dist[v]+e.cost+h[v]-h[e.to] {
+					dist[e.to] = dist[v] + e.cost + h[v] - h[e.to]
+					prevv[e.to] = v
+					preve[e.to] = i
+					heap.Push(pq, Item{v: e.to, dist: dist[e.to]})
+				}
+			}
+		}
+		if dist[t] == INF {
+			break
+		}
+		for v := 0; v < n; v++ {
+			if dist[v] < INF {
+				h[v] += dist[v]
+			}
+		}
+		d := maxf - flow
+		for v := t; v != s; v = prevv[v] {
+			e := g[prevv[v]][preve[v]]
+			if d > e.cap {
+				d = e.cap
+			}
+		}
+		flow += d
+		cost += d * h[t]
+		for v := t; v != s; v = prevv[v] {
+			e := g[prevv[v]][preve[v]]
+			e.cap -= d
+			g[v][e.rev].cap += d
+		}
+	}
+	return flow, cost
+}
+
+type strCase struct {
+	s string
+	a int
+}
+
+type testCase struct {
+	input    string
+	expected int
+}
+
+func solve(t string, arr []strCase) int {
+	m := len(t)
+	freqT := make([]int, 26)
+	for i := 0; i < m; i++ {
+		freqT[t[i]-'a']++
+	}
+	s := 0
+	charBase := 1
+	strBase := charBase + 26
+	sink := strBase + len(arr)
+	V := sink + 1
+	g := make(Graph, V)
+	for c := 0; c < 26; c++ {
+		if freqT[c] > 0 {
+			g.AddEdge(s, charBase+c, freqT[c], 0)
+		}
+	}
+	for i, item := range arr {
+		freqS := make([]int, 26)
+		for j := 0; j < len(item.s); j++ {
+			freqS[item.s[j]-'a']++
+		}
+		for c := 0; c < 26; c++ {
+			if freqS[c] > 0 {
+				g.AddEdge(charBase+c, strBase+i, freqS[c], i+1)
+			}
+		}
+		if item.a > 0 {
+			g.AddEdge(strBase+i, sink, item.a, 0)
+		}
+	}
+	if m == 0 {
+		return 0
+	}
+	flow, cost := minCostFlow(g, s, sink, m)
+	if flow < m {
+		return -1
+	}
+	return cost
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	tlen := rng.Intn(5) + 1
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	tb := make([]rune, tlen)
+	for i := range tb {
+		tb[i] = letters[rng.Intn(26)]
+	}
+	t := string(tb)
+	n := rng.Intn(4) + 1
+	arr := make([]strCase, n)
+	var sb strings.Builder
+	sb.WriteString(t)
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		slen := rng.Intn(5) + 1
+		sbuf := make([]rune, slen)
+		for j := range sbuf {
+			sbuf[j] = letters[rng.Intn(26)]
+		}
+		arr[i].s = string(sbuf)
+		arr[i].a = rng.Intn(slen + 1)
+		sb.WriteString(fmt.Sprintf("%s %d\n", arr[i].s, arr[i].a))
+	}
+	expect := solve(t, arr)
+	return testCase{input: sb.String(), expected: expect}
+}
+
+func runCase(bin string, tc testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, generateCase(rand.New(rand.NewSource(1))))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for contest 237 problems A–E
- each verifier generates over 100 test cases and checks a given binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e96c26bcc8324a602e6ea39bbecb1