### PR TITLE
Add Go solution for 656E

### DIFF
--- a/0-999/600-699/650-659/656/656E.go
+++ b/0-999/600-699/650-659/656/656E.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	dist := make([][]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			fmt.Fscan(reader, &dist[i][j])
+		}
+	}
+
+	// Floyd-Warshall algorithm
+	for k := 0; k < n; k++ {
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				if dist[i][j] > dist[i][k]+dist[k][j] {
+					dist[i][j] = dist[i][k] + dist[k][j]
+				}
+			}
+		}
+	}
+
+	maxDist := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if dist[i][j] > maxDist {
+				maxDist = dist[i][j]
+			}
+		}
+	}
+
+	writer := bufio.NewWriter(os.Stdout)
+	fmt.Fprintln(writer, maxDist)
+	writer.Flush()
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 656E using Floyd–Warshall to find the graph diameter

## Testing
- `go build 0-999/600-699/650-659/656/656E.go`

------
https://chatgpt.com/codex/tasks/task_e_6880ec7541ac8324806539328325b019