### PR TITLE
Add Go solution for problem 946C

### DIFF
--- a/0-999/900-999/940-949/946/946C.go
+++ b/0-999/900-999/940-949/946/946C.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var s string
+	if _, err := fmt.Fscan(reader, &s); err != nil {
+		return
+	}
+
+	target := byte('a')
+	b := []byte(s)
+	for i := 0; i < len(b) && target <= 'z'; i++ {
+		if b[i] <= target {
+			b[i] = target
+			target++
+		}
+	}
+
+	if target <= 'z' {
+		fmt.Fprintln(writer, "-1")
+	} else {
+		fmt.Fprintln(writer, string(b))
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for `946C` in Go

## Testing
- `go run 0-999/900-999/940-949/946/946C.go < input`
- `go vet 0-999/900-999/940-949/946/946C.go`


------
https://chatgpt.com/codex/tasks/task_e_6880a51e82e08324a6dc0bfa7d3e942b