### PR TITLE
Add Go solution for problem 689C

### DIFF
--- a/0-999/600-699/680-689/689/689C.go
+++ b/0-999/600-699/680-689/689/689C.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func countWays(n int64) int64 {
+	var res int64
+	for k := int64(2); k*k*k <= n; k++ {
+		res += n / (k * k * k)
+	}
+	return res
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var m int64
+	if _, err := fmt.Fscan(reader, &m); err != nil {
+		return
+	}
+
+	low := int64(1)
+	high := int64(1e18)
+	for low < high {
+		mid := (low + high) / 2
+		if countWays(mid) >= m {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+
+	if countWays(low) == m {
+		fmt.Println(low)
+	} else {
+		fmt.Println(-1)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution to count possible GP theft combinations and binary search for smallest `n`

## Testing
- `go run 0-999/600-699/680-689/689/689C.go << EOF
1
EOF`
- `go run 0-999/600-699/680-689/689/689C.go << EOF
8
EOF`
- `go run 0-999/600-699/680-689/689/689C.go << EOF
10
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6880da618970832492e478300a25804e