### PR TITLE
Add verifiers for contest 128

### DIFF
--- a/0-999/100-199/120-129/128/verifierA.go
+++ b/0-999/100-199/120-129/128/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+// runProgram runs the binary with the given input and returns its output.
+func runProgram(binary string, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, binary)
+    cmd.Stdin = strings.NewReader(input)
+    out, err := cmd.CombinedOutput()
+    return string(out), err
+}
+
+// hasStone checks if a statue occupies (r,c) at time t in the board.
+func hasStone(board []string, r, c, t int) bool {
+    pr := r - t
+    if pr < 0 {
+        return false
+    }
+    return board[pr][c] == 'S'
+}
+
+// solve runs BFS to see if Maria can reach Anna.
+func solve(board []string) string {
+    moves := [9][2]int{{0,0},{1,0},{-1,0},{0,1},{0,-1},{1,1},{1,-1},{-1,1},{-1,-1}}
+    type state struct{ r,c,t int }
+    visited := [8][8][9]bool{}
+    q := []state{{7,0,0}}
+    visited[7][0][0] = true
+    for qi := 0; qi < len(q); qi++ {
+        s := q[qi]
+        r,c,t := s.r,s.c,s.t
+        if hasStone(board,r,c,t) { continue }
+        if r == 0 && c == 7 { return "WIN" }
+        if t >= 8 { return "WIN" }
+        for _,mv := range moves {
+            nr,nc := r+mv[0], c+mv[1]
+            nt := t+1
+            if nr<0||nr>=8||nc<0||nc>=8 { continue }
+            if hasStone(board,nr,nc,t) || hasStone(board,nr,nc,nt) { continue }
+            if visited[nr][nc][nt] { continue }
+            visited[nr][nc][nt]=true
+            q = append(q,state{nr,nc,nt})
+        }
+    }
+    return "LOSE"
+}
+
+// randomBoard generates a random board with statues.
+func randomBoard(rng *rand.Rand) []string {
+    grid := make([][]rune,8)
+    for i:=0;i<8;i++ { grid[i] = []rune("........") }
+    grid[7][0]='M'
+    grid[0][7]='A'
+    num := rng.Intn(7) // up to 6 statues
+    for i:=0;i<num;i++ {
+        r := rng.Intn(8)
+        c := rng.Intn(8)
+        if (r==7&&c==0)||(r==0&&c==7)||grid[r][c]=='S' { i--; continue }
+        grid[r][c]='S'
+    }
+    res := make([]string,8)
+    for i:=0;i<8;i++ { res[i] = string(grid[i]) }
+    return res
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierA.go /path/to/binary")
+        return
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(42))
+    for i:=0;i<100;i++ {
+        board := randomBoard(rng)
+        input := strings.Join(board,"\n")+"\n"
+        expected := solve(board)
+        output, err := runProgram(bin,input)
+        if err != nil {
+            fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+            return
+        }
+        if strings.TrimSpace(output) != expected {
+            fmt.Printf("Test %d failed: expected %s got %s\n", i+1, expected, strings.TrimSpace(output))
+            return
+        }
+    }
+    fmt.Println("OK")
+}
+

--- a/0-999/100-199/120-129/128/verifierB.go
+++ b/0-999/100-199/120-129/128/verifierB.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+    "context"
+    "sort"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func runProgram(binary, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, binary)
+    cmd.Stdin = strings.NewReader(input)
+    out, err := cmd.CombinedOutput()
+    return string(out), err
+}
+
+func buildSA(s string) []int {
+    n := len(s)
+    sa := make([]int, n)
+    rank := make([]int, n)
+    tmp := make([]int, n)
+    for i := 0; i < n; i++ {
+        sa[i] = i
+        rank[i] = int(s[i])
+    }
+    for k := 1; k < n; k <<= 1 {
+        sort.Slice(sa, func(i, j int) bool {
+            a, b := sa[i], sa[j]
+            if rank[a] != rank[b] {
+                return rank[a] < rank[b]
+            }
+            ra, rb := -1, -1
+            if a+k < n { ra = rank[a+k] }
+            if b+k < n { rb = rank[b+k] }
+            return ra < rb
+        })
+        tmp[sa[0]] = 0
+        for i := 1; i < n; i++ {
+            prev, cur := sa[i-1], sa[i]
+            prev2, cur2 := -1, -1
+            if prev+k < n { prev2 = rank[prev+k] }
+            if cur+k < n { cur2 = rank[cur+k] }
+            if rank[prev] != rank[cur] || prev2 != cur2 {
+                tmp[cur] = tmp[prev] + 1
+            } else {
+                tmp[cur] = tmp[prev]
+            }
+        }
+        copy(rank, tmp)
+        if rank[sa[n-1]] == n-1 {
+            break
+        }
+    }
+    return sa
+}
+
+func buildLCP(s string, sa []int) []int {
+    n := len(s)
+    rank := make([]int, n)
+    for i := 0; i < n; i++ {
+        rank[sa[i]] = i
+    }
+    lcp := make([]int, n)
+    h := 0
+    for i := 0; i < n; i++ {
+        if rank[i] > 0 {
+            j := sa[rank[i]-1]
+            for i+h < n && j+h < n && s[i+h] == s[j+h] { h++ }
+            lcp[rank[i]] = h
+            if h > 0 { h-- }
+        }
+    }
+    return lcp
+}
+
+func solve(s string, k int64) string {
+    n := len(s)
+    sa := buildSA(s)
+    lcp := buildLCP(s, sa)
+    var total int64
+    for i := 0; i < n; i++ {
+        suffixLen := int64(n - sa[i])
+        common := int64(lcp[i])
+        cnt := suffixLen - common
+        if total+cnt >= k {
+            t := k - total
+            length := int(common + t)
+            return s[sa[i] : sa[i]+length]
+        }
+        total += cnt
+    }
+    return "No such line."
+}
+
+func randomTest(rng *rand.Rand) (string, int64) {
+    l := rng.Intn(10) + 1
+    b := make([]byte, l)
+    for i := range b {
+        b[i] = byte('a' + rng.Intn(3))
+    }
+    s := string(b)
+    maxK := l*(l+1)/2 + 1
+    k := int64(rng.Intn(maxK) + 1)
+    return s, k
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierB.go /path/to/binary")
+        return
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(42))
+    for i := 0; i < 100; i++ {
+        s, k := randomTest(rng)
+        input := fmt.Sprintf("%s\n%d\n", s, k)
+        expected := solve(s, k)
+        out, err := runProgram(bin, input)
+        if err != nil {
+            fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+            return
+        }
+        if strings.TrimSpace(out) != expected {
+            fmt.Printf("Test %d failed: expected %s got %s\n", i+1, expected, strings.TrimSpace(out))
+            return
+        }
+    }
+    fmt.Println("OK")
+}
+

