### PR TITLE
Add solution verifiers for contest 109

### DIFF
--- a/0-999/100-199/100-109/109/verifierA.go
+++ b/0-999/100-199/100-109/109/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isLucky(x int) bool {
+	if x == 0 {
+		return true
+	}
+	for x > 0 {
+		d := x % 10
+		if d != 4 && d != 7 {
+			return false
+		}
+		x /= 10
+	}
+	return true
+}
+
+func solveA(n int) string {
+	count4 := 0
+	for n%7 != 0 && n >= 4 {
+		n -= 4
+		count4++
+	}
+	if n%7 != 0 {
+		return "-1"
+	}
+	return strings.Repeat("4", count4) + strings.Repeat("7", n/7)
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("%d\n", n)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveA(n)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []int{1, 2, 3, 4, 5, 6, 7, 8, 11, 44, 47, 51, 1000000}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, rng.Intn(1000000)+1)
+	}
+	for i, n := range cases {
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %d\n", i+1, err, n)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/109/verifierB.go
+++ b/0-999/100-199/100-109/109/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	pl, pr, vl, vr, k int
+}
+
+func compileRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(os.TempDir(), "ref109B")
+	cmd := exec.Command("go", "build", "-o", exe, filepath.Join(dir, "109B.go"))
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	pl := rng.Intn(1000000000) + 1
+	pr := pl + rng.Intn(1000)
+	vl := rng.Intn(1000000000) + 1
+	vr := vl + rng.Intn(1000)
+	k := rng.Intn(10) + 1
+	return testCase{pl, pr, vl, vr, k}
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	input := fmt.Sprintf("%d %d %d %d %d\n", tc.pl, tc.pr, tc.vl, tc.vr, tc.k)
+	run := func(path string) (string, error) {
+		cmd := exec.Command(path)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err := cmd.Run()
+		return strings.TrimSpace(out.String()), err
+	}
+	expected, err := run(ref)
+	if err != nil {
+		return fmt.Errorf("reference error: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, got)
+	}
+	if expected == "" {
+		expected = "0"
+	}
+	if got == "" {
+		got = "0"
+	}
+	var expVal, gotVal float64
+	if _, err := fmt.Sscan(expected, &expVal); err != nil {
+		return fmt.Errorf("bad ref output: %v", err)
+	}
+	if _, err := fmt.Sscan(got, &gotVal); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	diff := gotVal - expVal
+	if diff < -1e-6 || diff > 1e-6 {
+		return fmt.Errorf("expected %.6f got %.6f", expVal, gotVal)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{1, 10, 1, 10, 2},
+		{1, 100, 1, 100, 3},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %v\n", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/109/verifierC.go
+++ b/0-999/100-199/100-109/109/verifierC.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type UF struct {
+	parent []int
+	size   []int
+}
+
+func NewUF(n int) *UF {
+	p := make([]int, n)
+	s := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = i
+		s[i] = 1
+	}
+	return &UF{p, s}
+}
+
+func (u *UF) Find(x int) int {
+	if u.parent[x] != x {
+		u.parent[x] = u.Find(u.parent[x])
+	}
+	return u.parent[x]
+}
+
+func (u *UF) Union(a, b int) {
+	a = u.Find(a)
+	b = u.Find(b)
+	if a == b {
+		return
+	}
+	if u.size[a] > u.size[b] {
+		a, b = b, a
+	}
+	u.parent[a] = b
+	u.size[b] += u.size[a]
+	u.size[a] = 0
+}
+
+func lucky(x int) bool {
+	if x == 0 {
+		return true
+	}
+	for x > 0 {
+		d := x % 10
+		if d != 4 && d != 7 {
+			return false
+		}
+		x /= 10
+	}
+	return true
+}
+
+func expectedOutput(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(r, &n)
+	uf := NewUF(n)
+	for i := 0; i < n-1; i++ {
+		var a, b, c int
+		fmt.Fscan(r, &a, &b, &c)
+		if !lucky(c) {
+			uf.Union(a-1, b-1)
+		}
+	}
+	total := int64(n)
+	var ans int64
+	for i := 0; i < n; i++ {
+		s := uf.size[i]
+		if s == 0 {
+			continue
+		}
+		rem := total - int64(s)
+		ans += int64(s) * rem * (rem - 1)
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		a := i
+		b := rng.Intn(i-1) + 1
+		w := rng.Intn(1000) + 1
+		if rng.Intn(5) == 0 {
+			if rng.Intn(2) == 0 {
+				w = 4
+			} else {
+				w = 7
+			}
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", a, b, w))
+	}
+	return sb.String()
+}
+
+func runCase(bin string, input string, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{
+		"1\n",
+		"2\n1 2 4\n",
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		exp := expectedOutput(tc)
+		if err := runCase(bin, tc, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/109/verifierD.go
+++ b/0-999/100-199/100-109/109/verifierD.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func lucky(x int) bool {
+	if x == 0 {
+		return true
+	}
+	for x > 0 {
+		d := x % 10
+		if d != 4 && d != 7 {
+			return false
+		}
+		x /= 10
+	}
+	return true
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(1000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func parseInput(input string) []int {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(r, &n)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &arr[i])
+	}
+	return arr
+}
+
+func hasLucky(arr []int) bool {
+	for _, v := range arr {
+		if lucky(v) {
+			return true
+		}
+	}
+	return false
+}
+
+func runCase(bin string, input string) error {
+	original := parseInput(input)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	reader := bufio.NewReader(strings.NewReader(out.String()))
+	var k int
+	if _, err := fmt.Fscan(reader, &k); err != nil {
+		return fmt.Errorf("cannot read k: %v", err)
+	}
+	arr := append([]int(nil), original...)
+	if k == -1 {
+		if hasLucky(arr) || !sort.IntsAreSorted(append([]int(nil), arr...)) {
+			return fmt.Errorf("unexpected -1 output")
+		}
+		if _, err := fmt.Fscan(reader, new(int)); err != io.EOF {
+			return fmt.Errorf("extra output")
+		}
+		return nil
+	}
+	n := len(arr)
+	if k < 0 || k > 2*n {
+		return fmt.Errorf("invalid k")
+	}
+	for i := 0; i < k; i++ {
+		var a, b int
+		if _, err := fmt.Fscan(reader, &a, &b); err != nil {
+			return fmt.Errorf("cannot read op %d: %v", i+1, err)
+		}
+		if a < 1 || a > n || b < 1 || b > n || a == b {
+			return fmt.Errorf("invalid op %d", i+1)
+		}
+		a--
+		b--
+		if !lucky(arr[a]) && !lucky(arr[b]) {
+			return fmt.Errorf("swap %d violates lucky condition", i+1)
+		}
+		arr[a], arr[b] = arr[b], arr[a]
+	}
+	if _, err := fmt.Fscan(reader, new(int)); err != io.EOF {
+		return fmt.Errorf("extra output")
+	}
+	sorted := append([]int(nil), original...)
+	sort.Ints(sorted)
+	for i := 0; i < n; i++ {
+		if arr[i] != sorted[i] {
+			return fmt.Errorf("array not sorted after swaps")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{
+		"1\n4\n",
+		"2\n1 2\n",
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/109/verifierE.go
+++ b/0-999/100-199/100-109/109/verifierE.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type testCase struct{ a, l int64 }
+
+func compileRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(os.TempDir(), "ref109E")
+	cmd := exec.Command("go", "build", "-o", exe, filepath.Join(dir, "109E.go"))
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	a := rng.Int63n(1000000) + 1
+	l := rng.Int63n(1000) + 1
+	return testCase{a, l}
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	input := fmt.Sprintf("%d %d\n", tc.a, tc.l)
+	run := func(path string) (string, error) {
+		cmd := exec.Command(path)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err := cmd.Run()
+		return strings.TrimSpace(out.String()), err
+	}
+	expected, err := run(ref)
+	if err != nil {
+		return fmt.Errorf("ref error: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, got)
+	}
+	if expected != got {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{1, 1}, {4, 3}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %v\n", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for Codeforces contest 109 problems A–E
- verifiers run given binary (or Go file via `go run`) against 100+ randomized test cases
- problem B and E use compiled reference solutions for validation
- problem D verifies custom swap logic

## Testing
- `go build 0-999/100-199/100-109/109/verifierA.go`
- `go build 0-999/100-199/100-109/109/verifierB.go`
- `go build 0-999/100-199/100-109/109/verifierC.go`
- `go build 0-999/100-199/100-109/109/verifierD.go`
- `go build 0-999/100-199/100-109/109/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6dcadbe883249004ff75e2469c39