### PR TITLE
Add Go solution for problem 926A

### DIFF
--- a/0-999/900-999/920-929/926/926A.go
+++ b/0-999/900-999/920-929/926/926A.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var l, r int64
+	if _, err := fmt.Fscan(reader, &l, &r); err != nil {
+		return
+	}
+
+	count := 0
+	for p2 := int64(1); p2 <= r; p2 *= 2 {
+		for p3 := int64(1); p2*p3 <= r; p3 *= 3 {
+			val := p2 * p3
+			if val >= l {
+				count++
+			}
+		}
+	}
+
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	fmt.Fprintln(writer, count)
+}


### PR DESCRIPTION
## Summary
- implement solution for counting 2-3 integers within a range

## Testing
- `gofmt -w 0-999/900-999/920-929/926/926A.go`
- `go build 0-999/900-999/920-929/926/926A.go`


------
https://chatgpt.com/codex/tasks/task_e_687f74aa5ba883249197ced749a414f8