### PR TITLE
Add Go solution for 639C

### DIFF
--- a/0-999/600-699/630-639/639/639C.go
+++ b/0-999/600-699/630-639/639/639C.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/big"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	var k int64
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+	a := make([]int64, n+1)
+	for i := 0; i <= n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+
+	// Evaluate P(2) using big integers
+	p := big.NewInt(0)
+	for i := n; i >= 0; i-- {
+		p.Lsh(p, 1)
+		p.Add(p, big.NewInt(a[i]))
+	}
+
+	y := new(big.Int).Set(p) // current value of P(2) >> j
+	divisible := true        // whether 2^j divides P(2)
+	ans := 0
+
+	for j := 0; j <= n; j++ {
+		if divisible && y.BitLen() <= 62 {
+			val := y.Int64()
+			diff := a[j] - val
+			if diff >= -k && diff <= k {
+				if j != n || diff != 0 {
+					ans++
+				}
+			}
+		}
+		// prepare for next shift
+		divisible = divisible && y.Bit(0) == 0
+		y.Rsh(y, 1)
+	}
+
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- add Go solution for contest 639 problem C

## Testing
- `go build 0-999/600-699/630-639/639/639C.go`
- `echo '3 109
10 -9 -3 5' | go run 0-999/600-699/630-639/639/639C.go`
- `echo '3 12
10 -9 -3 5' | go run 0-999/600-699/630-639/639/639C.go`


------
https://chatgpt.com/codex/tasks/task_e_68811a32002c8324b982a5bd9882f13c