### PR TITLE
Add Go solution for 822D

### DIFF
--- a/0-999/800-899/820-829/822/822D.go
+++ b/0-999/800-899/820-829/822/822D.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const MOD int64 = 1000000007
+const MAXN int = 5000000
+
+var spf []int
+var f []int64
+
+func sieve(n int) {
+	spf = make([]int, n+1)
+	primes := []int{}
+	for i := 2; i <= n; i++ {
+		if spf[i] == 0 {
+			spf[i] = i
+			primes = append(primes, i)
+		}
+		for _, p := range primes {
+			if p > spf[i] || i*p > n {
+				break
+			}
+			spf[i*p] = p
+		}
+	}
+}
+
+func precompute(n int) {
+	f = make([]int64, n+1)
+	f[1] = 0
+	for i := 2; i <= n; i++ {
+		p := spf[i]
+		f[i] = f[i/p] + int64(i)*(int64(p)-1)/2
+	}
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int64
+	var l, r int
+	if _, err := fmt.Fscan(reader, &t, &l, &r); err != nil {
+		return
+	}
+
+	sieve(r)
+	precompute(r)
+
+	res := int64(0)
+	pow := int64(1)
+	for i := l; i <= r; i++ {
+		res = (res + pow*(f[i]%MOD)) % MOD
+		pow = pow * t % MOD
+	}
+	fmt.Fprintln(writer, res%MOD)
+}


### PR DESCRIPTION
## Summary
- implement solution for 822D in Go
- use sieve to compute smallest prime factors
- precompute minimal comparisons for all n up to 5e6
- evaluate requested sum modulo 1e9+7

## Testing
- `go vet 0-999/800-899/820-829/822/822D.go`
- `go build 0-999/800-899/820-829/822/822D.go`
- `echo "2 2 4" | ./822D`

------
https://chatgpt.com/codex/tasks/task_e_68819cf7890083249c7656bbe6425068