### PR TITLE
Add Go solution for 599A

### DIFF
--- a/0-999/500-599/590-599/599/599A.go
+++ b/0-999/500-599/590-599/599/599A.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var d1, d2, d3 int
+	if _, err := fmt.Fscan(reader, &d1, &d2, &d3); err != nil {
+		return
+	}
+
+	option1 := d1 + d2 + d3
+	option2 := 2 * (d1 + d2)
+	option3 := 2 * (d1 + d3)
+	option4 := 2 * (d2 + d3)
+
+	ans := option1
+	if option2 < ans {
+		ans = option2
+	}
+	if option3 < ans {
+		ans = option3
+	}
+	if option4 < ans {
+		ans = option4
+	}
+
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- add solution `599A.go` implementing greedy minimal path for Patrick and Shopping

## Testing
- `go build 0-999/500-599/590-599/599/599A.go`

------
https://chatgpt.com/codex/tasks/task_e_6880ccaf00188324bdc60b7a65ff6a95