### PR TITLE
Add prime counting solution for 640F

### DIFF
--- a/0-999/600-699/640-649/640/640F.go
+++ b/0-999/600-699/640-649/640/640F.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var a, b int
+	if _, err := fmt.Fscan(reader, &a, &b); err != nil {
+		return
+	}
+	if b < 2 {
+		fmt.Println(0)
+		return
+	}
+	if a < 2 {
+		a = 2
+	}
+	// Sieve of Eratosthenes up to b
+	n := b
+	isPrime := make([]bool, n+1)
+	for i := 2; i <= n; i++ {
+		isPrime[i] = true
+	}
+	for p := 2; p*p <= n; p++ {
+		if isPrime[p] {
+			for m := p * p; m <= n; m += p {
+				isPrime[m] = false
+			}
+		}
+	}
+	cnt := 0
+	for i := a; i <= b; i++ {
+		if isPrime[i] {
+			cnt++
+		}
+	}
+	fmt.Println(cnt)
+}


### PR DESCRIPTION
## Summary
- implement prime counting using sieve for problemF

## Testing
- `go run 0-999/600-699/640-649/640/640F.go <<EOF
2 10
EOF`
- `go run 0-999/600-699/640-649/640/640F.go <<EOF
10 20
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68810d52c40c8324a52478fd34997966