### PR TITLE
Add solution for Codeforces 659A in Go

### DIFF
--- a/0-999/600-699/650-659/659/659A.go
+++ b/0-999/600-699/650-659/659/659A.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, a, b int
+	if _, err := fmt.Fscan(in, &n, &a, &b); err != nil {
+		return
+	}
+	pos := (a - 1 + b) % n
+	if pos < 0 {
+		pos += n
+	}
+	fmt.Println(pos + 1)
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 659A

## Testing
- `go run 0-999/600-699/650-659/659/659A.go << EOF
4 2 1
EOF`
- `go vet 0-999/600-699/650-659/659/659A.go`


------
https://chatgpt.com/codex/tasks/task_e_6880efbecb8483248f120a8e22db4377