### PR TITLE
Add Go solution for problem 926G

### DIFF
--- a/0-999/900-999/920-929/926/926G.go
+++ b/0-999/900-999/920-929/926/926G.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	odd, even := 0, 0
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(reader, &x)
+		if x%2 == 0 {
+			even++
+		} else {
+			odd++
+		}
+	}
+
+	var result int
+	if even >= odd {
+		result = odd
+	} else {
+		result = even + (odd-even)/3
+	}
+	fmt.Fprintln(writer, result)
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for `problemG.txt` of directory 926
- count odd/even bouquets and compute max number of valid groups

## Testing
- `go build 0-999/900-999/920-929/926/926G.go`

------
https://chatgpt.com/codex/tasks/task_e_687f73d810ec8324ae49112f6a6c52ea