### PR TITLE
Add solution for 809D

### DIFF
--- a/0-999/800-899/800-809/809/809D.go
+++ b/0-999/800-899/800-809/809/809D.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	intervals := make([][2]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &intervals[i][0], &intervals[i][1])
+	}
+	const INF int64 = 1 << 60
+	dp := make([]int64, n+2)
+	for i := 1; i < len(dp); i++ {
+		dp[i] = INF
+	}
+	dp[0] = -INF
+	maxLen := 0
+	for _, it := range intervals {
+		l, r := it[0], it[1]
+		for j := maxLen; j >= 0; j-- {
+			if dp[j] == INF {
+				continue
+			}
+			x := dp[j] + 1
+			if x < l {
+				x = l
+			}
+			if x <= r && x < dp[j+1] {
+				dp[j+1] = x
+				if j+1 > maxLen {
+					maxLen = j + 1
+				}
+			}
+		}
+	}
+	fmt.Println(maxLen)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problemD in contest 809
- dynamic programming over intervals to maximize subsequence length

## Testing
- `go run 0-999/800-899/800-809/809/809D.go <<EOF
3
1 1
2 2
3 3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688172a7653c8324b8123a8e9b29a224