### PR TITLE
Add Go solution for 570B

### DIFF
--- a/0-999/500-599/570-579/570/570B.go
+++ b/0-999/500-599/570-579/570/570B.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	fmt.Fscan(in, &n, &m)
+
+	if m == 1 {
+		if n == 1 {
+			fmt.Println(1)
+		} else {
+			fmt.Println(2)
+		}
+		return
+	}
+	if m == n {
+		fmt.Println(n - 1)
+		return
+	}
+
+	left := m - 1
+	right := n - m
+	if left >= right {
+		fmt.Println(m - 1)
+	} else {
+		fmt.Println(m + 1)
+	}
+}


### PR DESCRIPTION
## Summary
- add `570B.go` with implementation for problem B in contest 570

## Testing
- `go build 0-999/500-599/570-579/570/570B.go`


------
https://chatgpt.com/codex/tasks/task_e_6880c12a882c8324ae0f8cc57bef7dcf