### PR TITLE
Add Go verifiers for contest 107

### DIFF
--- a/0-999/100-199/100-109/107/verifierA.go
+++ b/0-999/100-199/100-109/107/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pipe struct{ from, to, d int }
+
+func solveA(n int, pipes []pipe) string {
+	to := make([][2]int, n+1)
+	in := make([]bool, n+1)
+	out := make([]bool, n+1)
+	for _, p := range pipes {
+		to[p.from][0] = p.to
+		to[p.from][1] = p.d
+		out[p.from] = true
+		in[p.to] = true
+	}
+	tanks := []int{}
+	for i := 1; i <= n; i++ {
+		if out[i] && !in[i] {
+			tanks = append(tanks, i)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(tanks)))
+	for _, t := range tanks {
+		at := to[t][0]
+		md := to[t][1]
+		for out[at] {
+			if md > to[at][1] {
+				md = to[at][1]
+			}
+			at = to[at][0]
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", t, at, md))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		usedIn := make([]bool, n+1)
+		usedOut := make([]bool, n+1)
+		p := rng.Intn(n)
+		pipes := make([]pipe, 0, p)
+		for j := 0; j < p; j++ {
+			a := rng.Intn(n) + 1
+			if usedOut[a] {
+				continue
+			}
+			b := rng.Intn(n) + 1
+			for b == a || usedIn[b] {
+				b = rng.Intn(n) + 1
+			}
+			d := rng.Intn(1000) + 1
+			usedOut[a] = true
+			usedIn[b] = true
+			pipes = append(pipes, pipe{a, b, d})
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, len(pipes)))
+		for _, pp := range pipes {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", pp.from, pp.to, pp.d))
+		}
+		input := sb.String()
+		expect := solveA(n, pipes)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, input, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/107/verifierB.go
+++ b/0-999/100-199/100-109/107/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testB struct {
+	n, m, h int
+	s       []int
+}
+
+func solveB(n, m, h int, s []int) string {
+	total := 0
+	for _, x := range s {
+		total += x
+	}
+	if total < n {
+		return "-1\n"
+	}
+	A := total - s[h-1]
+	B := n - 1
+	probNone := 1.0
+	if A < B {
+		probNone = 0.0
+	} else {
+		for i := 0; i < B; i++ {
+			probNone *= float64(A-i) / float64(total-1-i)
+		}
+	}
+	P := 1.0 - probNone
+	return fmt.Sprintf("%.10f\n", P)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		m := rng.Intn(6) + 1
+		n := rng.Intn(5) + 1
+		h := rng.Intn(m) + 1
+		s := make([]int, m)
+		for j := 0; j < m; j++ {
+			s[j] = rng.Intn(5) + 1
+		}
+		// occasionally make impossible
+		if rng.Intn(4) == 0 {
+			n = m + 100
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, h))
+		for j, val := range s {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", val))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := solveB(n, m, h, s)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		exp := strings.TrimSpace(expect)
+		if out != exp {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/107/verifierC.go
+++ b/0-999/100-199/100-109/107/verifierC.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+type solverC struct {
+	n   int
+	adj [][]int
+	inE []int
+}
+
+func newSolverC(n int, edges []edge) *solverC {
+	adj := make([][]int, n)
+	inE := make([]int, n)
+	for _, e := range edges {
+		u, v := e.u-1, e.v-1
+		if u < 0 || u >= n || v < 0 || v >= n {
+			continue
+		}
+		adj[u] = append(adj[u], v)
+		inE[v] |= 1 << u
+	}
+	return &solverC{n, adj, inE}
+}
+
+func (s *solverC) hasCycleUtil(v int, vis, rec []bool) bool {
+	vis[v] = true
+	rec[v] = true
+	for _, to := range s.adj[v] {
+		if !vis[to] {
+			if s.hasCycleUtil(to, vis, rec) {
+				return true
+			}
+		} else if rec[to] {
+			return true
+		}
+	}
+	rec[v] = false
+	return false
+}
+
+func (s *solverC) hasCycle() bool {
+	vis := make([]bool, s.n)
+	rec := make([]bool, s.n)
+	for i := 0; i < s.n; i++ {
+		if !vis[i] {
+			if s.hasCycleUtil(i, vis, rec) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *solverC) count(given []int) int64 {
+	size := 1 << s.n
+	dp := make([]int64, size)
+	dp[0] = 1
+	for mask := 0; mask < size-1; mask++ {
+		if dp[mask] == 0 {
+			continue
+		}
+		c := bits.OnesCount(uint(mask))
+		if given[c] == -1 {
+			for j := 0; j < s.n; j++ {
+				if mask&(1<<j) == 0 && mask&s.inE[j] == s.inE[j] {
+					dp[mask|1<<j] += dp[mask]
+				}
+			}
+		} else {
+			j := given[c]
+			if mask&s.inE[j] == s.inE[j] {
+				dp[mask|1<<j] += dp[mask]
+			}
+		}
+	}
+	return dp[size-1]
+}
+
+func (s *solverC) solve(year int64) (string, bool) {
+	year -= 2000
+	if s.hasCycle() {
+		return "", false
+	}
+	given := make([]int, s.n)
+	for i := 0; i < s.n; i++ {
+		given[i] = -1
+	}
+	used := make([]bool, s.n)
+	res := make([]int, s.n)
+	for i := 0; i < s.n; i++ {
+		found := false
+		for j := 0; j < s.n; j++ {
+			if !used[j] {
+				given[i] = j
+				used[j] = true
+				cnt := s.count(given)
+				if cnt >= year {
+					res[i] = j
+					found = true
+					break
+				}
+				year -= cnt
+				given[i] = -1
+				used[j] = false
+			}
+		}
+		if !found {
+			return "", false
+		}
+	}
+	var sb strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), true
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(n * n)
+		edges := make([]edge, 0, m)
+		exist := make(map[[2]int]bool)
+		for len(edges) < m {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			if a == b {
+				continue
+			}
+			key := [2]int{a, b}
+			if exist[key] {
+				continue
+			}
+			exist[key] = true
+			edges = append(edges, edge{a, b})
+		}
+		year := int64(rng.Intn(30) + 2001)
+		solver := newSolverC(n, edges)
+		expect, ok := solver.solve(int64(year))
+		if !ok {
+			expect = "The times have changed\n"
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, year, len(edges)))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+		}
+		input := sb.String()
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/107/verifierD.go
+++ b/0-999/100-199/100-109/107/verifierD.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 12345
+
+// pair of crime type and multiplicity
+type crime struct {
+	t byte
+	m int
+}
+
+func solveD(n int64, crimes []crime) int {
+	m := len(crimes)
+	crat := make([]int, m)
+	typ := make([]int, m)
+	need := make([]bool, 26)
+	for i, c := range crimes {
+		typ[i] = int(c.t - 'A')
+		crat[i] = c.m
+		need[typ[i]] = true
+	}
+	if m > 0 {
+		leaf := make([]bool, m)
+		for i := 0; i < m; i++ {
+			if !leaf[i] {
+				for j := i + 1; j < m; j++ {
+					if typ[j] == typ[i] && crat[j] == crat[i] {
+						leaf[j] = true
+					}
+				}
+			}
+		}
+		newT := make([]int, 0, m)
+		newC := make([]int, 0, m)
+		newT = append(newT, typ[0])
+		newC = append(newC, crat[0])
+		for i := 1; i < m; i++ {
+			if !leaf[i] {
+				newT = append(newT, typ[i])
+				newC = append(newC, crat[i])
+			}
+		}
+		typ = newT
+		crat = newC
+		m = len(typ)
+	}
+	// generate states
+	var states [][]int
+	var gen func([]int, int)
+	gen = func(v []int, t int) {
+		if t == m {
+			tmp := make([]int, m)
+			copy(tmp, v)
+			states = append(states, tmp)
+			return
+		}
+		for i := 0; i < crat[t]; i++ {
+			gen(append(v, i), t+1)
+		}
+	}
+	gen(nil, 0)
+	tot := len(states)
+	mn := make([]int, m+1)
+	mn[m] = 1
+	if m > 0 {
+		mn[m-1] = crat[m-1]
+		for i := m - 2; i >= 0; i-- {
+			mn[i] = mn[i+1] * crat[i]
+		}
+	}
+	g := make([][]int, tot)
+	for i := 0; i < tot; i++ {
+		g[i] = make([]int, tot)
+		for j := 0; j < tot; j++ {
+			num := 0
+			for t := 0; t < m; t++ {
+				num += ((states[i][t] + states[j][t]) % crat[t]) * mn[t+1]
+			}
+			g[i][j] = num
+		}
+	}
+	nx := make([][]int, tot)
+	for i := 0; i < tot; i++ {
+		nx[i] = make([]int, 26)
+		for j := 0; j < 26; j++ {
+			if !need[j] {
+				continue
+			}
+			num := 0
+			for t := 0; t < m; t++ {
+				add := 0
+				if typ[t] == j {
+					add = 1
+				}
+				num += ((states[i][t] + add) % crat[t]) * mn[t+1]
+			}
+			nx[i][j] = num
+		}
+	}
+	var rec func(int64) []int
+	rec = func(n int64) []int {
+		if n == 0 {
+			ret := make([]int, tot)
+			ret[0] = 1
+			return ret
+		}
+		half := rec(n >> 1)
+		ret := make([]int, tot)
+		for i := 0; i < tot; i++ {
+			vi := half[i]
+			if vi == 0 {
+				continue
+			}
+			for j := 0; j < tot; j++ {
+				ret[g[i][j]] = (ret[g[i][j]] + vi*half[j]) % mod
+			}
+		}
+		if n&1 == 1 {
+			tmp := make([]int, tot)
+			for j := 0; j < 26; j++ {
+				if need[j] {
+					tmp[nx[0][j]]++
+				}
+			}
+			ret1 := make([]int, tot)
+			for i := 0; i < tot; i++ {
+				vi := ret[i]
+				if vi == 0 {
+					continue
+				}
+				for j := 0; j < tot; j++ {
+					if tmp[j] == 0 {
+						continue
+					}
+					ret1[g[i][j]] = (ret1[g[i][j]] + vi*tmp[j]) % mod
+				}
+			}
+			return ret1
+		}
+		return ret
+	}
+	res := rec(n)
+	ans := 0
+	for i := 0; i < tot; i++ {
+		ok := make([]bool, 26)
+		for t := 0; t < m; t++ {
+			if states[i][t] == 0 {
+				ok[typ[t]] = true
+			}
+		}
+		valid := true
+		for j := 0; j < 26; j++ {
+			if need[j] && !ok[j] {
+				valid = false
+				break
+			}
+		}
+		if valid {
+			ans = (ans + res[i]) % mod
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := rng.Intn(3) + 1
+		crimes := make([]crime, c)
+		for j := 0; j < c; j++ {
+			crimes[j] = crime{t: byte('A' + rng.Intn(3)), m: rng.Intn(3) + 1}
+		}
+		n := int64(rng.Intn(20))
+		expect := solveD(n, crimes)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, c))
+		for _, cr := range crimes {
+			sb.WriteString(fmt.Sprintf("%c %d\n", cr.t, cr.m))
+		}
+		input := sb.String()
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != fmt.Sprint(expect) {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:%d\ngot:%s\n", i+1, input, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/107/verifierE.go
+++ b/0-999/100-199/100-109/107/verifierE.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const EPS = 1e-8
+
+type PT struct{ x, y float64 }
+
+func (p PT) Sub(q PT) PT        { return PT{p.x - q.x, p.y - q.y} }
+func (p PT) Cross(q PT) float64 { return p.x*q.y - p.y*q.x }
+
+func SG(x float64) int {
+	if x > EPS {
+		return 1
+	}
+	if x < -EPS {
+		return -1
+	}
+	return 0
+}
+
+func tri(p1, p2, p3 PT) float64 { return p2.Sub(p1).Cross(p3.Sub(p1)) }
+
+func segP(p, p1, p2 PT) float64 {
+	if SG(p1.x-p2.x) == 0 {
+		return (p.y - p1.y) / (p2.y - p1.y)
+	}
+	return (p.x - p1.x) / (p2.x - p1.x)
+}
+
+func polyUnion(polys [][]PT) float64 {
+	n := len(polys)
+	var sum float64
+	for i := 0; i < n; i++ {
+		p := polys[i]
+		m := len(p)
+		p2 := make([]PT, m+1)
+		copy(p2, p)
+		p2[m] = p[0]
+		for ii := 0; ii < m; ii++ {
+			a, b := p2[ii], p2[ii+1]
+			type inter struct {
+				t float64
+				d int
+			}
+			ev := []inter{{0, 0}, {1, 0}}
+			for j := 0; j < n; j++ {
+				if j == i {
+					continue
+				}
+				q := polys[j]
+				lq := len(q)
+				q2 := make([]PT, lq+1)
+				copy(q2, q)
+				q2[lq] = q[0]
+				for jj := 0; jj < lq; jj++ {
+					c, dpt := q2[jj], q2[jj+1]
+					ta := SG(tri(a, b, c))
+					tb := SG(tri(a, b, dpt))
+					if ta == 0 && tb == 0 {
+						if q2[jj+1].Sub(q2[jj]).Cross(b.Sub(a)) > 0 && j < i {
+							t1 := segP(c, a, b)
+							t2 := segP(dpt, a, b)
+							ev = append(ev, inter{t1, 1}, inter{t2, -1})
+						}
+					} else if ta >= 0 && tb < 0 {
+						tc := tri(c, dpt, a)
+						td := tri(c, dpt, b)
+						ev = append(ev, inter{tc / (tc - td), 1})
+					} else if ta < 0 && tb >= 0 {
+						tc := tri(c, dpt, a)
+						td := tri(c, dpt, b)
+						ev = append(ev, inter{tc / (tc - td), -1})
+					}
+				}
+			}
+			sort.Slice(ev, func(i, j int) bool { return ev[i].t < ev[j].t })
+			z := math.Min(math.Max(ev[0].t, 0), 1)
+			dcnt := ev[0].d
+			var covered float64
+			for k := 1; k < len(ev); k++ {
+				w := math.Min(math.Max(ev[k].t, 0), 1)
+				if dcnt == 0 {
+					covered += w - z
+				}
+				dcnt += ev[k].d
+				z = w
+			}
+			sum += a.Cross(b) * covered
+		}
+	}
+	return sum / 2
+}
+
+func solveE(rects [][]PT) float64 {
+	var sumArea float64
+	for i := 0; i < len(rects); i++ {
+		pts := rects[i]
+		var s float64
+		for j := 0; j < 3; j++ {
+			s += pts[j].Cross(pts[j+1])
+		}
+		s += pts[3].Cross(pts[0])
+		area := s / 2
+		if area < 0 {
+			for l, r := 0, 3; l < r; l, r = l+1, r-1 {
+				pts[l], pts[r] = pts[r], pts[l]
+			}
+			area = -area
+		}
+		sumArea += area
+		rects[i] = pts
+	}
+	union := polyUnion(rects)
+	return sumArea / union
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+func randomRect(rng *rand.Rand) []PT {
+	// axis-aligned for simplicity
+	x1 := rng.Float64()*20 - 10
+	y1 := rng.Float64()*20 - 10
+	w := rng.Float64()*5 + 0.1
+	h := rng.Float64()*5 + 0.1
+	rect := []PT{{x1, y1}, {x1 + w, y1}, {x1 + w, y1 + h}, {x1, y1 + h}}
+	// random rotate
+	ang := rng.Float64() * math.Pi * 2
+	cx := x1 + w/2
+	cy := y1 + h/2
+	for i := 0; i < 4; i++ {
+		rx := rect[i].x - cx
+		ry := rect[i].y - cy
+		rect[i].x = cx + rx*math.Cos(ang) - ry*math.Sin(ang)
+		rect[i].y = cy + rx*math.Sin(ang) + ry*math.Cos(ang)
+	}
+	return rect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(3) + 1
+		rects := make([][]PT, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			rects[j] = randomRect(rng)
+			for k := 0; k < 4; k++ {
+				sb.WriteString(fmt.Sprintf("%f %f", rects[j][k].x, rects[j][k].y))
+				if k == 3 {
+					sb.WriteByte('\n')
+				} else {
+					sb.WriteByte(' ')
+				}
+			}
+		}
+		input := sb.String()
+		expect := solveE(rects)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		val, err2 := strconv.ParseFloat(strings.TrimSpace(out), 64)
+		if err2 != nil {
+			fmt.Printf("case %d: cannot parse output\n", i+1)
+			os.Exit(1)
+		}
+		if math.Abs(val-expect) > 1e-6*math.Max(1, math.Abs(expect)) {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:%.6f\ngot:%s\n", i+1, input, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 107
- each verifier runs 100 randomized test cases and reports runtime errors
- format all verifier code with gofmt

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6dc0fb148324ba0b3cdadc606686