### PR TITLE
Add Go solution for problem 660D

### DIFF
--- a/0-999/600-699/660-669/660/660D.go
+++ b/0-999/600-699/660-669/660/660D.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type pair struct {
+	x int64
+	y int64
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	xs := make([]int64, n)
+	ys := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &xs[i], &ys[i])
+	}
+
+	cnt := make(map[pair]int64)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			p := pair{xs[i] + xs[j], ys[i] + ys[j]}
+			cnt[p]++
+		}
+	}
+
+	var res int64
+	for _, v := range cnt {
+		res += v * (v - 1) / 2
+	}
+	fmt.Fprintln(writer, res)
+}


### PR DESCRIPTION
## Summary
- add Go solution for `Number of Parallelograms` (CF 660D)

## Testing
- `go build 0-999/600-699/660-669/660/660D.go`


------
https://chatgpt.com/codex/tasks/task_e_688127e37a208324b4d4425a3a27a248