### PR TITLE
Add Go solution for 626C

### DIFF
--- a/0-999/600-699/620-629/626/626C.go
+++ b/0-999/600-699/620-629/626/626C.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m int64
+	fmt.Fscan(in, &n, &m)
+	l, r := int64(0), int64(6*(n+m))
+	if r == 0 {
+		r = 1
+	}
+	feasible := func(x int64) bool {
+		twosOnly := x/2 - x/6
+		threesOnly := x/3 - x/6
+		six := x / 6
+		need2 := n - twosOnly
+		if need2 < 0 {
+			need2 = 0
+		}
+		need3 := m - threesOnly
+		if need3 < 0 {
+			need3 = 0
+		}
+		return need2+need3 <= six
+	}
+	for l+1 < r {
+		mid := (l + r) / 2
+		if feasible(mid) {
+			r = mid
+		} else {
+			l = mid
+		}
+	}
+	fmt.Println(r)
+}


### PR DESCRIPTION
## Summary
- implement solution for problemC from contest 626 in Go

## Testing
- `go run 0-999/600-699/620-629/626/626C.go <<EOF
1 1
EOF`
- `go run 0-999/600-699/620-629/626/626C.go <<EOF
1 3
EOF`
- `go run 0-999/600-699/620-629/626/626C.go <<EOF
3 2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6880e4c9e3e88324b0b2a5f25a2f127e