### PR TITLE
Add Go solution for 868A

### DIFF
--- a/0-999/800-899/860-869/868/868A.go
+++ b/0-999/800-899/860-869/868/868A.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var pass string
+	if _, err := fmt.Fscan(reader, &pass); err != nil {
+		return
+	}
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	haveFirst := false
+	haveSecond := false
+	for i := 0; i < n; i++ {
+		var w string
+		fmt.Fscan(reader, &w)
+		if w == pass {
+			fmt.Println("YES")
+			return
+		}
+		if w[1] == pass[0] {
+			haveFirst = true
+		}
+		if w[0] == pass[1] {
+			haveSecond = true
+		}
+	}
+	if haveFirst && haveSecond {
+		fmt.Println("YES")
+	} else {
+		fmt.Println("NO")
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for `problemA` of contest 868

## Testing
- `go build 0-999/800-899/860-869/868/868A.go`

------
https://chatgpt.com/codex/tasks/task_e_6881422e2d4c83249dd75962c1d5aa87