### PR TITLE
Add solution verifiers for contest 195

### DIFF
--- a/0-999/100-199/190-199/195/verifierA.go
+++ b/0-999/100-199/190-199/195/verifierA.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(a, b, c int) int {
+	delta := a - b
+	num := delta * c
+	return (num + b - 1) / b
+}
+
+func solveAFromInput(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var a, b, c int
+	fmt.Fscan(r, &a, &b, &c)
+	return fmt.Sprint(solveA(a, b, c))
+}
+
+func generateCaseA(rng *rand.Rand) string {
+	a := rng.Intn(1000-1) + 2 // at least 2
+	b := rng.Intn(a-1) + 1
+	c := rng.Intn(1000) + 1
+	return fmt.Sprintf("%d %d %d\n", a, b, c)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseA(rng)
+		expect := solveAFromInput(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/195/verifierB.go
+++ b/0-999/100-199/190-199/195/verifierB.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type basket struct {
+	cnt   int
+	dist2 int
+	idx   int
+}
+
+type basketHeap []basket
+
+func (h basketHeap) Len() int { return len(h) }
+func (h basketHeap) Less(i, j int) bool {
+	if h[i].cnt != h[j].cnt {
+		return h[i].cnt < h[j].cnt
+	}
+	if h[i].dist2 != h[j].dist2 {
+		return h[i].dist2 < h[j].dist2
+	}
+	return h[i].idx < h[j].idx
+}
+func (h basketHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *basketHeap) Push(x interface{}) { *h = append(*h, x.(basket)) }
+func (h *basketHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(n, m int) []int {
+	h := make(basketHeap, 0, m)
+	center := m + 1
+	for i := 1; i <= m; i++ {
+		d2 := center - 2*i
+		if d2 < 0 {
+			d2 = -d2
+		}
+		h = append(h, basket{cnt: 0, dist2: d2, idx: i})
+	}
+	heap.Init(&h)
+	res := make([]int, n)
+	for i := 0; i < n; i++ {
+		b := heap.Pop(&h).(basket)
+		res[i] = b.idx
+		b.cnt++
+		heap.Push(&h, b)
+	}
+	return res
+}
+
+func solveBFromInput(input string) ([]int, int, error) {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n, m int
+	if _, err := fmt.Fscan(r, &n, &m); err != nil {
+		return nil, 0, err
+	}
+	return solveB(n, m), n, nil
+}
+
+func generateCaseB(rng *rand.Rand) string {
+	n := rng.Intn(50) + 1
+	m := rng.Intn(50) + 1
+	return fmt.Sprintf("%d %d\n", n, m)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseB(rng)
+		expect, n, err := solveBFromInput(tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "bad generated test: %v\n", err)
+			os.Exit(1)
+		}
+		gotStr, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		fields := strings.Fields(gotStr)
+		if len(fields) != n {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", i+1, n, len(fields), tc)
+			os.Exit(1)
+		}
+		for j, f := range fields {
+			v, err := strconv.Atoi(f)
+			if err != nil || v != expect[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed at ball %d: expected %d got %s\ninput:\n%s", i+1, j+1, expect[j], f, tc)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/195/verifierC.go
+++ b/0-999/100-199/190-199/195/verifierC.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type block struct {
+	tryLine   int
+	catchLine int
+	exType    string
+	msg       string
+}
+
+func solveCFromInput(input string) (string, error) {
+	r := bufio.NewScanner(strings.NewReader(input))
+	r.Scan()
+	var n int
+	fmt.Sscan(r.Text(), &n)
+	lines := make([]string, 0, n)
+	for r.Scan() {
+		lines = append(lines, strings.TrimSpace(r.Text()))
+	}
+	if len(lines) != n {
+		return "", fmt.Errorf("wrong line count")
+	}
+	tryStack := []int{}
+	blocks := []block{}
+	throwLine := -1
+	throwType := ""
+	for i, line := range lines {
+		s := strings.TrimSpace(line)
+		if strings.HasPrefix(s, "try") {
+			tryStack = append(tryStack, i)
+		} else if strings.HasPrefix(s, "catch") {
+			p1 := strings.Index(s, "(")
+			p2 := strings.LastIndex(s, ")")
+			inner := s[p1+1 : p2]
+			ci := strings.Index(inner, ",")
+			typ := strings.TrimSpace(inner[:ci])
+			msg := strings.TrimSpace(inner[ci+1:])
+			if len(msg) >= 2 && msg[0] == '"' && msg[len(msg)-1] == '"' {
+				msg = msg[1 : len(msg)-1]
+			}
+			t := tryStack[len(tryStack)-1]
+			tryStack = tryStack[:len(tryStack)-1]
+			blocks = append(blocks, block{tryLine: t, catchLine: i, exType: typ, msg: msg})
+		} else if strings.HasPrefix(s, "throw") {
+			p1 := strings.Index(s, "(")
+			p2 := strings.LastIndex(s, ")")
+			inner := strings.TrimSpace(s[p1+1 : p2])
+			throwType = inner
+			throwLine = i
+		}
+	}
+	bestCatch := n + 1
+	bestMsg := ""
+	for _, b := range blocks {
+		if b.tryLine < throwLine && throwLine < b.catchLine && b.exType == throwType {
+			if b.catchLine < bestCatch {
+				bestCatch = b.catchLine
+				bestMsg = b.msg
+			}
+		}
+	}
+	if bestMsg == "" {
+		return "Unhandled Exception", nil
+	}
+	return bestMsg, nil
+}
+
+func randomIdent(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	return sb.String()
+}
+
+func randomMsg(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	letters := "abcde"
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	return sb.String()
+}
+
+func generateCaseC(rng *rand.Rand) string {
+	depth := rng.Intn(5) + 1
+	var lines []string
+	for i := 0; i < depth; i++ {
+		lines = append(lines, "try")
+	}
+	thrType := randomIdent(rng)
+	lines = append(lines, fmt.Sprintf("throw(%s)", thrType))
+	for i := 0; i < depth; i++ {
+		typ := randomIdent(rng)
+		msg := randomMsg(rng)
+		lines = append(lines, fmt.Sprintf("catch(%s, \"%s\")", typ, msg))
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(lines))
+	for _, l := range lines {
+		sb.WriteString(l)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseC(rng)
+		expect, err := solveCFromInput(tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/195/verifierD.go
+++ b/0-999/100-199/190-199/195/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveDFromInput(input string) (int, error) {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(r, &n); err != nil {
+		return 0, err
+	}
+	m := make(map[[2]int64]struct{})
+	for i := 0; i < n; i++ {
+		var k, b int64
+		fmt.Fscan(r, &k, &b)
+		if k == 0 {
+			continue
+		}
+		num := -b
+		den := k
+		if den < 0 {
+			num = -num
+			den = -den
+		}
+		g := gcd(abs64(num), den)
+		num /= g
+		den /= g
+		m[[2]int64{num, den}] = struct{}{}
+	}
+	return len(m), nil
+}
+
+func generateCaseD(rng *rand.Rand) string {
+	n := rng.Intn(50) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		k := rng.Intn(11) - 5
+		b := rng.Intn(21) - 10
+		fmt.Fprintf(&sb, "%d %d\n", k, b)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseD(rng)
+		expectInt, err := solveDFromInput(tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		expect := fmt.Sprint(expectInt)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/195/verifierE.go
+++ b/0-999/100-199/190-199/195/verifierE.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+type DSU struct {
+	parent []int
+	weight []int64
+}
+
+func NewDSU(n int) *DSU {
+	parent := make([]int, n+1)
+	weight := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		parent[i] = i
+		weight[i] = 0
+	}
+	return &DSU{parent, weight}
+}
+
+func (d *DSU) find(u int) (int, int64) {
+	if d.parent[u] == u {
+		return u, 0
+	}
+	root, dist := d.find(d.parent[u])
+	d.parent[u] = root
+	d.weight[u] += dist
+	return root, d.weight[u]
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveEFromInput(input string) (int64, error) {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(r, &n); err != nil {
+		return 0, err
+	}
+	dsu := NewDSU(n)
+	var ans int64
+	for i := 1; i <= n; i++ {
+		var k int
+		fmt.Fscan(r, &k)
+		for j := 0; j < k; j++ {
+			var v int
+			var x int64
+			fmt.Fscan(r, &v, &x)
+			root, depth := dsu.find(v)
+			w := depth + x
+			dsu.parent[root] = i
+			dsu.weight[root] = w
+			wmod := w % mod
+			if wmod < 0 {
+				wmod += mod
+			}
+			ans = (ans + wmod) % mod
+		}
+	}
+	if ans < 0 {
+		ans += mod
+	}
+	return ans % mod, nil
+}
+
+func generateCaseE(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 1; i <= n; i++ {
+		maxk := i - 1
+		if maxk > 2 {
+			maxk = 2
+		}
+		k := rng.Intn(maxk + 1)
+		fmt.Fprintf(&sb, "%d", k)
+		for j := 0; j < k; j++ {
+			v := rng.Intn(i-1) + 1
+			x := rng.Intn(21) - 10
+			fmt.Fprintf(&sb, " %d %d", v, x)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseE(rng)
+		expectInt, err := solveEFromInput(tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		expect := fmt.Sprint(expectInt)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E in contest 195
- each verifier generates 100 random tests and checks an arbitrary binary

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e8b4484b883248c208be3791e245b