### PR TITLE
Add Go solution for problem 894A

### DIFF
--- a/0-999/800-899/890-899/894/894A.go
+++ b/0-999/800-899/890-899/894/894A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var s string
+	if _, err := fmt.Fscan(reader, &s); err != nil {
+		return
+	}
+	n := len(s)
+	count := 0
+	for i := 0; i < n; i++ {
+		if s[i] == 'Q' {
+			for j := i + 1; j < n; j++ {
+				if s[j] == 'A' {
+					for k := j + 1; k < n; k++ {
+						if s[k] == 'Q' {
+							count++
+						}
+					}
+				}
+			}
+		}
+	}
+	fmt.Println(count)
+}


### PR DESCRIPTION
## Summary
- implement solution 894A.go to count subsequences "QAQ"

## Testing
- `go build 0-999/800-899/890-899/894/894A.go`
- `echo QAQAQYSYIOIWIN | go run 0-999/800-899/890-899/894/894A.go`

------
https://chatgpt.com/codex/tasks/task_e_6881396abeb483249c91b99a7fe2de70