### PR TITLE
Add Go solution for 640G

### DIFF
--- a/0-999/600-699/640-649/640/640G.go
+++ b/0-999/600-699/640-649/640/640G.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"unicode"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var name string
+	if _, err := fmt.Fscan(reader, &name); err != nil {
+		return
+	}
+	var value string
+	if _, err := fmt.Fscan(reader, &value); err != nil {
+		return
+	}
+
+	prefix := 'i'
+	if strings.Contains(value, ".") {
+		prefix = 'f'
+	}
+
+	runes := []rune(name)
+	if len(runes) > 0 {
+		runes[0] = unicode.ToUpper(runes[0])
+	}
+	fmt.Fprintf(writer, "%c%s\n", prefix, string(runes))
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 640G

## Testing
- `go build 0-999/600-699/640-649/640/640G.go`
- `echo -e "length\n123" | go run 0-999/600-699/640-649/640/640G.go`
- `echo -e "value\n3.14" | go run 0-999/600-699/640-649/640/640G.go`


------
https://chatgpt.com/codex/tasks/task_e_68810d98d4b88324b7b009ce5d738053