### PR TITLE
Add contest 127 solution verifiers

### DIFF
--- a/0-999/100-199/120-129/127/verifierA.go
+++ b/0-999/100-199/120-129/127/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int }
+
+func solveCase(n, k int, pts []point) float64 {
+	var d float64
+	for i := 1; i < n; i++ {
+		dx := float64(pts[i-1].x - pts[i].x)
+		dy := float64(pts[i-1].y - pts[i].y)
+		d += math.Hypot(dx, dy)
+	}
+	return d * float64(k) / 50.0
+}
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	n := rng.Intn(99) + 2
+	k := rng.Intn(1000) + 1
+	pts := make([]point, n)
+	used := make(map[[2]int]bool)
+	for i := range pts {
+		for {
+			x := rng.Intn(41) - 20
+			y := rng.Intn(41) - 20
+			if !used[[2]int{x, y}] {
+				used[[2]int{x, y}] = true
+				pts[i] = point{x, y}
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, k, pts[0].x, pts[0].y))
+	for i := 1; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", pts[i].x, pts[i].y))
+	}
+	return sb.String(), solveCase(n, k, pts)
+}
+
+func runCase(bin, input string, expected float64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if math.Abs(got-expected) > 1e-4*math.Max(1.0, math.Abs(expected)) {
+		return fmt.Errorf("expected %.6f got %.6f", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/127/verifierB.go
+++ b/0-999/100-199/120-129/127/verifierB.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedFrames(a []int) int {
+	cnt := make([]int, 101)
+	for _, v := range a {
+		if v >= 1 && v <= 100 {
+			cnt[v]++
+		}
+	}
+	pairs := 0
+	for _, c := range cnt {
+		pairs += c / 2
+	}
+	return pairs / 2
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expectedFrames(arr)
+}
+
+func runCase(bin, input string, expected int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(strings.Fields(gotStr)[0])
+	if err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` for problem A of contest 127
- add `verifierB.go` for problem B of contest 127

## Testing
- `go run 0-999/100-199/120-129/127/verifierA.go /tmp/127A_bin`
- `go run 0-999/100-199/120-129/127/verifierB.go /tmp/127B_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e6e3ebbfc83249e71d11eb4281d0f