### PR TITLE
Add Go solution for Codeforces 591B

### DIFF
--- a/0-999/500-599/590-599/591/591B.go
+++ b/0-999/500-599/590-599/591/591B.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return
+	}
+	var s string
+	fmt.Fscan(reader, &s)
+
+	mapping := [26]byte{}
+	for i := 0; i < 26; i++ {
+		mapping[i] = byte('a' + i)
+	}
+
+	for i := 0; i < m; i++ {
+		var xs, ys string
+		fmt.Fscan(reader, &xs, &ys)
+		x := xs[0]
+		y := ys[0]
+		for j := 0; j < 26; j++ {
+			if mapping[j] == x {
+				mapping[j] = y
+			} else if mapping[j] == y {
+				mapping[j] = x
+			}
+		}
+	}
+
+	bytes := []byte(s)
+	for i := 0; i < len(bytes); i++ {
+		bytes[i] = mapping[bytes[i]-'a']
+	}
+	fmt.Fprintln(writer, string(bytes))
+}


### PR DESCRIPTION
## Summary
- add new Go solution for problem 591B (Rebranding)

## Testing
- `go build 0-999/500-599/590-599/591/591B.go`
- `printf "5 1\nabcde\na b\n" | go run 0-999/500-599/590-599/591/591B.go`

------
https://chatgpt.com/codex/tasks/task_e_6880cfb254cc83248692226887ed1a68