### PR TITLE
Add Go solution for 587A

### DIFF
--- a/0-999/500-599/580-589/587/587A.go
+++ b/0-999/500-599/580-589/587/587A.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	// Maximum exponent from input determines array size.
+	maxW := 0
+	weights := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &weights[i])
+		if weights[i] > maxW {
+			maxW = weights[i]
+		}
+	}
+
+	// Extra space for carries: log2(n) < 20, so add 70 to be safe.
+	cnt := make([]int, maxW+70)
+	for _, w := range weights {
+		cnt[w]++
+	}
+
+	for i := 0; i < len(cnt)-1; i++ {
+		pairs := cnt[i] / 2
+		if pairs > 0 {
+			cnt[i+1] += pairs
+			cnt[i] %= 2
+		}
+	}
+
+	steps := 0
+	for _, c := range cnt {
+		steps += c
+	}
+	fmt.Fprintln(writer, steps)
+}


### PR DESCRIPTION
## Summary
- implement solution for `Duff and Weight Lifting` in Go

## Testing
- `go build 0-999/500-599/580-589/587/587A.go`
- `./587A < /tmp/input.txt`

------
https://chatgpt.com/codex/tasks/task_e_6880ad70432083249318053ad80be4f4