### PR TITLE
Add Go solution for 802K

### DIFF
--- a/0-999/800-899/800-809/802/802K.go
+++ b/0-999/800-899/800-809/802/802K.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+type edge struct {
+	to   int
+	cost int
+}
+
+var (
+	n, k int
+	g    [][]edge
+	dp   []int64
+)
+
+func dfs(u, p int) {
+	gains := make([]int64, 0, len(g[u]))
+	for _, e := range g[u] {
+		if e.to == p {
+			continue
+		}
+		dfs(e.to, u)
+		gains = append(gains, int64(e.cost)+dp[e.to])
+	}
+	sort.Slice(gains, func(i, j int) bool { return gains[i] > gains[j] })
+	limit := k
+	if len(gains) < limit {
+		limit = len(gains)
+	}
+	var sum int64
+	for i := 0; i < limit; i++ {
+		sum += gains[i]
+	}
+	dp[u] = sum
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+	g = make([][]edge, n)
+	for i := 0; i < n-1; i++ {
+		var u, v, c int
+		fmt.Fscan(in, &u, &v, &c)
+		g[u] = append(g[u], edge{v, c})
+		g[v] = append(g[v], edge{u, c})
+	}
+	dp = make([]int64, n)
+	dfs(0, -1)
+	fmt.Println(dp[0])
+}


### PR DESCRIPTION
## Summary
- implement dynamic programming solution for problem 802K

## Testing
- `go build 0-999/800-899/800-809/802/802K.go`

------
https://chatgpt.com/codex/tasks/task_e_68816f5e1f1883248bad49edff22a104