### PR TITLE
Add contest 111 solution verifiers

### DIFF
--- a/0-999/100-199/110-119/111/verifierA.go
+++ b/0-999/100-199/110-119/111/verifierA.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, bool) {
+	n := rng.Intn(10) + 1 // 1..10
+	u := rng.Intn(50) + 1
+	y := u + n - 1 + rng.Intn(20)
+	maxSq := int64(u*u + n - 1)
+	x := rng.Int63n(maxSq) + 1
+	if rng.Intn(3) == 0 { // make unsatisfiable
+		if rng.Intn(2) == 0 {
+			y = n - 1 // y < n -> impossible
+		} else {
+			x = maxSq + int64(rng.Intn(10)+1)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x, y))
+	feasible := y >= n && int64(y-n+1)*int64(y-n+1)+int64(n-1) >= x
+	return sb.String(), feasible
+}
+
+func verify(input, output string, feasible bool) error {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	var x, y int64
+	fmt.Fscan(in, &n, &x, &y)
+	out := bufio.NewReader(strings.NewReader(strings.TrimSpace(output)))
+	var vals []int64
+	for {
+		var v int64
+		if _, err := fmt.Fscan(out, &v); err != nil {
+			break
+		}
+		vals = append(vals, v)
+	}
+	if feasible {
+		if len(vals) != n {
+			return fmt.Errorf("expected %d numbers, got %d", n, len(vals))
+		}
+		var sum, sq int64
+		for _, v := range vals {
+			if v <= 0 {
+				return fmt.Errorf("non-positive number %d", v)
+			}
+			sum += v
+			sq += v * v
+		}
+		if sum > y {
+			return fmt.Errorf("sum %d exceeds %d", sum, y)
+		}
+		if sq < x {
+			return fmt.Errorf("sum squares %d less than %d", sq, x)
+		}
+	} else {
+		if len(vals) != 1 || vals[0] != -1 {
+			return fmt.Errorf("expected -1 for impossible case")
+		}
+	}
+	return nil
+}
+
+func runCase(exe, input string, feasible bool) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return verify(input, out.String(), feasible)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, feasible := generateCase(rng)
+		if err := runCase(exe, in, feasible); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/110-119/111/verifierB.go
+++ b/0-999/100-199/110-119/111/verifierB.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const maxV = 100000
+
+var spf [maxV + 1]int
+
+func initSieve() {
+	for i := 2; i <= maxV; i++ {
+		if spf[i] == 0 {
+			spf[i] = i
+			if i <= maxV/i {
+				for j := i * i; j <= maxV; j += i {
+					if spf[j] == 0 {
+						spf[j] = i
+					}
+				}
+			}
+		}
+	}
+}
+
+func solveB(n int, xs, ys []int) []int {
+	last := make([]int, maxV+1)
+	for i := range last {
+		last[i] = -1
+	}
+	ans := make([]int, n)
+	for idx := 0; idx < n; idx++ {
+		x := xs[idx]
+		y := ys[idx]
+		ps := make([]int, 0)
+		cs := make([]int, 0)
+		xx := x
+		for xx > 1 {
+			p := spf[xx]
+			cnt := 0
+			for xx%p == 0 {
+				xx /= p
+				cnt++
+			}
+			ps = append(ps, p)
+			cs = append(cs, cnt)
+		}
+		l := idx - y
+		r := idx - 1
+		res := 0
+		var dfs func(int, int)
+		dfs = func(step, mul int) {
+			if step < 0 {
+				if last[mul] < l {
+					res++
+				}
+				last[mul] = r + 1
+				return
+			}
+			cur := mul
+			for i := 0; i <= cs[step]; i++ {
+				dfs(step-1, cur)
+				cur *= ps[step]
+			}
+		}
+		dfs(len(ps)-1, 1)
+		ans[idx] = res
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	xs := make([]int, n)
+	ys := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		xs[i] = rng.Intn(100000) + 1
+		ys[i] = rng.Intn(i + 1)
+		sb.WriteString(fmt.Sprintf("%d %d\n", xs[i], ys[i]))
+	}
+	out := solveB(n, xs, ys)
+	var sbAns strings.Builder
+	for _, v := range out {
+		sbAns.WriteString(fmt.Sprintf("%d\n", v))
+	}
+	return sb.String(), sbAns.String()
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	initSieve()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/110-119/111/verifierC.go
+++ b/0-999/100-199/110-119/111/verifierC.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(n, m int) int {
+	if n > m {
+		n, m = m, n
+	}
+	switch n {
+	case 1, 2:
+		return n*m - (m+2)/(4-n)
+	case 3:
+		m0 := m
+		res := m0*n - (m0/4)*3
+		r := m0 % 4
+		res -= r
+		if r == 0 {
+			res--
+		}
+		return res
+	case 4:
+		res := m*n - m
+		if m == 5 || m == 6 || m == 9 {
+			res--
+		}
+		return res
+	case 5:
+		m0 := m
+		res := m0*n - (m0/5)*6
+		if m0 == 7 {
+			res++
+		}
+		r := m0 % 5
+		res -= r
+		res--
+		if r > 1 {
+			res--
+		}
+		return res
+	case 6:
+		return m*n - 10
+	default:
+		return n * m
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	var n, m int
+	for {
+		n = rng.Intn(8) + 1
+		m = rng.Intn(8) + 1
+		if n*m <= 40 {
+			break
+		}
+	}
+	input := fmt.Sprintf("%d %d\n", n, m)
+	out := fmt.Sprintf("%d\n", solveC(n, m))
+	return input, out
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/110-119/111/verifierD.go
+++ b/0-999/100-199/110-119/111/verifierD.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+var c [1005][1005]int64
+var f [1005]int64
+var fz [2005]int64
+var fm [1005]int64
+
+func modExp(base, exp int64) int64 {
+	res := int64(1)
+	base %= mod
+	for exp > 0 {
+		if exp&1 == 1 {
+			res = res * base % mod
+		}
+		base = base * base % mod
+		exp >>= 1
+	}
+	return res
+}
+
+func getC(n int) {
+	for i := 0; i <= n; i++ {
+		c[i][0] = 1
+		for j := 1; j <= i; j++ {
+			c[i][j] = c[i-1][j] + c[i-1][j-1]
+			if c[i][j] >= mod {
+				c[i][j] -= mod
+			}
+		}
+	}
+}
+
+func solveD(n, m, k int) int64 {
+	if m == 1 {
+		return modExp(int64(k), int64(n))
+	}
+	getC(n)
+	for i := 1; i <= n; i++ {
+		f[i] = modExp(int64(i), int64(n))
+		for j := 1; j < i; j++ {
+			f[i] = (f[i] - f[j]*c[i][j]%mod + mod) % mod
+		}
+	}
+	fz[0], fm[0] = 1, 1
+	limit := 2 * n
+	if limit > k {
+		limit = k
+	}
+	for i := 1; i <= limit; i++ {
+		fz[i] = fz[i-1] * int64(k-i+1) % mod
+	}
+	for i := 1; i <= n; i++ {
+		fm[i] = fm[i-1] * modExp(int64(i), mod-2) % mod
+	}
+	var ans int64
+	for i := 0; i <= n && i <= k; i++ {
+		temp := modExp(int64(i), int64(m-2)*int64(n))
+		for j := 0; j <= n-i && i+2*j <= k; j++ {
+			idx := i + 2*j
+			term := temp * fz[idx] % mod
+			term = term * fm[i] % mod
+			term = term * fm[j] % mod
+			term = term * fm[j] % mod
+			val := f[i+j]
+			term = term * val % mod
+			term = term * val % mod
+			ans = (ans + term) % mod
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	k := rng.Intn(20) + 1
+	input := fmt.Sprintf("%d %d %d\n", n, m, k)
+	out := fmt.Sprintf("%d\n", solveD(n, m, k))
+	return input, out
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/110-119/111/verifierE.go
+++ b/0-999/100-199/110-119/111/verifierE.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(7) + 4 // 4..10
+	m := rng.Intn(7) + 4
+	x1 := rng.Intn(n-2) + 2
+	y1 := rng.Intn(m-2) + 2
+	var x2, y2 int
+	for {
+		x2 = rng.Intn(n-2) + 2
+		y2 = rng.Intn(m-2) + 2
+		if x2 != x1 && y2 != y1 {
+			break
+		}
+	}
+	return fmt.Sprintf("%d %d\n%d %d\n%d %d\n", n, m, x1, y1, x2, y2)
+}
+
+func verify(input, output string) error {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n, m int
+	var x1, y1, x2, y2 int
+	fmt.Fscan(in, &n, &m)
+	fmt.Fscan(in, &x1, &y1)
+	fmt.Fscan(in, &x2, &y2)
+
+	out := bufio.NewReader(strings.NewReader(output))
+	var k int
+	if _, err := fmt.Fscan(out, &k); err != nil {
+		return fmt.Errorf("parse k: %v", err)
+	}
+	coords := make([][2]int, k)
+	for i := 0; i < k; i++ {
+		if _, err := fmt.Fscan(out, &coords[i][0], &coords[i][1]); err != nil {
+			return fmt.Errorf("parse coord %d: %v", i+1, err)
+		}
+	}
+	if _, err := fmt.Fscan(out, new(int)); err == nil {
+		return fmt.Errorf("extra output data")
+	}
+	if k != n*m {
+		return fmt.Errorf("length %d expected %d", k, n*m)
+	}
+	if coords[0][0] != x1 || coords[0][1] != y1 {
+		return fmt.Errorf("path doesn't start at (%d,%d)", x1, y1)
+	}
+	if coords[k-1][0] != x2 || coords[k-1][1] != y2 {
+		return fmt.Errorf("path doesn't end at (%d,%d)", x2, y2)
+	}
+	seen := make(map[[2]int]bool)
+	prev := coords[0]
+	seen[prev] = true
+	for i := 1; i < k; i++ {
+		cur := coords[i]
+		if cur[0] < 1 || cur[0] > n || cur[1] < 1 || cur[1] > m {
+			return fmt.Errorf("cell out of bounds: %v", cur)
+		}
+		dx := cur[0] - prev[0]
+		if dx < 0 {
+			dx = -dx
+		}
+		dy := cur[1] - prev[1]
+		if dy < 0 {
+			dy = -dy
+		}
+		if dx+dy != 1 {
+			return fmt.Errorf("cells %v and %v not adjacent", prev, cur)
+		}
+		if seen[cur] {
+			return fmt.Errorf("cell %v repeated", cur)
+		}
+		seen[cur] = true
+		prev = cur
+	}
+	return nil
+}
+
+func runCase(exe, input string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return verify(input, out.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 111
- each verifier generates 100 random test cases
- verifiers check candidate solutions and report failures

## Testing
- `go build 0-999/100-199/110-119/111/verifierA.go`
- `go build 0-999/100-199/110-119/111/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6dd4e0a883249fc8b8b73f5ff3ed