### PR TITLE
Add Go solution for 981D

### DIFF
--- a/0-999/900-999/980-989/981/981D.go
+++ b/0-999/900-999/980-989/981/981D.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func can(prefix []int64, n, k int, mask int64) bool {
+	dp := make([]bool, n+1)
+	dp[0] = true
+	for step := 0; step < k; step++ {
+		next := make([]bool, n+1)
+		for i := 0; i <= n; i++ {
+			if !dp[i] {
+				continue
+			}
+			for j := i + 1; j <= n; j++ {
+				if ((prefix[j] - prefix[i]) & mask) == mask {
+					next[j] = true
+				}
+			}
+		}
+		dp = next
+	}
+	return dp[n]
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, k int
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	prefix := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i] + a[i]
+	}
+	var ans int64
+	for bit := 60; bit >= 0; bit-- {
+		candidate := ans | (1 << uint(bit))
+		if can(prefix, n, k, candidate) {
+			ans = candidate
+		}
+	}
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement problem 981D solution (Bookshelves) in Go

## Testing
- `go build 0-999/900-999/980-989/981/981D.go`
- `go vet 0-999/900-999/980-989/981/981D.go`


------
https://chatgpt.com/codex/tasks/task_e_6880717f6a1083249479745df460542e