### PR TITLE
Add Go solution verifiers for contest 228

### DIFF
--- a/0-999/200-299/220-229/228/verifierA.go
+++ b/0-999/200-299/220-229/228/verifierA.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expected(a, b, c, d int) string {
+	m := map[int]bool{a: true, b: true, c: true, d: true}
+	return fmt.Sprintf("%d", 4-len(m))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	type T [4]int
+	tests := []T{}
+	for a := 1; len(tests) < 100 && a <= 4; a++ {
+		for b := 1; len(tests) < 100 && b <= 4; b++ {
+			for c := 1; len(tests) < 100 && c <= 4; c++ {
+				for d := 1; len(tests) < 100 && d <= 4; d++ {
+					tests = append(tests, T{a, b, c, d})
+				}
+			}
+		}
+	}
+	for i, t := range tests {
+		in := fmt.Sprintf("%d %d %d %d\n", t[0], t[1], t[2], t[3])
+		exp := expected(t[0], t[1], t[2], t[3])
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed: input=%q expected=%s got=%s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("ok %d tests\n", len(tests))
+}

--- a/0-999/200-299/220-229/228/verifierB.go
+++ b/0-999/200-299/220-229/228/verifierB.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type matrix struct {
+	n, m int
+	data [][]int
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveB(a, b matrix) (int, int) {
+	limitX := max(a.n, b.n)
+	limitY := max(a.m, b.m)
+	bestSum := 0
+	bestX, bestY := 0, 0
+	for x := -limitX; x < limitX; x++ {
+		for y := -limitY; y < limitY; y++ {
+			sum := 0
+			rStart := max(0, -x)
+			rEnd := min(a.n, b.n-x)
+			cStart := max(0, -y)
+			cEnd := min(a.m, b.m-y)
+			for i := rStart; i < rEnd; i++ {
+				for j := cStart; j < cEnd; j++ {
+					sum += a.data[i][j] * b.data[i+x][j+y]
+				}
+			}
+			if sum > bestSum {
+				bestSum = sum
+				bestX = x
+				bestY = y
+			}
+		}
+	}
+	return bestX, bestY
+}
+
+func genTests() []struct {
+	in     string
+	expect string
+} {
+	tests := []struct{ in, expect string }{}
+	for m1 := 2; len(tests) < 100 && m1 <= 2; m1++ {
+		for mask1 := 0; len(tests) < 100 && mask1 < (1<<(2*m1)); mask1++ {
+			for mask2 := 0; len(tests) < 100 && mask2 < (1<<(2*m1)); mask2++ {
+				a := matrix{2, m1, make([][]int, 2)}
+				b := matrix{2, m1, make([][]int, 2)}
+				for i := 0; i < 2; i++ {
+					a.data[i] = make([]int, m1)
+					b.data[i] = make([]int, m1)
+					for j := 0; j < m1; j++ {
+						if mask1&(1<<(i*m1+j)) != 0 {
+							a.data[i][j] = 1
+						}
+						if mask2&(1<<(i*m1+j)) != 0 {
+							b.data[i][j] = 1
+						}
+					}
+				}
+				bx, by := solveB(a, b)
+				input := fmt.Sprintf("2 %d\n", m1)
+				for i := 0; i < 2; i++ {
+					for j := 0; j < m1; j++ {
+						input += fmt.Sprintf("%d", a.data[i][j])
+					}
+					input += "\n"
+				}
+				input += fmt.Sprintf("2 %d\n", m1)
+				for i := 0; i < 2; i++ {
+					for j := 0; j < m1; j++ {
+						input += fmt.Sprintf("%d", b.data[i][j])
+					}
+					input += "\n"
+				}
+				exp := fmt.Sprintf("%d %d", bx, by)
+				tests = append(tests, struct{ in, expect string }{input, exp})
+			}
+		}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != t.expect {
+			fmt.Printf("test %d failed: expected=%s got=%s\ninput:\n%s\n", i+1, t.expect, out, t.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("ok %d tests\n", len(tests))
+}

--- a/0-999/200-299/220-229/228/verifierC.go
+++ b/0-999/200-299/220-229/228/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func compileRef() (string, error) {
+	src := filepath.Join(".", "228C.go")
+	out := filepath.Join(os.TempDir(), "refC.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func genTests() []string {
+	tests := []string{}
+	for n := 2; len(tests) < 100 && n <= 3; n++ {
+		for m := 2; len(tests) < 100 && m <= 3; m++ {
+			cells := n * m
+			for mask := 0; len(tests) < 100 && mask < (1<<cells); mask++ {
+				var sb strings.Builder
+				fmt.Fprintf(&sb, "%d %d\n", n, m)
+				for i := 0; i < n; i++ {
+					for j := 0; j < m; j++ {
+						if mask&(1<<(i*m+j)) != 0 {
+							sb.WriteByte('*')
+						} else {
+							sb.WriteByte('.')
+						}
+					}
+					sb.WriteByte('\n')
+				}
+				tests = append(tests, sb.String())
+			}
+		}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("test %d failed:\ninput:\n%sexpected=%s got=%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("ok %d tests\n", len(tests))
+}

--- a/0-999/200-299/220-229/228/verifierD.go
+++ b/0-999/200-299/220-229/228/verifierD.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func zigzagSeq(z, length int) []int64 {
+	t := 2 * (z - 1)
+	res := make([]int64, length)
+	for i := 0; i < length; i++ {
+		m := (i + 1) % t
+		if m == 0 {
+			res[i] = 2
+		} else if m <= z {
+			res[i] = int64(m)
+		} else {
+			res[i] = int64(2*z - m)
+		}
+	}
+	return res
+}
+
+func solveD(input string) string {
+	rd := strings.Fields(input)
+	idx := 0
+	n := atoi(rd[idx])
+	idx++
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(atoi(rd[idx]))
+		idx++
+	}
+	m := atoi(rd[idx])
+	idx++
+	var out strings.Builder
+	for qi := 0; qi < m; qi++ {
+		ty := atoi(rd[idx])
+		idx++
+		if ty == 1 {
+			p := atoi(rd[idx])
+			idx++
+			v := int64(atoi(rd[idx]))
+			idx++
+			a[p-1] = v
+		} else {
+			l := atoi(rd[idx])
+			idx++
+			r := atoi(rd[idx])
+			idx++
+			z := atoi(rd[idx])
+			idx++
+			seq := zigzagSeq(z, r-l+1)
+			var sum int64
+			for i := l - 1; i < r; i++ {
+				sum += a[i] * seq[i-(l-1)]
+			}
+			out.WriteString(fmt.Sprintln(sum))
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func atoi(s string) int {
+	var n int
+	for i := 0; i < len(s); i++ {
+		n = n*10 + int(s[i]-'0')
+	}
+	return n
+}
+
+func genTests() []string {
+	r := rand.New(rand.NewSource(42))
+	tests := []string{}
+	for len(tests) < 100 {
+		n := r.Intn(3) + 3 // 3..5
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d ", r.Intn(5)+1)
+		}
+		sb.WriteByte('\n')
+		m := r.Intn(3) + 3 // 3..5 ops
+		fmt.Fprintf(&sb, "%d\n", m)
+		for i := 0; i < m; i++ {
+			if r.Intn(2) == 0 {
+				p := r.Intn(n) + 1
+				v := r.Intn(5) + 1
+				fmt.Fprintf(&sb, "1 %d %d\n", p, v)
+			} else {
+				l := r.Intn(n) + 1
+				rgt := r.Intn(n-l+1) + l
+				z := r.Intn(5) + 2
+				fmt.Fprintf(&sb, "2 %d %d %d\n", l, rgt, z)
+			}
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, in := range tests {
+		exp := solveD(strings.TrimSpace(in))
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("test %d failed:\ninput:\n%sexpected=%s got=%s\n", i+1, in, exp, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("ok %d tests\n", len(tests))
+}

--- a/0-999/200-299/220-229/228/verifierE.go
+++ b/0-999/200-299/220-229/228/verifierE.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func compileRef() (string, error) {
+	src := filepath.Join(".", "228E.go")
+	out := filepath.Join(os.TempDir(), "refE.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func genTests() []string {
+	r := rand.New(rand.NewSource(42))
+	tests := []string{}
+	for len(tests) < 100 {
+		n := r.Intn(3) + 2 // 2..4
+		maxM := n * (n - 1) / 2
+		m := r.Intn(maxM + 1)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		edges := make(map[[2]int]bool)
+		for i := 0; i < m; i++ {
+			var a, b int
+			for {
+				a = r.Intn(n) + 1
+				b = r.Intn(n) + 1
+				if a != b && !edges[[2]int{a, b}] && !edges[[2]int{b, a}] {
+					break
+				}
+			}
+			edges[[2]int{a, b}] = true
+			c := r.Intn(2)
+			fmt.Fprintf(&sb, "%d %d %d\n", a, b, c)
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("test %d failed:\ninput:\n%sexpected=%s got=%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("ok %d tests\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to validate any binary for problem A with 100 small tests
- add verifierB.go with naive overlap solver and 100 generated tests
- add verifierC.go compiling 228C.go as reference with 100 board cases
- add verifierD.go implementing naive Zigzag handling with 100 random tests
- add verifierE.go compiling 228E.go as reference with 100 random graph tests

## Testing
- `go run verifierA.go ./228A_bin`
- `go run verifierB.go ./228B_bin`
- `go run verifierC.go ./228C_bin`
- `go run verifierD.go ./228D_bin`
- `go run verifierE.go ./228E_bin`

------
https://chatgpt.com/codex/tasks/task_e_687e944bed6c8324a1bf28b24a1a4a5f