### PR TITLE
Add Go solution for 922B

### DIFF
--- a/0-999/900-999/920-929/922/922B.go
+++ b/0-999/900-999/920-929/922/922B.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+
+	var count int64
+	for a := 1; a <= n; a++ {
+		for b := a; b <= n; b++ {
+			c := a ^ b
+			if c < b || c > n {
+				continue
+			}
+			if a+b <= c {
+				continue
+			}
+			count++
+		}
+	}
+
+	fmt.Fprintln(out, count)
+}


### PR DESCRIPTION
## Summary
- implement solver for 922B (xorangle) in Go

## Testing
- `go run 0-999/900-999/920-929/922/922B.go << EOF
6
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687f6d8b8cd08324a402d329e3607465