### PR TITLE
Add verifiers for contest 162

### DIFF
--- a/0-999/100-199/160-169/162/verifierA.go
+++ b/0-999/100-199/160-169/162/verifierA.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	n int64
+}
+
+func pentagonal(n int64) string {
+	return fmt.Sprint((3*n*n - n) / 2)
+}
+
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	for i := int64(1); i <= 100; i++ {
+		tests = append(tests, test{n: i})
+	}
+	for len(tests) < 100 {
+		tests = append(tests, test{n: rand.Int63n(100) + 1})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n", t.n)
+		exp := pentagonal(t.n)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/100-199/160-169/162/verifierB.go
+++ b/0-999/100-199/160-169/162/verifierB.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type test struct {
+	n int64
+}
+
+func expected(n int64) string {
+	return strconv.FormatInt(n, 2)
+}
+
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	// include fixed edge cases
+	fixed := []int64{1, 2, 3, 4, 5, 10, 255, 256, 999999, 1000000}
+	for _, v := range fixed {
+		tests = append(tests, test{n: v})
+	}
+	for len(tests) < 100 {
+		tests = append(tests, test{n: rand.Int63n(1000000) + 1})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n", t.n)
+		exp := expected(t.n)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/100-199/160-169/162/verifierC.go
+++ b/0-999/100-199/160-169/162/verifierC.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	n int
+}
+
+func factorize(n int) string {
+	var factors []int
+	for i := 2; i*i <= n; i++ {
+		for n%i == 0 {
+			factors = append(factors, i)
+			n /= i
+		}
+	}
+	if n > 1 {
+		factors = append(factors, n)
+	}
+	var sb strings.Builder
+	for i, f := range factors {
+		if i > 0 {
+			sb.WriteByte('*')
+		}
+		fmt.Fprintf(&sb, "%d", f)
+	}
+	return sb.String()
+}
+
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	fixed := []int{2, 3, 4, 6, 8, 9, 10, 9973, 10000}
+	for _, v := range fixed {
+		tests = append(tests, test{n: v})
+	}
+	for len(tests) < 100 {
+		tests = append(tests, test{n: rand.Intn(9999) + 2})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n", t.n)
+		exp := factorize(t.n)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/100-199/160-169/162/verifierD.go
+++ b/0-999/100-199/160-169/162/verifierD.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func removeDigits(s string) string {
+	var b strings.Builder
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
+}
+
+type test struct {
+	s string
+}
+
+func randString(n int) string {
+	const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-={}[]:;<>?,./" // ascii 33..126 minus some extras but okay
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	fixed := []string{"abc123", "000", "no_digits", "1a2b3c", "!!!"}
+	for _, s := range fixed {
+		tests = append(tests, test{s: s})
+	}
+	for len(tests) < 100 {
+		l := rand.Intn(20) + 1
+		tests = append(tests, test{s: randString(l)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%s\n", t.s)
+		exp := removeDigits(t.s)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/100-199/160-169/162/verifierE.go
+++ b/0-999/100-199/160-169/162/verifierE.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func producesOutput(p string) string {
+	for _, c := range p {
+		if c == 'H' || c == 'Q' || c == '9' {
+			return "YES"
+		}
+	}
+	return "NO"
+}
+
+type test struct {
+	p string
+}
+
+func randProgram(n int) string {
+	const letters = "HQ9+abcdxyz123!@#"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	fixed := []string{"H", "Q", "9", "+", "abc"}
+	for _, s := range fixed {
+		tests = append(tests, test{p: s})
+	}
+	for len(tests) < 100 {
+		l := rand.Intn(10) + 1
+		tests = append(tests, test{p: randProgram(l)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%s\n", t.p)
+		exp := producesOutput(t.p)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/100-199/160-169/162/verifierF.go
+++ b/0-999/100-199/160-169/162/verifierF.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func trailingZeros(n int64) string {
+	var count int64
+	for p := int64(5); p <= n; p *= 5 {
+		count += n / p
+	}
+	return fmt.Sprint(count)
+}
+
+type test struct {
+	n int64
+}
+
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	fixed := []int64{1, 5, 10, 25, 50, 100, 1000, 1000000}
+	for _, v := range fixed {
+		tests = append(tests, test{n: v})
+	}
+	for len(tests) < 100 {
+		tests = append(tests, test{n: rand.Int63n(1000000) + 1})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n", t.n)
+		exp := trailingZeros(t.n)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/100-199/160-169/162/verifierG.go
+++ b/0-999/100-199/160-169/162/verifierG.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func parseBase(s string, base int) int {
+	v := 0
+	for _, c := range s {
+		var d int
+		if c >= '0' && c <= '9' {
+			d = int(c - '0')
+		} else {
+			d = int(c-'A') + 10
+		}
+		v = v*base + d
+	}
+	return v
+}
+
+func toBase(n, base int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []rune
+	for n > 0 {
+		rem := n % base
+		var c rune
+		if rem < 10 {
+			c = rune('0' + rem)
+		} else {
+			c = rune('A' + rem - 10)
+		}
+		digits = append(digits, c)
+		n /= base
+	}
+	for i, j := 0, len(digits)-1; i < j; i, j = i+1, j-1 {
+		digits[i], digits[j] = digits[j], digits[i]
+	}
+	return string(digits)
+}
+
+type test struct {
+	n     int
+	radix int
+	nums  []string
+}
+
+func randNum(radix int) string {
+	length := rand.Intn(5) + 1
+	digits := make([]rune, length)
+	for i := range digits {
+		d := rand.Intn(radix)
+		if d < 10 {
+			digits[i] = rune('0' + d)
+		} else {
+			digits[i] = rune('A' + d - 10)
+		}
+	}
+	return string(digits)
+}
+
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	for len(tests) < 100 {
+		n := rand.Intn(10) + 1
+		radix := rand.Intn(35) + 2
+		nums := make([]string, n)
+		for i := range nums {
+			nums[i] = randNum(radix)
+		}
+		tests = append(tests, test{n: n, radix: radix, nums: nums})
+	}
+	return tests
+}
+
+func expected(t test) string {
+	sum := 0
+	for _, s := range t.nums {
+		sum += parseBase(s, t.radix)
+	}
+	return toBase(sum, t.radix)
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n%d\n", t.n, t.radix))
+		for _, s := range t.nums {
+			sb.WriteString(fmt.Sprintf("%s\n", s))
+		}
+		input := sb.String()
+		exp := expected(t)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/100-199/160-169/162/verifierH.go
+++ b/0-999/100-199/160-169/162/verifierH.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func altCase(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if i%2 == 0 {
+			if b[i] >= 'a' && b[i] <= 'z' {
+				b[i] = b[i] - 'a' + 'A'
+			}
+		} else {
+			if b[i] >= 'A' && b[i] <= 'Z' {
+				b[i] = b[i] - 'A' + 'a'
+			}
+		}
+	}
+	return string(b)
+}
+
+type test struct {
+	s string
+}
+
+func randLetters(n int) string {
+	letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	fixed := []string{"a", "A", "abcDEF", "HelloWorld", "zzzz"}
+	for _, s := range fixed {
+		tests = append(tests, test{s: s})
+	}
+	for len(tests) < 100 {
+		l := rand.Intn(20) + 1
+		tests = append(tests, test{s: randLetters(l)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%s\n", t.s)
+		exp := altCase(t.s)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/100-199/160-169/162/verifierI.go
+++ b/0-999/100-199/160-169/162/verifierI.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func isPrime(n int) bool {
+	if n < 2 {
+		return false
+	}
+	if n%2 == 0 {
+		return n == 2
+	}
+	for i := 3; i*i <= n; i += 2 {
+		if n%i == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func truncatable(n int) string {
+	if strings.ContainsRune(fmt.Sprint(n), '0') {
+		return "NO"
+	}
+	if !isPrime(n) {
+		return "NO"
+	}
+	p := 10
+	for p <= n {
+		suffix := n % p
+		if !isPrime(suffix) {
+			return "NO"
+		}
+		p *= 10
+	}
+	return "YES"
+}
+
+type test struct {
+	n int
+}
+
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	fixed := []int{2, 3, 13, 23, 233, 2333, 2339, 53, 101}
+	for _, v := range fixed {
+		tests = append(tests, test{n: v})
+	}
+	for len(tests) < 100 {
+		tests = append(tests, test{n: rand.Intn(10000000-2) + 2})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n", t.n)
+		exp := truncatable(t.n)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/100-199/160-169/162/verifierJ.go
+++ b/0-999/100-199/160-169/162/verifierJ.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func balanced(s string) string {
+	depth := 0
+	for _, c := range s {
+		if c == '(' {
+			depth++
+		} else {
+			depth--
+		}
+		if depth < 0 {
+			return "NO"
+		}
+	}
+	if depth == 0 {
+		return "YES"
+	}
+	return "NO"
+}
+
+type test struct {
+	s string
+}
+
+func randSeq(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		if rand.Intn(2) == 0 {
+			b[i] = '('
+		} else {
+			b[i] = ')'
+		}
+	}
+	return string(b)
+}
+
+func generateTests() []test {
+	rand.Seed(42)
+	var tests []test
+	fixed := []string{"()", "(())", "(()())", "(", ")(", "(()"}
+	for _, s := range fixed {
+		tests = append(tests, test{s: s})
+	}
+	for len(tests) < 100 {
+		l := rand.Intn(20) + 1
+		tests = append(tests, test{s: randSeq(l)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierJ.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%s\n", t.s)
+		exp := balanced(t.s)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–J in contest 162
- each verifier generates 100 tests and runs a solution binary

## Testing
- `go run verifierA.go ./162A_bin`

------
https://chatgpt.com/codex/tasks/task_e_687e823c938083248783982934f0764a