### PR TITLE
Add Go verifiers for contest 234

### DIFF
--- a/0-999/200-299/230-239/234/verifierA.go
+++ b/0-999/200-299/230-239/234/verifierA.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+type testA struct {
+    n int
+    s string
+}
+
+func genTestsA() []testA {
+    rng := rand.New(rand.NewSource(42))
+    tests := make([]testA, 100)
+    for i := range tests {
+        n := rng.Intn(49)*2 + 4 // even between 4 and 100
+        b := make([]byte, n)
+        for j := range b {
+            if rng.Intn(2) == 0 {
+                b[j] = 'L'
+            } else {
+                b[j] = 'R'
+            }
+        }
+        tests[i] = testA{n: n, s: string(b)}
+    }
+    return tests
+}
+
+func run(bin string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return out.String(), nil
+}
+
+func checkOutputA(tc testA, out string) error {
+    scanner := bufio.NewScanner(strings.NewReader(out))
+    scanner.Split(bufio.ScanWords)
+    used := make([]bool, tc.n+1)
+    pairs := 0
+    for pairs < tc.n/2 {
+        if !scanner.Scan() {
+            return fmt.Errorf("insufficient output")
+        }
+        aStr := scanner.Text()
+        if !scanner.Scan() {
+            return fmt.Errorf("insufficient output")
+        }
+        bStr := scanner.Text()
+        a, err := strconv.Atoi(aStr)
+        if err != nil {
+            return fmt.Errorf("invalid integer %s", aStr)
+        }
+        b, err := strconv.Atoi(bStr)
+        if err != nil {
+            return fmt.Errorf("invalid integer %s", bStr)
+        }
+        if a < 1 || a > tc.n || b < 1 || b > tc.n {
+            return fmt.Errorf("index out of range")
+        }
+        if used[a] || used[b] || a == b {
+            return fmt.Errorf("student repeated")
+        }
+        if abs(a-b) == 1 {
+            return fmt.Errorf("adjacent students together")
+        }
+        if tc.s[a-1] == 'R' && tc.s[b-1] == 'L' {
+            return fmt.Errorf("hand conflict")
+        }
+        used[a] = true
+        used[b] = true
+        pairs++
+    }
+    if scanner.Scan() {
+        return fmt.Errorf("extra output")
+    }
+    for i := 1; i <= tc.n; i++ {
+        if !used[i] {
+            return fmt.Errorf("student %d missing", i)
+        }
+    }
+    return nil
+}
+
+func abs(x int) int { if x < 0 { return -x }; return x }
+
+func runCase(bin string, tc testA) error {
+    input := fmt.Sprintf("%d\n%s\n", tc.n, tc.s)
+    out, err := run(bin, input)
+    if err != nil { return err }
+    return checkOutputA(tc, out)
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsA()
+    for i, tc := range tests {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%v %s\n", i+1, err, tc.n, tc.s)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed\n", len(tests))
+}
+

