### PR TITLE
Add Go solution for problem 597B

### DIFF
--- a/0-999/500-599/590-599/597/597B.go
+++ b/0-999/500-599/590-599/597/597B.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// interval represents a rental request with start and finish times.
+type interval struct {
+	l int
+	r int
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	orders := make([]interval, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &orders[i].l, &orders[i].r)
+	}
+
+	// Sort orders by finish time to apply a greedy algorithm.
+	sort.Slice(orders, func(i, j int) bool {
+		if orders[i].r == orders[j].r {
+			return orders[i].l < orders[j].l
+		}
+		return orders[i].r < orders[j].r
+	})
+
+	count := 0
+	lastEnd := 0
+	for _, ord := range orders {
+		// Accept the order only if it starts strictly after the last accepted one.
+		if ord.l > lastEnd {
+			count++
+			lastEnd = ord.r
+		}
+	}
+
+	fmt.Fprintln(writer, count)
+}


### PR DESCRIPTION
## Summary
- implement greedy interval scheduling solution for problem 597B

## Testing
- `go build 0-999/500-599/590-599/597/597B.go`

------
https://chatgpt.com/codex/tasks/task_e_6880ce0db7d88324b96658a93ca6b9b4