### PR TITLE
Add verifiers for contest 144

### DIFF
--- a/0-999/100-199/140-149/144/verifierA.go
+++ b/0-999/100-199/140-149/144/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(a []int) int {
+	n := len(a)
+	maxVal, minVal := a[0], a[0]
+	maxIdx, minIdx := 0, 0
+	for i, v := range a {
+		if v > maxVal {
+			maxVal = v
+			maxIdx = i
+		}
+		if v <= minVal {
+			minVal = v
+			minIdx = i
+		}
+	}
+	moves := maxIdx + (n - 1 - minIdx)
+	if maxIdx > minIdx {
+		moves--
+	}
+	return moves
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(99) + 2
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	exp := fmt.Sprintf("%d", expected(arr))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/144/verifierB.go
+++ b/0-999/100-199/140-149/144/verifierB.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type heater struct {
+	x, y, r int
+}
+
+func covered(x, y int, hs []heater) bool {
+	for _, h := range hs {
+		dx := x - h.x
+		dy := y - h.y
+		if dx*dx+dy*dy <= h.r*h.r {
+			return true
+		}
+	}
+	return false
+}
+
+func expected(xa, ya, xb, yb int, hs []heater) string {
+	minX, maxX := xa, xb
+	if minX > maxX {
+		minX, maxX = maxX, minX
+	}
+	minY, maxY := ya, yb
+	if minY > maxY {
+		minY, maxY = maxY, minY
+	}
+	blankets := 0
+	for x := minX; x <= maxX; x++ {
+		if !covered(x, minY, hs) {
+			blankets++
+		}
+		if minY != maxY && !covered(x, maxY, hs) {
+			blankets++
+		}
+	}
+	for y := minY + 1; y <= maxY-1; y++ {
+		if !covered(minX, y, hs) {
+			blankets++
+		}
+		if minX != maxX && !covered(maxX, y, hs) {
+			blankets++
+		}
+	}
+	return fmt.Sprintf("%d", blankets)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	xa := rng.Intn(21) - 10
+	ya := rng.Intn(21) - 10
+	xb := rng.Intn(21) - 10
+	for xb == xa {
+		xb = rng.Intn(21) - 10
+	}
+	yb := rng.Intn(21) - 10
+	for yb == ya {
+		yb = rng.Intn(21) - 10
+	}
+	n := rng.Intn(5) + 1
+	hs := make([]heater, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", xa, ya, xb, yb))
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		hs[i].x = rng.Intn(21) - 10
+		hs[i].y = rng.Intn(21) - 10
+		hs[i].r = rng.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", hs[i].x, hs[i].y, hs[i].r))
+	}
+	exp := expected(xa, ya, xb, yb, hs)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/144/verifierC.go
+++ b/0-999/100-199/140-149/144/verifierC.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(s, p string) string {
+	n := len(s)
+	m := len(p)
+	if m > n {
+		return "0"
+	}
+	var countP [26]int
+	for i := 0; i < m; i++ {
+		countP[p[i]-'a']++
+	}
+	var countS [26]int
+	question := 0
+	for i := 0; i < m; i++ {
+		ch := s[i]
+		if ch == '?' {
+			question++
+		} else {
+			countS[ch-'a']++
+		}
+	}
+	check := func() bool {
+		total := 0
+		for c := 0; c < 26; c++ {
+			if countS[c] > countP[c] {
+				return false
+			}
+			total += countP[c] - countS[c]
+		}
+		return total == question
+	}
+	ans := 0
+	if check() {
+		ans++
+	}
+	for i := m; i < n; i++ {
+		old := s[i-m]
+		if old == '?' {
+			question--
+		} else {
+			countS[old-'a']--
+		}
+		ch := s[i]
+		if ch == '?' {
+			question++
+		} else {
+			countS[ch-'a']++
+		}
+		if check() {
+			ans++
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(n) + 1
+	alphabet := []byte("abcde")
+	sbS := strings.Builder{}
+	for i := 0; i < n; i++ {
+		if rng.Intn(5) == 0 {
+			sbS.WriteByte('?')
+		} else {
+			sbS.WriteByte(alphabet[rng.Intn(len(alphabet))])
+		}
+	}
+	sbP := strings.Builder{}
+	for i := 0; i < m; i++ {
+		sbP.WriteByte(alphabet[rng.Intn(len(alphabet))])
+	}
+	s := sbS.String()
+	p := sbP.String()
+	input := s + "\n" + p + "\n"
+	exp := expected(s, p)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/144/verifierD.go
+++ b/0-999/100-199/140-149/144/verifierD.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type edge struct {
+	u, v int
+	w    int64
+}
+
+type item struct {
+	v    int
+	dist int64
+}
+
+type minHeap []item
+
+func (h minHeap) Len() int            { return len(h) }
+func (h minHeap) Less(i, j int) bool  { return h[i].dist < h[j].dist }
+func (h minHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *minHeap) Push(x interface{}) { *h = append(*h, x.(item)) }
+func (h *minHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	it := old[n-1]
+	*h = old[:n-1]
+	return it
+}
+
+func expected(n, m, s int, L int64, edges []edge) string {
+	adj := make([][]struct {
+		to int
+		w  int64
+	}, n+1)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], struct {
+			to int
+			w  int64
+		}{e.v, e.w})
+		adj[e.v] = append(adj[e.v], struct {
+			to int
+			w  int64
+		}{e.u, e.w})
+	}
+	const INF = int64(1 << 60)
+	dist := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = INF
+	}
+	pq := &minHeap{}
+	heap.Init(pq)
+	dist[s] = 0
+	heap.Push(pq, item{v: s, dist: 0})
+	for pq.Len() > 0 {
+		cur := heap.Pop(pq).(item)
+		if cur.dist != dist[cur.v] {
+			continue
+		}
+		for _, e := range adj[cur.v] {
+			nd := cur.dist + e.w
+			if nd < dist[e.to] {
+				dist[e.to] = nd
+				heap.Push(pq, item{v: e.to, dist: nd})
+			}
+		}
+	}
+	var ans int64
+	for i := 1; i <= n; i++ {
+		if dist[i] == L {
+			ans++
+		}
+	}
+	for _, e := range edges {
+		du := dist[e.u]
+		dv := dist[e.v]
+		w := e.w
+		flagU := du < L && du+w > L && du+dv+w >= 2*L
+		flagV := dv < L && dv+w > L && du+dv+w >= 2*L
+		if flagU && flagV && du+dv+w == 2*L {
+			ans++
+		} else {
+			if flagU {
+				ans++
+			}
+			if flagV {
+				ans++
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges-(n-1)+1) + (n - 1)
+	edges := make([]edge, 0, m)
+	parent := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		w := int64(rng.Intn(10) + 1)
+		edges = append(edges, edge{p, i, w})
+		parent[i] = p
+	}
+	existing := map[[2]int]bool{}
+	for _, e := range edges {
+		if e.u < e.v {
+			existing[[2]int{e.u, e.v}] = true
+		} else {
+			existing[[2]int{e.v, e.u}] = true
+		}
+	}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		key := [2]int{u, v}
+		if u > v {
+			key = [2]int{v, u}
+		}
+		if existing[key] {
+			continue
+		}
+		existing[key] = true
+		w := int64(rng.Intn(10) + 1)
+		edges = append(edges, edge{u, v, w})
+	}
+	s := rng.Intn(n) + 1
+	L := int64(rng.Intn(20) + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, len(edges), s))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.u, e.v, e.w))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", L))
+	exp := expected(n, len(edges), s, L, edges)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/140-149/144/verifierE.go
+++ b/0-999/100-199/140-149/144/verifierE.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type segment struct {
+	l, r int
+	idx  int
+}
+
+type item struct {
+	r   int
+	idx int
+}
+
+type minHeap []item
+
+func (h minHeap) Len() int            { return len(h) }
+func (h minHeap) Less(i, j int) bool  { return h[i].r < h[j].r }
+func (h minHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *minHeap) Push(x interface{}) { *h = append(*h, x.(item)) }
+func (h *minHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	it := old[n-1]
+	*h = old[:n-1]
+	return it
+}
+
+func expected(n int, segs []segment) string {
+	sort.Slice(segs, func(i, j int) bool { return segs[i].l < segs[j].l })
+	h := &minHeap{}
+	heap.Init(h)
+	ans := make([]int, 0, len(segs))
+	j := 0
+	for l := 1; l <= n; l++ {
+		for j < len(segs) && segs[j].l == l {
+			heap.Push(h, item{r: segs[j].r, idx: segs[j].idx})
+			j++
+		}
+		for h.Len() > 0 && (*h)[0].r < l {
+			heap.Pop(h)
+		}
+		if h.Len() > 0 {
+			it := heap.Pop(h).(item)
+			ans = append(ans, it.idx)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d", len(ans)))
+	if len(ans) > 0 {
+		sb.WriteByte('\n')
+		for i, v := range ans {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+	} else {
+		sb.WriteByte('\n')
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	segs := make([]segment, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		var r, c int
+		for {
+			r = rng.Intn(n) + 1
+			c = rng.Intn(n) + 1
+			if r+c > n {
+				break
+			}
+		}
+		segs[i] = segment{l: n - r + 1, r: c, idx: i + 1}
+		sb.WriteString(fmt.Sprintf("%d %d\n", r, c))
+	}
+	exp := expected(n, segs)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems of Codeforces contest 144
- each verifier runs 100 randomly generated tests against any executable

## Testing
- `go run verifierA.go ./144A`
- `go run verifierB.go ./144B`
- `go run verifierC.go ./144C`
- `go run verifierD.go ./144D`
- `go run verifierE.go ./144E`

------
https://chatgpt.com/codex/tasks/task_e_687e77cbdbdc8324bd7f1c3f9da306fe