### PR TITLE
Add Go solution for 894B

### DIFF
--- a/0-999/800-899/890-899/894/894B.go
+++ b/0-999/800-899/890-899/894/894B.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 1000000007
+const modExp int64 = mod - 1
+
+func powMod(base, exp int64) int64 {
+	res := int64(1)
+	base %= mod
+	for exp > 0 {
+		if exp&1 == 1 {
+			res = res * base % mod
+		}
+		base = base * base % mod
+		exp >>= 1
+	}
+	return res
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n, m, k int64
+	if _, err := fmt.Fscan(reader, &n, &m, &k); err != nil {
+		return
+	}
+	if k == -1 && (n%2 != m%2) {
+		fmt.Println(0)
+		return
+	}
+	exp := ((n - 1) % modExp * ((m - 1) % modExp)) % modExp
+	fmt.Println(powMod(2, exp))
+}


### PR DESCRIPTION
## Summary
- implement solution to problem B in `894`
- use modular exponentiation for `2^((n-1)*(m-1))`
- handle parity case when `k = -1`

## Testing
- `go run 0-999/800-899/890-899/894/894B.go <<EOF
1 2 1
EOF`
- `go run 0-999/800-899/890-899/894/894B.go <<EOF
1 2 -1
EOF`
- `go build 0-999/800-899/890-899/894/894B.go`


------
https://chatgpt.com/codex/tasks/task_e_6881392494b483248f93ca176b376304