### PR TITLE
Add Go verifiers for contest 188

### DIFF
--- a/0-999/100-199/180-189/188/verifierA.go
+++ b/0-999/100-199/180-189/188/verifierA.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func hexagonal(n int64) int64 {
+	return 2*n*n - n
+}
+
+func run(binary, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := int64(1); i <= 100; i++ {
+		input := fmt.Sprintf("%d\n", i)
+		expected := fmt.Sprintf("%d", hexagonal(i))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Printf("wrong answer on test %d: expected %s got %s\n", i, expected, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/100-199/180-189/188/verifierB.go
+++ b/0-999/100-199/180-189/188/verifierB.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func reverse(n int64) int64 {
+	var r int64
+	for n > 0 {
+		r = r*10 + n%10
+		n /= 10
+	}
+	return r
+}
+
+func run(binary, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	bin := os.Args[1]
+	for i := 1; i <= 100; i++ {
+		a := rand.Int63n(1e9 + 1)
+		b := rand.Int63n(1e9 + 1)
+		input := fmt.Sprintf("%d %d\n", a, b)
+		expected := fmt.Sprintf("%d", a+reverse(b))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Printf("wrong answer on test %d: expected %s got %s\n", i, expected, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/100-199/180-189/188/verifierC.go
+++ b/0-999/100-199/180-189/188/verifierC.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int64) int64 {
+	return a / gcd(a, b) * b
+}
+
+func run(binary, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(43)
+	bin := os.Args[1]
+	for i := 1; i <= 100; i++ {
+		a := rand.Int63n(1000) + 1
+		b := rand.Int63n(1000) + 1
+		input := fmt.Sprintf("%d %d\n", a, b)
+		expected := fmt.Sprintf("%d", lcm(a, b))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Printf("wrong answer on test %d: expected %s got %s\n", i, expected, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/100-199/180-189/188/verifierD.go
+++ b/0-999/100-199/180-189/188/verifierD.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedPattern(n int) string {
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		sb.WriteString(strings.Repeat("*", i))
+		if i < n {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func run(binary, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 1; i <= 100; i++ {
+		n := ((i - 1) % 50) + 1 // values 1..50 repeated twice
+		input := fmt.Sprintf("%d\n", n)
+		expected := expectedPattern(n)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expected) {
+			fmt.Printf("wrong answer on test %d: expected\n%s\nbut got\n%s\n", i, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/100-199/180-189/188/verifierE.go
+++ b/0-999/100-199/180-189/188/verifierE.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func hasInstruction(p string) bool {
+	return strings.ContainsAny(p, "HQ9")
+}
+
+func randomString(r *rand.Rand) string {
+	n := r.Intn(100) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(r.Intn(94) + 33) // printable ASCII
+	}
+	return string(b)
+}
+
+func run(binary, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(44))
+	for i := 1; i <= 100; i++ {
+		s := randomString(r)
+		input := fmt.Sprintf("%s\n", s)
+		expected := "NO"
+		if hasInstruction(s) {
+			expected = "YES"
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Printf("wrong answer on test %d: expected %s got %s\n", i, expected, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/100-199/180-189/188/verifierF.go
+++ b/0-999/100-199/180-189/188/verifierF.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(binary, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(45))
+	for i := 1; i <= 100; i++ {
+		n := r.Int63n(1_000_000) + 1
+		input := fmt.Sprintf("%d\n", n)
+		expected := strconv.FormatInt(n, 2)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Printf("wrong answer on test %d: expected %s got %s\n", i, expected, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/100-199/180-189/188/verifierG.go
+++ b/0-999/100-199/180-189/188/verifierG.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(binary, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func generateArray(r *rand.Rand) ([]int, string) {
+	n := r.Intn(10) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		arr[i] = r.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", arr[i]))
+	}
+	return arr, sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(46))
+	for i := 1; i <= 100; i++ {
+		arr, input := generateArray(r)
+		expectedArr := make([]int, len(arr))
+		copy(expectedArr, arr)
+		sort.Ints(expectedArr)
+		var expBuf bytes.Buffer
+		for j, v := range expectedArr {
+			if j > 0 {
+				expBuf.WriteByte(' ')
+			}
+			fmt.Fprint(&expBuf, v)
+		}
+		expected := expBuf.String()
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Printf("wrong answer on test %d: expected %s got %s\n", i, expected, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/100-199/180-189/188/verifierH.go
+++ b/0-999/100-199/180-189/188/verifierH.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func simulate(seq string) int {
+	stack := []int{}
+	for _, c := range seq {
+		switch c {
+		case '+', '*':
+			if len(stack) < 2 {
+				return -1
+			}
+			a := stack[len(stack)-1]
+			b := stack[len(stack)-2]
+			stack = stack[:len(stack)-2]
+			var res int
+			if c == '+' {
+				res = a + b
+			} else {
+				res = a * b
+			}
+			if res > 1_000_000 {
+				return -1
+			}
+			stack = append(stack, res)
+		default:
+			stack = append(stack, int(c-'0'))
+		}
+	}
+	if len(stack) == 0 {
+		return 0
+	}
+	return stack[len(stack)-1]
+}
+
+func generate(r *rand.Rand) string {
+	for {
+		length := r.Intn(19) + 1
+		stackDepth := 0
+		var sb strings.Builder
+		for i := 0; i < length; i++ {
+			if stackDepth < 2 {
+				d := r.Intn(10)
+				sb.WriteByte(byte('0' + d))
+				stackDepth++
+				continue
+			}
+			if r.Intn(2) == 0 {
+				d := r.Intn(10)
+				sb.WriteByte(byte('0' + d))
+				stackDepth++
+			} else {
+				op := '+'
+				if r.Intn(2) == 0 {
+					op = '*'
+				}
+				sb.WriteByte(byte(op))
+				stackDepth--
+			}
+		}
+		seq := sb.String()
+		if res := simulate(seq); res != -1 {
+			return seq
+		}
+	}
+}
+
+func run(binary, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(47))
+	for i := 1; i <= 100; i++ {
+		seq := generate(r)
+		expected := fmt.Sprintf("%d", simulate(seq))
+		input := fmt.Sprintf("%s\n", seq)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Printf("wrong answer on test %d: expected %s got %s (seq %s)\n", i, expected, strings.TrimSpace(out), seq)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 188
- each verifier runs 100 tests and works with any binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`
- `go run verifierF.go ./solF`
- `go run verifierG.go ./solG`
- `go run verifierH.go ./solH`


------
https://chatgpt.com/codex/tasks/task_e_687e895a2c7483248e51c23bf7b5ec80