### PR TITLE
Add solution for 567C

### DIFF
--- a/0-999/500-599/560-569/567/567C.go
+++ b/0-999/500-599/560-569/567/567C.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	var k int64
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+
+	left := make(map[int64]int64)
+	right := make(map[int64]int64)
+	for _, v := range a {
+		right[v]++
+	}
+
+	var ans int64
+	for _, v := range a {
+		right[v]--
+		if v%k == 0 {
+			ans += left[v/k] * right[v*k]
+		}
+		left[v]++
+	}
+
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 567C

## Testing
- `go build 0-999/500-599/560-569/567/567C.go`

------
https://chatgpt.com/codex/tasks/task_e_6880c47736a883248f9ce471b311f47f