### PR TITLE
Add Go solution for 598A

### DIFF
--- a/0-999/500-599/590-599/598/598A.go
+++ b/0-999/500-599/590-599/598/598A.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		total := n * (n + 1) / 2
+		var sumPowers int64
+		for p := int64(1); p <= n; p <<= 1 {
+			sumPowers += p
+		}
+		result := total - 2*sumPowers
+		fmt.Fprintln(writer, result)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 598 problem A

## Testing
- `go build 0-999/500-599/590-599/598/598A.go`
- `echo -e "2\n4\n5\n" | go run 0-999/500-599/590-599/598/598A.go`

------
https://chatgpt.com/codex/tasks/task_e_6880d830a3a88324815989285cfc69bd