### PR TITLE
Add solution for 632A in Go

### DIFF
--- a/0-999/600-699/630-639/632/632A.go
+++ b/0-999/600-699/630-639/632/632A.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	var p int64
+	if _, err := fmt.Fscan(reader, &n, &p); err != nil {
+		return
+	}
+	ops := make([]string, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &ops[i])
+	}
+
+	var money, cur int64
+	for i := n - 1; i >= 0; i-- {
+		if ops[i] == "half" {
+			money += cur * p
+			cur *= 2
+		} else { // halfplus
+			money += cur*p + p/2
+			cur = cur*2 + 1
+		}
+	}
+
+	fmt.Fprintln(writer, money)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem A in contest 632

## Testing
- `go build 0-999/600-699/630-639/632/632A.go`
- `echo -e "2 2\nhalf\nhalfplus" | go run 0-999/600-699/630-639/632/632A.go`
- `echo -e "3 2\nhalfplus\nhalf\nhalfplus" | go run 0-999/600-699/630-639/632/632A.go`

------
https://chatgpt.com/codex/tasks/task_e_688114b7bca08324b1799340aa6fb54e