### PR TITLE
Add verifiers for contest 110

### DIFF
--- a/0-999/100-199/110-119/110/verifierA.go
+++ b/0-999/100-199/110-119/110/verifierA.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func expectedNearlyLucky(n uint64) string {
+	count := 0
+	for tmp := n; tmp > 0; tmp /= 10 {
+		d := tmp % 10
+		if d == 4 || d == 7 {
+			count++
+		}
+	}
+	if count == 0 {
+		return "NO"
+	}
+	for tmp := count; tmp > 0; tmp /= 10 {
+		d := tmp % 10
+		if d != 4 && d != 7 {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func runCase(bin string, input string, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input + "\n")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("execution error: %v (output: %s)", err, out.String())
+	}
+	result := strings.TrimSpace(out.String())
+	if result != expected {
+		return fmt.Errorf("expected %q got %q", expected, result)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("Usage: go run verifierA.go /path/to/binary")
+	}
+	bin := os.Args[1]
+	var cases []uint64
+	for i := 1; i <= 100; i++ {
+		cases = append(cases, uint64(i))
+	}
+	extras := []uint64{444444444444444444, 777777777777777777, 474747474747474747, 123456789876543210}
+	cases = append(cases, extras...)
+
+	for idx, n := range cases {
+		expect := expectedNearlyLucky(n)
+		if err := runCase(bin, strconv.FormatUint(n, 10), expect); err != nil {
+			log.Fatalf("case %d (%d) failed: %v", idx+1, n, err)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(cases))
+}

--- a/0-999/100-199/110-119/110/verifierB.go
+++ b/0-999/100-199/110-119/110/verifierB.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func expectedString(n int) string {
+	letters := []byte{'a', 'b', 'c', 'd'}
+	res := make([]byte, n)
+	for i := 0; i < n; i++ {
+		res[i] = letters[i%4]
+	}
+	return string(res)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input + "\n")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("execution error: %v (output: %s)", err, out.String())
+	}
+	result := strings.TrimSpace(out.String())
+	if result != expected {
+		return fmt.Errorf("expected %q got %q", expected, result)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("Usage: go run verifierB.go /path/to/binary")
+	}
+	bin := os.Args[1]
+	var cases []int
+	for i := 1; i <= 100; i++ {
+		cases = append(cases, i)
+	}
+	extras := []int{101, 256, 512, 1000, 100000}
+	cases = append(cases, extras...)
+
+	for idx, n := range cases {
+		expect := expectedString(n)
+		if err := runCase(bin, strconv.Itoa(n), expect); err != nil {
+			log.Fatalf("case %d (%d) failed: %v", idx+1, n, err)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest 110 problems A and B
- each verifier runs the target solution binary against more than 100 test cases
- allows usage: `go run verifierA.go /path/to/binary`

## Testing
- `go build 0-999/100-199/110-119/110/110A.go`
- `go run 0-999/100-199/110-119/110/verifierA.go ./110A`
- `go build 0-999/100-199/110-119/110/110B.go`
- `go run 0-999/100-199/110-119/110/verifierB.go ./110B`


------
https://chatgpt.com/codex/tasks/task_e_687e6dcfb10883248b048eda4566898d