### PR TITLE
Add Go solution for 954A

### DIFF
--- a/0-999/900-999/950-959/954/954A.go
+++ b/0-999/900-999/950-959/954/954A.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+func main() {
+    reader := bufio.NewReader(os.Stdin)
+    var n int
+    if _, err := fmt.Fscan(reader, &n); err != nil {
+        return
+    }
+    var s string
+    fmt.Fscan(reader, &s)
+    res := 0
+    for i := 0; i < n; {
+        res++
+        if i+1 < n && s[i] != s[i+1] {
+            i += 2
+        } else {
+            i++
+        }
+    }
+    fmt.Print(res)
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem 954A Diagonal Walking

## Testing
- `go vet 0-999/900-999/950-959/954/954A.go`
- `go build 0-999/900-999/950-959/954/954A.go`


------
https://chatgpt.com/codex/tasks/task_e_687f60664e5c8324b2e29aebd5011c1d