### PR TITLE
Add Go verifiers for contest 173

### DIFF
--- a/0-999/100-199/170-179/173/verifierA.go
+++ b/0-999/100-199/170-179/173/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveA(n int64, A, B string) (int64, int64) {
+	m := int64(len(A))
+	k := int64(len(B))
+	g := gcd(m, k)
+	l := m / g * k
+	var winA, winB int64
+	for i := int64(0); i < l; i++ {
+		a := A[i%m]
+		b := B[i%k]
+		if (a == 'R' && b == 'S') || (a == 'S' && b == 'P') || (a == 'P' && b == 'R') {
+			winA++
+		} else if (b == 'R' && a == 'S') || (b == 'S' && a == 'P') || (b == 'P' && a == 'R') {
+			winB++
+		}
+	}
+	full := n / l
+	rem := n % l
+	totalA := winA * full
+	totalB := winB * full
+	for i := int64(0); i < rem; i++ {
+		a := A[i%m]
+		b := B[i%k]
+		if (a == 'R' && b == 'S') || (a == 'S' && b == 'P') || (a == 'P' && b == 'R') {
+			totalA++
+		} else if (b == 'R' && a == 'S') || (b == 'S' && a == 'P') || (b == 'P' && a == 'R') {
+			totalB++
+		}
+	}
+	return totalB, totalA
+}
+
+func randSeq(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	letters := []byte{'R', 'S', 'P'}
+	for i := range b {
+		b[i] = letters[rng.Intn(3)]
+	}
+	return string(b)
+}
+
+func runCase(bin string, n int64, A, B string) error {
+	var input bytes.Buffer
+	fmt.Fprintf(&input, "%d\n%s\n%s\n", n, A, B)
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	reader := bufio.NewReader(&out)
+	var x, y int64
+	if _, err := fmt.Fscan(reader, &x, &y); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	expX, expY := solveA(n, A, B)
+	if x != expX || y != expY {
+		return fmt.Errorf("expected %d %d got %d %d", expX, expY, x, y)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tests := 100
+	for i := 0; i < tests; i++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		lenA := rng.Intn(50) + 1
+		lenB := rng.Intn(50) + 1
+		A := randSeq(rng, lenA)
+		B := randSeq(rng, lenB)
+		if err := runCase(bin, n, A, B); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d A=%s B=%s\n", i+1, err, n, A, B)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/170-179/173/verifierB.go
+++ b/0-999/100-199/170-179/173/verifierB.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"time"
+)
+
+const INF = int(1e9)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveB(n, m int, grid [][]byte) int {
+	dp1H := make([][]int, n)
+	dp1V := make([][]int, n)
+	for i := 0; i < n; i++ {
+		dp1H[i] = make([]int, m)
+		dp1V[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			dp1H[i][j] = INF
+			dp1V[i][j] = INF
+		}
+	}
+	dp1H[0][0] = 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if i == 0 && j == 0 {
+				continue
+			}
+			if j > 0 {
+				dp1H[i][j] = min(dp1H[i][j], dp1H[i][j-1])
+				if grid[i][j-1] == '#' && dp1V[i][j-1] < INF {
+					dp1H[i][j] = min(dp1H[i][j], dp1V[i][j-1]+1)
+				}
+			}
+			if i > 0 {
+				dp1V[i][j] = min(dp1V[i][j], dp1V[i-1][j])
+				if grid[i-1][j] == '#' && dp1H[i-1][j] < INF {
+					dp1V[i][j] = min(dp1V[i][j], dp1H[i-1][j]+1)
+				}
+			}
+		}
+	}
+	ds := make([][]int, n)
+	for i := 0; i < n; i++ {
+		ds[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			ds[i][j] = min(dp1H[i][j], dp1V[i][j])
+		}
+	}
+
+	dp2H := make([][]int, n)
+	dp2V := make([][]int, n)
+	for i := 0; i < n; i++ {
+		dp2H[i] = make([]int, m)
+		dp2V[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			dp2H[i][j] = INF
+			dp2V[i][j] = INF
+		}
+	}
+	dp2H[n-1][m-1] = 0
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if i == n-1 && j == m-1 {
+				continue
+			}
+			if j < m-1 {
+				dp2H[i][j] = min(dp2H[i][j], dp2H[i][j+1])
+				if grid[i][j+1] == '#' && dp2V[i][j+1] < INF {
+					dp2H[i][j] = min(dp2H[i][j], dp2V[i][j+1]+1)
+				}
+			}
+			if i < n-1 {
+				dp2V[i][j] = min(dp2V[i][j], dp2V[i+1][j])
+				if grid[i+1][j] == '#' && dp2H[i+1][j] < INF {
+					dp2V[i][j] = min(dp2V[i][j], dp2H[i+1][j]+1)
+				}
+			}
+		}
+	}
+	db := make([][]int, n)
+	for i := 0; i < n; i++ {
+		db[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			db[i][j] = min(dp2H[i][j], dp2V[i][j])
+		}
+	}
+	ans := INF
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '#' && ds[i][j] < INF && db[i][j] < INF {
+				cost := ds[i][j] + db[i][j]
+				if cost < ans {
+					ans = cost
+				}
+			}
+		}
+	}
+	if ans >= INF {
+		return -1
+	}
+	return ans
+}
+
+func runCase(bin string, n, m int, grid [][]byte) error {
+	var input bytes.Buffer
+	fmt.Fprintf(&input, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		input.Write(grid[i])
+		input.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(&out, &got); err != nil {
+		return fmt.Errorf("parse error: %v", err)
+	}
+	want := solveB(n, m, grid)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rng.Intn(10) + 2
+		m := rng.Intn(10) + 2
+		grid := make([][]byte, n)
+		for i := 0; i < n; i++ {
+			row := make([]byte, m)
+			for j := 0; j < m; j++ {
+				if rng.Intn(3) == 0 {
+					row[j] = '#'
+				} else {
+					row[j] = '.'
+				}
+			}
+			grid[i] = row
+		}
+		if err := runCase(bin, n, m, grid); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/170-179/173/verifierC.go
+++ b/0-999/100-199/170-179/173/verifierC.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"time"
+)
+
+func solveC(n, m int, a [][]int64) int64 {
+	P := make([][]int64, n+1)
+	for i := 0; i <= n; i++ {
+		P[i] = make([]int64, m+1)
+	}
+	for i := 1; i <= n; i++ {
+		rowSum := int64(0)
+		for j := 1; j <= m; j++ {
+			rowSum += a[i-1][j-1]
+			P[i][j] = P[i-1][j] + rowSum
+		}
+	}
+	maxSum := int64(-9e18)
+	maxK := n
+	if m < maxK {
+		maxK = m
+	}
+	for k := 3; k <= maxK; k += 2 {
+		kk := k
+		for i := 0; i+kk <= n; i++ {
+			i2 := i + kk
+			for j := 0; j+kk <= m; j++ {
+				j2 := j + kk
+				sum := P[i2][j2] - P[i][j2] - P[i2][j] + P[i][j]
+				if sum > maxSum {
+					maxSum = sum
+				}
+			}
+		}
+	}
+	return maxSum
+}
+
+func runCase(bin string, n, m int, a [][]int64) error {
+	var input bytes.Buffer
+	fmt.Fprintf(&input, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprintf(&input, "%d", a[i][j])
+		}
+		input.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(&out, &got); err != nil {
+		return fmt.Errorf("parse error: %v", err)
+	}
+	want := solveC(n, m, a)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rng.Intn(8) + 3
+		m := rng.Intn(8) + 3
+		a := make([][]int64, n)
+		for i := 0; i < n; i++ {
+			row := make([]int64, m)
+			for j := 0; j < m; j++ {
+				row[j] = int64(rng.Intn(2001) - 1000)
+			}
+			a[i] = row
+		}
+		if err := runCase(bin, n, m, a); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/170-179/173/verifierD.go
+++ b/0-999/100-199/170-179/173/verifierD.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// solveD replicates the reference solution and returns whether a solution
+// exists and one possible assignment if it does.
+func solveD(n int, edges [][2]int) (bool, []int) {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	col := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		col[i] = -1
+	}
+	queue := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		if col[i] != -1 {
+			continue
+		}
+		col[i] = 0
+		queue = queue[:0]
+		queue = append(queue, i)
+		for qi := 0; qi < len(queue); qi++ {
+			u := queue[qi]
+			for _, v := range adj[u] {
+				if col[v] == -1 {
+					col[v] = 1 - col[u]
+					queue = append(queue, v)
+				}
+			}
+		}
+	}
+	cnt := [2]int{}
+	for i := 1; i <= n; i++ {
+		cnt[col[i]]++
+	}
+	du := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		du[i] = len(adj[i])
+	}
+	idx := make([]int, n+1)
+	tot := 0
+
+	paint := func(x int) {
+		tot++
+		idx[x] = tot
+		vist := make([]bool, n+1)
+		for _, v := range adj[x] {
+			vist[v] = true
+		}
+		t := 0
+		for i := 1; i <= n && t < 2; i++ {
+			if idx[i] == 0 && col[i] != col[x] && !vist[i] {
+				tot++
+				idx[i] = tot
+				t++
+			}
+		}
+	}
+
+	outputIdx := func() []int {
+		res := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			if idx[i] == 0 && col[i] == 0 {
+				tot++
+				idx[i] = tot
+			}
+		}
+		for i := 1; i <= n; i++ {
+			if idx[i] == 0 && col[i] == 1 {
+				tot++
+				idx[i] = tot
+			}
+		}
+		for i := 1; i <= n; i++ {
+			res[i] = (idx[i]-1)/3 + 1
+		}
+		return res[1:]
+	}
+
+	if cnt[0]%3 == 0 {
+		return true, outputIdx()
+	}
+	if cnt[0]%3 == 2 {
+		for i := 1; i <= n; i++ {
+			col[i] = 1 - col[i]
+		}
+		cnt[0], cnt[1] = cnt[1], cnt[0]
+	}
+	for u := 1; u <= n; u++ {
+		if col[u] != 0 {
+			continue
+		}
+		if du[u]+2 <= cnt[1] {
+			paint(u)
+			return true, outputIdx()
+		}
+	}
+	tcnt := 0
+	for u := 1; u <= n; u++ {
+		if col[u] != 1 {
+			continue
+		}
+		if du[u]+2 <= cnt[0] {
+			paint(u)
+			tcnt++
+			if tcnt == 2 {
+				return true, outputIdx()
+			}
+		}
+	}
+	return false, nil
+}
+
+func verifyOutput(n int, edges [][2]int, solPossible bool, out string) error {
+	rdr := bufio.NewReader(strings.NewReader(strings.TrimSpace(out)))
+	first, err := rdr.ReadString('\n')
+	if err != nil && err.Error() != "EOF" {
+		return fmt.Errorf("read output: %v", err)
+	}
+	first = strings.TrimSpace(first)
+	if first == "NO" {
+		if solPossible {
+			return fmt.Errorf("expected YES, got NO")
+		}
+		return nil
+	}
+	if first != "YES" {
+		return fmt.Errorf("first token must be YES or NO")
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		if _, err := fmt.Fscan(rdr, &arr[i]); err != nil {
+			return fmt.Errorf("read assignment: %v", err)
+		}
+	}
+	k := n / 3
+	cnt := make([]int, k+1)
+	for _, g := range arr {
+		if g < 1 || g > k {
+			return fmt.Errorf("invalid group id %d", g)
+		}
+		cnt[g]++
+	}
+	for g := 1; g <= k; g++ {
+		if cnt[g] != 3 {
+			return fmt.Errorf("group %d size %d", g, cnt[g])
+		}
+	}
+	for _, e := range edges {
+		if arr[e[0]-1] == arr[e[1]-1] {
+			return fmt.Errorf("edge %d-%d same group", e[0], e[1])
+		}
+	}
+	if !solPossible {
+		return fmt.Errorf("expected NO, but got assignment")
+	}
+	return nil
+}
+
+func runCase(bin string, n int, edges [][2]int) error {
+	var input bytes.Buffer
+	fmt.Fprintf(&input, "%d %d\n", n, len(edges))
+	for _, e := range edges {
+		fmt.Fprintf(&input, "%d %d\n", e[0], e[1])
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	possible, _ := solveD(n, edges)
+	if err := verifyOutput(n, edges, possible, out.String()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		k := rng.Intn(5) + 1
+		n := 3 * k
+		maxEdges := n * (n - 1) / 2
+		m := rng.Intn(min(maxEdges, 4*n))
+		edges := make([][2]int, 0, m)
+		seen := make(map[[2]int]struct{})
+		for len(edges) < m {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			if u > v {
+				u, v = v, u
+			}
+			e := [2]int{u, v}
+			if _, ok := seen[e]; ok {
+				continue
+			}
+			seen[e] = struct{}{}
+			edges = append(edges, e)
+		}
+		if err := runCase(bin, n, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/0-999/100-199/170-179/173/verifierE.go
+++ b/0-999/100-199/170-179/173/verifierE.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"time"
+)
+
+type Fenwick struct {
+	n    int
+	tree []int
+}
+
+func NewFenwick(n int) *Fenwick {
+	return &Fenwick{n: n, tree: make([]int, n+1)}
+}
+
+func (f *Fenwick) Update(i, v int) {
+	i++
+	for ; i <= f.n; i += i & -i {
+		f.tree[i] += v
+	}
+}
+
+func (f *Fenwick) Query(i int) int {
+	i++
+	s := 0
+	for ; i > 0; i -= i & -i {
+		s += f.tree[i]
+	}
+	return s
+}
+
+type SegTree struct {
+	n    int
+	size int
+	tree []int
+}
+
+func NewSegTree(n int) *SegTree {
+	size := 1
+	for size < n {
+		size <<= 1
+	}
+	return &SegTree{n: n, size: size, tree: make([]int, 2*size)}
+}
+
+func (s *SegTree) Update(i, v int) {
+	i += s.size
+	if s.tree[i] >= v {
+		return
+	}
+	s.tree[i] = v
+	for i >>= 1; i > 0; i >>= 1 {
+		if s.tree[2*i] > s.tree[2*i+1] {
+			s.tree[i] = s.tree[2*i]
+		} else {
+			s.tree[i] = s.tree[2*i+1]
+		}
+	}
+}
+
+func (s *SegTree) Query(l, r int) int {
+	if l > r {
+		return 0
+	}
+	l += s.size
+	r += s.size
+	res := 0
+	for l <= r {
+		if l&1 == 1 {
+			if s.tree[l] > res {
+				res = s.tree[l]
+			}
+			l++
+		}
+		if r&1 == 0 {
+			if s.tree[r] > res {
+				res = s.tree[r]
+			}
+			r--
+		}
+		l >>= 1
+		r >>= 1
+	}
+	return res
+}
+
+func uniqueInts(a []int) []int {
+	n := 0
+	for i := 0; i < len(a); i++ {
+		if n == 0 || a[i] != a[n-1] {
+			a[n] = a[i]
+			n++
+		}
+	}
+	return a[:n]
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveE(n, ageK int, r []int, a []int, queries [][2]int) []int {
+	ages := make([]int, n)
+	copy(ages, a)
+	sort.Ints(ages)
+	ages = uniqueInts(ages)
+	m := len(ages)
+	idxAge := make([]int, n)
+	for i := 0; i < n; i++ {
+		idxAge[i] = sort.SearchInts(ages, a[i])
+	}
+	c := make([]int, n)
+	fenw := NewFenwick(m)
+	ord := make([]int, n)
+	for i := range ord {
+		ord[i] = i
+	}
+	sort.Slice(ord, func(i, j int) bool { return r[ord[i]] < r[ord[j]] })
+	for i := 0; i < n; {
+		j := i
+		for j < n && r[ord[j]] == r[ord[i]] {
+			j++
+		}
+		for k := i; k < j; k++ {
+			fenw.Update(idxAge[ord[k]], 1)
+		}
+		for k := i; k < j; k++ {
+			u := ord[k]
+			lo := a[u] - ageK
+			hi := a[u] + ageK
+			lidx := sort.SearchInts(ages, lo)
+			ridx := sort.Search(len(ages), func(x int) bool { return ages[x] > hi }) - 1
+			if lidx < 0 {
+				lidx = 0
+			}
+			if ridx >= 0 && lidx <= ridx {
+				c[u] = fenw.Query(ridx)
+				if lidx > 0 {
+					c[u] -= fenw.Query(lidx - 1)
+				}
+			} else {
+				c[u] = 0
+			}
+		}
+		i = j
+	}
+	q := len(queries)
+	type Query struct{ R0, lidx, ridx, idx int }
+	qs := make([]Query, q)
+	for i, qu := range queries {
+		x, y := qu[0], qu[1]
+		R0 := r[x]
+		if r[y] > R0 {
+			R0 = r[y]
+		}
+		lowAge := max(a[x]-ageK, a[y]-ageK)
+		highAge := min(a[x]+ageK, a[y]+ageK)
+		lidx := sort.SearchInts(ages, lowAge)
+		ridx := sort.Search(len(ages), func(u int) bool { return ages[u] > highAge }) - 1
+		qs[i] = Query{R0: R0, lidx: lidx, ridx: ridx, idx: i}
+	}
+	ordDesc := make([]int, n)
+	copy(ordDesc, ord)
+	sort.Slice(ordDesc, func(i, j int) bool { return r[ordDesc[i]] > r[ordDesc[j]] })
+	sort.Slice(qs, func(i, j int) bool { return qs[i].R0 > qs[j].R0 })
+	seg := NewSegTree(m)
+	ans := make([]int, q)
+	pi := 0
+	for _, qu := range qs {
+		for pi < n && r[ordDesc[pi]] >= qu.R0 {
+			u := ordDesc[pi]
+			seg.Update(idxAge[u], c[u])
+			pi++
+		}
+		if qu.lidx > qu.ridx {
+			ans[qu.idx] = -1
+		} else {
+			mv := seg.Query(qu.lidx, qu.ridx)
+			if mv == 0 {
+				ans[qu.idx] = -1
+			} else {
+				ans[qu.idx] = mv
+			}
+		}
+	}
+	return ans
+}
+
+func runCase(bin string, n, ageK int, r, a []int, queries [][2]int) error {
+	var input bytes.Buffer
+	fmt.Fprintf(&input, "%d %d\n", n, ageK)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprintf(&input, "%d", r[i])
+	}
+	input.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprintf(&input, "%d", a[i])
+	}
+	input.WriteByte('\n')
+	q := len(queries)
+	fmt.Fprintf(&input, "%d\n", q)
+	for _, qu := range queries {
+		fmt.Fprintf(&input, "%d %d\n", qu[0]+1, qu[1]+1)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(&out)
+	got := make([]int, 0, q)
+	for scanner.Scan() {
+		var v int
+		if _, err := fmt.Sscan(scanner.Text(), &v); err != nil {
+			return fmt.Errorf("parse output: %v", err)
+		}
+		got = append(got, v)
+	}
+	if len(got) != q {
+		return fmt.Errorf("expected %d lines, got %d", q, len(got))
+	}
+	want := solveE(n, ageK, r, a, queries)
+	for i := 0; i < q; i++ {
+		if got[i] != want[i] {
+			return fmt.Errorf("expected %d got %d", want[i], got[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rng.Intn(10) + 2
+		ageK := rng.Intn(5) + 1
+		r := make([]int, n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			r[i] = rng.Intn(20) + 1
+			a[i] = rng.Intn(20) + 1
+		}
+		q := rng.Intn(5) + 1
+		queries := make([][2]int, q)
+		for i := 0; i < q; i++ {
+			x := rng.Intn(n)
+			y := rng.Intn(n)
+			for y == x {
+				y = rng.Intn(n)
+			}
+			queries[i] = [2]int{x, y}
+		}
+		if err := runCase(bin, n, ageK, r, a, queries); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for contest 173 problems A–E
- each verifier runs 100 random test cases and checks a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e853f6e448324bdfc54099d9bba64