### PR TITLE
Add Go solution for problem 586A

### DIFF
--- a/0-999/500-599/580-589/586/586A.go
+++ b/0-999/500-599/580-589/586/586A.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	ans := 0
+	for i := 0; i < n; i++ {
+		if a[i] == 1 {
+			ans++
+		} else if i > 0 && i < n-1 && a[i-1] == 1 && a[i+1] == 1 {
+			ans++
+		}
+	}
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 586 problem A

## Testing
- `go build 0-999/500-599/580-589/586/586A.go`
- `go vet 0-999/500-599/580-589/586/586A.go`


------
https://chatgpt.com/codex/tasks/task_e_6880a87e28048324b5bc0812d530a37e