### PR TITLE
Add solution verifiers for contest 222

### DIFF
--- a/0-999/200-299/220-229/222/verifierA.go
+++ b/0-999/200-299/220-229/222/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n, k int
+	if _, err := fmt.Fscan(reader, &n, &k); err != nil {
+		return ""
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	target := a[k-1]
+	for i := k; i < n; i++ {
+		if a[i] != target {
+			return "-1"
+		}
+	}
+	idx := k - 1
+	for idx >= 0 && a[idx] == target {
+		idx--
+	}
+	return fmt.Sprintf("%d", idx+1)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(42))
+	var tests []test
+	fixed := []string{
+		"3 2\n1 1 1\n",
+		"3 1\n1 2 3\n",
+		"5 3\n2 2 2 2 2\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		k := rng.Intn(n) + 1
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(3) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", a[i])
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/200-299/220-229/222/verifierB.go
+++ b/0-999/200-299/220-229/222/verifierB.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n, m, k int
+	if _, err := fmt.Fscan(reader, &n, &m, &k); err != nil {
+		return ""
+	}
+	table := make([][]int, n)
+	for i := 0; i < n; i++ {
+		row := make([]int, m)
+		for j := 0; j < m; j++ {
+			fmt.Fscan(reader, &row[j])
+		}
+		table[i] = row
+	}
+	rowIdx := make([]int, n)
+	for i := 0; i < n; i++ {
+		rowIdx[i] = i
+	}
+	colIdx := make([]int, m)
+	for j := 0; j < m; j++ {
+		colIdx[j] = j
+	}
+	var out strings.Builder
+	for q := 0; q < k; q++ {
+		var op string
+		var x, y int
+		fmt.Fscan(reader, &op, &x, &y)
+		switch op[0] {
+		case 'r':
+			rowIdx[x-1], rowIdx[y-1] = rowIdx[y-1], rowIdx[x-1]
+		case 'c':
+			colIdx[x-1], colIdx[y-1] = colIdx[y-1], colIdx[x-1]
+		case 'g':
+			r := rowIdx[x-1]
+			c := colIdx[y-1]
+			fmt.Fprintf(&out, "%d\n", table[r][c])
+		}
+	}
+	return strings.TrimRight(out.String(), "\n")
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(43))
+	var tests []test
+	fixed := []string{
+		"1 1 1\n5\ng 1 1\n",
+		"2 2 3\n1 2\n3 4\nr 1 2\nc 1 2\ng 1 1\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(3) + 1
+		m := rng.Intn(3) + 1
+		k := rng.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				fmt.Fprintf(&sb, "%d ", rng.Intn(10))
+			}
+			sb.WriteByte('\n')
+		}
+		ops := []byte{'r', 'c', 'g'}
+		for i := 0; i < k; i++ {
+			op := ops[rng.Intn(len(ops))]
+			var x, y int
+			switch op {
+			case 'r':
+				x = rng.Intn(n) + 1
+				y = rng.Intn(n) + 1
+			case 'c':
+				x = rng.Intn(m) + 1
+				y = rng.Intn(m) + 1
+			case 'g':
+				x = rng.Intn(n) + 1
+				y = rng.Intn(m) + 1
+			}
+			fmt.Fprintf(&sb, "%c %d %d\n", op, x, y)
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/200-299/220-229/222/verifierC.go
+++ b/0-999/200-299/220-229/222/verifierC.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return ""
+	}
+	a := make([]int, n)
+	b := make([]int, m)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	for i := 0; i < m; i++ {
+		fmt.Fscan(reader, &b[i])
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			g := gcd(a[i], b[j])
+			if g > 1 {
+				a[i] /= g
+				b[j] /= g
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	return sb.String()
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(44))
+	var tests []test
+	fixed := []string{
+		"1 1\n2\n2\n",
+		"2 2\n4 9\n6 3\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(3) + 1
+		m := rng.Intn(3) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(20)+1)
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < m; i++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(20)+1)
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/200-299/220-229/222/verifierD.go
+++ b/0-999/200-299/220-229/222/verifierD.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n, x int
+	if _, err := fmt.Fscan(reader, &n, &x); err != nil {
+		return ""
+	}
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &b[i])
+	}
+	sort.Ints(a)
+	sort.Ints(b)
+	best := 1
+	i, j := 0, n-1
+	worst := 0
+	for i < n && j >= 0 {
+		if a[i]+b[j] >= x {
+			worst++
+			i++
+			j--
+		} else {
+			i++
+		}
+	}
+	return fmt.Sprintf("%d %d", best, worst)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(45))
+	var tests []test
+	fixed := []string{
+		"1 1\n1\n0\n",
+		"3 2\n1 1 1\n1 1 1\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		x := rng.Intn(10)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(10))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(10))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/200-299/220-229/222/verifierE.go
+++ b/0-999/200-299/220-229/222/verifierE.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod = 1000000007
+
+type test struct {
+	input    string
+	expected string
+}
+
+func charToIndex(c byte) int {
+	if c >= 'a' && c <= 'z' {
+		return int(c - 'a')
+	}
+	return int(c-'A') + 26
+}
+
+func indexToChar(i int) byte {
+	if i < 26 {
+		return byte('a' + i)
+	}
+	return byte('A' + i - 26)
+}
+
+func mul(a, b [][]int64, m int) [][]int64 {
+	c := make([][]int64, m)
+	for i := 0; i < m; i++ {
+		c[i] = make([]int64, m)
+		for k := 0; k < m; k++ {
+			if a[i][k] == 0 {
+				continue
+			}
+			aik := a[i][k]
+			for j := 0; j < m; j++ {
+				c[i][j] = (c[i][j] + aik*b[k][j]) % mod
+			}
+		}
+	}
+	return c
+}
+
+func matPow(a [][]int64, e int64, m int) [][]int64 {
+	res := make([][]int64, m)
+	for i := 0; i < m; i++ {
+		res[i] = make([]int64, m)
+		res[i][i] = 1
+	}
+	for e > 0 {
+		if e&1 == 1 {
+			res = mul(res, a, m)
+		}
+		a = mul(a, a, m)
+		e >>= 1
+	}
+	return res
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n int64
+	var m, k int
+	if _, err := fmt.Fscan(reader, &n, &m, &k); err != nil {
+		return ""
+	}
+	adj := make([][]int64, m)
+	for i := 0; i < m; i++ {
+		adj[i] = make([]int64, m)
+		for j := 0; j < m; j++ {
+			adj[i][j] = 1
+		}
+	}
+	for i := 0; i < k; i++ {
+		var s string
+		fmt.Fscan(reader, &s)
+		if len(s) != 2 {
+			continue
+		}
+		u := charToIndex(s[0])
+		v := charToIndex(s[1])
+		if u < m && v < m {
+			adj[u][v] = 0
+		}
+	}
+	var result int64
+	if n == 1 {
+		result = int64(m) % mod
+	} else {
+		p := matPow(adj, n-1, m)
+		var sum int64
+		for i := 0; i < m; i++ {
+			for j := 0; j < m; j++ {
+				sum = (sum + p[i][j]) % mod
+			}
+		}
+		result = sum
+	}
+	return fmt.Sprintf("%d", result)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(46))
+	var tests []test
+	fixed := []string{
+		"1 1 0\n",
+		"2 2 1\nab\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := int64(rng.Intn(5) + 1)
+		m := rng.Intn(4) + 1
+		maxPairs := m * m
+		k := rng.Intn(maxPairs + 1)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+		used := map[[2]int]bool{}
+		for i := 0; i < k; i++ {
+			for {
+				u := rng.Intn(m)
+				v := rng.Intn(m)
+				if !used[[2]int{u, v}] {
+					used[[2]int{u, v}] = true
+					sb.WriteByte(indexToChar(u))
+					sb.WriteByte(indexToChar(v))
+					sb.WriteByte('\n')
+					break
+				}
+			}
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.expected) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–E of contest 222
- each verifier generates 100 randomized tests and executes a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e92a744988324bd75941a2e5871fa