### PR TITLE
Add verifiers for contest 143

### DIFF
--- a/0-999/100-199/140-149/143/verifierA.go
+++ b/0-999/100-199/140-149/143/verifierA.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	r1, r2, c1, c2, d1, d2 int
+	solvable               bool
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func hasSolution(r1, r2, c1, c2, d1, d2 int) bool {
+	for a := 1; a <= 9; a++ {
+		for b := 1; b <= 9; b++ {
+			if a == b || a+b != r1 {
+				continue
+			}
+			for c := 1; c <= 9; c++ {
+				if c == a || c == b || a+c != c1 {
+					continue
+				}
+				d := r2 - c
+				if d < 1 || d > 9 || d == a || d == b || d == c {
+					continue
+				}
+				if b+d != c2 {
+					continue
+				}
+				if a+d != d1 {
+					continue
+				}
+				if b+c != d2 {
+					continue
+				}
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		if rng.Intn(4) == 0 { // generate unsolvable case 25%
+			for {
+				r1 := rng.Intn(20) + 1
+				r2 := rng.Intn(20) + 1
+				c1 := rng.Intn(20) + 1
+				c2 := rng.Intn(20) + 1
+				d1 := rng.Intn(20) + 1
+				d2 := rng.Intn(20) + 1
+				if !hasSolution(r1, r2, c1, c2, d1, d2) {
+					cases[i] = testCase{r1, r2, c1, c2, d1, d2, false}
+					break
+				}
+			}
+		} else { // solvable case
+			digits := rng.Perm(9)[:4]
+			a, b, c, d := digits[0]+1, digits[1]+1, digits[2]+1, digits[3]+1
+			r1 := a + b
+			r2 := c + d
+			c1 := a + c
+			c2 := b + d
+			d1 := a + d
+			d2 := b + c
+			cases[i] = testCase{r1, r2, c1, c2, d1, d2, true}
+		}
+	}
+	return cases
+}
+
+func checkOutput(out string, tc testCase) error {
+	out = strings.TrimSpace(out)
+	if out == "-1" {
+		if tc.solvable {
+			return fmt.Errorf("expected solution but got -1")
+		}
+		if hasSolution(tc.r1, tc.r2, tc.c1, tc.c2, tc.d1, tc.d2) {
+			return fmt.Errorf("solution exists but program output -1")
+		}
+		return nil
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) != 2 {
+		return fmt.Errorf("expected 2 lines, got %d", len(lines))
+	}
+	var a, b, c, d int
+	if _, err := fmt.Sscan(lines[0], &a, &b); err != nil {
+		return fmt.Errorf("cannot parse first line: %v", err)
+	}
+	if _, err := fmt.Sscan(lines[1], &c, &d); err != nil {
+		return fmt.Errorf("cannot parse second line: %v", err)
+	}
+	vals := []int{a, b, c, d}
+	used := map[int]bool{}
+	for _, v := range vals {
+		if v < 1 || v > 9 {
+			return fmt.Errorf("value %d out of range", v)
+		}
+		if used[v] {
+			return fmt.Errorf("values not distinct")
+		}
+		used[v] = true
+	}
+	if a+b != tc.r1 || c+d != tc.r2 || a+c != tc.c1 || b+d != tc.c2 || a+d != tc.d1 || b+c != tc.d2 {
+		return fmt.Errorf("values do not satisfy equations")
+	}
+	if !tc.solvable {
+		return fmt.Errorf("expected -1 for unsolvable case")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		input := fmt.Sprintf("%d %d %d %d %d %d\n", tc.r1, tc.r2, tc.c1, tc.c2, tc.d1, tc.d2)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := checkOutput(out, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%soutput:%s\n", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/143/verifierB.go
+++ b/0-999/100-199/140-149/143/verifierB.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	num      string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func formatFinancial(s string) string {
+	negative := false
+	if strings.HasPrefix(s, "-") {
+		negative = true
+		s = s[1:]
+	}
+	intPart := s
+	fracPart := ""
+	if idx := strings.IndexByte(s, '.'); idx >= 0 {
+		intPart = s[:idx]
+		fracPart = s[idx+1:]
+	}
+	var b strings.Builder
+	n := len(intPart)
+	for i, ch := range intPart {
+		if i > 0 && (n-i)%3 == 0 {
+			b.WriteByte(',')
+		}
+		b.WriteRune(ch)
+	}
+	formattedInt := b.String()
+	if len(fracPart) < 2 {
+		fracPart += strings.Repeat("0", 2-len(fracPart))
+	} else if len(fracPart) > 2 {
+		fracPart = fracPart[:2]
+	}
+	result := fmt.Sprintf("$%s.%s", formattedInt, fracPart)
+	if negative {
+		result = fmt.Sprintf("(%s)", result)
+	}
+	return result
+}
+
+func randomNumber(rng *rand.Rand) string {
+	negative := rng.Intn(2) == 0
+	intLen := rng.Intn(15) + 1
+	intPart := make([]byte, intLen)
+	intPart[0] = byte('1' + rng.Intn(9))
+	for i := 1; i < intLen; i++ {
+		intPart[i] = byte('0' + rng.Intn(10))
+	}
+	if rng.Intn(5) == 0 {
+		intPart = []byte("0")
+	}
+	fracLen := rng.Intn(6)
+	fracPart := make([]byte, fracLen)
+	for i := 0; i < fracLen; i++ {
+		fracPart[i] = byte('0' + rng.Intn(10))
+	}
+	if string(intPart) == "0" && fracLen == 0 {
+		negative = false
+	}
+	s := ""
+	if negative {
+		s += "-"
+	}
+	s += string(intPart)
+	if fracLen > 0 {
+		s += "." + string(fracPart)
+	}
+	return s
+}
+
+func generateCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 100)
+	for i := range cases {
+		num := randomNumber(rng)
+		exp := formatFinancial(num)
+		cases[i] = testCase{num: num, expected: exp}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generateCases()
+	for i, tc := range cases {
+		input := tc.num + "\n"
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:%sexpected:%s\nactual:%s\n", i+1, input, tc.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` and `verifierB.go` for contest 143
- each verifier generates 100 random test cases and checks a provided binary
- includes validation logic for both solvable and unsolvable scenarios (A) and
  financial formatting (B)

## Testing
- `go build 0-999/100-199/140-149/143/verifierA.go`
- `go build 0-999/100-199/140-149/143/verifierB.go`
- `go run 0-999/100-199/140-149/143/verifierA.go ./143A_bin`
- `go run 0-999/100-199/140-149/143/verifierB.go ./143B_bin`

------
https://chatgpt.com/codex/tasks/task_e_687e7785a1288324ac5f4c0bce5fdcc0