### PR TITLE
Add Go verifiers for contest 168

### DIFF
--- a/0-999/100-199/160-169/168/verifierA.go
+++ b/0-999/100-199/160-169/168/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, x, y int64) int64 {
+	required := (n*y + 99) / 100
+	if required < x {
+		return 0
+	}
+	return required - x
+}
+
+func runCase(bin string, n, x, y int64) error {
+	input := fmt.Sprintf("%d %d %d\n", n, x, y)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(&out, &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	want := expected(n, x, y)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	type tc struct{ n, x, y int64 }
+	cases := []tc{
+		{10, 1, 14},
+		{10, 10, 100},
+		{1, 1, 10000},
+		{5, 1, 120},
+		{9999, 5000, 50},
+		{10000, 1, 1},
+		{10000, 10000, 10000},
+		{2, 1, 51},
+		{7, 3, 0},
+		{3, 2, 200},
+	}
+	for i := 0; i < 100; i++ {
+		n := rng.Int63n(10000) + 1
+		x := rng.Int63n(n) + 1
+		y := rng.Int63n(10000) + 1
+		cases = append(cases, tc{n, x, y})
+	}
+	for i, c := range cases {
+		if err := runCase(bin, c.n, c.x, c.y); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/168/verifierB.go
+++ b/0-999/100-199/160-169/168/verifierB.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(input string) string {
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	var out strings.Builder
+	group := make([]string, 0)
+	flush := func() {
+		if len(group) == 0 {
+			return
+		}
+		for _, line := range group {
+			for i := 0; i < len(line); i++ {
+				if line[i] != ' ' {
+					out.WriteByte(line[i])
+				}
+			}
+		}
+		out.WriteByte('\n')
+		group = group[:0]
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) > 0 && line[len(line)-1] == '\r' {
+			line = line[:len(line)-1]
+		}
+		isAmp := false
+		for i := 0; i < len(line); i++ {
+			if line[i] == ' ' {
+				continue
+			}
+			if line[i] == '#' {
+				isAmp = true
+			}
+			break
+		}
+		if isAmp {
+			flush()
+			out.WriteString(line)
+			out.WriteByte('\n')
+		} else {
+			group = append(group, line)
+		}
+	}
+	flush()
+	return out.String()
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randomCase(rng *rand.Rand) string {
+	lines := rng.Intn(10) + 1
+	var sb strings.Builder
+	hasChar := false
+	for i := 0; i < lines; i++ {
+		l := rng.Intn(20)
+		for j := 0; j < l; j++ {
+			switch rng.Intn(4) {
+			case 0:
+				sb.WriteByte(byte('a' + rng.Intn(26)))
+				hasChar = true
+			case 1:
+				sb.WriteByte(' ')
+			case 2:
+				sb.WriteByte('#')
+				hasChar = true
+			default:
+				sb.WriteByte(byte('A' + rng.Intn(26)))
+				hasChar = true
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	if !hasChar {
+		sb.WriteString("a\n")
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{
+		"#abc\n  de f\n#x\n",
+		"hello world\n",
+		"#line1\nline2\nline3\n#end\n",
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		expect := solveB(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%sgot:\n%s", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` to check solutions for problem A with over 100 random tests
- add `verifierB.go` to check solutions for problem B with over 100 random tests

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`

------
https://chatgpt.com/codex/tasks/task_e_687e83e11ee083249dba5b37dffacf7a