### PR TITLE
Add Go solution for 688A

### DIFF
--- a/0-999/600-699/680-689/688/688A.go
+++ b/0-999/600-699/680-689/688/688A.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, d int
+	if _, err := fmt.Fscan(in, &n, &d); err != nil {
+		return
+	}
+	maxSeq := 0
+	curSeq := 0
+	for i := 0; i < d; i++ {
+		var s string
+		fmt.Fscan(in, &s)
+		ok := false
+		for j := 0; j < len(s); j++ {
+			if s[j] == '0' {
+				ok = true
+				break
+			}
+		}
+		if ok {
+			curSeq++
+			if curSeq > maxSeq {
+				maxSeq = curSeq
+			}
+		} else {
+			curSeq = 0
+		}
+	}
+	fmt.Fprintln(out, maxSeq)
+}


### PR DESCRIPTION
## Summary
- implement solution for 688A `Opponents`

## Testing
- `go build 0-999/600-699/680-689/688/688A.go`

------
https://chatgpt.com/codex/tasks/task_e_6880d98f2b348324ac18228df4c2fa2d