### PR TITLE
Add Go solution for 635A

### DIFF
--- a/0-999/600-699/630-639/635/635A.go
+++ b/0-999/600-699/630-639/635/635A.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var r, c, n, k int
+	if _, err := fmt.Fscan(in, &r, &c, &n, &k); err != nil {
+		return
+	}
+	grid := make([][]int, r+1)
+	for i := range grid {
+		grid[i] = make([]int, c+1)
+	}
+	for i := 0; i < n; i++ {
+		var x, y int
+		fmt.Fscan(in, &x, &y)
+		if x >= 1 && x <= r && y >= 1 && y <= c {
+			grid[x][y] = 1
+		}
+	}
+
+	prefix := make([][]int, r+1)
+	for i := range prefix {
+		prefix[i] = make([]int, c+1)
+	}
+	for i := 1; i <= r; i++ {
+		row := 0
+		for j := 1; j <= c; j++ {
+			row += grid[i][j]
+			prefix[i][j] = prefix[i-1][j] + row
+		}
+	}
+
+	ans := 0
+	for x1 := 1; x1 <= r; x1++ {
+		for x2 := x1; x2 <= r; x2++ {
+			for y1 := 1; y1 <= c; y1++ {
+				for y2 := y1; y2 <= c; y2++ {
+					count := prefix[x2][y2] - prefix[x1-1][y2] - prefix[x2][y1-1] + prefix[x1-1][y1-1]
+					if count >= k {
+						ans++
+					}
+				}
+			}
+		}
+	}
+
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- add Go implementation solving problemA (count rectangles containing at least `k` violas)

## Testing
- `go run 0-999/600-699/630-639/635/635A.go <<EOF
1 1 1 1
1 1
EOF`
- `go run 0-999/600-699/630-639/635/635A.go <<EOF
2 3 2 1
1 1
2 2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68811313127c8324a93a5a7dbd22f27e