### PR TITLE
Add Go solution for 919C Seat Arrangements

### DIFF
--- a/0-999/900-999/910-919/919/919C.go
+++ b/0-999/900-999/910-919/919/919C.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, m, k int
+	if _, err := fmt.Fscan(reader, &n, &m, &k); err != nil {
+		return
+	}
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &grid[i])
+	}
+
+	if k == 1 {
+		count := 0
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				if grid[i][j] == '.' {
+					count++
+				}
+			}
+		}
+		fmt.Fprintln(writer, count)
+		return
+	}
+
+	ans := 0
+	// horizontal
+	for i := 0; i < n; i++ {
+		length := 0
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '.' {
+				length++
+			} else {
+				if length >= k {
+					ans += length - k + 1
+				}
+				length = 0
+			}
+		}
+		if length >= k {
+			ans += length - k + 1
+		}
+	}
+
+	// vertical
+	for j := 0; j < m; j++ {
+		length := 0
+		for i := 0; i < n; i++ {
+			if grid[i][j] == '.' {
+				length++
+			} else {
+				if length >= k {
+					ans += length - k + 1
+				}
+				length = 0
+			}
+		}
+		if length >= k {
+			ans += length - k + 1
+		}
+	}
+
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement solution for `problemC.txt` (Codeforces 919C)

## Testing
- `go build 0-999/900-999/910-919/919/919C.go`
- `go run 0-999/900-999/910-919/919/919C.go <<EOF
3 4 2
...*
..*.
*...
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688097b2f68083248c8f4580c34221e7