### PR TITLE
Add Go verifiers for Codeforces contest 176

### DIFF
--- a/0-999/100-199/170-179/176/verifierA.go
+++ b/0-999/100-199/170-179/176/verifierA.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m, k int, a, b, c [][]int) int {
+	best := 0
+	for i := 0; i < n; i++ {
+		for h := 0; h < n; h++ {
+			if i == h {
+				continue
+			}
+			profits := make([]int, 0)
+			for j := 0; j < m; j++ {
+				p := b[h][j] - a[i][j]
+				if p > 0 {
+					for cnt := 0; cnt < c[i][j]; cnt++ {
+						profits = append(profits, p)
+					}
+				}
+			}
+			sort.Sort(sort.Reverse(sort.IntSlice(profits)))
+			sum := 0
+			limit := k
+			if len(profits) < limit {
+				limit = len(profits)
+			}
+			for t := 0; t < limit; t++ {
+				sum += profits[t]
+			}
+			if sum > best {
+				best = sum
+			}
+		}
+	}
+	return best
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rand.Seed(0)
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rand.Intn(3) + 2 // 2..4
+		m := rand.Intn(3) + 1 // 1..3
+		k := rand.Intn(5) + 1 // 1..5
+		names := make([]string, n)
+		a := make([][]int, n)
+		bvals := make([][]int, n)
+		cvals := make([][]int, n)
+		for i := 0; i < n; i++ {
+			names[i] = fmt.Sprintf("p%d", rand.Intn(100))
+			a[i] = make([]int, m)
+			bvals[i] = make([]int, m)
+			cvals[i] = make([]int, m)
+			for j := 0; j < m; j++ {
+				a[i][j] = rand.Intn(10) + 1
+				bvals[i][j] = rand.Intn(10) + 1
+				cvals[i][j] = rand.Intn(5)
+			}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+		for i := 0; i < n; i++ {
+			fmt.Fprint(&sb, names[i])
+			for j := 0; j < m; j++ {
+				fmt.Fprintf(&sb, " %d %d %d", a[i][j], bvals[i][j], cvals[i][j])
+			}
+			fmt.Fprintln(&sb)
+		}
+		input := sb.String()
+		exp := expected(n, m, k, a, bvals, cvals)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", tcase+1, err)
+			return
+		}
+		var got int
+		fmt.Sscan(out, &got)
+		if got != exp {
+			fmt.Printf("test %d failed: expected %d got %d\ninput:\n%s", tcase+1, exp, got, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/100-199/170-179/176/verifierB.go
+++ b/0-999/100-199/170-179/176/verifierB.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const MOD int64 = 1000000007
+
+func modpow(a, e int64) int64 {
+	res := int64(1)
+	a %= MOD
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func expected(start, end string, k int64) int64 {
+	n := len(start)
+	doubled := start + start
+	cnt := 0
+	cnt0 := 0
+	for s := 0; s < n; s++ {
+		if doubled[s:s+n] == end {
+			cnt++
+			if s == 0 {
+				cnt0 = 1
+			}
+		}
+	}
+	if cnt == 0 {
+		return 0
+	}
+	t := modpow(int64(n-1), k)
+	p := int64(1)
+	if k&1 == 1 {
+		p = MOD - 1
+	}
+	invN := modpow(int64(n), MOD-2)
+	C0 := (t + p*int64(n-1)) % MOD * invN % MOD
+	C1 := (t - p + MOD) % MOD * invN % MOD
+	ways := (int64(cnt0)*C0 + int64(cnt-cnt0)*C1) % MOD
+	return ways
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rand.Seed(1)
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rand.Intn(5) + 1
+		letters := []rune("abcde")
+		sb := strings.Builder{}
+		for i := 0; i < n; i++ {
+			sb.WriteRune(letters[rand.Intn(len(letters))])
+		}
+		start := sb.String()
+		shift := rand.Intn(n)
+		end := start[shift:] + start[:shift]
+		// occasionally produce non-rotation
+		if rand.Intn(4) == 0 {
+			endBytes := []rune(end)
+			pos := rand.Intn(n)
+			endBytes[pos] = letters[rand.Intn(len(letters))]
+			end = string(endBytes)
+		}
+		k := int64(rand.Intn(10))
+		input := fmt.Sprintf("%s\n%s\n%d\n", start, end, k)
+		exp := expected(start, end, k)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", tcase+1, err)
+			return
+		}
+		var got int64
+		fmt.Sscan(out, &got)
+		if got != exp {
+			fmt.Printf("test %d failed: expected %d got %d\ninput:\n%s", tcase+1, exp, got, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/100-199/170-179/176/verifierC.go
+++ b/0-999/100-199/170-179/176/verifierC.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m, x1, y1, x2, y2 int) string {
+	d := abs(x1-x2) + abs(y1-y2)
+	if n == 1 || m == 1 {
+		if d <= 4 {
+			return "First"
+		}
+		return "Second"
+	}
+	return "First"
+}
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rand.Seed(2)
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rand.Intn(4) + 1
+		m := rand.Intn(4) + 1
+		x1 := rand.Intn(n) + 1
+		y1 := rand.Intn(m) + 1
+		x2 := rand.Intn(n) + 1
+		y2 := rand.Intn(m) + 1
+		if x1 == x2 && y1 == y2 {
+			x2 = (x2 % n) + 1
+		}
+		input := fmt.Sprintf("%d %d %d %d %d %d\n", n, m, x1, y1, x2, y2)
+		exp := expected(n, m, x1, y1, x2, y2)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", tcase+1, err)
+			return
+		}
+		out = strings.TrimSpace(out)
+		if out != exp {
+			fmt.Printf("test %d failed: expected %s got %s\ninput:%s", tcase+1, exp, out, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/100-199/170-179/176/verifierD.go
+++ b/0-999/100-199/170-179/176/verifierD.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func lcs(a, b string) int {
+	n := len(a)
+	m := len(b)
+	dp := make([][]int, n+1)
+	for i := range dp {
+		dp[i] = make([]int, m+1)
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			if a[i-1] == b[j-1] {
+				dp[i][j] = dp[i-1][j-1] + 1
+			} else if dp[i-1][j] > dp[i][j-1] {
+				dp[i][j] = dp[i-1][j]
+			} else {
+				dp[i][j] = dp[i][j-1]
+			}
+		}
+	}
+	return dp[n][m]
+}
+
+func expected(base []string, idx []int, s string) int {
+	var b strings.Builder
+	for _, id := range idx {
+		b.WriteString(base[id])
+	}
+	t := b.String()
+	return lcs(s, t)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rand.Seed(3)
+	letters := []rune("abc")
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rand.Intn(3) + 1
+		base := make([]string, n)
+		for i := 0; i < n; i++ {
+			l := rand.Intn(3) + 1
+			var sb strings.Builder
+			for j := 0; j < l; j++ {
+				sb.WriteRune(letters[rand.Intn(len(letters))])
+			}
+			base[i] = sb.String()
+		}
+		m := rand.Intn(3) + 1
+		idx := make([]int, m)
+		for i := 0; i < m; i++ {
+			idx[i] = rand.Intn(n)
+		}
+		slen := rand.Intn(5)
+		var sb strings.Builder
+		for i := 0; i < slen; i++ {
+			sb.WriteRune(letters[rand.Intn(len(letters))])
+		}
+		s := sb.String()
+		// build input
+		var in strings.Builder
+		fmt.Fprintf(&in, "%d\n", n)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&in, "%s\n", base[i])
+		}
+		fmt.Fprintf(&in, "%d\n", m)
+		for i := 0; i < m; i++ {
+			fmt.Fprintf(&in, "%d ", idx[i]+1)
+		}
+		fmt.Fprint(&in, "\n")
+		fmt.Fprintf(&in, "%s\n", s)
+		input := in.String()
+		exp := expected(base, idx, s)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", tcase+1, err)
+			return
+		}
+		var got int
+		fmt.Sscan(out, &got)
+		if got != exp {
+			fmt.Printf("test %d failed: expected %d got %d\ninput:\n%s", tcase+1, exp, got, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/100-199/170-179/176/verifierE.go
+++ b/0-999/100-199/170-179/176/verifierE.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type edge struct {
+	to int
+	w  int
+}
+
+type tree struct {
+	n      int
+	adj    [][]edge
+	parent []int
+	weight []int
+	depth  []int
+	order  []int
+}
+
+func newTree(n int) *tree {
+	t := &tree{n: n}
+	t.adj = make([][]edge, n+1)
+	t.parent = make([]int, n+1)
+	t.weight = make([]int, n+1)
+	t.depth = make([]int, n+1)
+	t.order = make([]int, n+1)
+	return t
+}
+
+func (t *tree) add(u, v, w int) {
+	t.adj[u] = append(t.adj[u], edge{v, w})
+	t.adj[v] = append(t.adj[v], edge{u, w})
+}
+
+func (t *tree) dfs() {
+	visited := make([]bool, t.n+1)
+	stack := []int{1}
+	order := 0
+	t.parent[1] = 0
+	t.weight[1] = 0
+	t.depth[1] = 0
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if visited[v] {
+			continue
+		}
+		visited[v] = true
+		t.order[v] = order
+		order++
+		for _, e := range t.adj[v] {
+			if e.to == t.parent[v] {
+				continue
+			}
+			t.parent[e.to] = v
+			t.weight[e.to] = e.w
+			t.depth[e.to] = t.depth[v] + 1
+			stack = append(stack, e.to)
+		}
+	}
+}
+
+func (t *tree) pathEdges(u, v int, set map[[2]int]bool) {
+	for t.depth[u] > t.depth[v] {
+		k := edgeKey(u, t.parent[u])
+		set[k] = true
+		u = t.parent[u]
+	}
+	for t.depth[v] > t.depth[u] {
+		k := edgeKey(v, t.parent[v])
+		set[k] = true
+		v = t.parent[v]
+	}
+	for u != v {
+		k1 := edgeKey(u, t.parent[u])
+		set[k1] = true
+		u = t.parent[u]
+		k2 := edgeKey(v, t.parent[v])
+		set[k2] = true
+		v = t.parent[v]
+	}
+}
+
+func edgeKey(a, b int) [2]int {
+	if a < b {
+		return [2]int{a, b}
+	}
+	return [2]int{b, a}
+}
+
+func minimalSubtree(t *tree, active []int) int {
+	if len(active) <= 1 {
+		return 0
+	}
+	set := make(map[[2]int]bool)
+	for i := 0; i < len(active); i++ {
+		for j := i + 1; j < len(active); j++ {
+			t.pathEdges(active[i], active[j], set)
+		}
+	}
+	sum := 0
+	for e := range set {
+		// find weight
+		u, v := e[0], e[1]
+		if t.parent[u] == v {
+			sum += t.weight[u]
+		} else {
+			sum += t.weight[v]
+		}
+	}
+	return sum
+}
+
+func expected(n int, edges [][3]int, ops []string) []int {
+	tr := newTree(n)
+	for _, e := range edges {
+		tr.add(e[0], e[1], e[2])
+	}
+	tr.dfs()
+	active := make(map[int]bool)
+	answers := []int{}
+	for _, op := range ops {
+		if op[0] == '+' {
+			var x int
+			fmt.Sscanf(op[1:], "%d", &x)
+			active[x] = true
+		} else if op[0] == '-' {
+			var x int
+			fmt.Sscanf(op[1:], "%d", &x)
+			delete(active, x)
+		} else if op[0] == '?' {
+			list := make([]int, 0, len(active))
+			for v := range active {
+				list = append(list, v)
+			}
+			sort.Slice(list, func(i, j int) bool { return tr.order[list[i]] < tr.order[list[j]] })
+			ans := minimalSubtree(tr, list)
+			answers = append(answers, ans)
+		}
+	}
+	return answers
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rand.Seed(4)
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rand.Intn(5) + 2
+		edges := make([][3]int, 0, n-1)
+		// generate random tree using union method
+		for i := 2; i <= n; i++ {
+			p := rand.Intn(i-1) + 1
+			w := rand.Intn(10) + 1
+			edges = append(edges, [3]int{p, i, w})
+		}
+		q := rand.Intn(6) + 3
+		ops := make([]string, q)
+		active := make(map[int]bool)
+		ensuredQuestion := false
+		for i := 0; i < q; i++ {
+			typ := rand.Intn(3)
+			switch typ {
+			case 0:
+				x := rand.Intn(n) + 1
+				ops[i] = fmt.Sprintf("+ %d", x)
+				active[x] = true
+			case 1:
+				if len(active) == 0 {
+					x := rand.Intn(n) + 1
+					ops[i] = fmt.Sprintf("+ %d", x)
+					active[x] = true
+				} else {
+					var list []int
+					for v := range active {
+						list = append(list, v)
+					}
+					x := list[rand.Intn(len(list))]
+					ops[i] = fmt.Sprintf("- %d", x)
+					delete(active, x)
+				}
+			default:
+				ops[i] = "?"
+				ensuredQuestion = true
+			}
+		}
+		if !ensuredQuestion {
+			ops[q-1] = "?"
+		}
+		// Build input
+		var in strings.Builder
+		fmt.Fprintf(&in, "%d\n", n)
+		for _, e := range edges {
+			fmt.Fprintf(&in, "%d %d %d\n", e[0], e[1], e[2])
+		}
+		fmt.Fprintf(&in, "%d\n", q)
+		for _, op := range ops {
+			fmt.Fprintf(&in, "%s\n", op)
+		}
+		input := in.String()
+		exp := expected(n, edges, ops)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", tcase+1, err)
+			return
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) != len(exp) {
+			fmt.Printf("test %d failed: expected %d lines got %d\ninput:\n%s", tcase+1, len(exp), len(lines), input)
+			return
+		}
+		for i, line := range lines {
+			var got int
+			fmt.Sscan(line, &got)
+			if got != exp[i] {
+				fmt.Printf("test %d failed on answer %d: expected %d got %d\ninput:\n%s", tcase+1, i+1, exp[i], got, input)
+				return
+			}
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–E of contest 176
- each verifier runs 100 randomized tests against a provided binary
- allow binaries specified as compiled executables or `.go` files

## Testing
- `go run verifierA.go -- 176A.go`
- `go run verifierB.go -- 176B.go`
- `go run verifierC.go -- 176C.go`
- `go run verifierD.go -- 176D.go`
- `go run verifierE.go -- 176E.go` *(fails: runtime error from provided solution)*

------
https://chatgpt.com/codex/tasks/task_e_687e86117f8c8324b0703cb7a587ccfb