### PR TITLE
Add Go solution for 997A

### DIFF
--- a/0-999/900-999/990-999/997/997A.go
+++ b/0-999/900-999/990-999/997/997A.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	var x, y int64
+	fmt.Fscan(in, &n, &x, &y)
+	var s string
+	fmt.Fscan(in, &s)
+
+	zeros := 0
+	i := 0
+	for i < n {
+		if s[i] == '0' {
+			zeros++
+			for i < n && s[i] == '0' {
+				i++
+			}
+		} else {
+			i++
+		}
+	}
+	if zeros == 0 {
+		fmt.Println(0)
+		return
+	}
+	cost1 := int64(zeros) * y
+	cost2 := y + int64(zeros-1)*x
+	if cost1 < cost2 {
+		fmt.Println(cost1)
+	} else {
+		fmt.Println(cost2)
+	}
+}


### PR DESCRIPTION
## Summary
- implement binary string cost computation for problem 997A

## Testing
- `go build 0-999/900-999/990-999/997/997A.go`
- `echo -e "5 1 10\n01000" | go run 0-999/900-999/990-999/997/997A.go`
- `echo -e "5 1 1\n01000" | go run 0-999/900-999/990-999/997/997A.go`
- `echo -e "3 5 7\n111" | go run 0-999/900-999/990-999/997/997A.go`


------
https://chatgpt.com/codex/tasks/task_e_68807c0916d0832490bb5cc974ef6cc3