### PR TITLE
Add Go solution for problem 765C

### DIFF
--- a/0-999/700-799/760-769/765/765C.go
+++ b/0-999/700-799/760-769/765/765C.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var k, a, b int64
+	if _, err := fmt.Fscan(reader, &k, &a, &b); err != nil {
+		return
+	}
+	if (a < k && b < k) || (a%k != 0 && b%k != 0) || (a%k != 0 && b < k) || (b%k != 0 && a < k) {
+		fmt.Fprintln(writer, -1)
+		return
+	}
+	fmt.Fprintln(writer, a/k+b/k)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 765C

## Testing
- `go test ./...` *(fails: pattern ./... does not contain main module)*
- `go build 0-999/700-799/760-769/765/765C.go`

------
https://chatgpt.com/codex/tasks/task_e_6881ac5f0e3c8324bff7538904383f16