### PR TITLE
Add Go solution for 845D

### DIFF
--- a/0-999/800-899/840-849/845/845D.go
+++ b/0-999/800-899/840-849/845/845D.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+
+	currentSpeed := 0
+	var speedLimits []int
+	noOvertake := 0
+	ans := 0
+
+	for i := 0; i < n; i++ {
+		var t int
+		fmt.Fscan(in, &t)
+		switch t {
+		case 1:
+			var s int
+			fmt.Fscan(in, &s)
+			currentSpeed = s
+			for len(speedLimits) > 0 && currentSpeed > speedLimits[len(speedLimits)-1] {
+				ans++
+				speedLimits = speedLimits[:len(speedLimits)-1]
+			}
+		case 2:
+			if noOvertake > 0 {
+				ans += noOvertake
+				noOvertake = 0
+			}
+		case 3:
+			var limit int
+			fmt.Fscan(in, &limit)
+			if currentSpeed > limit {
+				ans++
+			} else {
+				speedLimits = append(speedLimits, limit)
+			}
+		case 4:
+			noOvertake = 0
+		case 5:
+			speedLimits = speedLimits[:0]
+		case 6:
+			noOvertake++
+		}
+	}
+
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 845D "Driving Test" in Go

## Testing
- `go build 0-999/800-899/840-849/845/845D.go`
- `./845D <<EOF
4
1 100
3 90
2
2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6881604e81008324b9fa3dd2e43d2683