### PR TITLE
Add verifiers for contest 192

### DIFF
--- a/0-999/100-199/190-199/192/verifierA.go
+++ b/0-999/100-199/190-199/192/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int64) string {
+	maxk := int((math.Sqrt(1+8*float64(n)) - 1) / 2)
+	t := make([]int64, maxk)
+	for i := 1; i <= maxk; i++ {
+		t[i-1] = int64(i*(i+1)) / 2
+	}
+	l, r := 0, len(t)-1
+	for l <= r {
+		s := t[l] + t[r]
+		if s == n {
+			return "YES"
+		}
+		if s < n {
+			l++
+		} else {
+			r--
+		}
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	expect := solveCase(n)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/192/verifierB.go
+++ b/0-999/100-199/190-199/192/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(a []int) int {
+	n := len(a)
+	best := a[0]
+	if a[n-1] < best {
+		best = a[n-1]
+	}
+	for i := 0; i+1 < n; i++ {
+		mx := a[i]
+		if a[i+1] > mx {
+			mx = a[i+1]
+		}
+		if mx < best {
+			best = mx
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(1000) + 1
+	a := make([]int, n)
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(1000) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	input := fmt.Sprintf("%d\n%s\n", n, sb.String())
+	expect := fmt.Sprintf("%d", solveCase(a))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for contest 192
- each verifier runs 100 random tests against a candidate binary

## Testing
- `go run verifierA.go ./192A_bin`
- `go run verifierB.go ./192B_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e8a722260832488e266420212e5ec