### PR TITLE
Add Go solution for 949B

### DIFF
--- a/0-999/900-999/940-949/949/949B.go
+++ b/0-999/900-999/940-949/949/949B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func solve(n, x int64) int64 {
+	if x%2 == 1 {
+		return (x + 1) / 2
+	}
+	if n%2 == 0 {
+		return n/2 + solve(n/2, x/2)
+	}
+	m := n / 2
+	i := x / 2
+	if i == 1 {
+		return m + 1 + solve(m, m)
+	}
+	return m + 1 + solve(m, i-1)
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, q int64
+	if _, err := fmt.Fscan(reader, &n, &q); err != nil {
+		return
+	}
+	for ; q > 0; q-- {
+		var x int64
+		fmt.Fscan(reader, &x)
+		fmt.Fprintln(writer, solve(n, x))
+	}
+}


### PR DESCRIPTION
## Summary
- implement problem B solution for contest 949 in Go

## Testing
- `go build 0-999/900-999/940-949/949/949B.go`


------
https://chatgpt.com/codex/tasks/task_e_6880a7959b4c832494e0a1a9be411306