### PR TITLE
Add Go solution for problem 977E

### DIFF
--- a/0-999/900-999/970-979/977/977E.go
+++ b/0-999/900-999/970-979/977/977E.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return
+	}
+
+	adj := make([][]int, n+1)
+	for i := 0; i < m; i++ {
+		var u, v int
+		fmt.Fscan(reader, &u, &v)
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+
+	visited := make([]bool, n+1)
+	ans := 0
+	for start := 1; start <= n; start++ {
+		if visited[start] {
+			continue
+		}
+		queue := []int{start}
+		visited[start] = true
+		good := true
+		for head := 0; head < len(queue); head++ {
+			v := queue[head]
+			if len(adj[v]) != 2 {
+				good = false
+			}
+			for _, to := range adj[v] {
+				if !visited[to] {
+					visited[to] = true
+					queue = append(queue, to)
+				}
+			}
+		}
+		if good {
+			ans++
+		}
+	}
+
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement BFS-based cycle counting for 977E

## Testing
- `go build 0-999/900-999/970-979/977/977E.go`
- `echo "3 3
1 2
2 3
3 1" | go run 0-999/900-999/970-979/977/977E.go`
- `echo "4 3
1 2
2 3
3 1" | go run 0-999/900-999/970-979/977/977E.go`
- `echo "4 4
1 2
2 3
3 4
4 1" | go run 0-999/900-999/970-979/977/977E.go`
- `echo "3 2
1 2
2 3" | go run 0-999/900-999/970-979/977/977E.go`


------
https://chatgpt.com/codex/tasks/task_e_687f5a19d7fc83249e11acceebcd92ac