### PR TITLE
Add solution verifiers for contest 149

### DIFF
--- a/0-999/100-199/140-149/149/verifierA.go
+++ b/0-999/100-199/140-149/149/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expectedAnswer(k int, a []int) int {
+	if k == 0 {
+		return 0
+	}
+	sort.Slice(a, func(i, j int) bool { return a[i] > a[j] })
+	sum := 0
+	for i, v := range a {
+		sum += v
+		if sum >= k {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+func generateCase(rng *rand.Rand) (int, []int) {
+	k := rng.Intn(101)
+	a := make([]int, 12)
+	for i := range a {
+		a[i] = rng.Intn(101)
+	}
+	return k, a
+}
+
+func runCase(bin string, k int, a []int) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", k))
+	for i, v := range a {
+		input.WriteString(fmt.Sprintf("%d", v))
+		if i+1 < len(a) {
+			input.WriteByte(' ')
+		}
+	}
+	input.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expect := expectedAnswer(k, append([]int(nil), a...))
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// edge cases
+	for _, k := range []int{0, 1, 50, 100} {
+		a := make([]int, 12)
+		for i := range a {
+			a[i] = 0
+		}
+		if err := runCase(bin, k, a); err != nil {
+			fmt.Fprintf(os.Stderr, "edge case k=%d failed: %v\n", k, err)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		k, a := generateCase(rng)
+		if err := runCase(bin, k, a); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: k=%d a=%v\n", i+1, err, k, a)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/149/verifierB.go
+++ b/0-999/100-199/140-149/149/verifierB.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func charValue(r rune) int {
+	if r >= '0' && r <= '9' {
+		return int(r - '0')
+	}
+	return int(r-'A') + 10
+}
+
+func evaluate(digits []int, base int) int {
+	v := 0
+	for _, d := range digits {
+		v = v*base + d
+	}
+	return v
+}
+
+func expectedRadixes(t string) []int {
+	parts := strings.Split(t, ":")
+	aStr, bStr := parts[0], parts[1]
+	aDigits := make([]int, len(aStr))
+	bDigits := make([]int, len(bStr))
+	maxDigit := 0
+	for i, r := range aStr {
+		d := charValue(r)
+		aDigits[i] = d
+		if d > maxDigit {
+			maxDigit = d
+		}
+	}
+	for i, r := range bStr {
+		d := charValue(r)
+		bDigits[i] = d
+		if d > maxDigit {
+			maxDigit = d
+		}
+	}
+	minBase := maxDigit + 1
+	if minBase < 2 {
+		minBase = 2
+	}
+	aConst := true
+	for i := 0; i < len(aDigits)-1; i++ {
+		if aDigits[i] != 0 {
+			aConst = false
+			break
+		}
+	}
+	bConst := true
+	for i := 0; i < len(bDigits)-1; i++ {
+		if bDigits[i] != 0 {
+			bConst = false
+			break
+		}
+	}
+	aVal := evaluate(aDigits, minBase)
+	bVal := evaluate(bDigits, minBase)
+	if aConst && bConst && aVal <= 23 && bVal <= 59 {
+		return []int{-1}
+	}
+	res := []int{}
+	for base := minBase; base <= 60; base++ {
+		av := evaluate(aDigits, base)
+		bv := evaluate(bDigits, base)
+		if av <= 23 && bv <= 59 {
+			res = append(res, base)
+		}
+	}
+	if len(res) == 0 {
+		return []int{0}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) string {
+	l1 := rng.Intn(5) + 1
+	l2 := rng.Intn(5) + 1
+	sb := strings.Builder{}
+	for i := 0; i < l1; i++ {
+		v := rng.Intn(36)
+		if v < 10 {
+			sb.WriteByte(byte('0' + v))
+		} else {
+			sb.WriteByte(byte('A' + v - 10))
+		}
+	}
+	sb.WriteByte(':')
+	for i := 0; i < l2; i++ {
+		v := rng.Intn(36)
+		if v < 10 {
+			sb.WriteByte(byte('0' + v))
+		} else {
+			sb.WriteByte(byte('A' + v - 10))
+		}
+	}
+	return sb.String()
+}
+
+func runCase(bin string, input string, expect []int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input + "\n")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	got := []int{}
+	for _, f := range fields {
+		var v int
+		fmt.Sscanf(f, "%d", &v)
+		got = append(got, v)
+	}
+	if len(got) != len(expect) {
+		return fmt.Errorf("expected %v got %v", expect, got)
+	}
+	for i := range got {
+		if got[i] != expect[i] {
+			return fmt.Errorf("expected %v got %v", expect, got)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// deterministic edge cases
+	for _, t := range []string{"0:0", "1:1", "A:1", "1:A"} {
+		exp := expectedRadixes(t)
+		if err := runCase(bin, t, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %s failed: %v\n", t, err)
+			os.Exit(1)
+		}
+	}
+	for i := 0; i < 100; i++ {
+		t := generateCase(rng)
+		exp := expectedRadixes(t)
+		if err := runCase(bin, t, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %s\n", i+1, err, t)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/149/verifierC.go
+++ b/0-999/100-199/140-149/149/verifierC.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (int, []int) {
+	n := rng.Intn(19) + 2 // 2..20
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(20) + 1
+	}
+	return n, a
+}
+
+func checkOutput(n int, skills []int, out string) error {
+	fields := strings.Fields(out)
+	if len(fields) < 2 {
+		return fmt.Errorf("not enough output")
+	}
+	x, err := strconv.Atoi(fields[0])
+	if err != nil || x < 0 || x > n {
+		return fmt.Errorf("invalid x")
+	}
+	if len(fields) < 1+x+1 {
+		return fmt.Errorf("not enough ids for team1")
+	}
+	team1 := make([]int, x)
+	used := make([]bool, n)
+	for i := 0; i < x; i++ {
+		id, err := strconv.Atoi(fields[1+i])
+		if err != nil || id < 1 || id > n || used[id-1] {
+			return fmt.Errorf("invalid team1 id")
+		}
+		used[id-1] = true
+		team1[i] = id - 1
+	}
+	idx := 1 + x
+	if idx >= len(fields) {
+		return fmt.Errorf("missing y")
+	}
+	y, err := strconv.Atoi(fields[idx])
+	if err != nil || y < 0 || x+y != n {
+		return fmt.Errorf("invalid y")
+	}
+	if len(fields) != idx+1+y {
+		return fmt.Errorf("wrong number of ids for team2")
+	}
+	team2 := make([]int, y)
+	for i := 0; i < y; i++ {
+		id, err := strconv.Atoi(fields[idx+1+i])
+		if err != nil || id < 1 || id > n || used[id-1] {
+			return fmt.Errorf("invalid team2 id")
+		}
+		used[id-1] = true
+		team2[i] = id - 1
+	}
+	if x+y != n {
+		return fmt.Errorf("counts don't add up")
+	}
+	maxSkill := 0
+	for _, v := range skills {
+		if v > maxSkill {
+			maxSkill = v
+		}
+	}
+	sum1 := 0
+	for _, id := range team1 {
+		sum1 += skills[id]
+	}
+	sum2 := 0
+	for _, id := range team2 {
+		sum2 += skills[id]
+	}
+	if abs(sum1-sum2) > maxSkill {
+		return fmt.Errorf("skill difference too large")
+	}
+	if abs(x-y) > 1 {
+		return fmt.Errorf("team size difference too large")
+	}
+	return nil
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func runCase(bin string, n int, a []int) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		input.WriteString(fmt.Sprintf("%d", v))
+		if i+1 < n {
+			input.WriteByte(' ')
+		}
+	}
+	input.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if err := checkOutput(n, a, strings.TrimSpace(out.String())); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		n, a := generateCase(rng)
+		if err := runCase(bin, n, a); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput n=%d a=%v\n", i+1, err, n, a)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/149/verifierD.go
+++ b/0-999/100-199/140-149/149/verifierD.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+func generateSeq(pairs int, rng *rand.Rand) string {
+	seq := make([]byte, 0, 2*pairs)
+	open := 0
+	for len(seq) < 2*pairs {
+		remaining := 2*pairs - len(seq)
+		if open == 0 {
+			seq = append(seq, '(')
+			open++
+		} else if open == remaining {
+			seq = append(seq, ')')
+			open--
+		} else if rng.Intn(2) == 0 {
+			seq = append(seq, '(')
+			open++
+		} else {
+			seq = append(seq, ')')
+			open--
+		}
+	}
+	return string(seq)
+}
+
+func matchBrackets(s string) []int {
+	n := len(s)
+	match := make([]int, n)
+	stack := []int{}
+	for i, c := range s {
+		if c == '(' {
+			stack = append(stack, i)
+		} else {
+			l := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			match[i] = l
+			match[l] = i
+		}
+	}
+	return match
+}
+
+func countColorings(s string) int {
+	n := len(s)
+	match := matchBrackets(s)
+	colors := make([]int, n)
+	var dfs func(int, int) int
+	dfs = func(idx int, prev int) int {
+		if idx == n {
+			return 1
+		}
+		if colors[idx] != 0 {
+			col := colors[idx]
+			if prev > 0 && col == prev {
+				return 0
+			}
+			return dfs(idx+1, col)
+		}
+		if s[idx] == ')' {
+			return dfs(idx+1, prev)
+		}
+		j := match[idx]
+		total := 0
+		for _, col := range []int{1, 2} {
+			if prev > 0 && col == prev {
+				continue
+			}
+			colors[idx] = col
+			total = (total + dfs(idx+1, col)) % MOD
+			colors[idx] = 0
+		}
+		for _, col := range []int{1, 2} {
+			colors[j] = col
+			total = (total + dfs(idx+1, prev)) % MOD
+			colors[j] = 0
+		}
+		return total % MOD
+	}
+	return dfs(0, 0) % MOD
+}
+
+func runCase(bin string, s string, expect int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(s + "\n")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got%MOD != expect%MOD {
+		return fmt.Errorf("expected %d got %d", expect%MOD, got%MOD)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		pairs := rng.Intn(4) + 1 // up to 5 pairs => length up to 10
+		s := generateSeq(pairs, rng)
+		expect := countColorings(s)
+		if err := runCase(bin, s, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %s\n", i+1, err, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/149/verifierE.go
+++ b/0-999/100-199/140-149/149/verifierE.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(6) + 2 // 2..7
+	letters := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	sb := strings.Builder{}
+	for i := 0; i < n; i++ {
+		sb.WriteRune(letters[rng.Intn(26)])
+	}
+	s := sb.String()
+	m := rng.Intn(5) + 1
+	words := make([]string, 0, m)
+	seen := map[string]bool{}
+	for len(words) < m {
+		l := rng.Intn(5) + 1
+		sb.Reset()
+		for i := 0; i < l; i++ {
+			sb.WriteRune(letters[rng.Intn(26)])
+		}
+		w := sb.String()
+		if !seen[w] {
+			seen[w] = true
+			words = append(words, w)
+		}
+	}
+	return s, words
+}
+
+func bruteCount(s string, words []string) int {
+	n := len(s)
+	set := map[string]bool{}
+	for a := 0; a < n; a++ {
+		for b := a; b < n; b++ {
+			for c := b + 1; c < n; c++ {
+				for d := c; d < n; d++ {
+					w := s[a:b+1] + s[c:d+1]
+					set[w] = true
+				}
+			}
+		}
+	}
+	count := 0
+	for _, w := range words {
+		if set[w] {
+			count++
+		}
+	}
+	return count
+}
+
+func runCase(bin string, s string, words []string, expect int) error {
+	var input strings.Builder
+	input.WriteString(s + "\n")
+	input.WriteString(fmt.Sprintf("%d\n", len(words)))
+	for _, w := range words {
+		input.WriteString(w + "\n")
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		s, words := generateCase(rng)
+		exp := bruteCount(s, words)
+		if err := runCase(bin, s, words, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput s=%s words=%v\n", i+1, err, s, words)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 149
- each verifier generates over 100 random tests and checks a binary's output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e7ccaf8708324a7d5580547462ac9