### PR TITLE
Add Go solution for 681B

### DIFF
--- a/0-999/600-699/680-689/681/681B.go
+++ b/0-999/600-699/680-689/681/681B.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int64
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+
+	for a := int64(0); a*1234567 <= n; a++ {
+		remA := n - a*1234567
+		for b := int64(0); b*123456 <= remA; b++ {
+			rem := remA - b*123456
+			if rem%1234 == 0 {
+				fmt.Fprintln(out, "YES")
+				return
+			}
+		}
+	}
+	fmt.Fprintln(out, "NO")
+}


### PR DESCRIPTION
## Summary
- implement Go solver for `681B` in `0-999/600-699/680-689/681/681B.go`

## Testing
- `go build 0-999/600-699/680-689/681/681B.go`
- `go test ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_6880d8bcebbc83248f8d1fd61aedb245