### PR TITLE
Add 909A Go solution

### DIFF
--- a/0-999/900-999/900-909/909/909A.go
+++ b/0-999/900-999/900-909/909/909A.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var first, last string
+	if _, err := fmt.Fscan(in, &first, &last); err != nil {
+		return
+	}
+	res := []byte{first[0]}
+	for i := 1; i < len(first) && first[i] < last[0]; i++ {
+		res = append(res, first[i])
+	}
+	res = append(res, last[0])
+	fmt.Println(string(res))
+}


### PR DESCRIPTION
## Summary
- add Go implementation for 909A

## Testing
- `go build ./0-999/900-999/900-909/909/909A.go`
- `go vet ./0-999/900-999/900-909/909/909A.go`


------
https://chatgpt.com/codex/tasks/task_e_687f52290e6883248c90d71038e1de5a