### PR TITLE
Add Go solution for 949D

### DIFF
--- a/0-999/900-999/940-949/949/949D.go
+++ b/0-999/900-999/940-949/949/949D.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func compute(arr []int, rooms, d, b int) int {
+	n := len(arr)
+	p := 0
+	var avail int64
+	miss := 0
+	for i := 1; i <= rooms; i++ {
+		limit := i * (d + 1)
+		if limit > n {
+			limit = n
+		}
+		for p < limit {
+			avail += int64(arr[p])
+			p++
+		}
+		if avail >= int64(b) {
+			avail -= int64(b)
+		} else {
+			miss++
+		}
+	}
+	return miss
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n, d, b int
+	if _, err := fmt.Fscan(reader, &n, &d, &b); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+
+	leftRooms := (n + 1) / 2
+	rightRooms := n / 2
+
+	left := compute(a, leftRooms, d, b)
+
+	// reverse array for right side
+	rev := make([]int, n)
+	for i := 0; i < n; i++ {
+		rev[i] = a[n-1-i]
+	}
+	right := compute(rev, rightRooms, d, b)
+
+	if left > right {
+		fmt.Println(left)
+	} else {
+		fmt.Println(right)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 949D `Curfew`

## Testing
- `go build 0-999/900-999/940-949/949/949D.go`

------
https://chatgpt.com/codex/tasks/task_e_6880a74f6bf0832480b6aa9618ee8a44