### PR TITLE
Add Go solution for 574A

### DIFF
--- a/0-999/500-599/570-579/574/574A.go
+++ b/0-999/500-599/570-579/574/574A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	votes := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &votes[i])
+	}
+	count := 0
+	for {
+		maxIdx := 0
+		for i := 1; i < n; i++ {
+			if votes[i] > votes[maxIdx] {
+				maxIdx = i
+			}
+		}
+		if maxIdx == 0 {
+			break
+		}
+		votes[0]++
+		votes[maxIdx]--
+		count++
+	}
+	fmt.Println(count)
+}


### PR DESCRIPTION
## Summary
- implement solution for Codeforces problem 574A "Bear and Elections" in Go

## Testing
- `gofmt -w 0-999/500-599/570-579/574/574A.go`


------
https://chatgpt.com/codex/tasks/task_e_6880bbb054108324b795dd58a680708a