### PR TITLE
Add Go solution for 594E

### DIFF
--- a/0-999/500-599/590-599/594/594E.go
+++ b/0-999/500-599/590-599/594/594E.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+var (
+    s    string
+    memo map[[2]int]string
+)
+
+func reverseString(str string) string {
+    b := []byte(str)
+    for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+        b[i], b[j] = b[j], b[i]
+    }
+    return string(b)
+}
+
+func minString(a, b string) string {
+    if a == "" {
+        return b
+    }
+    if b == "" {
+        return a
+    }
+    if a < b {
+        return a
+    }
+    return b
+}
+
+func solve(pos, k int) string {
+    if pos == len(s) {
+        return ""
+    }
+    if k == 1 {
+        rem := s[pos:]
+        rev := reverseString(rem)
+        if rem < rev {
+            return rem
+        }
+        return rev
+    }
+    key := [2]int{pos, k}
+    if v, ok := memo[key]; ok {
+        return v
+    }
+    best := ""
+    n := len(s)
+    for i := pos + 1; i <= n; i++ {
+        if k-1 > n-i {
+            continue
+        }
+        part := s[pos:i]
+        rest := solve(i, k-1)
+        best = minString(best, part+rest)
+        best = minString(best, reverseString(part)+rest)
+    }
+    memo[key] = best
+    return best
+}
+
+func main() {
+    reader := bufio.NewReader(os.Stdin)
+    fmt.Fscan(reader, &s)
+    var k int
+    fmt.Fscan(reader, &k)
+    memo = make(map[[2]int]string)
+    res := solve(0, k)
+    writer := bufio.NewWriter(os.Stdout)
+    fmt.Fprintln(writer, res)
+    writer.Flush()
+}
+


### PR DESCRIPTION
## Summary
- add a Go solver for problemE.txt in contest 594

## Testing
- `go vet ./...`
- `go test ./...` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_6880c77b27b4832490522fb8eb5c5107