### PR TITLE
Add Go solution for problem 908A

### DIFF
--- a/0-999/900-999/900-909/908/908A.go
+++ b/0-999/900-999/900-909/908/908A.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var s string
+	if _, err := fmt.Fscan(reader, &s); err != nil {
+		return
+	}
+	count := 0
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			if (c-'0')%2 == 1 {
+				count++
+			}
+		} else if c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u' {
+			count++
+		}
+	}
+	fmt.Println(count)
+}


### PR DESCRIPTION
## Summary
- implement solution for `908A` (vowel/odd digit count)

## Testing
- `go run 0-999/900-999/900-909/908/908A.go <<EOF
acba1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687f56446e608324a266713502087e79