### PR TITLE
Add Go verifiers for contest 108

### DIFF
--- a/0-999/100-199/100-109/108/verifierA.go
+++ b/0-999/100-199/100-109/108/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func nextPalTime(h, m int) string {
+	start := h*60 + m
+	for i := 1; i <= 24*60; i++ {
+		t := (start + i) % (24 * 60)
+		hh := t / 60
+		mm := t % 60
+		if hh/10 == mm%10 && hh%10 == mm/10 {
+			return fmt.Sprintf("%02d:%02d", hh, mm)
+		}
+	}
+	return "00:00"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	h := rng.Intn(24)
+	m := rng.Intn(60)
+	input := fmt.Sprintf("%02d:%02d\n", h, m)
+	expected := nextPalTime(h, m)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/108/verifierB.go
+++ b/0-999/100-199/100-109/108/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expectedOutput(a []int) string {
+	sort.Ints(a)
+	for i := 0; i < len(a)-1; i++ {
+		if a[i] != a[i+1] && a[i]*2 > a[i+1] {
+			return "YES"
+		}
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 2
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		// sizes between 1 and 1000
+		a[i] = rng.Intn(1000) + 1
+	}
+	exp := expectedOutput(append([]int(nil), a...))
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifierA for problem A of contest 108
- add Go verifierB for problem B of contest 108

## Testing
- `go run verifierA.go ./108A_bin`
- `go run verifierB.go ./108B_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e6dc59a4483249b410be03c03e772