### PR TITLE
Add Go solution for 588A

### DIFF
--- a/0-999/500-599/580-589/588/588A.go
+++ b/0-999/500-599/580-589/588/588A.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	var minPrice int64 = 1 << 60
+	var total int64
+	for i := 0; i < n; i++ {
+		var a, p int64
+		fmt.Fscan(in, &a, &p)
+		if p < minPrice {
+			minPrice = p
+		}
+		total += a * minPrice
+	}
+	fmt.Println(total)
+}


### PR DESCRIPTION
## Summary
- implement Duff and Meat in Go

## Testing
- `go build 0-999/500-599/580-589/588/588A.go`


------
https://chatgpt.com/codex/tasks/task_e_6880aa6cf4a483249c29a3806997e333