### PR TITLE
Add verifiers for contest 159

### DIFF
--- a/0-999/100-199/150-159/159/verifierA.go
+++ b/0-999/100-199/150-159/159/verifierA.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type logEntry struct {
+	a, b string
+	t    int
+}
+
+func solveA(n, d int, logs []logEntry) string {
+	nameToID := make(map[string]int)
+	var idToName []string
+	pairTimes := make(map[int64][]int)
+	outSet := make(map[int64]struct{})
+	key := func(u, v int) int64 { return (int64(u) << 32) | int64(uint32(v)) }
+	for _, lg := range logs {
+		p1, ok := nameToID[lg.a]
+		if !ok {
+			p1 = len(idToName)
+			nameToID[lg.a] = p1
+			idToName = append(idToName, lg.a)
+		}
+		p2, ok := nameToID[lg.b]
+		if !ok {
+			p2 = len(idToName)
+			nameToID[lg.b] = p2
+			idToName = append(idToName, lg.b)
+		}
+		k12 := key(p1, p2)
+		times := pairTimes[k12]
+		idx := sort.Search(len(times), func(i int) bool { return times[i] >= lg.t })
+		if idx == len(times) {
+			times = append(times, lg.t)
+		} else if times[idx] != lg.t {
+			times = append(times, 0)
+			copy(times[idx+1:], times[idx:])
+			times[idx] = lg.t
+		}
+		pairTimes[k12] = times
+		k21 := key(p2, p1)
+		rev := pairTimes[k21]
+		idx2 := sort.Search(len(rev), func(i int) bool { return rev[i] >= lg.t-d })
+		if idx2 < len(rev) && rev[idx2] != lg.t {
+			u, v := p1, p2
+			if u > v {
+				u, v = v, u
+			}
+			outSet[key(u, v)] = struct{}{}
+		}
+	}
+	type pair struct{ u, v int }
+	pairs := make([]pair, 0, len(outSet))
+	for kk := range outSet {
+		pairs = append(pairs, pair{u: int(kk >> 32), v: int(uint32(kk))})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].u != pairs[j].u {
+			return pairs[i].u < pairs[j].u
+		}
+		return pairs[i].v < pairs[j].v
+	})
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(pairs)))
+	for _, p := range pairs {
+		sb.WriteString(fmt.Sprintf("%s %s\n", idToName[p.u], idToName[p.v]))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randName(rng *rand.Rand) string {
+	length := rng.Intn(3) + 1
+	letters := []rune("abcde")
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 2
+		d := rng.Intn(10) + 1
+		logs := make([]logEntry, n)
+		t := 0
+		for j := 0; j < n; j++ {
+			a := randName(rng)
+			b := randName(rng)
+			for b == a {
+				b = randName(rng)
+			}
+			t += rng.Intn(3)
+			logs[j] = logEntry{a: a, b: b, t: t}
+			t += rng.Intn(3)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, d))
+		for _, lg := range logs {
+			sb.WriteString(fmt.Sprintf("%s %s %d\n", lg.a, lg.b, lg.t))
+		}
+		input := sb.String()
+		expected := solveA(n, d, logs)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/150-159/159/verifierB.go
+++ b/0-999/100-199/150-159/159/verifierB.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(n, m int, markers [][2]int, caps [][2]int) string {
+	const maxD = 1000
+	sumM := make([]int, maxD+1)
+	sumC := make([]int, maxD+1)
+	md := make([]map[int]int, maxD+1)
+	cd := make([]map[int]int, maxD+1)
+	for d := 0; d <= maxD; d++ {
+		md[d] = make(map[int]int)
+		cd[d] = make(map[int]int)
+	}
+	for _, p := range markers {
+		x, y := p[0], p[1]
+		sumM[y]++
+		md[y][x]++
+	}
+	for _, c := range caps {
+		a, b := c[0], c[1]
+		sumC[b]++
+		cd[b][a]++
+	}
+	total := 0
+	beautiful := 0
+	for d := 0; d <= maxD; d++ {
+		if sumM[d] == 0 || sumC[d] == 0 {
+			continue
+		}
+		t := sumM[d]
+		if sumC[d] < t {
+			t = sumC[d]
+		}
+		total += t
+		b := 0
+		for color, cntM := range md[d] {
+			cntC := cd[d][color]
+			if cntC < cntM {
+				b += cntC
+			} else {
+				b += cntM
+			}
+		}
+		if b > t {
+			b = t
+		}
+		beautiful += b
+	}
+	return fmt.Sprintf("%d %d", total, beautiful)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		markers := make([][2]int, n)
+		caps := make([][2]int, m)
+		for j := 0; j < n; j++ {
+			markers[j][0] = rng.Intn(5) + 1
+			markers[j][1] = rng.Intn(5) + 1
+		}
+		for j := 0; j < m; j++ {
+			caps[j][0] = rng.Intn(5) + 1
+			caps[j][1] = rng.Intn(5) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for _, p := range markers {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+		}
+		for _, c := range caps {
+			sb.WriteString(fmt.Sprintf("%d %d\n", c[0], c[1]))
+		}
+		input := sb.String()
+		expected := solveB(n, m, markers, caps)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/150-159/159/verifierC.go
+++ b/0-999/100-199/150-159/159/verifierC.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type BIT struct {
+	n    int
+	tree []int
+}
+
+func NewBIT(n int) *BIT {
+	return &BIT{n: n, tree: make([]int, n+1)}
+}
+
+func (b *BIT) Add(i, delta int) {
+	for x := i; x <= b.n; x += x & -x {
+		b.tree[x] += delta
+	}
+}
+
+func (b *BIT) Sum(i int) int {
+	s := 0
+	for x := i; x > 0; x -= x & -x {
+		s += b.tree[x]
+	}
+	return s
+}
+
+func (b *BIT) FindKth(k int) int {
+	pos := 0
+	bitMask := 1
+	for bitMask<<1 <= b.n {
+		bitMask <<= 1
+	}
+	for d := bitMask; d > 0; d >>= 1 {
+		nxt := pos + d
+		if nxt <= b.n && b.tree[nxt] < k {
+			pos = nxt
+			k -= b.tree[nxt]
+		}
+	}
+	return pos + 1
+}
+
+func solveC(k int, s string, ops [][2]interface{}) string {
+	m := len(s)
+	total := k * m
+	pos := make([][]int, 26)
+	for i := 0; i < total; i++ {
+		c := s[i%len(s)] - 'a'
+		pos[c] = append(pos[c], i)
+	}
+	bits := make([]*BIT, 26)
+	for c := 0; c < 26; c++ {
+		bits[c] = NewBIT(len(pos[c]))
+		for i := 1; i <= len(pos[c]); i++ {
+			bits[c].Add(i, 1)
+		}
+	}
+	deleted := make([]bool, total)
+	for _, op := range ops {
+		p := op[0].(int)
+		c := op[1].(byte)
+		idx := bits[c-'a'].FindKth(p) - 1
+		g := pos[c-'a'][idx]
+		deleted[g] = true
+		bits[c-'a'].Add(idx+1, -1)
+	}
+	res := make([]byte, 0, total)
+	for i := 0; i < total; i++ {
+		if !deleted[i] {
+			res = append(res, s[i%len(s)])
+		}
+	}
+	return string(res)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		k := rng.Intn(3) + 1
+		s := randString(rng, rng.Intn(4)+1)
+		total := k * len(s)
+		nOps := rng.Intn(total/2 + 1)
+		t := []byte(strings.Repeat(s, k))
+		ops := make([][2]interface{}, nOps)
+		for j := 0; j < nOps; j++ {
+			c := t[rng.Intn(len(t))]
+			// count occurrences
+			cnt := 0
+			for _, ch := range t {
+				if ch == c {
+					cnt++
+				}
+			}
+			p := rng.Intn(cnt) + 1
+			ops[j][0] = p
+			ops[j][1] = c
+			// delete
+			occ := 0
+			for idx := 0; idx < len(t); idx++ {
+				if t[idx] == c {
+					occ++
+					if occ == p {
+						t = append(t[:idx], t[idx+1:]...)
+						break
+					}
+				}
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n%s\n%d\n", k, s, nOps))
+		for _, op := range ops {
+			sb.WriteString(fmt.Sprintf("%d %c\n", op[0].(int), op[1].(byte)))
+		}
+		input := sb.String()
+		expected := solveC(k, s, ops)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/150-159/159/verifierD.go
+++ b/0-999/100-199/150-159/159/verifierD.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(s string) string {
+	n := len(s)
+	countEnd := make([]int64, n)
+	countStart := make([]int64, n)
+	for center := 0; center < n; center++ {
+		l, r := center, center
+		for l >= 0 && r < n && s[l] == s[r] {
+			countStart[l]++
+			countEnd[r]++
+			l--
+			r++
+		}
+	}
+	for center := 0; center < n-1; center++ {
+		l, r := center, center+1
+		for l >= 0 && r < n && s[l] == s[r] {
+			countStart[l]++
+			countEnd[r]++
+			l--
+			r++
+		}
+	}
+	suffix := make([]int64, n+1)
+	for i := n - 1; i >= 0; i-- {
+		suffix[i] = suffix[i+1] + countStart[i]
+	}
+	var ans int64
+	for b := 0; b < n-1; b++ {
+		if countEnd[b] > 0 {
+			ans += countEnd[b] * suffix[b+1]
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := randString(rng, rng.Intn(8)+1)
+		input := fmt.Sprintf("%s\n", s)
+		expected := solveD(s)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/150-159/159/verifierE.go
+++ b/0-999/100-199/150-159/159/verifierE.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Cube struct {
+	id    int
+	color int
+	size  int
+}
+
+func solveE(cubes []Cube) string {
+	colors := make(map[int]struct{})
+	for _, c := range cubes {
+		colors[c.color] = struct{}{}
+	}
+	bestHeight := 0
+	var bestSeq []int
+	colorList := make([]int, 0, len(colors))
+	for c := range colors {
+		colorList = append(colorList, c)
+	}
+	for i := 0; i < len(colorList); i++ {
+		for j := i + 1; j < len(colorList); j++ {
+			c1 := colorList[i]
+			c2 := colorList[j]
+			var list1, list2 []Cube
+			for _, c := range cubes {
+				if c.color == c1 {
+					list1 = append(list1, c)
+				} else if c.color == c2 {
+					list2 = append(list2, c)
+				}
+			}
+			sort.Slice(list1, func(i, j int) bool { return list1[i].size > list1[j].size })
+			sort.Slice(list2, func(i, j int) bool { return list2[i].size > list2[j].size })
+			for start := 0; start < 2; start++ {
+				h := 0
+				seq := []int{}
+				i1, i2 := 0, 0
+				cur := start
+				for {
+					if cur == 0 {
+						if i1 >= len(list1) {
+							break
+						}
+						seq = append(seq, list1[i1].id)
+						h += list1[i1].size
+						i1++
+						cur = 1
+					} else {
+						if i2 >= len(list2) {
+							break
+						}
+						seq = append(seq, list2[i2].id)
+						h += list2[i2].size
+						i2++
+						cur = 0
+					}
+				}
+				if h > bestHeight && len(seq) >= 2 {
+					bestHeight = h
+					bestSeq = append([]int(nil), seq...)
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n%d\n", bestHeight, len(bestSeq)))
+	for i, id := range bestSeq {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", id))
+	}
+	sb.WriteString("\n")
+	return strings.TrimSpace(sb.String())
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 2
+		cubes := make([]Cube, n)
+		for j := 0; j < n; j++ {
+			cubes[j] = Cube{id: j + 1, color: rng.Intn(3) + 1, size: rng.Intn(9) + 1}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for _, c := range cubes {
+			sb.WriteString(fmt.Sprintf("%d %d\n", c.color, c.size))
+		}
+		input := sb.String()
+		expected := solveE(cubes)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for each problem in contest 159
- each verifier generates 100 random tests and runs a given binary
- expected output computed with reference solution logic

## Testing
- `go build` on all verifier files

------
https://chatgpt.com/codex/tasks/task_e_687e816a88808324b64e18101ebbbd21