### PR TITLE
Add Go solution for problem 678B

### DIFF
--- a/0-999/600-699/670-679/678/678B.go
+++ b/0-999/600-699/670-679/678/678B.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func isLeap(y int) bool {
+	if y%400 == 0 {
+		return true
+	}
+	if y%100 == 0 {
+		return false
+	}
+	return y%4 == 0
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var y int
+	if _, err := fmt.Fscan(reader, &y); err != nil {
+		return
+	}
+
+	origLeap := isLeap(y)
+	shift := 0
+	for {
+		if isLeap(y) {
+			shift = (shift + 2) % 7
+		} else {
+			shift = (shift + 1) % 7
+		}
+		y++
+		if shift == 0 && isLeap(y) == origLeap {
+			fmt.Fprintln(writer, y)
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement algorithm to find next year with identical calendar

## Testing
- `go vet 0-999/600-699/670-679/678/678B.go`
- `echo 2016 | go run 0-999/600-699/670-679/678/678B.go`
- `echo 2015 | go run 0-999/600-699/670-679/678/678B.go`


------
https://chatgpt.com/codex/tasks/task_e_6880f9e0ae548324a7d890d61ef900ed