### PR TITLE
Add solution verifiers for contest 146

### DIFF
--- a/0-999/100-199/140-149/146/verifierA.go
+++ b/0-999/100-199/140-149/146/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n      int
+	s      string
+	expect string
+}
+
+func expected(n int, s string) string {
+	if len(s) != n {
+		return "NO"
+	}
+	half := n / 2
+	sum1, sum2 := 0, 0
+	for i := 0; i < n; i++ {
+		ch := s[i]
+		if ch != '4' && ch != '7' {
+			return "NO"
+		}
+		d := int(ch - '0')
+		if i < half {
+			sum1 += d
+		} else {
+			sum2 += d
+		}
+	}
+	if sum1 == sum2 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(25)*2 + 2 // even between 2 and 50
+	digits := make([]byte, n)
+	for i := 0; i < n; i++ {
+		digits[i] = byte(rng.Intn(10)) + '0'
+	}
+	ticket := string(digits)
+	input := fmt.Sprintf("%d\n%s\n", n, ticket)
+	exp := expected(n, ticket)
+	return input, exp
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s", strings.TrimSpace(exp), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/146/verifierB.go
+++ b/0-999/100-199/140-149/146/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "146B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runOracle(oracle, input string) (string, error) {
+	cmd := exec.Command(oracle)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genLucky(rng *rand.Rand) int {
+	for {
+		length := rng.Intn(5) + 1
+		var sb strings.Builder
+		for i := 0; i < length; i++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('4')
+			} else {
+				sb.WriteByte('7')
+			}
+		}
+		v, _ := strconv.Atoi(sb.String())
+		if v >= 1 && v <= 100000 {
+			return v
+		}
+	}
+}
+
+func genCase(rng *rand.Rand, oracle string) (string, string, error) {
+	a := rng.Intn(100000) + 1
+	b := genLucky(rng)
+	input := fmt.Sprintf("%d %d\n", a, b)
+	exp, err := runOracle(oracle, input)
+	if err != nil {
+		return "", "", err
+	}
+	return input, exp, nil
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", strings.TrimSpace(expected), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp, err := genCase(rng, oracle)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go and verifierB.go for contest 146

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`

------
https://chatgpt.com/codex/tasks/task_e_687e7bf8da688324ada42a69df73f72a