### PR TITLE
Add Go solution for 938B

### DIFF
--- a/0-999/900-999/930-939/938/938B.go
+++ b/0-999/900-999/930-939/938/938B.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	fmt.Fscan(reader, &n)
+	maxTime := 0
+	const limit = 1000000
+	for i := 0; i < n; i++ {
+		var pos int
+		fmt.Fscan(reader, &pos)
+		left := pos - 1
+		right := limit - pos
+		if right < left {
+			left = right
+		}
+		if left > maxTime {
+			maxTime = left
+		}
+	}
+	fmt.Fprintln(writer, maxTime)
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem `938B` under contest `938`

## Testing
- `go vet 0-999/900-999/930-939/938/938B.go`
- `go build 0-999/900-999/930-939/938/938B.go`

------
https://chatgpt.com/codex/tasks/task_e_68809c5a8c4083248716415af3fc1193