### PR TITLE
Add Go solution for 556A

### DIFF
--- a/0-999/500-599/550-559/556/556A.go
+++ b/0-999/500-599/550-559/556/556A.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	var s string
+	fmt.Fscan(reader, &s)
+
+	zeros := 0
+	ones := 0
+	for _, c := range s {
+		if c == '0' {
+			zeros++
+		} else if c == '1' {
+			ones++
+		}
+	}
+	diff := zeros - ones
+	if diff < 0 {
+		diff = -diff
+	}
+	fmt.Println(diff)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 556A

## Testing
- `go run 0-999/500-599/550-559/556/556A.go <<EOF`
  `4`
  `1100`
  `EOF`

------
https://chatgpt.com/codex/tasks/task_e_6880b18cfdb883248e71849d39516156