### PR TITLE
Add Go solution for 652C

### DIFF
--- a/0-999/600-699/650-659/652/652C.go
+++ b/0-999/600-699/650-659/652/652C.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return
+	}
+	perm := make([]int, n)
+	pos := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &perm[i])
+		pos[perm[i]] = i + 1
+	}
+
+	limit := make([]int, n+2)
+	for i := range limit {
+		limit[i] = n
+	}
+
+	for i := 0; i < m; i++ {
+		var a, b int
+		fmt.Fscan(reader, &a, &b)
+		x := pos[a]
+		y := pos[b]
+		if x > y {
+			x, y = y, x
+		}
+		if y-1 < limit[x] {
+			limit[x] = y - 1
+		}
+	}
+
+	for i := n - 1; i >= 1; i-- {
+		if limit[i+1] < limit[i] {
+			limit[i] = limit[i+1]
+		}
+	}
+
+	var ans int64
+	for i := 1; i <= n; i++ {
+		ans += int64(limit[i] - i + 1)
+	}
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 652C

## Testing
- `go vet 0-999/600-699/650-659/652/652C.go`
- `go build 0-999/600-699/650-659/652/652C.go`


------
https://chatgpt.com/codex/tasks/task_e_6880f1ef83ac832497368b2d1cd3ae74