### PR TITLE
Add solution verifiers for contest 140

### DIFF
--- a/0-999/100-199/140-149/140/verifierA.go
+++ b/0-999/100-199/140-149/140/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(n, R, r int) string {
+	Rf := float64(R)
+	rf := float64(r)
+	if n == 1 {
+		if Rf+1e-12 >= rf {
+			return "YES"
+		}
+		return "NO"
+	}
+	if R < 2*r {
+		return "NO"
+	}
+	angle := math.Pi / float64(n)
+	if math.Sin(angle)*(Rf-rf)+1e-12 >= rf {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	R := rng.Intn(1000) + 1
+	r := rng.Intn(1000) + 1
+	input := fmt.Sprintf("%d %d %d\n", n, R, r)
+	expect := solveA(n, R, r)
+	return input, expect
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCaseA(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/140/verifierB.go
+++ b/0-999/100-199/140-149/140/verifierB.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n       int
+	friends [][]int
+	alex    []int
+}
+
+func solveB(tc testCaseB) string {
+	n := tc.n
+	posF := make([][]int, n+1)
+	for i := 1; i <= n; i++ {
+		posF[i] = make([]int, n+1)
+		for j := 1; j <= n; j++ {
+			posF[i][tc.friends[i-1][j-1]] = j
+		}
+	}
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = tc.alex[i-1]
+	}
+	b1 := make([]int, n+1)
+	b2 := make([]int, n+1)
+	for k := 1; k <= n; k++ {
+		cnt := 0
+		for t := 1; t <= n; t++ {
+			card := a[t]
+			if card <= k {
+				cnt++
+				if cnt == 1 {
+					b1[k] = card
+				} else if cnt == 2 {
+					b2[k] = card
+					break
+				}
+			}
+		}
+	}
+	res := make([]int, n+1)
+	for j := 1; j <= n; j++ {
+		bestRank := n + 1
+		bestK := 1
+		for k := 1; k <= n; k++ {
+			cj := b1[k]
+			if cj == j {
+				cj = b2[k]
+			}
+			if cj == 0 {
+				continue
+			}
+			if posF[j][cj] < bestRank {
+				bestRank = posF[j][cj]
+				bestK = k
+			}
+		}
+		res[j] = bestK
+	}
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(res[i]))
+	}
+	return sb.String()
+}
+
+func generateCaseB(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 2
+	friends := make([][]int, n)
+	for i := 0; i < n; i++ {
+		perm := rng.Perm(n)
+		for j := range perm {
+			perm[j]++
+		}
+		friends[i] = perm
+	}
+	alexPerm := rng.Perm(n)
+	for j := range alexPerm {
+		alexPerm[j]++
+	}
+	tc := testCaseB{n: n, friends: friends, alex: alexPerm}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(friends[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	for j := 0; j < n; j++ {
+		if j > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(alexPerm[j]))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expect := solveB(tc)
+	return input, expect
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCaseB(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/140/verifierC.go
+++ b/0-999/100-199/140-149/140/verifierC.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func tryC(A []int, q int) bool {
+	n := len(A)
+	if n < 3*q {
+		return false
+	}
+	k := 0
+	if A[q-1] == A[n-q] {
+		return false
+	}
+	if A[q-1] == A[q] {
+		j := 0
+		for ; j < q; j++ {
+			if A[j] == A[q] {
+				break
+			}
+		}
+		i := q
+		for ; i < n; i++ {
+			if A[i] != A[q] {
+				break
+			}
+		}
+		i -= q
+		if i > j {
+			k += i - j
+		}
+	}
+	if n-k < 3*q {
+		return false
+	}
+	if A[n-q-1] == A[n-q] {
+		j := q
+		for ; j < n-q; j++ {
+			if A[j] == A[n-q] {
+				break
+			}
+		}
+		j -= k + q
+		i := n - q
+		for ; i < n; i++ {
+			if A[i] != A[n-q] {
+				break
+			}
+		}
+		i -= (n - q)
+		if i > j {
+			return false
+		}
+	}
+	return true
+}
+
+func outC(A []int, q int) string {
+	n := len(A)
+	i, j, k := 0, q, n-q
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for cnt := q; cnt > 0; cnt-- {
+		for A[i] == A[j] {
+			j++
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", A[k], A[j], A[i]))
+		i++
+		j++
+		k++
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func solveC(nums []int) string {
+	A := append([]int(nil), nums...)
+	sort.Ints(A)
+	l, r := 0, len(A)
+	for r > l+1 {
+		m := (l + r) / 2
+		if tryC(A, m) {
+			l = m
+		} else {
+			r = m
+		}
+	}
+	return outC(A, l)
+}
+
+func generateCaseC(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 3
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(20) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(arr[i]))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expect := solveC(arr)
+	return input, expect
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCaseC(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/140/verifierD.go
+++ b/0-999/100-199/140-149/140/verifierD.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveD(times []int) string {
+	sort.Ints(times)
+	const total = 710
+	const free = 350
+	sum := 0
+	count := 0
+	for _, t := range times {
+		if sum+t > total {
+			break
+		}
+		sum += t
+		count++
+	}
+	penalty := 0
+	sum = 0
+	for i := 0; i < count; i++ {
+		sum += times[i]
+		if sum > free {
+			penalty += sum - free
+		}
+	}
+	return fmt.Sprintf("%d %d", count, penalty)
+}
+
+func generateCaseD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(700) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(arr[i]))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expect := solveD(arr)
+	return input, expect
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCaseD(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/140/verifierE.go
+++ b/0-999/100-199/140-149/140/verifierE.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func enumerateSeq(m, length int, prev int, mask int, cnt []int) {
+	if length == 0 {
+		cnt[mask]++
+		return
+	}
+	for c := 0; c < m; c++ {
+		if c == prev {
+			continue
+		}
+		enumerateSeq(m, length-1, c, mask|(1<<c), cnt)
+	}
+}
+
+func layerWays(m int, l int) []int {
+	size := 1 << m
+	cnt := make([]int, size)
+	enumerateSeq(m, l, -1, 0, cnt)
+	return cnt
+}
+
+func solveE(n, m int, p int64, ls []int) string {
+	ways := make([][]int, n)
+	for i := 0; i < n; i++ {
+		ways[i] = layerWays(m, ls[i])
+	}
+	size := 1 << m
+	dp := make([]int64, size)
+	for mask, v := range ways[0] {
+		dp[mask] = int64(v) % p
+	}
+	for i := 1; i < n; i++ {
+		ndp := make([]int64, size)
+		for pm, pv := range dp {
+			if pv == 0 {
+				continue
+			}
+			for cm, cv := range ways[i] {
+				if cm != pm {
+					ndp[cm] = (ndp[cm] + pv*int64(cv)) % p
+				}
+			}
+		}
+		dp = ndp
+	}
+	var total int64
+	for _, v := range dp {
+		total = (total + v) % p
+	}
+	return fmt.Sprint(total)
+}
+
+func generateCaseE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 2
+	ls := make([]int, n)
+	for i := 0; i < n; i++ {
+		ls[i] = rng.Intn(3) + 1
+	}
+	p := int64(1000000007)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, p))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(ls[i]))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expect := solveE(n, m, p, ls)
+	return input, expect
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCaseE(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/140/verifierF.go
+++ b/0-999/100-199/140-149/140/verifierF.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type point struct {
+	x, y int
+}
+
+type pair struct {
+	x, y int
+}
+
+func checkCenter(cx2, cy2 int, pts []point, k int) bool {
+	mp := make(map[pair]int)
+	for _, p := range pts {
+		mp[pair{p.x, p.y}]++
+	}
+	removed := 0
+	for _, p := range pts {
+		if mp[pair{p.x, p.y}] == 0 {
+			continue
+		}
+		mp[pair{p.x, p.y}]--
+		sym := pair{cx2 - p.x, cy2 - p.y}
+		if mp[sym] > 0 {
+			mp[sym]--
+		} else {
+			removed++
+			if removed > k {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func solveF(n, k int, pts []point) string {
+	if k >= n {
+		return "-1"
+	}
+	candMap := make(map[pair]struct{})
+	for i := 0; i < n; i++ {
+		candMap[pair{2 * pts[i].x, 2 * pts[i].y}] = struct{}{}
+		for j := i + 1; j < n; j++ {
+			candMap[pair{pts[i].x + pts[j].x, pts[i].y + pts[j].y}] = struct{}{}
+		}
+	}
+	res := make([]pair, 0)
+	for c := range candMap {
+		if checkCenter(c.x, c.y, pts, k) {
+			res = append(res, c)
+		}
+	}
+	sort.Slice(res, func(i, j int) bool {
+		if res[i].x != res[j].x {
+			return res[i].x < res[j].x
+		}
+		return res[i].y < res[j].y
+	})
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(res)))
+	for _, c := range res {
+		sb.WriteString(fmt.Sprintf("%.1f %.1f\n", float64(c.x)/2.0, float64(c.y)/2.0))
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func generateCaseF(rng *rand.Rand) (string, string) {
+	n := rng.Intn(7) + 2
+	k := rng.Intn(3)
+	if k >= n {
+		k = n - 1
+	}
+	pts := make([]point, 0, n)
+	used := make(map[pair]bool)
+	for len(pts) < n {
+		x := rng.Intn(21) - 10
+		y := rng.Intn(21) - 10
+		p := pair{x, y}
+		if !used[p] {
+			used[p] = true
+			pts = append(pts, point{x, y})
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", pts[i].x, pts[i].y))
+	}
+	input := sb.String()
+	expect := solveF(n, k, pts)
+	return input, expect
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCaseF(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifierA.go for problem 140A
- add Go verifierB.go for problem 140B
- add Go verifierC.go for problem 140C
- add Go verifierD.go for problem 140D
- add Go verifierE.go for problem 140E
- add Go verifierF.go for problem 140F

All verifiers generate 100 random test cases, run the supplied binary, and compare the output against a reference implementation.

## Testing
- `go build 0-999/100-199/140-149/140/verifierA.go`
- `go build 0-999/100-199/140-149/140/verifierB.go`
- `go build 0-999/100-199/140-149/140/verifierC.go`
- `go build 0-999/100-199/140-149/140/verifierD.go`
- `go build 0-999/100-199/140-149/140/verifierE.go`
- `go build 0-999/100-199/140-149/140/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6eda9c2c832499e7cb240e54a2be