### PR TITLE
Add Go solution for 609A

### DIFF
--- a/0-999/600-699/600-609/609/609A.go
+++ b/0-999/600-699/600-609/609/609A.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, m int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	if _, err := fmt.Fscan(in, &m); err != nil {
+		return
+	}
+	drives := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &drives[i])
+	}
+	sort.Slice(drives, func(i, j int) bool { return drives[i] > drives[j] })
+	sum := 0
+	cnt := 0
+	for _, v := range drives {
+		sum += v
+		cnt++
+		if sum >= m {
+			break
+		}
+	}
+	fmt.Fprintln(out, cnt)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for USB flash drive problem

## Testing
- `go build 0-999/600-699/600-609/609/609A.go`
- `go vet 0-999/600-699/600-609/609/609A.go`


------
https://chatgpt.com/codex/tasks/task_e_6881074c2df88324b22b3c9487037a4e