### PR TITLE
Add solution verifiers for contest 160

### DIFF
--- a/0-999/100-199/160-169/160/verifierA.go
+++ b/0-999/100-199/160-169/160/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCaseA struct {
+	n     int
+	coins []int
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	var tests []testCaseA
+	// generate 100 random tests
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(100) + 1
+		coins := make([]int, n)
+		for j := range coins {
+			coins[j] = rand.Intn(100) + 1
+		}
+		tests = append(tests, testCaseA{n, coins})
+	}
+	// add some edge cases
+	tests = append(tests, testCaseA{1, []int{1}})
+	tests = append(tests, testCaseA{2, []int{1, 1}})
+
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", t.n))
+		for j, v := range t.coins {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := solveA(strings.NewReader(input))
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveA(r io.Reader) string {
+	in := bufio.NewReader(r)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return ""
+	}
+	coins := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &coins[i])
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(coins)))
+	total := 0
+	for _, v := range coins {
+		total += v
+	}
+	sum := 0
+	for i, v := range coins {
+		sum += v
+		if sum > total-sum {
+			return fmt.Sprintf("%d\n", i+1)
+		}
+	}
+	return ""
+}

--- a/0-999/100-199/160-169/160/verifierB.go
+++ b/0-999/100-199/160-169/160/verifierB.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCaseB struct {
+	n int
+	s string
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(43)
+	var tests []testCaseB
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(30) + 1
+		b := make([]byte, 2*n)
+		for j := range b {
+			b[j] = byte('0' + rand.Intn(10))
+		}
+		tests = append(tests, testCaseB{n, string(b)})
+	}
+	tests = append(tests, testCaseB{1, "12"})
+	tests = append(tests, testCaseB{2, "0000"})
+
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n%s\n", t.n, t.s)
+		expect := solveB(strings.NewReader(input))
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveB(r io.Reader) string {
+	in := bufio.NewReader(r)
+	var n int
+	var s string
+	fmt.Fscan(in, &n)
+	fmt.Fscan(in, &s)
+	a := []byte(s[:n])
+	b := []byte(s[n:])
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
+	less := true
+	greater := true
+	for i := 0; i < n; i++ {
+		if a[i] >= b[i] {
+			less = false
+		}
+		if a[i] <= b[i] {
+			greater = false
+		}
+	}
+	if less || greater {
+		return "YES\n"
+	}
+	return "NO\n"
+}

--- a/0-999/100-199/160-169/160/verifierC.go
+++ b/0-999/100-199/160-169/160/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCaseC struct {
+	n   int
+	k   int64
+	arr []int
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(44)
+	var tests []testCaseC
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(2001) - 1000
+		}
+		k := rand.Int63n(int64(n)*int64(n)) + 1
+		tests = append(tests, testCaseC{n, k, arr})
+	}
+	tests = append(tests, testCaseC{1, 1, []int{5}})
+
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.k))
+		for j, v := range t.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := solveC(strings.NewReader(input))
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solveC(r io.Reader) string {
+	in := bufio.NewReader(r)
+	var n int
+	var k int64
+	fmt.Fscan(in, &n, &k)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	sort.Ints(a)
+	idx1 := int((k - 1) / int64(n))
+	idx2 := int((k - 1) % int64(n))
+	return fmt.Sprintf("%d %d\n", a[idx1], a[idx2])
+}

