### PR TITLE
Add Go solution for 768B

### DIFF
--- a/0-999/700-799/760-769/768/768B.go
+++ b/0-999/700-799/760-769/768/768B.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var lenMemo map[int64]int64
+var onesMemo map[int64]int64
+
+func seqLen(n int64) int64 {
+	if n <= 1 {
+		return 1
+	}
+	if v, ok := lenMemo[n]; ok {
+		return v
+	}
+	v := 2*seqLen(n/2) + 1
+	lenMemo[n] = v
+	return v
+}
+
+func onesCount(n int64) int64 {
+	if n <= 1 {
+		return n
+	}
+	if v, ok := onesMemo[n]; ok {
+		return v
+	}
+	v := 2*onesCount(n/2) + n%2
+	onesMemo[n] = v
+	return v
+}
+
+func prefix(n, pos int64) int64 {
+	if pos <= 0 || n == 0 {
+		return 0
+	}
+	if n == 1 {
+		if pos >= 1 {
+			return 1
+		}
+		return 0
+	}
+	leftLen := seqLen(n / 2)
+	if pos <= leftLen {
+		return prefix(n/2, pos)
+	}
+	leftOnes := onesCount(n / 2)
+	if pos == leftLen+1 {
+		return leftOnes + n%2
+	}
+	return leftOnes + n%2 + prefix(n/2, pos-leftLen-1)
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, l, r int64
+	if _, err := fmt.Fscan(in, &n, &l, &r); err != nil {
+		return
+	}
+	lenMemo = make(map[int64]int64)
+	onesMemo = make(map[int64]int64)
+	ans := prefix(n, r) - prefix(n, l-1)
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement recursion-based solution for problem B in contest 768
- compute sequence length and prefix sums with memoization

## Testing
- `go run 0-999/700-799/760-769/768/768B.go <<EOF
7 2 5
EOF`
- `go run 0-999/700-799/760-769/768/768B.go <<EOF
10 3 10
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6881b220a0448324adb2790a91ef42f0