### PR TITLE
Add Go solution for 768A

### DIFF
--- a/0-999/700-799/760-769/768/768A.go
+++ b/0-999/700-799/760-769/768/768A.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	if n == 0 {
+		fmt.Fprintln(out, 0)
+		return
+	}
+	minVal, maxVal := a[0], a[0]
+	for _, v := range a {
+		if v < minVal {
+			minVal = v
+		}
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	count := 0
+	for _, v := range a {
+		if v > minVal && v < maxVal {
+			count++
+		}
+	}
+	fmt.Fprintln(out, count)
+}


### PR DESCRIPTION
## Summary
- implement problem 768A solution in Go

## Testing
- `go vet 0-999/700-799/760-769/768/768A.go`
- `go build 0-999/700-799/760-769/768/768A.go`


------
https://chatgpt.com/codex/tasks/task_e_6881b266bb108324ad60dab2c206fdc7