### PR TITLE
Add Go solution for problem 962D

### DIFF
--- a/0-999/900-999/960-969/962/962D.go
+++ b/0-999/900-999/960-969/962/962D.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+
+	pos := make(map[int64]int)
+	removed := make([]bool, n)
+
+	for i := 0; i < n; i++ {
+		v := a[i]
+		for {
+			if j, ok := pos[v]; ok {
+				delete(pos, v)
+				removed[j] = true
+				v *= 2
+			} else {
+				break
+			}
+		}
+		a[i] = v
+		pos[v] = i
+	}
+
+	cnt := 0
+	for i := 0; i < n; i++ {
+		if !removed[i] {
+			cnt++
+		}
+	}
+	fmt.Fprintln(out, cnt)
+	first := true
+	for i := 0; i < n; i++ {
+		if !removed[i] {
+			if !first {
+				fmt.Fprint(out, " ")
+			}
+			fmt.Fprint(out, a[i])
+			first = false
+		}
+	}
+	if cnt > 0 {
+		fmt.Fprintln(out)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for Codeforces 962D

## Testing
- `go build 0-999/900-999/960-969/962/962D.go`
- `go run 0-999/900-999/960-969/962/962D.go <<EOF
7
3 4 1 2 2 1 1
EOF`
- `go run 0-999/900-999/960-969/962/962D.go <<EOF
5
1 1 3 1 1
EOF`
- `go run 0-999/900-999/960-969/962/962D.go <<EOF
3
3 1 4
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68808512d3f88324929b78a39ef2e37f