### PR TITLE
Add verifiers for contest 204

### DIFF
--- a/0-999/200-299/200-209/204/verifierA.go
+++ b/0-999/200-299/200-209/204/verifierA.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCase struct {
+	l uint64
+	r uint64
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func countSameFirstLast(n uint64) uint64 {
+	if n == 0 {
+		return 0
+	}
+	s := strconv.FormatUint(n, 10)
+	length := len(s)
+	if length == 1 {
+		return n
+	}
+	pow10 := make([]uint64, length)
+	pow10[0] = 1
+	for i := 1; i < length; i++ {
+		pow10[i] = pow10[i-1] * 10
+	}
+	var ans uint64
+	for k := 1; k < length; k++ {
+		if k == 1 {
+			ans += 9
+		} else {
+			ans += 9 * pow10[k-2]
+		}
+	}
+	firstDigit := uint64(s[0] - '0')
+	for d := uint64(1); d < firstDigit; d++ {
+		if length == 1 {
+			ans += d
+		} else {
+			ans += pow10[length-2]
+		}
+	}
+	var mid uint64
+	if length > 2 {
+		m, _ := strconv.ParseUint(s[1:len(s)-1], 10, 64)
+		mid = m
+	}
+	ans += mid
+	lastDigit := uint64(s[len(s)-1] - '0')
+	if lastDigit >= firstDigit {
+		ans++
+	}
+	return ans
+}
+
+func solveA(l, r uint64) string {
+	var res uint64
+	if l > 1 {
+		res = countSameFirstLast(r) - countSameFirstLast(l-1)
+	} else {
+		res = countSameFirstLast(r)
+	}
+	return fmt.Sprintf("%d\n", res)
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 0, 100)
+	fixed := []testCase{
+		{1, 9}, {10, 99}, {1, 1000}, {123, 4567}, {1111, 9999},
+	}
+	tests = append(tests, fixed...)
+	for len(tests) < 100 {
+		l := rng.Uint64()%1000000 + 1
+		r := l + rng.Uint64()%1000000
+		tests = append(tests, testCase{l, r})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.l, t.r)
+		expect := strings.TrimSpace(solveA(t.l, t.r))
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/200-209/204/verifierB.go
+++ b/0-999/200-299/200-209/204/verifierB.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type card struct {
+	a int
+	b int
+}
+
+type testCase struct {
+	cards []card
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveB(cards []card) string {
+	n := len(cards)
+	fronts := make(map[int]int)
+	backs := make(map[int]int)
+	for _, c := range cards {
+		fronts[c.a]++
+		if c.b != c.a {
+			backs[c.b]++
+		}
+	}
+	needed := (n + 1) / 2
+	const INF = 1 << 60
+	ans := INF
+	for color, fcnt := range fronts {
+		if fcnt >= needed {
+			ans = 0
+			break
+		}
+		need := needed - fcnt
+		if bcnt, ok := backs[color]; ok && bcnt >= need {
+			if need < ans {
+				ans = need
+			}
+		}
+	}
+	for color, bcnt := range backs {
+		if _, seen := fronts[color]; seen {
+			continue
+		}
+		if bcnt >= needed && needed < ans {
+			ans = needed
+		}
+	}
+	if ans == INF {
+		return "-1\n"
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(2))
+	tests := make([]testCase, 0, 100)
+	fixed := []testCase{
+		{cards: []card{{4, 4}, {4, 4}, {7, 7}}},
+		{cards: []card{{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}}},
+	}
+	tests = append(tests, fixed...)
+	for len(tests) < 100 {
+		n := rng.Intn(8) + 1
+		cards := make([]card, n)
+		for i := 0; i < n; i++ {
+			a := rng.Intn(10) + 1
+			b := rng.Intn(10) + 1
+			cards[i] = card{a: a, b: b}
+		}
+		tests = append(tests, testCase{cards: cards})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", len(t.cards)))
+		for _, c := range t.cards {
+			input.WriteString(fmt.Sprintf("%d %d\n", c.a, c.b))
+		}
+		expect := strings.TrimSpace(solveB(t.cards))
+		out, err := runBinary(bin, input.String())
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/200-209/204/verifierC.go
+++ b/0-999/200-299/200-209/204/verifierC.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCase struct {
+	a string
+	b string
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveC(a, b string) string {
+	n := len(a)
+	v1 := make([][]int, 26)
+	v2 := make([][]int, 26)
+	for i := 0; i < n; i++ {
+		c1 := int(a[i] - 'A')
+		c2 := int(b[i] - 'A')
+		if c1 >= 0 && c1 < 26 {
+			v1[c1] = append(v1[c1], i)
+		}
+		if c2 >= 0 && c2 < 26 {
+			v2[c2] = append(v2[c2], i)
+		}
+	}
+	sum1 := make([][]float64, 26)
+	sum2 := make([][]float64, 26)
+	for i := 0; i < 26; i++ {
+		sz := len(v2[i])
+		if sz == 0 {
+			continue
+		}
+		sum1[i] = make([]float64, sz)
+		sum2[i] = make([]float64, sz)
+		for j := 0; j < sz; j++ {
+			val := float64(v2[i][j] + 1)
+			if j == 0 {
+				sum1[i][j] = val
+			} else {
+				sum1[i][j] = sum1[i][j-1] + val
+			}
+		}
+		for j := sz - 1; j >= 0; j-- {
+			val := float64(n - v2[i][j])
+			if j == sz-1 {
+				sum2[i][j] = val
+			} else {
+				sum2[i][j] = sum2[i][j+1] + val
+			}
+		}
+	}
+	var res float64
+	for i := 0; i < 26; i++ {
+		if len(v2[i]) == 0 {
+			continue
+		}
+		for _, pos := range v1[i] {
+			idx := sort.SearchInts(v2[i], pos)
+			if idx > 0 {
+				res += float64(n-pos) * sum1[i][idx-1]
+			}
+			if idx < len(v2[i]) {
+				res += float64(pos+1) * sum2[i][idx]
+			}
+		}
+	}
+	div := float64(n) * float64(n+1) * float64(2*n+1) / 6.0
+	return fmt.Sprintf("%.10f", res/div)
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(3))
+	tests := make([]testCase, 0, 100)
+	fixed := []testCase{{a: "AB", b: "BA"}, {a: "AAAA", b: "BBBB"}}
+	tests = append(tests, fixed...)
+	letters := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		sb1 := make([]byte, n)
+		sb2 := make([]byte, n)
+		for i := 0; i < n; i++ {
+			sb1[i] = letters[rng.Intn(26)]
+			sb2[i] = letters[rng.Intn(26)]
+		}
+		tests = append(tests, testCase{a: string(sb1), b: string(sb2)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n%s\n%s\n", len(t.a), t.a, t.b)
+		expect := strings.TrimSpace(solveC(t.a, t.b))
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/200-209/204/verifierD.go
+++ b/0-999/200-299/200-209/204/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "204D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+type testCase struct {
+	n int
+	k int
+	s string
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(4))
+	tests := make([]testCase, 0, 100)
+	fixed := []testCase{{n: 1, k: 1, s: "B"}, {n: 3, k: 1, s: "BWB"}}
+	tests = append(tests, fixed...)
+	letters := []byte("BWX")
+	for len(tests) < 100 {
+		n := rng.Intn(8) + 1
+		k := rng.Intn(n) + 1
+		sb := make([]byte, n)
+		for i := 0; i < n; i++ {
+			sb[i] = letters[rng.Intn(3)]
+		}
+		tests = append(tests, testCase{n: n, k: k, s: string(sb)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n%s\n", t.n, t.k, t.s)
+		expOut, err := run(oracle, input)
+		if err != nil {
+			fmt.Printf("oracle error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != expOut {
+			fmt.Printf("test %d failed. Expected %q got %q\n", i+1, expOut, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/200-299/200-209/204/verifierE.go
+++ b/0-999/200-299/200-209/204/verifierE.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "204E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+type testCase struct {
+	n    int
+	k    int
+	strs []string
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(5))
+	tests := make([]testCase, 0, 100)
+	fixed := []testCase{{n: 1, k: 1, strs: []string{"a"}}}
+	tests = append(tests, fixed...)
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	for len(tests) < 100 {
+		n := rng.Intn(4) + 1
+		k := rng.Intn(n) + 1
+		strs := make([]string, n)
+		for i := 0; i < n; i++ {
+			l := rng.Intn(5) + 1
+			b := make([]byte, l)
+			for j := 0; j < l; j++ {
+				b[j] = letters[rng.Intn(26)]
+			}
+			strs[i] = string(b)
+		}
+		tests = append(tests, testCase{n: n, k: k, strs: strs})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	tests := generateTests()
+	for i, t := range tests {
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d %d\n", t.n, t.k))
+		for _, s := range t.strs {
+			input.WriteString(fmt.Sprintf("%s\n", s))
+		}
+		expOut, err := run(oracle, input.String())
+		if err != nil {
+			fmt.Printf("oracle error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != expOut {
+			fmt.Printf("test %d failed. Expected %q got %q\n", i+1, expOut, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for all problems of Codeforces contest 204
- each verifier runs the provided binary (or Go file) against 100+ tests
- complex tasks use the original solution as an oracle

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e8dbad2b083249ba39c43b9ef374a