### PR TITLE
Add Go solution for Codeforces 672A

### DIFF
--- a/0-999/600-699/670-679/672/672A.go
+++ b/0-999/600-699/670-679/672/672A.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	// Build concatenated string until length >= n
+	s := make([]byte, 0, n+10)
+	for i := 1; len(s) < n; i++ {
+		s = append(s, fmt.Sprint(i)...)
+	}
+
+	fmt.Printf("%c\n", s[n-1])
+}


### PR DESCRIPTION
## Summary
- add solution `672A.go` for Codeforces problem 672A

## Testing
- `go build 0-999/600-699/670-679/672/672A.go`

------
https://chatgpt.com/codex/tasks/task_e_6880f4677180832499a3e57c4377b4e1