### PR TITLE
Add Go solution for Codeforces problem 903A

### DIFF
--- a/0-999/900-999/900-909/903/903A.go
+++ b/0-999/900-999/900-909/903/903A.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	for ; n > 0; n-- {
+		var x int
+		fmt.Fscan(reader, &x)
+		res := "NO"
+		for a := 0; a <= x; a += 3 {
+			if (x-a)%7 == 0 {
+				res = "YES"
+				break
+			}
+		}
+		fmt.Fprintln(writer, res)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `903A.go` to solve [problemA.txt](./0-999/900-999/900-909/903/problemA.txt)

## Testing
- `go build 0-999/900-999/900-909/903/903A.go`
- `echo -e "3\n6\n5\n1" | go run 0-999/900-999/900-909/903/903A.go`

------
https://chatgpt.com/codex/tasks/task_e_687f57a316c08324b04185f304d5a580