### PR TITLE
Add Go solution for problem 634A

### DIFF
--- a/0-999/600-699/630-639/634/634A.go
+++ b/0-999/600-699/630-639/634/634A.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &b[i])
+	}
+
+	aa := make([]int, 0, n-1)
+	for _, v := range a {
+		if v != 0 {
+			aa = append(aa, v)
+		}
+	}
+	bb := make([]int, 0, n-1)
+	for _, v := range b {
+		if v != 0 {
+			bb = append(bb, v)
+		}
+	}
+	if len(aa) != len(bb) {
+		fmt.Fprintln(writer, "NO")
+		return
+	}
+	m := len(aa)
+	if m == 0 {
+		fmt.Fprintln(writer, "YES")
+		return
+	}
+	pos := make([]int, n)
+	for i, v := range aa {
+		pos[v] = i
+	}
+	shift := -1
+	for i, v := range bb {
+		idx := pos[v]
+		d := (i - idx + m) % m
+		if shift == -1 {
+			shift = d
+		} else if shift != d {
+			fmt.Fprintln(writer, "NO")
+			return
+		}
+	}
+	fmt.Fprintln(writer, "YES")
+}


### PR DESCRIPTION
## Summary
- implement `634A.go` for the sliding statue puzzle
- read input and check if statue order matches by rotation after removing the empty pedestal

## Testing
- `go build 0-999/600-699/630-639/634/634A.go`
- `echo -e '3\n1 0 2\n0 1 2\n' | ./634A` outputs YES
- `echo -e '4\n1 2 0 3\n1 3 0 2\n' | ./634A` outputs NO

------
https://chatgpt.com/codex/tasks/task_e_688112cd0ae88324ac4bc502663d3d52