### PR TITLE
Add Go solution for 690A2

### DIFF
--- a/0-999/600-699/690-699/690/690A2.go
+++ b/0-999/600-699/690-699/690/690A2.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int64
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	fmt.Println((n - 1) / 2)
+}


### PR DESCRIPTION
## Summary
- implement solution for `690A2` problem

## Testing
- `go run 0-999/600-699/690-699/690/690A2.go <<EOF
1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68812f8eb51c8324aacee097074557b6