### PR TITLE
Add Go solution for 768E Game of Stones

### DIFF
--- a/0-999/700-799/760-769/768/768E.go
+++ b/0-999/700-799/760-769/768/768E.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	grundy := make([]int, 61)
+	for s := 1; s <= 60; s++ {
+		g := 1
+		for (g+1)*(g+2)/2 <= s {
+			g++
+		}
+		grundy[s] = g
+	}
+	xor := 0
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(in, &x)
+		xor ^= grundy[x]
+	}
+	if xor == 0 {
+		fmt.Println("YES")
+	} else {
+		fmt.Println("NO")
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation solving problem `768E`

## Testing
- `go build 0-999/700-799/760-769/768/768E.go`


------
https://chatgpt.com/codex/tasks/task_e_6881b0c1e64483249a4d7e0d6f208706