### PR TITLE
Add solution for 583A

### DIFF
--- a/0-999/500-599/580-589/583/583A.go
+++ b/0-999/500-599/580-589/583/583A.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	horiz := make([]bool, n+1)
+	vert := make([]bool, n+1)
+
+	res := make([]int, 0, n*n)
+	for day := 1; day <= n*n; day++ {
+		var h, v int
+		fmt.Fscan(reader, &h, &v)
+		if !horiz[h] && !vert[v] {
+			horiz[h] = true
+			vert[v] = true
+			res = append(res, day)
+		}
+	}
+
+	for i, d := range res {
+		if i > 0 {
+			writer.WriteByte(' ')
+		}
+		fmt.Fprint(writer, d)
+	}
+	if len(res) > 0 {
+		writer.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- solve problemA from contest 583 with Go

## Testing
- `go vet 0-999/500-599/580-589/583/583A.go`
- `go run 0-999/500-599/580-589/583/583A.go <<EOF
2
1 1
1 2
2 1
2 2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6880b0b9ebc08324a801f5d1012ef550