### PR TITLE
Add Go verifiers for Codeforces contest 182

### DIFF
--- a/0-999/100-199/180-189/182/verifierA.go
+++ b/0-999/100-199/180-189/182/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const refDirA = "./0-999/100-199/180-189/182"
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	refPath := filepath.Join(refDirA, "refA.bin")
+	cmd := exec.Command("go", "build", "-o", refPath, "182A.go")
+	cmd.Dir = refDirA
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refPath, nil
+}
+
+func genTest() string {
+	a := rand.Intn(5) + 1
+	b := rand.Intn(5) + 1
+	ax := rand.Intn(21) - 10
+	ay := rand.Intn(21) - 10
+	bx := rand.Intn(21) - 10
+	by := rand.Intn(21) - 10
+	n := rand.Intn(3) // 0..2 trenches
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", a, b)
+	fmt.Fprintf(&sb, "%d %d %d %d\n", ax, ay, bx, by)
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if rand.Intn(2) == 0 {
+			x := rand.Intn(21) - 10
+			y := rand.Intn(21) - 10
+			l := rand.Intn(b) + 1
+			y2 := y + l
+			fmt.Fprintf(&sb, "%d %d %d %d\n", x, y, x, y2)
+		} else {
+			x := rand.Intn(21) - 10
+			y := rand.Intn(21) - 10
+			l := rand.Intn(b) + 1
+			x2 := x + l
+			fmt.Fprintf(&sb, "%d %d %d %d\n", x, y, x2, y)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	rand.Seed(1)
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	total := 100
+	passed := 0
+	for i := 0; i < total; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			continue
+		}
+		if out == exp {
+			passed++
+		} else {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\n got:%s\n", i+1, input, exp, out)
+		}
+	}
+	fmt.Printf("Passed %d/%d tests\n", passed, total)
+}

--- a/0-999/100-199/180-189/182/verifierB.go
+++ b/0-999/100-199/180-189/182/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const refDirB = "./0-999/100-199/180-189/182"
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	refPath := filepath.Join(refDirB, "refB.bin")
+	cmd := exec.Command("go", "build", "-o", refPath, "182B.go")
+	cmd.Dir = refDirB
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refPath, nil
+}
+
+func genTest() string {
+	d := rand.Intn(50) + 1
+	n := rand.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", d)
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rand.Intn(d)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	rand.Seed(1)
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	total := 100
+	passed := 0
+	for i := 0; i < total; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			continue
+		}
+		if out == exp {
+			passed++
+		} else {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\n got:%s\n", i+1, input, exp, out)
+		}
+	}
+	fmt.Printf("Passed %d/%d tests\n", passed, total)
+}

--- a/0-999/100-199/180-189/182/verifierC.go
+++ b/0-999/100-199/180-189/182/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const refDirC = "./0-999/100-199/180-189/182"
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	refPath := filepath.Join(refDirC, "refC.bin")
+	cmd := exec.Command("go", "build", "-o", refPath, "182C.go")
+	cmd.Dir = refDirC
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refPath, nil
+}
+
+func genTest() string {
+	n := rand.Intn(10) + 2
+	length := rand.Intn(n) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, length)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		v := rand.Intn(11) - 5
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	k := rand.Intn(length) + 1
+	fmt.Fprintf(&sb, "%d\n", k)
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	rand.Seed(1)
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	total := 100
+	passed := 0
+	for i := 0; i < total; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			continue
+		}
+		if out == exp {
+			passed++
+		} else {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\n got:%s\n", i+1, input, exp, out)
+		}
+	}
+	fmt.Printf("Passed %d/%d tests\n", passed, total)
+}

--- a/0-999/100-199/180-189/182/verifierD.go
+++ b/0-999/100-199/180-189/182/verifierD.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const refDirD = "./0-999/100-199/180-189/182"
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	refPath := filepath.Join(refDirD, "refD.bin")
+	cmd := exec.Command("go", "build", "-o", refPath, "182D.go")
+	cmd.Dir = refDirD
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refPath, nil
+}
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rand.Intn(3))
+	}
+	return string(b)
+}
+
+func genTest() string {
+	l1 := rand.Intn(8) + 1
+	l2 := rand.Intn(8) + 1
+	s1 := randString(l1)
+	s2 := randString(l2)
+	return fmt.Sprintf("%s %s\n", s1, s2)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	rand.Seed(1)
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	total := 100
+	passed := 0
+	for i := 0; i < total; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			continue
+		}
+		if out == exp {
+			passed++
+		} else {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s\n got:%s\n", i+1, input, exp, out)
+		}
+	}
+	fmt.Printf("Passed %d/%d tests\n", passed, total)
+}

--- a/0-999/100-199/180-189/182/verifierE.go
+++ b/0-999/100-199/180-189/182/verifierE.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const refDirE = "./0-999/100-199/180-189/182"
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	refPath := filepath.Join(refDirE, "refE.bin")
+	cmd := exec.Command("go", "build", "-o", refPath, "182E.go")
+	cmd.Dir = refDirE
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refPath, nil
+}
+
+func genTest() string {
+	n := rand.Intn(3) + 1
+	l := rand.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, l)
+	for i := 0; i < n; i++ {
+		a := rand.Intn(5) + 1
+		b := rand.Intn(5) + 1
+		fmt.Fprintf(&sb, "%d %d\n", a, b)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	rand.Seed(1)
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	total := 100
+	passed := 0
+	for i := 0; i < total; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			continue
+		}
+		if out == exp {
+			passed++
+		} else {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s\n got:%s\n", i+1, input, exp, out)
+		}
+	}
+	fmt.Printf("Passed %d/%d tests\n", passed, total)
+}


### PR DESCRIPTION
## Summary
- add solution verifiers in Go for all problems of contest 182
- each verifier builds the reference solution, generates 100 random tests and checks a candidate binary

## Testing
- `go run 0-999/100-199/180-189/182/verifierA.go 0-999/100-199/180-189/182/candA`

------
https://chatgpt.com/codex/tasks/task_e_687e87b6026c83248521256fda8fefde