### PR TITLE
Add solution verifiers for contest 171

### DIFF
--- a/0-999/100-199/170-179/171/verifierA.go
+++ b/0-999/100-199/170-179/171/verifierA.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+var tests []testCase
+
+func init() {
+	for i := 0; i < 100; i++ {
+		a1 := int64(i) * 10000000
+		a2 := int64(999999999) - a1
+		tests = append(tests, testCase{
+			input:  fmt.Sprintf("%d %d\n", a1, a2),
+			output: fmt.Sprintf("%d", a1+a2),
+		})
+	}
+}
+
+func runTest(binary string, t testCase, idx int) error {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(t.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("test %d runtime error: %v\n%s", idx, err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(t.output)
+	if got != want {
+		return fmt.Errorf("test %d failed: expected %q got %q", idx, want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, t := range tests {
+		if err := runTest(bin, t, i+1); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/100-199/170-179/171/verifierB.go
+++ b/0-999/100-199/170-179/171/verifierB.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+var tests []testCase
+
+func init() {
+	for i := 0; i < 99; i++ {
+		a := 1 + i*182
+		res := int64(a) * int64(a+1) / 2
+		tests = append(tests, testCase{
+			input:  fmt.Sprintf("%d\n", a),
+			output: fmt.Sprintf("%d", res),
+		})
+	}
+	// final test at maximum
+	a := 18257
+	res := int64(a) * int64(a+1) / 2
+	tests = append(tests, testCase{
+		input:  fmt.Sprintf("%d\n", a),
+		output: fmt.Sprintf("%d", res),
+	})
+}
+
+func runTest(binary string, t testCase, idx int) error {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(t.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("test %d runtime error: %v\n%s", idx, err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(t.output)
+	if got != want {
+		return fmt.Errorf("test %d failed: expected %q got %q", idx, want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, t := range tests {
+		if err := runTest(bin, t, i+1); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/100-199/170-179/171/verifierC.go
+++ b/0-999/100-199/170-179/171/verifierC.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+var tests []testCase
+
+func init() {
+	for i := 0; i < 100; i++ {
+		carrots := (i*4 + 2)
+		calories := 0
+		chocolate := i*100 + 50
+		flour := 200
+		egg := 200
+		expected := i
+		tests = append(tests, testCase{
+			input:  fmt.Sprintf("%d %d %d %d %d\n", carrots, calories, chocolate, flour, egg),
+			output: fmt.Sprintf("%d", expected),
+		})
+	}
+}
+
+func runTest(binary string, t testCase, idx int) error {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(t.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("test %d runtime error: %v\n%s", idx, err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(t.output)
+	if got != want {
+		return fmt.Errorf("test %d failed: expected %q got %q", idx, want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, t := range tests {
+		if err := runTest(bin, t, i+1); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/100-199/170-179/171/verifierD.go
+++ b/0-999/100-199/170-179/171/verifierD.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+var tests []testCase
+
+func init() {
+	for i := 0; i < 100; i++ {
+		n := i
+		res := (n + 1) / 2
+		tests = append(tests, testCase{
+			input:  fmt.Sprintf("%d\n", n),
+			output: fmt.Sprintf("%d", res),
+		})
+	}
+}
+
+func runTest(binary string, t testCase, idx int) error {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(t.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("test %d runtime error: %v\n%s", idx, err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(t.output)
+	if got != want {
+		return fmt.Errorf("test %d failed: expected %q got %q", idx, want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, t := range tests {
+		if err := runTest(bin, t, i+1); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/100-199/170-179/171/verifierE.go
+++ b/0-999/100-199/170-179/171/verifierE.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+var tests []testCase
+
+func init() {
+	for i := 0; i < 100; i++ {
+		tests = append(tests, testCase{
+			input:  "",
+			output: "Brainfuck",
+		})
+	}
+}
+
+func runTest(binary string, t testCase, idx int) error {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(t.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("test %d runtime error: %v\n%s", idx, err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(t.output)
+	if got != want {
+		return fmt.Errorf("test %d failed: expected %q got %q", idx, want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, t := range tests {
+		if err := runTest(bin, t, i+1); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/100-199/170-179/171/verifierF.go
+++ b/0-999/100-199/170-179/171/verifierF.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+var primes = []int{
+	13, 17, 31, 37, 71, 73, 79, 97, 107, 113, 149, 157, 167, 179, 199, 311, 337, 347, 359, 389,
+	701, 709, 733, 739, 743, 751, 761, 769, 907, 937, 941, 953, 967, 971, 983, 991, 1009, 1021,
+	1031, 1033, 1061, 1069, 1091, 1097, 1103, 1109, 1151, 1153, 1181, 1193, 1201, 1213, 1217,
+	1223, 1229, 1231, 1237, 1249, 1259, 1279, 1283, 1301, 1321, 1381, 1399, 1409, 1429, 1439,
+	1453, 1471, 1487, 1499, 1511, 1523, 1559, 1583, 1597, 1601, 1619, 1657, 1669, 1723, 1733,
+	1741, 1753, 1789, 1811, 1831, 1847, 1867, 1879, 1901, 1913, 1933, 1949, 1979, 3011, 3019,
+	3023, 3049,
+}
+
+var tests []testCase
+
+func init() {
+	for i, p := range primes {
+		tests = append(tests, testCase{
+			input:  fmt.Sprintf("%d\n", i+1),
+			output: fmt.Sprintf("%d", p),
+		})
+	}
+}
+
+func runTest(binary string, t testCase, idx int) error {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(t.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("test %d runtime error: %v\n%s", idx, err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(t.output)
+	if got != want {
+		return fmt.Errorf("test %d failed: expected %q got %q", idx, want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, t := range tests {
+		if err := runTest(bin, t, i+1); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/100-199/170-179/171/verifierG.go
+++ b/0-999/100-199/170-179/171/verifierG.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+var tests []testCase
+
+func init() {
+	for i := 0; i < 100; i++ {
+		a1 := i * 2
+		a2 := 200 - i*2
+		a3 := i
+		arr := []int{a1, a2, a3}
+		sort.Ints(arr)
+		med := arr[1]
+		tests = append(tests, testCase{
+			input:  fmt.Sprintf("%d %d %d\n", a1, a2, a3),
+			output: fmt.Sprintf("%d", med),
+		})
+	}
+}
+
+func runTest(binary string, t testCase, idx int) error {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(t.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("test %d runtime error: %v\n%s", idx, err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(t.output)
+	if got != want {
+		return fmt.Errorf("test %d failed: expected %q got %q", idx, want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, t := range tests {
+		if err := runTest(bin, t, i+1); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/100-199/170-179/171/verifierH.go
+++ b/0-999/100-199/170-179/171/verifierH.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+var tests []testCase
+
+func init() {
+	for i := 0; i < 100; i++ {
+		a := i + 1
+		b := (i+1)*(i+2) + i
+		q := b / a
+		r := b % a
+		tests = append(tests, testCase{
+			input:  fmt.Sprintf("%d %d\n", a, b),
+			output: fmt.Sprintf("%d %d", q, r),
+		})
+	}
+}
+
+func runTest(binary string, t testCase, idx int) error {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(t.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("test %d runtime error: %v\n%s", idx, err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(t.output)
+	if got != want {
+		return fmt.Errorf("test %d failed: expected %q got %q", idx, want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, t := range tests {
+		if err := runTest(bin, t, i+1); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–H of contest 171
- each verifier runs 100 predefined test cases against a supplied binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_687e84b314e08324a0a4579fee7feeff