### PR TITLE
Add Go solution for problem 596B

### DIFF
--- a/0-999/500-599/590-599/596/596B.go
+++ b/0-999/500-599/590-599/596/596B.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	fmt.Fscan(reader, &n)
+	var prev int64
+	var ans int64
+	for i := 0; i < n; i++ {
+		var b int64
+		fmt.Fscan(reader, &b)
+		diff := b - prev
+		if diff < 0 {
+			diff = -diff
+		}
+		ans += diff
+		prev = b
+	}
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement `596B.go` for problem 596B

## Testing
- `go run 0-999/500-599/590-599/596/596B.go << EOF
5
1 2 3 4 5
EOF`
- `go run 0-999/500-599/590-599/596/596B.go << EOF
5
0 -1 -2 -2 0
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6880cf26808883248a6beb3b05e2f2b1