### PR TITLE
Add Go solution for problem 983A

### DIFF
--- a/0-999/900-999/980-989/983/983A.go
+++ b/0-999/900-999/980-989/983/983A.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	for ; n > 0; n-- {
+		var p, q, b int64
+		fmt.Fscan(reader, &p, &q, &b)
+
+		if p == 0 {
+			fmt.Fprintln(writer, "Finite")
+			continue
+		}
+		g := gcd(p, q)
+		q /= g
+		g = gcd(q, b)
+		for g > 1 {
+			for q%g == 0 {
+				q /= g
+			}
+			g = gcd(q, b)
+		}
+		if q == 1 {
+			fmt.Fprintln(writer, "Finite")
+		} else {
+			fmt.Fprintln(writer, "Infinite")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution `983A.go`
- uses gcd reduction to determine finiteness in base `b`

## Testing
- `go run 983A.go` with sample values

------
https://chatgpt.com/codex/tasks/task_e_687f77adb78083248eac0bd78665684c