### PR TITLE
Add Go solution for 630G

### DIFF
--- a/0-999/600-699/630-639/630/630G.go
+++ b/0-999/600-699/630-639/630/630G.go
@@ -1,0 +1,27 @@
+package main
+
+import "fmt"
+
+func C(n, k int64) int64 {
+	if k < 0 || k > n {
+		return 0
+	}
+	if k > n-k {
+		k = n - k
+	}
+	res := int64(1)
+	for i := int64(1); i <= k; i++ {
+		res = res * (n - k + i) / i
+	}
+	return res
+}
+
+func main() {
+	var n int64
+	if _, err := fmt.Scan(&n); err != nil {
+		return
+	}
+	a := C(n+4, 5)
+	b := C(n+2, 3)
+	fmt.Println(a * b)
+}


### PR DESCRIPTION
## Summary
- add a Go program for problem 630G to count pennant arrangements

## Testing
- `go build 0-999/600-699/630-639/630/630G.go`


------
https://chatgpt.com/codex/tasks/task_e_688118d353ac8324bb7a7067dee1271a