### PR TITLE
Add Go solution for 578B

### DIFF
--- a/0-999/500-599/570-579/578/578B.go
+++ b/0-999/500-599/570-579/578/578B.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, k int
+	var x int64
+	if _, err := fmt.Fscan(reader, &n, &k, &x); err != nil {
+		return
+	}
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+	}
+
+	prefix := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i] | arr[i]
+	}
+	suffix := make([]int64, n+1)
+	for i := n - 1; i >= 0; i-- {
+		suffix[i] = suffix[i+1] | arr[i]
+	}
+
+	pow := int64(1)
+	for i := 0; i < k; i++ {
+		pow *= x
+	}
+
+	var ans int64
+	for i := 0; i < n; i++ {
+		val := prefix[i] | (arr[i] * pow) | suffix[i+1]
+		if val > ans {
+			ans = val
+		}
+	}
+
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 578B

## Testing
- `go run 0-999/500-599/570-579/578/578B.go <<EOF
4 2 3
1 2 4 8
EOF`
- `go run 0-999/500-599/570-579/578/578B.go <<EOF
3 1 2
1 1 1
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6880bf85b4e88324ac9af1b262ade627