### PR TITLE
Add Go verifiers for contest 185

### DIFF
--- a/0-999/100-199/180-189/185/verifierA.go
+++ b/0-999/100-199/180-189/185/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "185A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Int63n(1_000_000_000_000_000_000) // up to 1e18
+	return fmt.Sprintf("%d\n", n)
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/180-189/185/verifierB.go
+++ b/0-999/100-199/180-189/185/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "185B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	s := rng.Intn(1000) + 1
+	a := rng.Intn(1001)
+	b := rng.Intn(1001)
+	c := rng.Intn(1001)
+	return fmt.Sprintf("%d\n%d %d %d\n", s, a, b, c)
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/180-189/185/verifierC.go
+++ b/0-999/100-199/180-189/185/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "185C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(20)+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		for j := 0; j < n-i; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(20)+1)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/180-189/185/verifierD.go
+++ b/0-999/100-199/180-189/185/verifierD.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "185D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+var primes = []int64{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31}
+
+func genCase(rng *rand.Rand) string {
+	k := rng.Intn(1_000_000) + 1
+	l := rng.Int63n(20)
+	r := l + rng.Int63n(10)
+	p := primes[rng.Intn(len(primes))]
+	return fmt.Sprintf("1\n%d %d %d %d\n", k, l, r, p)
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/180-189/185/verifierE.go
+++ b/0-999/100-199/180-189/185/verifierE.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "185E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(4)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		x := rng.Intn(21) - 10
+		y := rng.Intn(21) - 10
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	for i := 0; i < k; i++ {
+		x := rng.Intn(21) - 10
+		y := rng.Intn(21) - 10
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle run error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verification programs for contest 185 problems A–E
- each verifier builds the reference solution and runs 100 random tests
- usage example: `go run verifierA.go ./my_solution`

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e8887f6c883249c6524c4043a9578