### PR TITLE
Add Go solution for problem 649B

### DIFF
--- a/0-999/600-699/640-649/649/649B.go
+++ b/0-999/600-699/640-649/649/649B.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m, k int
+	if _, err := fmt.Fscan(in, &n, &m, &k); err != nil {
+		return
+	}
+	var a, b int
+	fmt.Fscan(in, &a, &b)
+
+	perEntrance := m * k
+	entranceA := (a-1)/perEntrance + 1
+	entranceB := (b-1)/perEntrance + 1
+	floorA := ((a-1)%perEntrance)/k + 1
+	floorB := ((b-1)%perEntrance)/k + 1
+
+	downA := min((floorA-1)*5, 10+(floorA-1))
+	upB := min((floorB-1)*5, 10+(floorB-1))
+
+	diff := abs(entranceA - entranceB)
+	walk := min(diff, n-diff) * 15
+
+	fmt.Println(downA + walk + upB)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 649B based on apartment positions and travel costs

## Testing
- `go build 0-999/600-699/640-649/649/649B.go`


------
https://chatgpt.com/codex/tasks/task_e_68810b67fad883248841e196850b8530