### PR TITLE
Add Go solution for 766A

### DIFF
--- a/0-999/700-799/760-769/766/766A.go
+++ b/0-999/700-799/760-769/766/766A.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var a, b string
+	fmt.Fscan(reader, &a)
+	fmt.Fscan(reader, &b)
+	if a == b {
+		fmt.Println(-1)
+	} else if len(a) > len(b) {
+		fmt.Println(len(a))
+	} else {
+		fmt.Println(len(b))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 766A

## Testing
- `go build 0-999/700-799/760-769/766/766A.go`
- `echo -e "abcd\ndefgh" | go run 0-999/700-799/760-769/766/766A.go`
- `echo -e "same\nsame" | go run 0-999/700-799/760-769/766/766A.go`


------
https://chatgpt.com/codex/tasks/task_e_6881b4de1c24832490c749fde3ff656b