### PR TITLE
Add Go solution for 662D

### DIFF
--- a/0-999/600-699/660-669/662/662D.go
+++ b/0-999/600-699/660-669/662/662D.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	pow10 := make([]int64, 10)
+	pow10[0] = 1
+	for i := 1; i < 10; i++ {
+		pow10[i] = pow10[i-1] * 10
+	}
+	start := make([]int64, 10)
+	start[1] = 1989
+	for i := 2; i < 10; i++ {
+		start[i] = start[i-1] + pow10[i-1]
+	}
+
+	for ; n > 0; n-- {
+		var abbr string
+		fmt.Fscan(reader, &abbr)
+		digits := strings.TrimSpace(abbr[4:])
+		k := len(digits)
+		val, _ := strconv.ParseInt(digits, 10, 64)
+		year := val
+		mod := pow10[k]
+		for year < start[k] {
+			year += mod
+		}
+		fmt.Fprintln(writer, year)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solver for problem 662D (International Abbreviation Olympiad)

## Testing
- `go build 0-999/600-699/660-669/662/662D.go`
- `cat <<EOF | ./662D
5
IAO'9
IAO'0
IAO'15
IAO'99
IAO'100
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68812ae6c73c8324b175f4bcf3f159d2