--- a/0-999/100-199/120-129/128/verifierC.go
+++ b/0-999/100-199/120-129/128/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+const MOD = 1000000007
+
+func runProgram(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    out, err := cmd.CombinedOutput()
+    return string(out), err
+}
+
+var memo map[[3]int]int
+
+func ways(w, h, k int) int {
+    if k == 0 {
+        return 1
+    }
+    if w <= 0 || h <= 0 {
+        return 0
+    }
+    key := [3]int{w, h, k}
+    if v, ok := memo[key]; ok {
+        return v
+    }
+    var total int64
+    for nw := 1; nw <= w-2; nw++ {
+        for nh := 1; nh <= h-2; nh++ {
+            cnt := (w - nw - 1) * (h - nh - 1)
+            if cnt <= 0 {
+                continue
+            }
+            inner := ways(nw, nh, k-1)
+            total += int64(cnt) * int64(inner)
+        }
+    }
+    memo[key] = int(total % MOD)
+    return memo[key]
+}
+
+func solve(n, m, k int) int {
+    memo = make(map[[3]int]int)
+    return ways(n, m, k)
+}
+
+func randomTest(rng *rand.Rand) (int, int, int) {
+    n := rng.Intn(8) + 3
+    m := rng.Intn(8) + 3
+    k := rng.Intn(3) + 1
+    return n, m, k
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierC.go /path/to/binary")
+        return
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(42))
+    for i := 0; i < 100; i++ {
+        n, m, k := randomTest(rng)
+        input := fmt.Sprintf("%d %d %d\n", n, m, k)
+        expected := solve(n, m, k)
+        out, err := runProgram(bin, input)
+        if err != nil {
+            fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+            return
+        }
+        out = strings.TrimSpace(out)
+        if out != fmt.Sprintf("%d", expected) {
+            fmt.Printf("Test %d failed: expected %d got %s\n", i+1, expected, out)
+            return
+        }
+    }
+    fmt.Println("OK")
+}
+

--- a/0-999/100-199/120-129/128/verifierD.go
+++ b/0-999/100-199/120-129/128/verifierD.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+    "context"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+    "time"
+)
+
+func runProgram(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    out, err := cmd.CombinedOutput()
+    return string(out), err
+}
+
+func solve(arr []int) string {
+    n := len(arr)
+    if n < 3 {
+        return "NO"
+    }
+    sort.Ints(arr)
+    uniq := []int{arr[0]}
+    cnt := []int{1}
+    last := arr[0]
+    for i := 1; i < n; i++ {
+        if arr[i] == last {
+            cnt[len(cnt)-1]++
+        } else {
+            if arr[i] != last+1 {
+                return "NO"
+            }
+            last = arr[i]
+            uniq = append(uniq, last)
+            cnt = append(cnt, 1)
+        }
+    }
+    ePrev := 0
+    for _, c := range cnt {
+        eCur := 2*c - ePrev
+        if eCur < 0 {
+            return "NO"
+        }
+        ePrev = eCur
+    }
+    if ePrev != 0 {
+        return "NO"
+    }
+    return "YES"
+}
+
+func randomTest(rng *rand.Rand) []int {
+    m := rng.Intn(5) + 3
+    // create consecutive numbers with possible duplicates
+    start := rng.Intn(10)
+    arr := make([]int, m)
+    for i := 0; i < m; i++ {
+        arr[i] = start + rng.Intn(3)
+    }
+    return arr
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierD.go /path/to/binary")
+        return
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(42))
+    for i := 0; i < 100; i++ {
+        arr := randomTest(rng)
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+        for j, v := range arr {
+            if j > 0 {
+                sb.WriteByte(' ')
+            }
+            sb.WriteString(fmt.Sprintf("%d", v))
+        }
+        sb.WriteByte('\n')
+        expected := solve(append([]int(nil), arr...))
+        out, err := runProgram(bin, sb.String())
+        if err != nil {
+            fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+            return
+        }
+        if strings.TrimSpace(out) != expected {
+            fmt.Printf("Test %d failed: expected %s got %s\n", i+1, expected, strings.TrimSpace(out))
+            return
+        }
+    }
+    fmt.Println("OK")
+}
+

