### PR TITLE
Add Go solution for 765B

### DIFF
--- a/0-999/700-799/760-769/765/765B.go
+++ b/0-999/700-799/760-769/765/765B.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var s string
+	if _, err := fmt.Fscan(reader, &s); err != nil {
+		return
+	}
+
+	seen := make([]bool, 26)
+	next := byte('a')
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 'a' || c > 'z' {
+			fmt.Fprintln(writer, "NO")
+			return
+		}
+		if !seen[c-'a'] {
+			if c != next {
+				fmt.Fprintln(writer, "NO")
+				return
+			}
+			seen[c-'a'] = true
+			next++
+		}
+	}
+	fmt.Fprintln(writer, "YES")
+}


### PR DESCRIPTION
## Summary
- add solution `765B.go` implementing alphabetical identifier check

## Testing
- `gofmt -w 0-999/700-799/760-769/765/765B.go`
- `go build 0-999/700-799/760-769/765/765B.go`


------
https://chatgpt.com/codex/tasks/task_e_6881aca58abc83249aa7f52535baf803