### PR TITLE
Add Go solution for 608A

### DIFF
--- a/0-999/600-699/600-609/608/608A.go
+++ b/0-999/600-699/600-609/608/608A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n, s int
+	if _, err := fmt.Fscan(reader, &n, &s); err != nil {
+		return
+	}
+	arrival := make([]int, s+1)
+	for i := 0; i < n; i++ {
+		var f, t int
+		fmt.Fscan(reader, &f, &t)
+		if arrival[f] < t {
+			arrival[f] = t
+		}
+	}
+	time := 0
+	for floor := s; floor > 0; floor-- {
+		if arrival[floor] > time {
+			time = arrival[floor]
+		}
+		time++
+	}
+	fmt.Println(time)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problemA in 608A.go

## Testing
- `gofmt -w 0-999/600-699/600-609/608/608A.go`
- `go vet ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_688101d1e9bc8324907c8ebc1e51ca0c