### PR TITLE
Add Go verifiers for contest 213

### DIFF
--- a/0-999/200-299/210-219/213/verifierA.go
+++ b/0-999/200-299/210-219/213/verifierA.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type caseA struct {
+	n   int
+	c   []int
+	pre [][]int
+}
+
+func genCaseA(rng *rand.Rand) caseA {
+	n := rng.Intn(8) + 2 // 2..9 to keep runtime small
+	c := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		c[i] = rng.Intn(3) + 1
+	}
+	pre := make([][]int, n+1)
+	for i := 1; i <= n; i++ {
+		k := rng.Intn(i) // prerequisites only from <i
+		used := map[int]bool{}
+		for j := 0; j < k; j++ {
+			for {
+				u := rng.Intn(i)
+				if u == 0 || used[u] {
+					continue
+				}
+				used[u] = true
+				pre[i] = append(pre[i], u)
+				break
+			}
+		}
+	}
+	return caseA{n, c, pre}
+}
+
+func solveA(tc caseA) int {
+	n := tc.n
+	c := tc.c
+	adj := make([][]int, n+1)
+	indeg0 := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		for _, u := range tc.pre[i] {
+			adj[u] = append(adj[u], i)
+			indeg0[i]++
+		}
+	}
+	moveCost := [4][4]int{{}, {0, 0, 1, 2}, {0, 2, 0, 1}, {0, 1, 2, 0}}
+	const INF = int(1 << 30)
+	res := INF
+	for start := 1; start <= 3; start++ {
+		indeg := make([]int, n+1)
+		copy(indeg, indeg0)
+		avail := make([][]int, 4)
+		for i := 1; i <= n; i++ {
+			if indeg[i] == 0 {
+				avail[c[i]] = append(avail[c[i]], i)
+			}
+		}
+		curr := start
+		cost := 0
+		done := 0
+		for done < n {
+			if len(avail[curr]) > 0 {
+				u := avail[curr][0]
+				avail[curr] = avail[curr][1:]
+				cost += 1
+				done++
+				for _, v := range adj[u] {
+					indeg[v]--
+					if indeg[v] == 0 {
+						avail[c[v]] = append(avail[c[v]], v)
+					}
+				}
+			} else {
+				bestM := 0
+				best := INF
+				for m := 1; m <= 3; m++ {
+					if len(avail[m]) > 0 && moveCost[curr][m] < best {
+						best = moveCost[curr][m]
+						bestM = m
+					}
+				}
+				if bestM == 0 {
+					break
+				}
+				cost += best
+				curr = bestM
+			}
+		}
+		if done == n && cost < res {
+			res = cost
+		}
+	}
+	return res
+}
+
+func runA(bin string, tc caseA) error {
+	var sb strings.Builder
+	fmt.Fprintln(&sb, tc.n)
+	for i := 1; i <= tc.n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, tc.c[i])
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= tc.n; i++ {
+		fmt.Fprint(&sb, len(tc.pre[i]))
+		for _, v := range tc.pre[i] {
+			fmt.Fprintf(&sb, " %d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solveA(tc)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := genCaseA(rng)
+		if err := runA(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/213/verifierB.go
+++ b/0-999/200-299/210-219/213/verifierB.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+type caseB struct {
+	n int
+	a [10]int
+}
+
+func genCaseB(rng *rand.Rand) caseB {
+	n := rng.Intn(20) + 1
+	var a [10]int
+	for i := 0; i < 10; i++ {
+		a[i] = rng.Intn(4) // small to keep compute quick
+	}
+	return caseB{n: n, a: a}
+}
+
+func solveB(tc caseB) int64 {
+	n := tc.n
+	a := tc.a
+	sumA := 0
+	maxN := n
+	for _, v := range a {
+		sumA += v
+		if v > maxN {
+			maxN = v
+		}
+	}
+	fact := make([]int64, maxN+1)
+	invfact := make([]int64, maxN+1)
+	fact[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invfact[maxN] = modPow(fact[maxN], mod-2)
+	for i := maxN; i > 0; i-- {
+		invfact[i-1] = invfact[i] * int64(i) % mod
+	}
+	pow10 := make([]int64, n+1)
+	pow10[0] = 1
+	for i := 1; i <= n; i++ {
+		pow10[i] = pow10[i-1] * 10 % mod
+	}
+	invAFact := int64(1)
+	for i := 0; i < 10; i++ {
+		if a[i] > maxN {
+			return 0
+		}
+		invAFact = invAFact * invfact[a[i]] % mod
+	}
+	a0p := a[0]
+	if a0p > 0 {
+		a0p--
+	}
+	sumAp := sumA
+	if a[0] > 0 {
+		sumAp--
+	}
+	invAPrime := invfact[a0p]
+	for i := 1; i < 10; i++ {
+		invAPrime = invAPrime * invfact[a[i]] % mod
+	}
+	var ans int64
+	for L := 1; L <= n; L++ {
+		var tot int64
+		if L >= sumA {
+			tot = fact[L] * pow10[L-sumA] % mod * invfact[L-sumA] % mod * invAFact % mod
+		}
+		var inv int64
+		if L-1 >= sumAp {
+			inv = fact[L-1] * pow10[L-1-sumAp] % mod * invfact[L-1-sumAp] % mod * invAPrime % mod
+		}
+		ans = (ans + tot - inv + mod) % mod
+	}
+	return ans
+}
+
+func runB(bin string, tc caseB) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", tc.n)
+	for i := 0; i < 10; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, tc.a[i])
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solveB(tc)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := genCaseB(rng)
+		if err := runB(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/213/verifierC.go
+++ b/0-999/200-299/210-219/213/verifierC.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type caseC struct {
+	n int
+	a [][]int
+}
+
+func genCaseC(rng *rand.Rand) caseC {
+	n := rng.Intn(6) + 2 // 2..7
+	a := make([][]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = make([]int, n+1)
+		for j := 1; j <= n; j++ {
+			a[i][j] = rng.Intn(21) - 10
+		}
+	}
+	return caseC{n, a}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveC(tc caseC) int {
+	n := tc.n
+	a := tc.a
+	const INF = -1 << 60
+	dpPrev := make([][]int, n+1)
+	dpCur := make([][]int, n+1)
+	for i := 0; i <= n; i++ {
+		dpPrev[i] = make([]int, n+1)
+		dpCur[i] = make([]int, n+1)
+		for j := 0; j <= n; j++ {
+			dpPrev[i][j] = INF
+			dpCur[i][j] = INF
+		}
+	}
+	dpPrev[1][1] = a[1][1]
+	for s := 3; s <= 2*n; s++ {
+		for i := 1; i <= n; i++ {
+			for j := 1; j <= n; j++ {
+				dpCur[i][j] = INF
+			}
+		}
+		for i1 := max(1, s-n); i1 <= n && i1 < s; i1++ {
+			j1 := s - i1
+			if j1 < 1 || j1 > n {
+				continue
+			}
+			for i2 := max(1, s-n); i2 <= n && i2 < s; i2++ {
+				j2 := s - i2
+				if j2 < 1 || j2 > n {
+					continue
+				}
+				best := dpPrev[i1][i2]
+				if i1 > 1 {
+					best = max(best, dpPrev[i1-1][i2])
+				}
+				if i2 > 1 {
+					best = max(best, dpPrev[i1][i2-1])
+				}
+				if i1 > 1 && i2 > 1 {
+					best = max(best, dpPrev[i1-1][i2-1])
+				}
+				if best <= INF/2 {
+					continue
+				}
+				val := best + a[i1][j1]
+				if i1 != i2 {
+					val += a[i2][j2]
+				}
+				dpCur[i1][i2] = val
+			}
+		}
+		dpPrev, dpCur = dpCur, dpPrev
+	}
+	return dpPrev[n][n]
+}
+
+func runC(bin string, tc caseC) error {
+	var sb strings.Builder
+	fmt.Fprintln(&sb, tc.n)
+	for i := 1; i <= tc.n; i++ {
+		for j := 1; j <= tc.n; j++ {
+			if j > 1 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprint(&sb, tc.a[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solveC(tc)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := genCaseC(rng)
+		if err := runC(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/213/verifierD.go
+++ b/0-999/200-299/210-219/213/verifierD.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Vec struct{ y, x float64 }
+
+func (v Vec) add(r Vec) Vec { return Vec{v.y + r.y, v.x + r.x} }
+func (v Vec) sub(r Vec) Vec { return Vec{v.y - r.y, v.x - r.x} }
+func rotate(l Vec, r float64) Vec {
+	return Vec{l.y*math.Cos(r) + l.x*math.Sin(r), l.x*math.Cos(r) - l.y*math.Sin(r)}
+}
+
+func genCaseD(rng *rand.Rand) int {
+	return rng.Intn(5) + 1
+}
+
+func solveD(n int) string {
+	PI := math.Atan2(0, -1)
+	a := 72.0 / 180.0 * PI
+	base := Vec{0, 10}
+	pts := make([]Vec, 0, 1+4*n)
+	pts = append(pts, Vec{0, 0})
+	for i := 0; i < n; i++ {
+		c := len(pts) - 1
+		pts = append(pts, pts[c].sub(rotate(base, -2*a)))
+		pts = append(pts, pts[c].add(rotate(base, -a)))
+		pts = append(pts, pts[len(pts)-1].add(base))
+		pts = append(pts, pts[len(pts)-1].add(rotate(base, a)))
+	}
+	var sb strings.Builder
+	fmt.Fprintln(&sb, len(pts))
+	for _, v := range pts {
+		fmt.Fprintf(&sb, "%.9f %.9f\n", v.x, v.y)
+	}
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d %d %d %d\n", i*4+1, i*4+3, i*4+4, i*4+5, i*4+2)
+	}
+	fmt.Fprint(&sb, 1)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, " %d %d %d %d", i*4+4, i*4+2, i*4+3, i*4+5)
+	}
+	for i := n - 1; i >= 0; i-- {
+		fmt.Fprintf(&sb, " %d", i*4+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runD(bin string, n int) error {
+	input := fmt.Sprintf("%d\n", n)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, string(out))
+	}
+	got := strings.TrimSpace(string(out))
+	exp := strings.TrimSpace(solveD(n))
+	if got != exp {
+		return fmt.Errorf("output mismatch")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		n := genCaseD(rng)
+		if err := runD(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/210-219/213/verifierE.go
+++ b/0-999/200-299/210-219/213/verifierE.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type caseE struct {
+	n, m int
+	a    []int
+	b    []int
+}
+
+func genPerm(rng *rand.Rand, n int) []int {
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = i + 1
+	}
+	rng.Shuffle(n, func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+	return arr
+}
+
+func genCaseE(rng *rand.Rand) caseE {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(10) + n
+	a := genPerm(rng, n)
+	b := genPerm(rng, m)
+	return caseE{n, m, a, b}
+}
+
+func matchPat(plBase, glBase, plTxt, glTxt []int, i, j int) bool {
+	s := i - j
+	if plBase[j] == 0 {
+		if plTxt[i] > s {
+			return false
+		}
+	} else {
+		if plTxt[i] != s+(j-plBase[j]) {
+			return false
+		}
+	}
+	if glBase[j] == 0 {
+		if glTxt[i] > s {
+			return false
+		}
+	} else {
+		if glTxt[i] != s+(j-glBase[j]) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchTxt(plPat, glPat, plTxt, glTxt []int, i, j int) bool {
+	s := i - j
+	if plPat[j] == 0 {
+		if plTxt[i] > s {
+			return false
+		}
+	} else {
+		if plTxt[i] != s+(j-plPat[j]) {
+			return false
+		}
+	}
+	if glPat[j] == 0 {
+		if glTxt[i] > s {
+			return false
+		}
+	} else {
+		if glTxt[i] != s+(j-glPat[j]) {
+			return false
+		}
+	}
+	return true
+}
+
+func solveE(tc caseE) int {
+	n := tc.n
+	m := tc.m
+	a := append([]int{0}, tc.a...)
+	b := append([]int{0}, tc.b...)
+	P := make([]int, m+2)
+	for i := 1; i <= m; i++ {
+		P[b[i]] = i
+	}
+	T := make([]int, m+1)
+	for v := 1; v <= m; v++ {
+		T[v] = P[v]
+	}
+	plPat := make([]int, n+1)
+	glPat := make([]int, n+1)
+	stack := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		for len(stack) > 0 && a[stack[len(stack)-1]] >= a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == 0 {
+			plPat[i] = 0
+		} else {
+			plPat[i] = stack[len(stack)-1]
+		}
+		stack = append(stack, i)
+	}
+	stack = stack[:0]
+	for i := 1; i <= n; i++ {
+		for len(stack) > 0 && a[stack[len(stack)-1]] <= a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == 0 {
+			glPat[i] = 0
+		} else {
+			glPat[i] = stack[len(stack)-1]
+		}
+		stack = append(stack, i)
+	}
+	plTxt := make([]int, m+1)
+	glTxt := make([]int, m+1)
+	stack = stack[:0]
+	for i := 1; i <= m; i++ {
+		for len(stack) > 0 && T[stack[len(stack)-1]] >= T[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == 0 {
+			plTxt[i] = 0
+		} else {
+			plTxt[i] = stack[len(stack)-1]
+		}
+		stack = append(stack, i)
+	}
+	stack = stack[:0]
+	for i := 1; i <= m; i++ {
+		for len(stack) > 0 && T[stack[len(stack)-1]] <= T[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == 0 {
+			glTxt[i] = 0
+		} else {
+			glTxt[i] = stack[len(stack)-1]
+		}
+		stack = append(stack, i)
+	}
+	pi := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		j := pi[i-1]
+		for j > 0 && !matchPat(plPat, glPat, plPat, glPat, i, j+1) {
+			j = pi[j]
+		}
+		if matchPat(plPat, glPat, plPat, glPat, i, j+1) {
+			j++
+		}
+		pi[i] = j
+	}
+	q := 0
+	count := 0
+	for i := 1; i <= m; i++ {
+		for q > 0 && !matchTxt(plPat, glPat, plTxt, glTxt, i, q+1) {
+			q = pi[q]
+		}
+		if matchTxt(plPat, glPat, plTxt, glTxt, i, q+1) {
+			q++
+		}
+		if q == n {
+			count++
+			q = pi[q]
+		}
+	}
+	return count
+}
+
+func runE(bin string, tc caseE) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solveE(tc)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		tc := genCaseE(rng)
+		if err := runE(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for Codeforces contest 213 problems A–E
- each verifier runs 100 generated test cases and checks a binary's output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e9030e5308324bd8d5b2488b4399b