### PR TITLE
Add Go solution for 593B

### DIFF
--- a/0-999/500-599/590-599/593/593B.go
+++ b/0-999/500-599/590-599/593/593B.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+    "sort"
+)
+
+type line struct {
+    y1 int64
+    y2 int64
+}
+
+func main() {
+    in := bufio.NewReader(os.Stdin)
+    var n int
+    var x1, x2 int64
+    if _, err := fmt.Fscan(in, &n, &x1, &x2); err != nil {
+        return
+    }
+    lines := make([]line, n)
+    for i := 0; i < n; i++ {
+        var k, b int64
+        if _, err := fmt.Fscan(in, &k, &b); err != nil {
+            return
+        }
+        lines[i].y1 = k*x1 + b
+        lines[i].y2 = k*x2 + b
+    }
+    sort.Slice(lines, func(i, j int) bool {
+        if lines[i].y1 == lines[j].y1 {
+            return lines[i].y2 < lines[j].y2
+        }
+        return lines[i].y1 < lines[j].y1
+    })
+    for i := 0; i < n-1; i++ {
+        if lines[i].y2 > lines[i+1].y2 {
+            fmt.Println("Yes")
+            return
+        }
+    }
+    fmt.Println("No")
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 593B

## Testing
- `go vet` *(not run: no vet or test instructions)*

------
https://chatgpt.com/codex/tasks/task_e_6880c91f8bec8324a043dc812ff69153