### PR TITLE
Add Go solution for problem 816A

### DIFF
--- a/0-999/800-899/810-819/816/816A.go
+++ b/0-999/800-899/810-819/816/816A.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+func isPalindrome(h, m int) bool {
+    return h/10 == m%10 && h%10 == m/10
+}
+
+func main() {
+    in := bufio.NewReader(os.Stdin)
+    var s string
+    if _, err := fmt.Fscan(in, &s); err != nil {
+        return
+    }
+    var hh, mm int
+    fmt.Sscanf(s, "%02d:%02d", &hh, &mm)
+    ans := 0
+    for {
+        if isPalindrome(hh, mm) {
+            fmt.Println(ans)
+            return
+        }
+        ans++
+        mm++
+        if mm == 60 {
+            mm = 0
+            hh = (hh + 1) % 24
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- solve `problemA.txt` for contest 816
- implement time simulation to find next palindromic clock time

## Testing
- `go build 0-999/800-899/810-819/816/816A.go`
- ran binary with input `05:45` to verify sample

------
https://chatgpt.com/codex/tasks/task_e_68814c09f3388324bd37a24c9ff5c61b