### PR TITLE
Add Go verifiers for Codeforces Round 191

### DIFF
--- a/0-999/100-199/190-199/191/verifierA.go
+++ b/0-999/100-199/190-199/191/verifierA.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(names []string) int64 {
+	const K = 26
+	const INF int64 = 1e18
+	dp := make([][K]int64, K)
+	for i := 0; i < K; i++ {
+		for j := 0; j < K; j++ {
+			dp[i][j] = -INF
+		}
+	}
+	var ans int64
+	for _, s := range names {
+		if len(s) == 0 {
+			continue
+		}
+		u := int(s[0] - 'a')
+		v := int(s[len(s)-1] - 'a')
+		w := int64(len(s))
+		for st := 0; st < K; st++ {
+			if dp[st][u] > -INF {
+				if dp[st][u]+w > dp[st][v] {
+					dp[st][v] = dp[st][u] + w
+				}
+			}
+		}
+		if w > dp[u][v] {
+			dp[u][v] = w
+		}
+		if dp[u][u] > ans {
+			ans = dp[u][u]
+		}
+		if dp[v][v] > ans {
+			ans = dp[v][v]
+		}
+	}
+	if ans < 0 {
+		ans = 0
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	names := make([]string, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(5) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('a' + rng.Intn(26))
+		}
+		names[i] = string(b)
+	}
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d\n", n)
+	for _, s := range names {
+		fmt.Fprintf(&in, "%s\n", s)
+	}
+	exp := fmt.Sprintf("%d", solve(names))
+	return in.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/191/verifierB.go
+++ b/0-999/100-199/190-199/191/verifierB.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n, k int, b int64, a []int64) int {
+	can := func(x int) bool {
+		drains := make([]int64, 0, n)
+		if x < n {
+			for i := 1; i <= n; i++ {
+				if i == x || i == n {
+					continue
+				}
+				drains = append(drains, a[i-1])
+			}
+		} else {
+			for i := 1; i < n; i++ {
+				if i == x {
+					continue
+				}
+				drains = append(drains, a[i-1])
+			}
+		}
+		need := k - 1
+		if need <= 0 {
+			return b < a[x-1]
+		}
+		if len(drains) == 0 {
+			return b < a[x-1]
+		}
+		sort.Slice(drains, func(i, j int) bool { return drains[i] > drains[j] })
+		var s int64
+		for i := 0; i < need && i < len(drains); i++ {
+			s += drains[i]
+			if s > b {
+				break
+			}
+		}
+		return s > b-a[x-1]
+	}
+	l, r := 1, n
+	ans := n
+	for l <= r {
+		mid := (l + r) / 2
+		if can(mid) {
+			ans = mid
+			r = mid - 1
+		} else {
+			l = mid + 1
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(9) + 2 // n>=2
+	k := rng.Intn(n-1) + 1
+	b := rng.Int63n(1000)
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = rng.Int63n(1000) + 1
+	}
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d %d\n", n, k)
+	fmt.Fprintf(&in, "%d\n", b)
+	for i, v := range a {
+		if i+1 == n {
+			fmt.Fprintf(&in, "%d\n", v)
+		} else {
+			fmt.Fprintf(&in, "%d ", v)
+		}
+	}
+	exp := fmt.Sprintf("%d", solve(n, k, b, a))
+	return in.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/191/verifierC.go
+++ b/0-999/100-199/190-199/191/verifierC.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to, id int
+}
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n int, edges [][2]int, k int, queries [][2]int) string {
+	adj := make([][]Edge, n+1)
+	for i, e := range edges {
+		u, v := e[0], e[1]
+		id := i + 1
+		adj[u] = append(adj[u], Edge{v, id})
+		adj[v] = append(adj[v], Edge{u, id})
+	}
+	parent := make([]int, n+1)
+	parentEdge := make([]int, n+1)
+	depth := make([]int, n+1)
+	order := make([]int, 0, n)
+	queue := []int{1}
+	parent[1] = 0
+	depth[1] = 0
+	for i := 0; i < len(queue); i++ {
+		u := queue[i]
+		order = append(order, u)
+		for _, e := range adj[u] {
+			v := e.to
+			if v == parent[u] {
+				continue
+			}
+			parent[v] = u
+			parentEdge[v] = e.id
+			depth[v] = depth[u] + 1
+			queue = append(queue, v)
+		}
+	}
+	const maxLog = 18
+	p := make([][]int, maxLog)
+	p[0] = make([]int, n+1)
+	for v := 1; v <= n; v++ {
+		p[0][v] = parent[v]
+	}
+	for l := 1; l < maxLog; l++ {
+		p[l] = make([]int, n+1)
+		for v := 1; v <= n; v++ {
+			p[l][v] = p[l-1][p[l-1][v]]
+		}
+	}
+	lca := func(u, v int) int {
+		if depth[u] < depth[v] {
+			u, v = v, u
+		}
+		diff := depth[u] - depth[v]
+		for l := 0; l < maxLog; l++ {
+			if diff&(1<<l) != 0 {
+				u = p[l][u]
+			}
+		}
+		if u == v {
+			return u
+		}
+		for l := maxLog - 1; l >= 0; l-- {
+			if p[l][u] != p[l][v] {
+				u = p[l][u]
+				v = p[l][v]
+			}
+		}
+		return parent[u]
+	}
+	cnt := make([]int64, n+1)
+	for _, q := range queries {
+		a, b := q[0], q[1]
+		cnt[a]++
+		cnt[b]++
+		l := lca(a, b)
+		cnt[l] -= 2
+	}
+	ans := make([]int64, n)
+	for i := len(order) - 1; i > 0; i-- {
+		v := order[i]
+		eid := parentEdge[v]
+		ans[eid-1] = cnt[v]
+		cnt[parent[v]] += cnt[v]
+	}
+	var sb strings.Builder
+	for i := 0; i < n-1; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", ans[i]))
+	}
+	return sb.String()
+}
+
+func generateTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(7) + 2
+	edges := generateTree(rng, n)
+	k := rng.Intn(n) + 1
+	queries := make([][2]int, k)
+	for i := 0; i < k; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		for b == a {
+			b = rng.Intn(n) + 1
+		}
+		queries[i] = [2]int{a, b}
+	}
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&in, "%d %d\n", e[0], e[1])
+	}
+	fmt.Fprintf(&in, "%d\n", k)
+	for _, q := range queries {
+		fmt.Fprintf(&in, "%d %d\n", q[0], q[1])
+	}
+	exp := solve(n, edges, k, queries)
+	return in.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/191/verifierD.go
+++ b/0-999/100-199/190-199/191/verifierD.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n int, edges [][2]int) string {
+	adj := make([][]int, n+1)
+	deg := make([]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	for u := 1; u <= n; u++ {
+		deg[u] = len(adj[u])
+	}
+	type frame struct{ u, parent, next int }
+	state := make([]int8, n+1)
+	pos := make([]int, n+1)
+	for i := range pos {
+		pos[i] = -1
+	}
+	stack := []int{}
+	cycleMark := make([]bool, n+1)
+	cycles := 0
+	dfsStack := []frame{{1, -1, 0}}
+	state[1] = 1
+	pos[1] = 0
+	stack = append(stack, 1)
+	for len(dfsStack) > 0 {
+		f := &dfsStack[len(dfsStack)-1]
+		u := f.u
+		if f.next < len(adj[u]) {
+			v := adj[u][f.next]
+			f.next++
+			if v == f.parent {
+				continue
+			}
+			if state[v] == 0 {
+				state[v] = 1
+				pos[v] = len(stack)
+				stack = append(stack, v)
+				dfsStack = append(dfsStack, frame{v, u, 0})
+			} else if state[v] == 1 {
+				cycles++
+				for i := pos[v]; i < len(stack); i++ {
+					cycleMark[stack[i]] = true
+				}
+			}
+		} else {
+			state[u] = 2
+			dfsStack = dfsStack[:len(dfsStack)-1]
+			stack = stack[:len(stack)-1]
+			pos[u] = -1
+		}
+	}
+	odd := 0
+	for u := 1; u <= n; u++ {
+		d := deg[u]
+		if cycleMark[u] {
+			d -= 2
+		}
+		if d%2 == 1 {
+			odd++
+		}
+	}
+	minLines := cycles + odd/2
+	maxLines := len(edges)
+	return fmt.Sprintf("%d %d", minLines, maxLines)
+}
+
+func generateTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func addCycle(rng *rand.Rand, edges [][2]int, n int) [][2]int {
+	u := rng.Intn(n) + 1
+	v := rng.Intn(n) + 1
+	for v == u {
+		v = rng.Intn(n) + 1
+	}
+	edges = append(edges, [2]int{u, v})
+	return edges
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	edges := generateTree(rng, n)
+	if rng.Intn(2) == 0 && n >= 3 {
+		edges = addCycle(rng, edges, n)
+	}
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d %d\n", n, len(edges))
+	for _, e := range edges {
+		fmt.Fprintf(&in, "%d %d\n", e[0], e[1])
+	}
+	exp := solve(n, edges)
+	return in.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/191/verifierE.go
+++ b/0-999/100-199/190-199/191/verifierE.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+// Fenwick tree
+type BIT struct {
+	n    int
+	tree []int
+}
+
+func newBIT(n int) *BIT {
+	return &BIT{n: n, tree: make([]int, n+1)}
+}
+
+func (b *BIT) update(i, v int) {
+	for ; i <= b.n; i += i & -i {
+		b.tree[i] += v
+	}
+}
+
+func (b *BIT) query(i int) int {
+	s := 0
+	for ; i > 0; i &= i - 1 {
+		s += b.tree[i]
+	}
+	return s
+}
+
+func unique64(a []int64) []int64 {
+	if len(a) == 0 {
+		return a
+	}
+	j := 0
+	for i := 1; i < len(a); i++ {
+		if a[i] != a[j] {
+			j++
+			a[j] = a[i]
+		}
+	}
+	return a[:j+1]
+}
+
+func solve(n int, k int64, arr []int64) string {
+	S := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		S[i+1] = S[i] + arr[i]
+	}
+	P := append([]int64(nil), S...)
+	sort.Slice(P, func(i, j int) bool { return P[i] < P[j] })
+	P = unique64(P)
+	count := func(x int64) int64 {
+		bit := newBIT(len(P))
+		var cnt int64
+		for _, sj := range S {
+			v := sj - x
+			idx := sort.Search(len(P), func(i int) bool { return P[i] > v })
+			cnt += int64(bit.query(idx))
+			pos := sort.Search(len(P), func(i int) bool { return P[i] >= sj })
+			bit.update(pos+1, 1)
+		}
+		return cnt
+	}
+	low, high := int64(-1e14), int64(1e14)
+	for low < high {
+		mid := (low + high + 1) >> 1
+		if count(mid) >= k {
+			low = mid
+		} else {
+			high = mid - 1
+		}
+	}
+	return fmt.Sprintf("%d", low)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	maxK := int64(n*(n+1)) / 2
+	k := rng.Int63n(maxK) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = rng.Int63n(101) - 50
+	}
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d %d\n", n, k)
+	for i, v := range arr {
+		if i+1 == n {
+			fmt.Fprintf(&in, "%d\n", v)
+		} else {
+			fmt.Fprintf(&in, "%d ", v)
+		}
+	}
+	exp := solve(n, k, arr)
+	return in.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E

Each verifier generates at least 100 test cases and checks a provided binary by comparing its output with the reference implementation.

## Testing
- `go run verifierA.go ./191A_bin` *(after building 191A.go)*
- `go run verifierB.go ./191B_bin`
- `go run verifierC.go ./191C_bin`
- `go run verifierD.go ./191D_bin`
- `go run verifierE.go ./191E_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e8a2c320083248bdf61de8d97ec4c