### PR TITLE
Add Go solution for 605A

### DIFF
--- a/0-999/600-699/600-609/605/605A.go
+++ b/0-999/600-699/600-609/605/605A.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	pos := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		var x int
+		fmt.Fscan(reader, &x)
+		pos[x] = i
+	}
+
+	best := 1
+	cur := 1
+	for i := 2; i <= n; i++ {
+		if pos[i] > pos[i-1] {
+			cur++
+		} else {
+			if cur > best {
+				best = cur
+			}
+			cur = 1
+		}
+	}
+	if cur > best {
+		best = cur
+	}
+
+	fmt.Fprintln(writer, n-best)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 605A using longest consecutive subsequence logic

## Testing
- `go run 0-999/600-699/600-609/605/605A.go` with sample input

------
https://chatgpt.com/codex/tasks/task_e_6880ff5adc908324b651a34f06b58478