--- a/0-999/100-199/160-169/160/verifierD.go
+++ b/0-999/100-199/160-169/160/verifierD.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type Edge struct {
+	u, v, w, id int
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(45)
+	var tests []string
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 2
+		m := rand.Intn(n*(n-1)/2-n+1) + n - 1
+		// generate connected graph
+		edges := make([]Edge, 0, m)
+		used := make(map[[2]int]bool)
+		// spanning tree
+		for i := 2; i <= n; i++ {
+			j := rand.Intn(i-1) + 1
+			w := rand.Intn(10) + 1
+			edges = append(edges, Edge{j, i, w, len(edges)})
+			used[[2]int{j, i}] = true
+			used[[2]int{i, j}] = true
+		}
+		for len(edges) < m {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			if u == v || used[[2]int{u, v}] {
+				continue
+			}
+			w := rand.Intn(10) + 1
+			edges = append(edges, Edge{u, v, w, len(edges)})
+			used[[2]int{u, v}] = true
+			used[[2]int{v, u}] = true
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", e.u, e.v, e.w))
+		}
+		tests = append(tests, sb.String())
+	}
+	for i, input := range tests {
+		expect := solveD(strings.NewReader(input))
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected \n%s\n got \n%s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+// DSU structure
+type DSU struct {
+	p, r []int
+}
+
+func NewDSU(n int) *DSU {
+	p := make([]int, n+1)
+	r := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		p[i] = i
+	}
+	return &DSU{p: p, r: r}
+}
+
+func (d *DSU) Find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.Find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *DSU) Union(a, b int) {
+	a = d.Find(a)
+	b = d.Find(b)
+	if a == b {
+		return
+	}
+	if d.r[a] < d.r[b] {
+		a, b = b, a
+	}
+	d.p[b] = a
+	if d.r[a] == d.r[b] {
+		d.r[a]++
+	}
+}
+
+func solveD(r io.Reader) string {
+	in := bufio.NewReader(r)
+	var n, m int
+	fmt.Fscan(in, &n, &m)
+	edges := make([]Edge, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(in, &edges[i].u, &edges[i].v, &edges[i].w)
+		edges[i].id = i
+	}
+	sort.Slice(edges, func(i, j int) bool { return edges[i].w < edges[j].w })
+	ans := make([]string, m)
+	dsu := NewDSU(n)
+	for i := 0; i < m; {
+		j := i
+		for j < m && edges[j].w == edges[i].w {
+			j++
+		}
+		type BE struct{ u, v, id int }
+		var be []BE
+		for k := i; k < j; k++ {
+			u := dsu.Find(edges[k].u)
+			v := dsu.Find(edges[k].v)
+			if u == v {
+				ans[edges[k].id] = "none"
+			} else {
+				be = append(be, BE{u, v, edges[k].id})
+			}
+		}
+		if len(be) > 0 {
+			comp := make(map[int]int)
+			idx := 0
+			for _, e := range be {
+				if _, ok := comp[e.u]; !ok {
+					comp[e.u] = idx
+					idx++
+				}
+				if _, ok := comp[e.v]; !ok {
+					comp[e.v] = idx
+					idx++
+				}
+			}
+			sz := idx
+			type Adj struct{ to, id int }
+			adj := make([][]Adj, sz)
+			pairCnt := make(map[int]int)
+			key := func(a, b int) int {
+				if a > b {
+					a, b = b, a
+				}
+				return a*sz + b
+			}
+			for _, e := range be {
+				u := comp[e.u]
+				v := comp[e.v]
+				k := key(u, v)
+				pairCnt[k]++
+				adj[u] = append(adj[u], Adj{v, e.id})
+				adj[v] = append(adj[v], Adj{u, e.id})
+			}
+			tin := make([]int, sz)
+			low := make([]int, sz)
+			vis := make([]bool, sz)
+			timer := 0
+			bridge := make(map[int]bool)
+			var dfs func(u, pe int)
+			dfs = func(u, pe int) {
+				vis[u] = true
+				timer++
+				tin[u] = timer
+				low[u] = timer
+				for _, e := range adj[u] {
+					v := e.to
+					id := e.id
+					if id == pe {
+						continue
+					}
+					if vis[v] {
+						if tin[v] < low[u] {
+							low[u] = tin[v]
+						}
+					} else {
+						dfs(v, id)
+						if low[v] < low[u] {
+							low[u] = low[v]
+						}
+						if low[v] > tin[u] {
+							if pairCnt[key(u, v)] == 1 {
+								bridge[id] = true
+							}
+						}
+					}
+				}
+			}
+			for u := 0; u < sz; u++ {
+				if !vis[u] {
+					dfs(u, -1)
+				}
+			}
+			for _, e := range be {
+				if bridge[e.id] {
+					ans[e.id] = "any"
+				} else {
+					ans[e.id] = "at least one"
+				}
+			}
+		}
+		for k := i; k < j; k++ {
+			dsu.Union(edges[k].u, edges[k].v)
+		}
+		i = j
+	}
+	var buf strings.Builder
+	for i := 0; i < m; i++ {
+		buf.WriteString(ans[i])
+		buf.WriteByte('\n')
+	}
+	return buf.String()
+}

