### PR TITLE
Add Go verifiers for Codeforces contest 215

### DIFF
--- a/0-999/200-299/210-219/215/verifierA.go
+++ b/0-999/200-299/210-219/215/verifierA.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "215A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	aSet := make(map[int]bool)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		for {
+			v := rng.Intn(20) + 1
+			if !aSet[v] {
+				aSet[v] = true
+				a[i] = v
+				break
+			}
+		}
+	}
+	sort.Ints(a)
+	bSet := make(map[int]bool)
+	b := make([]int, m)
+	for i := 0; i < m; i++ {
+		for {
+			v := rng.Intn(40) + 1
+			if !bSet[v] {
+				bSet[v] = true
+				b[i] = v
+				break
+			}
+		}
+	}
+	// guarantee at least one integer ratio
+	idx := rng.Intn(n)
+	r := rng.Intn(5) + 1
+	b[0] = a[idx] * r
+	sort.Ints(b)
+
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(strconv.Itoa(m))
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/215/verifierB.go
+++ b/0-999/200-299/210-219/215/verifierB.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "215B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func randDistinct(rng *rand.Rand, count, max int) []int {
+	set := make(map[int]bool)
+	res := make([]int, 0, count)
+	for len(res) < count {
+		v := rng.Intn(max) + 1
+		if !set[v] {
+			set[v] = true
+			res = append(res, v)
+		}
+	}
+	sort.Ints(res)
+	return res
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	k := rng.Intn(5) + 1
+	xs := randDistinct(rng, n, 50)
+	ys := randDistinct(rng, m, 50)
+	zs := randDistinct(rng, k, 50)
+	A := rng.Intn(10) + 1
+	B := rng.Intn(10) + 1
+
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	for _, v := range xs {
+		sb.WriteByte(' ')
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(strconv.Itoa(m))
+	for _, v := range ys {
+		sb.WriteByte(' ')
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(strconv.Itoa(k))
+	for _, v := range zs {
+		sb.WriteByte(' ')
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d %d\n", A, B))
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	var expected float64
+	if _, err := fmt.Sscan(strings.TrimSpace(refOut.String()), &expected); err != nil {
+		return fmt.Errorf("failed to parse reference output: %v", err)
+	}
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if math.Abs(got-expected) > 1e-6 {
+		return fmt.Errorf("expected %.10f got %.10f", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/215/verifierC.go
+++ b/0-999/200-299/210-219/215/verifierC.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "215C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(30) + 1
+	m := rng.Intn(30) + 1
+	s := rng.Intn(n*m) + 1
+	return fmt.Sprintf("%d %d %d\n", n, m, s)
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/215/verifierD.go
+++ b/0-999/200-299/210-219/215/verifierD.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "215D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		t := rng.Intn(20) + 1
+		T := t + rng.Intn(20)
+		if T < t {
+			T = t
+		}
+		x := rng.Intn(10) + 1
+		c := rng.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", t, T, x, c))
+	}
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/215/verifierE.go
+++ b/0-999/200-299/210-219/215/verifierE.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "215E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	l := rng.Int63n(1_000_000_000) + 1
+	r := l + rng.Int63n(1_000_000_000)
+	return fmt.Sprintf("%d %d\n", l, r)
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–E of contest 215
- each verifier builds a reference solution, generates 100 random tests, and checks the provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e90bd03508324aa00d6c438ce0dbf