### PR TITLE
Add verifiers for contest 134

### DIFF
--- a/0-999/100-199/130-139/134/verifierA.go
+++ b/0-999/100-199/130-139/134/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solve(n int, arr []int) string {
+	var sum int64
+	for _, v := range arr {
+		sum += int64(v)
+	}
+	if sum%int64(n) != 0 {
+		return "0"
+	}
+	target := sum / int64(n)
+	var idx []string
+	for i, v := range arr {
+		if int64(v) == target {
+			idx = append(idx, fmt.Sprint(i+1))
+		}
+	}
+	if len(idx) == 0 {
+		return "0"
+	}
+	return fmt.Sprintf("%d\n%s", len(idx), strings.Join(idx, " "))
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(50) + 2
+	arr := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		arr[i] = r.Intn(1000) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(arr[i]))
+	}
+	sb.WriteByte('\n')
+	expect := solve(n, arr)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/134/verifierB.go
+++ b/0-999/100-199/130-139/134/verifierB.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func steps(n int) int {
+	if n == 1 {
+		return 0
+	}
+	const inf = int(1e9)
+	minSteps := inf
+	for b := 1; b < n; b++ {
+		x, y := n, b
+		sum := 0
+		for y != 0 {
+			sum += x / y
+			x, y = y, x%y
+		}
+		if x != 1 {
+			continue
+		}
+		if sum-1 < minSteps {
+			minSteps = sum - 1
+		}
+	}
+	return minSteps
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(100000) + 1
+	expect := steps(n)
+	return fmt.Sprintf("%d\n", n), fmt.Sprint(expect)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/134/verifierC.go
+++ b/0-999/100-199/130-139/134/verifierC.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type Pair struct{ first, second int }
+
+type solver struct {
+	first []int
+	nxt   []int
+	mm    []Pair
+	ans   []Pair
+}
+
+func newSolver(maxn int) *solver {
+	return &solver{
+		first: make([]int, maxn),
+		nxt:   make([]int, maxn),
+		mm:    make([]Pair, maxn),
+		ans:   make([]Pair, 0, maxn),
+	}
+}
+
+func (s *solver) tj(x, y int) {
+	s.nxt[x] = s.first[y]
+	s.first[y] = x
+}
+
+func (s *solver) solve(n, sum int, a []int) string {
+	if sum%2 == 1 {
+		return "No"
+	}
+	s.ans = s.ans[:0]
+	for i := range s.first {
+		s.first[i] = 0
+	}
+	for i := range s.nxt {
+		s.nxt[i] = 0
+	}
+	for i := 1; i <= n; i++ {
+		s.tj(i, a[i-1])
+	}
+	for i := sum; i >= 1; i-- {
+		for s.first[i] != 0 {
+			x := s.first[i]
+			s.first[i] = s.nxt[x]
+			j := i
+			for k := 1; k <= i; k++ {
+				for j > 0 && s.first[j] == 0 {
+					j--
+				}
+				if j == 0 {
+					return "No"
+				}
+				mid := s.first[j]
+				s.mm[k] = Pair{mid, j}
+				s.first[j] = s.nxt[mid]
+				s.ans = append(s.ans, Pair{x, mid})
+			}
+			for k := 1; k <= i; k++ {
+				p := s.mm[k]
+				s.tj(p.first, p.second-1)
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("Yes\n")
+	sb.WriteString(fmt.Sprintln(len(s.ans)))
+	for _, p := range s.ans {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.first, p.second))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(r *rand.Rand, slv *solver) (string, string) {
+	n := r.Intn(10) + 1
+	sum := r.Intn(10*n + 1)
+	arr := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, sum))
+	for i := 0; i < n; i++ {
+		if sum > 0 {
+			arr[i] = r.Intn(sum + 1)
+		} else {
+			arr[i] = 0
+		}
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(arr[i]))
+	}
+	sb.WriteByte('\n')
+	expect := slv.solve(n, sum, arr)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	slv := newSolver(201000)
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r, slv)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 134 problems A–C
- each verifier runs 100 randomized tests using an internal reference solution

## Testing
- `go build verifierA.go`
- `./verifierA ./134A.go`
- `go build verifierB.go`
- `./verifierB ./134B.go`
- `go build verifierC.go`
- `./verifierC ./134C.go`

------
https://chatgpt.com/codex/tasks/task_e_687e6ebc60208324abce6647aed0aea4