### PR TITLE
Add Go solution for 597A

### DIFF
--- a/0-999/500-599/590-599/597/597A.go
+++ b/0-999/500-599/590-599/597/597A.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// floorDiv computes floor(a/b) for positive b
+func floorDiv(a, b int64) int64 {
+	if a >= 0 {
+		return a / b
+	}
+	// adjust for negative a to perform floor division
+	return -((-a + b - 1) / b)
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var k, a, b int64
+	if _, err := fmt.Fscan(in, &k, &a, &b); err != nil {
+		return
+	}
+	result := floorDiv(b, k) - floorDiv(a-1, k)
+	fmt.Println(result)
+}


### PR DESCRIPTION
## Summary
- implement 597A solution in Go using floor division for negative ranges

## Testing
- `go build 0-999/500-599/590-599/597/597A.go`


------
https://chatgpt.com/codex/tasks/task_e_6880ce53ba0c8324824dc4da0883b475