### PR TITLE
Add Go solution for problem 678A

### DIFF
--- a/0-999/600-699/670-679/678/678A.go
+++ b/0-999/600-699/670-679/678/678A.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	var n, k int64
+	if _, err := fmt.Scan(&n, &k); err != nil {
+		return
+	}
+	result := (n/k + 1) * k
+	fmt.Println(result)
+}


### PR DESCRIPTION
## Summary
- implement solution for 678A to compute the smallest multiple of `k` greater than `n`

## Testing
- `go build 0-999/600-699/670-679/678/678A.go`


------
https://chatgpt.com/codex/tasks/task_e_6880fa26cdfc8324aaea48a4234c4d81