### PR TITLE
Add verifiers for Codeforces contest 135

### DIFF
--- a/0-999/100-199/130-139/135/verifierA.go
+++ b/0-999/100-199/130-139/135/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(a []int) []int {
+	sort.Ints(a)
+	n := len(a)
+	b := make([]int, n)
+	k1 := 0
+	for k1 < n && a[k1] == 1 {
+		k1++
+	}
+	if k1 < n {
+		for i := 0; i <= k1 && i < n; i++ {
+			b[i] = 1
+		}
+		for i := k1 + 1; i < n; i++ {
+			b[i] = a[i-1]
+		}
+	} else {
+		for i := 0; i < n-1; i++ {
+			b[i] = 1
+		}
+		if n > 0 {
+			b[n-1] = 2
+		}
+	}
+	return b
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(9) + 1
+	}
+	expectArr := solveCase(append([]int(nil), arr...))
+	input := fmt.Sprintf("%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprint(v)
+	}
+	input += "\n"
+	var exp strings.Builder
+	for i, v := range expectArr {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(fmt.Sprint(v))
+	}
+	return input, exp.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/135/verifierB.go
+++ b/0-999/100-199/130-139/135/verifierB.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Point struct {
+	x, y float64
+}
+
+func (p Point) Sub(q Point) Point   { return Point{p.x - q.x, p.y - q.y} }
+func (p Point) Dot(q Point) float64 { return p.x*q.x + p.y*q.y }
+func eq(v float64) bool             { return math.Abs(v) < 1e-7 }
+
+func isSquare(a, b, c, d Point) bool {
+	pts := []Point{b, c, d}
+	idxs := [][3]int{{0, 1, 2}, {0, 2, 1}, {1, 0, 2}, {1, 2, 0}, {2, 0, 1}, {2, 1, 0}}
+	for _, id := range idxs {
+		ab := pts[id[0]].Sub(a)
+		ac := pts[id[1]].Sub(a)
+		ad := pts[id[2]].Sub(a)
+		if eq(ab.Dot(ac)) && eq(ab.Dot(ad)) && eq(ac.Dot(pts[id[2]].Sub(pts[id[1]]))) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRect(a, b, c, d Point) bool {
+	pts := []Point{b, c, d}
+	idxs := [][3]int{{0, 1, 2}, {0, 2, 1}, {1, 0, 2}, {1, 2, 0}, {2, 0, 1}, {2, 1, 0}}
+	for _, id := range idxs {
+		ab := pts[id[0]].Sub(a)
+		ac := pts[id[1]].Sub(a)
+		ad := pts[id[2]].Sub(a)
+		if eq(ab.Dot(ac)) && eq(ab.Dot(ad)) && eq(ad.Sub(ac).Dot(pts[id[2]].Sub(pts[id[1]]))) {
+			return true
+		}
+	}
+	return false
+}
+
+func existsPartition(P [8]Point) bool {
+	for i := 0; i < 5; i++ {
+		for j := i + 1; j < 6; j++ {
+			for k := j + 1; k < 7; k++ {
+				for l := k + 1; l < 8; l++ {
+					if isSquare(P[i], P[j], P[k], P[l]) {
+						rem := make([]int, 0, 4)
+						for m := 0; m < 8; m++ {
+							if m != i && m != j && m != k && m != l {
+								rem = append(rem, m)
+							}
+						}
+						if isRect(P[rem[0]], P[rem[1]], P[rem[2]], P[rem[3]]) {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseCandidate(out string) (bool, [4]int, [4]int, error) {
+	fields := strings.Fields(out)
+	if len(fields) == 1 && fields[0] == "NO" {
+		return false, [4]int{}, [4]int{}, nil
+	}
+	if len(fields) != 9 || fields[0] != "YES" {
+		return false, [4]int{}, [4]int{}, fmt.Errorf("bad output")
+	}
+	var sq [4]int
+	var rc [4]int
+	for i := 0; i < 4; i++ {
+		fmt.Sscan(fields[1+i], &sq[i])
+	}
+	for i := 0; i < 4; i++ {
+		fmt.Sscan(fields[5+i], &rc[i])
+	}
+	return true, sq, rc, nil
+}
+
+func checkSets(P [8]Point, sq, rc [4]int) bool {
+	used := make([]bool, 8)
+	for _, v := range sq {
+		if v < 1 || v > 8 || used[v-1] {
+			return false
+		}
+		used[v-1] = true
+	}
+	for _, v := range rc {
+		if v < 1 || v > 8 || used[v-1] {
+			return false
+		}
+		used[v-1] = true
+	}
+	var sqPts, rcPts [4]Point
+	for i, idx := range sq {
+		sqPts[i] = P[idx-1]
+	}
+	for i, idx := range rc {
+		rcPts[i] = P[idx-1]
+	}
+	return isSquare(sqPts[0], sqPts[1], sqPts[2], sqPts[3]) && isRect(rcPts[0], rcPts[1], rcPts[2], rcPts[3])
+}
+
+func generateCase(rng *rand.Rand) (string, bool, [8]Point) {
+	var P [8]Point
+	for i := 0; i < 8; i++ {
+		P[i] = Point{float64(rng.Intn(11) - 5), float64(rng.Intn(11) - 5)}
+	}
+	expect := existsPartition(P)
+	var sb strings.Builder
+	for i := 0; i < 8; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", int(P[i].x), int(P[i].y)))
+	}
+	return sb.String(), expect, P
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp, pts := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		has, sq, rc, err := parseCandidate(out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if has != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %v got %v\ninput:\n%s", i+1, exp, has, in)
+			os.Exit(1)
+		}
+		if has {
+			if !checkSets(pts, sq, rc) {
+				fmt.Fprintf(os.Stderr, "case %d failed: candidate produced invalid partition\ninput:\n%s", i+1, in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/135/verifierC.go
+++ b/0-999/100-199/130-139/135/verifierC.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(s string) []string {
+	n := len(s)
+	pos0 := []int{}
+	pos1 := []int{}
+	qpos := []int{}
+	for i, c := range s {
+		switch c {
+		case '0':
+			pos0 = append(pos0, i)
+		case '1':
+			pos1 = append(pos1, i)
+		case '?':
+			qpos = append(qpos, i)
+		}
+	}
+	C0 := len(pos0)
+	C1 := len(pos1)
+	Q := len(qpos)
+	D := n - 2
+	if D < 0 {
+		D = 0
+	}
+	m := D / 2
+	M := (D + 1) / 2
+	can00, can01, can10, can11 := false, false, false, false
+	if C0+Q >= m+2 {
+		can00 = true
+	}
+	if C1+Q >= M+2 {
+		can11 = true
+	}
+	if C0+Q >= m+1 && C1+Q >= M+1 {
+		L := m + 1 - C0
+		if L < 0 {
+			L = 0
+		}
+		R := C1 + Q - (M + 1)
+		if R > Q {
+			R = Q
+		}
+		if R >= L {
+			var Zmin int
+			if m < C0 {
+				Zmin = pos0[m]
+			} else {
+				Zmin = qpos[m-C0]
+			}
+			var Omax int
+			if M < C1 {
+				Omax = pos1[M]
+			} else {
+				idx := R + (M - C1)
+				if idx < 0 {
+					idx = 0
+				}
+				if idx >= len(qpos) {
+					idx = len(qpos) - 1
+				}
+				Omax = qpos[idx]
+			}
+			if Zmin < Omax {
+				can01 = true
+			}
+			var Zmax int
+			if m < C0 {
+				Zmax = pos0[m]
+			} else {
+				Zmax = qpos[Q-1]
+			}
+			var Omin int
+			if M < C1 {
+				Omin = pos1[M]
+			} else {
+				idx := M - C1
+				if idx < 0 {
+					idx = 0
+				}
+				if idx >= len(qpos) {
+					idx = len(qpos) - 1
+				}
+				Omin = qpos[idx]
+			}
+			if Zmax > Omin {
+				can10 = true
+			}
+		}
+	}
+	res := []string{}
+	if can00 {
+		res = append(res, "00")
+	}
+	if can01 {
+		res = append(res, "01")
+	}
+	if can10 {
+		res = append(res, "10")
+	}
+	if can11 {
+		res = append(res, "11")
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(20) + 2
+	bytes := make([]byte, n)
+	chars := []byte{'0', '1', '?'}
+	for i := range bytes {
+		bytes[i] = chars[rng.Intn(3)]
+	}
+	s := string(bytes)
+	expect := solveCase(s)
+	return s + "\n", expect
+}
+
+func compare(out string, expect []string) bool {
+	fields := strings.Fields(out)
+	if len(fields) != len(expect) {
+		return false
+	}
+	for i := range fields {
+		if fields[i] != expect[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if !compare(out, exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %v got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/135/verifierD.go
+++ b/0-999/100-199/130-139/135/verifierD.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(grid [][]byte) int {
+	n := len(grid)
+	if n == 0 {
+		return 0
+	}
+	m := len(grid[0])
+	outside := make([][]bool, n)
+	for i := range outside {
+		outside[i] = make([]bool, m)
+	}
+	dq := make([][2]int, 0)
+	for i := 0; i < n; i++ {
+		for _, j := range []int{0, m - 1} {
+			if grid[i][j] == '0' && !outside[i][j] {
+				outside[i][j] = true
+				dq = append(dq, [2]int{i, j})
+			}
+		}
+	}
+	for j := 0; j < m; j++ {
+		for _, i := range []int{0, n - 1} {
+			if grid[i][j] == '0' && !outside[i][j] {
+				outside[i][j] = true
+				dq = append(dq, [2]int{i, j})
+			}
+		}
+	}
+	for idx := 0; idx < len(dq); idx++ {
+		r, c := dq[idx][0], dq[idx][1]
+		for _, d := range [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}} {
+			nr, nc := r+d[0], c+d[1]
+			if nr >= 0 && nr < n && nc >= 0 && nc < m && grid[nr][nc] == '0' && !outside[nr][nc] {
+				outside[nr][nc] = true
+				dq = append(dq, [2]int{nr, nc})
+			}
+		}
+	}
+	dr := [4]int{-1, 0, 1, 0}
+	dc := [4]int{0, 1, 0, -1}
+	visited := make([][][]bool, n)
+	for i := range visited {
+		visited[i] = make([][]bool, m)
+		for j := range visited[i] {
+			visited[i][j] = make([]bool, 4)
+		}
+	}
+	best := 0
+	for r := 0; r < n; r++ {
+		for c := 0; c < m; c++ {
+			if grid[r][c] != '1' {
+				continue
+			}
+			for d := 0; d < 4; d++ {
+				nr, nc := r+dr[d], c+dc[d]
+				if nr < 0 || nr >= n || nc < 0 || nc >= m || grid[nr][nc] != '1' {
+					continue
+				}
+				if visited[r][c][d] {
+					continue
+				}
+				cr, cc, dir := r, c, d
+				startR, startC, startDir := r, c, d
+				length := 0
+				infinite := false
+				for {
+					visited[cr][cc][dir] = true
+					nr, nc := cr+dr[dir], cc+dc[dir]
+					if nr < 0 || nr >= n || nc < 0 || nc >= m || grid[nr][nc] != '1' {
+						infinite = true
+						break
+					}
+					found := false
+					for _, turn := range []int{1, 0, 3, 2} {
+						nd := (dir + turn) & 3
+						wr, wc := nr+dr[nd], nc+dc[nd]
+						if wr >= 0 && wr < n && wc >= 0 && wc < m && grid[wr][wc] == '1' {
+							cr, cc, dir = nr, nc, nd
+							found = true
+							break
+						}
+					}
+					if !found {
+						infinite = true
+						break
+					}
+					length++
+					if cr == startR && cc == startC && dir == startDir {
+						break
+					}
+				}
+				if !infinite && length > 0 && length > best {
+					best = length
+				}
+			}
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	grid := make([][]byte, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = '0'
+			} else {
+				row[j] = '1'
+			}
+		}
+		grid[i] = row
+		sb.WriteString(string(row) + "\n")
+	}
+	expect := solveCase(grid)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		var val int
+		if _, err := fmt.Sscan(out, &val); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d bad output: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, val, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–D of contest 135
- each verifier generates 100 random tests and checks a binary solution

## Testing
- `go vet 0-999/100-199/130-139/135/verifierA.go`
- `go vet 0-999/100-199/130-139/135/verifierB.go`
- `go vet 0-999/100-199/130-139/135/verifierC.go`
- `go vet 0-999/100-199/130-139/135/verifierD.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6ec186b88324be8647806ef0b283