### PR TITLE
Add Go verifiers for contest 88

### DIFF
--- a/0-999/0-99/80-89/88/verifierA.go
+++ b/0-999/0-99/80-89/88/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var notes = []string{"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "B", "H"}
+var noteMap = map[string]int{
+	"C": 0, "C#": 1, "D": 2, "D#": 3, "E": 4, "F": 5,
+	"F#": 6, "G": 7, "G#": 8, "A": 9, "B": 10, "H": 11,
+}
+var perms = [6][3]int{{0, 1, 2}, {0, 2, 1}, {1, 0, 2}, {1, 2, 0}, {2, 0, 1}, {2, 1, 0}}
+
+func classify(a, b, c string) string {
+	nums := []int{noteMap[a], noteMap[b], noteMap[c]}
+	for _, p := range perms {
+		x := nums[p[0]]
+		y := nums[p[1]]
+		z := nums[p[2]]
+		d1 := (y - x + 12) % 12
+		d2 := (z - y + 12) % 12
+		if d1 == 4 && d2 == 3 {
+			return "major"
+		}
+		if d1 == 3 && d2 == 4 {
+			return "minor"
+		}
+	}
+	return "strange"
+}
+
+func runCase(bin, input, expected string, idx int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	outBytes, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("runtime error on case %d: %v", idx, err)
+	}
+	out := strings.TrimSpace(string(outBytes))
+	if out != expected {
+		return fmt.Errorf("wrong answer on case %d: input=%q expected=%q got=%q", idx, strings.TrimSpace(input), expected, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	caseIdx := 0
+	for _, a := range notes {
+		for _, b := range notes {
+			for _, c := range notes {
+				input := fmt.Sprintf("%s %s %s\n", a, b, c)
+				expected := classify(a, b, c)
+				caseIdx++
+				if err := runCase(bin, input, expected, caseIdx); err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+			}
+		}
+	}
+	fmt.Printf("ok %d\n", caseIdx)
+}

--- a/0-999/0-99/80-89/88/verifierB.go
+++ b/0-999/0-99/80-89/88/verifierB.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pos struct{ r, c int }
+
+func solve(n, m, x int, board []string, q int, text string) string {
+	letters := make([][]pos, 26)
+	var shifts []pos
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			ch := board[i][j]
+			if ch == 'S' {
+				shifts = append(shifts, pos{i, j})
+			} else {
+				letters[ch-'a'] = append(letters[ch-'a'], pos{i, j})
+			}
+		}
+	}
+	good := make([]bool, 26)
+	if len(shifts) > 0 {
+		maxd2 := x * x
+		for i := 0; i < 26; i++ {
+			if len(letters[i]) == 0 {
+				continue
+			}
+			ok := false
+			for _, p := range letters[i] {
+				for _, s := range shifts {
+					dr := p.r - s.r
+					dc := p.c - s.c
+					if dr*dr+dc*dc <= maxd2 {
+						ok = true
+						break
+					}
+				}
+				if ok {
+					break
+				}
+			}
+			good[i] = ok
+		}
+	}
+	count := 0
+	for i := 0; i < q; i++ {
+		ch := text[i]
+		if ch >= 'a' && ch <= 'z' {
+			idx := ch - 'a'
+			if len(letters[idx]) == 0 {
+				return "-1"
+			}
+		} else {
+			idx := ch - 'A'
+			if len(letters[idx]) == 0 || len(shifts) == 0 {
+				return "-1"
+			}
+			if !good[idx] {
+				count++
+			}
+		}
+	}
+	return fmt.Sprint(count)
+}
+
+func genCase() (string, string) {
+	n := rand.Intn(4) + 1
+	m := rand.Intn(4) + 1
+	x := rand.Intn(5) + 1
+	board := make([]string, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rand.Float64() < 0.2 {
+				row[j] = 'S'
+			} else {
+				row[j] = byte('a' + rand.Intn(26))
+			}
+		}
+		board[i] = string(row)
+	}
+	q := rand.Intn(10) + 1
+	textb := make([]byte, q)
+	for i := 0; i < q; i++ {
+		if rand.Float64() < 0.5 {
+			textb[i] = byte('a' + rand.Intn(26))
+		} else {
+			textb[i] = byte('A' + rand.Intn(26))
+		}
+	}
+	text := string(textb)
+	in := fmt.Sprintf("%d %d %d\n", n, m, x)
+	for _, row := range board {
+		in += row + "\n"
+	}
+	in += fmt.Sprintf("%d\n%s\n", q, text)
+	out := solve(n, m, x, board, q, text)
+	return in, out
+}
+
+func runCase(bin, input, expected string, idx int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	outBytes, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("runtime error on case %d: %v", idx, err)
+	}
+	out := strings.TrimSpace(string(outBytes))
+	if out != expected {
+		return fmt.Errorf("wrong answer on case %d: expected %q got %q input:\n%s", idx, expected, out, input)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	tests := 150
+	for i := 1; i <= tests; i++ {
+		in, exp := genCase()
+		if err := runCase(bin, in, exp, i); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("ok %d\n", tests)
+}


### PR DESCRIPTION
## Summary
- add solution verifiers `verifierA.go` and `verifierB.go` for contest 88
- each verifier executes a provided binary on 100+ test cases

## Testing
- `go build 0-999/0-99/80-89/88/verifierA.go`
- `go build 0-999/0-99/80-89/88/verifierB.go`
- `go run 0-999/0-99/80-89/88/verifierA.go /tmp/88A`
- `go run 0-999/0-99/80-89/88/verifierB.go /tmp/88B`


------
https://chatgpt.com/codex/tasks/task_e_687e6d61879083249e24431366a6b445