### PR TITLE
Add Go solution for CF 583B

### DIFF
--- a/0-999/500-599/580-589/583/583B.go
+++ b/0-999/500-599/580-589/583/583B.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+
+	visited := make([]bool, n)
+	pieces := 0
+	count := 0
+	pos := 0
+	dir := 1
+	changes := 0
+
+	for count < n {
+		if !visited[pos] && pieces >= a[pos] {
+			visited[pos] = true
+			pieces++
+			count++
+			if count == n {
+				break
+			}
+		}
+		next := pos + dir
+		if next < 0 || next >= n {
+			dir = -dir
+			changes++
+			next = pos + dir
+		}
+		pos = next
+	}
+
+	fmt.Fprintln(out, changes)
+}


### PR DESCRIPTION
## Summary
- implement a simulator for problem 583B
- add `583B.go`

## Testing
- `go run 0-999/500-599/580-589/583/583B.go <<EOF
4
0 1 2 3
EOF`
- `go run 0-999/500-599/580-589/583/583B.go <<EOF
3
2 0 0
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6880b073c308832491f50fb6718b298c