### PR TITLE
Add Go solution for 841A

### DIFF
--- a/0-999/800-899/840-849/841/841A.go
+++ b/0-999/800-899/840-849/841/841A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, k int
+	if _, err := fmt.Fscan(reader, &n, &k); err != nil {
+		return
+	}
+	var s string
+	fmt.Fscan(reader, &s)
+	count := make(map[rune]int)
+	for _, ch := range s {
+		count[ch]++
+	}
+	for _, v := range count {
+		if v > k {
+			fmt.Fprintln(writer, "NO")
+			return
+		}
+	}
+	fmt.Fprintln(writer, "YES")
+}


### PR DESCRIPTION
## Summary
- add `841A.go` implementing solution for problemA

## Testing
- `go run 0-999/800-899/840-849/841/841A.go <<EOF
5 2
ababa
EOF`
- `go run 0-999/800-899/840-849/841/841A.go <<EOF
4 2
abab
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688164afc4b88324901a9dd3e7598dfe