### PR TITLE
Add stub Go solution for 578F

### DIFF
--- a/0-999/500-599/570-579/578/578F.go
+++ b/0-999/500-599/570-579/578/578F.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// TODO: Implement solution for problem F.
+// Placeholder implementation prints 0.
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	var mod int64
+	if _, err := fmt.Fscan(in, &n, &m, &mod); err != nil {
+		return
+	}
+	for i := 0; i < n; i++ {
+		var s string
+		fmt.Fscan(in, &s)
+	}
+	fmt.Println(0)
+}


### PR DESCRIPTION
## Summary
- add a placeholder Go implementation for problem 578F

## Testing
- `gofmt -w 0-999/500-599/570-579/578/578F.go`

------
https://chatgpt.com/codex/tasks/task_e_6880bf3f8ec083249b4a676cc17ceaa2