### PR TITLE
Add Go solution for Snacktower 767A

### DIFF
--- a/0-999/700-799/760-769/767/767A.go
+++ b/0-999/700-799/760-769/767/767A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	arrived := make([]bool, n+1)
+	expected := n
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(reader, &x)
+		arrived[x] = true
+		first := true
+		for expected > 0 && arrived[expected] {
+			if !first {
+				writer.WriteByte(' ')
+			}
+			fmt.Fprint(writer, expected)
+			expected--
+			first = false
+		}
+		writer.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 767A Snacktower

## Testing
- `go vet 0-999/700-799/760-769/767/767A.go`
- `go build 0-999/700-799/760-769/767/767A.go`


------
https://chatgpt.com/codex/tasks/task_e_6881af1ccb0083248a22fc5df859be05