### PR TITLE
Add Go solution for problem 685A

### DIFF
--- a/0-999/600-699/680-689/685/685A.go
+++ b/0-999/600-699/680-689/685/685A.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func digitsNeeded(x int) int {
+	d := 1
+	for x >= 7 {
+		x /= 7
+		d++
+	}
+	return d
+}
+
+func toBase7(x, d int) []int {
+	res := make([]int, d)
+	for i := d - 1; i >= 0; i-- {
+		res[i] = x % 7
+		x /= 7
+	}
+	return res
+}
+
+func distinct(hd, md []int) bool {
+	var used [7]bool
+	for _, v := range hd {
+		if used[v] {
+			return false
+		}
+		used[v] = true
+	}
+	for _, v := range md {
+		if used[v] {
+			return false
+		}
+		used[v] = true
+	}
+	return true
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	fmt.Fscan(in, &n, &m)
+
+	d1 := digitsNeeded(n - 1)
+	d2 := digitsNeeded(m - 1)
+
+	if d1+d2 > 7 {
+		fmt.Println(0)
+		return
+	}
+
+	ans := 0
+	for h := 0; h < n; h++ {
+		hd := toBase7(h, d1)
+		for mm := 0; mm < m; mm++ {
+			md := toBase7(mm, d2)
+			if distinct(hd, md) {
+				ans++
+			}
+		}
+	}
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement `685A.go` solving problemA

## Testing
- `go run ./0-999/600-699/680-689/685/685A.go << EOF
5 7
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6880dec34ca08324a8a478101214a38c