### PR TITLE
Add Go solver for 986B

### DIFF
--- a/0-999/900-999/980-989/986/986B.go
+++ b/0-999/900-999/980-989/986/986B.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	p := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(in, &p[i])
+	}
+	visited := make([]bool, n+1)
+	cycles := 0
+	for i := 1; i <= n; i++ {
+		if !visited[i] {
+			cycles++
+			for j := i; !visited[j]; j = p[j] {
+				visited[j] = true
+			}
+		}
+	}
+	parity := (n - cycles) % 2
+	petrParity := n % 2
+	if parity == petrParity {
+		fmt.Println("Petr")
+	} else {
+		fmt.Println("Um_nik")
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for contest 986 problem B in Go

## Testing
- `gofmt -w 0-999/900-999/980-989/986/986B.go`
- `go build 0-999/900-999/980-989/986/986B.go`


------
https://chatgpt.com/codex/tasks/task_e_68807420eef48324807a5de489aa141a