### PR TITLE
Add Go solution for Problem 598B

### DIFF
--- a/0-999/500-599/590-599/598/598B.go
+++ b/0-999/500-599/590-599/598/598B.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var s string
+	fmt.Fscan(in, &s)
+
+	var m int
+	fmt.Fscan(in, &m)
+
+	b := []byte(s)
+	for i := 0; i < m; i++ {
+		var l, r, k int
+		fmt.Fscan(in, &l, &r, &k)
+		l--
+		length := r - l
+		k %= length
+		if k > 0 {
+			tmp := append([]byte(nil), b[l:r]...)
+			copy(b[l:r], append(tmp[length-k:], tmp[:length-k]...))
+		}
+	}
+
+	fmt.Fprintln(out, string(b))
+}


### PR DESCRIPTION
## Summary
- add Go implementation for cyclic substring rotations in contest 598 problem B

## Testing
- `go build 0-999/500-599/590-599/598/598B.go`


------
https://chatgpt.com/codex/tasks/task_e_6880d7ea7ebc83249b557aefb0c919ae