### PR TITLE
Add Go verifiers for Codeforces Contest 120

### DIFF
--- a/0-999/100-199/120-129/120/verifierA.go
+++ b/0-999/100-199/120-129/120/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	door := "front"
+	if rng.Intn(2) == 0 {
+		door = "back"
+	}
+	a := rng.Intn(2) + 1
+	input := fmt.Sprintf("%s\n%d\n", door, a)
+	var res string
+	if (door == "front" && a == 1) || (door == "back" && a == 2) {
+		res = "L"
+	} else {
+		res = "R"
+	}
+	return input, res + "\n"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierA.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refA")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "120A.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, _ := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/120/verifierB.go
+++ b/0-999/100-199/120-129/120/verifierB.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	a := make([]int, n)
+	one := false
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			a[i] = 1
+			one = true
+		}
+	}
+	if !one {
+		idx := rng.Intn(n)
+		a[idx] = 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteByte('\n')
+	// compute expected
+	pos := k - 1
+	var ans int
+	for i := pos; i < n; i++ {
+		if a[i] == 1 {
+			ans = i + 1
+			break
+		}
+	}
+	if ans == 0 {
+		for i := 0; i < pos; i++ {
+			if a[i] == 1 {
+				ans = i + 1
+				break
+			}
+		}
+	}
+	return sb.String(), fmt.Sprintf("%d\n", ans)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierB.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refB")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "120B.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/120/verifierC.go
+++ b/0-999/100-199/120-129/120/verifierC.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type jar struct {
+	rem   int
+	eaten int
+}
+
+func expected(n, k int, arr []int) string {
+	jars := make([]jar, n)
+	for i := 0; i < n; i++ {
+		jars[i] = jar{rem: arr[i], eaten: 0}
+	}
+	total := 0
+	for len(jars) > 0 {
+		maxIdx := 0
+		for i := 1; i < len(jars); i++ {
+			if jars[i].rem > jars[maxIdx].rem {
+				maxIdx = i
+			}
+		}
+		j := &jars[maxIdx]
+		if j.rem < k || j.eaten >= 3 {
+			total += j.rem
+			jars = append(jars[:maxIdx], jars[maxIdx+1:]...)
+		} else {
+			j.rem -= k
+			j.eaten++
+		}
+	}
+	return fmt.Sprintf("%d\n", total)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(20) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(n, k, arr)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierC.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refC")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "120C.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/120/verifierD.go
+++ b/0-999/100-199/120-129/120/verifierD.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func expected(n, m int, grid [][]int, A, B, C int) string {
+	target := []int{A, B, C}
+	sort.Ints(target)
+	rowSum := make([]int, n)
+	for i := 0; i < n; i++ {
+		sum := 0
+		for j := 0; j < m; j++ {
+			sum += grid[i][j]
+		}
+		rowSum[i] = sum
+	}
+	prefRow := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		prefRow[i+1] = prefRow[i] + rowSum[i]
+	}
+	colSum := make([]int, m)
+	for j := 0; j < m; j++ {
+		sum := 0
+		for i := 0; i < n; i++ {
+			sum += grid[i][j]
+		}
+		colSum[j] = sum
+	}
+	prefCol := make([]int, m+1)
+	for j := 0; j < m; j++ {
+		prefCol[j+1] = prefCol[j] + colSum[j]
+	}
+	var ways int
+	if n >= 3 {
+		for c1 := 1; c1 <= n-2; c1++ {
+			for c2 := c1 + 1; c2 <= n-1; c2++ {
+				s1 := prefRow[c1]
+				s2 := prefRow[c2] - prefRow[c1]
+				s3 := prefRow[n] - prefRow[c2]
+				parts := []int{s1, s2, s3}
+				sort.Ints(parts)
+				if parts[0] == target[0] && parts[1] == target[1] && parts[2] == target[2] {
+					ways++
+				}
+			}
+		}
+	}
+	if m >= 3 {
+		for c1 := 1; c1 <= m-2; c1++ {
+			for c2 := c1 + 1; c2 <= m-1; c2++ {
+				s1 := prefCol[c1]
+				s2 := prefCol[c2] - prefCol[c1]
+				s3 := prefCol[m] - prefCol[c2]
+				parts := []int{s1, s2, s3}
+				sort.Ints(parts)
+				if parts[0] == target[0] && parts[1] == target[1] && parts[2] == target[2] {
+					ways++
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("%d\n", ways)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 3
+	m := rng.Intn(3) + 3
+	grid := make([][]int, n)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			grid[i][j] = rng.Intn(5)
+		}
+	}
+	A := rng.Intn(20)
+	B := rng.Intn(20)
+	C := rng.Intn(20)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", grid[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	fmt.Fprintf(&sb, "%d %d %d\n", A, B, C)
+	return sb.String(), expected(n, m, grid, A, B, C)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierD.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refD")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "120D.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/120/verifierE.go
+++ b/0-999/100-199/120-129/120/verifierE.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func expected(nums []int) string {
+	var sb strings.Builder
+	for i, n := range nums {
+		v := 1
+		if n%2 == 1 {
+			v = 0
+		}
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	T := 100
+	nums := make([]int, T)
+	for i := 0; i < T; i++ {
+		nums[i] = rng.Intn(10000) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	for i := 0; i < T; i++ {
+		fmt.Fprintf(&sb, "%d\n", nums[i])
+	}
+	return sb.String(), expected(nums)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierE.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refE")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "120E.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/120/verifierF.go
+++ b/0-999/100-199/120-129/120/verifierF.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func bfsFarthest(start int, adj [][]int) (int, int) {
+	n := len(adj)
+	dist := make([]int, n)
+	for i := range dist {
+		dist[i] = -1
+	}
+	q := []int{start}
+	dist[start] = 0
+	farNode, farDist := start, 0
+	for len(q) > 0 {
+		u := q[0]
+		q = q[1:]
+		for _, v := range adj[u] {
+			if dist[v] == -1 {
+				dist[v] = dist[u] + 1
+				q = append(q, v)
+			}
+		}
+		if dist[u] > farDist {
+			farDist = dist[u]
+			farNode = u
+		}
+	}
+	return farNode, farDist
+}
+
+func expected(n int, spiders []string) string {
+	idx := 0
+	total := 0
+	for i := 0; i < n; i++ {
+		parts := strings.Fields(spiders[i])
+		ni, _ := strconv.Atoi(parts[0])
+		edges := make([][2]int, ni-1)
+		for j := 0; j < ni-1; j++ {
+			u, _ := strconv.Atoi(parts[1+2*j])
+			v, _ := strconv.Atoi(parts[1+2*j+1])
+			u--
+			v--
+			edges[j] = [2]int{u, v}
+		}
+		adj := make([][]int, ni)
+		for _, e := range edges {
+			u, v := e[0], e[1]
+			adj[u] = append(adj[u], v)
+			adj[v] = append(adj[v], u)
+		}
+		far, _ := bfsFarthest(0, adj)
+		_, d := bfsFarthest(far, adj)
+		total += d
+		idx += ni - 1
+	}
+	return fmt.Sprintf("%d\n", total)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	spiders := make([]string, n)
+	for i := 0; i < n; i++ {
+		ni := rng.Intn(3) + 2
+		edges := make([][2]int, ni-1)
+		for j := 1; j < ni; j++ {
+			p := rng.Intn(j)
+			edges[j-1] = [2]int{p, j}
+		}
+		fmt.Fprintf(&sb, "%d", ni)
+		var line strings.Builder
+		fmt.Fprintf(&line, "%d", ni)
+		for _, e := range edges {
+			fmt.Fprintf(&sb, " %d %d", e[0]+1, e[1]+1)
+			fmt.Fprintf(&line, " %d %d", e[0]+1, e[1]+1)
+		}
+		sb.WriteByte('\n')
+		spiders[i] = line.String()
+	}
+	return sb.String(), expected(n, spiders)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierF.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refF")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "120F.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/120/verifierG.go
+++ b/0-999/100-199/120-129/120/verifierG.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateWord(rng *rand.Rand) string {
+	l := rng.Intn(5) + 1
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(2) + 1
+	tturn := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, tturn)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d %d %d\n", rng.Intn(5)+1, rng.Intn(5)+1, rng.Intn(5)+1, rng.Intn(5)+1)
+	}
+	m := rng.Intn(3) + 1
+	fmt.Fprintf(&sb, "%d\n", m)
+	for i := 0; i < m; i++ {
+		w := generateWord(rng)
+		fmt.Fprintf(&sb, "%s\n%d\n", w, rng.Intn(5)+1)
+	}
+	input := sb.String()
+	return input, runRef(input)
+}
+
+func runRef(input string) string {
+	ref := filepath.Join(filepath.Dir(os.Args[0]), "refG")
+	cmd := exec.Command(ref)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Run()
+	return out.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierG.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refG")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "120G.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s\n", t+1, input, expect, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/120/verifierH.go
+++ b/0-999/100-199/120-129/120/verifierH.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randomWord(rng *rand.Rand) string {
+	l := rng.Intn(6) + 1
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	words := make([]string, n)
+	for i := 0; i < n; i++ {
+		words[i] = randomWord(rng)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%s\n", words[i])
+	}
+	input := sb.String()
+	return input, runRef(input)
+}
+
+func runRef(input string) string {
+	ref := filepath.Join(filepath.Dir(os.Args[0]), "refH")
+	cmd := exec.Command(ref)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Run()
+	return out.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierH.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refH")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "120H.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s\n", t+1, input, expect, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/120/verifierI.go
+++ b/0-999/100-199/120-129/120/verifierI.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randomDigits(rng *rand.Rand) string {
+	n := (rng.Intn(4) + 1) * 2
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('0' + rng.Intn(10))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	s := randomDigits(rng)
+	input := s + "\n"
+	return input, runRef(input)
+}
+
+func runRef(input string) string {
+	ref := filepath.Join(filepath.Dir(os.Args[0]), "refI")
+	cmd := exec.Command(ref)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Run()
+	return out.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierI.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refI")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "120I.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s\n", t+1, input, expect, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/120-129/120/verifierJ.go
+++ b/0-999/100-199/120-129/120/verifierJ.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 2
+	xs := make([]int, n)
+	ys := make([]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		xs[i] = rng.Intn(21) - 10
+		ys[i] = rng.Intn(21) - 10
+		fmt.Fprintf(&sb, "%d %d\n", xs[i], ys[i])
+	}
+	input := sb.String()
+	return input, runRef(input)
+}
+
+func runRef(input string) string {
+	ref := filepath.Join(filepath.Dir(os.Args[0]), "refJ")
+	cmd := exec.Command(ref)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Run()
+	return out.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierJ.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refJ")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "120J.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, expect := generateCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%sactual:%s\n", t+1, input, expect, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new Go-based solution verifiers for contest 120
- each verifier builds the reference solution and checks candidate binaries against 100 random tests

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go verifierH.go verifierI.go verifierJ.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6e0252808324ab3dde6edc0fc353