### PR TITLE
Add Go solution for 690D1

### DIFF
--- a/0-999/600-699/690-699/690/690D1.go
+++ b/0-999/600-699/690-699/690/690D1.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var R, C int
+	if _, err := fmt.Fscan(reader, &R, &C); err != nil {
+		return
+	}
+	cols := make([]bool, C)
+	for i := 0; i < R; i++ {
+		var line string
+		fmt.Fscan(reader, &line)
+		for j := 0; j < C && j < len(line); j++ {
+			if line[j] == 'B' {
+				cols[j] = true
+			}
+		}
+	}
+	seg := 0
+	prev := false
+	for j := 0; j < C; j++ {
+		if cols[j] {
+			if !prev {
+				seg++
+			}
+			prev = true
+		} else {
+			prev = false
+		}
+	}
+	fmt.Println(seg)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem D1 in contest 690

## Testing
- `go build 0-999/600-699/690-699/690/690D1.go`

------
https://chatgpt.com/codex/tasks/task_e_688132d80ac083248e46ea5d0d7157c5