### PR TITLE
Add Go solution for 864B

### DIFF
--- a/0-999/800-899/860-869/864/864B.go
+++ b/0-999/800-899/860-869/864/864B.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	var s string
+	fmt.Fscan(reader, &s)
+
+	maxDistinct := 0
+	seen := make(map[rune]bool)
+	for _, ch := range s {
+		if 'a' <= ch && ch <= 'z' {
+			seen[ch] = true
+		} else {
+			if len(seen) > maxDistinct {
+				maxDistinct = len(seen)
+			}
+			seen = make(map[rune]bool)
+		}
+	}
+	if len(seen) > maxDistinct {
+		maxDistinct = len(seen)
+	}
+	fmt.Fprintln(writer, maxDistinct)
+}


### PR DESCRIPTION
## Summary
- add Go implementation for contest 864 problem B

## Testing
- `gofmt -w 0-999/800-899/860-869/864/864B.go`


------
https://chatgpt.com/codex/tasks/task_e_68814834709c8324ac8ecda462a05157