### PR TITLE
Add Go solution for 615A

### DIFF
--- a/0-999/600-699/610-619/615/615A.go
+++ b/0-999/600-699/610-619/615/615A.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return
+	}
+	bulbs := make([]bool, m+1)
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(reader, &x)
+		for j := 0; j < x; j++ {
+			var y int
+			fmt.Fscan(reader, &y)
+			if y >= 1 && y <= m {
+				bulbs[y] = true
+			}
+		}
+	}
+	for b := 1; b <= m; b++ {
+		if !bulbs[b] {
+			fmt.Fprintln(writer, "NO")
+			return
+		}
+	}
+	fmt.Fprintln(writer, "YES")
+}


### PR DESCRIPTION
## Summary
- implement solution for 615A

## Testing
- `go run 0-999/600-699/610-619/615/615A.go <<EOF
3 2
1 1
1 2
2 1 2
EOF
`
- `go run 0-999/600-699/610-619/615/615A.go <<EOF
2 3
2 1 2
1 1
EOF
`

------
https://chatgpt.com/codex/tasks/task_e_6881271139608324a78b77ce832880c5