### PR TITLE
Add Go solution for 954B

### DIFF
--- a/0-999/900-999/950-959/954/954B.go
+++ b/0-999/900-999/950-959/954/954B.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	var s string
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	if _, err := fmt.Fscan(in, &s); err != nil {
+		return
+	}
+	ans := n
+	for l := 1; l*2 <= n; l++ {
+		if s[:l] == s[l:2*l] {
+			ops := n - l + 1
+			if ops < ans {
+				ans = ops
+			}
+		}
+	}
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 954B

## Testing
- `go build 0-999/900-999/950-959/954/954B.go`
- `echo -e "7\nabcabca" | go run 0-999/900-999/950-959/954/954B.go`
- `echo -e "9\naaaaaaaaa" | go run 0-999/900-999/950-959/954/954B.go`
- `echo -e "1\na" | go run 0-999/900-999/950-959/954/954B.go`

------
https://chatgpt.com/codex/tasks/task_e_687f6020313c83249f32096691601489