### PR TITLE
Add Go verifiers for contest 183

### DIFF
--- a/0-999/100-199/180-189/183/verifierA.go
+++ b/0-999/100-199/180-189/183/verifierA.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	opts := []string{"UL", "UR", "DL", "DR", "ULDR"}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	cntUL, cntUR, cntDL, cntDR := 0, 0, 0, 0
+	for i := 0; i < n; i++ {
+		s := opts[rng.Intn(len(opts))]
+		fmt.Fprintln(&sb, s)
+		switch s {
+		case "UL":
+			cntUL++
+		case "UR":
+			cntUR++
+		case "DL":
+			cntDL++
+		case "DR":
+			cntDR++
+		}
+	}
+	total := int64(n)
+	freeU := total - int64(cntUR) - int64(cntDL)
+	freeV := total - int64(cntUL) - int64(cntDR)
+	ans := (freeU + 1) * (freeV + 1)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/180-189/183/verifierB.go
+++ b/0-999/100-199/180-189/183/verifierB.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func computeExpected(n int, xs, ys []int64) int64 {
+	type lineKey struct{ A, B, C int64 }
+	lines := make(map[lineKey]map[int]struct{})
+	m := len(xs)
+	for i := 0; i < m; i++ {
+		for j := i + 1; j < m; j++ {
+			x1, y1 := xs[i], ys[i]
+			x2, y2 := xs[j], ys[j]
+			A := y2 - y1
+			B := x1 - x2
+			C := -(A*x1 + B*y1)
+			if A == 0 && B == 0 {
+				continue
+			}
+			g := gcd(gcd(abs64(A), abs64(B)), abs64(C))
+			A /= g
+			B /= g
+			C /= g
+			if A < 0 || (A == 0 && B < 0) {
+				A, B, C = -A, -B, -C
+			}
+			key := lineKey{A, B, C}
+			set, ok := lines[key]
+			if !ok {
+				set = make(map[int]struct{})
+				lines[key] = set
+			}
+			set[i] = struct{}{}
+			set[j] = struct{}{}
+		}
+	}
+	extra := make(map[int]int)
+	for k, pts := range lines {
+		count := len(pts)
+		if count < 2 || k.A == 0 {
+			continue
+		}
+		if (-k.C)%k.A != 0 {
+			continue
+		}
+		x0 := int((-k.C) / k.A)
+		if x0 < 1 || x0 > n {
+			continue
+		}
+		if extra[x0] < count-1 {
+			extra[x0] = count - 1
+		}
+	}
+	ans := int64(n)
+	for _, v := range extra {
+		ans += int64(v)
+	}
+	return ans
+}
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	xs := make([]int64, m)
+	ys := make([]int64, m)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		xs[i] = int64(rng.Intn(n) + 1)
+		ys[i] = int64(rng.Intn(20) + 1)
+		fmt.Fprintf(&sb, "%d %d\n", xs[i], ys[i])
+	}
+	ans := computeExpected(n, xs, ys)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/180-189/183/verifierC.go
+++ b/0-999/100-199/180-189/183/verifierC.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func computeExpected(n int, edges [][2]int) int {
+	g := make([][]int, n)
+	grev := make([][]int, n)
+	for _, e := range edges {
+		u := e[0]
+		v := e[1]
+		g[u] = append(g[u], v)
+		grev[v] = append(grev[v], u)
+	}
+	visited := make([]bool, n)
+	order := make([]int, 0, n)
+	type frame struct{ v, i int }
+	for s := 0; s < n; s++ {
+		if visited[s] {
+			continue
+		}
+		stack := []frame{{s, 0}}
+		for len(stack) > 0 {
+			fr := &stack[len(stack)-1]
+			v, i := fr.v, fr.i
+			if i == 0 {
+				visited[v] = true
+			}
+			if fr.i < len(g[v]) {
+				to := g[v][fr.i]
+				fr.i++
+				if !visited[to] {
+					stack = append(stack, frame{to, 0})
+				}
+			} else {
+				order = append(order, v)
+				stack = stack[:len(stack)-1]
+			}
+		}
+	}
+	comp := make([]int, n)
+	for i := range comp {
+		comp[i] = -1
+	}
+	cid := 0
+	for i := n - 1; i >= 0; i-- {
+		v := order[i]
+		if comp[v] != -1 {
+			continue
+		}
+		stack := []int{v}
+		comp[v] = cid
+		for len(stack) > 0 {
+			u := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			for _, w := range grev[u] {
+				if comp[w] == -1 {
+					comp[w] = cid
+					stack = append(stack, w)
+				}
+			}
+		}
+		cid++
+	}
+	nodes := make([][]int, cid)
+	for v := 0; v < n; v++ {
+		nodes[comp[v]] = append(nodes[comp[v]], v)
+	}
+	globalG := 0
+	depth := make([]int, n)
+	mark := make([]bool, n)
+	for c := 0; c < cid; c++ {
+		if len(nodes[c]) == 0 {
+			continue
+		}
+		for _, v := range nodes[c] {
+			mark[v] = false
+			depth[v] = 0
+		}
+		root := nodes[c][0]
+		mark[root] = true
+		depth[root] = 0
+		stack := []int{root}
+		localG := 0
+		for len(stack) > 0 {
+			u := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			for _, v := range g[u] {
+				if comp[v] != c {
+					continue
+				}
+				if !mark[v] {
+					mark[v] = true
+					depth[v] = depth[u] + 1
+					stack = append(stack, v)
+				} else {
+					d := depth[u] + 1 - depth[v]
+					if d < 0 {
+						d = -d
+					}
+					localG = gcd(localG, d)
+				}
+			}
+		}
+		globalG = gcd(globalG, localG)
+	}
+	if globalG == 0 {
+		globalG = n
+	}
+	return globalG
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(15)
+	edges := make([][2]int, m)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		edges[i] = [2]int{u, v}
+		fmt.Fprintf(&sb, "%d %d\n", u+1, v+1)
+	}
+	ans := computeExpected(n, edges)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/180-189/183/verifierD.go
+++ b/0-999/100-199/180-189/183/verifierD.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func computeExpected(n, m int, prob [][]int) float64 {
+	a := make([][]float64, n+1)
+	for i := range a {
+		a[i] = make([]float64, m+1)
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			a[i][j] = float64(prob[i-1][j-1]) / 1000.0
+		}
+	}
+	g := make([][][2]float64, m+1)
+	for j := 0; j <= m; j++ {
+		g[j] = make([][2]float64, n+1)
+	}
+	G := make([]bool, m+1)
+	var ans float64
+	for j := 1; j <= m; j++ {
+		idx := 0
+		if G[j] {
+			idx = 1
+		}
+		for i := 1; i <= n; i++ {
+			other := idx ^ 1
+			g[j][i][idx] = (g[j][i-1][other]+1)*a[i][j] + g[j][i-1][idx]*(1-a[i][j])
+		}
+	}
+	for t := 1; t <= n; t++ {
+		mx := 0.0
+		p := 1
+		for j := 1; j <= m; j++ {
+			idx := 0
+			if G[j] {
+				idx = 1
+			}
+			diff := g[j][n][idx] - g[j][n][idx^1]
+			if diff > mx {
+				mx = diff
+				p = j
+			}
+		}
+		ans += mx
+		G[p] = !G[p]
+		idx := 0
+		if G[p] {
+			idx = 1
+		}
+		other := idx ^ 1
+		for i := 1; i <= n; i++ {
+			g[p][i][idx] = (g[p][i-1][other]+1)*a[i][p] + g[p][i-1][idx]*(1-a[i][p])
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(4) + 1
+	prob := make([][]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		prob[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			prob[i][j] = rng.Intn(1001)
+			fmt.Fprintf(&sb, "%d ", prob[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	ans := computeExpected(n, m, prob)
+	return sb.String(), fmt.Sprintf("%.10f", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		var got float64
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: bad output: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		expVal, _ := strconv.ParseFloat(exp, 64)
+		if math.Abs(got-expVal) > 1e-6 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.10f got %.10f\ninput:\n%s", i+1, expVal, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/180-189/183/verifierE.go
+++ b/0-999/100-199/180-189/183/verifierE.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func computeExpected(n, m int, a []int64) int64 {
+	maxK := m / n
+	check := func(k int) bool {
+		if k == 0 {
+			return true
+		}
+		kk := int64(k)
+		base := int64(n) * kk * (kk - 1) / 2
+		for j := 0; j < n; j++ {
+			req := kk*int64(j+1) + base
+			if req > a[j] {
+				return false
+			}
+		}
+		return true
+	}
+	lo, hi := 0, maxK+1
+	for lo+1 < hi {
+		mid := (lo + hi) >> 1
+		if check(mid) {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	k := lo
+	if k == 0 {
+		return 0
+	}
+	kk := int64(k)
+	kn := int64(n) * kk
+	minTotal := kn * (kn + 1) / 2
+	base := int64(n) * kk * (kk - 1) / 2
+	bLeft := make([]int64, n)
+	for j := 0; j < n; j++ {
+		minj := kk*int64(j+1) + base
+		bLeft[j] = a[j] - minj
+	}
+	var extra int64
+	nextVal := int64(m) + 1
+	for i := kn; i >= 1; i-- {
+		idx := int((i - 1) % int64(n))
+		maxMon := nextVal - 1
+		maxBud := i + bLeft[idx]
+		if maxMon > int64(m) {
+			maxMon = int64(m)
+		}
+		var si int64
+		if maxBud < maxMon {
+			si = maxBud
+		} else {
+			si = maxMon
+		}
+		if si < i {
+			si = i
+		}
+		extra += si - i
+		bLeft[idx] -= si - i
+		nextVal = si
+	}
+	return minTotal + extra
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(20) + n
+	a := make([]int64, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(m*n + 1))
+		fmt.Fprintf(&sb, "%d ", a[i])
+	}
+	sb.WriteByte('\n')
+	ans := computeExpected(n, m, a)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add randomised solution verifiers for contest 183
- verifiers cover problems A–E and run any binary given on the CLI
- each verifier generates 100 test cases and compares output with an internal reference implementation

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e87fc010883248e38c0a1c4c6a3e7