### PR TITLE
Add verifiers for contest 194

### DIFF
--- a/0-999/100-199/190-199/194/verifierA.go
+++ b/0-999/100-199/190-199/194/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(r *bufio.Reader) string {
+	var n, k int
+	if _, err := fmt.Fscan(r, &n, &k); err != nil {
+		return ""
+	}
+	for x2 := 0; x2 <= n; x2++ {
+		minSum := 3*n - x2
+		maxSum := 5*n - 3*x2
+		if k >= minSum && k <= maxSum {
+			return fmt.Sprintf("%d", x2)
+		}
+	}
+	return ""
+}
+
+func generateCaseA(rng *rand.Rand) string {
+	n := rng.Intn(50) + 1
+	x2 := rng.Intn(n + 1)
+	sum := 2 * x2
+	for i := 0; i < n-x2; i++ {
+		sum += rng.Intn(3) + 3
+	}
+	return fmt.Sprintf("%d %d\n", n, sum)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseA(rng)
+		expect := solveA(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/194/verifierB.go
+++ b/0-999/100-199/190-199/194/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveB(r *bufio.Reader) string {
+	var t int
+	if _, err := fmt.Fscan(r, &t); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for i := 0; i < t; i++ {
+		var n int64
+		fmt.Fscan(r, &n)
+		g := gcd(n+1, 4)
+		ans := 4*n/g + 1
+		sb.WriteString(fmt.Sprintf("%d\n", ans))
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func generateCaseB(rng *rand.Rand) string {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		sb.WriteString(fmt.Sprintf("%d ", n))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseB(rng)
+		expect := solveB(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems 194A and 194B

## Testing
- `go build ./0-999/100-199/190-199/194/verifierA.go`
- `go build ./0-999/100-199/190-199/194/verifierB.go`

------
https://chatgpt.com/codex/tasks/task_e_687e8afe414c832481f5a985a9c0db32