### PR TITLE
Add solution verifiers for contest 123

### DIFF
--- a/0-999/100-199/120-129/123/verifierA.go
+++ b/0-999/100-199/120-129/123/verifierA.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// DSU structure for solveA
+type DSU struct{ p []int }
+
+func newDSU(n int) *DSU {
+	p := make([]int, n+1)
+	for i := 0; i <= n; i++ {
+		p[i] = i
+	}
+	return &DSU{p: p}
+}
+
+func (d *DSU) find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *DSU) union(x, y int) {
+	rx := d.find(x)
+	ry := d.find(y)
+	if rx != ry {
+		d.p[ry] = rx
+	}
+}
+
+func solveA(s string) string {
+	n := len(s)
+	isPrime := make([]bool, n+1)
+	for i := 2; i <= n; i++ {
+		isPrime[i] = true
+	}
+	for i := 2; i*i <= n; i++ {
+		if isPrime[i] {
+			for j := i * i; j <= n; j += i {
+				isPrime[j] = false
+			}
+		}
+	}
+	dsu := newDSU(n)
+	for p := 2; p <= n; p++ {
+		if !isPrime[p] {
+			continue
+		}
+		for k := 2; p*k <= n; k++ {
+			dsu.union(p, p*k)
+		}
+	}
+	groups := make(map[int][]int)
+	for i := 1; i <= n; i++ {
+		r := dsu.find(i)
+		groups[r] = append(groups[r], i)
+	}
+	grpList := make([][]int, 0, len(groups))
+	for _, g := range groups {
+		grpList = append(grpList, g)
+	}
+	for i := 1; i < len(grpList); i++ {
+		j := i
+		for j > 0 && len(grpList[j-1]) < len(grpList[j]) {
+			grpList[j-1], grpList[j] = grpList[j], grpList[j-1]
+			j--
+		}
+	}
+	freq := make([]int, 26)
+	for i := 0; i < n; i++ {
+		freq[int(s[i]-'a')]++
+	}
+	res := make([]byte, n)
+	for _, g := range grpList {
+		size := len(g)
+		idx := -1
+		for j := 0; j < 26; j++ {
+			if freq[j] >= size {
+				idx = j
+				break
+			}
+		}
+		if idx == -1 {
+			return "NO"
+		}
+		for _, pos := range g {
+			res[pos-1] = byte('a' + idx)
+		}
+		freq[idx] -= size
+	}
+	return "YES\n" + string(res)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	s := string(b)
+	return s + "\n", s
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, s := genCase(rng)
+		expect := strings.TrimSpace(solveA(s))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/123/verifierB.go
+++ b/0-999/100-199/120-129/123/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func floorDiv(u, m int64) int64 {
+	if u >= 0 {
+		return u / m
+	}
+	return (u+1)/m - 1
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+func max(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveB(a, b, x1, y1, x2, y2 int64) string {
+	u1 := x1 + y1
+	u2 := x2 + y2
+	v1 := x1 - y1
+	v2 := x2 - y2
+	iu1 := floorDiv(u1, 2*a)
+	iu2 := floorDiv(u2, 2*a)
+	iv1 := floorDiv(v1, 2*b)
+	iv2 := floorDiv(v2, 2*b)
+	pu := abs(iu1 - iu2)
+	pv := abs(iv1 - iv2)
+	ans := max(pu, pv)
+	return fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, [6]int64) {
+	var data [6]int64
+	a := int64(rng.Intn(100) + 1)
+	b := int64(rng.Intn(100) + 1)
+	x1 := int64(rng.Intn(2000) - 1000)
+	y1 := int64(rng.Intn(2000) - 1000)
+	x2 := int64(rng.Intn(2000) - 1000)
+	y2 := int64(rng.Intn(2000) - 1000)
+	data[0] = a
+	data[1] = b
+	data[2] = x1
+	data[3] = y1
+	data[4] = x2
+	data[5] = y2
+	input := fmt.Sprintf("%d %d %d %d %d %d\n", a, b, x1, y1, x2, y2)
+	return input, data
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, data := genCase(rng)
+		expect := solveB(data[0], data[1], data[2], data[3], data[4], data[5])
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/123/verifierC.go
+++ b/0-999/100-199/120-129/123/verifierC.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveC(n, m int, k int64, mat [][]int) string {
+	D := n + m - 1
+	type cell struct {
+		p int
+		d int
+	}
+	cells := make([]cell, 0, n*m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			cells = append(cells, cell{p: mat[i][j], d: i + j})
+		}
+	}
+	sort.Slice(cells, func(i, j int) bool { return cells[i].p < cells[j].p })
+	seen := make([]bool, D)
+	order := make([]int, 0, D)
+	for _, c := range cells {
+		if !seen[c.d] {
+			seen[c.d] = true
+			order = append(order, c.d)
+		}
+	}
+	fixed := make([]int, D)
+	var countWays func() int64
+	countWays = func() int64 {
+		dp := make([]int64, D+2)
+		dp[0] = 1
+		for pos := 0; pos < D; pos++ {
+			ndp := make([]int64, D+2)
+			if fixed[pos] == 1 {
+				for bal := 0; bal <= D; bal++ {
+					v := dp[bal]
+					if v == 0 {
+						continue
+					}
+					nb := bal + 1
+					ndp[nb] += v
+					if ndp[nb] > k {
+						ndp[nb] = k
+					}
+				}
+			} else if fixed[pos] == 2 {
+				for bal := 1; bal <= D; bal++ {
+					v := dp[bal]
+					if v == 0 {
+						continue
+					}
+					nb := bal - 1
+					ndp[nb] += v
+					if ndp[nb] > k {
+						ndp[nb] = k
+					}
+				}
+			} else {
+				for bal := 0; bal <= D; bal++ {
+					v := dp[bal]
+					if v == 0 {
+						continue
+					}
+					nb := bal + 1
+					ndp[nb] += v
+					if ndp[nb] > k {
+						ndp[nb] = k
+					}
+					if bal > 0 {
+						nb2 := bal - 1
+						ndp[nb2] += v
+						if ndp[nb2] > k {
+							ndp[nb2] = k
+						}
+					}
+				}
+			}
+			dp = ndp
+		}
+		return dp[0]
+	}
+	for _, d := range order {
+		fixed[d] = 1
+		cnt := countWays()
+		if cnt < k {
+			k -= cnt
+			fixed[d] = 2
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if fixed[i+j] == 1 {
+				sb.WriteByte('(')
+			} else {
+				sb.WriteByte(')')
+			}
+		}
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, int, int, int64, [][]int) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	k := int64(rng.Intn(5) + 1)
+	mat := make([][]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		row := make([]int, m)
+		for j := 0; j < m; j++ {
+			v := rng.Intn(10)
+			row[j] = v
+		}
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", row[j]))
+		}
+		sb.WriteByte('\n')
+		mat[i] = row
+	}
+	return sb.String(), n, m, k, mat
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, n, m, k, mat := genCase(rng)
+		expect := strings.TrimSpace(solveC(n, m, k, mat))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/123/verifierD.go
+++ b/0-999/100-199/120-129/123/verifierD.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const ALPHA = 26
+
+type state struct {
+	next [ALPHA]int
+	link int
+	len  int
+	occ  int
+}
+
+func solveD(s string) string {
+	n := len(s)
+	st := make([]state, 2*n)
+	size, last := 1, 0
+	st[0].link = -1
+	var extend func(int)
+	extend = func(c int) {
+		cur := size
+		size++
+		st[cur].len = st[last].len + 1
+		st[cur].occ = 1
+		p := last
+		for p != -1 && st[p].next[c] == 0 {
+			st[p].next[c] = cur + 1
+			p = st[p].link
+		}
+		if p == -1 {
+			st[cur].link = 0
+		} else {
+			q := st[p].next[c] - 1
+			if st[p].len+1 == st[q].len {
+				st[cur].link = q
+			} else {
+				clone := size
+				size++
+				st[clone] = st[q]
+				st[clone].len = st[p].len + 1
+				st[clone].occ = 0
+				for p != -1 && st[p].next[c] == q+1 {
+					st[p].next[c] = clone + 1
+					p = st[p].link
+				}
+				st[q].link = clone
+				st[cur].link = clone
+			}
+		}
+		last = cur
+	}
+	for i := 0; i < n; i++ {
+		extend(int(s[i] - 'a'))
+	}
+	maxLen := n
+	cntLen := make([]int, maxLen+1)
+	for i := 0; i < size; i++ {
+		cntLen[st[i].len]++
+	}
+	pos := make([]int, maxLen+1)
+	for l := 1; l <= maxLen; l++ {
+		pos[l] = pos[l-1] + cntLen[l-1]
+	}
+	order := make([]int, size)
+	for i := 0; i < size; i++ {
+		l := st[i].len
+		order[pos[l]] = i
+		pos[l]++
+	}
+	for i := size - 1; i >= 0; i-- {
+		v := order[i]
+		if st[v].link != -1 {
+			st[st[v].link].occ += st[v].occ
+		}
+	}
+	var ans uint64
+	for i := 0; i < size; i++ {
+		linkLen := 0
+		if st[i].link != -1 {
+			linkLen = st[st[i].link].len
+		}
+		delta := st[i].len - linkLen
+		if delta > 0 {
+			c := uint64(st[i].occ)
+			ans += uint64(delta) * c * (c + 1) / 2
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	s := string(b)
+	return s + "\n", s
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, s := genCase(rng)
+		expect := solveD(s)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/123/verifierE.go
+++ b/0-999/100-199/120-129/123/verifierE.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(n int, edges [][2]int, stVals, enVals []int64) string {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	st := make([]int64, n+1)
+	en := make([]int64, n+1)
+	var sst, sen int64
+	for i := 1; i <= n; i++ {
+		st[i] = stVals[i-1]
+		en[i] = enVals[i-1]
+		sst += st[i]
+		sen += en[i]
+	}
+	parent := make([]int, n+1)
+	order := make([]int, 0, n)
+	stack := []int{1}
+	parent[1] = 0
+	for len(stack) > 0 {
+		x := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, x)
+		for _, y := range adj[x] {
+			if y != parent[x] {
+				parent[y] = x
+				stack = append(stack, y)
+			}
+		}
+	}
+	size := make([]int64, n+1)
+	stSum := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		size[i] = 1
+		stSum[i] = st[i]
+	}
+	var ans float64
+	for i := len(order) - 1; i >= 0; i-- {
+		x := order[i]
+		p := parent[x]
+		if p != 0 {
+			size[p] += size[x]
+			stSum[p] += stSum[x]
+			ans += float64(stSum[x]) * float64(size[x]) * float64(en[p])
+		}
+		ans += float64(sst-stSum[x]) * float64(int64(n)-size[x]) * float64(en[x])
+	}
+	res := ans / float64(sst) / float64(sen)
+	return fmt.Sprintf("%.11f", res)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, int, [][2]int, []int64, []int64) {
+	n := rng.Intn(5) + 1
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{i, p})
+	}
+	stVals := make([]int64, n)
+	enVals := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	for i := 0; i < n; i++ {
+		stVals[i] = int64(rng.Intn(10) + 1)
+		enVals[i] = int64(rng.Intn(10) + 1)
+		sb.WriteString(fmt.Sprintf("%d %d\n", stVals[i], enVals[i]))
+	}
+	return sb.String(), n, edges, stVals, enVals
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, n, edges, stVals, enVals := genCase(rng)
+		expect := solveE(n, edges, stVals, enVals)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 123
- implement logic from the reference solutions
- generate random tests (100 per run)
- fix input generation for `verifierC.go`

## Testing
- `go build 0-999/100-199/120-129/123/verifierA.go`
- `go build 0-999/100-199/120-129/123/verifierB.go`
- `go build 0-999/100-199/120-129/123/verifierC.go`
- `go build 0-999/100-199/120-129/123/verifierD.go`
- `go build 0-999/100-199/120-129/123/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e6e2a51b08324a480da350a1a1c56