### PR TITLE
Add Go verifiers for contest 197

### DIFF
--- a/0-999/100-199/190-199/197/verifierA.go
+++ b/0-999/100-199/190-199/197/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(a, b, r int) string {
+	na := a / (2 * r)
+	nb := b / (2 * r)
+	total := na * nb
+	if total%2 == 1 {
+		return "First"
+	}
+	return "Second"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases [][3]int
+	edge := [][3]int{
+		{1, 1, 1},
+		{2, 2, 1},
+		{100, 100, 1},
+		{1, 100, 1},
+		{100, 1, 1},
+		{2, 1, 1},
+		{1, 2, 1},
+		{2, 2, 2},
+		{3, 3, 2},
+		{2, 3, 1},
+		{3, 2, 1},
+	}
+	cases = append(cases, edge...)
+	for i := 0; i < 100; i++ {
+		a := rng.Intn(100) + 1
+		b := rng.Intn(100) + 1
+		r := rng.Intn(100) + 1
+		cases = append(cases, [3]int{a, b, r})
+	}
+
+	for i, c := range cases {
+		input := fmt.Sprintf("%d %d %d\n", c[0], c[1], c[2])
+		want := expected(c[0], c[1], c[2])
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/100-199/190-199/197/verifierB.go
+++ b/0-999/100-199/190-199/197/verifierB.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		a = -a
+	}
+	return a
+}
+
+func expected(n, m, a0, b0 int) string {
+	switch {
+	case n > m:
+		if (a0 > 0 && b0 > 0) || (a0 < 0 && b0 < 0) {
+			return "Infinity"
+		}
+		return "-Infinity"
+	case n < m:
+		return "0/1"
+	default:
+		num := a0
+		den := b0
+		if den < 0 {
+			num = -num
+			den = -den
+		}
+		g := gcd(num, den)
+		num /= g
+		den /= g
+		return fmt.Sprintf("%d/%d", num, den)
+	}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildInput(rng *rand.Rand, n, m, a0, b0 int) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	sb.WriteString(fmt.Sprintf("%d", a0))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf(" %d", rng.Intn(201)-100))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d", b0))
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprintf(" %d", rng.Intn(201)-100))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type caseB struct {
+		n, m   int
+		a0, b0 int
+	}
+	var cases []caseB
+	edge := []caseB{
+		{2, 1, 1, 1},
+		{3, 2, -2, 5},
+		{1, 2, 10, -5},
+		{2, 2, 4, 2},
+		{1, 1, -2, 4},
+		{1, 1, 2, -3},
+		{0, 0, -1, -1},
+		{0, 0, 5, -10},
+		{5, 2, 100, 100},
+		{5, 5, 5, 7},
+	}
+	cases = append(cases, edge...)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(101)
+		m := rng.Intn(101)
+		a0 := rng.Intn(201) - 100
+		if a0 == 0 {
+			a0 = 1
+		}
+		b0 := rng.Intn(201) - 100
+		if b0 == 0 {
+			b0 = 1
+		}
+		cases = append(cases, caseB{n, m, a0, b0})
+	}
+
+	for i, c := range cases {
+		input := buildInput(rng, c.n, c.m, c.a0, c.b0)
+		want := expected(c.n, c.m, c.a0, c.b0)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` under contest 197
- each verifier generates 100+ tests and checks any provided solution

## Testing
- `go run 0-999/100-199/190-199/197/verifierA.go -- 0-999/100-199/190-199/197/197A.go`
- `go run 0-999/100-199/190-199/197/verifierB.go -- 0-999/100-199/190-199/197/197B.go`

------
https://chatgpt.com/codex/tasks/task_e_687e8bd04f748324a25c891b6dbfa795