### PR TITLE
Add naive Go solution for 578D

### DIFF
--- a/0-999/500-599/570-579/578/578D.go
+++ b/0-999/500-599/570-579/578/578D.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return
+	}
+	var s string
+	fmt.Fscan(in, &s)
+
+	alphabet := make([]byte, m)
+	for i := 0; i < m; i++ {
+		alphabet[i] = byte('a' + i)
+	}
+
+	unique := make(map[string]struct{})
+
+	for i := 0; i < n; i++ {
+		// string after removing position i
+		u := s[:i] + s[i+1:]
+		for j := 0; j < n; j++ {
+			for _, c := range alphabet {
+				if j == i && byte(c) == s[i] {
+					continue
+				}
+				t := u[:j] + string(c) + u[j:]
+				if t == s {
+					continue
+				}
+				unique[t] = struct{}{}
+			}
+		}
+	}
+
+	fmt.Println(len(unique))
+}


### PR DESCRIPTION
## Summary
- implement solution for problemD in directory `578`

## Testing
- `gofmt -w ./0-999/500-599/570-579/578/578D.go`


------
https://chatgpt.com/codex/tasks/task_e_6880bef9774c8324ad7ef5c95629b875