### PR TITLE
Add Go solution for problem 608B

### DIFF
--- a/0-999/600-699/600-609/608/608B.go
+++ b/0-999/600-699/600-609/608/608B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var a, b string
+	if _, err := fmt.Fscan(reader, &a); err != nil {
+		return
+	}
+	fmt.Fscan(reader, &b)
+	n := len(a)
+	m := len(b)
+	pref := make([]int, m+1)
+	for i := 0; i < m; i++ {
+		pref[i+1] = pref[i]
+		if b[i] == '1' {
+			pref[i+1]++
+		}
+	}
+	segLen := m - n + 1
+	var ans int64
+	for i := 0; i < n; i++ {
+		l := i
+		r := i + segLen - 1
+		ones := pref[r+1] - pref[l]
+		if a[i] == '0' {
+			ans += int64(ones)
+		} else {
+			ans += int64(segLen - ones)
+		}
+	}
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement algorithm for summing Hamming distances between a and all substrings of b
- use prefix sums to count ones in relevant ranges

## Testing
- `go build 0-999/600-699/600-609/608/608B.go`
- `echo -e "01\n00111" | go run 0-999/600-699/600-609/608/608B.go`

------
https://chatgpt.com/codex/tasks/task_e_6881018bdd7c8324bcf0aec376d1a8a4