### PR TITLE
Add Go solution for Codeforces 946B

### DIFF
--- a/0-999/900-999/940-949/946/946B.go
+++ b/0-999/900-999/940-949/946/946B.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var a, b int64
+	if _, err := fmt.Fscan(reader, &a, &b); err != nil {
+		return
+	}
+	for {
+		if a == 0 || b == 0 {
+			break
+		}
+		if a >= 2*b {
+			a %= 2 * b
+			continue
+		}
+		if b >= 2*a {
+			b %= 2 * a
+			continue
+		}
+		break
+	}
+	fmt.Fprintf(writer, "%d %d\n", a, b)
+}


### PR DESCRIPTION
## Summary
- add Go solution implementing the weird subtraction process for problem 946B

## Testing
- `go run 0-999/900-999/940-949/946/946B.go` with sample numbers

------
https://chatgpt.com/codex/tasks/task_e_6880a564983083249d44cb9be2a4d5d2