### PR TITLE
Add Go solution for problem 573B

### DIFF
--- a/0-999/500-599/570-579/573/573B.go
+++ b/0-999/500-599/570-579/573/573B.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(in, &n)
+	h := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &h[i])
+	}
+	if n == 1 {
+		fmt.Println(h[0])
+		return
+	}
+	left := make([]int, n)
+	right := make([]int, n)
+	left[0] = 1
+	if left[0] > h[0] {
+		left[0] = h[0]
+	}
+	for i := 1; i < n; i++ {
+		left[i] = left[i-1] + 1
+		if left[i] > h[i] {
+			left[i] = h[i]
+		}
+	}
+	right[n-1] = 1
+	if right[n-1] > h[n-1] {
+		right[n-1] = h[n-1]
+	}
+	for i := n - 2; i >= 0; i-- {
+		right[i] = right[i+1] + 1
+		if right[i] > h[i] {
+			right[i] = h[i]
+		}
+	}
+	ans := 0
+	for i := 0; i < n; i++ {
+		v := left[i]
+		if right[i] < v {
+			v = right[i]
+		}
+		if v > ans {
+			ans = v
+		}
+	}
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for Codeforces problem 573B

## Testing
- `go run 0-999/500-599/570-579/573/573B.go <<EOF
3
1 2 3
EOF`
- `go run 0-999/500-599/570-579/573/573B.go <<EOF
1
5
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6880bcc870b4832493564a10a49a6882