### PR TITLE
Add verifiers for contest 187

### DIFF
--- a/0-999/100-199/180-189/187/verifierA.go
+++ b/0-999/100-199/180-189/187/verifierA.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input string
+	ans   int
+}
+
+func expected(a, b []int) int {
+	n := len(a)
+	pos := make([]int, n+1)
+	for i, v := range a {
+		pos[v] = i
+	}
+	length := 1
+	cur := pos[b[n-1]]
+	for i := n - 2; i >= 0; i-- {
+		p := pos[b[i]]
+		if p < cur {
+			length++
+			cur = p
+		} else {
+			break
+		}
+	}
+	return n - length
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	a := rng.Perm(n)
+	b := rng.Perm(n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v + 1))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v + 1))
+	}
+	sb.WriteByte('\n')
+	aa := make([]int, n)
+	bb := make([]int, n)
+	for i := 0; i < n; i++ {
+		aa[i] = a[i] + 1
+		bb[i] = b[i] + 1
+	}
+	return testCase{input: sb.String(), ans: expected(aa, bb)}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got != tc.ans {
+		return fmt.Errorf("expected %d got %d", tc.ans, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{
+		{input: "1\n1\n1\n", ans: 0},
+		{input: "3\n1 2 3\n1 2 3\n", ans: 0},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for idx, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/180-189/187/verifierB.go
+++ b/0-999/100-199/180-189/187/verifierB.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const INF int64 = 1 << 60
+
+func floyd(dist [][]int64) {
+	n := len(dist)
+	for k := 0; k < n; k++ {
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				if v := dist[i][k] + dist[k][j]; v < dist[i][j] {
+					dist[i][j] = v
+				}
+			}
+		}
+	}
+}
+
+func solveCase(input string) []int64 {
+	in := strings.Split(strings.TrimSpace(input), "\n")
+	// We'll parse manually using fmt
+	reader := strings.NewReader(strings.Join(in, "\n"))
+	var n, m, r int
+	fmt.Fscan(reader, &n, &m, &r)
+	distC := make([][][]int64, m)
+	for c := 0; c < m; c++ {
+		distC[c] = make([][]int64, n)
+		for i := 0; i < n; i++ {
+			distC[c][i] = make([]int64, n)
+			for j := 0; j < n; j++ {
+				fmt.Fscan(reader, &distC[c][i][j])
+			}
+		}
+		floyd(distC[c])
+	}
+	D0 := make([][]int64, n)
+	for i := 0; i < n; i++ {
+		D0[i] = make([]int64, n)
+		for j := 0; j < n; j++ {
+			best := INF
+			for c := 0; c < m; c++ {
+				if distC[c][i][j] < best {
+					best = distC[c][i][j]
+				}
+			}
+			D0[i][j] = best
+		}
+	}
+	answers := make([]int64, r)
+	for idx := 0; idx < r; idx++ {
+		var s, t, k int
+		fmt.Fscan(reader, &s, &t, &k)
+		s--
+		t--
+		seg := k + 1
+		dpPrev := make([]int64, n)
+		for i := range dpPrev {
+			dpPrev[i] = INF
+		}
+		dpPrev[s] = 0
+		for step := 0; step < seg; step++ {
+			dpCurr := make([]int64, n)
+			for i := range dpCurr {
+				dpCurr[i] = INF
+			}
+			for u := 0; u < n; u++ {
+				if dpPrev[u] == INF {
+					continue
+				}
+				for v := 0; v < n; v++ {
+					if val := dpPrev[u] + D0[u][v]; val < dpCurr[v] {
+						dpCurr[v] = val
+					}
+				}
+			}
+			dpPrev = dpCurr
+		}
+		answers[idx] = dpPrev[t]
+	}
+	return answers
+}
+
+func generateCase(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(3) + 2
+	m := rng.Intn(3) + 1
+	r := rng.Intn(2) + 1
+	distC := make([][][]int64, m)
+	for c := 0; c < m; c++ {
+		distC[c] = make([][]int64, n)
+		for i := 0; i < n; i++ {
+			distC[c][i] = make([]int64, n)
+			for j := 0; j < n; j++ {
+				if i == j {
+					distC[c][i][j] = 0
+				} else {
+					distC[c][i][j] = int64(rng.Intn(9) + 1)
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, r)
+	for c := 0; c < m; c++ {
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprint(distC[c][i][j]))
+			}
+			sb.WriteByte('\n')
+		}
+	}
+	queries := make([][3]int, r)
+	for i := 0; i < r; i++ {
+		s := rng.Intn(n) + 1
+		t := rng.Intn(n) + 1
+		for t == s {
+			t = rng.Intn(n) + 1
+		}
+		k := rng.Intn(2)
+		queries[i] = [3]int{s, t, k}
+		fmt.Fprintf(&sb, "%d %d %d\n", s, t, k)
+	}
+	ans := solveCase(sb.String())
+	return sb.String(), ans
+}
+
+func runCase(bin string, in string, exp []int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outR := strings.Fields(strings.TrimSpace(out.String()))
+	if len(outR) < len(exp) {
+		return fmt.Errorf("expected %d lines, got %d", len(exp), len(outR))
+	}
+	for i, v := range exp {
+		var got int64
+		fmt.Sscan(outR[i], &got)
+		if got != v {
+			return fmt.Errorf("line %d: expected %d got %d", i+1, v, got)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/180-189/187/verifierC.go
+++ b/0-999/100-199/180-189/187/verifierC.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const INF int = 1 << 30
+
+func bfs(n int, edges [][]int, src int) []int {
+	dist := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = -1
+	}
+	q := []int{src}
+	dist[src] = 0
+	for qi := 0; qi < len(q); qi++ {
+		x := q[qi]
+		for _, y := range edges[x] {
+			if dist[y] == -1 {
+				dist[y] = dist[x] + 1
+				q = append(q, y)
+			}
+		}
+	}
+	return dist
+}
+
+func expectedAnswer(n, m, k int, vols []int, edgesU, edgesV []int, s, t int) int {
+	edges := make([][]int, n+1)
+	for i := 0; i < m; i++ {
+		u := edgesU[i]
+		v := edgesV[i]
+		edges[u] = append(edges[u], v)
+		edges[v] = append(edges[v], u)
+	}
+	distAll := make([][]int, n+1)
+	for i := 1; i <= n; i++ {
+		distAll[i] = bfs(n, edges, i)
+	}
+	if distAll[s][t] < 0 {
+		return -1
+	}
+	volIdx := make(map[int]int)
+	for i, v := range vols {
+		volIdx[v] = i
+	}
+	kVol := len(vols)
+	distVolT := make([]int, kVol)
+	for i, v := range vols {
+		distVolT[i] = distAll[v][t]
+	}
+	startIdx := volIdx[s]
+	maxQ := distAll[s][t]
+	for q := 0; q <= maxQ; q++ {
+		adj := make([][]int, kVol)
+		for i := 0; i < kVol; i++ {
+			for j := i + 1; j < kVol; j++ {
+				if distAll[vols[i]][vols[j]] <= q {
+					adj[i] = append(adj[i], j)
+					adj[j] = append(adj[j], i)
+				}
+			}
+		}
+		vis := make([]bool, kVol)
+		qarr := []int{startIdx}
+		vis[startIdx] = true
+		for qi := 0; qi < len(qarr); qi++ {
+			u := qarr[qi]
+			if distVolT[u] <= q {
+				return q
+			}
+			for _, v := range adj[u] {
+				if !vis[v] {
+					vis[v] = true
+					qarr = append(qarr, v)
+				}
+			}
+		}
+	}
+	return maxQ
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(6) + 2
+	m := rng.Intn(n*(n-1)/2-1) + n
+	k := rng.Intn(n-1) + 1
+	edgesU := make([]int, m)
+	edgesV := make([]int, m)
+	edgeSet := make(map[[2]int]struct{})
+	for i := 0; i < m; {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		key := [2]int{u, v}
+		if _, ok := edgeSet[key]; ok {
+			continue
+		}
+		edgeSet[key] = struct{}{}
+		edgesU[i] = u
+		edgesV[i] = v
+		i++
+	}
+	vols := rng.Perm(n)[:k]
+	for i := range vols {
+		vols[i]++
+	}
+	s := vols[0]
+	t := rng.Intn(n) + 1
+	for t == s {
+		t = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i, v := range vols {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", edgesU[i], edgesV[i])
+	}
+	fmt.Fprintf(&sb, "%d %d\n", s, t)
+	ans := expectedAnswer(n, m, k, vols, edgesU, edgesV, s, t)
+	return sb.String(), ans
+}
+
+func runCase(bin string, input string, exp int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/180-189/187/verifierD.go
+++ b/0-999/100-199/180-189/187/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func simulate(segs []int64, g, r int64, start int64) int64 {
+	t := start
+	cycle := g + r
+	for i := 0; i < len(segs)-1; i++ {
+		t += segs[i]
+		mod := t % cycle
+		if mod >= g {
+			t += cycle - mod
+		}
+	}
+	t += segs[len(segs)-1]
+	return t
+}
+
+func generateCase(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(5) + 1
+	g := int64(rng.Intn(5) + 1)
+	r := int64(rng.Intn(5) + 1)
+	segs := make([]int64, n+1)
+	for i := 0; i <= n; i++ {
+		segs[i] = int64(rng.Intn(5) + 1)
+	}
+	q := rng.Intn(3) + 1
+	starts := make([]int64, q)
+	for i := 0; i < q; i++ {
+		starts[i] = int64(rng.Intn(10))
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, g, r)
+	for i, v := range segs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", q)
+	for i := 0; i < q; i++ {
+		fmt.Fprintf(&sb, "%d\n", starts[i])
+	}
+	answers := make([]int64, q)
+	for i := 0; i < q; i++ {
+		answers[i] = simulate(segs, g, r, starts[i])
+	}
+	return sb.String(), answers
+}
+
+func runCase(bin, input string, exp []int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) < len(exp) {
+		return fmt.Errorf("expected %d numbers, got %d", len(exp), len(fields))
+	}
+	for i, v := range exp {
+		var got int64
+		fmt.Sscan(fields[i], &got)
+		if got != v {
+			return fmt.Errorf("answer %d: expected %d got %d", i+1, v, got)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/180-189/187/verifierE.go
+++ b/0-999/100-199/180-189/187/verifierE.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func brute(n, l, s int, x []int) (uint64, []int, bool) {
+	idxs := make([]int, 0, n-1)
+	for i := 1; i <= n; i++ {
+		if i != s {
+			idxs = append(idxs, i)
+		}
+	}
+	bestTime := uint64(^uint64(0))
+	var bestOrder []int
+	perm := make([]int, len(idxs))
+	copy(perm, idxs)
+	for {
+		left := l
+		right := n - 1 - l
+		cur := s
+		var tm uint64
+		valid := true
+		for _, nxt := range perm {
+			if nxt < cur {
+				if left == 0 {
+					valid = false
+					break
+				}
+				left--
+				tm += uint64(x[cur] - x[nxt])
+			} else {
+				if right == 0 {
+					valid = false
+					break
+				}
+				right--
+				tm += uint64(x[nxt] - x[cur])
+			}
+			cur = nxt
+		}
+		if valid && left == 0 && right == 0 {
+			if tm < bestTime {
+				bestTime = tm
+				bestOrder = append([]int(nil), perm...)
+			}
+		}
+		if !nextPermutation(perm) {
+			break
+		}
+	}
+	if bestOrder == nil {
+		return 0, nil, false
+	}
+	return bestTime, bestOrder, true
+}
+
+func nextPermutation(a []int) bool {
+	i := len(a) - 2
+	for i >= 0 && a[i] >= a[i+1] {
+		i--
+	}
+	if i < 0 {
+		return false
+	}
+	j := len(a) - 1
+	for a[j] <= a[i] {
+		j--
+	}
+	a[i], a[j] = a[j], a[i]
+	for k, l := i+1, len(a)-1; k < l; k, l = k+1, l-1 {
+		a[k], a[l] = a[l], a[k]
+	}
+	return true
+}
+
+func generateCase(rng *rand.Rand) (string, uint64, []int, bool) {
+	n := rng.Intn(6) + 2
+	l := rng.Intn(n - 1)
+	s := rng.Intn(n) + 1
+	x := make([]int, n+1)
+	cur := 0
+	for i := 1; i <= n; i++ {
+		cur += rng.Intn(5) + 1
+		x[i] = cur
+	}
+	time, order, ok := brute(n, l, s, x)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, l, s)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(x[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), time, order, ok
+}
+
+func runCase(bin string, input string, expTime uint64, expOrder []int, has bool) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if !has {
+		if strings.TrimSpace(outLines[0]) != "-1" {
+			return fmt.Errorf("expected -1")
+		}
+		return nil
+	}
+	var gotTime uint64
+	fmt.Sscan(strings.TrimSpace(outLines[0]), &gotTime)
+	if gotTime != expTime {
+		return fmt.Errorf("expected time %d got %d", expTime, gotTime)
+	}
+	if len(outLines) < 2 {
+		return fmt.Errorf("missing sequence line")
+	}
+	gotStrs := strings.Fields(strings.TrimSpace(outLines[1]))
+	if len(gotStrs) != len(expOrder) {
+		return fmt.Errorf("sequence length mismatch")
+	}
+	for i, s := range gotStrs {
+		var v int
+		fmt.Sscan(s, &v)
+		if v != expOrder[i] {
+			return fmt.Errorf("seq pos %d expected %d got %d", i+1, expOrder[i], v)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, ans, order, ok := generateCase(rng)
+		if err := runCase(bin, in, ans, order, ok); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for contest 187 problems A–E
- each verifier runs 100+ small randomized test cases

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e8913d2a88324892a07fc102d8476