### PR TITLE
Add Go solution for Codeforces problem 691B

### DIFF
--- a/0-999/600-699/690-699/691/691B.go
+++ b/0-999/600-699/690-699/691/691B.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	s, _ := reader.ReadString('\n')
+	s = strings.TrimSpace(s)
+
+	mirror := map[rune]rune{
+		'A': 'A', 'H': 'H', 'I': 'I', 'M': 'M',
+		'O': 'O', 'T': 'T', 'U': 'U', 'V': 'V',
+		'W': 'W', 'X': 'X', 'Y': 'Y',
+		'b': 'd', 'd': 'b', 'p': 'q', 'q': 'p',
+		'o': 'o', 'v': 'v', 'w': 'w', 'x': 'x',
+	}
+
+	n := len(s)
+	for i := 0; i < n; i++ {
+		c := rune(s[i])
+		m, ok := mirror[c]
+		if !ok || m != rune(s[n-1-i]) {
+			fmt.Println("NIE")
+			return
+		}
+	}
+	fmt.Println("TAK")
+}


### PR DESCRIPTION
## Summary
- implement Go solution for s-palindrome check

## Testing
- `go vet 0-999/600-699/690-699/691/691B.go`
- `go build 0-999/600-699/690-699/691/691B.go`


------
https://chatgpt.com/codex/tasks/task_e_688136214bbc83249cc214b6b7dc961d