### PR TITLE
Add Go solution for contest 958 problem C1

### DIFF
--- a/0-999/900-999/950-959/958/958C1.go
+++ b/0-999/900-999/950-959/958/958C1.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, p int
+	if _, err := fmt.Fscan(reader, &n, &p); err != nil {
+		return
+	}
+	arr := make([]int64, n)
+	var total int64
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+		total += arr[i]
+	}
+	var prefix int64
+	var best int64
+	for i := 0; i < n-1; i++ {
+		prefix += arr[i]
+		s1 := prefix % int64(p)
+		s2 := (total - prefix) % int64(p)
+		if cur := s1 + s2; cur > best {
+			best = cur
+		}
+	}
+	fmt.Fprintln(writer, best)
+}


### PR DESCRIPTION
## Summary
- implement Go solver for 958C1 – maximum score of two contiguous parts

## Testing
- `go build 0-999/900-999/950-959/958/958C1.go`
- `cat <<EOF | ./958C1
4 10
3 4 7 2
EOF`
- `cat <<EOF | ./958C1
9 12
16 3 24 13 9 8 7 5 12
EOF`


------
https://chatgpt.com/codex/tasks/task_e_687f67cb37e08324878fe14828403dbd