### PR TITLE
Add Go verifiers for contest 145

### DIFF
--- a/0-999/100-199/140-149/145/verifierA.go
+++ b/0-999/100-199/140-149/145/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(a, b string) int {
+	cnt47, cnt74 := 0, 0
+	for i := range a {
+		if a[i] == '4' && b[i] == '7' {
+			cnt47++
+		} else if a[i] == '7' && b[i] == '4' {
+			cnt74++
+		}
+	}
+	if cnt47 > cnt74 {
+		return cnt47
+	}
+	return cnt74
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(50) + 1
+	var a, b strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			a.WriteByte('4')
+		} else {
+			a.WriteByte('7')
+		}
+		if rng.Intn(2) == 0 {
+			b.WriteByte('4')
+		} else {
+			b.WriteByte('7')
+		}
+	}
+	input := fmt.Sprintf("%s\n%s\n", a.String(), b.String())
+	return input, solve(a.String(), b.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		var got int
+		fmt.Sscan(out, &got)
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/145/verifierB.go
+++ b/0-999/100-199/140-149/145/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(a1, a2, a3, a4 int) string {
+	var start, end byte
+	switch {
+	case a3 == a4:
+		start, end = '4', '4'
+	case a3 == a4+1:
+		start, end = '4', '7'
+	case a4 == a3+1:
+		start, end = '7', '4'
+	default:
+		return "-1"
+	}
+	var seg4, seg7, k int
+	switch {
+	case start == '4' && end == '4':
+		k = a3
+		seg4, seg7 = k+1, k
+	case start == '4' && end == '7':
+		k = a4
+		seg4, seg7 = k+1, k+1
+	case start == '7' && end == '4':
+		k = a3
+		seg4, seg7 = k+1, k+1
+	case start == '7' && end == '7':
+		k = a3
+		seg4, seg7 = k, k+1
+	}
+	if a1 < seg4 || a2 < seg7 {
+		return "-1"
+	}
+	size4First := a1 - (seg4 - 1)
+	size7Last := a2 - (seg7 - 1)
+	totalLen := a1 + a2
+	var b strings.Builder
+	b.Grow(totalLen)
+	idx4, idx7 := 0, 0
+	current := start
+	for i := 0; i < seg4+seg7; i++ {
+		if current == '4' {
+			idx4++
+			cnt := 1
+			if idx4 == 1 {
+				cnt = size4First
+			}
+			b.WriteString(strings.Repeat("4", cnt))
+			current = '7'
+		} else {
+			idx7++
+			cnt := 1
+			if idx7 == seg7 {
+				cnt = size7Last
+			}
+			b.WriteString(strings.Repeat("7", cnt))
+			current = '4'
+		}
+	}
+	return b.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	a1 := rng.Intn(6)
+	a2 := rng.Intn(6)
+	a3 := rng.Intn(6)
+	a4 := rng.Intn(6)
+	input := fmt.Sprintf("%d %d %d %d\n", a1, a2, a3, a4)
+	return input, solveB(a1, a2, a3, a4)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/145/verifierC.go
+++ b/0-999/100-199/140-149/145/verifierC.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func isLucky(x int) bool {
+	if x <= 0 {
+		return false
+	}
+	for x > 0 {
+		d := x % 10
+		if d != 4 && d != 7 {
+			return false
+		}
+		x /= 10
+	}
+	return true
+}
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	a %= mod
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func modInv(a int64) int64 { return modPow(a, mod-2) }
+
+func nCr(n int64, r int, fact, invFact []int64) int64 {
+	if r < 0 || n < int64(r) {
+		return 0
+	}
+	return fact[n] * invFact[r] % mod * invFact[n-int64(r)] % mod
+}
+
+func solveCase(n, k int, arr []int) int64 {
+	freq := make(map[int]int)
+	U := 0
+	for _, x := range arr {
+		if isLucky(x) {
+			freq[x]++
+		} else {
+			U++
+		}
+	}
+	counts := make([]int, 0, len(freq))
+	for _, c := range freq {
+		counts = append(counts, c)
+	}
+	m := len(counts)
+	dp := make([]int64, m+1)
+	dp[0] = 1
+	for _, c := range counts {
+		cc := int64(c)
+		for t := m; t >= 1; t-- {
+			dp[t] = (dp[t] + dp[t-1]*cc) % mod
+		}
+	}
+	fact := make([]int64, n+1)
+	invFact := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invFact[n] = modInv(fact[n])
+	for i := n; i > 0; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % mod
+	}
+	ans := int64(0)
+	maxT := m
+	if k < maxT {
+		maxT = k
+	}
+	for t := 0; t <= maxT; t++ {
+		rem := k - t
+		if rem < 0 || rem > U {
+			continue
+		}
+		waysLucky := dp[t]
+		waysUnlucky := nCr(int64(U), rem, fact, invFact)
+		ans = (ans + waysLucky*waysUnlucky) % mod
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(4) == 0 {
+			// lucky number
+			digits := []int{4, 7}
+			val := 0
+			for j := 0; j < rng.Intn(3)+1; j++ {
+				val = val*10 + digits[rng.Intn(2)]
+			}
+			arr[i] = val
+		} else {
+			arr[i] = rng.Intn(100) + 1
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	exp := fmt.Sprintf("%d", solveCase(n, k, arr))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/145/verifierD.go
+++ b/0-999/100-199/140-149/145/verifierD.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isLucky(x int) bool {
+	if x <= 0 {
+		return false
+	}
+	for x > 0 {
+		d := x % 10
+		if d != 4 && d != 7 {
+			return false
+		}
+		x /= 10
+	}
+	return true
+}
+
+func noCommonLucky(a1, a2 []int) bool {
+	seen := make(map[int]bool)
+	for _, v := range a1 {
+		if isLucky(v) {
+			seen[v] = true
+		}
+	}
+	for _, v := range a2 {
+		if isLucky(v) && seen[v] {
+			return false
+		}
+	}
+	return true
+}
+
+func solve(arr []int) int64 {
+	n := len(arr)
+	var ans int64
+	for l1 := 0; l1 < n; l1++ {
+		for r1 := l1; r1 < n; r1++ {
+			for l2 := r1 + 1; l2 < n; l2++ {
+				for r2 := l2; r2 < n; r2++ {
+					if noCommonLucky(arr[l1:r1+1], arr[l2:r2+1]) {
+						ans++
+					}
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	arr := make([]int, n)
+	luckyVals := []int{4, 7, 44, 47, 74, 77}
+	for i := range arr {
+		if rng.Intn(3) == 0 {
+			arr[i] = luckyVals[rng.Intn(len(luckyVals))]
+		} else {
+			arr[i] = rng.Intn(100) + 1
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	exp := fmt.Sprintf("%d", solve(arr))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/145/verifierE.go
+++ b/0-999/100-199/140-149/145/verifierE.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func longestNonDecreasing(s []byte) int {
+	n := len(s)
+	prefix4 := make([]int, n+1)
+	suffix7 := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		prefix4[i+1] = prefix4[i]
+		if s[i] == '4' {
+			prefix4[i+1]++
+		}
+	}
+	for i := n - 1; i >= 0; i-- {
+		suffix7[i] = suffix7[i+1]
+		if s[i] == '7' {
+			suffix7[i]++
+		}
+	}
+	best := 0
+	for i := 0; i <= n; i++ {
+		val := prefix4[i] + suffix7[i]
+		if val > best {
+			best = val
+		}
+	}
+	return best
+}
+
+func solveCase(s string, queries []string) string {
+	arr := []byte(s)
+	var out strings.Builder
+	for _, q := range queries {
+		parts := strings.Fields(q)
+		if parts[0] == "switch" {
+			l := toInt(parts[1]) - 1
+			r := toInt(parts[2]) - 1
+			for i := l; i <= r; i++ {
+				if arr[i] == '4' {
+					arr[i] = '7'
+				} else {
+					arr[i] = '4'
+				}
+			}
+		} else {
+			out.WriteString(fmt.Sprintf("%d\n", longestNonDecreasing(arr)))
+		}
+	}
+	return strings.TrimRight(out.String(), "\n")
+}
+
+func toInt(s string) int { var x int; fmt.Sscan(s, &x); return x }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 1
+	m := rng.Intn(15) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	arr := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			arr[i] = '4'
+		} else {
+			arr[i] = '7'
+		}
+	}
+	sb.WriteString(string(arr))
+	sb.WriteByte('\n')
+	queries := make([]string, m)
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			queries[i] = fmt.Sprintf("switch %d %d", l, r)
+		} else {
+			queries[i] = "count"
+		}
+		sb.WriteString(queries[i])
+		sb.WriteByte('\n')
+	}
+	exp := solveCase(string(arr), queries)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifier programs for problems A–E of contest 145
- each verifier generates 100 random tests and runs any given binary (or Go file via `go run`)

## Testing
- `go run verifierA.go ./145A`
- `go run verifierB.go ./145B`
- `go run verifierC.go ./145C`
- `go run verifierD.go ./145D` *(fails: expected 5 got 4)*
- `go run verifierE.go ./145E`


------
https://chatgpt.com/codex/tasks/task_e_687e7bb4d2248324afbda3369aed7dca