### PR TITLE
Add Go solution for 593A

### DIFF
--- a/0-999/500-599/590-599/593/593A.go
+++ b/0-999/500-599/590-599/593/593A.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/bits"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	type word struct {
+		mask uint32
+		len  int
+	}
+	words := make([]word, 0, n)
+
+	for i := 0; i < n; i++ {
+		var s string
+		fmt.Fscan(reader, &s)
+		var m uint32
+		for _, ch := range s {
+			m |= 1 << (ch - 'a')
+		}
+		if bits.OnesCount32(m) <= 2 {
+			words = append(words, word{m, len(s)})
+		}
+	}
+
+	maxLen := 0
+	for i := 0; i < 26; i++ {
+		for j := i; j < 26; j++ {
+			pairMask := uint32((1 << i) | (1 << j))
+			sum := 0
+			for _, w := range words {
+				if w.mask & ^pairMask == 0 {
+					sum += w.len
+				}
+			}
+			if sum > maxLen {
+				maxLen = sum
+			}
+		}
+	}
+
+	fmt.Fprintln(writer, maxLen)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 593A

## Testing
- `go vet 0-999/500-599/590-599/593/593A.go`
- `go build 0-999/500-599/590-599/593/593A.go`

------
https://chatgpt.com/codex/tasks/task_e_6880c965a2bc83248b080c45c2ced0f0