### PR TITLE
Add solution verifiers for contest 131

### DIFF
--- a/0-999/100-199/130-139/131/verifierA.go
+++ b/0-999/100-199/130-139/131/verifierA.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isCapsLockError(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	allUpper := true
+	for _, c := range s {
+		if c < 'A' || c > 'Z' {
+			allUpper = false
+			break
+		}
+	}
+	if allUpper {
+		return true
+	}
+	for i, c := range s {
+		if i == 0 {
+			continue
+		}
+		if c < 'A' || c > 'Z' {
+			return false
+		}
+	}
+	return true
+}
+
+func solveCase(s string) string {
+	if isCapsLockError(s) {
+		r := []rune(s)
+		for i, c := range r {
+			if c >= 'a' && c <= 'z' {
+				r[i] = c - ('a' - 'A')
+			} else if c >= 'A' && c <= 'Z' {
+				r[i] = c + ('a' - 'A')
+			}
+		}
+		s = string(r)
+	}
+	return s
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	b := make([]rune, n)
+	if rng.Float64() < 0.5 {
+		// generate caps lock error
+		if rng.Float64() < 0.5 {
+			for i := range b {
+				b[i] = rune('A' + rng.Intn(26))
+			}
+		} else {
+			b[0] = rune('a' + rng.Intn(26))
+			for i := 1; i < n; i++ {
+				b[i] = rune('A' + rng.Intn(26))
+			}
+		}
+	} else {
+		for i := range b {
+			if rng.Float64() < 0.5 {
+				b[i] = rune('a' + rng.Intn(26))
+			} else {
+				b[i] = rune('A' + rng.Intn(26))
+			}
+		}
+		// ensure not caps lock error
+		if isCapsLockError(string(b)) {
+			i := rng.Intn(n)
+			if b[i] >= 'a' && b[i] <= 'z' {
+				b[i] = b[i] - ('a' - 'A')
+			} else {
+				b[i] = b[i] + ('a' - 'A')
+			}
+		}
+	}
+	s := string(b)
+	input := s + "\n"
+	expected := solveCase(s)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/131/verifierB.go
+++ b/0-999/100-199/130-139/131/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(nums []int) string {
+	var cnt [21]int64
+	for _, t := range nums {
+		if t < -10 || t > 10 {
+			continue
+		}
+		cnt[t+10]++
+	}
+	var res int64
+	z := cnt[0+10]
+	if z > 1 {
+		res += z * (z - 1) / 2
+	}
+	for x := 1; x <= 10; x++ {
+		res += cnt[x+10] * cnt[-x+10]
+	}
+	return fmt.Sprint(res)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	nums := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		nums[i] = rng.Intn(21) - 10
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", nums[i]))
+	}
+	sb.WriteByte('\n')
+	expected := solveCase(nums)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/131/verifierC.go
+++ b/0-999/100-199/130-139/131/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func combTable(max int) [][]int64 {
+	C := make([][]int64, max+1)
+	for i := 0; i <= max; i++ {
+		C[i] = make([]int64, i+1)
+		C[i][0] = 1
+		for j := 1; j <= i; j++ {
+			if j == i {
+				C[i][j] = 1
+			} else {
+				C[i][j] = C[i-1][j-1] + C[i-1][j]
+			}
+		}
+	}
+	return C
+}
+
+func solveCase(n, m, t int) string {
+	maxNM := n
+	if m > maxNM {
+		maxNM = m
+	}
+	C := combTable(maxNM)
+	var result int64
+	for b := 4; b <= n; b++ {
+		g := t - b
+		if g < 1 || g > m {
+			continue
+		}
+		result += C[n][b] * C[m][g]
+	}
+	return fmt.Sprint(result)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(27) + 4    // 4..30
+	m := rng.Intn(30) + 1    // 1..30
+	t := rng.Intn(n+m-4) + 5 // ensure between 5 and n+m
+	if t > n+m {
+		t = n + m
+	}
+	input := fmt.Sprintf("%d %d %d\n", n, m, t)
+	expected := solveCase(n, m, t)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/131/verifierD.go
+++ b/0-999/100-199/130-139/131/verifierD.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func solveCase(n int, edges []edge) string {
+	adj := make([][]int, n+1)
+	degree := make([]int, n+1)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+		degree[e.u]++
+		degree[e.v]++
+	}
+	inCycle := make([]bool, n+1)
+	for i := 1; i <= n; i++ {
+		inCycle[i] = true
+	}
+	queue := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		if degree[i] == 1 {
+			queue = append(queue, i)
+		}
+	}
+	for head := 0; head < len(queue); head++ {
+		u := queue[head]
+		inCycle[u] = false
+		for _, v := range adj[u] {
+			if inCycle[v] {
+				degree[v]--
+				if degree[v] == 1 {
+					queue = append(queue, v)
+				}
+			}
+		}
+	}
+	dist := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = -1
+	}
+	bfs := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		if inCycle[i] {
+			dist[i] = 0
+			bfs = append(bfs, i)
+		}
+	}
+	for head := 0; head < len(bfs); head++ {
+		u := bfs[head]
+		for _, v := range adj[u] {
+			if dist[v] == -1 {
+				dist[v] = dist[u] + 1
+				bfs = append(bfs, v)
+			}
+		}
+	}
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(dist[i]))
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(7) + 3 // 3..9
+	edges := make([]edge, 0, n)
+	cycleLen := rng.Intn(n-1) + 2
+	for i := 1; i <= cycleLen; i++ {
+		u := i
+		v := i%cycleLen + 1
+		edges = append(edges, edge{u, v})
+	}
+	for v := cycleLen + 1; v <= n; v++ {
+		p := rng.Intn(v-1) + 1
+		edges = append(edges, edge{v, p})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	input := sb.String()
+	expected := solveCase(n, edges)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/131/verifierE.go
+++ b/0-999/100-199/130-139/131/verifierE.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type queen struct{ r, c int }
+
+func solveCase(n, m int, qs []queen) string {
+	idx := make([]int, m)
+	for i := 0; i < m; i++ {
+		idx[i] = i
+	}
+	att := make([]int, m)
+	// rows
+	sort.Slice(idx, func(i, j int) bool {
+		if qs[idx[i]].r != qs[idx[j]].r {
+			return qs[idx[i]].r < qs[idx[j]].r
+		}
+		return qs[idx[i]].c < qs[idx[j]].c
+	})
+	for i := 0; i+1 < m; i++ {
+		a, b := idx[i], idx[i+1]
+		if qs[a].r == qs[b].r {
+			att[a]++
+			att[b]++
+		}
+	}
+	// cols
+	for i := 0; i < m; i++ {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(i, j int) bool {
+		if qs[idx[i]].c != qs[idx[j]].c {
+			return qs[idx[i]].c < qs[idx[j]].c
+		}
+		return qs[idx[i]].r < qs[idx[j]].r
+	})
+	for i := 0; i+1 < m; i++ {
+		a, b := idx[i], idx[i+1]
+		if qs[a].c == qs[b].c {
+			att[a]++
+			att[b]++
+		}
+	}
+	// main diag r-c
+	for i := 0; i < m; i++ {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(i, j int) bool {
+		ai, aj := idx[i], idx[j]
+		di := qs[ai].r - qs[ai].c
+		dj := qs[aj].r - qs[aj].c
+		if di != dj {
+			return di < dj
+		}
+		return qs[ai].r < qs[aj].r
+	})
+	for i := 0; i+1 < m; i++ {
+		a, b := idx[i], idx[i+1]
+		if qs[a].r-qs[a].c == qs[b].r-qs[b].c {
+			att[a]++
+			att[b]++
+		}
+	}
+	// anti diag r+c
+	for i := 0; i < m; i++ {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(i, j int) bool {
+		ai, aj := idx[i], idx[j]
+		si := qs[ai].r + qs[ai].c
+		sj := qs[aj].r + qs[aj].c
+		if si != sj {
+			return si < sj
+		}
+		return qs[ai].r < qs[aj].r
+	})
+	for i := 0; i+1 < m; i++ {
+		a, b := idx[i], idx[i+1]
+		if qs[a].r+qs[a].c == qs[b].r+qs[b].c {
+			att[a]++
+			att[b]++
+		}
+	}
+	res := make([]int, 9)
+	for i := 0; i < m; i++ {
+		if att[i] >= 0 && att[i] <= 8 {
+			res[att[i]]++
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < 9; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(res[i]))
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	maxM := n * n
+	if maxM > 50 {
+		maxM = 50
+	}
+	m := rng.Intn(maxM) + 1
+	used := make(map[int]bool)
+	qs := make([]queen, 0, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for len(qs) < m {
+		r := rng.Intn(n) + 1
+		c := rng.Intn(n) + 1
+		key := r*n + c
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		qs = append(qs, queen{r, c})
+		sb.WriteString(fmt.Sprintf("%d %d\n", r, c))
+	}
+	input := sb.String()
+	expected := solveCase(n, m, qs)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/130-139/131/verifierF.go
+++ b/0-999/100-199/130-139/131/verifierF.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func countStars(grid []string) [][]int {
+	n := len(grid)
+	m := len(grid[0])
+	N := n - 2
+	M := m - 2
+	star := make([][]int, N)
+	for i := 0; i < N; i++ {
+		star[i] = make([]int, M)
+		for j := 0; j < M; j++ {
+			gi := i + 1
+			gj := j + 1
+			if grid[gi][gj] == '1' && grid[gi-1][gj] == '1' && grid[gi+1][gj] == '1' && grid[gi][gj-1] == '1' && grid[gi][gj+1] == '1' {
+				star[i][j] = 1
+			}
+		}
+	}
+	return star
+}
+
+func solveCase(n, m, k int, grid []string) string {
+	N := n - 2
+	M := m - 2
+	if N <= 0 || M <= 0 {
+		return "0"
+	}
+	star := countStars(grid)
+	colSum := make([]int, M)
+	S := make([]int, M+1)
+	var ans int64
+	for l := 0; l < N; l++ {
+		for j := 0; j < M; j++ {
+			colSum[j] = 0
+		}
+		for r := l; r < N; r++ {
+			for j := 0; j < M; j++ {
+				colSum[j] += star[r][j]
+			}
+			S[0] = 0
+			for j := 1; j <= M; j++ {
+				S[j] = S[j-1] + colSum[j-1]
+			}
+			var innerSum int64
+			c := 0
+			for R := 1; R <= M; R++ {
+				if S[R] < k {
+					continue
+				}
+				target := S[R] - k
+				for c <= R-1 && S[c] <= target {
+					c++
+				}
+				t := c
+				tri := int64(t) * int64(t+1) / 2
+				innerSum += tri * int64(M+1-R)
+			}
+			if innerSum != 0 {
+				A := int64(l+1) * int64(N-r)
+				ans += A * innerSum
+			}
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 3
+	m := rng.Intn(5) + 3
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Float64() < 0.5 {
+				b[j] = '0'
+			} else {
+				b[j] = '1'
+			}
+		}
+		grid[i] = string(b)
+	}
+	k := rng.Intn(n*m) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		sb.WriteString(grid[i])
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	expected := solveCase(n, m, k, grid)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go based verifiers for contest `131` problems A through F
- each verifier generates 100 randomized test cases and checks any solution binary

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`
- `go run verifierF.go ./solF`


------
https://chatgpt.com/codex/tasks/task_e_687e6ead3cfc8324929af55fc70520c5