### PR TITLE
Improve webserver instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,61 @@ cd 0-999/0-99/90-99/90
 go run verifierA.go ./mySolutionA
 go run verifierB.go ./mySolutionB
 ```
+
+## Running the local webserver
+
+The `webserver.go` program lets you browse contests and test solutions
+directly from your browser. Launch it from the repository root:
+
+```bash
+go run webserver.go
+```
+
+Open <http://localhost:8081> to see the list of contests. Each problem page
+allows you to paste code or upload a file in C, C++, Go, Rust, Java or Python.
+If a verifier is present in the contest directory it will run automatically
+after compilation.
+
+### Required compilers
+
+The web server relies on external compilers/interpreters. Install the
+following tools so every language option works:
+
+- `gcc` and `g++`
+- `javac`/`java`
+- `go`
+- `rustc`
+- `python3`
+
+Below are minimal installation commands for common platforms.
+
+**Linux (Debian/Ubuntu)**
+
+```bash
+sudo apt update
+sudo apt install build-essential openjdk-17-jdk golang rustc python3
+```
+
+**macOS (Homebrew)**
+
+```bash
+brew install gcc openjdk go rust python
+```
+
+**Windows**
+
+- Install [MSYS2](https://www.msys2.org/) or enable the
+  [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl/).
+- With MSYS2 you can run:
+
+```bash
+pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-libgfortran \
+  mingw-w64-x86_64-go mingw-w64-x86_64-rust mingw-w64-x86_64-python
+```
+
+Alternatively use the official installers for
+[MinGW-w64](https://www.mingw-w64.org/),
+[Adoptium JDK](https://adoptium.net/),
+[Go](https://go.dev/dl/),
+[Rust](https://rustup.rs/) and
+[Python](https://www.python.org/downloads/).


### PR DESCRIPTION
## Summary
- update README with webserver usage
- document compiler requirements for macOS, Linux, and Windows

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain main module)*
- `go run webserver.go`

------
https://chatgpt.com/codex/tasks/task_e_68819e4250bc8324859369e89d995fa0