### PR TITLE
Add Go solution for problem 920C

### DIFF
--- a/0-999/900-999/920-929/920/920C.go
+++ b/0-999/900-999/920-929/920/920C.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	var s string
+	fmt.Fscan(reader, &s)
+
+	i := 0
+	for i < n-1 {
+		if s[i] == '1' {
+			start := i
+			for i < n-1 && s[i] == '1' {
+				i++
+			}
+			end := i
+			sort.Ints(a[start : end+1])
+		} else {
+			i++
+		}
+	}
+
+	for i := 0; i < n; i++ {
+		if a[i] != i+1 {
+			fmt.Fprintln(writer, "NO")
+			return
+		}
+	}
+	fmt.Fprintln(writer, "YES")
+}


### PR DESCRIPTION
## Summary
- implement solution for sorting a permutation with allowed adjacent swaps
- place new file `920C.go` alongside other problem solutions

## Testing
- `go build 0-999/900-999/920-929/920/920C.go`

------
https://chatgpt.com/codex/tasks/task_e_687f711b00108324bd5cfd556ef0e90f