### PR TITLE
Add Go solution for 807A

### DIFF
--- a/0-999/800-899/800-809/807/807A.go
+++ b/0-999/800-899/800-809/807/807A.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	ratings := make([]int, n)
+	rated := false
+	for i := 0; i < n; i++ {
+		var a, b int
+		fmt.Fscan(reader, &a, &b)
+		if a != b {
+			rated = true
+		}
+		ratings[i] = a
+	}
+
+	if rated {
+		fmt.Fprintln(writer, "rated")
+		return
+	}
+
+	for i := 1; i < n; i++ {
+		if ratings[i] > ratings[i-1] {
+			fmt.Fprintln(writer, "unrated")
+			return
+		}
+	}
+
+	fmt.Fprintln(writer, "maybe")
+}


### PR DESCRIPTION
## Summary
- implement solver for problem A in contest 807

## Testing
- `gofmt -w 0-999/800-899/800-809/807/807A.go`


------
https://chatgpt.com/codex/tasks/task_e_6881721bacac832493480398042bd8c9