### PR TITLE
Add Go solution for problem 797B

### DIFF
--- a/0-999/700-799/790-799/797/797B.go
+++ b/0-999/700-799/790-799/797/797B.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	sum := 0
+	const inf = int(1e9)
+	minPosOdd := inf
+	maxNegOdd := -inf
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(reader, &x)
+		if x > 0 {
+			sum += x
+		}
+		if x%2 != 0 {
+			if x > 0 {
+				if x < minPosOdd {
+					minPosOdd = x
+				}
+			} else {
+				if x > maxNegOdd {
+					maxNegOdd = x
+				}
+			}
+		}
+	}
+	if sum%2 == 1 {
+		fmt.Println(sum)
+		return
+	}
+	best := -inf
+	if minPosOdd != inf {
+		if s := sum - minPosOdd; s%2 != 0 && s > best {
+			best = s
+		}
+	}
+	if maxNegOdd != -inf {
+		if s := sum + maxNegOdd; s%2 != 0 && s > best {
+			best = s
+		}
+	}
+	fmt.Println(best)
+}


### PR DESCRIPTION
## Summary
- implement `797B.go` with an odd-sum subsequence solver using greedy parity logic

## Testing
- `go build 0-999/700-799/790-799/797/797B.go`


------
https://chatgpt.com/codex/tasks/task_e_6881b63cc2408324a8fe6cb58c16d710