### PR TITLE
Add Go solution for 804A

### DIFF
--- a/0-999/800-899/800-809/804/804A.go
+++ b/0-999/800-899/800-809/804/804A.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	fmt.Fprintln(writer, (n-1)/2)
+}


### PR DESCRIPTION
## Summary
- implement 804A solution in Go

## Testing
- `go build 0-999/800-899/800-809/804/804A.go`
- `echo 5 | go run 0-999/800-899/800-809/804/804A.go`

------
https://chatgpt.com/codex/tasks/task_e_68816c14dce8832487e24a575de7e6c7