### PR TITLE
Add verifiers for contest 98

### DIFF
--- a/0-999/0-99/90-99/98/verifierA.go
+++ b/0-999/0-99/90-99/98/verifierA.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var colorMap = map[rune]int{'R': 0, 'O': 1, 'Y': 2, 'G': 3, 'B': 4, 'V': 5}
+
+func compose(p, g []int) []int {
+	r := make([]int, len(p))
+	for i := range p {
+		r[i] = g[p[i]]
+	}
+	return r
+}
+
+func key(p []int) string {
+	b := make([]byte, len(p))
+	for i, v := range p {
+		b[i] = byte(v)
+	}
+	return string(b)
+}
+
+var perms = genGroup()
+
+func genGroup() [][]int {
+	Rx := []int{1, 5, 2, 0, 4, 3}
+	Ry := []int{2, 1, 5, 3, 0, 4}
+	Rz := []int{0, 2, 3, 4, 1, 5}
+	perms := [][]int{}
+	seen := map[string]bool{}
+	id := []int{0, 1, 2, 3, 4, 5}
+	queue := [][]int{id}
+	seen[key(id)] = true
+	gens := [][]int{Rx, Ry, Rz}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		perms = append(perms, cur)
+		for _, g := range gens {
+			nxt := compose(cur, g)
+			k := key(nxt)
+			if !seen[k] {
+				seen[k] = true
+				queue = append(queue, nxt)
+			}
+		}
+	}
+	return perms
+}
+
+func cycles(perm []int) []int {
+	vis := make([]bool, len(perm))
+	var cyc []int
+	for i := 0; i < len(perm); i++ {
+		if !vis[i] {
+			j := i
+			cnt := 0
+			for !vis[j] {
+				vis[j] = true
+				cnt++
+				j = perm[j]
+			}
+			if cnt > 0 {
+				cyc = append(cyc, cnt)
+			}
+		}
+	}
+	return cyc
+}
+
+func dfsAssign(cyc []int, avail, used [6]int, idx int) int {
+	if idx == len(cyc) {
+		for i := 0; i < 6; i++ {
+			if used[i] != avail[i] {
+				return 0
+			}
+		}
+		return 1
+	}
+	cnt := 0
+	l := cyc[idx]
+	for c := 0; c < 6; c++ {
+		if used[c]+l <= avail[c] {
+			used[c] += l
+			cnt += dfsAssign(cyc, avail, used, idx+1)
+			used[c] -= l
+		}
+	}
+	return cnt
+}
+
+func solve(input string) string {
+	s := strings.TrimSpace(input)
+	var avail [6]int
+	for _, ch := range s {
+		if idx, ok := colorMap[ch]; ok {
+			avail[idx]++
+		}
+	}
+
+	total := 0
+	for _, p := range perms {
+		cyc := cycles(p)
+		total += dfsAssign(cyc, avail, [6]int{}, 0)
+	}
+	return fmt.Sprintf("%d", total/len(perms))
+}
+
+func genCase(rng *rand.Rand) string {
+	chars := []byte{'R', 'O', 'Y', 'G', 'B', 'V'}
+	b := make([]byte, 6)
+	for i := 0; i < 6; i++ {
+		b[i] = chars[rng.Intn(len(chars))]
+	}
+	return string(b) + "\n"
+}
+
+func runCase(bin string, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expected := solve(input)
+		if err := runCase(bin, input, expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/90-99/98/verifierB.go
+++ b/0-999/0-99/90-99/98/verifierB.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solve(n int) string {
+	if n == 1 {
+		return "0/1"
+	}
+	k := bits.Len(uint(n)) - 1
+	m := (1 << (k + 1)) - n
+	num := n*(k+1) - m
+	den := n
+	g := gcd(num, den)
+	num /= g
+	den /= g
+	return fmt.Sprintf("%d/%d", num, den)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10000) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func runCase(bin string, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		var n int
+		fmt.Sscan(strings.TrimSpace(input), &n)
+		expected := solve(n)
+		if err := runCase(bin, input, expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/90-99/98/verifierC.go
+++ b/0-999/0-99/90-99/98/verifierC.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func f(x, A, B, L float64) float64 {
+	y := math.Sqrt(L*L - x*x)
+	return (A*x + B*y - x*y) / L
+}
+
+func solve(A, B, L float64) string {
+	if L <= B {
+		v := math.Min(A, L)
+		return fmt.Sprintf("%.8f", v)
+	} else if L <= A {
+		v := math.Min(B, L)
+		return fmt.Sprintf("%.8f", v)
+	}
+	left, right := 0.0, L
+	var ma, mb float64
+	for i := 0; i < 500; i++ {
+		ma = (left*3 + right) / 4
+		mb = (left + right*3) / 4
+		fa := f(ma, A, B, L)
+		fb := f(mb, A, B, L)
+		if fa < fb {
+			right = mb
+		} else {
+			left = ma
+		}
+	}
+	ff := f((left+right)/2, A, B, L)
+	ff = math.Min(ff, L)
+	ff = math.Min(ff, A)
+	if ff < 1e-8 {
+		return "My poor head =("
+	}
+	return fmt.Sprintf("%.8f", ff)
+}
+
+func genCase(rng *rand.Rand) string {
+	A := float64(rng.Intn(10000) + 1)
+	B := float64(rng.Intn(10000) + 1)
+	L := float64(rng.Intn(10000) + 1)
+	return fmt.Sprintf("%f %f %f\n", A, B, L)
+}
+
+func runCase(bin string, input string, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	if expected == "My poor head =(" {
+		if gotStr != expected {
+			return fmt.Errorf("expected %s got %s", expected, gotStr)
+		}
+		return nil
+	}
+	var got float64
+	if _, err := fmt.Sscan(gotStr, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	var exp float64
+	fmt.Sscan(expected, &exp)
+	if math.Abs(got-exp) > 1e-6 {
+		return fmt.Errorf("expected %s got %s", expected, gotStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		var A, B, L float64
+		fmt.Sscan(input, &A, &B, &L)
+		expected := solve(A, B, L)
+		if err := runCase(bin, input, expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/90-99/98/verifierD.go
+++ b/0-999/0-99/90-99/98/verifierD.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ x, y int }
+
+func dfs0(a []int, n int, m, x, y, z int) int {
+	if m == 0 {
+		return 0
+	}
+	i := m
+	for i > 0 && a[i] == a[m] {
+		i--
+	}
+	if z != 0 && i+1 < m {
+		t1 := dfs0(a, n, i, x, y, 0) + (m - i) + dfs0(a, n, i, y, x, 0) + (m - i) + dfs0(a, n, i, x, y, 1)
+		t2 := dfs0(a, n, n-1, x, 6-x-y, 0) + 1 + dfs0(a, n, n-1, 6-x-y, y, 0)
+		if t1 < t2 {
+			return t1
+		}
+		return t2
+	}
+	return dfs0(a, n, i, x, 6-x-y, 0) + (m - i) + dfs0(a, n, i, 6-x-y, y, 0)
+}
+
+func dfs(a []int, n int, m, x, y, z int, out *[]pair) int {
+	if m == 0 {
+		return 0
+	}
+	i := m
+	for i > 0 && a[i] == a[m] {
+		i--
+	}
+	if z != 0 && i+1 < m {
+		t1 := dfs0(a, n, i, x, y, 0) + (m - i) + dfs0(a, n, i, y, x, 0) + (m - i) + dfs0(a, n, i, x, y, 1)
+		t2 := dfs0(a, n, n-1, x, 6-x-y, 0) + 1 + dfs0(a, n, n-1, 6-x-y, y, 0)
+		if t1 < t2 {
+			dfs(a, n, i, x, y, 0, out)
+			for j := m; j > i; j-- {
+				*out = append(*out, pair{x, 6 - x - y})
+			}
+			dfs(a, n, i, y, x, 0, out)
+			for j := m; j > i; j-- {
+				*out = append(*out, pair{6 - x - y, y})
+			}
+			dfs(a, n, i, x, y, 1, out)
+			return t1
+		}
+		dfs(a, n, n-1, x, 6-x-y, 0, out)
+		*out = append(*out, pair{x, y})
+		dfs(a, n, n-1, 6-x-y, y, 0, out)
+		return t2
+	}
+	t := dfs(a, n, i, x, 6-x-y, 0, out) + (m - i)
+	for j := m; j > i; j-- {
+		*out = append(*out, pair{x, y})
+	}
+	t += dfs(a, n, i, 6-x-y, y, 0, out)
+	return t
+}
+
+func solve(input string) string {
+	fields := strings.Fields(input)
+	if len(fields) == 0 {
+		return ""
+	}
+	var n int
+	fmt.Sscan(fields[0], &n)
+	a := make([]int, n+1)
+	idx := 1
+	for i := n; i >= 1; i-- {
+		fmt.Sscan(fields[idx], &a[i])
+		idx++
+	}
+	out := []pair{}
+	cnt := dfs(a, n, n, 1, 3, 1, &out)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", cnt))
+	for _, p := range out {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.x, p.y))
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	arr := make([]int, n)
+	arr[0] = rng.Intn(20) + 1
+	for i := 1; i < n; i++ {
+		arr[i] = rng.Intn(arr[i-1]) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", arr[i]))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func runCase(bin string, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expected := solve(strings.TrimSpace(input))
+		if err := runCase(bin, input, expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/90-99/98/verifierE.go
+++ b/0-999/0-99/90-99/98/verifierE.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const maxN = 1005
+
+var memo [maxN][maxN]float64
+var seen [maxN][maxN]bool
+
+func dfs(x, y int) float64 {
+	if x == 0 || y == 0 {
+		return 1.0 / float64(y+1)
+	}
+	if seen[x][y] {
+		return memo[x][y]
+	}
+	seen[x][y] = true
+	a := 1 - dfs(y, x-1)
+	b := float64(y) / float64(y+1) * (1 - dfs(y-1, x))
+	c := b + 1.0/float64(y+1)
+	p := (c - b) / (1 - a - b + c)
+	memo[x][y] = p*(a-c) + c
+	return memo[x][y]
+}
+
+func solve(n, m int) string {
+	res := dfs(n, m)
+	return fmt.Sprintf("%.10f %.10f", res, 1-res)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(1001)
+	m := rng.Intn(1001)
+	return fmt.Sprintf("%d %d\n", n, m)
+}
+
+func runCase(bin string, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	expFields := strings.Fields(expected)
+	if len(fields) != 2 {
+		return fmt.Errorf("expected two numbers got %v", fields)
+	}
+	var got1, got2 float64
+	if _, err := fmt.Sscan(fields[0], &got1); err != nil {
+		return fmt.Errorf("bad out: %v", err)
+	}
+	if _, err := fmt.Sscan(fields[1], &got2); err != nil {
+		return fmt.Errorf("bad out: %v", err)
+	}
+	var exp1, exp2 float64
+	fmt.Sscan(expFields[0], &exp1)
+	fmt.Sscan(expFields[1], &exp2)
+	if math.Abs(got1-exp1) > 1e-9 || math.Abs(got2-exp2) > 1e-9 {
+		return fmt.Errorf("expected %s got %s", expected, strings.Join(fields, " "))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		var n, m int
+		fmt.Sscan(input, &n, &m)
+		// reset memo arrays
+		for a := 0; a <= n; a++ {
+			for b := 0; b <= m; b++ {
+				seen[a][b] = false
+			}
+		}
+		expected := solve(n, m)
+		if err := runCase(bin, input, expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 98
- each verifier generates 100 random tests and checks a given binary

## Testing
- `go vet 0-999/0-99/90-99/98/verifierA.go`
- `go vet 0-999/0-99/90-99/98/verifierB.go`
- `go vet 0-999/0-99/90-99/98/verifierC.go`
- `go vet 0-999/0-99/90-99/98/verifierD.go`
- `go vet 0-999/0-99/90-99/98/verifierE.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_687e6d9361b88324bc2027b5239e1fb6