### PR TITLE
Add Go solution for problem 612C

### DIFF
--- a/0-999/600-699/610-619/612/612C.go
+++ b/0-999/600-699/610-619/612/612C.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var s string
+	fmt.Fscan(reader, &s)
+
+	stack := make([]byte, 0, len(s))
+	closing := map[byte]byte{
+		'(': ')',
+		'[': ']',
+		'{': '}',
+		'<': '>',
+	}
+
+	var cnt int
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if _, ok := closing[ch]; ok { // opening bracket
+			stack = append(stack, ch)
+		} else { // closing bracket
+			if len(stack) == 0 {
+				fmt.Fprintln(writer, "Impossible")
+				return
+			}
+			top := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if closing[top] != ch {
+				cnt++
+			}
+		}
+	}
+	if len(stack) != 0 {
+		fmt.Fprintln(writer, "Impossible")
+		return
+	}
+	fmt.Fprintln(writer, cnt)
+}


### PR DESCRIPTION
## Summary
- implement solution for Codeforces problem 612C

## Testing
- `go run 0-999/600-699/610-619/612/612C.go <<EOF
<({[<[]>]})>
EOF`
- `echo "([)]" | go run 0-999/600-699/610-619/612/612C.go`

------
https://chatgpt.com/codex/tasks/task_e_688125b2a41883248539a5bfd8b34697