### PR TITLE
Add Go solution for 640C

### DIFF
--- a/0-999/600-699/640-649/640/640C.go
+++ b/0-999/600-699/640-649/640/640C.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	sum := 0
+	for {
+		var x int
+		_, err := fmt.Fscan(reader, &x)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return
+		}
+		sum += x
+	}
+	fmt.Println(sum)
+}


### PR DESCRIPTION
## Summary
- implement `640C.go` for problem C

## Testing
- `go run 0-999/600-699/640-649/640/640C.go <<<'1
2
3'`

------
https://chatgpt.com/codex/tasks/task_e_68810ddf8b4483248e973843e5e97d18