### PR TITLE
Add Go solution for Codeforces 932A

### DIFF
--- a/0-999/900-999/930-939/932/932A.go
+++ b/0-999/900-999/930-939/932/932A.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var s string
+	fmt.Fscan(reader, &s)
+	n := len(s)
+	b := make([]byte, n*2)
+	for i := 0; i < n; i++ {
+		b[i] = s[i]
+		b[2*n-1-i] = s[i]
+	}
+	fmt.Println(string(b))
+}


### PR DESCRIPTION
## Summary
- implement solution `932A.go`
- output `A` followed by reversed `A` to guarantee a palindrome

## Testing
- `go build 0-999/900-999/930-939/932/932A.go`


------
https://chatgpt.com/codex/tasks/task_e_6880a102b97c8324bfb1d65121e3e7de