### PR TITLE
Add Go verifiers for Codeforces contest 93

### DIFF
--- a/0-999/0-99/90-99/93/verifierA.go
+++ b/0-999/0-99/90-99/93/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type testCase struct {
+    n, m, a, b int64
+}
+
+func solve(n, m, a, b int64) int64 {
+    ra := (a - 1) / m
+    rb := (b - 1) / m
+    ca := (a-1)%m + 1
+    cb := (b-1)%m + 1
+    if ra == rb {
+        return 1
+    } else if ca == 1 && cb == m {
+        return 1
+    } else if ra+1 == rb {
+        return 2
+    }
+    return 3
+}
+
+func runCase(bin string, tc testCase) error {
+    input := fmt.Sprintf("%d %d %d %d\n", tc.n, tc.m, tc.a, tc.b)
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    var ans int64
+    if _, err := fmt.Fscan(strings.NewReader(strings.TrimSpace(out.String())), &ans); err != nil {
+        return fmt.Errorf("invalid output: %v", err)
+    }
+    expected := solve(tc.n, tc.m, tc.a, tc.b)
+    if ans != expected {
+        return fmt.Errorf("expected %d got %d", expected, ans)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+    var cases []testCase
+    cases = append(cases, testCase{n: 1, m: 1, a: 1, b: 1})
+    cases = append(cases, testCase{n: 10, m: 5, a: 3, b: 9})
+    cases = append(cases, testCase{n: 10, m: 5, a: 1, b: 10})
+    for i := 0; i < 100; i++ {
+        n := rng.Int63n(1_000_000_000) + 1
+        m := rng.Int63n(1_000_000_000) + 1
+        if n < 1 {
+            n = 1
+        }
+        a := rng.Int63n(n) + 1
+        b := a + rng.Int63n(n-a+1)
+        cases = append(cases, testCase{n: n, m: m, a: a, b: b})
+    }
+
+    for i, tc := range cases {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput: %d %d %d %d\n", i+1, err, tc.n, tc.m, tc.a, tc.b)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/0-99/90-99/93/verifierB.go
+++ b/0-999/0-99/90-99/93/verifierB.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func solve(n, W, m int) string {
+    if n < m && m%(m-n) > 0 {
+        return "NO\n"
+    }
+    var sb strings.Builder
+    sb.WriteString("YES\n")
+    cur, used := 1, 0
+    for i := 0; i < m; i++ {
+        sum := 0
+        printed := false
+        for sum < n {
+            cnt := n - sum
+            if m-used < cnt {
+                cnt = m - used
+            }
+            if printed {
+                sb.WriteByte(' ')
+            }
+            length := float64(cnt) / float64(m) * float64(W)
+            sb.WriteString(fmt.Sprintf("%d %.16f", cur, length))
+            printed = true
+            used += cnt
+            sum += cnt
+            if used == m {
+                cur++
+                used = 0
+            }
+        }
+        sb.WriteByte('\n')
+    }
+    return sb.String()
+}
+
+type testCase struct {
+    n, W, m int
+}
+
+func runCase(bin string, tc testCase) error {
+    input := fmt.Sprintf("%d %d %d\n", tc.n, tc.W, tc.m)
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    expected := strings.TrimSpace(solve(tc.n, tc.W, tc.m))
+    got := strings.TrimSpace(out.String())
+    if expected != got {
+        return fmt.Errorf("expected:\n%s\n-- got:\n%s", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+    var cases []testCase
+    cases = append(cases, testCase{n: 1, W: 100, m: 2})
+    cases = append(cases, testCase{n: 3, W: 10, m: 2})
+    cases = append(cases, testCase{n: 5, W: 123, m: 5})
+    for i := 0; i < 100; i++ {
+        n := rng.Intn(50) + 1
+        W := rng.Intn(901) + 100
+        m := rng.Intn(49) + 2
+        cases = append(cases, testCase{n: n, W: W, m: m})
+    }
+
+    for i, tc := range cases {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput: %d %d %d\n", i+1, err, tc.n, tc.W, tc.m)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/0-99/90-99/93/verifierC.go
+++ b/0-999/0-99/90-99/93/verifierC.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+var (
+    mul = [4]int{1, 2, 4, 8}
+    node = [100]struct{ a, b, c, d int }{}
+    target int
+    steps int
+    builder strings.Builder
+    found bool
+)
+
+func dfs(x int) {
+    if found {
+        return
+    }
+    if x == steps {
+        if node[x].a == target {
+            builder.WriteString(fmt.Sprintf("%d\n", steps-1))
+            for i := 2; i <= steps; i++ {
+                reg := byte('a' + i - 1)
+                builder.WriteString("lea e")
+                builder.WriteByte(reg)
+                builder.WriteString("x, [")
+                if node[i].b != 0 {
+                    base := byte('a' + node[i].b - 1)
+                    builder.WriteString(fmt.Sprintf("e%cx + ", base))
+                }
+                if node[i].d != 0 {
+                    builder.WriteString(fmt.Sprintf("%d*", mul[node[i].d]))
+                }
+                src := byte('a' + node[i].c - 1)
+                builder.WriteString(fmt.Sprintf("e%cx]\n", src))
+            }
+            found = true
+        }
+        return
+    }
+    for i := 0; i <= x && !found; i++ {
+        for j := 1; j <= x && !found; j++ {
+            for k := 0; k < 4 && !found; k++ {
+                A := node[i].a + mul[k]*node[j].a
+                if A <= node[x].a || A > target {
+                    continue
+                }
+                node[x+1] = struct{ a, b, c, d int }{A, i, j, k}
+                dfs(x + 1)
+            }
+        }
+    }
+}
+
+func compute(n int) string {
+    target = n
+    for steps = 1; ; steps++ {
+        node[1] = struct{ a, b, c, d int }{1, 0, 0, 0}
+        builder.Reset()
+        found = false
+        dfs(1)
+        if found {
+            return builder.String()
+        }
+    }
+}
+
+type testCase struct{
+    n int
+}
+
+func runCase(bin string, tc testCase) error {
+    input := fmt.Sprintf("%d\n", tc.n)
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    expected := strings.TrimSpace(compute(tc.n))
+    got := strings.TrimSpace(out.String())
+    if expected != got {
+        return fmt.Errorf("expected:\n%s\n-- got:\n%s", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+    var cases []testCase
+    cases = append(cases, testCase{n: 1})
+    cases = append(cases, testCase{n: 2})
+    cases = append(cases, testCase{n: 255})
+    for i:=0;i<100;i++ {
+        n := rng.Intn(255) + 1
+        cases = append(cases, testCase{n: n})
+    }
+
+    for i, tc := range cases {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput: %d\n", i+1, err, tc.n)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/0-99/90-99/93/verifierD.go
+++ b/0-999/0-99/90-99/93/verifierD.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+const MOD int64 = 1000000007
+const inv2 int64 = 500000004
+
+func compute(L, R int64) int64 {
+    allowedAdj := func(i, j int) bool {
+        if i == j {
+            return false
+        }
+        if (i == 0 && j == 1) || (i == 1 && j == 0) {
+            return false
+        }
+        if (i == 2 && j == 3) || (i == 3 && j == 2) {
+            return false
+        }
+        return true
+    }
+    forbiddenTriple := map[[3]int]bool{
+        {3, 0, 2}: true,
+        {2, 0, 3}: true,
+    }
+    var pair [][2]int
+    idx := make(map[[2]int]int)
+    for i := 0; i < 4; i++ {
+        for j := 0; j < 4; j++ {
+            if allowedAdj(i, j) {
+                id := len(pair)
+                pair = append(pair, [2]int{i, j})
+                idx[[2]int{i, j}] = id
+            }
+        }
+    }
+    m := len(pair)
+    T := make([][]int64, m)
+    for i := range T {
+        T[i] = make([]int64, m)
+    }
+    for a := 0; a < m; a++ {
+        i1, i2 := pair[a][0], pair[a][1]
+        for k := 0; k < 4; k++ {
+            if !allowedAdj(i2, k) {
+                continue
+            }
+            if forbiddenTriple[[3]int{i1, i2, k}] {
+                continue
+            }
+            b := idx[[2]int{i2, k}]
+            T[a][b] = 1
+        }
+    }
+    size := m + 1
+    M := make([][]int64, size)
+    for i := range M {
+        M[i] = make([]int64, size)
+    }
+    for i := 0; i < m; i++ {
+        for j := 0; j < m; j++ {
+            M[i][j] = T[i][j]
+        }
+    }
+    for j := 0; j < m; j++ {
+        M[m][j] = 1
+    }
+    M[m][m] = 1
+    v2 := make([]int64, size)
+    for i := 0; i < m; i++ {
+        v2[i] = 1
+    }
+    v2[m] = int64(m)
+    mul := func(A, B [][]int64) [][]int64 {
+        n := len(A)
+        C := make([][]int64, n)
+        for i := range C {
+            C[i] = make([]int64, n)
+        }
+        for i := 0; i < n; i++ {
+            for k := 0; k < n; k++ {
+                if A[i][k] == 0 {
+                    continue
+                }
+                aik := A[i][k]
+                for j := 0; j < n; j++ {
+                    C[i][j] = (C[i][j] + aik*B[k][j]) % MOD
+                }
+            }
+        }
+        return C
+    }
+    var pow func(mat [][]int64, e int64) [][]int64
+    pow = func(mat [][]int64, e int64) [][]int64 {
+        n := len(mat)
+        res := make([][]int64, n)
+        for i := 0; i < n; i++ {
+            res[i] = make([]int64, n)
+            res[i][i] = 1
+        }
+        base := mat
+        for e > 0 {
+            if e&1 == 1 {
+                res = mul(res, base)
+            }
+            base = mul(base, base)
+            e >>= 1
+        }
+        return res
+    }
+    sumA := func(b int64) int64 {
+        if b < 2 {
+            return 0
+        }
+        Mexp := pow(M, b-2)
+        var s int64
+        for j := 0; j < size; j++ {
+            s = (s + v2[j]*Mexp[j][m]) % MOD
+        }
+        return s
+    }
+    var S1 int64
+    if L <= 1 && R >= 1 {
+        S1 = (S1 + 4) % MOD
+    }
+    l2 := L
+    if l2 < 2 {
+        l2 = 2
+    }
+    if R >= 2 && l2 <= R {
+        S1 = (S1 + (sumA(R)-sumA(l2-1)+MOD)%MOD) % MOD
+    }
+    k1 := (L + 2) / 2
+    if L%2 == 0 {
+        k1 = L/2 + 1
+    }
+    k2 := (R + 1) / 2
+    var S2 int64
+    if k1 <= k2 {
+        if k1 <= 1 && k2 >= 1 {
+            S2 = (S2 + 4) % MOD
+        }
+        kk1 := k1
+        if kk1 < 2 {
+            kk1 = 2
+        }
+        if k2 >= 2 && kk1 <= k2 {
+            S2 = (S2 + (sumA(k2)-sumA(kk1-1)+MOD)%MOD) % MOD
+        }
+    }
+    ans := (S1 + S2) % MOD * inv2 % MOD
+    return ans
+}
+
+type testCase struct {
+    L, R int64
+}
+
+func runCase(bin string, tc testCase) error {
+    input := fmt.Sprintf("%d %d\n", tc.L, tc.R)
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    var val int64
+    if _, err := fmt.Fscan(strings.NewReader(strings.TrimSpace(out.String())), &val); err != nil {
+        return fmt.Errorf("invalid output: %v", err)
+    }
+    expected := compute(tc.L, tc.R)
+    if val != expected {
+        return fmt.Errorf("expected %d got %d", expected, val)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+    var cases []testCase
+    cases = append(cases, testCase{L: 1, R: 1})
+    cases = append(cases, testCase{L: 1, R: 3})
+    cases = append(cases, testCase{L: 123, R: 12345})
+    for i := 0; i < 100; i++ {
+        L := rng.Int63n(1_000_000_000) + 1
+        R := L + rng.Int63n(1_000_000_000-L+1)
+        cases = append(cases, testCase{L: L, R: R})
+    }
+
+    for i, tc := range cases {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput: %d %d\n", i+1, err, tc.L, tc.R)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/0-99/90-99/93/verifierE.go
+++ b/0-999/0-99/90-99/93/verifierE.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+    "time"
+)
+
+func compute(n uint64, arr []uint64) int64 {
+    sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+    if len(arr) > 0 && arr[0] == 1 {
+        return 0
+    }
+    var res int64
+    var dfs func(idx int, prod uint64, depth int)
+    dfs = func(idx int, prod uint64, depth int) {
+        for i := idx; i < len(arr); i++ {
+            ai := arr[i]
+            if prod > n/ai {
+                continue
+            }
+            newProd := prod * ai
+            cnt := int64(n / newProd)
+            if depth%2 == 0 {
+                res += cnt
+            } else {
+                res -= cnt
+            }
+            dfs(i+1, newProd, depth+1)
+        }
+    }
+    dfs(0, 1, 0)
+    damage := int64(n) - res
+    return damage
+}
+
+type testCase struct {
+    n  uint64
+    k  int
+    a  []uint64
+}
+
+func runCase(bin string, tc testCase) error {
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+    for i := 0; i < tc.k; i++ {
+        if i > 0 {
+            sb.WriteByte(' ')
+        }
+        sb.WriteString(fmt.Sprintf("%d", tc.a[i]))
+    }
+    sb.WriteByte('\n')
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(sb.String())
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    var val int64
+    if _, err := fmt.Fscan(strings.NewReader(strings.TrimSpace(out.String())), &val); err != nil {
+        return fmt.Errorf("invalid output: %v", err)
+    }
+    expected := compute(tc.n, append([]uint64(nil), tc.a...))
+    if val != expected {
+        return fmt.Errorf("expected %d got %d", expected, val)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+    var cases []testCase
+    cases = append(cases, testCase{n: 1, k: 1, a: []uint64{2}})
+    cases = append(cases, testCase{n: 10, k: 2, a: []uint64{2,3}})
+    cases = append(cases, testCase{n: 1000, k: 3, a: []uint64{2,5,7}})
+    for i := 0; i < 100; i++ {
+        n := rng.Uint64()%1_000_000 + 1
+        k := rng.Intn(5) + 1
+        arr := make([]uint64, k)
+        used := make(map[uint64]bool)
+        for j := 0; j < k; j++ {
+            for {
+                v := rng.Uint64()%1000 + 2
+                if !used[v] {
+                    used[v] = true
+                    arr[j] = v
+                    break
+                }
+            }
+        }
+        cases = append(cases, testCase{n: n, k: k, a: arr})
+    }
+
+    for i, tc := range cases {
+        if err := runCase(bin, tc); err != nil {
+            fmt.Fprintf(os.Stderr, "test %d failed: %v\n", i+1, err)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 93 problems A–E
- each verifier runs the provided binary on at least 100 random tests

## Testing
- `go run verifierA.go ./93A_bin`
- `go run verifierB.go ./93B_bin`
- `go run verifierC.go ./93C_bin`
- `go run verifierD.go ./93D_bin`
- `go run verifierE.go ./93E_bin`


------
https://chatgpt.com/codex/tasks/task_e_687e6d7a618083248fa13e98ce535f7a