### PR TITLE
Add Go verifiers for Codeforces contest 219

### DIFF
--- a/0-999/200-299/210-219/219/verifierA.go
+++ b/0-999/200-299/210-219/219/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswerA(k int, s string) string {
+	freq := make([]int, 26)
+	for i := 0; i < len(s); i++ {
+		freq[s[i]-'a']++
+	}
+	for j := 0; j < 26; j++ {
+		if freq[j]%k != 0 {
+			return "-1"
+		}
+	}
+	var part []byte
+	for j := 0; j < 26; j++ {
+		cnt := freq[j] / k
+		for i := 0; i < cnt; i++ {
+			part = append(part, byte('a'+j))
+		}
+	}
+	return strings.Repeat(string(part), k)
+}
+
+func generateCaseA(rng *rand.Rand) (int, string) {
+	k := rng.Intn(5) + 1
+	n := rng.Intn(10) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return k, string(b)
+}
+
+func runCaseA(bin string, k int, s string) error {
+	input := fmt.Sprintf("%d\n%s\n", k, s)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedAnswerA(k, s)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// simple deterministic case
+	if err := runCaseA(bin, 1, "a"); err != nil {
+		fmt.Fprintln(os.Stderr, "deterministic case failed:", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		k, s := generateCaseA(rng)
+		if err := runCaseA(bin, k, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d\n%s\n", i+1, err, k, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/219/verifierB.go
+++ b/0-999/200-299/210-219/219/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func trailingNines(x int64) int {
+	cnt := 0
+	for x%10 == 9 {
+		cnt++
+		x /= 10
+	}
+	return cnt
+}
+
+func expectedAnswerB(p, d int64) int64 {
+	best := p
+	bestK := trailingNines(p)
+	pow10 := make([]int64, 19)
+	pow10[0] = 1
+	for i := 1; i < 19; i++ {
+		pow10[i] = pow10[i-1] * 10
+	}
+	for k := bestK + 1; k < 19; k++ {
+		mod := pow10[k]
+		if p < mod {
+			break
+		}
+		cand := (p/mod)*mod - 1
+		if cand >= 0 && p-cand <= d {
+			best = cand
+			bestK = k
+		}
+	}
+	return best
+}
+
+func generateCaseB(rng *rand.Rand) (int64, int64) {
+	p := rng.Int63n(1_000_000_000_000) + 1 // up to 1e12
+	d := rng.Int63n(p)
+	return p, d
+}
+
+func runCaseB(bin string, p, d int64) error {
+	input := fmt.Sprintf("%d %d\n", p, d)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := fmt.Sprint(expectedAnswerB(p, d))
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// deterministic test
+	if err := runCaseB(bin, 99, 10); err != nil {
+		fmt.Fprintln(os.Stderr, "deterministic case failed:", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		p, d := generateCaseB(rng)
+		if err := runCaseB(bin, p, d); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %d\n", i+1, err, p, d)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/219/verifierC.go
+++ b/0-999/200-299/210-219/219/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCaseC(n, k int, str string) (int, string) {
+	s := []byte(str)
+	if k == 2 {
+		pattern1 := make([]byte, n)
+		pattern2 := make([]byte, n)
+		changes1, changes2 := 0, 0
+		for i := 0; i < n; i++ {
+			pattern1[i] = byte('A' + byte(i%2))
+			pattern2[i] = byte('A' + byte((i+1)%2))
+			if s[i] != pattern1[i] {
+				changes1++
+			}
+			if s[i] != pattern2[i] {
+				changes2++
+			}
+		}
+		if changes1 <= changes2 {
+			return changes1, string(pattern1)
+		}
+		return changes2, string(pattern2)
+	}
+	changes := 0
+	for i := 0; i+1 < n; i++ {
+		if s[i] == s[i+1] {
+			changes++
+			for c := byte('A'); c < byte('A'+k); c++ {
+				if c != s[i] && (i+2 >= n || c != s[i+2]) {
+					s[i+1] = c
+					break
+				}
+			}
+		}
+	}
+	return changes, string(s)
+}
+
+func generateCaseC(rng *rand.Rand) (int, int, string) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(5) + 2 // at least 2
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('A' + rng.Intn(k))
+	}
+	return n, k, string(b)
+}
+
+func runCaseC(bin string, n, k int, s string) error {
+	input := fmt.Sprintf("%d %d\n%s\n", n, k, s)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) < 2 {
+		return fmt.Errorf("output too short: %q", out.String())
+	}
+	var gotChanges int
+	fmt.Sscan(fields[0], &gotChanges)
+	repainted := fields[1]
+	expChanges, expStr := solveCaseC(n, k, s)
+	if gotChanges != expChanges || repainted != expStr {
+		return fmt.Errorf("expected %d %s got %d %s", expChanges, expStr, gotChanges, repainted)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// deterministic case
+	if err := runCaseC(bin, 1, 2, "A"); err != nil {
+		fmt.Fprintln(os.Stderr, "deterministic case failed:", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		n, k, s := generateCaseC(rng)
+		if err := runCaseC(bin, n, k, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %d\n%s\n", i+1, err, n, k, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/219/verifierD.go
+++ b/0-999/200-299/210-219/219/verifierD.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	u, v int
+}
+
+type Edge struct{ to, cost int }
+
+func expectedAnswerD(n int, edges []edge) (int, []int) {
+	adj := make([][]Edge, n+1)
+	for _, e := range edges {
+		u, v := e.u, e.v
+		adj[u] = append(adj[u], Edge{v, 0})
+		adj[v] = append(adj[v], Edge{u, 1})
+	}
+	dp := make([]int, n+1)
+	parent := make([]int, n+1)
+	costToParent := make([]int, n+1)
+	visited := make([]bool, n+1)
+	queue := []int{1}
+	visited[1] = true
+	for i := 0; i < len(queue); i++ {
+		u := queue[i]
+		for _, e := range adj[u] {
+			v, c := e.to, e.cost
+			if !visited[v] {
+				visited[v] = true
+				dp[1] += c
+				parent[v] = u
+				costToParent[v] = c
+				queue = append(queue, v)
+			}
+		}
+	}
+	for i := 1; i < len(queue); i++ {
+		v := queue[i]
+		u := parent[v]
+		c := costToParent[v]
+		dp[v] = dp[u] - c + (1 - c)
+	}
+	minCost := dp[1]
+	for i := 2; i <= n; i++ {
+		if dp[i] < minCost {
+			minCost = dp[i]
+		}
+	}
+	var caps []int
+	for i := 1; i <= n; i++ {
+		if dp[i] == minCost {
+			caps = append(caps, i)
+		}
+	}
+	return minCost, caps
+}
+
+func generateCaseD(rng *rand.Rand) (int, []edge) {
+	n := rng.Intn(10) + 2
+	edges := make([]edge, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		if rng.Intn(2) == 0 {
+			edges[i-2] = edge{p, i}
+		} else {
+			edges[i-2] = edge{i, p}
+		}
+	}
+	return n, edges
+}
+
+func runCaseD(bin string, n int, edges []edge) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) < 1 {
+		return fmt.Errorf("no output")
+	}
+	var gotMin int
+	fmt.Sscan(fields[0], &gotMin)
+	gotCap := make([]int, 0)
+	for _, f := range fields[1:] {
+		var v int
+		fmt.Sscan(f, &v)
+		gotCap = append(gotCap, v)
+	}
+	expMin, expCap := expectedAnswerD(n, edges)
+	if gotMin != expMin || len(gotCap) != len(expCap) {
+		return fmt.Errorf("expected %d %v got %d %v", expMin, expCap, gotMin, gotCap)
+	}
+	for i := range gotCap {
+		if gotCap[i] != expCap[i] {
+			return fmt.Errorf("expected %d %v got %d %v", expMin, expCap, gotMin, gotCap)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	if err := runCaseD(bin, 2, []edge{{1, 2}}); err != nil {
+		fmt.Fprintln(os.Stderr, "deterministic case failed:", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		n, edges := generateCaseD(rng)
+		if err := runCaseD(bin, n, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/219/verifierE.go
+++ b/0-999/200-299/210-219/219/verifierE.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type op struct {
+	t, id int
+}
+
+func chooseSpot(n int, occupied map[int]bool) int {
+	if len(occupied) == 0 {
+		return 1
+	}
+	bestPos := -1
+	bestDist := -1
+	for pos := 1; pos <= n; pos++ {
+		if occupied[pos] {
+			continue
+		}
+		minDist := math.MaxInt32
+		for o := range occupied {
+			d := int(math.Abs(float64(pos - o)))
+			if d < minDist {
+				minDist = d
+			}
+		}
+		dist := 4 * minDist
+		if dist > bestDist || (dist == bestDist && pos < bestPos) {
+			bestDist = dist
+			bestPos = pos
+		}
+	}
+	return bestPos
+}
+
+func expectedAnswerE(n int, ops []op) []int {
+	occupied := make(map[int]bool)
+	carPos := make(map[int]int)
+	result := make([]int, 0)
+	for _, o := range ops {
+		if o.t == 1 {
+			pos := chooseSpot(n, occupied)
+			result = append(result, pos)
+			occupied[pos] = true
+			carPos[o.id] = pos
+		} else {
+			pos := carPos[o.id]
+			delete(carPos, o.id)
+			delete(occupied, pos)
+		}
+	}
+	return result
+}
+
+func generateCaseE(rng *rand.Rand) (int, []op) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(20) + 1
+	ops := make([]op, 0, m)
+	nextID := 1
+	parked := make([]int, 0)
+	for i := 0; i < m; i++ {
+		if len(parked) == 0 || (len(parked) < n && rng.Intn(2) == 0) {
+			// arrival
+			id := nextID
+			nextID++
+			ops = append(ops, op{1, id})
+			parked = append(parked, id)
+		} else {
+			// departure
+			idx := rng.Intn(len(parked))
+			id := parked[idx]
+			parked = append(parked[:idx], parked[idx+1:]...)
+			ops = append(ops, op{2, id})
+		}
+	}
+	return n, ops
+}
+
+func runCaseE(bin string, n int, ops []op) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(ops)))
+	for _, o := range ops {
+		sb.WriteString(fmt.Sprintf("%d %d\n", o.t, o.id))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	expected := expectedAnswerE(n, ops)
+	if len(fields) != len(expected) {
+		return fmt.Errorf("expected %d numbers got %d", len(expected), len(fields))
+	}
+	for i, f := range fields {
+		var val int
+		fmt.Sscan(f, &val)
+		if val != expected[i] {
+			return fmt.Errorf("expected %v got %v", expected, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	if err := runCaseE(bin, 1, []op{{1, 1}}); err != nil {
+		fmt.Fprintln(os.Stderr, "deterministic case failed:", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		n, ops := generateCaseE(rng)
+		if err := runCaseE(bin, n, ops); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier for problem A
- add Go verifier for problem B
- add Go verifier for problem C
- add Go verifier for problem D
- add Go verifier for problem E

Each verifier generates at least 100 random test cases and checks a binary's output against an expected solution.

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_687e91d57cd483248a50a9541b873509