### PR TITLE
Add Go verifiers for Round 153

### DIFF
--- a/0-999/100-199/150-159/153/verifierA.go
+++ b/0-999/100-199/150-159/153/verifierA.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, a, b int) error {
+	input := fmt.Sprintf("%d %d\n", a, b)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	var got int
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != a+b {
+		return fmt.Errorf("expected %d got %d", a+b, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	edge := [][2]int{{1, 1}, {1, 100000}, {100000, 1}, {100000, 100000}, {2, 3}, {99999, 12345}}
+	idx := 0
+	for ; idx < len(edge); idx++ {
+		a, b := edge[idx][0], edge[idx][1]
+		if err := runCase(bin, a, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (a=%d b=%d)\n", idx+1, err, a, b)
+			os.Exit(1)
+		}
+	}
+	for ; idx < 100; idx++ {
+		a := rng.Intn(100000) + 1
+		b := rng.Intn(100000) + 1
+		if err := runCase(bin, a, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (a=%d b=%d)\n", idx+1, err, a, b)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}

--- a/0-999/100-199/150-159/153/verifierB.go
+++ b/0-999/100-199/150-159/153/verifierB.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("%d\n", n)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	expected := strconv.FormatInt(int64(n), 2)
+	if out != expected {
+		return fmt.Errorf("expected %s got %s", expected, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	edge := []int{1, 2, 3, 7, 8, 15, 16, 255, 256, 1000000}
+	idx := 0
+	for ; idx < len(edge); idx++ {
+		n := edge[idx]
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (n=%d)\n", idx+1, err, n)
+			os.Exit(1)
+		}
+	}
+	for ; idx < 100; idx++ {
+		n := rng.Intn(1000000) + 1
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (n=%d)\n", idx+1, err, n)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}

--- a/0-999/100-199/150-159/153/verifierC.go
+++ b/0-999/100-199/150-159/153/verifierC.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func encrypt(s string, k int) string {
+	r := []rune(s)
+	for i, ch := range r {
+		if ch >= 'A' && ch <= 'Z' {
+			r[i] = rune('A' + (int(ch-'A')+k)%26)
+		}
+	}
+	return string(r)
+}
+
+func runCase(bin, s string, k int) error {
+	input := fmt.Sprintf("%s %d\n", s, k)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	expected := encrypt(s, k)
+	if out != expected {
+		return fmt.Errorf("expected %s got %s", expected, out)
+	}
+	return nil
+}
+
+func randomString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('A' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	edge := []struct {
+		s string
+		k int
+	}{
+		{"A", 0}, {"Z", 0}, {"ABC", 25}, {"XYZ", 1}, {"HELLOWORLD", 13},
+	}
+	idx := 0
+	for ; idx < len(edge); idx++ {
+		c := edge[idx]
+		if err := runCase(bin, c.s, c.k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (s=%s k=%d)\n", idx+1, err, c.s, c.k)
+			os.Exit(1)
+		}
+	}
+	for ; idx < 100; idx++ {
+		s := randomString(rng, rng.Intn(10)+1)
+		k := rng.Intn(26)
+		if err := runCase(bin, s, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (s=%s k=%d)\n", idx+1, err, s, k)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}

--- a/0-999/100-199/150-159/153/verifierD.go
+++ b/0-999/100-199/150-159/153/verifierD.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, date time.Time, shift int) error {
+	input := fmt.Sprintf("%s %d\n", date.Format("02.01.2006"), shift)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	expected := date.AddDate(0, 0, shift).Format("02.01.2006")
+	if out != expected {
+		return fmt.Errorf("expected %s got %s", expected, out)
+	}
+	return nil
+}
+
+func randomDate(rng *rand.Rand) time.Time {
+	year := rng.Intn(41) + 1980 // 1980-2020
+	// choose a random day in the year
+	start := time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)
+	day := rng.Intn(365)
+	if start.AddDate(0, 0, day).Year() != year { // handle leap year
+		day = rng.Intn(366)
+	}
+	return start.AddDate(0, 0, day)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	edge := []struct {
+		date  time.Time
+		shift int
+	}{
+		{time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC), 0},
+		{time.Date(2020, 12, 31, 0, 0, 0, 0, time.UTC), -1},
+		{time.Date(2016, 2, 28, 0, 0, 0, 0, time.UTC), 1}, // leap year
+		{time.Date(2019, 12, 31, 0, 0, 0, 0, time.UTC), 1},
+	}
+	idx := 0
+	for ; idx < len(edge); idx++ {
+		e := edge[idx]
+		if err := runCase(bin, e.date, e.shift); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (date=%s shift=%d)\n", idx+1, err, e.date.Format("02.01.2006"), e.shift)
+			os.Exit(1)
+		}
+	}
+	for ; idx < 100; idx++ {
+		d := randomDate(rng)
+		shift := rng.Intn(2001) - 1000
+		if err := runCase(bin, d, shift); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v (date=%s shift=%d)\n", idx+1, err, d.Format("02.01.2006"), shift)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}

--- a/0-999/100-199/150-159/153/verifierE.go
+++ b/0-999/100-199/150-159/153/verifierE.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(pts [][2]int) float64 {
+	maxd2 := 0.0
+	for i := 0; i < len(pts); i++ {
+		for j := i + 1; j < len(pts); j++ {
+			dx := float64(pts[i][0] - pts[j][0])
+			dy := float64(pts[i][1] - pts[j][1])
+			d2 := dx*dx + dy*dy
+			if d2 > maxd2 {
+				maxd2 = d2
+			}
+		}
+	}
+	return math.Sqrt(maxd2)
+}
+
+func runCase(bin string, pts [][2]int) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", len(pts)))
+	for _, p := range pts {
+		input.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+	}
+	out, err := run(bin, input.String())
+	if err != nil {
+		return err
+	}
+	var got float64
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := expected(pts)
+	if math.Abs(got-exp) > 1e-4 {
+		return fmt.Errorf("expected %.5f got %.5f", exp, got)
+	}
+	return nil
+}
+
+func randomPoints(rng *rand.Rand, n int) [][2]int {
+	pts := make([][2]int, n)
+	for i := range pts {
+		pts[i][0] = rng.Intn(101) - 50
+		pts[i][1] = rng.Intn(101) - 50
+	}
+	return pts
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	edge := [][][2]int{
+		{{0, 0}, {0, 0}},
+		{{0, 0}, {3, 4}},
+		{{-50, -50}, {50, 50}},
+		{{-50, 50}, {50, -50}, {0, 0}},
+	}
+	idx := 0
+	for ; idx < len(edge); idx++ {
+		if err := runCase(bin, edge[idx]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	for ; idx < 100; idx++ {
+		n := rng.Intn(49) + 2
+		pts := randomPoints(rng, n)
+		if err := runCase(bin, pts); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for contest 153 problems A–E
- support running any binary or Go solution
- include 100 randomized tests in each verifier

## Testing
- `go build 0-999/100-199/150-159/153/verifierA.go`
- `go build 0-999/100-199/150-159/153/verifierB.go`
- `go build 0-999/100-199/150-159/153/verifierC.go`
- `go build 0-999/100-199/150-159/153/verifierD.go`
- `go build 0-999/100-199/150-159/153/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e7de308908324a5ff21559d9185e7