### PR TITLE
Add Go solution for 831C

### DIFF
--- a/0-999/800-899/830-839/831/831C.go
+++ b/0-999/800-899/830-839/831/831C.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var k, n int
+	if _, err := fmt.Fscan(in, &k, &n); err != nil {
+		return
+	}
+	a := make([]int, k)
+	for i := 0; i < k; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &b[i])
+	}
+
+	pref := make([]int, k)
+	sum := 0
+	for i := 0; i < k; i++ {
+		sum += a[i]
+		pref[i] = sum
+	}
+
+	prefSet := make(map[int]struct{})
+	for _, val := range pref {
+		prefSet[val] = struct{}{}
+	}
+
+	candidateSet := make(map[int]struct{})
+	for _, val := range pref {
+		candidateSet[b[0]-val] = struct{}{}
+	}
+
+	cnt := 0
+	for x := range candidateSet {
+		ok := true
+		for _, bj := range b {
+			if _, ok2 := prefSet[bj-x]; !ok2 {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			cnt++
+		}
+	}
+
+	fmt.Println(cnt)
+}


### PR DESCRIPTION
## Summary
- add `831C.go` with implementation for problem C of contest 831

## Testing
- `go build 0-999/800-899/830-839/831/831C.go`
- `go vet 0-999/800-899/830-839/831/831C.go`


------
https://chatgpt.com/codex/tasks/task_e_68815bec63908324926c3a8bbccbebb2