### PR TITLE
Add Go verifiers for contest 229

### DIFF
--- a/0-999/200-299/220-229/229/verifierA.go
+++ b/0-999/200-299/220-229/229/verifierA.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n, m int
+	rows []string
+	ans  int
+}
+
+func solveA(tc testCaseA) int {
+	const INF = int(1e9)
+	total := make([]int, tc.m)
+	for _, row := range tc.rows {
+		has1 := false
+		for i := 0; i < tc.m; i++ {
+			if row[i] == '1' {
+				has1 = true
+				break
+			}
+		}
+		if !has1 {
+			return -1
+		}
+		dist := make([]int, tc.m)
+		for i := range dist {
+			dist[i] = INF
+		}
+		last := -INF
+		for j := 0; j < 2*tc.m; j++ {
+			idx := j % tc.m
+			if row[idx] == '1' {
+				last = j
+			}
+			if last >= 0 {
+				d := j - last
+				if d < dist[idx] {
+					dist[idx] = d
+				}
+			}
+		}
+		last = 2*tc.m + INF
+		for j := 2*tc.m - 1; j >= 0; j-- {
+			idx := j % tc.m
+			if row[idx] == '1' {
+				last = j
+			}
+			d := last - j
+			if d < dist[idx] {
+				dist[idx] = d
+			}
+		}
+		for i := 0; i < tc.m; i++ {
+			total[i] += dist[i]
+		}
+	}
+	ans := INF
+	for i := 0; i < tc.m; i++ {
+		if total[i] < ans {
+			ans = total[i]
+		}
+	}
+	if ans >= INF {
+		return -1
+	}
+	return ans
+}
+
+func genCaseA(rng *rand.Rand) testCaseA {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(6) + 1
+	rows := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		has1 := false
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				b[j] = '0'
+			} else {
+				b[j] = '1'
+				has1 = true
+			}
+		}
+		if !has1 && rng.Intn(5) != 0 {
+			b[rng.Intn(m)] = '1'
+		}
+		rows[i] = string(b)
+	}
+	tc := testCaseA{n: n, m: m, rows: rows}
+	tc.ans = solveA(tc)
+	return tc
+}
+
+func runCaseA(bin string, tc testCaseA) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+	for _, r := range tc.rows {
+		fmt.Fprintln(&sb, r)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != 1 {
+		return fmt.Errorf("expected 1 number got %d", len(fields))
+	}
+	val, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid integer: %v", err)
+	}
+	if val != tc.ans {
+		return fmt.Errorf("expected %d got %d", tc.ans, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseA(rng)
+		if err := runCaseA(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/220-229/229/verifierB.go
+++ b/0-999/200-299/220-229/229/verifierB.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edgeB struct {
+	a, b int
+	w    int64
+}
+
+type testCaseB struct {
+	n     int
+	edges []edgeB
+	forb  [][]int64
+	ans   int64
+}
+
+type pqItem struct {
+	node int
+	dist int64
+}
+
+type pq []pqItem
+
+func (p pq) Len() int            { return len(p) }
+func (p pq) Less(i, j int) bool  { return p[i].dist < p[j].dist }
+func (p pq) Swap(i, j int)       { p[i], p[j] = p[j], p[i] }
+func (p *pq) Push(x interface{}) { *p = append(*p, x.(pqItem)) }
+func (p *pq) Pop() interface{} {
+	old := *p
+	n := len(old)
+	it := old[n-1]
+	*p = old[:n-1]
+	return it
+}
+
+type interval struct{ l, r int64 }
+
+func solveB(tc testCaseB) int64 {
+	n := tc.n
+	adj := make([][]edgeB, n+1)
+	for _, e := range tc.edges {
+		adj[e.a] = append(adj[e.a], e)
+		adj[e.b] = append(adj[e.b], edgeB{e.b, e.a, e.w})
+	}
+	forb := make([][]interval, n+1)
+	for i := 1; i <= n; i++ {
+		t := tc.forb[i]
+		if len(t) == 0 {
+			continue
+		}
+		ivs := make([]interval, 0, len(t))
+		start := t[0]
+		prev := t[0]
+		for j := 1; j < len(t); j++ {
+			if t[j] == prev+1 {
+				prev = t[j]
+			} else {
+				ivs = append(ivs, interval{start, prev})
+				start = t[j]
+				prev = t[j]
+			}
+		}
+		ivs = append(ivs, interval{start, prev})
+		forb[i] = ivs
+	}
+	const INF int64 = 1 << 62
+	dist := make([]int64, n+1)
+	for i := range dist {
+		dist[i] = INF
+	}
+	dist[1] = 0
+	pq := &pq{}
+	heap.Push(pq, pqItem{1, 0})
+	for pq.Len() > 0 {
+		it := heap.Pop(pq).(pqItem)
+		u := it.node
+		d := it.dist
+		if d != dist[u] {
+			continue
+		}
+		if u == n {
+			break
+		}
+		dep := d
+		ivs := forb[u]
+		if len(ivs) > 0 {
+			idx := sort.Search(len(ivs), func(i int) bool { return ivs[i].l > d }) - 1
+			if idx >= 0 && ivs[idx].l <= d && d <= ivs[idx].r {
+				dep = ivs[idx].r + 1
+			}
+		}
+		for _, e := range adj[u] {
+			v := e.b
+			nd := dep + e.w
+			if nd < dist[v] {
+				dist[v] = nd
+				heap.Push(pq, pqItem{v, nd})
+			}
+		}
+	}
+	if dist[n] == INF {
+		return -1
+	}
+	return dist[n]
+}
+
+func genCaseB(rng *rand.Rand) testCaseB {
+	n := rng.Intn(4) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	edges := make([]edgeB, 0, m)
+	exist := make(map[[2]int]bool)
+	for len(edges) < m {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a == b {
+			continue
+		}
+		if a > b {
+			a, b = b, a
+		}
+		key := [2]int{a, b}
+		if exist[key] {
+			continue
+		}
+		exist[key] = true
+		w := int64(rng.Intn(10) + 1)
+		edges = append(edges, edgeB{a, b, w})
+	}
+	forb := make([][]int64, n+1)
+	for i := 1; i <= n; i++ {
+		k := rng.Intn(3)
+		t := make([]int64, k)
+		cur := int64(0)
+		for j := 0; j < k; j++ {
+			cur += int64(rng.Intn(4) + 1)
+			t[j] = cur
+		}
+		forb[i] = t
+	}
+	tc := testCaseB{n: n, edges: edges, forb: forb}
+	tc.ans = solveB(tc)
+	return tc
+}
+
+func runCaseB(bin string, tc testCaseB) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, len(tc.edges))
+	for _, e := range tc.edges {
+		fmt.Fprintf(&sb, "%d %d %d\n", e.a, e.b, e.w)
+	}
+	for i := 1; i <= tc.n; i++ {
+		fmt.Fprintf(&sb, "%d", len(tc.forb[i]))
+		for _, v := range tc.forb[i] {
+			fmt.Fprintf(&sb, " %d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != 1 {
+		return fmt.Errorf("expected 1 number got %d", len(fields))
+	}
+	val, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid integer: %v", err)
+	}
+	if val != tc.ans {
+		return fmt.Errorf("expected %d got %d", tc.ans, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseB(rng)
+		if err := runCaseB(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/220-229/229/verifierC.go
+++ b/0-999/200-299/220-229/229/verifierC.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edgeC struct{ a, b int }
+
+type testCaseC struct {
+	n     int
+	edges []edgeC
+	ans   int64
+}
+
+func solveC(tc testCaseC) int64 {
+	deg := make([]int64, tc.n)
+	for _, e := range tc.edges {
+		deg[e.a-1]++
+		deg[e.b-1]++
+	}
+	N := int64(tc.n)
+	if tc.n < 3 {
+		return 0
+	}
+	total := N * (N - 1) * (N - 2) / 6
+	var S int64
+	for i := 0; i < tc.n; i++ {
+		S += deg[i] * (N - 1 - deg[i])
+	}
+	return total - S/2
+}
+
+func genCaseC(rng *rand.Rand) testCaseC {
+	n := rng.Intn(6) + 1
+	edges := make([]edgeC, 0)
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			if rng.Intn(2) == 0 {
+				continue
+			}
+			edges = append(edges, edgeC{i, j})
+		}
+	}
+	tc := testCaseC{n: n, edges: edges}
+	tc.ans = solveC(tc)
+	return tc
+}
+
+func runCaseC(bin string, tc testCaseC) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, len(tc.edges))
+	for _, e := range tc.edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.a, e.b)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != 1 {
+		return fmt.Errorf("expected 1 number got %d", len(fields))
+	}
+	val, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid integer: %v", err)
+	}
+	if val != tc.ans {
+		return fmt.Errorf("expected %d got %d", tc.ans, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseC(rng)
+		if err := runCaseC(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/220-229/229/verifierD.go
+++ b/0-999/200-299/220-229/229/verifierD.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseD struct {
+	n   int
+	h   []int64
+	ans int
+}
+
+func solveD(tc testCaseD) int {
+	n := tc.n
+	p := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		p[i+1] = p[i] + tc.h[i]
+	}
+	dp := make([]int, n+1)
+	best := make([]int64, n+1)
+	const inf int64 = 1<<63 - 1
+	best[0] = 0
+	for i := 1; i <= n; i++ {
+		dp[i] = 0
+		best[i] = inf
+		for j := i - 1; j >= 0; j-- {
+			s := p[i] - p[j]
+			if s < best[j] {
+				continue
+			}
+			seg := dp[j] + 1
+			if seg > dp[i] || (seg == dp[i] && s < best[i]) {
+				dp[i] = seg
+				best[i] = s
+			}
+		}
+	}
+	return n - dp[n]
+}
+
+func genCaseD(rng *rand.Rand) testCaseD {
+	n := rng.Intn(6) + 1
+	h := make([]int64, n)
+	for i := range h {
+		h[i] = int64(rng.Intn(10) + 1)
+	}
+	tc := testCaseD{n: n, h: h}
+	tc.ans = solveD(tc)
+	return tc
+}
+
+func runCaseD(bin string, tc testCaseD) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", tc.n)
+	for i, v := range tc.h {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != 1 {
+		return fmt.Errorf("expected 1 number got %d", len(fields))
+	}
+	val, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid integer: %v", err)
+	}
+	if val != tc.ans {
+		return fmt.Errorf("expected %d got %d", tc.ans, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseD(rng)
+		if err := runCaseD(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/220-229/229/verifierE.go
+++ b/0-999/200-299/220-229/229/verifierE.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseE struct {
+	n    int
+	m    int
+	k    []int
+	vals [][]int
+	ans  float64
+}
+
+type pair struct{ val, grp int }
+
+func solveE(tc testCaseE) float64 {
+	var v []pair
+	for i := 0; i < tc.m; i++ {
+		for _, x := range tc.vals[i] {
+			v = append(v, pair{x, i})
+		}
+	}
+	sort.Slice(v, func(i, j int) bool { return v[i].val > v[j].val })
+	threshold := v[tc.n-1].val
+	a := make([]int, tc.m)
+	kRem := make([]int, tc.m)
+	copy(kRem, tc.k)
+	p := 1.0
+	done := 0
+	for i := 0; i < len(v) && v[i].val != threshold; i++ {
+		cur := v[i].grp
+		den := kRem[cur]
+		if den < 1 {
+			den = 1
+		}
+		p *= float64(a[cur]+1) / float64(den)
+		a[cur]++
+		kRem[cur]--
+		done++
+	}
+	var ids []int
+	for i := 0; i < len(v) && v[i].val >= threshold; i++ {
+		if v[i].val == threshold {
+			ids = append(ids, v[i].grp)
+		}
+	}
+	s := len(ids)
+	tmp := make([]float64, s)
+	for j := 0; j < s; j++ {
+		cur := ids[j]
+		den := kRem[cur]
+		if den < 1 {
+			den = 1
+		}
+		tmp[j] = float64(a[cur]+1) / float64(den)
+	}
+	f := make([][]float64, s+1)
+	for i := range f {
+		f[i] = make([]float64, s+1)
+	}
+	f[0][0] = p
+	for j := 0; j < s; j++ {
+		for i := 0; i <= j; i++ {
+			cur := f[i][j]
+			if cur == 0 {
+				continue
+			}
+			f[i+1][j+1] += cur * tmp[j] * float64(i+1) / float64(j+1)
+			f[i][j+1] += cur * float64(j-i+1) / float64(j+1)
+		}
+	}
+	return f[tc.n-done][s]
+}
+
+func genCaseE(rng *rand.Rand) testCaseE {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	k := make([]int, m)
+	vals := make([][]int, m)
+	total := 0
+	for i := 0; i < m; i++ {
+		k[i] = rng.Intn(3) + 1
+		vals[i] = make([]int, k[i])
+		for j := 0; j < k[i]; j++ {
+			vals[i][j] = rng.Intn(20) + 1
+		}
+		sort.Ints(vals[i])
+		sort.Slice(vals[i], func(a, b int) bool { return vals[i][a] > vals[i][b] })
+		total += k[i]
+	}
+	if n > total {
+		n = total
+	}
+	tc := testCaseE{n: n, m: m, k: k, vals: vals}
+	tc.ans = solveE(tc)
+	return tc
+}
+
+func runCaseE(bin string, tc testCaseE) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+	for i := 0; i < tc.m; i++ {
+		fmt.Fprintf(&sb, "%d", tc.k[i])
+		for _, v := range tc.vals[i] {
+			fmt.Fprintf(&sb, " %d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	str := strings.TrimSpace(out.String())
+	val, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		return fmt.Errorf("invalid float output: %v", err)
+	}
+	diff := val - tc.ans
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > 1e-6 {
+		return fmt.Errorf("expected %.10f got %.10f", tc.ans, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseE(rng)
+		if err := runCaseE(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go through verifierE.go for contest 229
- each verifier generates 100 random tests and checks candidate solution output

## Testing
- `go build 0-999/200-299/220-229/229/verifierA.go`
- `go build 0-999/200-299/220-229/229/verifierB.go`
- `go build 0-999/200-299/220-229/229/verifierC.go`
- `go build 0-999/200-299/220-229/229/verifierD.go`
- `go build 0-999/200-299/220-229/229/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e94920964832483bb87bcfb417b41