### PR TITLE
Add contest 100 Go verifiers

### DIFF
--- a/0-999/100-199/100-109/100/verifierA.go
+++ b/0-999/100-199/100-109/100/verifierA.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type TestCase struct {
+    input string
+    ans   string
+}
+
+func solve(n, k, n1 int) string {
+    if n1 >= n || k >= 4 {
+        return "YES"
+    }
+    return "NO"
+}
+
+func genTests() []TestCase {
+    r := rand.New(rand.NewSource(1))
+    cases := make([]TestCase, 100)
+    for i := 0; i < 100; i++ {
+        n := r.Intn(20) + 1
+        k := r.Intn(6)
+        n1 := r.Intn(20) + 1
+        input := fmt.Sprintf("%d %d %d\n", n, k, n1)
+        ans := solve(n, k, n1)
+        cases[i] = TestCase{input: input, ans: ans}
+    }
+    return cases
+}
+
+func run(bin string, in string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, tc := range tests {
+        got, err := run(bin, tc.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != tc.ans {
+            fmt.Fprintf(os.Stderr, "test %d failed: input %q expected %q got %q\n", i+1, tc.input, tc.ans, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("ok %d tests\n", len(tests))
+}
+

--- a/0-999/100-199/100-109/100/verifierB.go
+++ b/0-999/100-199/100-109/100/verifierB.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+)
+
+type TestCase struct {
+    input string
+    ans   string
+}
+
+func solve(nums []int) string {
+    n := len(nums)
+    for i := 0; i < n; i++ {
+        for j := i + 1; j < n; j++ {
+            a, b := nums[i], nums[j]
+            ok := false
+            if a != 0 && b%a == 0 {
+                ok = true
+            } else if b != 0 && a%b == 0 {
+                ok = true
+            }
+            if !ok {
+                return "NOT FRIENDS"
+            }
+        }
+    }
+    return "FRIENDS"
+}
+
+func genTests() []TestCase {
+    r := rand.New(rand.NewSource(2))
+    cases := make([]TestCase, 100)
+    for i := 0; i < 100; i++ {
+        n := r.Intn(5) + 1
+        arr := make([]int, n)
+        for j := 0; j < n; j++ {
+            v := r.Intn(21) - 10
+            if v == 0 {
+                v = 1
+            }
+            arr[j] = v
+        }
+        sort.Ints(arr)
+        parts := make([]string, n)
+        for j, v := range arr {
+            parts[j] = fmt.Sprintf("%d", v)
+        }
+        input := fmt.Sprintf("%d\n%s\n", n, strings.Join(parts, ","))
+        ans := solve(arr)
+        cases[i] = TestCase{input: input, ans: ans}
+    }
+    return cases
+}
+
+func run(bin, in string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, tc := range tests {
+        got, err := run(bin, tc.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != tc.ans {
+            fmt.Fprintf(os.Stderr, "test %d failed: input %q expected %q got %q\n", i+1, tc.input, tc.ans, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("ok %d tests\n", len(tests))
+}
+

--- a/0-999/100-199/100-109/100/verifierC.go
+++ b/0-999/100-199/100-109/100/verifierC.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/big"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type TestCase struct {
+    input string
+    ans   string
+}
+
+func solve(a, b string) string {
+    A := new(big.Int)
+    B := new(big.Int)
+    A.SetString(a, 10)
+    B.SetString(b, 10)
+    return new(big.Int).Add(A, B).String()
+}
+
+func randomInt(r *rand.Rand, digits int) string {
+    b := make([]byte, digits)
+    for i := 0; i < digits; i++ {
+        d := byte(r.Intn(10))
+        if i == 0 && d == 0 {
+            d = byte(r.Intn(9) + 1)
+        }
+        b[i] = '0' + d
+    }
+    return string(b)
+}
+
+func genTests() []TestCase {
+    r := rand.New(rand.NewSource(3))
+    cases := make([]TestCase, 100)
+    for i := 0; i < 100; i++ {
+        d1 := r.Intn(20) + 1
+        d2 := r.Intn(20) + 1
+        a := randomInt(r, d1)
+        b := randomInt(r, d2)
+        input := fmt.Sprintf("%s\n%s\n", a, b)
+        ans := solve(a, b)
+        cases[i] = TestCase{input: input, ans: ans}
+    }
+    return cases
+}
+
+func run(bin, in string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, tc := range tests {
+        got, err := run(bin, tc.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != tc.ans {
+            fmt.Fprintf(os.Stderr, "test %d failed: input %q expected %q got %q\n", i+1, tc.input, tc.ans, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("ok %d tests\n", len(tests))
+}
+

--- a/0-999/100-199/100-109/100/verifierD.go
+++ b/0-999/100-199/100-109/100/verifierD.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type TestCase struct {
+    input string
+    ans   string
+}
+
+func solve(n int, s, t string) string {
+    ls := len(s)
+    lt := len(t)
+    i := 0
+    max := ls
+    if lt < max {
+        max = lt
+    }
+    for i < max && s[i] == t[i] {
+        i++
+    }
+    ops := (ls - i) + (lt - i)
+    if ops <= n {
+        return "YES"
+    }
+    return "NO"
+}
+
+func genString(r *rand.Rand, l int) string {
+    if l <= 0 {
+        l = 1
+    }
+    b := make([]byte, l)
+    for i := range b {
+        b[i] = byte('a' + r.Intn(3))
+    }
+    return string(b)
+}
+
+func genTests() []TestCase {
+    r := rand.New(rand.NewSource(4))
+    cases := make([]TestCase, 100)
+    for i := 0; i < 100; i++ {
+        n := r.Intn(20) + 1
+        s := genString(r, r.Intn(10)+1)
+        t := genString(r, r.Intn(10)+1)
+        input := fmt.Sprintf("%d\n%s\n%s\n", n, s, t)
+        ans := solve(n, s, t)
+        cases[i] = TestCase{input: input, ans: ans}
+    }
+    return cases
+}
+
+func run(bin, in string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, tc := range tests {
+        got, err := run(bin, tc.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != tc.ans {
+            fmt.Fprintf(os.Stderr, "test %d failed: input %q expected %q got %q\n", i+1, tc.input, tc.ans, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("ok %d tests\n", len(tests))
+}
+

--- a/0-999/100-199/100-109/100/verifierE.go
+++ b/0-999/100-199/100-109/100/verifierE.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type TestCase struct {
+    input string
+    ans   string
+}
+
+func apply(n int, states []string, keys []int) []string {
+    wordIdx := make(map[string]int)
+    words := []string{}
+    init := make([]bool, n)
+    for i, s := range states {
+        if _, ok := wordIdx[s]; !ok {
+            wordIdx[s] = len(words)
+            words = append(words, s)
+        }
+        init[i] = wordIdx[s] == 1
+    }
+    parity := make([]bool, n+1)
+    for _, k := range keys {
+        if k >= 1 && k <= n {
+            parity[k] = !parity[k]
+        }
+    }
+    for i := 1; i <= n; i++ {
+        if !parity[i] {
+            continue
+        }
+        for j := i; j <= n; j += i {
+            init[j-1] = !init[j-1]
+        }
+    }
+    res := make([]string, n)
+    for i, b := range init {
+        if b {
+            if len(words) > 1 {
+                res[i] = words[1]
+            } else {
+                res[i] = words[0]
+            }
+        } else {
+            res[i] = words[0]
+        }
+    }
+    return res
+}
+
+func genTests() []TestCase {
+    r := rand.New(rand.NewSource(5))
+    cases := make([]TestCase, 100)
+    for i := 0; i < 100; i++ {
+        n := r.Intn(6) + 1
+        words := []string{"on", "off"}
+        states := make([]string, n)
+        for j := 0; j < n; j++ {
+            states[j] = words[r.Intn(2)]
+        }
+        k := r.Intn(n) + 1
+        keys := make([]int, k)
+        for j := 0; j < k; j++ {
+            keys[j] = r.Intn(n) + 1
+        }
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for j, s := range states {
+            sb.WriteString(s)
+            if j+1 < n {
+                sb.WriteByte(' ')
+            }
+        }
+        sb.WriteString("\n")
+        sb.WriteString(fmt.Sprintf("%d\n", k))
+        for j, x := range keys {
+            sb.WriteString(fmt.Sprintf("%d", x))
+            if j+1 < k {
+                sb.WriteByte(' ')
+            }
+        }
+        sb.WriteString("\n")
+        final := apply(n, states, keys)
+        ans := strings.Join(final, " ")
+        cases[i] = TestCase{input: sb.String(), ans: ans}
+    }
+    return cases
+}
+
+func run(bin, in string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, tc := range tests {
+        got, err := run(bin, tc.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != tc.ans {
+            fmt.Fprintf(os.Stderr, "test %d failed: input %q expected %q got %q\n", i+1, tc.input, tc.ans, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("ok %d tests\n", len(tests))
+}
+

--- a/0-999/100-199/100-109/100/verifierF.go
+++ b/0-999/100-199/100-109/100/verifierF.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+type TestCase struct {
+    input string
+    ans   string
+}
+
+func poly(a []int) []int {
+    coeffs := []int{1}
+    for _, ai := range a {
+        m := len(coeffs)
+        nxt := make([]int, m+1)
+        for j := 0; j < m; j++ {
+            nxt[j] += ai * coeffs[j]
+            nxt[j+1] += coeffs[j]
+        }
+        coeffs = nxt
+    }
+    return coeffs
+}
+
+func formatPoly(coeffs []int) string {
+    var sb strings.Builder
+    first := true
+    deg := len(coeffs) - 1
+    for k := deg; k >= 0; k-- {
+        c := coeffs[k]
+        if c == 0 {
+            continue
+        }
+        if first {
+            if c < 0 {
+                sb.WriteByte('-')
+                c = -c
+            }
+            first = false
+        } else {
+            if c < 0 {
+                sb.WriteString(" - ")
+                c = -c
+            } else {
+                sb.WriteString(" + ")
+            }
+        }
+        if k == 0 {
+            sb.WriteString(strconv.Itoa(c))
+        } else {
+            if c != 1 {
+                sb.WriteString(strconv.Itoa(c))
+                sb.WriteByte('*')
+            }
+            sb.WriteByte('X')
+            if k != 1 {
+                sb.WriteByte('^')
+                sb.WriteString(strconv.Itoa(k))
+            }
+        }
+    }
+    return "p(x) = " + sb.String()
+}
+
+func genTests() []TestCase {
+    r := rand.New(rand.NewSource(6))
+    cases := make([]TestCase, 100)
+    for i := 0; i < 100; i++ {
+        n := r.Intn(4) + 1
+        a := make([]int, n)
+        for j := 0; j < n; j++ {
+            v := r.Intn(7) - 3
+            a[j] = v
+        }
+        coeffs := poly(a)
+        ans := formatPoly(coeffs)
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for j, v := range a {
+            if j > 0 {
+                sb.WriteByte(' ')
+            }
+            sb.WriteString(fmt.Sprintf("%d", v))
+        }
+        sb.WriteString("\n")
+        cases[i] = TestCase{input: sb.String(), ans: ans}
+    }
+    return cases
+}
+
+func run(bin, in string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, tc := range tests {
+        got, err := run(bin, tc.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != tc.ans {
+            fmt.Fprintf(os.Stderr, "test %d failed: input %q expected %q got %q\n", i+1, tc.input, tc.ans, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("ok %d tests\n", len(tests))
+}
+

--- a/0-999/100-199/100-109/100/verifierG.go
+++ b/0-999/100-199/100-109/100/verifierG.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type TestCase struct {
+    input string
+    ans   string
+}
+
+type Record struct {
+    name string
+    year int
+}
+
+func solve(records []Record, cands []string) string {
+    used := make(map[string]int)
+    for _, r := range records {
+        if prev, ok := used[r.name]; !ok || r.year > prev {
+            used[r.name] = r.year
+        }
+    }
+    var unusedBest string
+    haveUnused := false
+    var usedBest string
+    var usedYearBest int
+    haveUsed := false
+    for _, cand := range cands {
+        if year, ok := used[cand]; !ok {
+            if !haveUnused || cand > unusedBest {
+                unusedBest = cand
+                haveUnused = true
+            }
+        } else {
+            if !haveUsed || year < usedYearBest || (year == usedYearBest && cand > usedBest) {
+                usedYearBest = year
+                usedBest = cand
+                haveUsed = true
+            }
+        }
+    }
+    if haveUnused {
+        return unusedBest
+    }
+    return usedBest
+}
+
+func randomName(r *rand.Rand) string {
+    b := []byte{'a' + byte(r.Intn(26)), 'a' + byte(r.Intn(26))}
+    return string(b)
+}
+
+func genTests() []TestCase {
+    r := rand.New(rand.NewSource(7))
+    cases := make([]TestCase, 100)
+    for i := 0; i < 100; i++ {
+        n := r.Intn(5) + 1
+        rec := make([]Record, n)
+        for j := 0; j < n; j++ {
+            rec[j] = Record{randomName(r), 1990 + r.Intn(35)}
+        }
+        m := r.Intn(5) + 1
+        cand := make([]string, m)
+        for j := 0; j < m; j++ {
+            cand[j] = randomName(r)
+        }
+        ans := solve(rec, cand)
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for j, rc := range rec {
+            sb.WriteString(fmt.Sprintf("%s %d\n", rc.name, rc.year))
+            if j == n-1 {
+                // nothing
+            }
+        }
+        sb.WriteString(fmt.Sprintf("%d\n", m))
+        for j, c := range cand {
+            if j > 0 {
+                sb.WriteByte(' ')
+            }
+            sb.WriteString(c)
+        }
+        sb.WriteString("\n")
+        cases[i] = TestCase{input: sb.String(), ans: ans}
+    }
+    return cases
+}
+
+func run(bin, in string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, tc := range tests {
+        got, err := run(bin, tc.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != tc.ans {
+            fmt.Fprintf(os.Stderr, "test %d failed: input %q expected %q got %q\n", i+1, tc.input, tc.ans, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("ok %d tests\n", len(tests))
+}
+

--- a/0-999/100-199/100-109/100/verifierH.go
+++ b/0-999/100-199/100-109/100/verifierH.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type TestCase struct {
+    input string
+    ans   string
+}
+
+func isValid(grid [10]string) bool {
+    var g [10][10]byte
+    for i := 0; i < 10; i++ {
+        for j := 0; j < 10; j++ {
+            if j < len(grid[i]) && grid[i][j] == '*' {
+                g[i][j] = '*'
+            } else {
+                g[i][j] = '0'
+            }
+        }
+    }
+    diag := [4][2]int{{-1, -1}, {-1, 1}, {1, -1}, {1, 1}}
+    for i := 0; i < 10; i++ {
+        for j := 0; j < 10; j++ {
+            if g[i][j] != '*' {
+                continue
+            }
+            for _, d := range diag {
+                ni, nj := i+d[0], j+d[1]
+                if ni >= 0 && ni < 10 && nj >= 0 && nj < 10 && g[ni][nj] == '*' {
+                    return false
+                }
+            }
+        }
+    }
+    var vis [10][10]bool
+    counts := map[int]int{1: 0, 2: 0, 3: 0, 4: 0}
+    dirs := [4][2]int{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
+    for i := 0; i < 10; i++ {
+        for j := 0; j < 10; j++ {
+            if g[i][j] == '*' && !vis[i][j] {
+                stack := [][2]int{{i, j}}
+                vis[i][j] = true
+                var cells [][2]int
+                cells = append(cells, [2]int{i, j})
+                for len(stack) > 0 {
+                    cur := stack[len(stack)-1]
+                    stack = stack[:len(stack)-1]
+                    ci, cj := cur[0], cur[1]
+                    for _, d := range dirs {
+                        ni, nj := ci+d[0], cj+d[1]
+                        if ni >= 0 && ni < 10 && nj >= 0 && nj < 10 && g[ni][nj] == '*' && !vis[ni][nj] {
+                            vis[ni][nj] = true
+                            stack = append(stack, [2]int{ni, nj})
+                            cells = append(cells, [2]int{ni, nj})
+                        }
+                    }
+                }
+                size := len(cells)
+                if size < 1 || size > 4 {
+                    return false
+                }
+                minI, maxI, minJ, maxJ := 10, -1, 10, -1
+                setC := make(map[[2]int]bool)
+                for _, c := range cells {
+                    setC[c] = true
+                    if c[0] < minI {
+                        minI = c[0]
+                    }
+                    if c[0] > maxI {
+                        maxI = c[0]
+                    }
+                    if c[1] < minJ {
+                        minJ = c[1]
+                    }
+                    if c[1] > maxJ {
+                        maxJ = c[1]
+                    }
+                }
+                if minI == maxI {
+                    if maxJ-minJ+1 != size {
+                        return false
+                    }
+                    for jj := minJ; jj <= maxJ; jj++ {
+                        if !setC[[2]int{minI, jj}] {
+                            return false
+                        }
+                    }
+                } else if minJ == maxJ {
+                    if maxI-minI+1 != size {
+                        return false
+                    }
+                    for ii := minI; ii <= maxI; ii++ {
+                        if !setC[[2]int{ii, minJ}] {
+                            return false
+                        }
+                    }
+                } else {
+                    return false
+                }
+                counts[size]++
+            }
+        }
+    }
+    required := map[int]int{1: 4, 2: 3, 3: 2, 4: 1}
+    for k, v := range required {
+        if counts[k] != v {
+            return false
+        }
+    }
+    return true
+}
+
+func genBoard(r *rand.Rand) [10]string {
+    var g [10]string
+    for i := 0; i < 10; i++ {
+        var row strings.Builder
+        for j := 0; j < 10; j++ {
+            if r.Intn(5) == 0 {
+                row.WriteByte('*')
+            } else {
+                row.WriteByte('.')
+            }
+        }
+        g[i] = row.String()
+    }
+    return g
+}
+
+func genTests() []TestCase {
+    r := rand.New(rand.NewSource(8))
+    cases := make([]TestCase, 100)
+    for i := 0; i < 100; i++ {
+        b := genBoard(r)
+        valid := isValid(b)
+        var sb strings.Builder
+        sb.WriteString("1\n")
+        for j := 0; j < 10; j++ {
+            sb.WriteString(b[j])
+            sb.WriteByte('\n')
+        }
+        ans := "NO"
+        if valid {
+            ans = "YES"
+        }
+        cases[i] = TestCase{input: sb.String(), ans: ans}
+    }
+    return cases
+}
+
+func run(bin, in string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, tc := range tests {
+        got, err := run(bin, tc.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != tc.ans {
+            fmt.Fprintf(os.Stderr, "test %d failed expected %q got %q\n", i+1, tc.ans, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("ok %d tests\n", len(tests))
+}
+

--- a/0-999/100-199/100-109/100/verifierI.go
+++ b/0-999/100-199/100-109/100/verifierI.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type TestCase struct {
+    input string
+    ans   string
+}
+
+func rotate(k, xi, yi int) string {
+    x := float64(xi)
+    y := float64(yi)
+    theta := float64(k) * math.Pi / 180.0
+    c := math.Cos(theta)
+    s := math.Sin(theta)
+    x2 := x*c - y*s
+    y2 := x*s + y*c
+    return fmt.Sprintf("%.10f %.10f", x2, y2)
+}
+
+func genTests() []TestCase {
+    r := rand.New(rand.NewSource(9))
+    cases := make([]TestCase, 100)
+    for i := 0; i < 100; i++ {
+        k := r.Intn(360)
+        xi := r.Intn(201) - 100
+        yi := r.Intn(201) - 100
+        input := fmt.Sprintf("%d %d %d\n", k, xi, yi)
+        ans := rotate(k, xi, yi)
+        cases[i] = TestCase{input: input, ans: ans}
+    }
+    return cases
+}
+
+func run(bin, in string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierI.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, tc := range tests {
+        got, err := run(bin, tc.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != tc.ans {
+            fmt.Fprintf(os.Stderr, "test %d failed: input %q expected %q got %q\n", i+1, tc.input, tc.ans, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("ok %d tests\n", len(tests))
+}
+

--- a/0-999/100-199/100-109/100/verifierJ.go
+++ b/0-999/100-199/100-109/100/verifierJ.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+)
+
+type TestCase struct {
+    input string
+    ans   string
+}
+
+type Interval struct {
+    l, r int
+}
+
+type Clique struct {
+    unionL, unionR int
+    comL, comR     int
+}
+
+type Color struct {
+    cliques []Clique
+}
+
+func (c *Color) canUse(x Interval) bool {
+    count := 0
+    for _, cl := range c.cliques {
+        if x.r < cl.unionL || x.l > cl.unionR {
+            continue
+        }
+        if x.r >= cl.comL && x.l <= cl.comR {
+            count++
+            if count > 1 {
+                return false
+            }
+        } else {
+            return false
+        }
+    }
+    return true
+}
+
+func (c *Color) add(x Interval) {
+    for i := range c.cliques {
+        cl := &c.cliques[i]
+        if x.r >= cl.comL && x.l <= cl.comR {
+            if x.l < cl.unionL {
+                cl.unionL = x.l
+            }
+            if x.r > cl.unionR {
+                cl.unionR = x.r
+            }
+            if x.l > cl.comL {
+                cl.comL = x.l
+            }
+            if x.r < cl.comR {
+                cl.comR = x.r
+            }
+            return
+        }
+    }
+    c.cliques = append(c.cliques, Clique{unionL: x.l, unionR: x.r, comL: x.l, comR: x.r})
+}
+
+func colorCount(intervals []Interval) int {
+    sort.Slice(intervals, func(i, j int) bool {
+        if intervals[i].l != intervals[j].l {
+            return intervals[i].l < intervals[j].l
+        }
+        return intervals[i].r < intervals[j].r
+    })
+    var colors []Color
+    for _, iv := range intervals {
+        placed := false
+        for ci := range colors {
+            if colors[ci].canUse(iv) {
+                colors[ci].add(iv)
+                placed = true
+                break
+            }
+        }
+        if !placed {
+            var c Color
+            c.cliques = []Clique{{unionL: iv.l, unionR: iv.r, comL: iv.l, comR: iv.r}}
+            colors = append(colors, c)
+        }
+    }
+    return len(colors)
+}
+
+func genTests() []TestCase {
+    r := rand.New(rand.NewSource(10))
+    cases := make([]TestCase, 100)
+    for i := 0; i < 100; i++ {
+        n := r.Intn(4) + 1
+        ints := make([]Interval, n)
+        for j := 0; j < n; j++ {
+            a := r.Intn(10)
+            b := a + r.Intn(5) + 1
+            ints[j] = Interval{a, b}
+        }
+        ans := colorCount(ints)
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for j, iv := range ints {
+            sb.WriteString(fmt.Sprintf("%d %d\n", iv.l, iv.r))
+            if j == n-1 {
+            }
+        }
+        cases[i] = TestCase{input: sb.String(), ans: fmt.Sprintf("%d", ans)}
+    }
+    return cases
+}
+
+func run(bin, in string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierJ.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTests()
+    for i, tc := range tests {
+        got, err := run(bin, tc.input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != tc.ans {
+            fmt.Fprintf(os.Stderr, "test %d failed: input %q expected %q got %q\n", i+1, tc.input, tc.ans, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("ok %d tests\n", len(tests))
+}
+


### PR DESCRIPTION
## Summary
- add verifier programs for problems A through J of contest 100
- each verifier runs a provided binary on 100 deterministic random tests
- tests check the binary's output against an internal model solution

## Testing
- `go run verifierA.go ./A_bin`
- `go run verifierB.go ./B_bin`
- `go run verifierC.go ./C_bin`
- `go run verifierD.go ./D_bin`
- `go run verifierE.go ./E_bin`
- `go run verifierF.go ./F_bin`
- `go run verifierG.go ./G_bin`
- `go run verifierH.go ./H_bin`
- `go run verifierI.go ./I_bin`
- `go run verifierJ.go ./J_bin`

------
https://chatgpt.com/codex/tasks/task_e_687e6d9d93b4832488860c3151cc27e5