### PR TITLE
Add Go solution for problem 764B

### DIFF
--- a/0-999/700-799/760-769/764/764B.go
+++ b/0-999/700-799/760-769/764/764B.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	for i := 0; i < n/2; i++ {
+		if i%2 == 0 {
+			j := n - 1 - i
+			a[i], a[j] = a[j], a[i]
+		}
+	}
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			fmt.Fprint(out, " ")
+		}
+		fmt.Fprint(out, a[i])
+	}
+	fmt.Fprintln(out)
+}


### PR DESCRIPTION
## Summary
- implement `764B.go` to solve Timofey and cubes

## Testing
- `go vet 0-999/700-799/760-769/764/764B.go`
- `go build 0-999/700-799/760-769/764/764B.go`


------
https://chatgpt.com/codex/tasks/task_e_6881ab0033108324a928de1aaf22006c