### PR TITLE
Add Go solution for 952F

### DIFF
--- a/0-999/900-999/950-959/952/952F.go
+++ b/0-999/900-999/950-959/952/952F.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var expr string
+	fmt.Fscan(in, &expr)
+	expr += "+" // sentinel to flush last number
+
+	var result, cur int64
+	sign := int64(1)
+	for i := 0; i < len(expr); i++ {
+		c := expr[i]
+		if c == '+' || c == '-' {
+			result += sign * cur
+			cur = 0
+		}
+		if c == '-' {
+			sign = -1
+		}
+		if c == '+' {
+			sign = 1
+		}
+		cur = cur*10 + int64(int(c)-int('0'))
+	}
+	fmt.Print(result)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 952F (2 + 2 != 4)

## Testing
- `gofmt -w 0-999/900-999/950-959/952/952F.go`

------
https://chatgpt.com/codex/tasks/task_e_687f60f2852883248ba9fbf677a133df