### PR TITLE
Add Go solution for problem 975A

### DIFF
--- a/0-999/900-999/970-979/975/975A.go
+++ b/0-999/900-999/970-979/975/975A.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	fmt.Fscan(in, &n)
+	roots := make(map[string]bool)
+	for i := 0; i < n; i++ {
+		var s string
+		fmt.Fscan(in, &s)
+		seen := make([]bool, 26)
+		for _, ch := range s {
+			seen[ch-'a'] = true
+		}
+		var root []byte
+		for j := 0; j < 26; j++ {
+			if seen[j] {
+				root = append(root, byte('a'+j))
+			}
+		}
+		roots[string(root)] = true
+	}
+	fmt.Fprintln(out, len(roots))
+}


### PR DESCRIPTION
## Summary
- implement solution for problem A of contest 975
- count unique roots of given words

## Testing
- `go build 0-999/900-999/970-979/975/975A.go`
- `echo -e '4\nabc bca def aa\n' | go run 0-999/900-999/970-979/975/975A.go`

------
https://chatgpt.com/codex/tasks/task_e_687f5e7b99c08324baa5069c4dde2ebc