### PR TITLE
Add Go solution for problem 888C

### DIFF
--- a/0-999/800-899/880-889/888/888C.go
+++ b/0-999/800-899/880-889/888/888C.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var s string
+	if _, err := fmt.Fscan(reader, &s); err != nil {
+		return
+	}
+
+	n := len(s)
+	best := n + 1
+	for ch := byte('a'); ch <= byte('z'); ch++ {
+		last := -1
+		maxDiff := 0
+		for i := 0; i < n; i++ {
+			if s[i] == ch {
+				diff := i - last
+				if diff > maxDiff {
+					maxDiff = diff
+				}
+				last = i
+			}
+		}
+		diff := n - last
+		if diff > maxDiff {
+			maxDiff = diff
+		}
+		if maxDiff < best {
+			best = maxDiff
+		}
+	}
+
+	fmt.Fprintln(writer, best)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for finding minimal k with a k-dominant character

## Testing
- `go build 0-999/800-899/880-889/888/888C.go`


------
https://chatgpt.com/codex/tasks/task_e_6881a27201048324817c8facb37c237f