### PR TITLE
Add Go verifiers for contest 152

### DIFF
--- a/0-999/100-199/150-159/152/verifierA.go
+++ b/0-999/100-199/150-159/152/verifierA.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(input string) (string, error) {
+	in := strings.Fields(input)
+	if len(in) < 2 {
+		return "", fmt.Errorf("invalid input")
+	}
+	idx := 0
+	n := toInt(in[idx])
+	idx++
+	m := toInt(in[idx])
+	idx++
+	grades := make([]string, n)
+	for i := 0; i < n; i++ {
+		if idx >= len(in) {
+			return "", fmt.Errorf("invalid input grades")
+		}
+		grades[i] = in[idx]
+		idx++
+	}
+	maxGrade := make([]byte, m)
+	for j := 0; j < m; j++ {
+		maxGrade[j] = '0'
+		for i := 0; i < n; i++ {
+			if grades[i][j] > maxGrade[j] {
+				maxGrade[j] = grades[i][j]
+			}
+		}
+	}
+	count := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grades[i][j] == maxGrade[j] {
+				count++
+				break
+			}
+		}
+	}
+	return fmt.Sprintf("%d", count), nil
+}
+
+func toInt(s string) int {
+	var v int
+	fmt.Sscan(s, &v)
+	return v
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(8) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			sb.WriteByte(byte('1' + rng.Intn(9)))
+		}
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		exp, err := expected(strings.ReplaceAll(tc, "\n", " "))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/150-159/152/verifierB.go
+++ b/0-999/100-199/150-159/152/verifierB.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(input string) string {
+	fields := strings.Fields(input)
+	idx := 0
+	n := toInt64(fields[idx])
+	idx++
+	m := toInt64(fields[idx])
+	idx++
+	xc := toInt64(fields[idx])
+	idx++
+	yc := toInt64(fields[idx])
+	idx++
+	k := toInt(fields[idx])
+	idx++
+	var total int64
+	const inf int64 = 1 << 60
+	for i := 0; i < k; i++ {
+		dx := toInt64(fields[idx])
+		idx++
+		dy := toInt64(fields[idx])
+		idx++
+		var t1, t2 int64
+		if dx > 0 {
+			t1 = (n - xc) / dx
+		} else if dx < 0 {
+			t1 = (1 - xc) / dx
+		} else {
+			t1 = inf
+		}
+		if dy > 0 {
+			t2 = (m - yc) / dy
+		} else if dy < 0 {
+			t2 = (1 - yc) / dy
+		} else {
+			t2 = inf
+		}
+		t := t1
+		if t2 < t {
+			t = t2
+		}
+		if t < 0 {
+			t = 0
+		}
+		total += t
+		xc += t * dx
+		yc += t * dy
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+func toInt(s string) int {
+	var v int
+	fmt.Sscan(s, &v)
+	return v
+}
+
+func toInt64(s string) int64 {
+	var v int64
+	fmt.Sscan(s, &v)
+	return v
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Int63n(1000) + 1
+	m := rng.Int63n(1000) + 1
+	xc := rng.Int63n(n) + 1
+	yc := rng.Int63n(m) + 1
+	k := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	fmt.Fprintf(&sb, "%d %d\n", xc, yc)
+	fmt.Fprintf(&sb, "%d\n", k)
+	for i := 0; i < k; i++ {
+		dx := rng.Int63n(21) - 10
+		dy := rng.Int63n(21) - 10
+		if dx == 0 && dy == 0 {
+			dx = 1
+		}
+		fmt.Fprintf(&sb, "%d %d\n", dx, dy)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		exp := expected(strings.ReplaceAll(tc, "\n", " "))
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/150-159/152/verifierC.go
+++ b/0-999/100-199/150-159/152/verifierC.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func expected(input string) string {
+	fields := strings.Fields(input)
+	idx := 0
+	n := toInt(fields[idx])
+	idx++
+	m := toInt(fields[idx])
+	idx++
+	names := make([]string, n)
+	for i := 0; i < n; i++ {
+		names[i] = fields[idx]
+		idx++
+	}
+	res := 1
+	for col := 0; col < m; col++ {
+		seen := make(map[byte]bool)
+		for i := 0; i < n; i++ {
+			seen[names[i][col]] = true
+		}
+		res = res * len(seen) % mod
+	}
+	return fmt.Sprintf("%d", res)
+}
+
+func toInt(s string) int {
+	var v int
+	fmt.Sscan(s, &v)
+	return v
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomName(m int, rng *rand.Rand) string {
+	b := make([]byte, m)
+	for i := range b {
+		b[i] = byte('A' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	m := rng.Intn(6) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%s\n", randomName(m, rng))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		exp := expected(strings.ReplaceAll(tc, "\n", " "))
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/150-159/152/verifierD.go
+++ b/0-999/100-199/150-159/152/verifierD.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateFrame(n, m int, rng *rand.Rand) (int, int, int, int) {
+	x1 := rng.Intn(n-2) + 1
+	x2 := rng.Intn(n-x1-1) + x1 + 2
+	y1 := rng.Intn(m-2) + 1
+	y2 := rng.Intn(m-y1-1) + y1 + 2
+	return x1, y1, x2, y2
+}
+
+func applyFrame(g [][]byte, x1, y1, x2, y2 int) {
+	for y := y1; y <= y2; y++ {
+		g[x1][y] = '#'
+		g[x2][y] = '#'
+	}
+	for x := x1; x <= x2; x++ {
+		g[x][y1] = '#'
+		g[x][y2] = '#'
+	}
+}
+
+func generateYesCase(rng *rand.Rand) (string, [][]byte) {
+	n := rng.Intn(4) + 3 // 3..6
+	m := rng.Intn(4) + 3
+	grid := make([][]byte, n+1)
+	for i := range grid {
+		grid[i] = make([]byte, m+1)
+		for j := range grid[i] {
+			grid[i][j] = '.'
+		}
+	}
+	x1, y1, x2, y2 := generateFrame(n, m, rng)
+	x3, y3, x4, y4 := generateFrame(n, m, rng)
+	applyFrame(grid, x1, y1, x2, y2)
+	applyFrame(grid, x3, y3, x4, y4)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			sb.WriteByte(grid[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), grid
+}
+
+func generateNoCase(rng *rand.Rand) (string, [][]byte) {
+	s, g := generateYesCase(rng)
+	nFields := strings.Fields(s)
+	n := toInt(nFields[0])
+	m := toInt(nFields[1])
+	// flip random cell
+	x := rng.Intn(n) + 1
+	y := rng.Intn(m) + 1
+	if g[x][y] == '#' {
+		g[x][y] = '.'
+	} else {
+		g[x][y] = '#'
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			sb.WriteByte(g[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), g
+}
+
+func framesMatch(grid [][]byte, rects [][4]int) bool {
+	n := len(grid) - 1
+	m := len(grid[0]) - 1
+	other := make([][]byte, n+1)
+	for i := range other {
+		other[i] = make([]byte, m+1)
+		for j := range other[i] {
+			other[i][j] = '.'
+		}
+	}
+	for _, r := range rects {
+		x1, y1, x2, y2 := r[0], r[1], r[2], r[3]
+		if x1 < 1 || y1 < 1 || x2 > n || y2 > m || x1+2 > x2 || y1+2 > y2 {
+			return false
+		}
+		for y := y1; y <= y2; y++ {
+			other[x1][y] = '#'
+			other[x2][y] = '#'
+		}
+		for x := x1; x <= x2; x++ {
+			other[x][y1] = '#'
+			other[x][y2] = '#'
+		}
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			if other[i][j] != grid[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func findFrames(grid [][]byte) (bool, [4]int, [4]int) {
+	n := len(grid) - 1
+	m := len(grid[0]) - 1
+	for x1 := 1; x1 <= n-2; x1++ {
+		for x2 := x1 + 2; x2 <= n; x2++ {
+			for y1 := 1; y1 <= m-2; y1++ {
+				for y2 := y1 + 2; y2 <= m; y2++ {
+					for a1 := 1; a1 <= n-2; a1++ {
+						for a2 := a1 + 2; a2 <= n; a2++ {
+							for b1 := 1; b1 <= m-2; b1++ {
+								for b2 := b1 + 2; b2 <= m; b2++ {
+									rects := [][4]int{{x1, y1, x2, y2}, {a1, b1, a2, b2}}
+									if framesMatch(grid, rects) {
+										return true, [4]int{x1, y1, x2, y2}, [4]int{a1, b1, a2, b2}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return false, [4]int{}, [4]int{}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyOutput(grid [][]byte, output string, expectYes bool) error {
+	outR := bufio.NewReader(strings.NewReader(output))
+	var ans string
+	if _, err := fmt.Fscan(outR, &ans); err != nil {
+		return fmt.Errorf("bad output")
+	}
+	ans = strings.ToUpper(ans)
+	if ans == "NO" {
+		if expectYes {
+			return fmt.Errorf("expected YES got NO")
+		}
+		return nil
+	}
+	if ans != "YES" {
+		return fmt.Errorf("invalid first token")
+	}
+	var r1 [4]int
+	var r2 [4]int
+	if _, err := fmt.Fscan(outR, &r1[0], &r1[1], &r1[2], &r1[3]); err != nil {
+		return fmt.Errorf("failed to read first rectangle")
+	}
+	if _, err := fmt.Fscan(outR, &r2[0], &r2[1], &r2[2], &r2[3]); err != nil {
+		return fmt.Errorf("failed to read second rectangle")
+	}
+	if !framesMatch(grid, [][4]int{r1, r2}) {
+		return fmt.Errorf("rectangles do not match grid")
+	}
+	if !expectYes {
+		return fmt.Errorf("expected NO but got YES")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		var tc string
+		var grid [][]byte
+		var expectYes bool
+		if i%2 == 0 {
+			tc, grid = generateYesCase(rng)
+			expectYes = true
+		} else {
+			tc, grid = generateNoCase(rng)
+			ok, _, _ := findFrames(grid)
+			expectYes = ok
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if err := verifyOutput(grid, got, expectYes); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func toInt(s string) int {
+	var v int
+	fmt.Sscan(s, &v)
+	return v
+}

--- a/0-999/100-199/150-159/152/verifierE.go
+++ b/0-999/100-199/150-159/152/verifierE.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const INF = int(^uint(0) >> 1)
+
+func solve(n, m int, mat []int, specs [][2]int) int {
+	K := len(specs)
+	nm := n * m
+	st := make([]int, nm)
+	spec := make([]int, K)
+	for i, p := range specs {
+		idx := p[0]*m + p[1]
+		st[idx] = 1 << i
+		spec[i] = idx
+	}
+	maxMask := 1 << K
+	dp := make([][]int, nm)
+	inq := make([][]bool, nm)
+	preIdx := make([][]int, nm)
+	preMask := make([][]int, nm)
+	for i := 0; i < nm; i++ {
+		dp[i] = make([]int, maxMask)
+		inq[i] = make([]bool, maxMask)
+		preIdx[i] = make([]int, maxMask)
+		preMask[i] = make([]int, maxMask)
+		for j := 0; j < maxMask; j++ {
+			dp[i][j] = INF
+			preIdx[i][j] = -1
+		}
+	}
+	for i := 0; i < K; i++ {
+		idx := spec[i]
+		mask := 1 << i
+		dp[idx][mask] = mat[idx]
+	}
+	dx := []int{0, 1, 0, -1}
+	dy := []int{1, 0, -1, 0}
+	type node struct{ u, s int }
+	full := maxMask - 1
+	last := spec[K-1]
+	for s := 1; s <= full; s++ {
+		queue := make([]node, 0)
+		for u := 0; u < nm; u++ {
+			if st[u] != 0 && st[u]&s == 0 {
+				continue
+			}
+			for p := (s - 1) & s; p > 0; p = (p - 1) & s {
+				if dp[u][p] >= INF || dp[u][s-p] >= INF {
+					continue
+				}
+				s1 := p | st[u]
+				s2 := (s - p) | st[u]
+				cost := dp[u][s1] + dp[u][s2] - mat[u]
+				if cost < dp[u][s] {
+					dp[u][s] = cost
+					preIdx[u][s] = u
+					preMask[u][s] = s1
+				}
+			}
+			if dp[u][s] < INF {
+				inq[u][s] = true
+				queue = append(queue, node{u, s})
+			}
+		}
+		for head := 0; head < len(queue); head++ {
+			cur := queue[head]
+			u, ms := cur.u, cur.s
+			inq[u][ms] = false
+			ux := u / m
+			uy := u % m
+			base := dp[u][ms]
+			for dir := 0; dir < 4; dir++ {
+				vx := ux + dx[dir]
+				vy := uy + dy[dir]
+				if vx < 0 || vx >= n || vy < 0 || vy >= m {
+					continue
+				}
+				v := vx*m + vy
+				ts := ms | st[v]
+				nc := base + mat[v]
+				if nc < dp[v][ts] {
+					dp[v][ts] = nc
+					preIdx[v][ts] = u
+					preMask[v][ts] = ms
+					if !inq[v][ts] && ts == ms {
+						inq[v][ts] = true
+						queue = append(queue, node{v, ts})
+					}
+				}
+			}
+		}
+	}
+	return dp[last][full]
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(3) + 2 // 2..4
+	m := rng.Intn(3) + 2 // 2..4
+	k := rng.Intn(3) + 1 // 1..3
+	nm := n * m
+	mat := make([]int, nm)
+	for i := 0; i < nm; i++ {
+		mat[i] = rng.Intn(5) + 1
+	}
+	specs := make([][2]int, k)
+	posUsed := make(map[int]bool)
+	for i := 0; i < k; i++ {
+		for {
+			x := rng.Intn(n)
+			y := rng.Intn(m)
+			idx := x*m + y
+			if !posUsed[idx] {
+				posUsed[idx] = true
+				specs[i] = [2]int{x, y}
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < nm; i++ {
+		fmt.Fprintf(&sb, "%d ", mat[i])
+	}
+	sb.WriteByte('\n')
+	for _, p := range specs {
+		fmt.Fprintf(&sb, "%d %d\n", p[0]+1, p[1]+1)
+	}
+	cost := solve(n, m, mat, specs)
+	return sb.String(), cost
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return out.String(), nil
+}
+
+func parseOutput(n, m int, specs [][2]int, mat []int, output string, expect int) error {
+	r := bufio.NewReader(strings.NewReader(output))
+	var cost int
+	if _, err := fmt.Fscan(r, &cost); err != nil {
+		return fmt.Errorf("cannot read cost")
+	}
+	if cost != expect {
+		return fmt.Errorf("expected cost %d got %d", expect, cost)
+	}
+	layout := make([]string, n)
+	for i := 0; i < n; i++ {
+		line, err := r.ReadString('\n')
+		if err != nil && i != n-1 {
+			return fmt.Errorf("not enough lines")
+		}
+		line = strings.TrimSpace(line)
+		if len(line) != m {
+			return fmt.Errorf("invalid line length")
+		}
+		layout[i] = line
+	}
+	// check cost from layout
+	sum := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if layout[i][j] == 'X' {
+				sum += mat[i*m+j]
+			}
+		}
+	}
+	if sum != cost {
+		return fmt.Errorf("cost mismatch")
+	}
+	// check all special cells covered and connected
+	visited := make([][]bool, n)
+	for i := range visited {
+		visited[i] = make([]bool, m)
+	}
+	var start [2]int
+	for _, sp := range specs {
+		if layout[sp[0]][sp[1]] != 'X' {
+			return fmt.Errorf("special cell not covered")
+		}
+		start = sp
+	}
+	queue := [][2]int{start}
+	visited[start[0]][start[1]] = true
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for head := 0; head < len(queue); head++ {
+		p := queue[head]
+		for _, d := range dirs {
+			nx := p[0] + d[0]
+			ny := p[1] + d[1]
+			if nx >= 0 && nx < n && ny >= 0 && ny < m {
+				if !visited[nx][ny] && layout[nx][ny] == 'X' {
+					visited[nx][ny] = true
+					queue = append(queue, [2]int{nx, ny})
+				}
+			}
+		}
+	}
+	for _, sp := range specs {
+		if !visited[sp[0]][sp[1]] {
+			return fmt.Errorf("special cells not connected")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc, expect := generateCase(rng)
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		// parse input again to obtain matrix and specs
+		fields := strings.Fields(tc)
+		idx := 0
+		n := toInt(fields[idx])
+		idx++
+		m := toInt(fields[idx])
+		idx++
+		k := toInt(fields[idx])
+		idx++
+		nm := n * m
+		mat := make([]int, nm)
+		for i2 := 0; i2 < nm; i2++ {
+			mat[i2] = toInt(fields[idx])
+			idx++
+		}
+		specs := make([][2]int, k)
+		for i2 := 0; i2 < k; i2++ {
+			x := toInt(fields[idx])
+			idx++
+			y := toInt(fields[idx])
+			idx++
+			specs[i2] = [2]int{x - 1, y - 1}
+		}
+		if err := parseOutput(n, m, specs, mat, got, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, tc, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func toInt(s string) int {
+	var v int
+	fmt.Sscan(s, &v)
+	return v
+}


### PR DESCRIPTION
## Summary
- add new Go verifiers for contest 152 problems A–E
- each verifier generates 100 random tests and checks against a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e7d9d2f1c8324a48f45fbd81f2ff1