### PR TITLE
Add Go solution for problem 603A

### DIFF
--- a/0-999/600-699/600-609/603/603A.go
+++ b/0-999/600-699/600-609/603/603A.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	var s string
+	if _, err := fmt.Fscan(reader, &n, &s); err != nil {
+		return
+	}
+	if len(s) == 0 {
+		fmt.Fprintln(writer, 0)
+		return
+	}
+	// count transitions and equal adjacent pairs
+	transitions := 0
+	equalCnt := 0
+	for i := 0; i+1 < len(s); i++ {
+		if s[i] != s[i+1] {
+			transitions++
+		} else {
+			equalCnt++
+		}
+	}
+
+	// after flipping one substring, at most two boundaries change
+	delta := 0
+	if equalCnt >= 2 {
+		delta = 2
+	} else if equalCnt == 1 {
+		delta = 1
+	}
+
+	result := transitions + delta + 1
+	fmt.Fprintln(writer, result)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 603A
- count adjacent transitions to compute maximal alternating subsequence length after flipping one substring

## Testing
- `go vet 0-999/600-699/600-609/603/603A.go`
- `go build 0-999/600-699/600-609/603/603A.go`


------
https://chatgpt.com/codex/tasks/task_e_68810145a654832485eba694de5ebeff