### PR TITLE
Add Go solution for 662A

### DIFF
--- a/0-999/600-699/660-669/662/662A.go
+++ b/0-999/600-699/660-669/662/662A.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	base := uint64(0)
+	diffs := make([]uint64, n)
+	for i := 0; i < n; i++ {
+		var a, b uint64
+		fmt.Fscan(reader, &a, &b)
+		base ^= a
+		diffs[i] = a ^ b
+	}
+
+	var basis [64]uint64
+	rank := 0
+	for _, d := range diffs {
+		x := d
+		for j := 63; j >= 0; j-- {
+			if (x>>uint(j))&1 == 0 {
+				continue
+			}
+			if basis[j] == 0 {
+				basis[j] = x
+				rank++
+				break
+			}
+			x ^= basis[j]
+		}
+	}
+
+	// check if base is in span of diffs
+	inSpan := func(v uint64) bool {
+		x := v
+		for j := 63; j >= 0; j-- {
+			if (x>>uint(j))&1 == 0 {
+				continue
+			}
+			if basis[j] == 0 {
+				return false
+			}
+			x ^= basis[j]
+		}
+		return true
+	}(base)
+
+	if !inSpan {
+		fmt.Fprint(writer, "1/1")
+		return
+	}
+
+	denom := uint64(1) << uint(rank)
+	numer := denom - 1
+	fmt.Fprintf(writer, "%d/%d", numer, denom)
+}


### PR DESCRIPTION
## Summary
- implement Gambling Nim probability solution in Go for problem A of contest 662

## Testing
- `go build 0-999/600-699/660-669/662/662A.go`

------
https://chatgpt.com/codex/tasks/task_e_68812b730bd083248d846afbdeae3d8e