### PR TITLE
Add Go solution for 959B

### DIFF
--- a/0-999/900-999/950-959/959/959B.go
+++ b/0-999/900-999/950-959/959/959B.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, k, m int
+	if _, err := fmt.Fscan(reader, &n, &k, &m); err != nil {
+		return
+	}
+
+	words := make([]string, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &words[i])
+	}
+
+	costs := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &costs[i])
+	}
+
+	wordIndex := make(map[string]int, n)
+	for i, w := range words {
+		wordIndex[w] = i
+	}
+
+	group := make([]int, n)
+	minCost := make([]int64, k)
+	for g := 0; g < k; g++ {
+		var x int
+		fmt.Fscan(reader, &x)
+		minVal := int64(1<<63 - 1)
+		for j := 0; j < x; j++ {
+			var idx int
+			fmt.Fscan(reader, &idx)
+			idx--
+			group[idx] = g
+			if costs[idx] < minVal {
+				minVal = costs[idx]
+			}
+		}
+		minCost[g] = minVal
+	}
+
+	var total int64
+	for i := 0; i < m; i++ {
+		var w string
+		fmt.Fscan(reader, &w)
+		idx := wordIndex[w]
+		g := group[idx]
+		total += minCost[g]
+	}
+
+	fmt.Fprintln(writer, total)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problemB in contest 959

## Testing
- `go build 0-999/900-999/950-959/959/959B.go`
- `go vet 0-999/900-999/950-959/959/959B.go`


------
https://chatgpt.com/codex/tasks/task_e_687f650e1df483249b711166288fc3c5