### PR TITLE
Add Go solution for problem 600B

### DIFF
--- a/0-999/600-699/600-609/600/600B.go
+++ b/0-999/600-699/600-609/600/600B.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	b := make([]int, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(in, &b[i])
+	}
+	sort.Ints(a)
+
+	out := bufio.NewWriter(os.Stdout)
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		x := b[i]
+		cnt := sort.Search(len(a), func(j int) bool { return a[j] > x })
+		fmt.Fprint(out, cnt)
+	}
+	out.WriteByte('\n')
+	out.Flush()
+}


### PR DESCRIPTION
## Summary
- implement `600B.go` for problem "Queries about less or equal elements"
- use binary search on sorted array `a` to count elements for each query

## Testing
- `go build 0-999/600-699/600-609/600/600B.go`


------
https://chatgpt.com/codex/tasks/task_e_68810448f45c8324ad3c97089440c33a