### PR TITLE
Add Go solution verifiers for contest 137

### DIFF
--- a/0-999/100-199/130-139/137/verifierA.go
+++ b/0-999/100-199/130-139/137/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func computeVisits(s string) int {
+	visits := 0
+	var curr rune
+	cnt := 0
+	for _, r := range s {
+		if cnt == 0 {
+			curr = r
+			cnt = 1
+			continue
+		}
+		if r == curr {
+			if cnt < 5 {
+				cnt++
+			} else {
+				visits++
+				cnt = 1
+			}
+		} else {
+			visits++
+			curr = r
+			cnt = 1
+		}
+	}
+	if cnt > 0 {
+		visits++
+	}
+	return visits
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = 'P'
+		} else {
+			b[i] = 'C'
+		}
+	}
+	s := string(b)
+	exp := fmt.Sprintf("%d", computeVisits(s))
+	return s + "\n", exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/137/verifierB.go
+++ b/0-999/100-199/130-139/137/verifierB.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func computeChanges(nums []int) int {
+	n := len(nums)
+	seen := make([]bool, n+1)
+	distinct := 0
+	for _, x := range nums {
+		if x >= 1 && x <= n && !seen[x] {
+			seen[x] = true
+			distinct++
+		}
+	}
+	return n - distinct
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	nums := make([]int, n)
+	for i := 0; i < n; i++ {
+		nums[i] = rng.Intn(5000) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	exp := fmt.Sprintf("%d", computeChanges(nums))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/137/verifierC.go
+++ b/0-999/100-199/130-139/137/verifierC.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func computeIncluded(intervals [][2]int) int {
+	sort.Slice(intervals, func(i, j int) bool { return intervals[i][0] < intervals[j][0] })
+	count := 0
+	maxEnd := -1 << 60
+	for _, iv := range intervals {
+		if iv[1] < maxEnd {
+			count++
+		} else if iv[1] > maxEnd {
+			maxEnd = iv[1]
+		}
+	}
+	return count
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	vals := rng.Perm(2 * n)
+	intervals := make([][2]int, n)
+	for i := 0; i < n; i++ {
+		a := vals[2*i] + 1
+		b := vals[2*i+1] + 1
+		if a > b {
+			a, b = b, a
+		}
+		intervals[i] = [2]int{a, b}
+	}
+	// shuffle order
+	rng.Shuffle(n, func(i, j int) { intervals[i], intervals[j] = intervals[j], intervals[i] })
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, iv := range intervals {
+		fmt.Fprintf(&sb, "%d %d\n", iv[0], iv[1])
+	}
+	exp := fmt.Sprintf("%d", computeIncluded(append([][2]int(nil), intervals...)))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/137/verifierD.go
+++ b/0-999/100-199/130-139/137/verifierD.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compute(s string, k int) (int, string) {
+	n := len(s)
+	cost := make([][]int, n)
+	for i := range cost {
+		cost[i] = make([]int, n)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := i + 1; j < n; j++ {
+			c := 0
+			if s[i] != s[j] {
+				c = 1
+			}
+			if i+1 <= j-1 {
+				cost[i][j] = cost[i+1][j-1] + c
+			} else {
+				cost[i][j] = c
+			}
+		}
+	}
+	const inf = 1_000_000_000
+	dp := make([][]int, k+1)
+	prev := make([][]int, k+1)
+	for p := 0; p <= k; p++ {
+		dp[p] = make([]int, n)
+		prev[p] = make([]int, n)
+		for i := 0; i < n; i++ {
+			dp[p][i] = inf
+			prev[p][i] = -1
+		}
+	}
+	for i := 0; i < n; i++ {
+		dp[1][i] = cost[0][i]
+		prev[1][i] = -1
+	}
+	for p := 2; p <= k; p++ {
+		for i := p - 1; i < n; i++ {
+			for t := p - 2; t < i; t++ {
+				cur := dp[p-1][t] + cost[t+1][i]
+				if cur < dp[p][i] {
+					dp[p][i] = cur
+					prev[p][i] = t
+				}
+			}
+		}
+	}
+	best := inf
+	bp := 1
+	for p := 1; p <= k; p++ {
+		if dp[p][n-1] < best {
+			best = dp[p][n-1]
+			bp = p
+		}
+	}
+	segments := make([][2]int, 0, bp)
+	p := bp
+	i := n - 1
+	for p > 0 {
+		t := prev[p][i]
+		l := 0
+		if t >= 0 {
+			l = t + 1
+		}
+		segments = append(segments, [2]int{l, i})
+		i = t
+		p--
+	}
+	for l, r := 0, len(segments)-1; l < r; l, r = l+1, r-1 {
+		segments[l], segments[r] = segments[r], segments[l]
+	}
+	runes := []rune(s)
+	for _, seg := range segments {
+		l, r := seg[0], seg[1]
+		for a, b := l, r; a < b; a, b = a+1, b-1 {
+			if runes[a] != runes[b] {
+				runes[b] = runes[a]
+			}
+		}
+	}
+	out := make([]rune, 0, n+len(segments)-1)
+	for idx, seg := range segments {
+		if idx > 0 {
+			out = append(out, '+')
+		}
+		for j := seg[0]; j <= seg[1]; j++ {
+			out = append(out, runes[j])
+		}
+	}
+	return best, string(out)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	s := string(b)
+	k := rng.Intn(n) + 1
+	expCost, expStr := compute(s, k)
+	var sb strings.Builder
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", k)
+	input := sb.String()
+	exp := fmt.Sprintf("%d\n%s", expCost, expStr)
+	return input, exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/137/verifierE.go
+++ b/0-999/100-199/130-139/137/verifierE.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func isVowel(c byte) bool {
+	switch c {
+	case 'a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U':
+		return true
+	}
+	return false
+}
+
+func compute(s string) string {
+	n := len(s)
+	A := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		if isVowel(s[i-1]) {
+			A[i] = A[i-1] + 1
+		} else {
+			A[i] = A[i-1] - 2
+		}
+	}
+	comp := make([]int, n+1)
+	vals := append([]int(nil), A...)
+	sort.Ints(vals)
+	uniq := []int{vals[0]}
+	for _, v := range vals[1:] {
+		if v != uniq[len(uniq)-1] {
+			uniq = append(uniq, v)
+		}
+	}
+	m := len(uniq)
+	for i := 0; i <= n; i++ {
+		idx := sort.SearchInts(uniq, A[i])
+		comp[i] = idx + 1
+	}
+	INF := n + 5
+	tree := make([]int, m+1)
+	for i := 1; i <= m; i++ {
+		tree[i] = INF
+	}
+	update := func(pos, v int) {
+		for pos <= m {
+			if v < tree[pos] {
+				tree[pos] = v
+			}
+			pos += pos & -pos
+		}
+	}
+	query := func(pos int) int {
+		res := INF
+		for pos > 0 {
+			if tree[pos] < res {
+				res = tree[pos]
+			}
+			pos -= pos & -pos
+		}
+		return res
+	}
+	update(m-comp[0]+1, 0)
+	maxlen := 0
+	count := 0
+	for r := 1; r <= n; r++ {
+		cr := comp[r]
+		lmin := query(m - cr + 1)
+		if lmin < INF {
+			length := r - lmin
+			if length > maxlen {
+				maxlen = length
+				count = 1
+			} else if length == maxlen {
+				count++
+			}
+		}
+		update(m-comp[r]+1, r)
+	}
+	if count > 0 {
+		return fmt.Sprintf("%d %d", maxlen, count)
+	}
+	return "No solution"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	b := make([]byte, n)
+	letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	for i := 0; i < n; i++ {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	s := string(b)
+	exp := compute(s)
+	return s + "\n", exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go..verifierE.go for problems A-E in contest 137
- each verifier generates 100 random test cases, runs the provided binary and checks the output

## Testing
- `go build 0-999/100-199/130-139/137/verifierA.go`
- `go build 0-999/100-199/130-139/137/verifierB.go`
- `go build 0-999/100-199/130-139/137/verifierC.go`
- `go build 0-999/100-199/130-139/137/verifierD.go`
- `go build 0-999/100-199/130-139/137/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e6ecba16c83249749bec23dcd60fd