### PR TITLE
Add Go solution for Codeforces 916A

### DIFF
--- a/0-999/900-999/910-919/916/916A.go
+++ b/0-999/900-999/910-919/916/916A.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func contains7(n int) bool {
+	return n%10 == 7 || n/10 == 7
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var x, hh, mm int
+	if _, err := fmt.Fscan(in, &x, &hh, &mm); err != nil {
+		return
+	}
+
+	cnt := 0
+	for {
+		if contains7(hh) || contains7(mm) {
+			fmt.Fprintln(out, cnt)
+			return
+		}
+		mm -= x
+		for mm < 0 {
+			mm += 60
+			hh--
+		}
+		if hh < 0 {
+			hh += 24
+		}
+		cnt++
+	}
+}


### PR DESCRIPTION
## Summary
- add solution `916A.go`

## Testing
- `go build 0-999/900-999/910-919/916/916A.go`

------
https://chatgpt.com/codex/tasks/task_e_6880960e78348324a4190d29e9c3c6e6