### PR TITLE
Add Go solution for Balanced Substring 873B

### DIFF
--- a/0-999/800-899/870-879/873/873B.go
+++ b/0-999/800-899/870-879/873/873B.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	var s string
+	fmt.Fscan(reader, &s)
+
+	diffPos := make(map[int]int)
+	diffPos[0] = 0
+	diff := 0
+	best := 0
+
+	for i := 1; i <= n; i++ {
+		if s[i-1] == '1' {
+			diff++
+		} else {
+			diff--
+		}
+		if pos, ok := diffPos[diff]; ok {
+			if i-pos > best {
+				best = i - pos
+			}
+		} else {
+			diffPos[diff] = i
+		}
+	}
+
+	fmt.Fprintln(writer, best)
+}


### PR DESCRIPTION
## Summary
- implement `873B.go` with prefix-difference map approach

## Testing
- `go build 873B.go`

------
https://chatgpt.com/codex/tasks/task_e_688175f0cee4832493c30322b45db9d4