### PR TITLE
Add Go solution for 858C

### DIFF
--- a/0-999/800-899/850-859/858/858C.go
+++ b/0-999/800-899/850-859/858/858C.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func isVowel(c byte) bool {
+	switch c {
+	case 'a', 'e', 'i', 'o', 'u':
+		return true
+	}
+	return false
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var s string
+	if _, err := fmt.Fscan(in, &s); err != nil {
+		return
+	}
+
+	cur := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if len(cur) >= 2 && !isVowel(c) && !isVowel(cur[len(cur)-1]) && !isVowel(cur[len(cur)-2]) && !(c == cur[len(cur)-1] && cur[len(cur)-1] == cur[len(cur)-2]) {
+			out.Write(cur)
+			out.WriteByte(' ')
+			cur = cur[:0]
+		}
+		cur = append(cur, c)
+	}
+	out.Write(cur)
+	out.WriteByte('\n')
+}


### PR DESCRIPTION
## Summary
- implement Beroffice editor split logic in `858C.go`

## Testing
- `gofmt -w 0-999/800-899/850-859/858/858C.go`
- `go build 0-999/800-899/850-859/858/858C.go`


------
https://chatgpt.com/codex/tasks/task_e_6881835c37a4832483aea95f41ddd543