### PR TITLE
Add Go verifiers for contest 166

### DIFF
--- a/0-999/100-199/160-169/166/verifierA.go
+++ b/0-999/100-199/160-169/166/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type team struct{ problems, time int }
+
+func expected(n, k int, teams []team) int {
+	sort.Slice(teams, func(i, j int) bool {
+		if teams[i].problems != teams[j].problems {
+			return teams[i].problems > teams[j].problems
+		}
+		return teams[i].time < teams[j].time
+	})
+	p := teams[k-1].problems
+	t := teams[k-1].time
+	cnt := 0
+	for _, tm := range teams {
+		if tm.problems == p && tm.time == t {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(50) + 1
+	k := rng.Intn(n) + 1
+	teams := make([]team, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		teams[i] = team{rng.Intn(50) + 1, rng.Intn(50) + 1}
+		fmt.Fprintf(&sb, "%d %d\n", teams[i].problems, teams[i].time)
+	}
+	return sb.String(), expected(n, k, teams)
+}
+
+func runCase(exe, input string, expectedAns int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expectedAns {
+		return fmt.Errorf("expected %d got %d", expectedAns, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/166/verifierB.go
+++ b/0-999/100-199/160-169/166/verifierB.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Point struct{ x, y int64 }
+
+func cross(a, b, c Point) int64 {
+	return (b.x-a.x)*(c.y-a.y) - (b.y-a.y)*(c.x-a.x)
+}
+
+func pointInConvex(poly []Point, q Point) bool {
+	n := len(poly)
+	if cross(poly[0], poly[1], q) <= 0 {
+		return false
+	}
+	if cross(poly[0], poly[n-1], q) >= 0 {
+		return false
+	}
+	l, r := 1, n-1
+	for l+1 < r {
+		m := (l + r) >> 1
+		if cross(poly[0], poly[m], q) > 0 {
+			l = m
+		} else {
+			r = m
+		}
+	}
+	if cross(poly[l], poly[l+1], q) <= 0 {
+		return false
+	}
+	return true
+}
+
+func expected(polyA, polyB []Point) string {
+	poly := make([]Point, len(polyA))
+	copy(poly, polyA)
+	for i := 0; i < len(poly)/2; i++ {
+		poly[i], poly[len(poly)-1-i] = poly[len(poly)-1-i], poly[i]
+	}
+	for _, q := range polyB {
+		if !pointInConvex(poly, q) {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func randomPointInside(poly []Point, rng *rand.Rand) Point {
+	for {
+		var px, py float64
+		remain := 1.0
+		for i := 0; i < len(poly)-1; i++ {
+			w := rng.Float64() * remain
+			px += w * float64(poly[i].x)
+			py += w * float64(poly[i].y)
+			remain -= w
+		}
+		px += remain * float64(poly[len(poly)-1].x)
+		py += remain * float64(poly[len(poly)-1].y)
+		p := Point{int64(math.Round(px)), int64(math.Round(py))}
+		if pointInConvex(poly, p) {
+			return p
+		}
+	}
+}
+
+func genPolyA(rng *rand.Rand) []Point {
+	n := rng.Intn(6) + 3
+	base := rng.Float64() * 2 * math.Pi
+	r := float64(100 + rng.Intn(50))
+	poly := make([]Point, n)
+	for i := 0; i < n; i++ {
+		ang := base - float64(i)*2*math.Pi/float64(n)
+		x := int64(math.Round(r*math.Cos(ang))) + 1000
+		y := int64(math.Round(r*math.Sin(ang))) + 1000
+		poly[i] = Point{x, y}
+	}
+	return poly
+}
+
+func genPolyBInside(A []Point, rng *rand.Rand) []Point {
+	m := rng.Intn(6) + 3
+	center := randomPointInside(A, rng)
+	rad := float64(rng.Intn(30)+1) / 2
+	base := rng.Float64() * 2 * math.Pi
+	poly := make([]Point, m)
+	for i := 0; i < m; i++ {
+		ang := base - float64(i)*2*math.Pi/float64(m)
+		x := center.x + int64(math.Round(rad*math.Cos(ang)))
+		y := center.y + int64(math.Round(rad*math.Sin(ang)))
+		poly[i] = Point{x, y}
+	}
+	return poly
+}
+
+func genPolyBOutside(A []Point, rng *rand.Rand) []Point {
+	m := rng.Intn(6) + 3
+	cx := A[0].x + 300
+	cy := A[0].y + 300
+	rad := float64(rng.Intn(30)+1) / 2
+	base := rng.Float64() * 2 * math.Pi
+	poly := make([]Point, m)
+	for i := 0; i < m; i++ {
+		ang := base - float64(i)*2*math.Pi/float64(m)
+		x := cx + int64(math.Round(rad*math.Cos(ang)))
+		y := cy + int64(math.Round(rad*math.Sin(ang)))
+		poly[i] = Point{x, y}
+	}
+	return poly
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	A := genPolyA(rng)
+	inside := rng.Intn(2) == 0
+	var B []Point
+	if inside {
+		B = genPolyBInside(A, rng)
+	} else {
+		B = genPolyBOutside(A, rng)
+	}
+	var sb strings.Builder
+	fmt.Fprintln(&sb, len(A))
+	for _, p := range A {
+		fmt.Fprintf(&sb, "%d %d\n", p.x, p.y)
+	}
+	fmt.Fprintln(&sb, len(B))
+	for _, p := range B {
+		fmt.Fprintf(&sb, "%d %d\n", p.x, p.y)
+	}
+	return sb.String(), expected(A, B)
+}
+
+func runCase(exe, input, expectedAns string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	res := strings.TrimSpace(out.String())
+	if res != expectedAns {
+		return fmt.Errorf("expected %s got %s", expectedAns, res)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/166/verifierC.go
+++ b/0-999/100-199/160-169/166/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, x int, arr []int) int {
+	L, E := 0, 0
+	for _, v := range arr {
+		if v < x {
+			L++
+		} else if v == x {
+			E++
+		}
+	}
+	k := 0
+	for {
+		N := n + k
+		pos := (N + 1) / 2
+		if pos > L && pos <= L+E+k {
+			return k
+		}
+		k++
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10) + 1
+	x := rng.Intn(100) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, x)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100) + 1
+		if i > 0 {
+			fmt.Fprint(&sb, " ")
+		}
+		fmt.Fprint(&sb, arr[i])
+	}
+	fmt.Fprintln(&sb)
+	return sb.String(), expected(n, x, arr)
+}
+
+func runCase(exe, input string, expectedAns int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expectedAns {
+		return fmt.Errorf("expected %d got %d", expectedAns, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/166/verifierD.go
+++ b/0-999/100-199/160-169/166/verifierD.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func bruteProfit(c, s, d, l []int) int {
+	n := len(c)
+	m := len(d)
+	type state struct{ i, mask int }
+	memo := make(map[state]int)
+	var dfs func(i, mask int) int
+	dfs = func(i, mask int) int {
+		if i == n {
+			return 0
+		}
+		st := state{i, mask}
+		if val, ok := memo[st]; ok {
+			return val
+		}
+		res := dfs(i+1, mask)
+		for j := 0; j < m; j++ {
+			if mask&(1<<j) == 0 && c[i] <= d[j] && (l[j] == s[i] || l[j] == s[i]-1) {
+				val := c[i] + dfs(i+1, mask|(1<<j))
+				if val > res {
+					res = val
+				}
+			}
+		}
+		memo[st] = res
+		return res
+	}
+	return dfs(0, 0)
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(4) + 2
+	c := make([]int, n)
+	s := make([]int, n)
+	usedSizes := rand.Perm(50)
+	var sb strings.Builder
+	fmt.Fprintln(&sb, n)
+	for i := 0; i < n; i++ {
+		c[i] = rng.Intn(20) + 1
+		s[i] = usedSizes[i] + 1
+		fmt.Fprintf(&sb, "%d %d\n", c[i], s[i])
+	}
+	m := rng.Intn(4) + 2
+	dVal := make([]int, m)
+	lVal := make([]int, m)
+	fmt.Fprintln(&sb, m)
+	for i := 0; i < m; i++ {
+		dVal[i] = rng.Intn(20) + 1
+		lVal[i] = rng.Intn(50) + 1
+		fmt.Fprintf(&sb, "%d %d\n", dVal[i], lVal[i])
+	}
+	exp := bruteProfit(c, s, dVal, lVal)
+	return sb.String(), exp
+}
+
+func runCase(exe, input string, expectedAns int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expectedAns {
+		return fmt.Errorf("expected %d got %d", expectedAns, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/166/verifierE.go
+++ b/0-999/100-199/160-169/166/verifierE.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+type mat [2][2]int64
+
+func mul(a, b mat) mat {
+	return mat{
+		{(a[0][0]*b[0][0] + a[0][1]*b[1][0]) % mod, (a[0][0]*b[0][1] + a[0][1]*b[1][1]) % mod},
+		{(a[1][0]*b[0][0] + a[1][1]*b[1][0]) % mod, (a[1][0]*b[0][1] + a[1][1]*b[1][1]) % mod},
+	}
+}
+
+func powMat(m mat, e int64) mat {
+	res := mat{{1, 0}, {0, 1}}
+	for e > 0 {
+		if e&1 == 1 {
+			res = mul(res, m)
+		}
+		m = mul(m, m)
+		e >>= 1
+	}
+	return res
+}
+
+func expected(n int64) int64 {
+	base := mat{{0, 3}, {1, 2}}
+	mn := powMat(base, n)
+	return mn[0][0] % mod
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Int63n(1000000) + 1
+	return fmt.Sprintf("%d\n", n), expected(n)
+}
+
+func runCase(exe, input string, expectedAns int64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expectedAns {
+		return fmt.Errorf("expected %d got %d", expectedAns, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers in Go for problems A–E of contest 166
- each verifier generates 100 random test cases and checks a provided binary

## Testing
- `go run verifierA.go ./166A.bin`

------
https://chatgpt.com/codex/tasks/task_e_687e8354e1b88324b39e8fb4d4bc1322