### PR TITLE
Add Go solution for problem 664A

### DIFF
--- a/0-999/600-699/660-669/664/664A.go
+++ b/0-999/600-699/660-669/664/664A.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var a, b string
+	if _, err := fmt.Fscan(reader, &a, &b); err != nil {
+		return
+	}
+	if a == b {
+		fmt.Fprintln(writer, a)
+	} else {
+		fmt.Fprintln(writer, 1)
+	}
+}


### PR DESCRIPTION
## Summary
- add `664A.go` solving GCD over range problem

## Testing
- `go vet 0-999/600-699/660-669/664/664A.go`
- `go build 0-999/600-699/660-669/664/664A.go`


------
https://chatgpt.com/codex/tasks/task_e_68812a5aa0bc8324bc22053c3e50c9ff