### PR TITLE
Add verifiers for Codeforces 103

### DIFF
--- a/0-999/100-199/100-109/103/verifierA.go
+++ b/0-999/100-199/100-109/103/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect int64
+}
+
+func solveCase(a []int64) int64 {
+	ans := int64(len(a))
+	for i, v := range a {
+		ans += (v - 1) * int64(i+1)
+	}
+	return ans
+}
+
+func buildCase(a []int64) testCase {
+	var sb strings.Builder
+	n := len(a)
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", a[i])
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expect: solveCase(a)}
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = rng.Int63n(100) + 1
+	}
+	return buildCase(a)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expect {
+		return fmt.Errorf("expected %d got %d", tc.expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	// fixed edge cases
+	cases = append(cases, buildCase([]int64{1}))
+	cases = append(cases, buildCase([]int64{5, 3, 2}))
+	cases = append(cases, buildCase([]int64{1, 1, 1, 1}))
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/103/verifierB.go
+++ b/0-999/100-199/100-109/103/verifierB.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func isCthulhu(n int, edges [][2]int) bool {
+	if n < 3 || len(edges) != n {
+		return false
+	}
+	g := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	q := make([]int, 0, n)
+	seen := make([]bool, n)
+	q = append(q, 0)
+	seen[0] = true
+	for i := 0; i < len(q); i++ {
+		v := q[i]
+		for _, to := range g[v] {
+			if !seen[to] {
+				seen[to] = true
+				q = append(q, to)
+			}
+		}
+	}
+	for _, s := range seen {
+		if !s {
+			return false
+		}
+	}
+	return true
+}
+
+func buildCase(n int, edges [][2]int) testCase {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, len(edges))
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0]+1, e[1]+1)
+	}
+	expect := "NO\n"
+	if isCthulhu(n, edges) {
+		expect = "FHTAGN!\n"
+	}
+	return testCase{input: sb.String(), expect: expect}
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	var edges [][2]int
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if rng.Intn(3) == 0 {
+				edges = append(edges, [2]int{i, j})
+			}
+		}
+	}
+	return buildCase(n, edges)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	if strings.TrimSpace(got) != strings.TrimSpace(tc.expect) {
+		return fmt.Errorf("expected %q got %q", tc.expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	// simple
+	cases = append(cases, buildCase(1, nil))
+	cases = append(cases, buildCase(3, [][2]int{{0, 1}, {1, 2}, {2, 0}}))
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/103/verifierC.go
+++ b/0-999/100-199/100-109/103/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func cal(n, k, x int64) byte {
+	if n&1 == 1 {
+		if x == n {
+			if k > 0 {
+				return 'X'
+			}
+			return '.'
+		}
+		n--
+		k--
+	}
+	if x%2 == 0 {
+		if x <= n-k*2 {
+			return '.'
+		}
+		return 'X'
+	}
+	if x < n-(k-n/2)*2 {
+		return '.'
+	}
+	return 'X'
+}
+
+func solve(n, k int64, qs []int64) string {
+	res := make([]byte, len(qs))
+	for i, x := range qs {
+		res[i] = cal(n, k, x)
+	}
+	return string(res) + "\n"
+}
+
+func buildCase(n, k int64, qs []int64) testCase {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, k, len(qs))
+	for _, x := range qs {
+		fmt.Fprintf(&sb, "%d ", x)
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expect: solve(n, k, qs)}
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Int63n(40) + 1
+	k := rng.Int63n(n + 1)
+	p := rng.Intn(20) + 1
+	qs := make([]int64, p)
+	for i := range qs {
+		qs[i] = rng.Int63n(n) + 1
+	}
+	return buildCase(n, k, qs)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	if strings.TrimSpace(got) != strings.TrimSpace(tc.expect) {
+		return fmt.Errorf("expected %q got %q", tc.expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, buildCase(1, 1, []int64{1}))
+	cases = append(cases, buildCase(6, 3, []int64{1, 2, 3, 4, 5, 6}))
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/103/verifierD.go
+++ b/0-999/100-199/100-109/103/verifierD.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type query struct{ a, b int }
+
+type testCase struct {
+	input  string
+	expect []int64
+}
+
+func solve(w []int64, qs []query) []int64 {
+	res := make([]int64, len(qs))
+	for i, q := range qs {
+		var sum int64
+		for j := q.a; j < len(w); j += q.b {
+			sum += w[j]
+		}
+		res[i] = sum
+	}
+	return res
+}
+
+func buildCase(w []int64, qs []query) testCase {
+	var sb strings.Builder
+	n := len(w)
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", w[i])
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", len(qs))
+	for _, q := range qs {
+		fmt.Fprintf(&sb, "%d %d\n", q.a+1, q.b)
+	}
+	return testCase{input: sb.String(), expect: solve(w, qs)}
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	w := make([]int64, n)
+	for i := range w {
+		w[i] = rng.Int63n(100) - 50
+	}
+	p := rng.Intn(20) + 1
+	qs := make([]query, p)
+	for i := range qs {
+		qs[i].a = rng.Intn(n)
+		qs[i].b = rng.Intn(n) + 1
+	}
+	return buildCase(w, qs)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != len(tc.expect) {
+		return fmt.Errorf("expected %d numbers got %d", len(tc.expect), len(fields))
+	}
+	for i, f := range fields {
+		var v int64
+		if _, err := fmt.Sscan(f, &v); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if v != tc.expect[i] {
+			return fmt.Errorf("expected %v got %v", tc.expect, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, buildCase([]int64{1}, []query{{0, 1}}))
+	cases = append(cases, buildCase([]int64{5, 3, 2}, []query{{0, 1}, {1, 2}}))
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/100-199/100-109/103/verifierE.go
+++ b/0-999/100-199/100-109/103/verifierE.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect int
+}
+
+const INF = 1000000000
+
+type Edge struct{ to, rev, cap int }
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solve(sets [][]int, costs []int) int {
+	n := len(sets)
+	// bipartite matching
+	p := make([]int, n)
+	q := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i], q[i] = -1, -1
+	}
+	was := make([]bool, n)
+	var dfs func(int) bool
+	dfs = func(v int) bool {
+		was[v] = true
+		for _, u := range sets[v] {
+			if q[u] == -1 {
+				q[u] = v
+				p[v] = u
+				return true
+			}
+		}
+		for _, u := range sets[v] {
+			w := q[u]
+			if !was[w] && dfs(w) {
+				q[u] = v
+				p[v] = u
+				return true
+			}
+		}
+		return false
+	}
+	now := 0
+	for now < n {
+		for i := range was {
+			was[i] = false
+		}
+		for i := 0; i < n; i++ {
+			if p[i] == -1 && !was[i] {
+				if dfs(i) {
+					now++
+				}
+			}
+		}
+	}
+	N := n + 2
+	S, T := n, n+1
+	G := make([][]Edge, N)
+	addEdge := func(u, v, c int) {
+		G[u] = append(G[u], Edge{v, len(G[v]), c})
+		G[v] = append(G[v], Edge{u, len(G[u]) - 1, 0})
+	}
+	sumNeg := 0
+	for i := 0; i < n; i++ {
+		if costs[i] >= 0 {
+			addEdge(i, T, costs[i])
+		} else {
+			sumNeg += costs[i]
+			addEdge(S, i, -costs[i])
+		}
+	}
+	for i := 0; i < n; i++ {
+		for _, j := range sets[i] {
+			if q[j] != i {
+				addEdge(i, q[j], INF)
+			}
+		}
+	}
+	level := make([]int, N)
+	iter := make([]int, N)
+	bfs := func(mn int) bool {
+		for i := range level {
+			level[i] = -1
+		}
+		q := []int{S}
+		level[S] = 0
+		for qi := 0; qi < len(q); qi++ {
+			v := q[qi]
+			for _, e := range G[v] {
+				if e.cap >= mn && level[e.to] < 0 {
+					level[e.to] = level[v] + 1
+					q = append(q, e.to)
+				}
+			}
+		}
+		return level[T] >= 0
+	}
+	var dfsf func(int, int, int) int
+	dfsf = func(v, up, mn int) int {
+		if v == T {
+			return up
+		}
+		res := 0
+		for ; up >= mn && iter[v] < len(G[v]); iter[v]++ {
+			e := &G[v][iter[v]]
+			if e.cap < mn || level[e.to] != level[v]+1 {
+				continue
+			}
+			f := dfsf(e.to, min(up, e.cap), mn)
+			if f > 0 {
+				e.cap -= f
+				G[e.to][e.rev].cap += f
+				up -= f
+				res += f
+			}
+		}
+		return res
+	}
+	flow := 0
+	for mn := 1 << 20; mn > 0; mn >>= 1 {
+		for bfs(mn) {
+			for i := range iter {
+				iter[i] = 0
+			}
+			for {
+				f := dfsf(S, INF, mn)
+				if f == 0 {
+					break
+				}
+				flow += f
+			}
+		}
+	}
+	return flow + sumNeg
+}
+
+func buildCase(sets [][]int, costs []int) testCase {
+	var sb strings.Builder
+	n := len(sets)
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", len(sets[i]))
+		for _, x := range sets[i] {
+			fmt.Fprintf(&sb, "%d ", x+1)
+		}
+		sb.WriteByte('\n')
+	}
+	for i, c := range costs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", c)
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expect: solve(sets, costs)}
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	sets := make([][]int, n)
+	for i := 0; i < n; i++ {
+		m := rng.Intn(n) + 1
+		used := map[int]bool{i: true}
+		sets[i] = []int{i}
+		for len(sets[i]) < m {
+			v := rng.Intn(n)
+			if !used[v] {
+				used[v] = true
+				sets[i] = append(sets[i], v)
+			}
+		}
+	}
+	costs := make([]int, n)
+	for i := range costs {
+		costs[i] = rng.Intn(201) - 100
+	}
+	return buildCase(sets, costs)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expect {
+		return fmt.Errorf("expected %d got %d", tc.expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	sets := [][]int{{0}, {1}}
+	costs := []int{5, -3}
+	cases = append(cases, buildCase(sets, costs))
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go-based verifiers for contest 103 problems (A–E)
- each verifier generates over 100 test cases and checks a compiled solution

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e6dac91a88324b3a6bfc05f7107e0