--- a/0-999/100-199/160-169/160/verifierE.go
+++ b/0-999/100-199/160-169/160/verifierE.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type Bus struct {
+	s, f int
+	t    int
+	id   int
+}
+
+type Query struct {
+	l, r, b   int
+	id        int
+	low, high int
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(46)
+	var tests []string
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(5) + 1
+		buses := make([]Bus, n)
+		usedT := make(map[int]bool)
+		for i := 0; i < n; i++ {
+			s := rand.Intn(20) + 1
+			f := rand.Intn(20-s) + s + 1
+			var ti int
+			for {
+				ti = rand.Intn(100) + 1
+				if !usedT[ti] {
+					usedT[ti] = true
+					break
+				}
+			}
+			buses[i] = Bus{s, f, ti, i + 1}
+		}
+		people := make([]Query, m)
+		for i := 0; i < m; i++ {
+			l := rand.Intn(20) + 1
+			r := rand.Intn(20-l) + l + 1
+			b := rand.Intn(100) + 1
+			people[i] = Query{l, r, b, i, 0, n - 1}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for _, b := range buses {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", b.s, b.f, b.t))
+		}
+		for _, q := range people {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", q.l, q.r, q.b))
+		}
+		tests = append(tests, sb.String())
+	}
+	for i, input := range tests {
+		expect := solveE(strings.NewReader(input))
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+// --- solution for problem E ---
+
+type SegTree struct {
+	n    int
+	tree []int
+}
+
+func NewSegTree(n int) *SegTree {
+	size := 1
+	for size < n {
+		size <<= 1
+	}
+	return &SegTree{n: size, tree: make([]int, 2*size)}
+}
+
+func (st *SegTree) Update(pos, val int) {
+	i := pos + st.n
+	if st.tree[i] >= val {
+		return
+	}
+	st.tree[i] = val
+	for i >>= 1; i > 0; i >>= 1 {
+		if st.tree[2*i] > st.tree[2*i+1] {
+			st.tree[i] = st.tree[2*i]
+		} else {
+			st.tree[i] = st.tree[2*i+1]
+		}
+	}
+}
+
+func (st *SegTree) Query(r int) int {
+	l := st.n
+	rr := r + st.n
+	maxv := 0
+	for l <= rr {
+		if l&1 == 1 {
+			if st.tree[l] > maxv {
+				maxv = st.tree[l]
+			}
+			l++
+		}
+		if rr&1 == 0 {
+			if st.tree[rr] > maxv {
+				maxv = st.tree[rr]
+			}
+			rr--
+		}
+		l >>= 1
+		rr >>= 1
+	}
+	return maxv
+}
+
+func solveE(r io.Reader) string {
+	in := bufio.NewReader(r)
+	var n, m int
+	fmt.Fscan(in, &n, &m)
+	buses := make([]Bus, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &buses[i].s, &buses[i].f, &buses[i].t)
+		buses[i].id = i + 1
+	}
+	queries := make([]Query, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(in, &queries[i].l, &queries[i].r, &queries[i].b)
+		queries[i].id = i
+		queries[i].low = 0
+		queries[i].high = n - 1
+	}
+	sort.Slice(buses, func(i, j int) bool { return buses[i].t < buses[j].t })
+	tList := make([]int, n)
+	for i := range buses {
+		tList[i] = buses[i].t
+	}
+	for i := range queries {
+		lb := sort.Search(n, func(j int) bool { return tList[j] >= queries[i].b })
+		if lb >= n {
+			queries[i].low = n
+			queries[i].high = -1
+		} else {
+			queries[i].low = lb
+			queries[i].high = n - 1
+		}
+	}
+	coords := make([]int, 0, n+m)
+	for _, b := range buses {
+		coords = append(coords, b.s)
+	}
+	for _, q := range queries {
+		coords = append(coords, q.l)
+	}
+	sort.Ints(coords)
+	uniq := coords[:1]
+	for i := 1; i < len(coords); i++ {
+		if coords[i] != coords[i-1] {
+			uniq = append(uniq, coords[i])
+		}
+	}
+	getPos := func(x int) int { return sort.SearchInts(uniq, x) }
+	sPos := make([]int, n)
+	for i := range buses {
+		sPos[i] = getPos(buses[i].s)
+	}
+	lPos := make([]int, m)
+	for i := range queries {
+		lPos[i] = getPos(queries[i].l)
+	}
+	type Task struct{ mid, qi int }
+	for {
+		tasks := make([]Task, 0, m)
+		for i := range queries {
+			if queries[i].low <= queries[i].high {
+				mid := (queries[i].low + queries[i].high) >> 1
+				tasks = append(tasks, Task{mid, i})
+			}
+		}
+		if len(tasks) == 0 {
+			break
+		}
+		sort.Slice(tasks, func(i, j int) bool { return tasks[i].mid < tasks[j].mid })
+		st := NewSegTree(len(uniq))
+		p := -1
+		for _, t := range tasks {
+			mid, qi := t.mid, t.qi
+			for p < mid {
+				p++
+				st.Update(sPos[p], buses[p].f)
+			}
+			if st.Query(lPos[qi]) >= queries[qi].r {
+				queries[qi].high = mid - 1
+			} else {
+				queries[qi].low = mid + 1
+			}
+		}
+	}
+	ans := make([]int, m)
+	for i := range queries {
+		if queries[i].low < n {
+			ans[queries[i].id] = buses[queries[i].low].id
+		} else {
+			ans[queries[i].id] = -1
+		}
+	}
+	var buf strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		buf.WriteString(strconv.Itoa(v))
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–E of contest 160
- each verifier generates at least 100 test cases
- verifiers execute a target binary and compare with an internal solver

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e81b0bbfc83248919d1cfb48136f9