### PR TITLE
Add Go solution for problem 580A

### DIFF
--- a/0-999/500-599/580-589/580/580A.go
+++ b/0-999/500-599/580-589/580/580A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// This program solves the problem described in problemA.txt.
+// It reads a sequence of integers and outputs the length of the
+// longest contiguous non-decreasing subsequence.
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	maxLen := 0
+	currLen := 0
+	var prev int
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(in, &x)
+		if i == 0 || x >= prev {
+			currLen++
+		} else {
+			currLen = 1
+		}
+		if currLen > maxLen {
+			maxLen = currLen
+		}
+		prev = x
+	}
+	fmt.Println(maxLen)
+}


### PR DESCRIPTION
## Summary
- implement `580A.go` for contest 580 problem A

## Testing
- `go build 0-999/500-599/580-589/580/580A.go`

------
https://chatgpt.com/codex/tasks/task_e_6880abcb8d9483249873edd918a1bae1