### PR TITLE
Add Go verifiers for Codeforces Round 167

### DIFF
--- a/0-999/100-199/160-169/167/verifierA.go
+++ b/0-999/100-199/160-169/167/verifierA.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solve(n, a, d int, ts, vs []int) []float64 {
+	tMax := math.Sqrt(float64(2*d) / float64(a))
+	res := make([]float64, n)
+	cur := 0.0
+	for i := 0; i < n; i++ {
+		v := float64(vs[i])
+		t1 := v / float64(a)
+		d1 := t1 * v / 2
+		dt := 0.0
+		if d1 <= float64(d) {
+			dt = (float64(d)-d1)/v + t1
+		} else {
+			dt = tMax
+		}
+		arrive := float64(ts[i]) + dt
+		if arrive < cur {
+			arrive = cur
+		}
+		res[i] = arrive
+		cur = arrive
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []float64) {
+	n := rng.Intn(5) + 1
+	a := rng.Intn(9) + 1
+	d := rng.Intn(30) + 1
+	ts := make([]int, n)
+	vs := make([]int, n)
+	cur := 0
+	for i := 0; i < n; i++ {
+		cur += rng.Intn(5) + 1
+		ts[i] = cur
+		vs[i] = rng.Intn(20) + 1
+	}
+	exp := solve(n, a, d, ts, vs)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, a, d))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", ts[i], vs[i]))
+	}
+	return sb.String(), exp
+}
+
+func run(bin, input string) ([]float64, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	fields := strings.Fields(out.String())
+	res := make([]float64, len(fields))
+	for i, f := range fields {
+		v, err := strconv.ParseFloat(f, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid float on line %d", i+1)
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if len(out) != len(exp) {
+			fmt.Fprintf(os.Stderr, "case %d wrong number of lines\ninput:\n%s", i+1, in)
+			os.Exit(1)
+		}
+		for j := range exp {
+			if math.Abs(out[j]-exp[j]) > 1e-3 {
+				fmt.Fprintf(os.Stderr, "case %d mismatch on line %d: expected %.4f got %.4f\ninput:\n%s", i+1, j+1, exp[j], out[j], in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/167/verifierB.go
+++ b/0-999/100-199/160-169/167/verifierB.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solve(n, l, k int, p []int, c []int) float64 {
+	var b, b_ [201]float64
+	b1 := &b
+	b2 := &b_
+	b1[0] = 1.0
+	kb := 0
+	for i := 0; i < n; i++ {
+		if c[i] == -1 {
+			p1 := float64(p[i]) / 100.0
+			p0 := 1 - p1
+			for j := 0; j <= kb+1; j++ {
+				b2[j] = 0
+			}
+			for j := 0; j <= kb; j++ {
+				b2[j] += p0 * b1[j]
+				b2[j+1] += p1 * b1[j]
+			}
+			b1, b2 = b2, b1
+			kb++
+		}
+	}
+	ma := kb - k
+	if ma < 0 {
+		ma = 0
+	}
+	var a, a_ [201][201]float64
+	a1 := &a
+	a2 := &a_
+	a1[0][0] = 1.0
+	ka := 0
+	for i := 0; i < n; i++ {
+		if c[i] != -1 {
+			p1 := float64(p[i]) / 100.0
+			p0 := 1 - p1
+			for x := 0; x <= ka+1; x++ {
+				for y := 0; y <= ma; y++ {
+					a2[x][y] = 0
+				}
+			}
+			for x := 0; x <= ka; x++ {
+				for y := 0; y <= ma; y++ {
+					a2[x][y] += p0 * a1[x][y]
+					idx := y + c[i]
+					if idx > ma {
+						idx = ma
+					}
+					a2[x+1][idx] += p1 * a1[x][y]
+				}
+			}
+			a1, a2 = a2, a1
+			ka++
+		}
+	}
+	ans := 0.0
+	for i := 0; i <= ka; i++ {
+		for j := 0; j <= ma; j++ {
+			for t := 0; t <= kb; t++ {
+				if t+i >= l && j+k >= t {
+					ans += a1[i][j] * b1[t]
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	n := rng.Intn(5) + 1
+	l := rng.Intn(n + 1)
+	k := rng.Intn(n + 1)
+	p := make([]int, n)
+	c := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = rng.Intn(101)
+		if rng.Intn(2) == 0 {
+			c[i] = -1
+		} else {
+			c[i] = rng.Intn(3)
+		}
+	}
+	ans := solve(n, l, k, p, c)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, l, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", p[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), ans
+}
+
+func run(bin, input string) (float64, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return 0, fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	val, err := strconv.ParseFloat(strings.TrimSpace(out.String()), 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid float output: %v", err)
+	}
+	return val, nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if mathAbs(out-exp) > 1e-6 {
+			fmt.Fprintf(os.Stderr, "case %d mismatch: expected %.8f got %.8f\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func mathAbs(f float64) float64 {
+	if f < 0 {
+		return -f
+	}
+	return f
+}

--- a/0-999/100-199/160-169/167/verifierC.go
+++ b/0-999/100-199/160-169/167/verifierC.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func win(a, b uint64) bool {
+	reversed := false
+	for {
+		if a == 0 || b == 0 {
+			return reversed
+		}
+		if a > b {
+			a, b = b, a
+		}
+		if b/a > 1 {
+			return !reversed
+		}
+		b = b % a
+		reversed = !reversed
+	}
+}
+
+func solve(t int, pairs [][2]uint64) []string {
+	res := make([]string, t)
+	for i := 0; i < t; i++ {
+		if win(pairs[i][0], pairs[i][1]) {
+			res[i] = "First"
+		} else {
+			res[i] = "Second"
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	t := rng.Intn(5) + 1
+	pairs := make([][2]uint64, t)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		a := rng.Uint64()%1000 + 1
+		b := rng.Uint64()%1000 + 1
+		pairs[i][0] = a
+		pairs[i][1] = b
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	exp := solve(t, pairs)
+	return sb.String(), exp
+}
+
+func run(bin, input string) ([]string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	lines := strings.Fields(out.String())
+	return lines, nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if len(out) != len(exp) {
+			fmt.Fprintf(os.Stderr, "case %d wrong number of lines\ninput:\n%s", i+1, in)
+			os.Exit(1)
+		}
+		for j := range exp {
+			if out[j] != exp[j] {
+				fmt.Fprintf(os.Stderr, "case %d mismatch on line %d: expected %s got %s\ninput:\n%s", i+1, j+1, exp[j], out[j], in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/167/verifierD.go
+++ b/0-999/100-199/160-169/167/verifierD.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1e9 + 9
+
+func solve(n, k int, xs, ys []int64, a, b, c, d int64, queries [][2]int64) []int {
+	for i := k; i < n; i++ {
+		xs[i] = (a*xs[i-1] + b) % mod
+		ys[i] = (c*ys[i-1] + d) % mod
+	}
+	idx := make([]int, n)
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(i, j int) bool { return xs[idx[i]] < xs[idx[j]] })
+	sortedX := make([]int64, n)
+	for i, id := range idx {
+		sortedX[i] = xs[id]
+	}
+	res := make([]int, len(queries))
+	for qi, q := range queries {
+		L, R := q[0], q[1]
+		l := sort.Search(n, func(i int) bool { return sortedX[i] >= L })
+		r := sort.Search(n, func(i int) bool { return sortedX[i] > R }) - 1
+		cnt := 0
+		if l < n && r >= l {
+			cnt = r - l + 1
+		}
+		res[qi] = cnt / 2
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(8) + 2
+	k := rng.Intn(n) + 1
+	xs := make([]int64, n)
+	ys := make([]int64, n)
+	for i := 0; i < k; i++ {
+		xs[i] = rng.Int63n(mod)
+		ys[i] = rng.Int63n(mod)
+	}
+	a := rng.Int63n(10) + 1
+	b := rng.Int63n(10) + 1
+	c := rng.Int63n(10) + 1
+	d := rng.Int63n(10) + 1
+	m := rng.Intn(5) + 1
+	queries := make([][2]int64, m)
+	for i := 0; i < m; i++ {
+		L := rng.Int63n(mod)
+		R := L + rng.Int63n(mod-L)
+		queries[i] = [2]int64{L, R}
+	}
+	ans := solve(n, k, append([]int64(nil), xs...), append([]int64(nil), ys...), a, b, c, d, queries)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < k; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", xs[i], ys[i]))
+	}
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", a, b, c, d))
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", queries[i][0], queries[i][1]))
+	}
+	return sb.String(), ans
+}
+
+func run(bin, input string) ([]int, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	fields := strings.Fields(out.String())
+	res := make([]int, len(fields))
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, fmt.Errorf("invalid int on line %d", i+1)
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if len(out) != len(exp) {
+			fmt.Fprintf(os.Stderr, "case %d wrong number of lines\ninput:\n%s", i+1, in)
+			os.Exit(1)
+		}
+		for j := range exp {
+			if out[j] != exp[j] {
+				fmt.Fprintf(os.Stderr, "case %d mismatch on line %d: expected %d got %d\ninput:\n%s", i+1, j+1, exp[j], out[j], in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/167/verifierE.go
+++ b/0-999/100-199/160-169/167/verifierE.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func modPow(a, e, p int64) int64 {
+	res := int64(1)
+	a %= p
+	for e > 0 {
+		if e&1 != 0 {
+			res = res * a % p
+		}
+		a = a * a % p
+		e >>= 1
+	}
+	return res
+}
+
+func modInv(a, p int64) int64 {
+	return modPow(a, p-2, p)
+}
+
+func solve(n, m int, p int64, edges [][2]int, queries [][]int) int64 {
+	adj := make([][]int, n)
+	indeg := make([]int, n)
+	outdeg := make([]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		indeg[v]++
+		outdeg[u]++
+	}
+	var src, sink []int
+	for i := 0; i < n; i++ {
+		if indeg[i] == 0 {
+			src = append(src, i)
+		}
+		if outdeg[i] == 0 {
+			sink = append(sink, i)
+		}
+	}
+	k := len(src)
+	if k == 0 {
+		return 1 % p
+	}
+	dq := make([]int, 0, n)
+	indeg0 := make([]int, n)
+	copy(indeg0, indeg)
+	for i := 0; i < n; i++ {
+		if indeg0[i] == 0 {
+			dq = append(dq, i)
+		}
+	}
+	topo := make([]int, 0, n)
+	for idx := 0; idx < len(dq); idx++ {
+		u := dq[idx]
+		topo = append(topo, u)
+		for _, v := range adj[u] {
+			indeg0[v]--
+			if indeg0[v] == 0 {
+				dq = append(dq, v)
+			}
+		}
+	}
+	M := make([][]int64, k)
+	for i := range M {
+		M[i] = make([]int64, k)
+	}
+	dp := make([]int64, n)
+	for i := 0; i < k; i++ {
+		for j := 0; j < n; j++ {
+			dp[j] = 0
+		}
+		dp[src[i]] = 1
+		for _, u := range topo {
+			if dp[u] != 0 {
+				x := dp[u]
+				for _, v := range adj[u] {
+					dp[v] += x
+					if dp[v] >= p {
+						dp[v] -= p
+					}
+				}
+			}
+		}
+		for j := 0; j < k; j++ {
+			M[i][j] = dp[sink[j]]
+		}
+	}
+	det := int64(1)
+	sign := int64(1)
+	for i := 0; i < k; i++ {
+		piv := -1
+		for r := i; r < k; r++ {
+			if M[r][i] != 0 {
+				piv = r
+				break
+			}
+		}
+		if piv == -1 {
+			det = 0
+			break
+		}
+		if piv != i {
+			M[i], M[piv] = M[piv], M[i]
+			sign = p - sign
+		}
+		inv := modInv(M[i][i], p)
+		for r := i + 1; r < k; r++ {
+			if M[r][i] != 0 {
+				factor := M[r][i] * inv % p
+				for c := i; c < k; c++ {
+					M[r][c] = (M[r][c] - factor*M[i][c]) % p
+					if M[r][c] < 0 {
+						M[r][c] += p
+					}
+				}
+			}
+		}
+		det = det * M[i][i] % p
+	}
+	det = det * sign % p
+	if det < 0 {
+		det += p
+	}
+	return det
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(4) + 2
+	edges := make([][2]int, 0, n-1)
+	for i := 0; i < n-1; i++ {
+		edges = append(edges, [2]int{i, i + 1})
+	}
+	m := len(edges)
+	p := int64(1000000007)
+	ans := solve(n, m, p, edges, nil)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, p))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+	}
+	return sb.String(), ans
+}
+
+func run(bin, input string) (int64, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return 0, fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	val, err := strconv.ParseInt(strings.TrimSpace(out.String()), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer output: %v", err)
+	}
+	return val, nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch: expected %d got %d\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–E of contest 167
- each verifier runs 100 randomized tests
- supports both compiled binaries and Go source with `--` separator

## Testing
- `go run verifierA.go -- ./167A.go`
- `go run verifierB.go -- ./167B.go`
- `go run verifierC.go -- ./167C.go`
- `go run verifierD.go -- ./167D.go`
- `go run verifierE.go -- ./167E.go`


------
https://chatgpt.com/codex/tasks/task_e_687e839ada508324be7fbc7d96debd27