### PR TITLE
Add Go solution for 690A1

### DIFF
--- a/0-999/600-699/690-699/690/690A1.go
+++ b/0-999/600-699/690-699/690/690A1.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int64
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	ans := (n + 1) / 2
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem 690A1

## Testing
- `go build 0-999/600-699/690-699/690/690A1.go`
- `printf '1\n' | ./690A1`
- `printf '5\n' | ./690A1`


------
https://chatgpt.com/codex/tasks/task_e_68812fd4d630832489a928fca2ce7ea8