### PR TITLE
Add verifiers for contest 216

### DIFF
--- a/0-999/200-299/210-219/216/verifierA.go
+++ b/0-999/200-299/210-219/216/verifierA.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func compute(a, b, c int) int {
+	return a*b + b*c + a*c - a - b - c + 1
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		a := rand.Intn(999) + 2
+		b := rand.Intn(999) + 2
+		c := rand.Intn(999) + 2
+		input := fmt.Sprintf("%d %d %d\n", a, b, c)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: invalid output\n", i)
+			os.Exit(1)
+		}
+		if val != compute(a, b, c) {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %d\n", i, compute(a, b, c), val)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/216/verifierB.go
+++ b/0-999/200-299/210-219/216/verifierB.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n     int
+	edges [][2]int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase() testCaseB {
+	n := rand.Intn(19) + 2 // 2..20
+	edges := make([][2]int, 0, n)
+	deg := make([]int, n+1)
+	for i := 1; i < n; i++ {
+		if rand.Intn(2) == 0 {
+			u, v := i, i+1
+			edges = append(edges, [2]int{u, v})
+			deg[u]++
+			deg[v]++
+		}
+	}
+	if rand.Intn(2) == 0 {
+		u, v := 1, n
+		if deg[u] < 2 && deg[v] < 2 {
+			edges = append(edges, [2]int{u, v})
+			deg[u]++
+			deg[v]++
+		}
+	}
+	if len(edges) == 0 {
+		edges = append(edges, [2]int{1, 2})
+	}
+	return testCaseB{n: n, edges: edges}
+}
+
+func compute(tc testCaseB) int {
+	n := tc.n
+	adj := make([][]int, n+1)
+	for _, e := range tc.edges {
+		u := e[0]
+		v := e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	visited := make([]bool, n+1)
+	bench := 0
+	oddPath := 0
+	for i := 1; i <= n; i++ {
+		if visited[i] {
+			continue
+		}
+		stack := []int{i}
+		visited[i] = true
+		nodes := 0
+		degSum := 0
+		for len(stack) > 0 {
+			u := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			nodes++
+			degSum += len(adj[u])
+			for _, v := range adj[u] {
+				if !visited[v] {
+					visited[v] = true
+					stack = append(stack, v)
+				}
+			}
+		}
+		edgesCnt := degSum / 2
+		if edgesCnt == nodes {
+			if nodes%2 == 1 {
+				bench++
+			}
+		} else {
+			if nodes%2 == 1 {
+				oddPath++
+			}
+		}
+	}
+	if oddPath%2 == 1 {
+		bench++
+	}
+	return bench
+}
+
+func buildInput(tc testCaseB) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, len(tc.edges)))
+	for _, e := range tc.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		tc := generateCase()
+		input := buildInput(tc)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: invalid output\n", i)
+			os.Exit(1)
+		}
+		exp := compute(tc)
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %d\n", i, exp, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/216/verifierC.go
+++ b/0-999/200-299/210-219/216/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func computeCase(n, m, k int) (int, []int) {
+	if n == 2 && m == 2 && k == 1 {
+		return 4, []int{1, 2, 3, 4}
+	}
+	q := 0
+	if n+n == n+m+1 && k == 1 {
+		q = 1
+	}
+	if n+n < n+m+1 {
+		q = 1
+	}
+	total := k*2 + q
+	res := make([]int, 0, total)
+	for i := 0; i < k; i++ {
+		res = append(res, 1)
+	}
+	res = append(res, n)
+	for i := 0; i < k-1; i++ {
+		res = append(res, n+1)
+	}
+	a := 0
+	if n == m && k == 1 {
+		a = 1
+	}
+	if q == 1 {
+		res = append(res, n+m-a)
+	}
+	return total, res
+}
+
+func buildInput(n, m, k int) string {
+	return fmt.Sprintf("%d %d %d\n", n, m, k)
+}
+
+func parseInts(s string) ([]int, error) {
+	scan := strings.Fields(s)
+	vals := make([]int, len(scan))
+	for i, f := range scan {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, err
+		}
+		vals[i] = v
+	}
+	return vals, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		n := rand.Intn(9) + 2   // 2..10
+		m := rand.Intn(n-1) + 1 // 1..n
+		k := rand.Intn(n) + 1   // 1..n
+		input := buildInput(n, m, k)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+		vals, err := parseInts(out)
+		if err != nil || len(vals) == 0 {
+			fmt.Fprintf(os.Stderr, "case %d: bad output\n", i)
+			os.Exit(1)
+		}
+		expZ, expArr := computeCase(n, m, k)
+		if vals[0] != expZ || len(vals)-1 != expZ {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d numbers, got %d\n", i, expZ, len(vals)-1)
+			os.Exit(1)
+		}
+		for j := 0; j < expZ; j++ {
+			if vals[j+1] != expArr[j] {
+				fmt.Fprintf(os.Stderr, "case %d: mismatch\n", i)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/216/verifierD.go
+++ b/0-999/200-299/210-219/216/verifierD.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseD struct {
+	n       int
+	sectors [][]int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase() testCaseD {
+	n := rand.Intn(4) + 3 // 3..6
+	sectors := make([][]int, n)
+	for i := 0; i < n; i++ {
+		k := rand.Intn(3) + 1
+		start := i*1000 + 1
+		arr := make([]int, k)
+		for j := 0; j < k; j++ {
+			arr[j] = start + rand.Intn(900)
+		}
+		sort.Ints(arr)
+		sectors[i] = arr
+	}
+	return testCaseD{n: n, sectors: sectors}
+}
+
+func compute(tc testCaseD) int {
+	n := tc.n
+	sectors := make([][]int, n)
+	for i := 0; i < n; i++ {
+		sec := append([]int(nil), tc.sectors[i]...)
+		sort.Ints(sec)
+		sectors[i] = sec
+	}
+	unstable := 0
+	for i := 0; i < n; i++ {
+		left := sectors[(i-1+n)%n]
+		right := sectors[(i+1)%n]
+		cur := sectors[i]
+		for j := 0; j+1 < len(cur); j++ {
+			a, b := cur[j], cur[j+1]
+			l1 := sort.Search(len(left), func(x int) bool { return left[x] > a })
+			l2 := sort.Search(len(left), func(x int) bool { return left[x] >= b })
+			r1 := sort.Search(len(right), func(x int) bool { return right[x] > a })
+			r2 := sort.Search(len(right), func(x int) bool { return right[x] >= b })
+			if l2-l1 != r2-r1 {
+				unstable++
+			}
+		}
+	}
+	return unstable
+}
+
+func buildInput(tc testCaseD) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for _, sec := range tc.sectors {
+		sb.WriteString(fmt.Sprintf("%d", len(sec)))
+		for _, v := range sec {
+			sb.WriteString(fmt.Sprintf(" %d", v))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		tc := generateCase()
+		input := buildInput(tc)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: invalid output\n", i)
+			os.Exit(1)
+		}
+		exp := compute(tc)
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %d\n", i, exp, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/216/verifierE.go
+++ b/0-999/200-299/210-219/216/verifierE.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseE struct {
+	k int64
+	b int64
+	a []int64
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase() testCaseE {
+	k := int64(rand.Intn(9) + 2) // 2..10
+	b := int64(rand.Intn(int(k)))
+	n := rand.Intn(20) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rand.Intn(int(k)))
+	}
+	return testCaseE{k: k, b: b, a: arr}
+}
+
+func compute(tc testCaseE) int64 {
+	k := tc.k
+	b := tc.b
+	n := len(tc.a)
+	P := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		P[i+1] = P[i] + tc.a[i]
+	}
+	M := k - 1
+	if b == 0 {
+		cnt := make(map[int64]int64)
+		for _, v := range P {
+			cnt[v]++
+		}
+		var result int64
+		for _, c := range cnt {
+			if c > 1 {
+				result += c * (c - 1) / 2
+			}
+		}
+		return result
+	}
+	if b == M {
+		cntMod := make(map[int64]int64)
+		cntExact := make(map[int64]int64)
+		cntMod[P[0]%M] = 1
+		cntExact[P[0]] = 1
+		var totalMod, totalExact int64
+		for j := 1; j <= n; j++ {
+			r := P[j] % M
+			totalMod += cntMod[r]
+			totalExact += cntExact[P[j]]
+			cntMod[r]++
+			cntExact[P[j]]++
+		}
+		return totalMod - totalExact
+	}
+	cntMod := make(map[int64]int64)
+	cntMod[P[0]%M] = 1
+	var result int64
+	for j := 1; j <= n; j++ {
+		r := P[j] % M
+		need := r - b
+		need %= M
+		if need < 0 {
+			need += M
+		}
+		result += cntMod[need]
+		cntMod[r]++
+	}
+	return result
+}
+
+func buildInput(tc testCaseE) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.k, tc.b, len(tc.a)))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		tc := generateCase()
+		input := buildInput(tc)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: invalid output\n", i)
+			os.Exit(1)
+		}
+		exp := compute(tc)
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %d\n", i, exp, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers `verifierA.go` – `verifierE.go` for contest 216
- each verifier generates 100 random test cases and checks a given binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e91033f1c8324ab1711d319615815