### PR TITLE
Add Go verifiers for Codeforces contest 218

### DIFF
--- a/0-999/200-299/210-219/218/verifierA.go
+++ b/0-999/200-299/210-219/218/verifierA.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, k  int
+	r     []int
+	input string
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 1
+	k := rng.Intn(n) + 1
+	total := 2*n + 1
+	y := make([]int, total)
+	for i := 0; i < total; i += 2 {
+		y[i] = rng.Intn(41)
+	}
+	for i := 1; i < total; i += 2 {
+		left := y[i-1]
+		right := y[i+1]
+		base := max(left, right) + 1
+		y[i] = base + rng.Intn(99-base+1)
+	}
+	r := append([]int(nil), y...)
+	peaks := make([]int, 0, n)
+	for i := 1; i < total; i += 2 {
+		peaks = append(peaks, i)
+	}
+	rng.Shuffle(len(peaks), func(i, j int) { peaks[i], peaks[j] = peaks[j], peaks[i] })
+	for i := 0; i < k; i++ {
+		r[peaks[i]]++
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < total; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", r[i]))
+	}
+	sb.WriteByte('\n')
+	return testCase{n: n, k: k, r: r, input: sb.String()}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func checkOutput(tc testCase, out string) error {
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) != len(tc.r) {
+		return fmt.Errorf("expected %d numbers got %d", len(tc.r), len(fields))
+	}
+	y := make([]int, len(tc.r))
+	for i, f := range fields {
+		if _, err := fmt.Sscan(f, &y[i]); err != nil {
+			return fmt.Errorf("bad int %q", f)
+		}
+		if y[i] < 0 || y[i] > 100 {
+			return fmt.Errorf("value out of range %d", y[i])
+		}
+	}
+	for i := 1; i < len(y)-1; i += 2 {
+		if !(y[i] > y[i-1] && y[i] > y[i+1]) {
+			return fmt.Errorf("peak %d not higher than neighbours", i+1)
+		}
+	}
+	count := 0
+	for i := 0; i < len(y); i++ {
+		if i%2 == 1 {
+			diff := tc.r[i] - y[i]
+			if diff == 1 {
+				count++
+			} else if diff != 0 {
+				return fmt.Errorf("peak %d difference %d not 0 or 1", i+1, diff)
+			}
+		} else if tc.r[i] != y[i] {
+			return fmt.Errorf("index %d expected %d got %d", i+1, tc.r[i], y[i])
+		}
+	}
+	if count != tc.k {
+		return fmt.Errorf("expected %d changed peaks got %d", tc.k, count)
+	}
+	return nil
+}
+
+func runCase(exe string, tc testCase) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return checkOutput(tc, out.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(exe, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/218/verifierB.go
+++ b/0-999/200-299/210-219/218/verifierB.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m        int
+	seats       []int
+	input       string
+	expectedMax int
+	expectedMin int
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(1000) + 1
+	m := rng.Intn(10) + 1
+	seats := make([]int, m)
+	total := 0
+	for i := 0; i < m; i++ {
+		seats[i] = rng.Intn(1000) + 1
+		total += seats[i]
+	}
+	if total < n {
+		seats[0] += n - total
+		total = n
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", seats[i]))
+	}
+	sb.WriteByte('\n')
+	maxSum, minSum := calc(seats, n)
+	return testCase{n: n, m: m, seats: seats, input: sb.String(), expectedMax: maxSum, expectedMin: minSum}
+}
+
+func calc(seats []int, n int) (int, int) {
+	maxH := &maxHeap{}
+	minH := &minHeap{}
+	for _, v := range seats {
+		heap.Push(maxH, v)
+		heap.Push(minH, v)
+	}
+	heap.Init(maxH)
+	heap.Init(minH)
+	maxSum, minSum := 0, 0
+	for i := 0; i < n; i++ {
+		x := heap.Pop(maxH).(int)
+		maxSum += x
+		if x-1 > 0 {
+			heap.Push(maxH, x-1)
+		}
+		y := heap.Pop(minH).(int)
+		minSum += y
+		if y-1 > 0 {
+			heap.Push(minH, y-1)
+		}
+	}
+	return maxSum, minSum
+}
+
+type maxHeap []int
+
+func (h maxHeap) Len() int            { return len(h) }
+func (h maxHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h maxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *maxHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *maxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+type minHeap []int
+
+func (h minHeap) Len() int            { return len(h) }
+func (h minHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h minHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *minHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *minHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func runCase(exe string, tc testCase) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != 2 {
+		return fmt.Errorf("expected 2 numbers got %d", len(fields))
+	}
+	var a, b int
+	if _, err := fmt.Sscan(fields[0], &a); err != nil {
+		return fmt.Errorf("bad number %q", fields[0])
+	}
+	if _, err := fmt.Sscan(fields[1], &b); err != nil {
+		return fmt.Errorf("bad number %q", fields[1])
+	}
+	if a != tc.expectedMax || b != tc.expectedMin {
+		return fmt.Errorf("expected %d %d got %d %d", tc.expectedMax, tc.expectedMin, a, b)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(exe, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement verifierA.go and verifierB.go for contest 218
- each verifier generates random cases and checks program output
- verifies executable with at least 100 tests

## Testing
- `go run verifierA.go ./218A.go` *(compiled binary)*
- `go run verifierB.go ./218B.go` *(compiled binary)*

------
https://chatgpt.com/codex/tasks/task_e_687e918f3a848324805998facb325880