### PR TITLE
Add Go solution for CF 959E

### DIFF
--- a/0-999/900-999/950-959/959/959E.go
+++ b/0-999/900-999/950-959/959/959E.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int64
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+
+	m := n - 1
+	var res int64
+	for bit := int64(1); bit <= m; bit <<= 1 {
+		res += bit * (m/bit - m/(bit<<1))
+	}
+	fmt.Fprintln(out, res)
+}


### PR DESCRIPTION
## Summary
- add `959E.go` implementing solution for XOR MST

## Testing
- `go build 0-999/900-999/950-959/959/959E.go`
- `echo 8 | go run 0-999/900-999/950-959/959/959E.go`
- `echo 5 | go run 0-999/900-999/950-959/959/959E.go`
- `echo 1000000000000 | go run 0-999/900-999/950-959/959/959E.go | head`

------
https://chatgpt.com/codex/tasks/task_e_687f643c13f08324ba7b2c2dc61c94f8