### PR TITLE
Add Go verifiers for Codeforces contest 190

### DIFF
--- a/0-999/100-199/190-199/190/verifierA.go
+++ b/0-999/100-199/190-199/190/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func solve(n, m int) string {
+	if n == 0 && m > 0 {
+		return "Impossible"
+	}
+	minFare := n
+	if m > n {
+		minFare = m
+	}
+	var maxFare int
+	if m == 0 {
+		maxFare = n
+	} else {
+		maxFare = n + m - 1
+	}
+	return fmt.Sprintf("%d %d", minFare, maxFare)
+}
+
+func generateCases() []testCase {
+	rand.Seed(1)
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(11) // 0..10
+		m := rand.Intn(11)
+		buf := bytes.Buffer{}
+		fmt.Fprintf(&buf, "%d %d\n", n, m)
+		cases[i] = testCase{input: buf.String(), expected: solve(n, m)}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierA.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/190/verifierB.go
+++ b/0-999/100-199/190-199/190/verifierB.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func solve(a, b, r1, x, y, r2 float64) string {
+	dx := a - x
+	dy := b - y
+	d := math.Hypot(dx, dy)
+	var res float64
+	if d > r1+r2 {
+		res = (d - r1 - r2) / 2
+	} else if d+math.Min(r1, r2) < math.Max(r1, r2) {
+		res = (math.Max(r1, r2) - math.Min(r1, r2) - d) / 2
+	} else {
+		res = 0
+	}
+	return fmt.Sprintf("%.12f", res)
+}
+
+func generateCases() []testCase {
+	rand.Seed(2)
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		a := float64(rand.Intn(21) - 10)
+		b := float64(rand.Intn(21) - 10)
+		x := float64(rand.Intn(21) - 10)
+		y := float64(rand.Intn(21) - 10)
+		// ensure centers not equal
+		if a == x && b == y {
+			x += 1
+		}
+		r1 := float64(rand.Intn(10) + 1)
+		r2 := float64(rand.Intn(10) + 1)
+		buf := bytes.Buffer{}
+		fmt.Fprintf(&buf, "%.0f %.0f %.0f\n", a, b, r1)
+		fmt.Fprintf(&buf, "%.0f %.0f %.0f\n", x, y, r2)
+		cases[i] = testCase{input: buf.String(), expected: solve(a, b, r1, x, y, r2)}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierB.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/190/verifierC.go
+++ b/0-999/100-199/190-199/190/verifierC.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func parse(tokens []string) (string, bool) {
+	type frame struct{ state int }
+	frames := make([]frame, 0, len(tokens))
+	var out strings.Builder
+	for i, tok := range tokens {
+		if tok == "int" {
+			out.WriteString("int")
+			for len(frames) > 0 && frames[len(frames)-1].state == 1 {
+				out.WriteByte('>')
+				frames = frames[:len(frames)-1]
+			}
+			if len(frames) > 0 && frames[len(frames)-1].state == 0 {
+				out.WriteByte(',')
+				frames[len(frames)-1].state = 1
+			} else if len(frames) == 0 && i != len(tokens)-1 {
+				return "Error occurred", false
+			}
+		} else if tok == "pair" {
+			out.WriteString("pair<")
+			frames = append(frames, frame{state: 0})
+		} else {
+			return "Error occurred", false
+		}
+	}
+	if len(frames) != 0 {
+		return "Error occurred", false
+	}
+	return out.String(), true
+}
+
+func genValid(depth int) []string {
+	if depth > 3 || rand.Intn(2) == 0 {
+		return []string{"int"}
+	}
+	left := genValid(depth + 1)
+	right := genValid(depth + 1)
+	return append(append([]string{"pair"}, left...), right...)
+}
+
+func generateCases() []testCase {
+	rand.Seed(3)
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		valid := rand.Intn(2) == 0
+		if valid {
+			tokens := genValid(0)
+			n := 0
+			for _, t := range tokens {
+				if t == "int" {
+					n++
+				}
+			}
+			buf := bytes.Buffer{}
+			fmt.Fprintf(&buf, "%d\n", n)
+			for j, t := range tokens {
+				if j > 0 {
+					fmt.Fprint(&buf, " ")
+				}
+				fmt.Fprint(&buf, t)
+			}
+			buf.WriteByte('\n')
+			res, _ := parse(tokens)
+			cases[i] = testCase{input: buf.String(), expected: res}
+		} else {
+			n := rand.Intn(4) + 1
+			total := n + rand.Intn(3) // maybe extra pair tokens
+			tokens := make([]string, total)
+			intsPlaced := 0
+			for j := 0; j < total; j++ {
+				if intsPlaced < n && rand.Intn(2) == 0 {
+					tokens[j] = "int"
+					intsPlaced++
+				} else {
+					tokens[j] = "pair"
+				}
+			}
+			for intsPlaced < n {
+				tokens[rand.Intn(total)] = "int"
+				intsPlaced++
+			}
+			buf := bytes.Buffer{}
+			fmt.Fprintf(&buf, "%d\n", n)
+			for j, t := range tokens {
+				if j > 0 {
+					fmt.Fprint(&buf, " ")
+				}
+				fmt.Fprint(&buf, t)
+			}
+			buf.WriteByte('\n')
+			res, _ := parse(tokens)
+			cases[i] = testCase{input: buf.String(), expected: res}
+		}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierC.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/190/verifierD.go
+++ b/0-999/100-199/190-199/190/verifierD.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func solve(n, k int, arr []int) string {
+	pos := make(map[int][]int)
+	curMax := 0
+	var ans int64
+	for i, v := range arr {
+		idx := i + 1
+		lst := pos[v]
+		lst = append(lst, idx)
+		pos[v] = lst
+		if len(lst) >= k {
+			t := lst[len(lst)-k]
+			if t > curMax {
+				curMax = t
+			}
+		}
+		if curMax > 0 {
+			ans += int64(curMax)
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCases() []testCase {
+	rand.Seed(4)
+	cases := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(n) + 1
+		arr := make([]int, n)
+		buf := bytes.Buffer{}
+		fmt.Fprintf(&buf, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			arr[j] = rand.Intn(10)
+			if j > 0 {
+				fmt.Fprint(&buf, " ")
+			}
+			fmt.Fprint(&buf, arr[j])
+		}
+		buf.WriteByte('\n')
+		cases[i] = testCase{input: buf.String(), expected: solve(n, k, arr)}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierD.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\nactual:%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/190-199/190/verifierE.go
+++ b/0-999/100-199/190-199/190/verifierE.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func solve(n, m int, edges [][2]int) string {
+	neighbors := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		neighbors[u] = append(neighbors[u], v)
+		neighbors[v] = append(neighbors[v], u)
+	}
+
+	num := make([]int, n+2)
+	bel := make([]int, n+2)
+	wz := make([]int, n+2)
+	dl := make([]int, n+2)
+	for i := 1; i <= n; i++ {
+		dl[i] = i
+		wz[i] = i
+	}
+
+	top, now := 0, 0
+	for i := 1; i <= n; i++ {
+		if now < i {
+			now = i
+			top++
+		}
+		x := dl[i]
+		bel[x] = top
+		num[top]++
+		td := n
+		for _, j := range neighbors[x] {
+			if wz[j] <= now {
+				continue
+			}
+			if wz[j] > td {
+				continue
+			}
+			y := dl[td]
+			wz[y], wz[j] = wz[j], wz[y]
+			dl[wz[y]], dl[wz[j]] = y, j
+			td--
+		}
+		now = td
+	}
+
+	a := make([]int, n)
+	for i := 1; i <= n; i++ {
+		a[i-1] = i
+	}
+	sort.Slice(a, func(i, j int) bool {
+		if bel[a[i]] != bel[a[j]] {
+			return bel[a[i]] < bel[a[j]]
+		}
+		return a[i] < a[j]
+	})
+
+	var out bytes.Buffer
+	fmt.Fprintln(&out, top)
+	idx := 0
+	for comp := 1; comp <= top; comp++ {
+		fmt.Fprintf(&out, "%d", num[comp])
+		for k := 0; k < num[comp]; k++ {
+			fmt.Fprintf(&out, " %d", a[idx])
+			idx++
+		}
+		out.WriteByte('\n')
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateCases() []testCase {
+	rand.Seed(5)
+	cases := make([]testCase, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(8) + 1
+		maxEdges := n * (n - 1) / 2
+		m := rand.Intn(maxEdges + 1)
+		edges := make([][2]int, 0, m)
+		used := map[[2]int]bool{}
+		for len(edges) < m {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			if u > v {
+				u, v = v, u
+			}
+			e := [2]int{u, v}
+			if used[e] {
+				continue
+			}
+			used[e] = true
+			edges = append(edges, e)
+		}
+		buf := bytes.Buffer{}
+		fmt.Fprintf(&buf, "%d %d\n", n, m)
+		for _, e := range edges {
+			fmt.Fprintf(&buf, "%d %d\n", e[0], e[1])
+		}
+		cases[t] = testCase{input: buf.String(), expected: solve(n, m, edges)}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierE.go <binary>")
+		os.Exit(1)
+	}
+	cases := generateCases()
+	for i, tc := range cases {
+		out, err := runBinary(os.Args[1], tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, tc.input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 190 problems A–E
- each verifier generates 100 random test cases and checks the output of a provided binary

## Testing
- `go run 0-999/100-199/190-199/190/verifierA.go ./190A.bin`
- `go run 0-999/100-199/190-199/190/verifierB.go ./190B.bin`
- `go run 0-999/100-199/190-199/190/verifierC.go ./190C.bin`
- `go run 0-999/100-199/190-199/190/verifierD.go ./190D.bin`
- `go run 0-999/100-199/190-199/190/verifierE.go ./190E.bin`

------
https://chatgpt.com/codex/tasks/task_e_687e89e63f5883248072a540f40f1bb3