### PR TITLE
Add verifiers for contest 198

### DIFF
--- a/0-999/100-199/190-199/198/verifierA.go
+++ b/0-999/100-199/190-199/198/verifierA.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(k, b, n, t int64) int64 {
+	cur := int64(1)
+	steps := int64(0)
+	for steps < n && k*cur+b <= t {
+		cur = k*cur + b
+		steps++
+	}
+	return n - steps
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	k := int64(rng.Intn(5) + 1)
+	b := int64(rng.Intn(5))
+	n := int64(rng.Intn(10) + 1)
+	tVal := int64(rng.Intn(1000))
+	input := fmt.Sprintf("%d %d %d %d\n", k, b, n, tVal)
+	ans := solve(k, b, n, tVal)
+	return input, fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin string, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/198/verifierB.go
+++ b/0-999/100-199/190-199/198/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type state struct{ wall, pos, time int }
+
+func solve(n, k int, left, right string) string {
+	l := []byte(" " + left)
+	r := []byte(" " + right)
+	visited := make([][]bool, 2)
+	visited[0] = make([]bool, n+2)
+	visited[1] = make([]bool, n+2)
+	q := []state{{0, 1, 0}}
+	visited[0][1] = true
+	for head := 0; head < len(q); head++ {
+		cur := q[head]
+		w, p, t := cur.wall, cur.pos, cur.time
+		moves := []int{p + 1, p - 1, p + k}
+		walls := []int{w, w, 1 - w}
+		for i, np := range moves {
+			nw := walls[i]
+			nt := t + 1
+			if np > n {
+				return "YES"
+			}
+			if np <= nt || np < 1 {
+				continue
+			}
+			if visited[nw][np] {
+				continue
+			}
+			if (nw == 0 && l[np] == 'X') || (nw == 1 && r[np] == 'X') {
+				continue
+			}
+			visited[nw][np] = true
+			q = append(q, state{nw, np, nt})
+		}
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(20) + 1
+	left := make([]byte, n)
+	right := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(4) == 0 {
+			left[i] = 'X'
+		} else {
+			left[i] = '-'
+		}
+		if rng.Intn(4) == 0 {
+			right[i] = 'X'
+		} else {
+			right[i] = '-'
+		}
+	}
+	left[0] = '-'
+	inp := fmt.Sprintf("%d %d\n%s\n%s\n", n, k, string(left), string(right))
+	ans := solve(n, k, string(left), string(right))
+	return inp, ans
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/198/verifierC.go
+++ b/0-999/100-199/190-199/198/verifierC.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var (
+	xx, yy, vv        float64
+	x, y, v, rrGlobal float64
+	tx, ty            float64
+)
+
+func getPos(m float64) float64 {
+	qx := x + (tx-x)*m
+	qy := y + (ty-y)*m
+	return math.Hypot(qx, qy)
+}
+
+func getExt(x0, y0 float64) (float64, float64) {
+	c := math.Hypot(x0, y0)
+	a := rrGlobal
+	b := math.Sqrt(c*c - a*a)
+	return b, math.Acos(a / c)
+}
+
+func check(t float64) float64 {
+	l2, r2 := 0.0, 1.0
+	for i := 0; i < 200; i++ {
+		m1 := (2*l2 + r2) / 3
+		m2 := (l2 + 2*r2) / 3
+		if getPos(m1) <= getPos(m2) {
+			r2 = m2
+		} else {
+			l2 = m1
+		}
+	}
+	if getPos(l2) >= rrGlobal {
+		return math.Hypot(x-tx, y-ty)
+	}
+	spang := math.Abs(math.Atan2(y, x) - math.Atan2(ty, tx))
+	if 2*math.Pi-spang < spang {
+		spang = 2*math.Pi - spang
+	}
+	b1, ang1 := getExt(x, y)
+	b2, ang2 := getExt(tx, ty)
+	spang -= (ang1 + ang2)
+	return b1 + b2 + spang*rrGlobal
+}
+
+func solveCase(xp, yp, vp, x1, y1, v1, r float64) float64 {
+	xx, yy, vv = xp, yp, vp
+	x, y, v, rrGlobal = x1, y1, v1, r
+	stang := math.Atan2(yy, xx)
+	rr := math.Hypot(xx, yy)
+	l, rtime := 0.0, 1e7
+	for i := 0; i < 200; i++ {
+		m := (l + rtime) / 2
+		nang := stang + vv*m/rr
+		tx = math.Cos(nang) * rr
+		ty = math.Sin(nang) * rr
+		if check(m) <= v*m {
+			rtime = m
+		} else {
+			l = m
+		}
+	}
+	return rtime
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	xp := rng.Float64()*20 - 10
+	yp := rng.Float64()*20 - 10
+	vp := rng.Float64()*5 + 1
+	x1 := rng.Float64()*20 - 10
+	y1 := rng.Float64()*20 - 10
+	r := rng.Float64()*5 + 1
+	v1 := vp + rng.Float64()*5 + 0.1
+	if math.Hypot(x1, y1) <= r {
+		x1 += r
+		y1 += r
+	}
+	if math.Hypot(xp, yp) <= r {
+		xp += r
+		yp += r
+	}
+	inp := fmt.Sprintf("%.4f %.4f %.4f\n%.4f %.4f %.4f %.4f\n", xp, yp, vp, x1, y1, v1, r)
+	ans := solveCase(xp, yp, vp, x1, y1, v1, r)
+	return inp, fmt.Sprintf("%.6f", ans)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if _, err := fmt.Sscanf(got, "%f", new(float64)); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	// compare with tolerance
+	var gotVal float64
+	fmt.Sscanf(got, "%f", &gotVal)
+	var expVal float64
+	fmt.Sscanf(expected, "%f", &expVal)
+	if math.Abs(gotVal-expVal) > 1e-3 {
+		return fmt.Errorf("expected %.6f got %s", expVal, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/198/verifierD.go
+++ b/0-999/100-199/190-199/198/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildCube(n int) [][][]int {
+	a := make([][][]int, n)
+	for x := 0; x < n; x++ {
+		a[x] = make([][]int, n)
+		for y := 0; y < n; y++ {
+			a[x][y] = make([]int, n)
+		}
+	}
+	cnt := 1
+	idx := 0
+	for x := 0; x < n; x++ {
+		if x%2 == 0 {
+			for y := 0; y < n; y++ {
+				if idx%2 == 0 {
+					for z := 0; z < n; z++ {
+						a[x][y][z] = cnt
+						cnt++
+					}
+				} else {
+					for z := n - 1; z >= 0; z-- {
+						a[x][y][z] = cnt
+						cnt++
+					}
+				}
+				idx++
+			}
+		} else {
+			for y := n - 1; y >= 0; y-- {
+				if idx%2 == 0 {
+					for z := 0; z < n; z++ {
+						a[x][y][z] = cnt
+						cnt++
+					}
+				} else {
+					for z := n - 1; z >= 0; z-- {
+						a[x][y][z] = cnt
+						cnt++
+					}
+				}
+				idx++
+			}
+		}
+	}
+	return a
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	cube := buildCube(n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for z := 0; z < n; z++ {
+		for x := 0; x < n; x++ {
+			for y := 0; y < n; y++ {
+				if y > 0 {
+					sb.WriteByte(' ')
+				}
+				fmt.Fprintf(&sb, "%d", cube[x][y][z])
+			}
+			sb.WriteByte('\n')
+		}
+		if z != n-1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return fmt.Sprintf("%d\n", n), sb.String()
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("output mismatch")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/198/verifierE.go
+++ b/0-999/100-199/190-199/198/verifierE.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Gripper struct {
+	x, y    int64
+	m, p, r int64
+}
+
+type Node struct {
+	p, r int64
+}
+
+func dist2(x1, y1, x2, y2 int64) int64 {
+	dx := x1 - x2
+	if dx < 0 {
+		dx = -dx
+	}
+	dy := y1 - y2
+	if dy < 0 {
+		dy = -dy
+	}
+	return dx*dx + dy*dy
+}
+
+func solve(x0, y0, p0, r0 int64, gs []Gripper) int {
+	n := len(gs)
+	visited := make([]bool, n)
+	queue := []Node{{p0, r0}}
+	count := 0
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for i, g := range gs {
+			if visited[i] {
+				continue
+			}
+			if g.m <= cur.p && dist2(x0, y0, g.x, g.y) <= cur.r*cur.r {
+				visited[i] = true
+				queue = append(queue, Node{g.p, g.r})
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	x := int64(rng.Intn(41) - 20)
+	y := int64(rng.Intn(41) - 20)
+	p := int64(rng.Intn(20) + 1)
+	r := int64(rng.Intn(20) + 1)
+	n := rng.Intn(20)
+	gr := make([]Gripper, n)
+	for i := 0; i < n; i++ {
+		gx := int64(rng.Intn(41) - 20)
+		gy := int64(rng.Intn(41) - 20)
+		if gx == x && gy == y {
+			gx++
+		}
+		m := int64(rng.Intn(20) + 1)
+		p2 := int64(rng.Intn(20) + 1)
+		r2 := int64(rng.Intn(20) + 1)
+		gr[i] = Gripper{gx, gy, m, p2, r2}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d %d\n", x, y, p, r, n)
+	for _, g := range gr {
+		fmt.Fprintf(&sb, "%d %d %d %d %d\n", g.x, g.y, g.m, g.p, g.r)
+	}
+	ans := solve(x, y, p, r, gr)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–E of contest 198
- each verifier accepts a binary path and checks 100 random cases
- reference logic is embedded in the verifier files

## Testing
- `go build 0-999/100-199/190-199/198/verifierA.go`
- `go build 0-999/100-199/190-199/198/verifierB.go`
- `go build 0-999/100-199/190-199/198/verifierC.go`
- `go build 0-999/100-199/190-199/198/verifierD.go`
- `go build 0-999/100-199/190-199/198/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e8c16ad888324a39a65a31f8914ab