### PR TITLE
Add Go solution for problem 847G

### DIFF
--- a/0-999/800-899/840-849/847/847G.go
+++ b/0-999/800-899/840-849/847/847G.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	counts := make([]int, 7)
+	for i := 0; i < n; i++ {
+		var s string
+		fmt.Fscan(in, &s)
+		for j, c := range s {
+			if c == '1' {
+				counts[j]++
+			}
+		}
+	}
+	maxRooms := 0
+	for _, v := range counts {
+		if v > maxRooms {
+			maxRooms = v
+		}
+	}
+	out := bufio.NewWriter(os.Stdout)
+	fmt.Fprintln(out, maxRooms)
+	out.Flush()
+}


### PR DESCRIPTION
## Summary
- add implementation for `problemG` of contest 847
- compute maximum number of groups per time slot

## Testing
- `go build 0-999/800-899/840-849/847/847G.go`

------
https://chatgpt.com/codex/tasks/task_e_688169e3d6e08324bbf0e7e54493004b