### PR TITLE
Add Go verifiers for contest 115

### DIFF
--- a/0-999/100-199/110-119/115/verifierA.go
+++ b/0-999/100-199/110-119/115/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveA(p []int) int {
+	n := len(p)
+	depth := make([]int, n)
+	var dfs func(int) int
+	dfs = func(u int) int {
+		if depth[u] != 0 {
+			return depth[u]
+		}
+		if p[u] == -1 {
+			depth[u] = 1
+		} else {
+			depth[u] = dfs(p[u]) + 1
+		}
+		return depth[u]
+	}
+	maxD := 0
+	for i := 0; i < n; i++ {
+		d := dfs(i)
+		if d > maxD {
+			maxD = d
+		}
+	}
+	return maxD
+}
+
+func genCase() (string, int) {
+	n := rand.Intn(20) + 1
+	parents := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i == 0 || rand.Intn(2) == 0 {
+			parents[i] = -1
+		} else {
+			parents[i] = rand.Intn(i)
+		}
+		if parents[i] == -1 {
+			sb.WriteString("-1")
+		} else {
+			sb.WriteString(fmt.Sprintf("%d", parents[i]+1))
+		}
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	expect := solveA(parents)
+	return sb.String(), expect
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	for t := 1; t <= 100; t++ {
+		in, expect := genCase()
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			fmt.Println(in)
+			return
+		}
+		if strings.TrimSpace(got) != fmt.Sprint(expect) {
+			fmt.Printf("Test %d failed\nInput:\n%s\nExpected: %d\nGot: %s\n", t, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/110-119/115/verifierB.go
+++ b/0-999/100-199/110-119/115/verifierB.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+type seg struct{ r, l, rr int }
+
+func solveB(n, m int, grid []string) int {
+	weeds := []seg{}
+	for i := 0; i < n; i++ {
+		l, r := m+1, 0
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 'W' {
+				if j+1 < l {
+					l = j + 1
+				}
+				if j+1 > r {
+					r = j + 1
+				}
+			}
+		}
+		if r > 0 {
+			weeds = append(weeds, seg{i + 1, l, r})
+		}
+	}
+	if len(weeds) == 0 {
+		return 0
+	}
+	k := len(weeds)
+	const INF = int(1e9)
+	dp0 := make([]int, k)
+	dp1 := make([]int, k)
+	f := weeds[0]
+	base := f.r - 1
+	dp0[0] = base + (2*f.rr - f.l - 1)
+	dp1[0] = base + (f.rr - 1)
+	for t := 1; t < k; t++ {
+		c := weeds[t]
+		p := weeds[t-1]
+		gap := c.r - p.r
+		nd0, nd1 := INF, INF
+		start := p.l
+		costL := min(abs(start-c.l)+2*(c.rr-c.l), abs(start-c.rr)+(c.rr-c.l))
+		costR := min(abs(start-c.rr)+2*(c.rr-c.l), abs(start-c.l)+(c.rr-c.l))
+		nd0 = min(nd0, dp0[t-1]+gap+costL)
+		nd1 = min(nd1, dp0[t-1]+gap+costR)
+		start = p.rr
+		costL = min(abs(start-c.l)+2*(c.rr-c.l), abs(start-c.rr)+(c.rr-c.l))
+		costR = min(abs(start-c.rr)+2*(c.rr-c.l), abs(start-c.l)+(c.rr-c.l))
+		nd0 = min(nd0, dp1[t-1]+gap+costL)
+		nd1 = min(nd1, dp1[t-1]+gap+costR)
+		dp0[t], dp1[t] = nd0, nd1
+	}
+	res := dp0[k-1]
+	if dp1[k-1] < res {
+		res = dp1[k-1]
+	}
+	return res
+}
+
+func genCase() (string, int) {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(10) + 1
+	grid := make([]string, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rand.Intn(2) == 0 {
+				row[j] = '.'
+			} else {
+				row[j] = 'W'
+			}
+		}
+		grid[i] = string(row)
+		sb.WriteString(grid[i])
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	expect := solveB(n, m, grid)
+	return sb.String(), expect
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	for t := 1; t <= 100; t++ {
+		in, expect := genCase()
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			fmt.Println(in)
+			return
+		}
+		if strings.TrimSpace(got) != fmt.Sprint(expect) {
+			fmt.Printf("Test %d failed\nInput:\n%s\nExpected: %d\nGot: %s\n", t, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/110-119/115/verifierC.go
+++ b/0-999/100-199/110-119/115/verifierC.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const MOD = 1000003
+
+func solveC(n, m int, grid []string) int {
+	total := 1
+	for i := 0; i < n; i++ {
+		ways := 0
+		for p := 0; p < 2; p++ {
+			ok := true
+			for j := 0; j < m; j++ {
+				c := grid[i][j]
+				var exp byte
+				if (j%2 == 0) == (p == 0) {
+					exp = 'L'
+				} else {
+					exp = 'R'
+				}
+				if c == '1' || c == '3' {
+					if exp != 'L' {
+						ok = false
+						break
+					}
+				} else if c == '2' || c == '4' {
+					if exp != 'R' {
+						ok = false
+						break
+					}
+				}
+			}
+			if ok {
+				ways++
+			}
+		}
+		if ways == 0 {
+			return 0
+		}
+		total = (total * ways) % MOD
+	}
+	for j := 0; j < m; j++ {
+		ways := 0
+		for p := 0; p < 2; p++ {
+			ok := true
+			for i := 0; i < n; i++ {
+				c := grid[i][j]
+				var exp byte
+				if (i%2 == 0) == (p == 0) {
+					exp = 'T'
+				} else {
+					exp = 'B'
+				}
+				if c == '1' || c == '2' {
+					if exp != 'T' {
+						ok = false
+						break
+					}
+				} else if c == '3' || c == '4' {
+					if exp != 'B' {
+						ok = false
+						break
+					}
+				}
+			}
+			if ok {
+				ways++
+			}
+		}
+		if ways == 0 {
+			return 0
+		}
+		total = (total * ways) % MOD
+	}
+	return total
+}
+
+func genCase() (string, int) {
+	n := rand.Intn(4) + 1
+	m := rand.Intn(4) + 1
+	grid := make([]string, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	chars := []byte{'1', '2', '3', '4', '.'}
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			row[j] = chars[rand.Intn(len(chars))]
+		}
+		grid[i] = string(row)
+		sb.WriteString(grid[i])
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	expect := solveC(n, m, grid)
+	return sb.String(), expect
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	for t := 1; t <= 100; t++ {
+		in, expect := genCase()
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			fmt.Println(in)
+			return
+		}
+		if strings.TrimSpace(got) != fmt.Sprint(expect) {
+			fmt.Printf("Test %d failed\nInput:\n%s\nExpected: %d\nGot: %s\n", t, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/110-119/115/verifierD.go
+++ b/0-999/100-199/110-119/115/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const MODD = 1000003
+
+func solveD(s string) int {
+	n := len(s)
+	non := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		non[i+1] = non[i]
+		if s[i] < '0' || s[i] > '9' {
+			non[i+1]++
+		}
+	}
+	dp := make([][]int, n)
+	for i := range dp {
+		dp[i] = make([]int, n)
+	}
+	for length := 1; length <= n; length++ {
+		for i := 0; i+length-1 < n; i++ {
+			j := i + length - 1
+			if non[j+1]-non[i] == 0 {
+				dp[i][j] = 1
+				continue
+			}
+			ways := 0
+			if (s[i] == '+' || s[i] == '-') && i+1 <= j {
+				ways = dp[i+1][j]
+			}
+			for k := i + 1; k < j; k++ {
+				c := s[k]
+				if c == '+' || c == '-' || c == '*' || c == '/' {
+					left := dp[i][k-1]
+					if left != 0 {
+						right := dp[k+1][j]
+						if right != 0 {
+							ways = (ways + left*right) % MODD
+						}
+					}
+				}
+			}
+			dp[i][j] = ways
+		}
+	}
+	return dp[0][n-1] % MODD
+}
+
+func genCase() (string, int) {
+	length := rand.Intn(10) + 1
+	chars := []byte("0123456789+-*/")
+	b := make([]byte, length)
+	for i := 0; i < length; i++ {
+		b[i] = chars[rand.Intn(len(chars))]
+	}
+	s := string(b)
+	expect := solveD(s)
+	return s + "\n", expect
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	for t := 1; t <= 100; t++ {
+		in, expect := genCase()
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			fmt.Println(in)
+			return
+		}
+		if strings.TrimSpace(got) != fmt.Sprint(expect) {
+			fmt.Printf("Test %d failed\nInput:\n%s\nExpected: %d\nGot: %s\n", t, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/110-119/115/verifierE.go
+++ b/0-999/100-199/110-119/115/verifierE.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type race struct {
+	l, r int
+	p    int64
+}
+
+func solveE(n int, costs []int64, races []race) int64 {
+	prefix := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		prefix[i] = prefix[i-1] + costs[i-1]
+	}
+	byL := make([][]race, n+2)
+	for _, rc := range races {
+		if rc.l >= 1 && rc.l <= n {
+			byL[rc.l] = append(byL[rc.l], rc)
+		}
+	}
+	dp := make([]int64, n+3)
+	for i := n; i >= 1; i-- {
+		best := dp[i+1]
+		for _, rc := range byL[i] {
+			costSeg := prefix[rc.r] - prefix[i-1]
+			temp := dp[rc.r+1] + rc.p - costSeg
+			if temp > best {
+				best = temp
+			}
+		}
+		dp[i] = best
+	}
+	if dp[1] < 0 {
+		return 0
+	}
+	return dp[1]
+}
+
+func genCase() (string, string) {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(10)
+	costs := make([]int64, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		costs[i] = int64(rand.Intn(10))
+		fmt.Fprintf(&sb, "%d\n", costs[i])
+	}
+	races := make([]race, m)
+	for i := 0; i < m; i++ {
+		l := rand.Intn(n) + 1
+		r := rand.Intn(n-l+1) + l
+		p := int64(rand.Intn(20))
+		races[i] = race{l, l, 0}
+		races[i].r = r
+		races[i].p = p
+		fmt.Fprintf(&sb, "%d %d %d\n", l, r, p)
+	}
+	input := sb.String()
+	expect := solveE(n, costs, races)
+	return input, fmt.Sprint(expect)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	for t := 1; t <= 100; t++ {
+		in, expect := genCase()
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			fmt.Println(in)
+			return
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("Test %d failed\nInput:\n%s\nExpected: %s\nGot: %s\n", t, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifiers for problems A–E of contest 115
- each verifier generates 100 random tests and checks a binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6de91b4c8324a4751231eece7509