### PR TITLE
Add Go verifiers for contest 163

### DIFF
--- a/0-999/100-199/160-169/163/verifierA.go
+++ b/0-999/100-199/160-169/163/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+// countSub returns the number of subsequences of t equal to sub.
+func countSub(t, sub string) int64 {
+	m := len(sub)
+	dp := make([]int64, m+1)
+	dp[0] = 1
+	for i := 0; i < len(t); i++ {
+		for j := m - 1; j >= 0; j-- {
+			if sub[j] == t[i] {
+				dp[j+1] += dp[j]
+			}
+		}
+	}
+	return dp[m]
+}
+
+func expectedAnswer(s, t string) int64 {
+	var ans int64
+	for i := 0; i < len(s); i++ {
+		for j := i + 1; j <= len(s); j++ {
+			sub := s[i:j]
+			ans = (ans + countSub(t, sub)) % mod
+		}
+	}
+	return ans % mod
+}
+
+// run executes the binary or go source with the given input and returns trimmed output.
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomString(rng *rand.Rand, n int) string {
+	letters := []byte{"a", "b", "c"}
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		slen := rng.Intn(5) + 1
+		tlen := rng.Intn(6) + 1
+		s := randomString(rng, slen)
+		t := randomString(rng, tlen)
+		input := fmt.Sprintf("%s\n%s\n", s, t)
+		expected := expectedAnswer(s, t)
+		gotStr, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseInt(strings.TrimSpace(gotStr), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: cannot parse output: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got%mod != expected%mod {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, expected%mod, got%mod, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/163/verifierB.go
+++ b/0-999/100-199/160-169/163/verifierB.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// buildOracle compiles 163B.go into a temporary binary.
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "163B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+// run executes a binary or go source file with given input.
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n) + 1
+	h := rng.Intn(10) + 1
+	weights := make([]int, n)
+	speeds := make([]int, n)
+	for i := 0; i < n; i++ {
+		weights[i] = rng.Intn(50) + 1
+	}
+	for i := 0; i < n; i++ {
+		speeds[i] = rng.Intn(50) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, k, h))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", weights[i]))
+		if i+1 < n {
+			sb.WriteString(" ")
+		}
+	}
+	sb.WriteString("\n")
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", speeds[i]))
+		if i+1 < n {
+			sb.WriteString(" ")
+		}
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expected, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/163/verifierC.go
+++ b/0-999/100-199/160-169/163/verifierC.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "163C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	l := rng.Intn(100) + 1
+	v1 := rng.Intn(20) + 1
+	v2 := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(2 * l)
+	}
+	// sort arr ascending
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if arr[j] < arr[i] {
+				arr[i], arr[j] = arr[j], arr[i]
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, l, v1, v2))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteString(" ")
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func parseFloats(out string) ([]float64, error) {
+	fields := strings.Fields(strings.TrimSpace(out))
+	res := make([]float64, len(fields))
+	for i, f := range fields {
+		val, err := strconv.ParseFloat(f, 64)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = val
+	}
+	return res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expectedOut, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		expectedVals, err := parseFloats(expectedOut)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle parse error: %v\n", err)
+			os.Exit(1)
+		}
+		gotOut, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		gotVals, err := parseFloats(gotOut)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: parse output: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if len(gotVals) != len(expectedVals) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d values got %d\ninput:\n%s", i+1, len(expectedVals), len(gotVals), input)
+			os.Exit(1)
+		}
+		for j := range gotVals {
+			diff := gotVals[j] - expectedVals[j]
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff > 1e-6 {
+				fmt.Fprintf(os.Stderr, "case %d failed on value %d: expected %f got %f\ninput:\n%s", i+1, j, expectedVals[j], gotVals[j], input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/163/verifierD.go
+++ b/0-999/100-199/160-169/163/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "163D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+var primes = []int{2, 3, 5, 7, 11, 13, 17, 19, 23}
+
+func generateCase(rng *rand.Rand) string {
+	k := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", k))
+	for i := 0; i < k; i++ {
+		p := primes[rng.Intn(len(primes))]
+		e := rng.Intn(3) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", p, e))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expected, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/160-169/163/verifierE.go
+++ b/0-999/100-199/160-169/163/verifierE.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "163E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	letters := []byte{"a", "b", "c"}
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	patterns := make([]string, k)
+	for i := 0; i < k; i++ {
+		patterns[i] = randString(rng, rng.Intn(3)+1)
+		sb.WriteString(patterns[i] + "\n")
+	}
+	for i := 0; i < n; i++ {
+		typ := rng.Intn(3)
+		switch typ {
+		case 0:
+			id := rng.Intn(k) + 1
+			sb.WriteString(fmt.Sprintf("+%d\n", id))
+		case 1:
+			id := rng.Intn(k) + 1
+			sb.WriteString(fmt.Sprintf("-%d\n", id))
+		default:
+			text := randString(rng, rng.Intn(4)+1)
+			sb.WriteString("?" + text + "\n")
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expected, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifiers for problems A–E of contest 163
- each verifier generates 100 random test cases and checks a solution binary against a reference solution

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_687e8282ad1c832492f9ee369a0c6c91