### PR TITLE
Add Go solution for problem 990A

### DIFF
--- a/0-999/900-999/990-999/990/990A.go
+++ b/0-999/900-999/990-999/990/990A.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n, m, a, b int64
+	if _, err := fmt.Fscan(reader, &n, &m, &a, &b); err != nil {
+		return
+	}
+	remainder := n % m
+	if remainder == 0 {
+		fmt.Println(0)
+		return
+	}
+	addCost := (m - remainder) * a
+	removeCost := remainder * b
+	if addCost < removeCost {
+		fmt.Println(addCost)
+	} else {
+		fmt.Println(removeCost)
+	}
+}


### PR DESCRIPTION
## Summary
- Implement Go solution for CF problem 990A

## Testing
- `go build 0-999/900-999/990-999/990/990A.go`
- `go run 0-999/900-999/990-999/990/990A.go` with sample values

------
https://chatgpt.com/codex/tasks/task_e_68807d67f298832499ed18937b63a2e4