### PR TITLE
Add Go solution for problem 965C

### DIFF
--- a/0-999/900-999/960-969/965/965C.go
+++ b/0-999/900-999/960-969/965/965C.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, k, m, d int64
+	if _, err := fmt.Fscan(reader, &n, &k, &m, &d); err != nil {
+		return
+	}
+	var ans int64
+	for i := int64(1); i <= d; i++ {
+		t := (i-1)*k + 1
+		if t > n {
+			break
+		}
+		x := n / t
+		if x > m {
+			x = m
+		}
+		if x == 0 {
+			continue
+		}
+		val := x * i
+		if val > ans {
+			ans = val
+		}
+	}
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 965C in Go

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain main module)*
- `go test ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_688083fa5c28832498f911019cb8c973