### PR TITLE
Add solution for 656C

### DIFF
--- a/0-999/600-699/650-659/656/656C.go
+++ b/0-999/600-699/650-659/656/656C.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var s string
+	if _, err := fmt.Fscan(in, &s); err != nil {
+		return
+	}
+	var upperSum, lowerSum int
+	for _, ch := range s {
+		if ch >= 'A' && ch <= 'Z' {
+			upperSum += int(ch - 'A' + 1)
+		} else if ch >= 'a' && ch <= 'z' {
+			lowerSum += int(ch - 'a' + 1)
+		}
+	}
+	fmt.Println(upperSum - lowerSum)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 656 problem C

## Testing
- `go run 0-999/600-699/650-659/656/656C.go <<EOF
Codeforces
EOF`
- `go run 0-999/600-699/650-659/656/656C.go <<EOF
APRIL.1st
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6880ed8dba948324b88b53a701be0bdc