### PR TITLE
Add Go verifiers for contest 92

### DIFF
--- a/0-999/0-99/90-99/92/verifierA.go
+++ b/0-999/0-99/90-99/92/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, m int) int {
+	rem := m
+	i := 1
+	for {
+		if rem < i {
+			break
+		}
+		rem -= i
+		i++
+		if i > n {
+			i = 1
+		}
+	}
+	return rem
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	m := rng.Intn(10000) + 1
+	exp := expected(n, m)
+	input := fmt.Sprintf("%d %d\n", n, m)
+	out := fmt.Sprintf("%d\n", exp)
+	return input, out
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %s got %s", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/90-99/92/verifierB.go
+++ b/0-999/0-99/90-99/92/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func stepsBinary(s string) int {
+	x := new(big.Int)
+	x.SetString(s, 2)
+	one := big.NewInt(1)
+	steps := 0
+	for x.Cmp(one) != 0 {
+		if x.Bit(0) == 1 {
+			x.Add(x, one)
+		} else {
+			x.Rsh(x, 1)
+		}
+		steps++
+	}
+	return steps
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(200) + 1
+	b := make([]byte, n)
+	b[0] = '1'
+	for i := 1; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	s := string(b)
+	exp := stepsBinary(s)
+	input := fmt.Sprintf("%s\n", s)
+	out := fmt.Sprintf("%d\n", exp)
+	return input, out
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if outStr != exp {
+		return fmt.Errorf("expected %s got %s", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 92 problems A and B
- verifiers run 100 random cases against any binary

## Testing
- `go run verifierA.go ./92A`
- `go run verifierB.go ./92B`


------
https://chatgpt.com/codex/tasks/task_e_687e6d7528e4832493cea951123bd309