### PR TITLE
Add solution for problem 585C

### DIFF
--- a/0-999/500-599/580-589/585/585C.go
+++ b/0-999/500-599/580-589/585/585C.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var x, y int64
+	if _, err := fmt.Fscan(in, &x, &y); err != nil {
+		return
+	}
+	if gcd(x, y) != 1 {
+		fmt.Fprintln(out, "Impossible")
+		return
+	}
+	type step struct {
+		k int64
+		c byte
+	}
+	var res []step
+	for x > 1 || y > 1 {
+		if x > y {
+			k := (x - 1) / y
+			res = append(res, step{k, 'A'})
+			x -= k * y
+		} else {
+			k := (y - 1) / x
+			res = append(res, step{k, 'B'})
+			y -= k * x
+		}
+	}
+	for _, st := range res {
+		fmt.Fprintf(out, "%d%c", st.k, st.c)
+	}
+	fmt.Fprintln(out)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problemC in contest 585
- use Euclidean-like approach to output compressed sequence of `A` and `B`

## Testing
- `go run 0-999/500-599/580-589/585/585C.go <<EOF
3 2
EOF`
- `go run 0-999/500-599/580-589/585/585C.go <<EOF
4 1
EOF`
- `go run 0-999/500-599/580-589/585/585C.go <<EOF
2 2
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6880af5b3910832482e135ab2849ee70