### PR TITLE
Add Go verifiers for Codeforces contest 87

### DIFF
--- a/0-999/0-99/80-89/87/verifierA.go
+++ b/0-999/0-99/80-89/87/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleA"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/87/87A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	a := rng.Intn(1_000_000) + 1
+	b := rng.Intn(1_000_000) + 1
+	for a == b {
+		b = rng.Intn(1_000_000) + 1
+	}
+	return fmt.Sprintf("%d %d\n", a, b)
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/87/verifierB.go
+++ b/0-999/0-99/80-89/87/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleB"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/87/87B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func randomName(rng *rand.Rand) string {
+	for {
+		l := rng.Intn(5) + 1
+		b := make([]byte, l)
+		for i := range b {
+			b[i] = byte('a' + rng.Intn(26))
+		}
+		s := string(b)
+		if s != "void" && s != "errtype" {
+			return s
+		}
+	}
+}
+
+func randomTypeExpr(rng *rand.Rand, names []string) string {
+	prefix := rng.Intn(3)
+	suffix := rng.Intn(3)
+	base := names[rng.Intn(len(names))]
+	return strings.Repeat("&", prefix) + base + strings.Repeat("*", suffix)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	names := []string{"void", "errtype"}
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			// typedef
+			a := randomTypeExpr(rng, names)
+			b := randomName(rng)
+			fmt.Fprintf(&sb, "typedef %s %s\n", a, b)
+			names = append(names, b)
+		} else {
+			a := randomTypeExpr(rng, names)
+			fmt.Fprintf(&sb, "typeof %s\n", a)
+		}
+	}
+	return sb.String()
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/87/verifierC.go
+++ b/0-999/0-99/80-89/87/verifierC.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleC"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/87/87C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(1000) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/87/verifierD.go
+++ b/0-999/0-99/80-89/87/verifierD.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleD"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/87/87D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(15) + 2
+	type edge struct{ u, v, w int }
+	edges := make([]edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		u := i
+		v := rng.Intn(i-1) + 1
+		w := rng.Intn(100) + 1
+		edges = append(edges, edge{u, v, w})
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d %d\n", e.u, e.v, e.w)
+	}
+	return sb.String()
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/0-99/80-89/87/verifierE.go
+++ b/0-999/0-99/80-89/87/verifierE.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int }
+
+func buildOracle() (string, error) {
+	exe := "oracleE"
+	cmd := exec.Command("go", "build", "-o", exe, "./0-999/0-99/80-89/87/87E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func genTriangle(rng *rand.Rand) []point {
+	x0 := rng.Intn(10)
+	y0 := rng.Intn(10)
+	dx1 := rng.Intn(5) + 1
+	dx2 := rng.Intn(dx1)
+	dy := rng.Intn(5) + 1
+	p1 := point{x0, y0}
+	p2 := point{x0 + dx1, y0}
+	p3 := point{x0 + dx2, y0 + dy}
+	return []point{p1, p2, p3}
+}
+
+func generateCase(rng *rand.Rand) string {
+	var sb strings.Builder
+	for i := 0; i < 3; i++ {
+		pts := genTriangle(rng)
+		fmt.Fprintf(&sb, "%d\n", len(pts))
+		for _, p := range pts {
+			fmt.Fprintf(&sb, "%d %d\n", p.x, p.y)
+		}
+	}
+	m := rng.Intn(5) + 1
+	fmt.Fprintf(&sb, "%d\n", m)
+	for i := 0; i < m; i++ {
+		x := rng.Intn(15)
+		y := rng.Intn(15)
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	return sb.String()
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runProg("./"+oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failure on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement verifierA.go-E.go for contest 87
- each verifier compiles the official solution as an oracle
- 100 randomized test cases are generated per problem

## Testing
- `go build 0-999/0-99/80-89/87/verifierA.go`
- `go build 0-999/0-99/80-89/87/verifierB.go`
- `go build 0-999/0-99/80-89/87/verifierC.go`
- `go build 0-999/0-99/80-89/87/verifierD.go`
- `go build 0-999/0-99/80-89/87/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_687e6d5da6488324ad80ec941b3eea19