### PR TITLE
Add Go verifiers for contest 206

### DIFF
--- a/0-999/200-299/200-209/206/verifierA.go
+++ b/0-999/200-299/200-209/206/verifierA.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type seq struct {
+	value int64
+	id    int
+}
+
+type seqHeap []seq
+
+func (h seqHeap) Len() int            { return len(h) }
+func (h seqHeap) Less(i, j int) bool  { return h[i].value < h[j].value }
+func (h seqHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *seqHeap) Push(x interface{}) { *h = append(*h, x.(seq)) }
+func (h *seqHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func solveA(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return ""
+	}
+	k := make([]int, n)
+	xi := make([]int64, n)
+	yi := make([]int64, n)
+	mi := make([]int64, n)
+	curr := make([]int64, n)
+	pos := make([]int, n)
+	total := 0
+	for i := 0; i < n; i++ {
+		var a1 int64
+		fmt.Fscan(in, &k[i], &a1, &xi[i], &yi[i], &mi[i])
+		curr[i] = a1
+		pos[i] = 1
+		total += k[i]
+	}
+	h := &seqHeap{}
+	heap.Init(h)
+	for i := 0; i < n; i++ {
+		if k[i] > 0 {
+			heap.Push(h, seq{value: curr[i], id: i})
+		}
+	}
+	var badCount int64
+	var prev int64
+	first := true
+	for h.Len() > 0 {
+		s := heap.Pop(h).(seq)
+		v := s.value
+		i := s.id
+		if first {
+			prev = v
+			first = false
+		} else {
+			if prev > v {
+				badCount++
+			}
+			prev = v
+		}
+		pos[i]++
+		if pos[i] < k[i] {
+			next := (curr[i]*xi[i] + yi[i]) % mi[i]
+			curr[i] = next
+			heap.Push(h, seq{value: next, id: i})
+		}
+	}
+	return fmt.Sprintf("%d\n", badCount)
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	lines := make([]string, n+1)
+	lines[0] = fmt.Sprintf("%d", n)
+	for i := 0; i < n; i++ {
+		k := rng.Intn(4) + 1
+		m := rng.Int63n(1000) + 1
+		a1 := rng.Int63n(m)
+		xi := rng.Int63n(1000) + 1
+		yi := rng.Int63n(1000)
+		lines[i+1] = fmt.Sprintf("%d %d %d %d %d", k, a1, xi, yi, m)
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		expect := strings.TrimSpace(solveA(tc))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		gotLine := strings.TrimSpace(strings.SplitN(got, "\n", 2)[0])
+		if gotLine != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, gotLine, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/200-209/206/verifierB.go
+++ b/0-999/200-299/200-209/206/verifierB.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+// -------- reference solution --------
+type maxHeap []int
+
+func (h maxHeap) Len() int            { return len(h) }
+func (h maxHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h maxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *maxHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *maxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func solveB(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(in, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	N := 2 * n
+	pairs := make([]struct{ l, j int }, N)
+	for j := 1; j <= N; j++ {
+		aj := a[(j-1)%n]
+		l := j - aj
+		if l < 1 {
+			l = 1
+		}
+		pairs[j-1] = struct{ l, j int }{l, j}
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].l < pairs[j].l })
+	R := make([]int, N+2)
+	h := &maxHeap{}
+	heap.Init(h)
+	idx := 0
+	for i := 1; i <= N; i++ {
+		for idx < N && pairs[idx].l <= i {
+			heap.Push(h, pairs[idx].j)
+			idx++
+		}
+		for h.Len() > 0 {
+			top := (*h)[0]
+			if top <= i {
+				heap.Pop(h)
+			} else {
+				break
+			}
+		}
+		if h.Len() == 0 {
+			R[i] = i
+		} else {
+			R[i] = (*h)[0]
+		}
+	}
+	R[N+1] = N + 1
+	maxLg := 0
+	for (1 << maxLg) <= N {
+		maxLg++
+	}
+	up := make([][]int, maxLg)
+	up[0] = make([]int, N+2)
+	for i := 1; i <= N; i++ {
+		up[0][i] = R[i]
+	}
+	for k := 1; k < maxLg; k++ {
+		up[k] = make([]int, N+2)
+		for i := 1; i <= N; i++ {
+			up[k][i] = up[k-1][up[k-1][i]]
+		}
+	}
+	var total int64
+	for s := 1; s <= n; s++ {
+		target := s + n - 1
+		cur := s
+		var cnt int64
+		for k := maxLg - 1; k >= 0; k-- {
+			nxt := up[k][cur]
+			if nxt < target {
+				cur = nxt
+				cnt += 1 << k
+			}
+		}
+		if cur < target {
+			cnt++
+		}
+		total += cnt
+	}
+	return fmt.Sprintf("%d\n", total)
+}
+
+// -------- runner --------
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	nums := make([]string, n+1)
+	nums[0] = fmt.Sprintf("%d", n)
+	for i := 0; i < n; i++ {
+		nums[i+1] = fmt.Sprintf("%d", rng.Intn(10)+1)
+	}
+	return strings.Join(nums, " \n") + "\n"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		expect := strings.TrimSpace(solveB(tc))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		gotLine := strings.TrimSpace(strings.SplitN(got, "\n", 2)[0])
+		if gotLine != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, gotLine, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/200-209/206/verifierC.go
+++ b/0-999/200-299/200-209/206/verifierC.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// reference implementation from 206C1.go
+func solveC(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return ""
+	}
+	s1 := []string{""}
+	count1 := map[string]int{"": 1}
+	t2 := []string{""}
+	parent2 := []int{-1}
+	count2 := map[string]int{"": 1}
+	total := int64(1)
+	var out bytes.Buffer
+	for i := 0; i < n; i++ {
+		var t, v int
+		var cs string
+		fmt.Fscan(reader, &t, &v, &cs)
+		c := cs
+		v--
+		if t == 1 {
+			s := c + s1[v]
+			s1 = append(s1, s)
+			count1[s]++
+			if cnt2, ok := count2[s]; ok {
+				total += int64(cnt2)
+			}
+		} else {
+			newID := len(t2)
+			parent2 = append(parent2, v)
+			tstr := t2[v] + c
+			t2 = append(t2, tstr)
+			for j := newID; j >= 0; j = parent2[j] {
+				prefixLen := len(t2[j])
+				s := tstr[prefixLen:]
+				count2[s]++
+				if cnt1, ok := count1[s]; ok {
+					total += int64(cnt1)
+				}
+				if j == 0 {
+					break
+				}
+			}
+		}
+		fmt.Fprintln(&out, total)
+	}
+	return out.String()
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	lines := make([]string, n+1)
+	lines[0] = fmt.Sprintf("%d", n)
+	size1, size2 := 1, 1
+	for i := 0; i < n; i++ {
+		t := rng.Intn(2) + 1
+		var v int
+		if t == 1 {
+			v = rng.Intn(size1) + 1
+			size1++
+		} else {
+			v = rng.Intn(size2) + 1
+			size2++
+		}
+		c := string('a' + rune(rng.Intn(26)))
+		lines[i+1] = fmt.Sprintf("%d %d %s", t, v, c)
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		expect := strings.TrimSpace(solveC(tc))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, expect, strings.TrimSpace(got), tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/200-209/206/verifierD.go
+++ b/0-999/200-299/200-209/206/verifierD.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) string {
+	lines := []string{
+		fmt.Sprintf("%d", rng.Intn(1000)),
+		"doc",
+		"sample text",
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		ans := strings.TrimSpace(out)
+		if ans != "1" && ans != "2" && ans != "3" {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid output %q\n", i+1, ans)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D

## Testing
- `go run 0-999/200-299/200-209/206/verifierA.go /tmp/206A1`
- `go run 0-999/200-299/200-209/206/verifierB.go /tmp/206B1`
- `go run 0-999/200-299/200-209/206/verifierC.go /tmp/206C1_fixed`
- `go run 0-999/200-299/200-209/206/verifierD.go /tmp/206D1`


------
https://chatgpt.com/codex/tasks/task_e_687e8e46a4808324bdf04d502c8da097