### PR TITLE
Add Go solution for 985D

### DIFF
--- a/0-999/900-999/980-989/985/985D.go
+++ b/0-999/900-999/980-989/985/985D.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func maxSum(len, H int64) int64 {
+	if len <= H {
+		return len * (len + 1) / 2
+	}
+	k := (len - H + 2) / 2
+	return k*H + k*(k-1)/2 + (len-k)*(len-k+1)/2
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var n, H int64
+	fmt.Fscan(in, &n, &H)
+	lo, hi := int64(1), int64(2000000000)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if maxSum(mid, H) >= n {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	fmt.Fprintln(out, lo)
+}


### PR DESCRIPTION
## Summary
- add `985D.go` implementing binary search to find minimal castle length

## Testing
- `go vet 0-999/900-999/980-989/985/985D.go`

------
https://chatgpt.com/codex/tasks/task_e_687f78c623d083249c2e29f9f7028bfd