### PR TITLE
Add verifiers for contest 133

### DIFF
--- a/0-999/100-199/130-139/133/verifierA.go
+++ b/0-999/100-199/130-139/133/verifierA.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedOutput(s string) string {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case 'H', 'Q', '9':
+			return "YES"
+		}
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1 // length 1..100
+	b := make([]byte, n)
+	for i := range b {
+		// ASCII 33..126 inclusive
+		b[i] = byte(rng.Intn(94) + 33)
+	}
+	return string(b)
+}
+
+func runCase(bin, input string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input + "\n")
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedOutput(input)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/133/verifierB.go
+++ b/0-999/100-199/130-139/133/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000003
+
+var codes = map[rune]string{
+	'>': "1000",
+	'<': "1001",
+	'+': "1010",
+	'-': "1011",
+	'.': "1100",
+	',': "1101",
+	'[': "1110",
+	']': "1111",
+}
+
+var charset = []rune{'<', '>', '+', '-', '.', ',', '[', ']'}
+
+func expectedOutput(s string) string {
+	result := 0
+	for _, ch := range s {
+		code, ok := codes[ch]
+		if !ok {
+			continue
+		}
+		for _, bit := range code {
+			result = (result*2 + int(bit-'0')) % mod
+		}
+	}
+	return fmt.Sprint(result)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = charset[rng.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func runCase(bin, input string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input + "\n")
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedOutput(input)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new verification tools `verifierA.go` and `verifierB.go` for contest 133
- verifiers generate 100 random test cases and execute a given binary

## Testing
- `go build 0-999/100-199/130-139/133/verifierA.go`
- `go build 0-999/100-199/130-139/133/verifierB.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6eb798208324b5633f57055136f1