--- a/0-999/200-299/230-239/234/verifierB.go
+++ b/0-999/200-299/230-239/234/verifierB.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strconv"
+    "strings"
+)
+
+type testB struct {
+    n int
+    k int
+    a []int
+}
+
+func genTestsB() []testB {
+    rng := rand.New(rand.NewSource(43))
+    tests := make([]testB, 100)
+    for i := range tests {
+        n := rng.Intn(50) + 1
+        k := rng.Intn(n) + 1
+        arr := make([]int, n)
+        for j := range arr {
+            arr[j] = rng.Intn(101)
+        }
+        tests[i] = testB{n: n, k: k, a: arr}
+    }
+    return tests
+}
+
+func kthLargest(a []int, k int) int {
+    b := append([]int(nil), a...)
+    sort.Ints(b)
+    return b[len(b)-k]
+}
+
+func run(bin string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return out.String(), nil
+}
+
+func runCase(bin string, tc testB) error {
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+    for i, v := range tc.a {
+        if i > 0 { sb.WriteByte(' ') }
+        sb.WriteString(strconv.Itoa(v))
+    }
+    sb.WriteByte('\n')
+    out, err := run(bin, sb.String())
+    if err != nil { return err }
+    scanner := bufio.NewScanner(strings.NewReader(out))
+    scanner.Split(bufio.ScanWords)
+    if !scanner.Scan() { return fmt.Errorf("missing threshold") }
+    threshStr := scanner.Text()
+    t, err := strconv.Atoi(threshStr)
+    if err != nil { return fmt.Errorf("bad threshold") }
+    indices := make([]int, 0, tc.k)
+    for i := 0; i < tc.k; i++ {
+        if !scanner.Scan() { return fmt.Errorf("missing index") }
+        v, err := strconv.Atoi(scanner.Text())
+        if err != nil { return fmt.Errorf("bad index") }
+        indices = append(indices, v)
+    }
+    if scanner.Scan() { return fmt.Errorf("extra output") }
+    seen := make(map[int]bool)
+    minVal := 101
+    for _, idx := range indices {
+        if idx < 1 || idx > tc.n { return fmt.Errorf("index out of range") }
+        if seen[idx] { return fmt.Errorf("duplicate index") }
+        seen[idx] = true
+        val := tc.a[idx-1]
+        if val < minVal { minVal = val }
+    }
+    if minVal != t { return fmt.Errorf("reported threshold mismatch") }
+    if t != kthLargest(tc.a, tc.k) { return fmt.Errorf("threshold not optimal") }
+    if len(indices) != tc.k { return fmt.Errorf("incorrect number of indices") }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsB()
+    for i, tc := range tests {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed\n", len(tests))
+}
+

--- a/0-999/200-299/230-239/234/verifierC.go
+++ b/0-999/200-299/230-239/234/verifierC.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+type testC struct {
+    n int
+    t []int
+}
+
+func genTestsC() []testC {
+    rng := rand.New(rand.NewSource(44))
+    tests := make([]testC, 100)
+    for i := range tests {
+        n := rng.Intn(20) + 2
+        arr := make([]int, n)
+        for j := range arr {
+            v := rng.Intn(21) - 10
+            if v >= 0 {
+                v++
+            }
+            arr[j] = v
+        }
+        tests[i] = testC{n: n, t: arr}
+    }
+    return tests
+}
+
+func solveC(tc testC) int {
+    n := tc.n
+    t := tc.t
+    prefix := make([]int, n+1)
+    for i := 1; i <= n; i++ {
+        prefix[i] = prefix[i-1]
+        if t[i-1] >= 0 {
+            prefix[i]++
+        }
+    }
+    suffix := make([]int, n+2)
+    for i := n; i >= 1; i-- {
+        suffix[i] = suffix[i+1]
+        if t[i-1] <= 0 {
+            suffix[i]++
+        }
+    }
+    ans := n
+    for k := 1; k <= n-1; k++ {
+        cost := prefix[k] + suffix[k+1]
+        if cost < ans {
+            ans = cost
+        }
+    }
+    return ans
+}
+
+func run(bin string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return out.String(), nil
+}
+
+func runCase(bin string, tc testC) error {
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+    for i, v := range tc.t {
+        if i > 0 { sb.WriteByte(' ') }
+        sb.WriteString(strconv.Itoa(v))
+    }
+    sb.WriteByte('\n')
+    out, err := run(bin, sb.String())
+    if err != nil { return err }
+    expected := solveC(tc)
+    valStr := strings.TrimSpace(out)
+    val, err := strconv.Atoi(valStr)
+    if err != nil { return fmt.Errorf("invalid output") }
+    if val != expected { return fmt.Errorf("expected %d got %d", expected, val) }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsC()
+    for i, tc := range tests {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed\n", len(tests))
+}
+

--- a/0-999/200-299/230-239/234/verifierD.go
+++ b/0-999/200-299/230-239/234/verifierD.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+type movie struct {
+    title string
+    actors []int
+}
+
+type testD struct {
+    m int
+    fav []int
+    movies []movie
+}
+
+func genTestsD() []testD {
+    rng := rand.New(rand.NewSource(45))
+    tests := make([]testD, 100)
+    for i := range tests {
+        m := rng.Intn(10) + 1
+        k := rng.Intn(m) + 1
+        fav := rng.Perm(m)[:k]
+        for j := range fav { fav[j] += 1 }
+        n := rng.Intn(5) + 1
+        movies := make([]movie, n)
+        for j := 0; j < n; j++ {
+            d := rng.Intn(m) + 1
+            used := make(map[int]bool)
+            actors := make([]int, d)
+            for x := 0; x < d; x++ {
+                if rng.Intn(3) == 0 {
+                    actors[x] = 0
+                } else {
+                    for {
+                        v := rng.Intn(m) + 1
+                        if !used[v] {
+                            used[v] = true
+                            actors[x] = v
+                            break
+                        }
+                    }
+                }
+            }
+            movies[j] = movie{title: fmt.Sprintf("mv%d_%d", i, j), actors: actors}
+        }
+        tests[i] = testD{m: m, fav: fav, movies: movies}
+    }
+    return tests
+}
+
+func solveD(tc testD) []int {
+    m := tc.m
+    k := len(tc.fav)
+    fav := make([]bool, m+1)
+    for _, x := range tc.fav {
+        fav[x] = true
+    }
+    n := len(tc.movies)
+    minFav := make([]int, n)
+    maxFav := make([]int, n)
+    for i, mv := range tc.movies {
+        knownFav := 0
+        knownNonFav := 0
+        zeros := 0
+        for _, b := range mv.actors {
+            if b == 0 {
+                zeros++
+            } else if fav[b] {
+                knownFav++
+            } else {
+                knownNonFav++
+            }
+        }
+        availableNonFav := (m - k) - knownNonFav
+        extraMin := 0
+        if zeros > availableNonFav {
+            extraMin = zeros - availableNonFav
+        }
+        minFav[i] = knownFav + extraMin
+        availableFav := k - knownFav
+        extraMax := zeros
+        if extraMax > availableFav {
+            extraMax = availableFav
+        }
+        maxFav[i] = knownFav + extraMax
+    }
+    res := make([]int, n)
+    for i := 0; i < n; i++ {
+        isSureFav := true
+        isSureNotFav := false
+        for j := 0; j < n; j++ {
+            if i == j { continue }
+            if maxFav[j] > minFav[i] {
+                isSureFav = false
+            }
+            if minFav[j] > maxFav[i] {
+                isSureNotFav = true
+            }
+        }
+        if isSureFav {
+            res[i] = 0
+        } else if isSureNotFav {
+            res[i] = 1
+        } else {
+            res[i] = 2
+        }
+    }
+    return res
+}
+
+func run(bin string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return out.String(), nil
+}
+
+func runCase(bin string, tc testD) error {
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d\n", tc.m, len(tc.fav)))
+    for i, v := range tc.fav {
+        if i > 0 { sb.WriteByte(' ') }
+        sb.WriteString(strconv.Itoa(v))
+    }
+    sb.WriteByte('\n')
+    sb.WriteString(fmt.Sprintf("%d\n", len(tc.movies)))
+    for _, mv := range tc.movies {
+        sb.WriteString(fmt.Sprintf("%s\n", mv.title))
+        sb.WriteString(fmt.Sprintf("%d\n", len(mv.actors)))
+        for i, v := range mv.actors {
+            if i > 0 { sb.WriteByte(' ') }
+            sb.WriteString(strconv.Itoa(v))
+        }
+        sb.WriteByte('\n')
+    }
+    out, err := run(bin, sb.String())
+    if err != nil { return err }
+    expected := solveD(tc)
+    scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(out)))
+    for _, exp := range expected {
+        if !scanner.Scan() { return fmt.Errorf("missing output line") }
+        val, err := strconv.Atoi(strings.TrimSpace(scanner.Text()))
+        if err != nil { return fmt.Errorf("bad integer") }
+        if val != exp { return fmt.Errorf("expected %d got %d", exp, val) }
+    }
+    if scanner.Scan() { return fmt.Errorf("extra output") }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsD()
+    for i, tc := range tests {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed\n", len(tests))
+}
+

--- a/0-999/200-299/230-239/234/verifierE.go
+++ b/0-999/200-299/230-239/234/verifierE.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+)
+
+type team struct {
+    name   string
+    rating int
+}
+
+type testE struct {
+    n int
+    x int
+    a int
+    b int
+    c int
+    teams []team
+}
+
+func genTestsE() []testE {
+    rng := rand.New(rand.NewSource(46))
+    tests := make([]testE, 100)
+    for i := range tests {
+        m := (rng.Intn(3)+1)*4 // 4,8,12,16
+        x := rng.Intn(100) + 1
+        a := rng.Intn(100) + 1
+        b := rng.Intn(100) + 1
+        c := rng.Intn(100) + 1
+        teams := make([]team, m)
+        ratings := rng.Perm(m*5 + 50)
+        for j := 0; j < m; j++ {
+            teams[j] = team{fmt.Sprintf("T%d_%d", i, j), ratings[j]}
+        }
+        tests[i] = testE{n: m, x: x, a: a, b: b, c: c, teams: teams}
+    }
+    return tests
+}
+
+func solveE(tc testE) [][]string {
+    x := tc.x
+    a := tc.a
+    b := tc.b
+    c := tc.c
+    n := tc.n
+    teams := append([]team(nil), tc.teams...)
+    sort.Slice(teams, func(i, j int) bool { return teams[i].rating > teams[j].rating })
+    m := n / 4
+    baskets := make([][]team, 4)
+    for i := 0; i < 4; i++ {
+        baskets[i] = append([]team(nil), teams[i*m:(i+1)*m]...)
+    }
+    rng := func() int { x = (x*a + b) % c; return x }
+    groups := make([][]team, m)
+    for gi := 0; gi < m-1; gi++ {
+        var group []team
+        for bi := 0; bi < 4; bi++ {
+            k := rng()
+            idx := k % len(baskets[bi])
+            group = append(group, baskets[bi][idx])
+            baskets[bi] = append(baskets[bi][:idx], baskets[bi][idx+1:]...)
+        }
+        sort.Slice(group, func(i, j int) bool { return group[i].rating > group[j].rating })
+        groups[gi] = group
+    }
+    var last []team
+    for bi := 0; bi < 4; bi++ {
+        last = append(last, baskets[bi][0])
+    }
+    sort.Slice(last, func(i, j int) bool { return last[i].rating > last[j].rating })
+    groups[m-1] = last
+    res := make([][]string, m)
+    for i, g := range groups {
+        names := make([]string, len(g))
+        for j, t := range g {
+            names[j] = t.name
+        }
+        res[i] = names
+    }
+    return res
+}
+
+func run(bin string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return out.String(), nil
+}
+
+func runCase(bin string, tc testE) error {
+    var sb strings.Builder
+    fmt.Fprintf(&sb, "%d\n%d %d %d %d\n", tc.n, tc.x, tc.a, tc.b, tc.c)
+    for _, t := range tc.teams {
+        fmt.Fprintf(&sb, "%s %d\n", t.name, t.rating)
+    }
+    out, err := run(bin, sb.String())
+    if err != nil { return err }
+    expected := solveE(tc)
+    scanner := bufio.NewScanner(strings.NewReader(out))
+    for i, group := range expected {
+        if !scanner.Scan() { return fmt.Errorf("missing group letter") }
+        letter := strings.TrimSpace(scanner.Text())
+        if letter != string('A'+i) { return fmt.Errorf("wrong group letter") }
+        for range group {
+            if !scanner.Scan() { return fmt.Errorf("missing team name") }
+            name := strings.TrimSpace(scanner.Text())
+            valid := false
+            for _, nm := range group {
+                if nm == name { valid = true; break }
+            }
+            if !valid { return fmt.Errorf("unexpected team name %s", name) }
+        }
+    }
+    if scanner.Scan() { return fmt.Errorf("extra output") }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsE()
+    for i, tc := range tests {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed\n", len(tests))
+}
+

--- a/0-999/200-299/230-239/234/verifierF.go
+++ b/0-999/200-299/230-239/234/verifierF.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+type testF struct {
+    n int
+    a int
+    b int
+    h []int
+}
+
+func genTestsF() []testF {
+    rng := rand.New(rand.NewSource(47))
+    tests := make([]testF, 100)
+    for i := range tests {
+        n := rng.Intn(8) + 1
+        h := make([]int, n)
+        total := 0
+        for j := range h {
+            h[j] = rng.Intn(10) + 1
+            total += h[j]
+        }
+        a := rng.Intn(total + 10)
+        b := rng.Intn(total + 10)
+        tests[i] = testF{n: n, a: a, b: b, h: h}
+    }
+    return tests
+}
+
+func min(a, b int) int { if a < b { return a }; return b }
+
+func solveF(tc testF) int {
+    n := tc.n
+    a := tc.a
+    b := tc.b
+    h := tc.h
+    total := 0
+    for _, v := range h { total += v }
+    if total > a+b { return -1 }
+    const INF = int(1e9)
+    prev0 := make([]int, a+1)
+    prev1 := make([]int, a+1)
+    for i := range prev0 { prev0[i] = INF; prev1[i] = INF }
+    if h[0] <= a { prev0[h[0]] = 0 }
+    prev1[0] = 0
+    for i := 1; i < n; i++ {
+        hi := h[i]
+        hip := h[i-1]
+        next0 := make([]int, a+1)
+        next1 := make([]int, a+1)
+        for j := range next0 { next0[j] = INF; next1[j] = INF }
+        cost := min(hip, hi)
+        for r := 0; r <= a; r++ {
+            v0 := prev0[r]
+            if v0 < INF {
+                nr := r + hi
+                if nr <= a && v0 < next0[nr] {
+                    next0[nr] = v0
+                }
+                if v0+cost < next1[r] { next1[r] = v0 + cost }
+            }
+            v1 := prev1[r]
+            if v1 < INF {
+                nr := r + hi
+                if nr <= a && v1+cost < next0[nr] { next0[nr] = v1 + cost }
+                if v1 < next1[r] { next1[r] = v1 }
+            }
+        }
+        prev0, prev1 = next0, next1
+    }
+    ans := INF
+    start := 0
+    if total > b { start = total - b }
+    for r := start; r <= a; r++ {
+        if prev0[r] < ans { ans = prev0[r] }
+        if prev1[r] < ans { ans = prev1[r] }
+    }
+    if ans == INF { return -1 }
+    return ans
+}
+
+func run(bin string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return out.String(), nil
+}
+
+func runCase(bin string, tc testF) error {
+    var sb strings.Builder
+    fmt.Fprintf(&sb, "%d\n%d %d\n", tc.n, tc.a, tc.b)
+    for i, v := range tc.h {
+        if i > 0 { sb.WriteByte(' ') }
+        sb.WriteString(strconv.Itoa(v))
+    }
+    sb.WriteByte('\n')
+    out, err := run(bin, sb.String())
+    if err != nil { return err }
+    expected := solveF(tc)
+    valStr := strings.TrimSpace(out)
+    val, err := strconv.Atoi(valStr)
+    if err != nil { return fmt.Errorf("bad output") }
+    if val != expected { return fmt.Errorf("expected %d got %d", expected, val) }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsF()
+    for i, tc := range tests {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed\n", len(tests))
+}
+

--- a/0-999/200-299/230-239/234/verifierG.go
+++ b/0-999/200-299/230-239/234/verifierG.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+type testG struct {
+    n int
+}
+
+func genTestsG() []testG {
+    rng := rand.New(rand.NewSource(48))
+    tests := make([]testG, 100)
+    for i := range tests {
+        tests[i] = testG{n: rng.Intn(18) + 2}
+    }
+    return tests
+}
+
+func run(bin string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return out.String(), nil
+}
+
+func checkSchedule(n int, m int, practices [][]int) error {
+    r := 0
+    for (1<<r) < n { r++ }
+    if m != r { return fmt.Errorf("m should be %d", r) }
+    for _, p := range practices {
+        if len(p) == 0 || len(p) >= n { return fmt.Errorf("invalid team size") }
+        seen := make(map[int]bool)
+        for _, v := range p {
+            if v < 1 || v > n { return fmt.Errorf("index out of range") }
+            if seen[v] { return fmt.Errorf("duplicate index in practice") }
+            seen[v] = true
+        }
+    }
+    sep := make([][]bool, n)
+    for i := range sep { sep[i] = make([]bool, n) }
+    for _, p := range practices {
+        mark := make([]bool, n+1)
+        for _, v := range p { mark[v] = true }
+        for i := 1; i <= n; i++ {
+            for j := i + 1; j <= n; j++ {
+                if mark[i] != mark[j] {
+                    sep[i-1][j-1] = true
+                    sep[j-1][i-1] = true
+                }
+            }
+        }
+    }
+    for i := 0; i < n; i++ {
+        for j := i + 1; j < n; j++ {
+            if !sep[i][j] { return fmt.Errorf("pair %d %d never separated", i+1, j+1) }
+        }
+    }
+    return nil
+}
+
+func runCase(bin string, tc testG) error {
+    input := fmt.Sprintf("%d\n", tc.n)
+    out, err := run(bin, input)
+    if err != nil { return err }
+    scanner := bufio.NewScanner(strings.NewReader(out))
+    scanner.Split(bufio.ScanWords)
+    if !scanner.Scan() { return fmt.Errorf("missing m") }
+    m, err := strconv.Atoi(scanner.Text())
+    if err != nil { return fmt.Errorf("invalid m") }
+    practices := make([][]int, m)
+    for i := 0; i < m; i++ {
+        if !scanner.Scan() { return fmt.Errorf("missing team size") }
+        f, err := strconv.Atoi(scanner.Text())
+        if err != nil { return fmt.Errorf("bad team size") }
+        p := make([]int, f)
+        for j := 0; j < f; j++ {
+            if !scanner.Scan() { return fmt.Errorf("missing player index") }
+            v, err := strconv.Atoi(scanner.Text())
+            if err != nil { return fmt.Errorf("bad index") }
+            p[j] = v
+        }
+        practices[i] = p
+    }
+    if scanner.Scan() { return fmt.Errorf("extra output") }
+    return checkSchedule(tc.n, m, practices)
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsG()
+    for i, tc := range tests {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed\n", len(tests))
+}
+

--- a/0-999/200-299/230-239/234/verifierH.go
+++ b/0-999/200-299/230-239/234/verifierH.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+    "bufio"
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+type testH struct {
+    a []int
+    b []int
+}
+
+func genTestsH() []testH {
+    rng := rand.New(rand.NewSource(49))
+    tests := make([]testH, 100)
+    for i := range tests {
+        n := rng.Intn(5) + 1
+        m := rng.Intn(5) + 1
+        A := make([]int, n)
+        B := make([]int, m)
+        for j := 0; j < n; j++ { A[j] = rng.Intn(2) }
+        for j := 0; j < m; j++ { B[j] = rng.Intn(2) }
+        tests[i] = testH{a: A, b: B}
+    }
+    return tests
+}
+
+func solveOps(a, b []int) int {
+    n := len(a)
+    m := len(b)
+    total := n + m
+    ia, ib, im := n-1, m-1, total-1
+    c := 0
+    ops := 0
+    for ia >= 0 || ib >= 0 {
+        for ia >= 0 && a[ia] == c { ia--; im-- }
+        for ib >= 0 && b[ib] == c { ib--; im-- }
+        ops++
+        if c == 0 { c = 1 } else { c = 0 }
+    }
+    return ops - 1
+}
+
+func run(bin string, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return out.String(), nil
+}
+
+func applyOps(order []int, a, b []int, flips []int) ([]int, error) {
+    n := len(a)
+    m := len(b)
+    vals := make([]int, n+m)
+    for i, idx := range order {
+        if idx < 1 || idx > n+m { return nil, fmt.Errorf("index out of range") }
+        if idx <= n {
+            vals[i] = a[idx-1]
+        } else {
+            vals[i] = b[idx-n-1]
+        }
+    }
+    // check relative order
+    posA := 0
+    posB := 0
+    for _, idx := range order {
+        if idx <= n {
+            posA++
+            if idx != posA {
+                return nil, fmt.Errorf("order not preserved")
+            }
+        } else {
+            posB++
+            if idx != n+posB {
+                return nil, fmt.Errorf("order not preserved")
+            }
+        }
+    }
+    for _, k := range flips {
+        if k < 1 || k > len(vals) { return nil, fmt.Errorf("bad flip size") }
+        for i := 0; i < k/2; i++ {
+            vals[i], vals[k-1-i] = vals[k-1-i]^1, vals[i]^1
+        }
+        if k%2 == 1 { vals[k/2] ^= 1 }
+    }
+    return vals, nil
+}
+
+func runCase(bin string, tc testH) error {
+    var sb strings.Builder
+    fmt.Fprintf(&sb, "%d\n", len(tc.a))
+    for i, v := range tc.a { if i>0 {sb.WriteByte(' ')}; sb.WriteString(strconv.Itoa(v)) }
+    sb.WriteByte('\n')
+    fmt.Fprintf(&sb, "%d\n", len(tc.b))
+    for i, v := range tc.b { if i>0 {sb.WriteByte(' ')}; sb.WriteString(strconv.Itoa(v)) }
+    sb.WriteByte('\n')
+    out, err := run(bin, sb.String())
+    if err != nil { return err }
+    scanner := bufio.NewScanner(strings.NewReader(out))
+    scanner.Split(bufio.ScanWords)
+    order := make([]int, len(tc.a)+len(tc.b))
+    for i := range order {
+        if !scanner.Scan() { return fmt.Errorf("missing order element") }
+        v, err := strconv.Atoi(scanner.Text())
+        if err != nil { return fmt.Errorf("bad order element") }
+        order[i] = v
+    }
+    if !scanner.Scan() { return fmt.Errorf("missing op count") }
+    x, err := strconv.Atoi(scanner.Text())
+    if err != nil { return fmt.Errorf("bad op count") }
+    flips := make([]int, x)
+    for i := 0; i < x; i++ {
+        if !scanner.Scan() { return fmt.Errorf("missing flip value") }
+        v, err := strconv.Atoi(scanner.Text())
+        if err != nil { return fmt.Errorf("bad flip value") }
+        flips[i] = v
+    }
+    if scanner.Scan() { return fmt.Errorf("extra output") }
+    result, err := applyOps(order, tc.a, tc.b, flips)
+    if err != nil { return err }
+    for _, v := range result {
+        if v != 0 { return fmt.Errorf("final deck not all face down") }
+    }
+    if x != solveOps(tc.a, tc.b) { return fmt.Errorf("operations not minimal") }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsH()
+    for i, tc := range tests {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed\n", len(tests))
+}
+


### PR DESCRIPTION
## Summary
- add standalone verification tools for contest 234 problems A–H
- each verifier runs 100 randomized tests and checks a submitted binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_687e95f06ca48324a5c3452629bfa883