### PR TITLE
Add Go verifiers for contest 157

### DIFF
--- a/0-999/100-199/150-159/157/verifierA.go
+++ b/0-999/100-199/150-159/157/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(board [][]int) int {
+	n := len(board)
+	rowSum := make([]int, n)
+	colSum := make([]int, n)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			v := board[i][j]
+			rowSum[i] += v
+			colSum[j] += v
+		}
+	}
+	cnt := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if colSum[j] > rowSum[i] {
+				cnt++
+			}
+		}
+	}
+	return cnt
+}
+
+func runCase(bin string, board [][]int) error {
+	var input strings.Builder
+	n := len(board)
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(fmt.Sprintf("%d", board[i][j]))
+		}
+		input.WriteByte('\n')
+	}
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input.String())
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(&buf, &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	exp := expected(board)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d\ninput:\n%s", exp, got, input.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(30) + 1
+		board := make([][]int, n)
+		for r := 0; r < n; r++ {
+			board[r] = make([]int, n)
+			for c := 0; c < n; c++ {
+				board[r][c] = rng.Intn(100) + 1
+			}
+		}
+		if err := runCase(bin, board); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/150-159/157/verifierB.go
+++ b/0-999/100-199/150-159/157/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(radii []int) float64 {
+	sort.Ints(radii)
+	n := len(radii)
+	var s float64
+	for i, r := range radii {
+		area := math.Pi * float64(r*r)
+		if n%2 == 1 {
+			if i%2 == 0 {
+				s += area
+			} else {
+				s -= area
+			}
+		} else {
+			if i%2 == 0 {
+				s -= area
+			} else {
+				s += area
+			}
+		}
+	}
+	return s
+}
+
+func runCase(bin string, radii []int) error {
+	var input strings.Builder
+	n := len(radii)
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for i, r := range radii {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprintf("%d", r))
+	}
+	input.WriteByte('\n')
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input.String())
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(&buf, &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	exp := expected(append([]int(nil), radii...))
+	if math.Abs(got-exp) > 1e-4*math.Max(1, math.Abs(exp)) {
+		return fmt.Errorf("expected %.5f got %.5f\ninput:\n%s", exp, got, input.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(100) + 1
+		radii := make([]int, n)
+		used := make(map[int]bool)
+		for j := 0; j < n; j++ {
+			for {
+				r := rng.Intn(1000) + 1
+				if !used[r] {
+					used[r] = true
+					radii[j] = r
+					break
+				}
+			}
+		}
+		if err := runCase(bin, radii); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add random-test verifiers for 157A and 157B
- each verifier runs 100 randomized test cases
- solutions can be tested via `go run verifierA.go ./binary` or `go run verifierB.go ./binary`

## Testing
- `go run verifierA.go ./157A`
- `go run verifierB.go ./157B`

------
https://chatgpt.com/codex/tasks/task_e_687e80de7d748324ba531c6834eef551