### PR TITLE
Add Go solution for 558C

### DIFF
--- a/0-999/500-599/550-559/558/558C.go
+++ b/0-999/500-599/550-559/558/558C.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const maxVal = 200000
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	dist := make([]int, maxVal+1)
+	cnt := make([]int, maxVal+1)
+
+	for i := 0; i < n; i++ {
+		var v int
+		fmt.Fscan(reader, &v)
+		visited := make(map[int]bool)
+
+		val := v
+		j := 0
+		for val > 0 {
+			x := val
+			k := 0
+			for x <= maxVal {
+				if !visited[x] {
+					dist[x] += j + k
+					cnt[x]++
+					visited[x] = true
+				}
+				x <<= 1
+				k++
+			}
+			val >>= 1
+			j++
+		}
+		// handle zero
+		if !visited[0] {
+			dist[0] += j
+			cnt[0]++
+		}
+	}
+
+	ans := int(^uint(0) >> 1)
+	for x := 0; x <= maxVal; x++ {
+		if cnt[x] == n && dist[x] < ans {
+			ans = dist[x]
+		}
+	}
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- add implementation of `Amr and Chemistry` in Go

## Testing
- `go run 0-999/500-599/550-559/558/558C.go <<EOF
3
4 8 2
EOF`
- `go run 0-999/500-599/550-559/558/558C.go <<EOF
4
1 1 1 1
EOF`
- `go run 0-999/500-599/550-559/558/558C.go <<EOF
2
1 100000
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6880b25f5a048324999954daa8afbc3f