### PR TITLE
Add Go solution for problem 825C

### DIFF
--- a/0-999/800-899/820-829/825/825C.go
+++ b/0-999/800-899/820-829/825/825C.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	var k int64
+	if _, err := fmt.Fscan(reader, &n, &k); err != nil {
+		return
+	}
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+
+	ans := 0
+	for _, ai := range a {
+		need := (ai + 1) / 2
+		for k < need {
+			k *= 2
+			ans++
+		}
+		if ai > k {
+			k = ai
+		}
+	}
+
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement solution for problem C in contest 825 using Go

## Testing
- `gofmt -w 0-999/800-899/820-829/825/825C.go`


------
https://chatgpt.com/codex/tasks/task_e_68819bdf1e508324b5176bb51edce27c