### PR TITLE
Add Go solution for 632C

### DIFF
--- a/0-999/600-699/630-639/632/632C.go
+++ b/0-999/600-699/630-639/632/632C.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	arr := make([]string, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+	}
+	sort.Slice(arr, func(i, j int) bool {
+		return arr[i]+arr[j] < arr[j]+arr[i]
+	})
+	// Concatenate result
+	var b strings.Builder
+	for _, s := range arr {
+		b.WriteString(s)
+	}
+	fmt.Println(b.String())
+}


### PR DESCRIPTION
## Summary
- implement Go solution for 632C to produce lexicographically smallest concatenation

## Testing
- `go build 0-999/600-699/630-639/632/632C.go`

------
https://chatgpt.com/codex/tasks/task_e_6881142b8b4c832487219b47bf28a776