### PR TITLE
Add Go solution for 637A

### DIFF
--- a/0-999/600-699/630-639/637/637A.go
+++ b/0-999/600-699/630-639/637/637A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	counts := make(map[int]int)
+	bestID := 0
+	bestCount := 0
+	for i := 0; i < n; i++ {
+		var id int
+		fmt.Fscan(reader, &id)
+		counts[id]++
+		if counts[id] > bestCount {
+			bestCount = counts[id]
+			bestID = id
+		}
+	}
+	fmt.Fprintln(writer, bestID)
+}


### PR DESCRIPTION
## Summary
- implement solution for contest problem 637A

## Testing
- `go run 0-999/600-699/630-639/637/637A.go << EOF
5
1 3 2 2 1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688115d03ef483249ae372ad7a038a45