### PR TITLE
Add Go verifiers for contest 165

### DIFF
--- a/0-999/100-199/160-169/165/verifierA.go
+++ b/0-999/100-199/160-169/165/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int }
+
+func expected(points []point) int {
+	n := len(points)
+	count := 0
+	for i := 0; i < n; i++ {
+		hasL, hasR, hasU, hasD := false, false, false, false
+		for j := 0; j < n; j++ {
+			if i == j {
+				continue
+			}
+			if points[j].x == points[i].x {
+				if points[j].y > points[i].y {
+					hasU = true
+				}
+				if points[j].y < points[i].y {
+					hasD = true
+				}
+			}
+			if points[j].y == points[i].y {
+				if points[j].x > points[i].x {
+					hasR = true
+				}
+				if points[j].x < points[i].x {
+					hasL = true
+				}
+			}
+		}
+		if hasL && hasR && hasU && hasD {
+			count++
+		}
+	}
+	return count
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(20) + 1
+	if rng.Float64() < 0.1 {
+		n = 200
+	}
+	pts := make([]point, n)
+	for i := 0; i < n; i++ {
+		pts[i] = point{rng.Intn(21) - 10, rng.Intn(21) - 10}
+	}
+	var b strings.Builder
+	fmt.Fprintln(&b, n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "%d %d\n", pts[i].x, pts[i].y)
+	}
+	return b.String(), expected(pts)
+}
+
+func runCase(bin, input string, exp int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/165/verifierB.go
+++ b/0-999/100-199/160-169/165/verifierB.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func total(v, k int64) int64 {
+	var sum int64
+	for v > 0 {
+		sum += v
+		v /= k
+	}
+	return sum
+}
+
+func expected(n, k int64) int64 {
+	low, high := int64(1), n
+	for low < high {
+		mid := (low + high) / 2
+		if total(mid, k) >= n {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+	return low
+}
+
+func genCase(rng *rand.Rand) (string, int64) {
+	n := rng.Int63n(1_000_000_000) + 1
+	k := rng.Int63n(9) + 2 // 2..10
+	if rng.Float64() < 0.2 {
+		n = rng.Int63n(1000) + 1
+	}
+	input := fmt.Sprintf("%d %d\n", n, k)
+	return input, expected(n, k)
+}
+
+func runCase(bin, input string, exp int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/165/verifierC.go
+++ b/0-999/100-199/160-169/165/verifierC.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(k int, s string) int64 {
+	n := len(s)
+	if k == 0 {
+		var res int64
+		var zeroLen int64
+		for i := 0; i < n; i++ {
+			if s[i] == '0' {
+				zeroLen++
+			} else {
+				res += zeroLen * (zeroLen + 1) / 2
+				zeroLen = 0
+			}
+		}
+		res += zeroLen * (zeroLen + 1) / 2
+		return res
+	}
+	positions := []int{-1}
+	for i := 0; i < n; i++ {
+		if s[i] == '1' {
+			positions = append(positions, i)
+		}
+	}
+	positions = append(positions, n)
+	cnt := len(positions) - 2
+	if k > cnt {
+		return 0
+	}
+	var res int64
+	for i := 1; i <= cnt-k+1; i++ {
+		leftZeros := int64(positions[i] - positions[i-1])
+		rightZeros := int64(positions[i+k] - positions[i+k-1])
+		res += leftZeros * rightZeros
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(50) + 1
+	if rng.Float64() < 0.2 {
+		n = rng.Intn(200) + 1
+	}
+	bs := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			bs[i] = '0'
+		} else {
+			bs[i] = '1'
+		}
+	}
+	k := rng.Intn(n + 1)
+	input := fmt.Sprintf("%d\n%s\n", k, string(bs))
+	return input, expected(k, string(bs))
+}
+
+func runCase(bin, input string, exp int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/165/verifierD.go
+++ b/0-999/100-199/160-169/165/verifierD.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func bfs(n int, edges []edge, black []bool, a, b int) int {
+	q := []int{a}
+	dist := make([]int, n+1)
+	for i := range dist {
+		dist[i] = -1
+	}
+	dist[a] = 0
+	for len(q) > 0 {
+		v := q[0]
+		q = q[1:]
+		if v == b {
+			return dist[v]
+		}
+		for idx, e := range edges {
+			if !black[idx] {
+				continue
+			}
+			if e.u == v && dist[e.v] == -1 {
+				dist[e.v] = dist[v] + 1
+				q = append(q, e.v)
+			} else if e.v == v && dist[e.u] == -1 {
+				dist[e.u] = dist[v] + 1
+				q = append(q, e.u)
+			}
+		}
+	}
+	return -1
+}
+
+func genTree(rng *rand.Rand, n int) []edge {
+	edges := make([]edge, 0, n-1)
+	if rng.Intn(2) == 0 {
+		for i := 2; i <= n; i++ {
+			edges = append(edges, edge{i - 1, i})
+		}
+	} else {
+		for i := 2; i <= n; i++ {
+			edges = append(edges, edge{1, i})
+		}
+	}
+	return edges
+}
+
+func genCase(rng *rand.Rand) (string, int, []edge, []string) {
+	n := rng.Intn(6) + 2
+	edges := genTree(rng, n)
+	m := rng.Intn(20) + 1
+	var ops []string
+	var b strings.Builder
+	fmt.Fprintln(&b, n)
+	for _, e := range edges {
+		fmt.Fprintf(&b, "%d %d\n", e.u, e.v)
+	}
+	fmt.Fprintln(&b, m)
+	for i := 0; i < m; i++ {
+		t := rng.Intn(3) + 1
+		if t == 1 {
+			id := rng.Intn(len(edges)) + 1
+			ops = append(ops, fmt.Sprintf("1 %d", id))
+			fmt.Fprintf(&b, "1 %d\n", id)
+		} else if t == 2 {
+			id := rng.Intn(len(edges)) + 1
+			ops = append(ops, fmt.Sprintf("2 %d", id))
+			fmt.Fprintf(&b, "2 %d\n", id)
+		} else {
+			a := rng.Intn(n) + 1
+			c := rng.Intn(n) + 1
+			ops = append(ops, fmt.Sprintf("3 %d %d", a, c))
+			fmt.Fprintf(&b, "3 %d %d\n", a, c)
+		}
+	}
+	return b.String(), n, edges, ops
+}
+
+func simulate(n int, edges []edge, ops []string) []int {
+	black := make([]bool, len(edges))
+	for i := range black {
+		black[i] = true
+	}
+	var ans []int
+	for _, line := range ops {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		switch fields[0] {
+		case "1":
+			var id int
+			fmt.Sscan(fields[1], &id)
+			black[id-1] = true
+		case "2":
+			var id int
+			fmt.Sscan(fields[1], &id)
+			black[id-1] = false
+		case "3":
+			var a, b int
+			fmt.Sscan(fields[1], &a)
+			fmt.Sscan(fields[2], &b)
+			ans = append(ans, bfs(n, edges, black, a, b))
+		}
+	}
+	return ans
+}
+
+func runCase(bin, stringInput string, exp []int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(stringInput)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out.String()))
+	var got []int
+	for scanner.Scan() {
+		var x int
+		fmt.Sscan(scanner.Text(), &x)
+		got = append(got, x)
+	}
+	if len(got) != len(exp) {
+		return fmt.Errorf("expected %v got %v", exp, got)
+	}
+	for i := range got {
+		if got[i] != exp[i] {
+			return fmt.Errorf("expected %v got %v", exp, got)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, n, edges, ops := genCase(rng)
+		exp := simulate(n, edges, ops)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/165/verifierE.go
+++ b/0-999/100-199/160-169/165/verifierE.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compatible(a, b int) bool { return a&b == 0 }
+
+func expected(arr []int) []int {
+	n := len(arr)
+	res := make([]int, n)
+	for i := 0; i < n; i++ {
+		res[i] = -1
+		for j := 0; j < n; j++ {
+			if i == j {
+				continue
+			}
+			if compatible(arr[i], arr[j]) {
+				res[i] = arr[j]
+				break
+			}
+		}
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(256)
+	}
+	var b strings.Builder
+	fmt.Fprintln(&b, n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "%d ", arr[i])
+	}
+	fmt.Fprintln(&b)
+	return b.String(), expected(arr)
+}
+
+func runCase(bin, input string, exp []int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != len(exp) {
+		return fmt.Errorf("expected %v got %s", exp, out.String())
+	}
+	for i, f := range fields {
+		var x int
+		fmt.Sscan(f, &x)
+		if x != exp[i] {
+			return fmt.Errorf("expected %v got %v", exp, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to test 165A solutions
- add verifierB.go to test 165B solutions
- add verifierC.go to test 165C solutions
- add verifierD.go to test 165D solutions
- add verifierE.go to test 165E solutions

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e830f04608324b7d10904601e66f5