### PR TITLE
Add Go solution for Codeforces 559B

### DIFF
--- a/0-999/500-599/550-559/559/559B.go
+++ b/0-999/500-599/550-559/559/559B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func canonical(s string) string {
+	if len(s)%2 == 1 {
+		return s
+	}
+	mid := len(s) / 2
+	left := canonical(s[:mid])
+	right := canonical(s[mid:])
+	if left < right {
+		return left + right
+	}
+	if left > right {
+		return right + left
+	}
+	// left == right
+	return left + right
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var a, b string
+	if _, err := fmt.Fscan(reader, &a); err != nil {
+		return
+	}
+	fmt.Fscan(reader, &b)
+	if canonical(a) == canonical(b) {
+		fmt.Println("YES")
+	} else {
+		fmt.Println("NO")
+	}
+}


### PR DESCRIPTION
## Summary
- implement canonicalization approach for problem 559B Equivalent Strings

## Testing
- `go run 0-999/500-599/550-559/559/559B.go <<EOF
abaabb
aababb
EOF`
- `go run 0-999/500-599/550-559/559/559B.go <<EOF
aabb
abab
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6880b377fae083248bb9497bae1e2e2a