### PR TITLE
Add verifiers for CF contest 158

### DIFF
--- a/0-999/100-199/150-159/158/verifierA.go
+++ b/0-999/100-199/150-159/158/verifierA.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedA(n, k int, scores []int) int {
+	threshold := scores[k-1]
+	cnt := 0
+	for _, s := range scores {
+		if s >= threshold && s > 0 {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(50) + 1
+		k := rng.Intn(n) + 1
+		scores := make([]int, n)
+		scores[0] = rng.Intn(101)
+		for i := 1; i < n; i++ {
+			scores[i] = rng.Intn(scores[i-1] + 1)
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for i, s := range scores {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", s)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := expectedA(n, k, scores)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", t+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != fmt.Sprint(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", t+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/150-159/158/verifierB.go
+++ b/0-999/100-199/150-159/158/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedB(groups []int) int {
+	counts := make([]int, 5)
+	for _, g := range groups {
+		if g >= 1 && g <= 4 {
+			counts[g]++
+		}
+	}
+	taxis := counts[4]
+	taxis += counts[3]
+	if counts[1] > counts[3] {
+		counts[1] -= counts[3]
+	} else {
+		counts[1] = 0
+	}
+	taxis += counts[2] / 2
+	if counts[2]%2 != 0 {
+		taxis++
+		if counts[1] > 2 {
+			counts[1] -= 2
+		} else {
+			counts[1] = 0
+		}
+	}
+	if counts[1] > 0 {
+		taxis += (counts[1] + 3) / 4
+	}
+	return taxis
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(1000) + 1
+		groups := make([]int, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			g := rng.Intn(4) + 1
+			groups[i] = g
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", g)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := expectedB(groups)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", t+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != fmt.Sprint(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", t+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/150-159/158/verifierC.go
+++ b/0-999/100-199/150-159/158/verifierC.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(input string) string {
+	lines := strings.Split(strings.TrimSpace(input), "\n")
+	n := 0
+	fmt.Sscan(lines[0], &n)
+	path := make([]string, 0)
+	var out []string
+	for i := 1; i <= n; i++ {
+		fields := strings.Fields(lines[i])
+		if fields[0] == "pwd" {
+			if len(path) == 0 {
+				out = append(out, "/")
+			} else {
+				out = append(out, "/"+strings.Join(path, "/")+"/")
+			}
+		} else {
+			p := fields[1]
+			if strings.HasPrefix(p, "/") {
+				path = path[:0]
+			}
+			parts := strings.Split(p, "/")
+			for _, part := range parts {
+				if part == "" {
+					continue
+				}
+				if part == ".." {
+					if len(path) > 0 {
+						path = path[:len(path)-1]
+					}
+				} else {
+					path = append(path, part)
+				}
+			}
+		}
+	}
+	return strings.Join(out, "\n") + "\n"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randName(rng *rand.Rand) string {
+	l := rng.Intn(5) + 1
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	path := make([]string, 0)
+	var lines []string
+	hasPwd := false
+	for i := 0; i < n; i++ {
+		if rng.Intn(3) == 0 { // pwd
+			lines = append(lines, "pwd")
+			hasPwd = true
+		} else { // cd
+			absolute := rng.Intn(2) == 0
+			var segs []string
+			temp := make([]string, len(path))
+			copy(temp, path)
+			count := rng.Intn(5)
+			if absolute {
+				temp = temp[:0]
+			}
+			for j := 0; j < count; j++ {
+				if rng.Intn(3) == 0 && len(temp) > 0 {
+					segs = append(segs, "..")
+					temp = temp[:len(temp)-1]
+				} else {
+					name := randName(rng)
+					segs = append(segs, name)
+					temp = append(temp, name)
+				}
+			}
+			if absolute {
+				path = temp
+				if len(segs) == 0 {
+					lines = append(lines, "cd /")
+				} else {
+					lines = append(lines, "cd /"+strings.Join(segs, "/"))
+				}
+			} else {
+				path = temp
+				if len(segs) == 0 {
+					lines = append(lines, "cd .")
+				} else {
+					lines = append(lines, "cd "+strings.Join(segs, "/"))
+				}
+			}
+		}
+	}
+	if !hasPwd {
+		lines = append(lines, "pwd")
+	}
+	return fmt.Sprintf("%d\n%s\n", len(lines), strings.Join(lines, "\n"))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		expected := solveC(input)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", t+1, err, out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected:\n%s\ngot:\n%sinput:\n%s", t+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/150-159/158/verifierD.go
+++ b/0-999/100-199/150-159/158/verifierD.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedD(vals []int64) int64 {
+	n := len(vals)
+	ans := int64(-1 << 60)
+	for k := 3; k <= n; k++ {
+		if n%k != 0 {
+			continue
+		}
+		step := n / k
+		for off := 0; off < step; off++ {
+			var sum int64
+			for j := 0; j < k; j++ {
+				sum += vals[off+j*step]
+			}
+			if sum > ans {
+				ans = sum
+			}
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(30) + 3
+	vals := make([]int64, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		vals[i] = int64(rng.Intn(2001) - 1000)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", vals[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expectedD(vals)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", t+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != fmt.Sprint(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", t+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/150-159/158/verifierE.go
+++ b/0-999/100-199/150-159/158/verifierE.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedE(n, k int, tvals, dvals []int) int {
+	if n == 0 || k >= n {
+		return 86400
+	}
+	costPre := make([]int, n)
+	for i := 0; i < n; i++ {
+		cntGood := 0
+		for j := 0; j < i; j++ {
+			if tvals[j]+dvals[j] <= tvals[i] {
+				cntGood++
+			}
+		}
+		costPre[i] = i - cntGood
+	}
+	costPost := make([]int, n)
+	for i := 0; i < n; i++ {
+		cntBad := 0
+		endI := tvals[i] + dvals[i]
+		for j := i + 1; j < n; j++ {
+			if tvals[j] < endI {
+				cntBad++
+			}
+		}
+		costPost[i] = cntBad
+	}
+	best := 0
+	for e := 0; e < n; e++ {
+		if e <= k {
+			gap := tvals[e] - 1
+			if gap > best {
+				best = gap
+			}
+		}
+	}
+	for s := 0; s < n; s++ {
+		if costPre[s]+costPost[s] <= k {
+			gap := 86400 - (tvals[s] + dvals[s]) + 1
+			if gap > best {
+				best = gap
+			}
+		}
+	}
+	for s := 0; s < n; s++ {
+		pre := costPre[s]
+		if pre > k {
+			continue
+		}
+		baseEnd := tvals[s] + dvals[s]
+		maxMid := k - pre
+		limit := s + 1 + maxMid
+		if limit > n-1 {
+			limit = n - 1
+		}
+		for e := s + 1; e <= limit; e++ {
+			gap := tvals[e] - baseEnd
+			if gap > best {
+				best = gap
+			}
+		}
+	}
+	if best < 0 {
+		best = 0
+	}
+	if best > 86400 {
+		best = 86400
+	}
+	return best
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10)
+	k := 0
+	if n > 0 {
+		k = rng.Intn(n + 1)
+	}
+	tvals := make([]int, n)
+	dvals := make([]int, n)
+	cur := rng.Intn(86400-n+1) + 1
+	for i := 0; i < n; i++ {
+		tvals[i] = cur
+		dvals[i] = rng.Intn(1000) + 1
+		if i < n-1 {
+			cur += rng.Intn((86400-cur)-(n-i-1)) + 1
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", tvals[i], dvals[i])
+	}
+	return sb.String(), expectedE(n, k, tvals, dvals)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", t+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != fmt.Sprint(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", t+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone verifiers for Codeforces contest 158
- verifiers cover problems A–E and run 100 random tests each

## Testing
- `gofmt -w 0-999/100-199/150-159/158/verifierA.go`
- `gofmt -w 0-999/100-199/150-159/158/verifierB.go`
- `gofmt -w 0-999/100-199/150-159/158/verifierC.go`
- `gofmt -w 0-999/100-199/150-159/158/verifierD.go`
- `gofmt -w 0-999/100-199/150-159/158/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e8125221483248f282c9a9d520e17