### PR TITLE
Add Go solution for 989A

### DIFF
--- a/0-999/900-999/980-989/989/989A.go
+++ b/0-999/900-999/980-989/989/989A.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var s string
+	if _, err := fmt.Fscan(in, &s); err != nil {
+		return
+	}
+	n := len(s)
+	for i := 0; i+2 < n; i++ {
+		hasA, hasB, hasC := false, false, false
+		for j := 0; j < 3; j++ {
+			switch s[i+j] {
+			case 'A':
+				hasA = true
+			case 'B':
+				hasB = true
+			case 'C':
+				hasC = true
+			}
+		}
+		if hasA && hasB && hasC {
+			fmt.Println("Yes")
+			return
+		}
+	}
+	fmt.Println("No")
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 989 problem A

## Testing
- `go build 0-999/900-999/980-989/989/989A.go`
- `./989A <<EOF
ABC
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68807020d4f483249b90576f1f0e19a5