### PR TITLE
Add Go verifiers for Codeforces contest 138

### DIFF
--- a/0-999/100-199/130-139/138/verifierA.go
+++ b/0-999/100-199/130-139/138/verifierA.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isVowel(b byte) bool {
+	switch b {
+	case 'a', 'e', 'i', 'o', 'u':
+		return true
+	}
+	return false
+}
+
+func getSuffix(s string, k int) string {
+	cnt := 0
+	for i := len(s) - 1; i >= 0; i-- {
+		if isVowel(s[i]) {
+			cnt++
+			if cnt == k {
+				return s[i:]
+			}
+		}
+	}
+	return ""
+}
+
+func expectedAnswer(lines []string, k int) string {
+	n := len(lines) / 4
+	suffixes := make([]string, len(lines))
+	for i, line := range lines {
+		suffixes[i] = getSuffix(line, k)
+		if suffixes[i] == "" {
+			return "NO"
+		}
+	}
+	possibleAABB, possibleABAB, possibleABBA := true, true, true
+	allAAAA := true
+	for i := 0; i < n; i++ {
+		a := suffixes[4*i]
+		b := suffixes[4*i+1]
+		c := suffixes[4*i+2]
+		d := suffixes[4*i+3]
+		if a == b && b == c && c == d {
+			continue
+		}
+		allAAAA = false
+		curAABB := (a == b && c == d)
+		curABAB := (a == c && b == d)
+		curABBA := (a == d && b == c)
+		if !curAABB && !curABAB && !curABBA {
+			return "NO"
+		}
+		if !curAABB {
+			possibleAABB = false
+		}
+		if !curABAB {
+			possibleABAB = false
+		}
+		if !curABBA {
+			possibleABBA = false
+		}
+	}
+	if allAAAA {
+		return "aaaa"
+	}
+	count := 0
+	scheme := ""
+	if possibleAABB {
+		count++
+		scheme = "aabb"
+	}
+	if possibleABAB {
+		count++
+		scheme = "abab"
+	}
+	if possibleABBA {
+		count++
+		scheme = "abba"
+	}
+	if count == 1 {
+		return scheme
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	lines := make([]string, 4*n)
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	vowels := "aeiou"
+	for i := 0; i < 4*n; i++ {
+		l := rng.Intn(10) + 1
+		var w strings.Builder
+		for j := 0; j < l; j++ {
+			if rng.Float64() < 0.4 {
+				w.WriteByte(vowels[rng.Intn(len(vowels))])
+			} else {
+				w.WriteByte(letters[rng.Intn(len(letters))])
+			}
+		}
+		lines[i] = w.String()
+		fmt.Fprintln(&sb, lines[i])
+	}
+	exp := expectedAnswer(lines, k)
+	return sb.String(), exp
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/138/verifierB.go
+++ b/0-999/100-199/130-139/138/verifierB.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type state struct {
+	c1    [10]uint8
+	c2    [10]uint8
+	carry uint8
+}
+
+func encode(st state) string {
+	var b bytes.Buffer
+	for i := 0; i < 10; i++ {
+		b.WriteByte(st.c1[i])
+	}
+	for i := 0; i < 10; i++ {
+		b.WriteByte(st.c2[i])
+	}
+	b.WriteByte(st.carry)
+	return b.String()
+}
+
+func dfs(c1, c2 [10]uint8, carry uint8, memo map[string]int) int {
+	st := state{c1, c2, carry}
+	key := encode(st)
+	if v, ok := memo[key]; ok {
+		return v
+	}
+	best := 0
+	for i := 0; i < 10; i++ {
+		if c1[i] == 0 {
+			continue
+		}
+		c1[i]--
+		for j := 0; j < 10; j++ {
+			if c2[j] == 0 {
+				continue
+			}
+			c2[j]--
+			if int(i)+int(j)+int(carry)%10 == 0 {
+				newCarry := uint8((int(i) + int(j) + int(carry)) / 10)
+				val := 1 + dfs(c1, c2, newCarry, memo)
+				if val > best {
+					best = val
+				}
+			}
+			c2[j]++
+		}
+		c1[i]++
+	}
+	memo[key] = best
+	return best
+}
+
+func maxTrailingZeros(s string) int {
+	var c1, c2 [10]uint8
+	for i := 0; i < len(s); i++ {
+		d := s[i] - '0'
+		c1[d]++
+		c2[d]++
+	}
+	memo := make(map[string]int)
+	return dfs(c1, c2, 0, memo)
+}
+
+func trailingZerosOfSum(a, b string) int {
+	i := len(a) - 1
+	j := len(b) - 1
+	carry := 0
+	zeros := 0
+	for i >= 0 || j >= 0 {
+		da, db := 0, 0
+		if i >= 0 {
+			da = int(a[i] - '0')
+			i--
+		}
+		if j >= 0 {
+			db = int(b[j] - '0')
+			j--
+		}
+		v := da + db + carry
+		d := v % 10
+		carry = v / 10
+		if d == 0 {
+			zeros++
+		} else {
+			return zeros
+		}
+	}
+	if carry%10 == 0 && carry > 0 {
+		zeros++
+	}
+	return zeros
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	l := rng.Intn(6) + 1
+	var sb strings.Builder
+	digits := make([]byte, l)
+	for i := 0; i < l; i++ {
+		digits[i] = byte('0' + rng.Intn(10))
+	}
+	s := string(digits)
+	fmt.Fprintf(&sb, "%s\n", s)
+	exp := maxTrailingZeros(s)
+	return sb.String(), exp
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, in)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) < 2 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected two lines of output\n", t)
+			os.Exit(1)
+		}
+		a := strings.TrimSpace(lines[0])
+		b := strings.TrimSpace(lines[1])
+		if len(a) != len(strings.TrimSpace(in))-1 || len(b) != len(strings.TrimSpace(in))-1 {
+			fmt.Fprintf(os.Stderr, "case %d failed: output length mismatch\n", t)
+			os.Exit(1)
+		}
+		var cntOrig [10]int
+		for i := 0; i < len(in)-1; i++ {
+			cntOrig[in[i]-'0']++
+		}
+		var cntA, cntB [10]int
+		for i := 0; i < len(a); i++ {
+			if a[i] < '0' || a[i] > '9' {
+				fmt.Fprintf(os.Stderr, "case %d failed: invalid digit in output\n", t)
+				os.Exit(1)
+			}
+			cntA[a[i]-'0']++
+		}
+		for i := 0; i < len(b); i++ {
+			if b[i] < '0' || b[i] > '9' {
+				fmt.Fprintf(os.Stderr, "case %d failed: invalid digit in output\n", t)
+				os.Exit(1)
+			}
+			cntB[b[i]-'0']++
+		}
+		for d := 0; d < 10; d++ {
+			if cntA[d] != cntOrig[d] || cntB[d] != cntOrig[d] {
+				fmt.Fprintf(os.Stderr, "case %d failed: output is not a permutation\n", t)
+				os.Exit(1)
+			}
+		}
+		got := trailingZerosOfSum(a, b)
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d trailing zeros, got %d\ninput:\n%soutput:\n%s", t, exp, got, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/138/verifierC.go
+++ b/0-999/100-199/130-139/138/verifierC.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Tree struct {
+	a, h int
+	l, r int
+}
+
+type Mush struct {
+	b, z int
+}
+
+func expected(trees []Tree, mush []Mush) float64 {
+	n := len(trees)
+	m := len(mush)
+	var dfs func(idx int, prob float64, mask int)
+	total := 0.0
+	dfs = func(idx int, prob float64, mask int) {
+		if idx == n {
+			sum := 0
+			for j := 0; j < m; j++ {
+				if mask&(1<<j) != 0 {
+					sum += mush[j].z
+				}
+			}
+			total += prob * float64(sum)
+			return
+		}
+		t := trees[idx]
+		// stand
+		pStand := float64(100-t.l-t.r) / 100.0
+		if pStand > 0 {
+			dfs(idx+1, prob*pStand, mask)
+		}
+		// left
+		if t.l > 0 {
+			newMask := mask
+			for j := 0; j < m; j++ {
+				if newMask&(1<<j) == 0 {
+					continue
+				}
+				if mush[j].b >= t.a-t.h && mush[j].b < t.a {
+					newMask &^= 1 << j
+				}
+			}
+			dfs(idx+1, prob*float64(t.l)/100.0, newMask)
+		}
+		// right
+		if t.r > 0 {
+			newMask := mask
+			for j := 0; j < m; j++ {
+				if newMask&(1<<j) == 0 {
+					continue
+				}
+				if mush[j].b > t.a && mush[j].b <= t.a+t.h {
+					newMask &^= 1 << j
+				}
+			}
+			dfs(idx+1, prob*float64(t.r)/100.0, newMask)
+		}
+	}
+	dfs(0, 1.0, (1<<m)-1)
+	return total
+}
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	trees := make([]Tree, n)
+	mush := make([]Mush, m)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		trees[i] = Tree{a: rng.Intn(11) - 5, h: rng.Intn(5) + 1, l: rng.Intn(101)}
+		trees[i].r = rng.Intn(101 - trees[i].l)
+		fmt.Fprintf(&sb, "%d %d %d %d\n", trees[i].a, trees[i].h, trees[i].l, trees[i].r)
+	}
+	for j := 0; j < m; j++ {
+		mush[j] = Mush{b: rng.Intn(11) - 5, z: rng.Intn(10) + 1}
+		fmt.Fprintf(&sb, "%d %d\n", mush[j].b, mush[j].z)
+	}
+	exp := expected(trees, mush)
+	return sb.String(), exp
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseFloat(s string) (float64, error) {
+	var v float64
+	_, err := fmt.Sscan(s, &v)
+	return v, err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, in)
+			os.Exit(1)
+		}
+		got, err := parseFloat(out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid float output %q\n", t, out)
+			os.Exit(1)
+		}
+		if diff := got - exp; diff < -1e-4 || diff > 1e-4 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.6f got %.6f\ninput:\n%s", t, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/138/verifierD.go
+++ b/0-999/100-199/130-139/138/verifierD.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var n, m int
+var grid [][]byte
+
+func inBounds(x, y int) bool {
+	return x >= 0 && x < n && y >= 0 && y < m
+}
+
+func applyMove(mask uint32, x, y int) uint32 {
+	idx := x*m + y
+	bit := uint32(1) << idx
+	if mask&bit == 0 {
+		return mask
+	}
+	mask &^= bit
+	var dirs [][2]int
+	switch grid[x][y] {
+	case 'L':
+		dirs = [][2]int{{1, -1}, {-1, 1}}
+	case 'R':
+		dirs = [][2]int{{-1, -1}, {1, 1}}
+	case 'X':
+		dirs = [][2]int{{1, -1}, {-1, 1}, {-1, -1}, {1, 1}}
+	}
+	for _, d := range dirs {
+		nx, ny := x+d[0], y+d[1]
+		for inBounds(nx, ny) {
+			idx := nx*m + ny
+			b := uint32(1) << idx
+			if mask&b == 0 {
+				break
+			}
+			mask &^= b
+			nx += d[0]
+			ny += d[1]
+		}
+	}
+	return mask
+}
+
+var memo map[uint32]int
+
+func grundy(mask uint32) int {
+	if mask == 0 {
+		return 0
+	}
+	if v, ok := memo[mask]; ok {
+		return v
+	}
+	moves := make(map[int]struct{})
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			idx := i*m + j
+			if mask&(1<<idx) != 0 {
+				nm := applyMove(mask, i, j)
+				g := grundy(nm)
+				moves[g] = struct{}{}
+			}
+		}
+	}
+	mex := 0
+	for {
+		if _, ok := moves[mex]; !ok {
+			break
+		}
+		mex++
+	}
+	memo[mask] = mex
+	return mex
+}
+
+func expectedWinner(g [][]byte) string {
+	n = len(g)
+	m = len(g[0])
+	grid = g
+	memo = make(map[uint32]int)
+	mask := uint32(0)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			mask |= 1 << (i*m + j)
+		}
+	}
+	if grundy(mask) != 0 {
+		return "WIN"
+	}
+	return "LOSE"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n = rng.Intn(3) + 1
+	m = rng.Intn(3) + 1
+	grid = make([][]byte, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	chars := []byte{'L', 'R', 'X'}
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			row[j] = chars[rng.Intn(len(chars))]
+		}
+		grid[i] = row
+		sb.Write(row)
+		sb.WriteByte('\n')
+	}
+	exp := expectedWinner(grid)
+	return sb.String(), exp
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/138/verifierE.go
+++ b/0-999/100-199/130-139/138/verifierE.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Constr struct {
+	c    byte
+	l, r int
+}
+
+func expectedCount(s string, k, L, R int, cons []Constr) int64 {
+	n := len(s)
+	pref := make([][26]int, n+1)
+	for i := 0; i < n; i++ {
+		pref[i+1] = pref[i]
+		pref[i+1][s[i]-'a']++
+	}
+	var total int64
+	for i := 0; i < n; i++ {
+		for j := i; j < n; j++ {
+			cnt := 0
+			for _, c := range cons {
+				val := pref[j+1][c.c-'a'] - pref[i][c.c-'a']
+				if val >= c.l && val <= c.r {
+					cnt++
+				}
+			}
+			if cnt >= L && cnt <= R {
+				total++
+			}
+		}
+	}
+	return total
+}
+
+func randomString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(6) + 1
+	s := randomString(rng, n)
+	k := rng.Intn(3) + 1
+	L := rng.Intn(k + 1)
+	R := L + rng.Intn(k-L+1)
+	cons := make([]Constr, k)
+	var sb strings.Builder
+	fmt.Fprintln(&sb, s)
+	fmt.Fprintf(&sb, "%d %d %d\n", k, L, R)
+	for i := 0; i < k; i++ {
+		c := byte('a' + rng.Intn(3))
+		l := rng.Intn(n + 1)
+		r := l + rng.Intn(n-l+1)
+		cons[i] = Constr{c, l, r}
+		fmt.Fprintf(&sb, "%c %d %d\n", c, l, r)
+	}
+	exp := expectedCount(s, k, L, R, cons)
+	return sb.String(), exp
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, in)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid output %q\n", t, out)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", t, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` through `verifierE.go` for contest 138
- each verifier generates 100 random tests and checks the provided solution binary

## Testing
- `go build 0-999/100-199/130-139/138/verifierA.go`
- `go build 0-999/100-199/130-139/138/verifierB.go`
- `go build 0-999/100-199/130-139/138/verifierC.go`
- `go build 0-999/100-199/130-139/138/verifierD.go`
- `go build 0-999/100-199/130-139/138/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e6ed0a9a88324b4fc391b03528227