### PR TITLE
Add verifiers for contest 122

### DIFF
--- a/0-999/100-199/120-129/122/verifierA.go
+++ b/0-999/100-199/120-129/122/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isAlmostLucky(n int) bool {
+	lucky := []int{4, 7, 44, 47, 74, 77, 444, 447, 474, 477, 744, 747, 774, 777}
+	for _, v := range lucky {
+		if n%v == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	special := []int{1, 4, 7, 16, 44, 47, 74, 77, 444, 447, 474, 477, 744, 747, 774, 777, 1000}
+	for i, n := range special {
+		exp := "NO"
+		if isAlmostLucky(n) {
+			exp = "YES"
+		}
+		input := fmt.Sprintf("%d\n", n)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("special case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("special case %d failed: n=%d expected %s got %s\n", i+1, n, exp, got)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(1000) + 1
+		exp := "NO"
+		if isAlmostLucky(n) {
+			exp = "YES"
+		}
+		input := fmt.Sprintf("%d\n", n)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("case %d failed: n=%d expected %s got %s\n", i+1, n, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/122/verifierB.go
+++ b/0-999/100-199/120-129/122/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(s string) string {
+	n := len(s)
+	best := ""
+	bestCount := 0
+	for i := 0; i < n; i++ {
+		if s[i] != '4' && s[i] != '7' {
+			continue
+		}
+		for j := i; j < n && (s[j] == '4' || s[j] == '7'); j++ {
+			substr := s[i : j+1]
+			count := 0
+			for k := 0; k+len(substr) <= n; k++ {
+				if s[k:k+len(substr)] == substr {
+					count++
+				}
+			}
+			if count > bestCount || (count == bestCount && (best == "" || substr < best)) {
+				best = substr
+				bestCount = count
+			}
+		}
+	}
+	if bestCount == 0 {
+		return "-1"
+	}
+	return best
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	special := []string{"4", "7", "47", "444", "123", "7777777", "123447744"}
+	for i, s := range special {
+		exp := solveB(s)
+		input := fmt.Sprintf("%s\n", s)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("special case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("special case %d failed: s=%s expected %s got %s\n", i+1, s, exp, got)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		length := rng.Intn(50) + 1
+		b := make([]byte, length)
+		for j := 0; j < length; j++ {
+			b[j] = byte('0' + rng.Intn(10))
+		}
+		s := string(b)
+		exp := solveB(s)
+		input := fmt.Sprintf("%s\n", s)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("case %d failed: s=%s expected %s got %s\n", i+1, s, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for contest 122
- each verifier runs special cases and 100 random tests against a provided binary

## Testing
- `go build 0-999/100-199/120-129/122/verifierA.go`
- `go build 0-999/100-199/120-129/122/verifierB.go`

------
https://chatgpt.com/codex/tasks/task_e_687e6e25b01c83248e07496c652ed666