### PR TITLE
Add Go solution for problem 802M

### DIFF
--- a/0-999/800-899/800-809/802/802M.go
+++ b/0-999/800-899/800-809/802/802M.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, k int
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	sort.Ints(a)
+	sum := 0
+	for i := 0; i < k && i < len(a); i++ {
+		sum += a[i]
+	}
+	fmt.Fprintln(out, sum)
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for problem 802M (April Fools' Problem - easy)

## Testing
- `go build 0-999/800-899/800-809/802/802M.go`


------
https://chatgpt.com/codex/tasks/task_e_68816e45b994832488d868aac7d0b0d4