### PR TITLE
Add Go solution for tree lifeline counting problem

### DIFF
--- a/0-999/600-699/690-699/690/690F1.go
+++ b/0-999/600-699/690-699/690/690F1.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	deg := make([]int, n)
+	for i := 0; i < n-1; i++ {
+		var a, b int
+		fmt.Fscan(reader, &a, &b)
+		a--
+		b--
+		deg[a]++
+		deg[b]++
+	}
+	var ans int64
+	for _, d := range deg {
+		ans += int64(d*(d-1)) / 2
+	}
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement `690F1.go` with counting of paths of length two

## Testing
- `go build 0-999/600-699/690-699/690/690F1.go`

------
https://chatgpt.com/codex/tasks/task_e_68812f48a5bc8324b3f393c7523d0c28