### PR TITLE
Add Go solution for problem 847E

### DIFF
--- a/0-999/800-899/840-849/847/847E.go
+++ b/0-999/800-899/840-849/847/847E.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func canEat(t int, stars, packs []int) bool {
+	j := 0
+	for _, p := range packs {
+		if j >= len(stars) {
+			return true
+		}
+		if stars[j] > p {
+			// all remaining stars to the right
+			reach := p + t
+			for j < len(stars) && stars[j] <= reach {
+				j++
+			}
+		} else {
+			// first star is on or left of packman
+			d := p - stars[j]
+			if d > t {
+				return false
+			}
+			reach := max(p+(t-2*d), p+(t-d)/2)
+			for j < len(stars) && stars[j] <= reach {
+				j++
+			}
+		}
+	}
+	return j >= len(stars)
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	var field string
+	fmt.Fscan(in, &field)
+
+	stars := make([]int, 0)
+	packs := make([]int, 0)
+	for i := 0; i < n; i++ {
+		switch field[i] {
+		case '*':
+			stars = append(stars, i)
+		case 'P':
+			packs = append(packs, i)
+		}
+	}
+
+	l, r := 0, 2*n
+	for l < r {
+		mid := (l + r) / 2
+		if canEat(mid, stars, packs) {
+			r = mid
+		} else {
+			l = mid + 1
+		}
+	}
+	fmt.Println(l)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `problemE.txt`
- algorithm uses binary search and greedy coverage check for packmen positions

## Testing
- `go build 0-999/800-899/840-849/847/847E.go`
- `cat <<EOF | go run 0-999/800-899/840-849/847/847E.go
7
*..P.*P
EOF`
- `cat <<EOF | go run 0-999/800-899/840-849/847/847E.go
10
.**PP.*P.*
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68816911e4c883248f90fbe5dea23385