### PR TITLE
Add Go solution for 678C

### DIFF
--- a/0-999/600-699/670-679/678/678C.go
+++ b/0-999/600-699/670-679/678/678C.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func max(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, a, b, p, q int64
+	if _, err := fmt.Fscan(in, &n, &a, &b, &p, &q); err != nil {
+		return
+	}
+	g := gcd(a, b)
+	lcm := a / g * b
+	countA := n / a
+	countB := n / b
+	countBoth := int64(0)
+	if lcm <= n {
+		countBoth = n / lcm
+	}
+	result := (countA-countBoth)*p + (countB-countBoth)*q + countBoth*max(p, q)
+	fmt.Println(result)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 678C "Joty and Chocolate"

## Testing
- `gofmt -w 0-999/600-699/670-679/678/678C.go`

------
https://chatgpt.com/codex/tasks/task_e_6880f99a9b448324889776456030c0c4