### PR TITLE
Add Go solution for 859A

### DIFF
--- a/0-999/800-899/850-859/859/859A.go
+++ b/0-999/800-899/850-859/859/859A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var k int
+	if _, err := fmt.Fscan(reader, &k); err != nil {
+		return
+	}
+	maxRank := 0
+	for i := 0; i < k; i++ {
+		var r int
+		fmt.Fscan(reader, &r)
+		if r > maxRank {
+			maxRank = r
+		}
+	}
+	if maxRank < 25 {
+		fmt.Fprintln(writer, 0)
+	} else {
+		fmt.Fprintln(writer, maxRank-25)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 859A

## Testing
- `gofmt -w 0-999/800-899/850-859/859/859A.go`
- `go vet ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68817efa7cbc8324ba9a785f865c9ce5