### PR TITLE
Add Go verifiers for contest 89

### DIFF
--- a/0-999/0-99/80-89/89/verifierA.go
+++ b/0-999/0-99/80-89/89/verifierA.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n int
+	m int64
+	k int64
+	a []int64
+}
+
+func solveA(tc testCaseA) int64 {
+	n := tc.n
+	m := tc.m
+	k := tc.k
+	a := tc.a
+	if n%2 == 0 {
+		return 0
+	}
+	t := make([]int64, n)
+	for i := 1; i < n; i++ {
+		t[i] = a[i-1] + a[i] - t[i-1]
+	}
+	L := int64(-1 << 60)
+	for i := 0; i < n; i++ {
+		if i%2 == 0 {
+			if v := -t[i]; v > L {
+				L = v
+			}
+		}
+	}
+	x0 := a[0]
+	maxRed := x0 - L
+	if maxRed < 0 {
+		maxRed = 0
+	}
+	cost := int64(n/2 + 1)
+	per := m / cost
+	if per <= 0 {
+		return 0
+	}
+	total := per * k
+	if total > maxRed {
+		total = maxRed
+	}
+	return total
+}
+
+func runCaseA(bin string, tc testCaseA) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.m, tc.k))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expected := solveA(tc)
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func genCaseA(rng *rand.Rand) testCaseA {
+	n := rng.Intn(10) + 1
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = rng.Int63n(100000)
+	}
+	m := rng.Int63n(1000000000) + 1
+	k := rng.Int63n(1000000000) + 1
+	return testCaseA{n, m, k, a}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseA(rng)
+		if err := runCaseA(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/89/verifierB.go
+++ b/0-999/0-99/80-89/89/verifierB.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Widget struct {
+	kind     int //0 simple,1 HBox,2 VBox
+	w, h     int
+	border   int
+	spacing  int
+	children []string
+}
+
+func compute(name string, widgets map[string]*Widget, memoW, memoH map[string]int) (int, int) {
+	if w, ok := memoW[name]; ok {
+		return w, memoH[name]
+	}
+	wgt := widgets[name]
+	var w, h int
+	switch wgt.kind {
+	case 0:
+		w, h = wgt.w, wgt.h
+	case 1, 2:
+		n := len(wgt.children)
+		if n == 0 {
+			w, h = 0, 0
+		} else {
+			sumW, sumH := 0, 0
+			maxW, maxH := 0, 0
+			for _, ch := range wgt.children {
+				cw, chh := compute(ch, widgets, memoW, memoH)
+				sumW += cw
+				sumH += chh
+				if cw > maxW {
+					maxW = cw
+				}
+				if chh > maxH {
+					maxH = chh
+				}
+			}
+			if wgt.kind == 1 {
+				w = sumW + wgt.spacing*(n-1) + 2*wgt.border
+				h = maxH + 2*wgt.border
+			} else {
+				w = maxW + 2*wgt.border
+				h = sumH + wgt.spacing*(n-1) + 2*wgt.border
+			}
+		}
+	}
+	memoW[name] = w
+	memoH[name] = h
+	return w, h
+}
+
+type scriptCase struct {
+	n       int
+	lines   []string
+	widgets map[string]*Widget
+	names   []string
+}
+
+func genCaseB(rng *rand.Rand) scriptCase {
+	wc := rng.Intn(5) + 3
+	lines := make([]string, 0)
+	widgets := make(map[string]*Widget)
+	names := make([]string, 0)
+	for i := 0; i < wc; i++ {
+		name := fmt.Sprintf("w%d", i)
+		names = append(names, name)
+		kind := rng.Intn(3)
+		switch kind {
+		case 0:
+			w := rng.Intn(10)
+			h := rng.Intn(10)
+			lines = append(lines, fmt.Sprintf("Widget %s(%d,%d)", name, w, h))
+			widgets[name] = &Widget{kind: 0, w: w, h: h}
+		case 1:
+			lines = append(lines, fmt.Sprintf("HBox %s", name))
+			widgets[name] = &Widget{kind: 1, border: rng.Intn(4), spacing: rng.Intn(3)}
+			lines = append(lines, fmt.Sprintf("%s.set_border(%d)", name, widgets[name].border))
+			lines = append(lines, fmt.Sprintf("%s.set_spacing(%d)", name, widgets[name].spacing))
+		case 2:
+			lines = append(lines, fmt.Sprintf("VBox %s", name))
+			widgets[name] = &Widget{kind: 2, border: rng.Intn(4), spacing: rng.Intn(3)}
+			lines = append(lines, fmt.Sprintf("%s.set_border(%d)", name, widgets[name].border))
+			lines = append(lines, fmt.Sprintf("%s.set_spacing(%d)", name, widgets[name].spacing))
+		}
+	}
+	// pack operations
+	for i, name := range names {
+		wgt := widgets[name]
+		if wgt.kind == 0 {
+			continue
+		}
+		childCount := rng.Intn(len(names))
+		for j := 0; j < childCount; j++ {
+			idx := rng.Intn(i + 1) // ensure child created before container
+			if names[idx] == name {
+				continue
+			}
+			wgt.children = append(wgt.children, names[idx])
+			lines = append(lines, fmt.Sprintf("%s.pack(%s)", name, names[idx]))
+		}
+	}
+	return scriptCase{n: len(lines), lines: lines, widgets: widgets, names: names}
+}
+
+func solveB(sc scriptCase) string {
+	memoW := make(map[string]int)
+	memoH := make(map[string]int)
+	names := append([]string(nil), sc.names...)
+	sort.Strings(names)
+	var sb strings.Builder
+	for _, name := range names {
+		w, h := compute(name, sc.widgets, memoW, memoH)
+		sb.WriteString(fmt.Sprintf("%s %d %d\n", name, w, h))
+	}
+	return sb.String()
+}
+
+func runCaseB(bin string, sc scriptCase) error {
+	input := fmt.Sprintf("%d\n%s\n", sc.n, strings.Join(sc.lines, "\n"))
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	expected := solveB(sc)
+	if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected:\n%sbut got:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		sc := genCaseB(rng)
+		if err := runCaseB(bin, sc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/89/verifierC.go
+++ b/0-999/0-99/80-89/89/verifierC.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+// chip struct
+type chip struct {
+	r, c int
+	dir  byte
+}
+
+type gridCase struct {
+	n, m int
+	grid []string
+}
+
+func genCaseC(rng *rand.Rand) gridCase {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	grid := make([]string, n)
+	dirs := []byte{'L', 'R', 'U', 'D', '.'}
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			b[j] = dirs[rng.Intn(len(dirs))]
+		}
+		grid[i] = string(b)
+	}
+	// ensure at least one chip
+	has := false
+	for _, row := range grid {
+		if strings.ContainsAny(row, "LRUD") {
+			has = true
+			break
+		}
+	}
+	if !has {
+		i := rng.Intn(n)
+		j := rng.Intn(m)
+		d := dirs[rng.Intn(4)]
+		row := []byte(grid[i])
+		row[j] = d
+		grid[i] = string(row)
+	}
+	return gridCase{n, m, grid}
+}
+
+func collectChips(gc gridCase) ([]chip, [][]int) {
+	n, m := gc.n, gc.m
+	chips := make([]chip, 0)
+	id := make([][]int, n)
+	for i := 0; i < n; i++ {
+		id[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			id[i][j] = -1
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			d := gc.grid[i][j]
+			if d == 'L' || d == 'R' || d == 'U' || d == 'D' {
+				id[i][j] = len(chips)
+				chips = append(chips, chip{i, j, d})
+			}
+		}
+	}
+	return chips, id
+}
+
+func solveC(gc gridCase) (int, int) {
+	chips, _ := collectChips(gc)
+	k := len(chips)
+	if k == 0 {
+		return 0, 0
+	}
+	l := make([]int, k)
+	r := make([]int, k)
+	u := make([]int, k)
+	d := make([]int, k)
+	for i := 0; i < k; i++ {
+		l[i], r[i], u[i], d[i] = -1, -1, -1, -1
+	}
+	rowMap := make(map[int][]int)
+	for i, ch := range chips {
+		rowMap[ch.r] = append(rowMap[ch.r], i)
+	}
+	for _, idxs := range rowMap {
+		sort.Slice(idxs, func(i, j int) bool { return chips[idxs[i]].c < chips[idxs[j]].c })
+		for t := 0; t < len(idxs); t++ {
+			if t > 0 {
+				l[idxs[t]] = idxs[t-1]
+			}
+			if t+1 < len(idxs) {
+				r[idxs[t]] = idxs[t+1]
+			}
+		}
+	}
+	colMap := make(map[int][]int)
+	for i, ch := range chips {
+		colMap[ch.c] = append(colMap[ch.c], i)
+	}
+	for _, idxs := range colMap {
+		sort.Slice(idxs, func(i, j int) bool { return chips[idxs[i]].r < chips[idxs[j]].r })
+		for t := 0; t < len(idxs); t++ {
+			if t > 0 {
+				u[idxs[t]] = idxs[t-1]
+			}
+			if t+1 < len(idxs) {
+				d[idxs[t]] = idxs[t+1]
+			}
+		}
+	}
+	maxPoints := 0
+	ways := 0
+	for start := 0; start < k; start++ {
+		lc := append([]int(nil), l...)
+		rc := append([]int(nil), r...)
+		uc := append([]int(nil), u...)
+		dc := append([]int(nil), d...)
+		points := 0
+		curr := start
+		for {
+			var nxt int
+			switch chips[curr].dir {
+			case 'L':
+				nxt = lc[curr]
+			case 'R':
+				nxt = rc[curr]
+			case 'U':
+				nxt = uc[curr]
+			case 'D':
+				nxt = dc[curr]
+			}
+			if lc[curr] != -1 {
+				rc[lc[curr]] = rc[curr]
+			}
+			if rc[curr] != -1 {
+				lc[rc[curr]] = lc[curr]
+			}
+			if uc[curr] != -1 {
+				dc[uc[curr]] = dc[curr]
+			}
+			if dc[curr] != -1 {
+				uc[dc[curr]] = uc[curr]
+			}
+			points++
+			if nxt == -1 {
+				break
+			}
+			curr = nxt
+		}
+		if points > maxPoints {
+			maxPoints = points
+			ways = 1
+		} else if points == maxPoints {
+			ways++
+		}
+	}
+	return maxPoints, ways
+}
+
+func runCaseC(bin string, gc gridCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", gc.n, gc.m))
+	for i := 0; i < gc.n; i++ {
+		sb.WriteString(gc.grid[i])
+		if i+1 < gc.n {
+			sb.WriteByte('\n')
+		}
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got1, got2 int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got1, &got2); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp1, exp2 := solveC(gc)
+	if got1 != exp1 || got2 != exp2 {
+		return fmt.Errorf("expected %d %d got %d %d", exp1, exp2, got1, got2)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		gc := genCaseC(rng)
+		if err := runCaseC(bin, gc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/89/verifierD.go
+++ b/0-999/0-99/80-89/89/verifierD.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type P struct{ x, y, z float64 }
+
+func (p P) add(q P) P       { return P{p.x + q.x, p.y + q.y, p.z + q.z} }
+func (p P) sub(q P) P       { return P{p.x - q.x, p.y - q.y, p.z - q.z} }
+func (p P) mul(k float64) P { return P{p.x * k, p.y * k, p.z * k} }
+func (p P) dot(q P) float64 { return p.x*q.x + p.y*q.y + p.z*q.z }
+func (p P) cross(q P) P {
+	return P{
+		p.y*q.z - p.z*q.y,
+		p.z*q.x - p.x*q.z,
+		p.x*q.y - p.y*q.x,
+	}
+}
+func (p P) mag2() float64 { return p.dot(p) }
+func (p P) mag() float64  { return math.Sqrt(p.mag2()) }
+
+const inf = 1e20
+const eps = 1e-9
+
+func f(a, o P, r1, r2 float64, v P) (bool, float64) {
+	A := v.mag2()
+	B := 2 * a.sub(o).dot(v)
+	C := a.sub(o).mag2() - (r1+r2)*(r1+r2)
+	D := B*B - 4*A*C
+	if D < 0 {
+		return false, 0
+	}
+	if D > 0 {
+		D = math.Sqrt(D)
+	}
+	t := (-B - D) / (2 * A)
+	return t > 0, t
+}
+
+type mine struct {
+	cen    P
+	r      float64
+	spikes []P
+}
+
+type caseD struct {
+	A, V  P
+	R     float64
+	mines []mine
+}
+
+func solveD(c caseD) float64 {
+	ans := inf
+	upd := func(t float64) {
+		if t < ans {
+			ans = t
+		}
+	}
+	for _, m := range c.mines {
+		if ok, t := f(c.A, m.cen, c.R, m.r, c.V); ok {
+			upd(t)
+		}
+		for _, p := range m.spikes {
+			if ok, t := f(c.A, m.cen, c.R, 0, c.V); ok {
+				upd(t)
+			}
+			if ok, t := f(c.A, m.cen.add(p), c.R, 0, c.V); ok {
+				upd(t)
+			}
+			c1 := m.cen
+			d := m.cen.add(p)
+			cd := d.sub(c1)
+			ca := c1.sub(c.A)
+			crossVc := c.V.cross(cd)
+			A1 := crossVc.mag2()
+			if math.Abs(A1) < eps {
+				continue
+			}
+			B := crossVc.mag() * ca.cross(cd).mag()
+			C := ca.cross(cd).mag2()
+			D := B*B - 4*A1*C
+			if D >= 0 {
+				if D > 0 {
+					D = math.Sqrt(D)
+				}
+				t1 := (-B + D) / (2 * A1)
+				if t1 > 0 {
+					Q := c.A.add(c.V.mul(t1))
+					if Q.sub(c1).dot(cd) >= 0 && Q.sub(d).dot(c1.sub(d)) >= 0 {
+						upd(t1)
+					}
+				}
+			}
+		}
+	}
+	if ans == inf {
+		return -1
+	}
+	return ans
+}
+
+func genCaseD(rng *rand.Rand) caseD {
+	A := P{float64(rng.Intn(41) - 20), float64(rng.Intn(41) - 20), float64(rng.Intn(41) - 20)}
+	V := P{}
+	for V.x == 0 && V.y == 0 && V.z == 0 {
+		V = P{float64(rng.Intn(11) - 5), float64(rng.Intn(11) - 5), float64(rng.Intn(11) - 5)}
+	}
+	R := float64(rng.Intn(10) + 10)
+	m := mine{}
+	m.cen = P{float64(rng.Intn(41) - 20), float64(rng.Intn(41) - 20), float64(rng.Intn(41) - 20)}
+	m.r = float64(rng.Intn(5) + 1)
+	spikeCount := rng.Intn(3)
+	m.spikes = make([]P, spikeCount)
+	for i := 0; i < spikeCount; i++ {
+		for {
+			p := P{float64(rng.Intn(11) - 5), float64(rng.Intn(11) - 5), float64(rng.Intn(11) - 5)}
+			if d := p.mag(); d > m.r && d <= 1.5*m.r {
+				m.spikes[i] = p
+				break
+			}
+		}
+	}
+	// ensure initial distance > R + r
+	for math.Sqrt(m.cen.sub(A).mag2()) <= R+m.r {
+		m.cen.x += 10
+	}
+	return caseD{A, V, R, []mine{m}}
+}
+
+func runCaseD(bin string, c caseD) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d %d %d %d\n", int(c.A.x), int(c.A.y), int(c.A.z), int(c.V.x), int(c.V.y), int(c.V.z), int(c.R)))
+	sb.WriteString("1\n")
+	m := c.mines[0]
+	sb.WriteString(fmt.Sprintf("%d %d %d %d %d\n", int(m.cen.x), int(m.cen.y), int(m.cen.z), int(m.r), len(m.spikes)))
+	for _, p := range m.spikes {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", int(p.x), int(p.y), int(p.z)))
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solveD(c)
+	if exp < 0 && got != -1 {
+		return fmt.Errorf("expected -1 got %.6f", got)
+	}
+	if exp >= 0 && (got < 0 || math.Abs(got-exp) > 1e-6) {
+		return fmt.Errorf("expected %.6f got %.6f", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := genCaseD(rng)
+		if err := runCaseD(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/89/verifierE.go
+++ b/0-999/0-99/80-89/89/verifierE.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(a []int) string {
+	n := len(a) - 1
+	var sb strings.Builder
+	l, r := n, 0
+	for i := 1; i <= n; i++ {
+		if a[i] > 0 {
+			if i < l {
+				l = i
+			}
+			if i > r {
+				r = i
+			}
+		}
+	}
+	p := -1
+	for r > 0 {
+		i := p + 2
+		for i <= r && a[i] == 0 {
+			sb.WriteString("AR")
+			p++
+			i++
+		}
+		value := 1
+		d := 0
+		first := true
+		for i = p + 2; i <= r; i++ {
+			if a[i] > 0 {
+				value += 4
+				if first {
+					d++
+				}
+			} else {
+				value--
+				first = false
+			}
+			if value <= 0 {
+				tar := d
+				for j := 0; j < tar; j++ {
+					sb.WriteString("AR")
+				}
+				sb.WriteByte('A')
+				for j := 0; j < tar; j++ {
+					sb.WriteByte('L')
+				}
+				sb.WriteByte('A')
+				for j := p + 2; j < p+d+2; j++ {
+					if a[j] > 0 {
+						a[j]--
+					}
+				}
+				break
+			}
+		}
+		if value > 0 {
+			tar := r - p - 1
+			for i = 0; i < tar; i++ {
+				sb.WriteString("AR")
+			}
+			sb.WriteString("AL")
+			p = r - 2
+			if a[r] == 1 {
+				for p+1 >= l && a[p+1] <= 1 {
+					p--
+					sb.WriteByte('L')
+				}
+			}
+			for p+1 >= l && a[p+1] > 1 {
+				p--
+				sb.WriteByte('L')
+			}
+			sb.WriteByte('A')
+			for i = p + 2; i <= r; i++ {
+				if a[i] > 0 {
+					a[i]--
+				}
+			}
+		}
+		l = n
+		r = 0
+		for i := 1; i <= n; i++ {
+			if a[i] > 0 {
+				if i < l {
+					l = i
+				}
+				if i > r {
+					r = i
+				}
+			}
+		}
+	}
+	return sb.String()
+}
+
+type caseE struct {
+	n int
+	a []int
+}
+
+func genCaseE(rng *rand.Rand) caseE {
+	n := rng.Intn(10) + 1
+	a := make([]int, n+1)
+	pos := false
+	for i := 1; i <= n; i++ {
+		if rng.Intn(2) == 0 {
+			a[i] = rng.Intn(4)
+		} else {
+			a[i] = 0
+		}
+		if a[i] > 0 {
+			pos = true
+		}
+	}
+	if !pos {
+		a[rng.Intn(n)+1] = rng.Intn(3) + 1
+	}
+	return caseE{n, a}
+}
+
+func runCaseE(bin string, c caseE) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", c.n))
+	for i := 1; i <= c.n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c.a[i]))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := solveE(append([]int(nil), c.a...))
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := genCaseE(rng)
+		if err := runCaseE(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new solution verifiers for all problems of contest 89 (A–E)
- each verifier runs 100 random tests and checks a provided binary

## Testing
- `go run verifierA.go ./89A`
- `go run verifierB.go ./89B`
- `go run verifierC.go ./89C`
- `go run verifierD.go ./89D`
- `go run verifierE.go ./89E`

------
https://chatgpt.com/codex/tasks/task_e_687e6d65f5f4832493d11b497bce1f98