### PR TITLE
Add Go solution for 803A

### DIFF
--- a/0-999/800-899/800-809/803/803A.go
+++ b/0-999/800-899/800-809/803/803A.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, k int
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+
+	matrix := make([][]int, n)
+	for i := range matrix {
+		matrix[i] = make([]int, n)
+	}
+
+	for i := 0; i < n && k > 0; i++ {
+		if k > 0 {
+			matrix[i][i] = 1
+			k--
+		}
+		for j := i + 1; j < n && k >= 2; j++ {
+			matrix[i][j] = 1
+			matrix[j][i] = 1
+			k -= 2
+		}
+	}
+
+	if k > 0 {
+		fmt.Println(-1)
+		return
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				fmt.Print(" ")
+			}
+			fmt.Print(matrix[i][j])
+		}
+		fmt.Println()
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 803A

## Testing
- `go build ./0-999/800-899/800-809/803/803A.go`
- `go run 803A.go <<EOF
2 3
EOF`
- `go run 803A.go <<EOF
2 4
EOF`
- `go run 803A.go <<EOF
2 5
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68816db97b7c83248d627070d5a9d27b