### PR TITLE
Add Go solution for problem 939B

### DIFF
--- a/0-999/900-999/930-939/939/939B.go
+++ b/0-999/900-999/930-939/939/939B.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int64
+	var k int
+	fmt.Fscan(reader, &n, &k)
+
+	var bestIdx int
+	var bestCount int64
+	var maxTransport int64
+
+	for i := 1; i <= k; i++ {
+		var a int64
+		fmt.Fscan(reader, &a)
+		cnt := n / a
+		transported := cnt * a
+		if transported > maxTransport {
+			maxTransport = transported
+			bestIdx = i
+			bestCount = cnt
+		}
+	}
+
+	fmt.Fprintf(writer, "%d %d\n", bestIdx, bestCount)
+}


### PR DESCRIPTION
## Summary
- implement solution for problem B in contest 939

## Testing
- `gofmt -w 0-999/900-999/930-939/939/939B.go`
- `go build 0-999/900-999/930-939/939/939B.go`


------
https://chatgpt.com/codex/tasks/task_e_68809d730c0c8324ad2200608f67b7c5