### PR TITLE
Add solution for problem 965D

### DIFF
--- a/0-999/900-999/960-969/965/965D.go
+++ b/0-999/900-999/960-969/965/965D.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var w, l int
+	if _, err := fmt.Fscan(in, &w, &l); err != nil {
+		return
+	}
+
+	stones := make([]int64, w)
+	for i := 1; i <= w-1; i++ {
+		fmt.Fscan(in, &stones[i])
+	}
+
+	prefix := make([]int64, w)
+	for i := 1; i <= w-1; i++ {
+		prefix[i] = prefix[i-1] + stones[i]
+	}
+
+	ans := int64(1<<63 - 1)
+	for start := 1; start <= w-l; start++ {
+		sum := prefix[start+l-1] - prefix[start-1]
+		if sum < ans {
+			ans = sum
+		}
+	}
+
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 965 problem D

## Testing
- `gofmt -w 0-999/900-999/960-969/965/965D.go`
- `go build 0-999/900-999/960-969/965/965D.go`
- `go vet ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_688083b437bc832492910faae624175f