### PR TITLE
Add Go solution for 633B

### DIFF
--- a/0-999/600-699/630-639/633/633B.go
+++ b/0-999/600-699/630-639/633/633B.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// countZeros returns the number of trailing zeros in n!
+func countZeros(n int) int {
+	count := 0
+	for n > 0 {
+		n /= 5
+		count += n
+	}
+	return count
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var m int
+	if _, err := fmt.Fscan(reader, &m); err != nil {
+		return
+	}
+	low, high := 0, 5*m
+	for low < high {
+		mid := (low + high) / 2
+		if countZeros(mid) < m {
+			low = mid + 1
+		} else {
+			high = mid
+		}
+	}
+	if countZeros(low) != m {
+		fmt.Println(0)
+		return
+	}
+	fmt.Println(5)
+	for i := 0; i < 5; i++ {
+		if i > 0 {
+			fmt.Print(" ")
+		}
+		fmt.Print(low + i)
+	}
+	fmt.Println()
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem 633B

## Testing
- `go run 0-999/600-699/630-639/633/633B.go <<EOF
1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68811240c0608324b7f475f11d380007