### PR TITLE
Add Go solution for problem 683D

### DIFF
--- a/0-999/600-699/680-689/683/683D.go
+++ b/0-999/600-699/680-689/683/683D.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var q int
+	if _, err := fmt.Fscan(reader, &q); err != nil {
+		return
+	}
+	for ; q > 0; q-- {
+		var n, m, p int
+		fmt.Fscan(reader, &n, &m, &p)
+		if p > n*m {
+			fmt.Fprintln(writer, "No")
+			continue
+		}
+		possible := false
+		for d := 1; d*d <= p && !possible; d++ {
+			if p%d == 0 {
+				x := d
+				y := p / d
+				if (x <= n && y <= m) || (x <= m && y <= n) {
+					possible = true
+				}
+			}
+		}
+		if possible {
+			fmt.Fprintln(writer, "Yes")
+		} else {
+			fmt.Fprintln(writer, "No")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 683D

## Testing
- `go vet 0-999/600-699/680-689/683/683D.go`
- `go run 0-999/600-699/680-689/683/683D.go <<EOF`
  `3`
  `2 2 2`
  `3 3 4`
  `4 4 6`
  `EOF`

------
https://chatgpt.com/codex/tasks/task_e_6880e067fd048324b722856f8f14c0bb