### PR TITLE
Add Go solution for problem 976B

### DIFF
--- a/0-999/900-999/970-979/976/976B.go
+++ b/0-999/900-999/970-979/976/976B.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, m, k int64
+	if _, err := fmt.Fscan(in, &n, &m, &k); err != nil {
+		return
+	}
+
+	if k < n {
+		fmt.Fprintf(out, "%d %d\n", k+1, 1)
+		return
+	}
+	k -= n - 1
+	if k < m {
+		fmt.Fprintf(out, "%d %d\n", n, k+1)
+		return
+	}
+	k -= m
+	m1 := m - 1
+	rowOffset := k / m1
+	rem := k % m1
+	row := n - 1 - rowOffset
+	var col int64
+	if rowOffset%2 == 0 {
+		col = m - rem
+	} else {
+		col = 2 + rem
+	}
+	fmt.Fprintf(out, "%d %d\n", row, col)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `976B` under `0-999/900-999/970-979/976/`

## Testing
- `go build 0-999/900-999/970-979/976/976B.go`
- `go vet 0-999/900-999/970-979/976/976B.go`
- `for k in 0 1 2 3 4 5 6 7 8 9 10 11; do echo "4 3 $k" | go run 0-999/900-999/970-979/976/976B.go; done`
- `echo "2 2 3" | go run 0-999/900-999/970-979/976/976B.go`

------
https://chatgpt.com/codex/tasks/task_e_687f5d1d4a2c8324ab569849f33b689d