### PR TITLE
Add Go solution for 834A

### DIFF
--- a/0-999/800-899/830-839/834/834A.go
+++ b/0-999/800-899/830-839/834/834A.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	var s, t string
+	var n int64
+	if _, err := fmt.Scan(&s, &t); err != nil {
+		return
+	}
+	if _, err := fmt.Scan(&n); err != nil {
+		return
+	}
+	pos := map[byte]int{'^': 0, '>': 1, 'v': 2, '<': 3}
+	start := pos[s[0]]
+	end := pos[t[0]]
+	step := int(n % 4)
+	cw := (start + step) % 4
+	ccw := (start - step) % 4
+	if ccw < 0 {
+		ccw += 4
+	}
+	if cw == end && ccw == end {
+		fmt.Println("undefined")
+	} else if cw == end {
+		fmt.Println("cw")
+	} else if ccw == end {
+		fmt.Println("ccw")
+	} else {
+		fmt.Println("undefined")
+	}
+}


### PR DESCRIPTION
## Summary
- implement solver for 834A (The Useless Toy) in Go

## Testing
- `go run 0-999/800-899/830-839/834/834A.go << EOF
^ >
1
EOF`
- `go build 0-999/800-899/830-839/834/834A.go`
- `go vet 0-999/800-899/830-839/834/834A.go`


------
https://chatgpt.com/codex/tasks/task_e_68815a47b6c48324a6fdad8406a8b650