### PR TITLE
Add Go solution verifiers for contest 161

### DIFF
--- a/0-999/100-199/160-169/161/verifierA.go
+++ b/0-999/100-199/160-169/161/verifierA.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n, m int
+	x, y int64
+	a, b []int64
+}
+
+func generateTest() Test {
+	n := rand.Intn(20) + 1
+	m := rand.Intn(20) + 1
+	x := int64(rand.Intn(5))
+	y := int64(rand.Intn(5))
+	a := make([]int64, n)
+	b := make([]int64, m)
+	cur := rand.Intn(3) + 1
+	for i := 0; i < n; i++ {
+		cur += rand.Intn(3)
+		a[i] = int64(cur)
+	}
+	cur = rand.Intn(3) + 1
+	for j := 0; j < m; j++ {
+		cur += rand.Intn(3)
+		b[j] = int64(cur)
+	}
+	return Test{n, m, x, y, a, b}
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", t.n, t.m, t.x, t.y)
+	for i, v := range t.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range t.b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func solve(t Test) (int, [][2]int) {
+	i, j := 0, 0
+	res := make([][2]int, 0)
+	for i < t.n && j < t.m {
+		low := t.a[i] - t.x
+		high := t.a[i] + t.y
+		if t.b[j] < low {
+			j++
+		} else if t.b[j] > high {
+			i++
+		} else {
+			res = append(res, [2]int{i + 1, j + 1})
+			i++
+			j++
+		}
+	}
+	return len(res), res
+}
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func checkOutput(output string, t Test, expectedK int) error {
+	r := strings.NewReader(output)
+	var k int
+	if _, err := fmt.Fscan(r, &k); err != nil {
+		return fmt.Errorf("failed to read k: %v", err)
+	}
+	if k != expectedK {
+		return fmt.Errorf("expected %d pairs, got %d", expectedK, k)
+	}
+	usedS := make(map[int]bool)
+	usedV := make(map[int]bool)
+	for i := 0; i < k; i++ {
+		var u, v int
+		if _, err := fmt.Fscan(r, &u, &v); err != nil {
+			return fmt.Errorf("failed to read pair %d: %v", i+1, err)
+		}
+		if u < 1 || u > t.n || v < 1 || v > t.m {
+			return fmt.Errorf("invalid indices in pair %d", i+1)
+		}
+		if usedS[u] || usedV[v] {
+			return fmt.Errorf("duplicate indices in pair %d", i+1)
+		}
+		usedS[u] = true
+		usedV[v] = true
+		if t.b[v-1] < t.a[u-1]-t.x || t.b[v-1] > t.a[u-1]+t.y {
+			return fmt.Errorf("pair %d does not satisfy constraints", i+1)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go <binary>")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for tcase := 0; tcase < 100; tcase++ {
+		t := generateTest()
+		inp := t.Input()
+		expK, _ := solve(t)
+		out, err := runBinary(binary, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", tcase+1, err)
+			os.Exit(1)
+		}
+		if err := checkOutput(out, t, expK); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n%s\noutput:\n%s\n", tcase+1, err, inp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/100-199/160-169/161/verifierB.go
+++ b/0-999/100-199/160-169/161/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n     int
+	votes []int
+}
+
+func generateTest() Test {
+	n := rand.Intn(20) + 1
+	votes := make([]int, n)
+	for i := 0; i < n; i++ {
+		votes[i] = rand.Intn(10)
+	}
+	return Test{n, votes}
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t.n)
+	for i, v := range t.votes {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func solve(t Test) string {
+	sum := 0
+	for _, v := range t.votes {
+		sum += v
+	}
+	if t.votes[0] > sum-t.votes[0] {
+		return "Yes"
+	}
+	return "No"
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		t := generateTest()
+		inp := t.Input()
+		exp := solve(t)
+		out, err := runBinary(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\ninput:\n%s\n", i+1, exp, out, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/100-199/160-169/161/verifierC.go
+++ b/0-999/100-199/160-169/161/verifierC.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var lenK [31]int64
+
+func min(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+func max(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+var memo map[string]int64
+
+func rec(k int, l1, r1, l2, r2 int64) int64 {
+	if l1 > r1 || l2 > r2 || k <= 0 {
+		return 0
+	}
+	key := fmt.Sprintf("%d_%d_%d_%d_%d", k, l1, r1, l2, r2)
+	if v, ok := memo[key]; ok {
+		return v
+	}
+	total := lenK[k]
+	if l1 <= 1 && r1 >= total {
+		return r2 - l2 + 1
+	}
+	if l2 <= 1 && r2 >= total {
+		return r1 - l1 + 1
+	}
+	if l1 == l2 && r1 == r2 {
+		return r1 - l1 + 1
+	}
+	mid := (total + 1) / 2
+	var ans int64
+	if l1 <= mid && mid <= r1 && l2 <= mid && mid <= r2 {
+		left := min(mid-l1, mid-l2)
+		right := min(r1-mid, r2-mid)
+		ans = 1 + left + right
+	}
+	l1l, r1l := l1, min(r1, mid-1)
+	l2l, r2l := l2, min(r2, mid-1)
+	l1r, r1r := max(1, l1-mid), max(int64(0), r1-mid)
+	l2r, r2r := max(1, l2-mid), max(int64(0), r2-mid)
+	if l1l <= r1l && l2l <= r2l {
+		if v := rec(k-1, l1l, r1l, l2l, r2l); v > ans {
+			ans = v
+		}
+	}
+	if l1r <= r1r && l2r <= r2r {
+		if v := rec(k-1, l1r, r1r, l2r, r2r); v > ans {
+			ans = v
+		}
+	}
+	if l1l <= r1l && l2r <= r2r {
+		if v := rec(k-1, l1l, r1l, l2r, r2r); v > ans {
+			ans = v
+		}
+	}
+	if l1r <= r1r && l2l <= r2l {
+		if v := rec(k-1, l1r, r1r, l2l, r2l); v > ans {
+			ans = v
+		}
+	}
+	memo[key] = ans
+	return ans
+}
+
+type Test struct{ l1, r1, l2, r2 int64 }
+
+func generateTest() Test {
+	l1 := int64(rand.Intn(100) + 1)
+	r1 := l1 + int64(rand.Intn(100))
+	l2 := int64(rand.Intn(100) + 1)
+	r2 := l2 + int64(rand.Intn(100))
+	return Test{l1, r1, l2, r2}
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("%d %d %d %d\n", t.l1, t.r1, t.l2, t.r2)
+}
+
+func solve(t Test) int64 {
+	memo = make(map[string]int64)
+	return rec(30, t.l1, t.r1, t.l2, t.r2)
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	lenK[0] = 0
+	lenK[1] = 1
+	for i := 2; i <= 30; i++ {
+		lenK[i] = lenK[i-1]*2 + 1
+	}
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		t := generateTest()
+		inp := t.Input()
+		exp := solve(t)
+		out, err := runBinary(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var got int64
+		if _, e := fmt.Sscan(out, &got); e != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to parse output: %v\n", i+1, e)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %d got %d\ninput:%s\n", i+1, exp, got, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/100-199/160-169/161/verifierD.go
+++ b/0-999/100-199/160-169/161/verifierD.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var (
+	k       int
+	adj     [][]int
+	removed []bool
+	sz      []int
+	ans     int64
+)
+
+func dfsSize(u, p int) {
+	sz[u] = 1
+	for _, v := range adj[u] {
+		if v != p && !removed[v] {
+			dfsSize(v, u)
+			sz[u] += sz[v]
+		}
+	}
+}
+
+func dfsCentroid(u, p, total int) int {
+	for _, v := range adj[u] {
+		if v != p && !removed[v] {
+			if sz[v] > total/2 {
+				return dfsCentroid(v, u, total)
+			}
+		}
+	}
+	return u
+}
+
+func dfsCount(u, p, depth int, cnt []int) {
+	if depth > k {
+		return
+	}
+	cnt[depth]++
+	for _, v := range adj[u] {
+		if v != p && !removed[v] {
+			dfsCount(v, u, depth+1, cnt)
+		}
+	}
+}
+
+func solve(u int) {
+	dfsSize(u, -1)
+	c := dfsCentroid(u, -1, sz[u])
+	removed[c] = true
+	freq := make([]int, k+1)
+	freq[0] = 1
+	for _, v := range adj[c] {
+		if removed[v] {
+			continue
+		}
+		cnt := make([]int, k+1)
+		dfsCount(v, c, 1, cnt)
+		for d := 1; d <= k; d++ {
+			if cnt[d] > 0 && k-d >= 0 {
+				ans += int64(cnt[d]) * int64(freq[k-d])
+			}
+		}
+		for d := 1; d <= k; d++ {
+			freq[d] += cnt[d]
+		}
+	}
+	for _, v := range adj[c] {
+		if !removed[v] {
+			solve(v)
+		}
+	}
+}
+
+type Test struct {
+	n     int
+	k     int
+	edges [][2]int
+}
+
+func generateTest() Test {
+	n := rand.Intn(10) + 1
+	k := rand.Intn(n)
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	return Test{n, k, edges}
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", t.n, t.k)
+	for _, e := range t.edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	return sb.String()
+}
+
+func solveTest(t Test) int64 {
+	k = t.k
+	adj = make([][]int, t.n+1)
+	removed = make([]bool, t.n+1)
+	sz = make([]int, t.n+1)
+	for _, e := range t.edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	ans = 0
+	solve(1)
+	return ans
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		t := generateTest()
+		inp := t.Input()
+		exp := solveTest(t)
+		out, err := runBinary(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var got int64
+		if _, e := fmt.Sscan(out, &got); e != nil {
+			fmt.Fprintf(os.Stderr, "test %d parse error: %v\n", i+1, e)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %d got %d\ninput:\n%s\n", i+1, exp, got, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/100-199/160-169/161/verifierE.go
+++ b/0-999/100-199/160-169/161/verifierE.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const maxV = 100000
+
+var isPrime [maxV]bool
+var primesByLen [][]string
+var prefixMap [][]map[string][]string
+
+func initData() {
+	for i := 2; i < maxV; i++ {
+		isPrime[i] = true
+	}
+	for i := 2; i*i < maxV; i++ {
+		if isPrime[i] {
+			for j := i * i; j < maxV; j += i {
+				isPrime[j] = false
+			}
+		}
+	}
+	primesByLen = make([][]string, 6)
+	for v := 2; v < maxV; v++ {
+		if !isPrime[v] {
+			continue
+		}
+		s := fmt.Sprintf("%05d", v)
+		for n := 1; n <= 5; n++ {
+			primesByLen[n] = append(primesByLen[n], s[5-n:])
+		}
+	}
+	prefixMap = make([][]map[string][]string, 6)
+	for n := 1; n <= 5; n++ {
+		prefixMap[n] = make([]map[string][]string, n+1)
+		for L := 0; L <= n; L++ {
+			prefixMap[n][L] = make(map[string][]string)
+		}
+		for _, p := range primesByLen[n] {
+			for L := 1; L < n; L++ {
+				pre := p[:L]
+				prefixMap[n][L][pre] = append(prefixMap[n][L][pre], p)
+			}
+		}
+	}
+}
+
+type Test struct {
+	t      int
+	primes []string
+}
+
+func randomPrime(n int) string {
+	lst := primesByLen[n]
+	return strings.TrimLeft(lst[rand.Intn(len(lst))], "0")
+}
+
+func generateTest() Test {
+	t := rand.Intn(5) + 1
+	primes := make([]string, t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(5) + 1
+		// choose prime without leading zero
+		for {
+			p := randomPrime(n)
+			if len(p) == n {
+				primes[i] = p
+				break
+			}
+		}
+	}
+	return Test{t, primes}
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t.t)
+	for _, p := range t.primes {
+		fmt.Fprintf(&sb, "%s\n", p)
+	}
+	return sb.String()
+}
+
+func countMatrices(pi string) int64 {
+	n := len(pi)
+	var mat [5][5]byte
+	for j := 0; j < n; j++ {
+		mat[0][j] = pi[j]
+		mat[j][0] = pi[j]
+	}
+	var dfs func(i int) int64
+	dfs = func(i int) int64 {
+		if i > n {
+			return 1
+		}
+		idx := i - 1
+		pre := make([]byte, idx)
+		for j := 0; j < idx; j++ {
+			pre[j] = mat[idx][j]
+		}
+		cand := prefixMap[n][idx][string(pre)]
+		var cnt int64
+		for _, pstr := range cand {
+			for j := idx; j < n; j++ {
+				mat[idx][j] = pstr[j]
+				if j > idx {
+					mat[j][idx] = pstr[j]
+				}
+			}
+			cnt += dfs(i + 1)
+		}
+		return cnt
+	}
+	if n == 1 {
+		return 1
+	}
+	return dfs(2)
+}
+
+func solve(t Test) []int64 {
+	res := make([]int64, t.t)
+	for i, p := range t.primes {
+		res[i] = countMatrices(p)
+	}
+	return res
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	initData()
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		t := generateTest()
+		inp := t.Input()
+		exp := solve(t)
+		out, err := runBinary(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		outs := strings.Fields(out)
+		if len(outs) != len(exp) {
+			fmt.Fprintf(os.Stderr, "test %d wrong number of outputs\ninput:\n%s\noutput:\n%s\n", i+1, inp, out)
+			os.Exit(1)
+		}
+		for j, valStr := range outs {
+			var val int64
+			if _, e := fmt.Sscan(valStr, &val); e != nil {
+				fmt.Fprintf(os.Stderr, "test %d parse error: %v\n", i+1, e)
+				os.Exit(1)
+			}
+			if val != exp[j] {
+				fmt.Fprintf(os.Stderr, "test %d failed: expected %d got %d at line %d\ninput:\n%s\n", i+1, exp[j], val, j+1, inp)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–E in contest 161
- each verifier runs 100 randomized tests against any solution binary
- verifiers validate output correctness and report failures

## Testing
- `go build verifierA.go`
- `go run verifierA.go ./solA`
- `go build verifierB.go`
- `go run verifierB.go ./solB`
- `go build verifierC.go`
- `go run verifierC.go ./solC`
- `go build verifierD.go`
- `go run verifierD.go ./solD`
- `go build verifierE.go`
- `go run verifierE.go ./solE`

------
https://chatgpt.com/codex/tasks/task_e_687e81f69ed08324bf955571936f52db