### PR TITLE
Add naive Go solution for 997E

### DIFF
--- a/0-999/900-999/990-999/997/997E.go
+++ b/0-999/900-999/990-999/997/997E.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	fmt.Fscan(in, &n)
+	p := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &p[i])
+	}
+	var q int
+	fmt.Fscan(in, &q)
+	for ; q > 0; q-- {
+		var l, r int
+		fmt.Fscan(in, &l, &r)
+		l--
+		r--
+		var count int64
+		for i := l; i <= r; i++ {
+			minVal := p[i]
+			maxVal := p[i]
+			for j := i; j <= r; j++ {
+				if p[j] < minVal {
+					minVal = p[j]
+				}
+				if p[j] > maxVal {
+					maxVal = p[j]
+				}
+				if maxVal-minVal == j-i {
+					count++
+				}
+			}
+		}
+		fmt.Fprintln(out, count)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a straightforward enumerative solution for problem E in 997 folder

## Testing
- `gofmt -w 0-999/900-999/990-999/997/997E.go`

------
https://chatgpt.com/codex/tasks/task_e_68807af097e08324a5ed3fcfc0a3a9d8