### PR TITLE
Add Go solution verifiers for Codeforces contest 225

### DIFF
--- a/0-999/200-299/220-229/225/verifierA.go
+++ b/0-999/200-299/220-229/225/verifierA.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type ori struct{ top, bottom, front, back, right, left int }
+
+func orientations() []ori {
+	var res []ori
+	for t := 1; t <= 6; t++ {
+		bt := 7 - t
+		for f := 1; f <= 6; f++ {
+			if f == t || f == bt {
+				continue
+			}
+			bk := 7 - f
+			rem := make([]int, 0, 2)
+			for v := 1; v <= 6; v++ {
+				if v != t && v != bt && v != f && v != bk {
+					rem = append(rem, v)
+				}
+			}
+			res = append(res, ori{t, bt, f, bk, rem[0], rem[1]})
+			res = append(res, ori{t, bt, f, bk, rem[1], rem[0]})
+		}
+	}
+	return res
+}
+
+func solve(n int, x int, a, b []int) string {
+	oris := orientations()
+	m := len(oris)
+	dp := make([]int, m)
+	for j, o := range oris {
+		if o.top == x && o.front == a[0] && o.right == b[0] {
+			dp[j] = 1
+		}
+	}
+	for i := 1; i < n; i++ {
+		next := make([]int, m)
+		for j, o := range oris {
+			if o.front != a[i] || o.right != b[i] {
+				continue
+			}
+			sum := 0
+			for k, p := range oris {
+				if dp[k] == 0 {
+					continue
+				}
+				if p.bottom != o.top {
+					sum += dp[k]
+					if sum >= 2 {
+						sum = 2
+						break
+					}
+				}
+			}
+			next[j] = sum
+		}
+		dp = next
+	}
+	total := 0
+	for _, v := range dp {
+		total += v
+		if total >= 2 {
+			break
+		}
+	}
+	if total == 1 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(1))
+	oris := orientations()
+	for t := 1; t <= 100; t++ {
+		n := r.Intn(10) + 1
+		seq := make([]ori, n)
+		seq[0] = oris[r.Intn(len(oris))]
+		for i := 1; i < n; i++ {
+			options := make([]ori, 0, len(oris))
+			for _, o := range oris {
+				if o.top != seq[i-1].bottom {
+					options = append(options, o)
+				}
+			}
+			seq[i] = options[r.Intn(len(options))]
+		}
+		x := seq[0].top
+		a := make([]int, n)
+		b := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = seq[i].front
+			b[i] = seq[i].right
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n%d\n", n, x)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", a[i], b[i])
+		}
+		input := sb.String()
+		expected := solve(n, x, a, b)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:\n%s", t, err, input)
+			return
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Printf("Test %d FAILED\nInput:\n%sExpected: %s\nGot: %s\n", t, input, expected, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/220-229/225/verifierB.go
+++ b/0-999/200-299/220-229/225/verifierB.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func kbonacci(k int, limit int64) []int64 {
+	f := []int64{0, 1}
+	for {
+		sum := int64(0)
+		for j := 1; j <= k && j < len(f); j++ {
+			sum += f[len(f)-j]
+		}
+		f = append(f, sum)
+		if sum > limit {
+			break
+		}
+	}
+	return f
+}
+
+func contains(seq []int64, v int64) bool {
+	for _, x := range seq {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(2))
+	for t := 1; t <= 100; t++ {
+		s := int64(r.Intn(1000000-1) + 1)
+		k := r.Intn(8) + 2
+		input := fmt.Sprintf("%d %d\n", s, k)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:%s", t, err, input)
+			return
+		}
+		fields := strings.Fields(out)
+		if len(fields) < 1 {
+			fmt.Printf("Test %d invalid output\nInput:%sGot:%s", t, input, out)
+			return
+		}
+		m, errm := strconv.Atoi(fields[0])
+		if errm != nil || m < 2 || m != len(fields)-1 {
+			fmt.Printf("Test %d invalid m\nInput:%sGot:%s", t, input, out)
+			return
+		}
+		nums := make([]int64, m)
+		for i := 0; i < m; i++ {
+			val, err := strconv.ParseInt(fields[i+1], 10, 64)
+			if err != nil {
+				fmt.Printf("Test %d invalid number\nInput:%sGot:%s", t, input, out)
+				return
+			}
+			nums[i] = val
+		}
+		seq := kbonacci(k, s)
+		set := make(map[int64]bool)
+		var sum int64
+		for _, v := range nums {
+			if set[v] {
+				fmt.Printf("Test %d numbers not distinct\n", t)
+				return
+			}
+			set[v] = true
+			if !contains(seq, v) {
+				fmt.Printf("Test %d number %d not k-bonacci\n", t, v)
+				return
+			}
+			sum += v
+		}
+		if sum != s {
+			fmt.Printf("Test %d wrong sum expected %d got %d\n", t, s, sum)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/220-229/225/verifierC.go
+++ b/0-999/200-299/220-229/225/verifierC.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solve(n, m, x, y int, grid []string) int {
+	blacks := make([]int, m+1)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '#' {
+				blacks[j+1]++
+			}
+		}
+	}
+	costW := make([]int, m+1)
+	costB := make([]int, m+1)
+	for j := 1; j <= m; j++ {
+		costW[j] = blacks[j]
+		costB[j] = n - blacks[j]
+	}
+	prefW := make([]int, m+1)
+	prefB := make([]int, m+1)
+	for j := 1; j <= m; j++ {
+		prefW[j] = prefW[j-1] + costW[j]
+		prefB[j] = prefB[j-1] + costB[j]
+	}
+	const INF = 1 << 30
+	dp := make([][2]int, m+1)
+	for j := 0; j <= m; j++ {
+		dp[j][0], dp[j][1] = INF, INF
+	}
+	dp[0][0], dp[0][1] = 0, 0
+	for j := 1; j <= m; j++ {
+		for k := x; k <= y && k <= j; k++ {
+			cost := prefW[j] - prefW[j-k]
+			if dp[j-k][1]+cost < dp[j][0] {
+				dp[j][0] = dp[j-k][1] + cost
+			}
+		}
+		for k := x; k <= y && k <= j; k++ {
+			cost := prefB[j] - prefB[j-k]
+			if dp[j-k][0]+cost < dp[j][1] {
+				dp[j][1] = dp[j-k][0] + cost
+			}
+		}
+	}
+	ans := dp[m][0]
+	if dp[m][1] < ans {
+		ans = dp[m][1]
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(3))
+	for t := 1; t <= 100; t++ {
+		n := r.Intn(4) + 3 //3..6
+		m := r.Intn(4) + 3 //3..6
+		x := r.Intn(min(3, m)) + 1
+		y := r.Intn(m-x+1) + x
+		grid := make([]string, n)
+		for i := 0; i < n; i++ {
+			sb := strings.Builder{}
+			for j := 0; j < m; j++ {
+				if r.Intn(2) == 0 {
+					sb.WriteByte('.')
+				} else {
+					sb.WriteByte('#')
+				}
+			}
+			grid[i] = sb.String()
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d\n", n, m, x, y)
+		for i := 0; i < n; i++ {
+			sb.WriteString(grid[i])
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expected := fmt.Sprintf("%d", solve(n, m, x, y, grid))
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:\n%s", t, err, input)
+			return
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Printf("Test %d FAILED\nInput:\n%sExpected:%s Got:%s\n", t, input, expected, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/220-229/225/verifierD.go
+++ b/0-999/200-299/220-229/225/verifierD.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type point struct{ x, y int }
+
+func neighbors(p point, n, m int) []point {
+	dirs := []point{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
+	res := make([]point, 0, 4)
+	for _, d := range dirs {
+		nx, ny := p.x+d.x, p.y+d.y
+		if nx >= 0 && nx < n && ny >= 0 && ny < m {
+			res = append(res, point{nx, ny})
+		}
+	}
+	return res
+}
+
+func bfs(n, m int, grid [][]byte, snake []point, apple point) int {
+	length := len(snake)
+	start := make([]point, length)
+	copy(start, snake)
+	type state struct {
+		s []point
+		d int
+	}
+	key := func(s []point) string {
+		sb := strings.Builder{}
+		for _, p := range s {
+			sb.WriteByte(byte(p.x))
+			sb.WriteByte(byte(p.y))
+		}
+		return sb.String()
+	}
+	visited := map[string]bool{key(start): true}
+	q := []state{{start, 0}}
+	for head := 0; head < len(q); head++ {
+		cur := q[head]
+		if cur.s[0] == apple {
+			return cur.d
+		}
+		for _, nb := range neighbors(cur.s[0], n, m) {
+			if grid[nb.x][nb.y] == '#' {
+				continue
+			}
+			collide := false
+			for i := 0; i < length-1; i++ {
+				if cur.s[i] == nb {
+					collide = true
+					break
+				}
+			}
+			if collide {
+				continue
+			}
+			ns := make([]point, length)
+			copy(ns[1:], cur.s[:length-1])
+			ns[0] = nb
+			k := key(ns)
+			if !visited[k] {
+				visited[k] = true
+				q = append(q, state{ns, cur.d + 1})
+			}
+		}
+	}
+	return -1
+}
+
+func genCase(r *rand.Rand) (string, int) {
+	for {
+		n := r.Intn(3) + 3 //3..5
+		m := r.Intn(3) + 3
+		grid := make([][]byte, n)
+		for i := 0; i < n; i++ {
+			grid[i] = make([]byte, m)
+			for j := 0; j < m; j++ {
+				grid[i][j] = '.'
+			}
+		}
+		// snake length
+		length := r.Intn(3) + 3 //3..5
+		// random head
+		hx := r.Intn(n)
+		hy := r.Intn(m)
+		snake := []point{{hx, hy}}
+		used := map[point]bool{{hx, hy}: true}
+		cur := point{hx, hy}
+		ok := true
+		for i := 1; i < length; i++ {
+			opts := neighbors(cur, n, m)
+			ps := make([]point, 0, len(opts))
+			for _, p := range opts {
+				if !used[p] {
+					ps = append(ps, p)
+				}
+			}
+			if len(ps) == 0 {
+				ok = false
+				break
+			}
+			nxt := ps[r.Intn(len(ps))]
+			snake = append(snake, nxt)
+			used[nxt] = true
+			cur = nxt
+		}
+		if !ok {
+			continue
+		}
+		for i, p := range snake {
+			grid[p.x][p.y] = byte('1' + i)
+		}
+		// apple
+		var ax, ay int
+		for {
+			ax = r.Intn(n)
+			ay = r.Intn(m)
+			if grid[ax][ay] == '.' {
+				break
+			}
+		}
+		grid[ax][ay] = '@'
+		// some walls
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				if grid[i][j] == '.' && r.Intn(5) == 0 {
+					grid[i][j] = '#'
+				}
+			}
+		}
+		lines := make([]string, n)
+		for i := 0; i < n; i++ {
+			lines[i] = string(grid[i])
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for i := 0; i < n; i++ {
+			sb.WriteString(lines[i])
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expect := bfs(n, m, grid, snake, point{ax, ay})
+		return input, expect
+	}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(4))
+	for t := 1; t <= 100; t++ {
+		input, expected := genCase(r)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:\n%s", t, err, input)
+			return
+		}
+		if strings.TrimSpace(out) != fmt.Sprintf("%d", expected) {
+			fmt.Printf("Test %d FAILED\nInput:\n%sExpected:%d Got:%s\n", t, input, expected, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/220-229/225/verifierE.go
+++ b/0-999/200-299/220-229/225/verifierE.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n int) int64 {
+	const mod = 1000000007
+	count := 0
+	for z := 1; ; z++ {
+		found := false
+		for x := 1; x <= 2*z; x++ {
+			f := x / 2
+			num := z - f
+			if num <= 0 {
+				break
+			}
+			denom := x + 1
+			if num%denom == 0 {
+				y := num / denom
+				if y > 0 {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			count++
+			if count == n {
+				return int64(z) % mod
+			}
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(5))
+	for t := 1; t <= 100; t++ {
+		n := r.Intn(20) + 1
+		input := fmt.Sprintf("%d\n", n)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:%s", t, err, input)
+			return
+		}
+		expected := solve(n)
+		got, errp := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if errp != nil || got != expected {
+			fmt.Printf("Test %d FAILED\nInput:%sExpected:%d Got:%s\n", t, input, expected, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for Problem A
- add verifierB.go for Problem B
- add verifierC.go for Problem C
- add verifierD.go for Problem D
- add verifierE.go for Problem E

Each verifier generates 100 random test cases using a deterministic seed and checks a provided binary against the reference logic from the repository’s Go solutions.

## Testing
- `go build 0-999/200-299/220-229/225/verifierA.go`
- `go build 0-999/200-299/220-229/225/verifierB.go`
- `go build 0-999/200-299/220-229/225/verifierC.go`
- `go build 0-999/200-299/220-229/225/verifierD.go`
- `go build 0-999/200-299/220-229/225/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e937989148324a58a5b1a4a261267