### PR TITLE
Add contest 118 verifiers

### DIFF
--- a/0-999/100-199/110-119/118/verifierA.go
+++ b/0-999/100-199/110-119/118/verifierA.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var vowels = map[byte]bool{
+	'A': true, 'O': true, 'Y': true, 'E': true, 'U': true, 'I': true,
+	'a': true, 'o': true, 'y': true, 'e': true, 'u': true, 'i': true,
+}
+
+func solve(s string) string {
+	var sb strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if vowels[c] {
+			continue
+		}
+		if c >= 'A' && c <= 'Z' {
+			c = c - 'A' + 'a'
+		}
+		sb.WriteByte('.')
+		sb.WriteByte(c)
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = byte('A' + rng.Intn(26))
+		} else {
+			b[i] = byte('a' + rng.Intn(26))
+		}
+	}
+	s := string(b)
+	return s + "\n", solve(s)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected '%s' got '%s'", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/110-119/118/verifierB.go
+++ b/0-999/100-199/110-119/118/verifierB.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func draw(n int) string {
+	var sb strings.Builder
+	total := 2*n + 1
+	for line := 0; line < total; line++ {
+		t := n - line
+		if t < 0 {
+			t = -t
+		}
+		m := n - t
+		for i := 0; i < t; i++ {
+			sb.WriteByte(' ')
+		}
+		for i := 0; i <= m; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", i))
+		}
+		for i := m - 1; i >= 0; i-- {
+			sb.WriteByte(' ')
+			sb.WriteString(fmt.Sprintf("%d", i))
+		}
+		if line+1 < total {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2 // 2..9
+	return fmt.Sprintf("%d\n", n), draw(n)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimRight(out.String(), "\n")
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/110-119/118/verifierC.go
+++ b/0-999/100-199/110-119/118/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n, k int, s string) (int, string) {
+	bytesArr := []byte(s)
+	bestCost := math.MaxInt64
+	bestResult := ""
+	for target := byte('0'); target <= '9'; target++ {
+		cnt := 0
+		for i := 0; i < n; i++ {
+			if bytesArr[i] == target {
+				cnt++
+			}
+		}
+		need := k - cnt
+		cost := 0
+		b := make([]byte, n)
+		copy(b, bytesArr)
+		if need > 0 {
+			for d := 1; d <= 9 && need > 0; d++ {
+				for i := 0; i < n && need > 0; i++ {
+					if b[i] > target && int(b[i]-target) == d {
+						cost += d
+						b[i] = target
+						need--
+					}
+				}
+				for i := n - 1; i >= 0 && need > 0; i-- {
+					if b[i] < target && int(target-b[i]) == d {
+						cost += d
+						b[i] = target
+						need--
+					}
+				}
+			}
+		}
+		result := string(b)
+		if cost < bestCost || (cost == bestCost && result < bestResult) {
+			bestCost = cost
+			bestResult = result
+		}
+	}
+	return bestCost, bestResult
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	digits := make([]byte, n)
+	for i := 0; i < n; i++ {
+		digits[i] = byte('0' + rng.Intn(10))
+	}
+	s := string(digits)
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	cost, res := solveCase(n, k, s)
+	input := sb.String()
+	expected := fmt.Sprintf("%d\n%s", cost, res)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/110-119/118/verifierD.go
+++ b/0-999/100-199/110-119/118/verifierD.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 100000000
+
+func solveCase(n1, n2, k1, k2 int) int {
+	dpF := make([][]int, n1+1)
+	dpH := make([][]int, n1+1)
+	for i := 0; i <= n1; i++ {
+		dpF[i] = make([]int, n2+1)
+		dpH[i] = make([]int, n2+1)
+	}
+	dpF[0][0] = 1
+	dpH[0][0] = 1
+	for i := 0; i <= n1; i++ {
+		for j := 0; j <= n2; j++ {
+			if i == 0 && j == 0 {
+				continue
+			}
+			if i > 0 {
+				sum := 0
+				for x := 1; x <= k1 && x <= i; x++ {
+					sum += dpH[i-x][j]
+					if sum >= mod {
+						sum -= mod
+					}
+				}
+				dpF[i][j] = sum
+			}
+			if j > 0 {
+				sum := 0
+				for y := 1; y <= k2 && y <= j; y++ {
+					sum += dpF[i][j-y]
+					if sum >= mod {
+						sum -= mod
+					}
+				}
+				dpH[i][j] = sum
+			}
+		}
+	}
+	ans := dpF[n1][n2] + dpH[n1][n2]
+	ans %= mod
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n1 := rng.Intn(10) + 1
+	n2 := rng.Intn(10) + 1
+	k1 := rng.Intn(10) + 1
+	k2 := rng.Intn(10) + 1
+	input := fmt.Sprintf("%d %d %d %d\n", n1, n2, k1, k2)
+	ans := solveCase(n1, n2, k1, k2)
+	return input, fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/110-119/118/verifierE.go
+++ b/0-999/100-199/110-119/118/verifierE.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	u, v int
+}
+
+type directedEdge struct {
+	from, to int
+}
+
+func orientGraph(n int, edges []Edge) (bool, []directedEdge) {
+	m := len(edges)
+	adj := make([][]struct{ to, id int }, n+1)
+	for i, e := range edges {
+		id := i + 1
+		adj[e.u] = append(adj[e.u], struct{ to, id int }{e.v, id})
+		adj[e.v] = append(adj[e.v], struct{ to, id int }{e.u, id})
+	}
+	visited := make([]bool, n+1)
+	dep := make([]int, n+1)
+	low := make([]int, n+1)
+	parent := make([]int, n+1)
+	done := make([]bool, m+1)
+	ans := make([]directedEdge, m+1)
+	hasBridge := false
+
+	var dfs func(x int)
+	dfs = func(x int) {
+		visited[x] = true
+		low[x] = dep[x]
+		for _, e := range adj[x] {
+			j := e.to
+			id := e.id
+			if !visited[j] {
+				if !done[id] {
+					done[id] = true
+					ans[id] = directedEdge{x, j}
+				}
+				parent[j] = x
+				dep[j] = dep[x] + 1
+				dfs(j)
+				if low[j] < low[x] {
+					low[x] = low[j]
+				}
+				if low[j] > dep[x] {
+					hasBridge = true
+				}
+			} else if j != parent[x] {
+				if dep[j] < low[x] {
+					low[x] = dep[j]
+				}
+				if !done[id] {
+					done[id] = true
+					ans[id] = directedEdge{x, j}
+				}
+			}
+		}
+	}
+
+	dfs(1)
+	if hasBridge {
+		return false, nil
+	}
+	out := make([]directedEdge, 0, m)
+	for i := 1; i <= m; i++ {
+		out = append(out, ans[i])
+	}
+	return true, out
+}
+
+func isStronglyConnected(n int, dirs []directedEdge) bool {
+	adj := make([][]int, n+1)
+	for _, e := range dirs {
+		adj[e.from] = append(adj[e.from], e.to)
+	}
+	// bfs from 1
+	vis := make([]bool, n+1)
+	queue := []int{1}
+	vis[1] = true
+	for len(queue) > 0 {
+		x := queue[0]
+		queue = queue[1:]
+		for _, y := range adj[x] {
+			if !vis[y] {
+				vis[y] = true
+				queue = append(queue, y)
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if !vis[i] {
+			return false
+		}
+	}
+	// check reverse
+	radj := make([][]int, n+1)
+	for _, e := range dirs {
+		radj[e.to] = append(radj[e.to], e.from)
+	}
+	vis = make([]bool, n+1)
+	queue = []int{1}
+	vis[1] = true
+	for len(queue) > 0 {
+		x := queue[0]
+		queue = queue[1:]
+		for _, y := range radj[x] {
+			if !vis[y] {
+				vis[y] = true
+				queue = append(queue, y)
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if !vis[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func generateCase(rng *rand.Rand) (string, int, bool, []directedEdge) {
+	n := rng.Intn(8) + 2 // 2..9 nodes to keep tests small
+	// Ensure connectivity: start with tree
+	edges := make([]Edge, 0, n*n)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, Edge{p, i})
+	}
+	extra := rng.Intn(n) // add up to n-1 extra edges
+	seen := make(map[[2]int]bool)
+	for _, e := range edges {
+		if e.u < e.v {
+			seen[[2]int{e.u, e.v}] = true
+		} else {
+			seen[[2]int{e.v, e.u}] = true
+		}
+	}
+	for i := 0; i < extra; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			i--
+			continue
+		}
+		key := [2]int{u, v}
+		if u > v {
+			key = [2]int{v, u}
+		}
+		if seen[key] {
+			i--
+			continue
+		}
+		seen[key] = true
+		edges = append(edges, Edge{u, v})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	ok, dirs := orientGraph(n, edges)
+	return sb.String(), n, ok, dirs
+}
+
+func expectedOutput(ok bool, dirs []directedEdge) string {
+	if !ok {
+		return "0"
+	}
+	var sb strings.Builder
+	for _, d := range dirs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", d.from, d.to))
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func runCase(bin string, input string, n int, expectOK bool, expDirs []directedEdge) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expectedOutput(expectOK, expDirs) {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expectedOutput(expectOK, expDirs), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n, ok, dirs := generateCase(rng)
+		if err := runCase(bin, in, n, ok, dirs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 118 problems A-E
- generate 100 random tests for each verifier
- run each solution against the corresponding binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6df80eec8324ba7e4cfa99940a60