--- a/0-999/100-199/120-129/128/verifierE.go
+++ b/0-999/100-199/120-129/128/verifierE.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+    "context"
+    "fmt"
+    "math"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+    "time"
+)
+
+func runProgram(bin, input string) (string, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+    defer cancel()
+    cmd := exec.CommandContext(ctx, bin)
+    cmd.Stdin = strings.NewReader(input)
+    out, err := cmd.CombinedOutput()
+    return string(out), err
+}
+
+func solve(n int, k int64, xs, ys, rs []float64) int64 {
+    M := 1
+    pi := math.Pi
+    for i := 0; i < n; i++ {
+        type ev struct{ a float64; d int }
+        events := make([]ev, 0, 2*(n-1))
+        for j := 0; j < n; j++ {
+            if j == i { continue }
+            dx := xs[j] - xs[i]
+            dy := ys[j] - ys[i]
+            dist := math.Hypot(dx, dy)
+            if dist <= rs[j] { continue }
+            phi := math.Atan2(dy, dx)
+            ang := math.Asin(rs[j] / dist)
+            width := ang * 2.0
+            L := math.Mod(phi-ang, pi)
+            if L < 0 { L += pi }
+            R := L + width
+            if R < pi {
+                events = append(events, ev{L,1}, ev{R,-1})
+            } else {
+                events = append(events, ev{L,1}, ev{pi,-1}, ev{0,1}, ev{R-pi,-1})
+            }
+        }
+        if len(events) == 0 { continue }
+        sort.Slice(events, func(a,b int) bool {
+            if events[a].a == events[b].a {
+                return events[a].d > events[b].d
+            }
+            return events[a].a < events[b].a
+        })
+        cnt,best := 0,0
+        for _,e := range events {
+            cnt += e.d
+            if cnt > best { best = cnt }
+        }
+        if best+1 > M { M = best+1 }
+    }
+    return int64(n) + k*int64(M)
+}
+
+func randomTest(rng *rand.Rand) (int,int64,[]float64,[]float64,[]float64) {
+    n := rng.Intn(4)+1
+    k := int64(rng.Intn(6))
+    xs := make([]float64,n)
+    ys := make([]float64,n)
+    rs := make([]float64,n)
+    for i:=0;i<n;i++ {
+        for {
+            xs[i] = rng.Float64()*10 - 5
+            ys[i] = rng.Float64()*10 - 5
+            rs[i] = rng.Float64()*2 + 0.5
+            ok := true
+            for j:=0;j<i;j++ {
+                dx := xs[i]-xs[j]
+                dy := ys[i]-ys[j]
+                d := math.Hypot(dx,dy)
+                if d <= rs[i]+rs[j] { ok=false; break }
+            }
+            if ok { break }
+        }
+    }
+    return n,k,xs,ys,rs
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierE.go /path/to/binary")
+        return
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(42))
+    for i:=0;i<100;i++ {
+        n,k,xs,ys,rs := randomTest(rng)
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+        for j:=0;j<n;j++ {
+            sb.WriteString(fmt.Sprintf("%.2f %.2f %.2f\n", xs[j], ys[j], rs[j]))
+        }
+        expected := solve(n,k,xs,ys,rs)
+        out, err := runProgram(bin, sb.String())
+        if err != nil {
+            fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+            return
+        }
+        if strings.TrimSpace(out) != fmt.Sprintf("%d", expected) {
+            fmt.Printf("Test %d failed: expected %d got %s\n", i+1, expected, strings.TrimSpace(out))
+            return
+        }
+    }
+    fmt.Println("OK")
+}
+


### PR DESCRIPTION
## Summary
- implement `verifierA.go` – random boards and BFS solver
- implement `verifierB.go` – k-th substring checker
- implement `verifierC.go` – simple recursive DP for rectangle game
- implement `verifierD.go` – cycle feasibility checker
- implement `verifierE.go` – circle cutting solver

Each verifier runs 100 deterministic tests against an arbitrary binary.

## Testing
- `go run verifierA.go ./128A`
- `go run verifierB.go ./128B`
- `go run verifierC.go ./128C`
- `go run verifierD.go ./128D`
- `go run verifierE.go ./128E`


------
https://chatgpt.com/codex/tasks/task_e_687e6e8aa6648324b84faff8fabc5a73