### PR TITLE
Add Go solution for problem 640D

### DIFF
--- a/0-999/600-699/640-649/640/640D.go
+++ b/0-999/600-699/640-649/640/640D.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return
+	}
+	parts := strings.Fields(line)
+	arr := make([]int, len(parts))
+	for i, p := range parts {
+		v, err := strconv.Atoi(p)
+		if err != nil {
+			return
+		}
+		arr[i] = v
+	}
+	maxDiff := 0
+	for i := 0; i < len(arr)-1; i++ {
+		diff := arr[i] - arr[i+1]
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > maxDiff {
+			maxDiff = diff
+		}
+	}
+	fmt.Println(maxDiff)
+}


### PR DESCRIPTION
## Summary
- implement `640D.go` to compute largest absolute difference of adjacent array elements

## Testing
- `go run 0-999/600-699/640-649/640/640D.go <<EOF
1 2 3 8 6
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68810d0ca2e883249faa752d58dad242