### PR TITLE
Add solution for 599C

### DIFF
--- a/0-999/500-599/590-599/599/599C.go
+++ b/0-999/500-599/590-599/599/599C.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+
+	prefixMax := make([]int, n)
+	prefixMax[0] = a[0]
+	for i := 1; i < n; i++ {
+		if a[i] > prefixMax[i-1] {
+			prefixMax[i] = a[i]
+		} else {
+			prefixMax[i] = prefixMax[i-1]
+		}
+	}
+
+	suffixMin := make([]int, n)
+	suffixMin[n-1] = a[n-1]
+	for i := n - 2; i >= 0; i-- {
+		if a[i] < suffixMin[i+1] {
+			suffixMin[i] = a[i]
+		} else {
+			suffixMin[i] = suffixMin[i+1]
+		}
+	}
+
+	ans := 1
+	for i := 0; i < n-1; i++ {
+		if prefixMax[i] <= suffixMin[i+1] {
+			ans++
+		}
+	}
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 599C

## Testing
- `go vet 0-999/500-599/590-599/599/599C.go`
- `echo -e "3\n3 2 1" | go run 0-999/500-599/590-599/599/599C.go`
- `echo -e "3\n1 3 2" | go run 0-999/500-599/590-599/599/599C.go`


------
https://chatgpt.com/codex/tasks/task_e_6880cc2323a083249d8cbb04b5d8d507