### PR TITLE
Add Go solution for 929A

### DIFF
--- a/0-999/900-999/920-929/929/929A.go
+++ b/0-999/900-999/920-929/929/929A.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+func main() {
+    reader := bufio.NewReader(os.Stdin)
+    writer := bufio.NewWriter(os.Stdout)
+    defer writer.Flush()
+
+    var n, k int
+    if _, err := fmt.Fscan(reader, &n, &k); err != nil {
+        return
+    }
+    x := make([]int, n)
+    for i := 0; i < n; i++ {
+        fmt.Fscan(reader, &x[i])
+    }
+
+    cnt := 0
+    i := 0
+    for i < n-1 {
+        j := i
+        for j+1 < n && x[j+1]-x[i] <= k {
+            j++
+        }
+        if j == i {
+            fmt.Fprintln(writer, -1)
+            return
+        }
+        cnt++
+        i = j
+    }
+    fmt.Fprintln(writer, cnt)
+}


### PR DESCRIPTION
## Summary
- implement `929A.go` for bike rentals problem

## Testing
- `go build -o /tmp/929A.bin 0-999/900-999/920-929/929/929A.go`
- manual run of binary with sample inputs

------
https://chatgpt.com/codex/tasks/task_e_687f7002794083248b19bf7d7c7dcddb