### PR TITLE
Add Go solution for CF 676C

### DIFF
--- a/0-999/600-699/670-679/676/676C.go
+++ b/0-999/600-699/670-679/676/676C.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+   "bufio"
+   "fmt"
+   "os"
+)
+
+func maxLen(s string, k int, ch byte) int {
+   left := 0
+   count := 0
+   best := 0
+   for right := 0; right < len(s); right++ {
+      if s[right] != ch {
+         count++
+      }
+      for count > k {
+         if s[left] != ch {
+            count--
+         }
+         left++
+      }
+      if cur := right - left + 1; cur > best {
+         best = cur
+      }
+   }
+   return best
+}
+
+func main() {
+   reader := bufio.NewReader(os.Stdin)
+   writer := bufio.NewWriter(os.Stdout)
+   defer writer.Flush()
+
+   var n, k int
+   if _, err := fmt.Fscan(reader, &n, &k); err != nil {
+      return
+   }
+   var s string
+   fmt.Fscan(reader, &s)
+
+   resA := maxLen(s, k, 'a')
+   resB := maxLen(s, k, 'b')
+   if resA > resB {
+      fmt.Fprintln(writer, resA)
+   } else {
+      fmt.Fprintln(writer, resB)
+   }
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 676C in Go

## Testing
- `go build 0-999/600-699/670-679/676/676C.go`
- `go vet 0-999/600-699/670-679/676/676C.go`
- `go run 0-999/600-699/670-679/676/676C.go <<EOF
5 1
aabbb
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6880f72390448324a2120de9b738d41e