### PR TITLE
Add Go solution for tournament possible winners

### DIFF
--- a/0-999/800-899/870-879/878/878C.go
+++ b/0-999/800-899/870-879/878/878C.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func dominates(a, b []int) bool {
+	for i := range a {
+		if a[i] <= b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, k int
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+
+	nondom := make([][]int, 0)
+	for i := 0; i < n; i++ {
+		p := make([]int, k)
+		for j := 0; j < k; j++ {
+			fmt.Fscan(in, &p[j])
+		}
+
+		// check if any existing nondominated player dominates p
+		dominated := false
+		for _, q := range nondom {
+			if dominates(q, p) {
+				dominated = true
+				break
+			}
+		}
+		if !dominated {
+			// remove players dominated by p
+			newSet := nondom[:0]
+			for _, q := range nondom {
+				if !dominates(p, q) {
+					newSet = append(newSet, q)
+				}
+			}
+			nondom = append(newSet, p)
+		}
+
+		fmt.Fprintln(out, len(nondom))
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for 878/problem C (tournament winners)

## Testing
- `go build 0-999/800-899/870-879/878/878C.go`


------
https://chatgpt.com/codex/tasks/task_e_68817cc97f3c832495b3ffbb5d8b3c18