### PR TITLE
Add Go solution for 926C

### DIFF
--- a/0-999/900-999/920-929/926/926C.go
+++ b/0-999/900-999/920-929/926/926C.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	runs := []int{}
+	var prev, val int
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &val)
+		if i == 0 {
+			prev = val
+			runs = append(runs, 1)
+		} else {
+			if val == prev {
+				runs[len(runs)-1]++
+			} else {
+				prev = val
+				runs = append(runs, 1)
+			}
+		}
+	}
+
+	ok := true
+	for i := 1; i < len(runs); i++ {
+		if runs[i] != runs[0] {
+			ok = false
+			break
+		}
+	}
+
+	if ok {
+		fmt.Fprintln(writer, "YES")
+	} else {
+		fmt.Fprintln(writer, "NO")
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 926C

## Testing
- `go run 0-999/900-999/920-929/926/926C.go <<EOF
3
0 0 0
EOF`
- `echo -e "7\n0 0 0 1 1 1 1" | go run 0-999/900-999/920-929/926/926C.go`
- `echo -e "4\n0 1 0 1" | go run 0-999/900-999/920-929/926/926C.go`


------
https://chatgpt.com/codex/tasks/task_e_687f741e2acc8324b52dd277b23b389a