### PR TITLE
Add naive Go solution for 799F

### DIFF
--- a/0-999/700-799/790-799/799/799F.go
+++ b/0-999/700-799/790-799/799/799F.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return
+	}
+	l := make([]int, n)
+	r := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &l[i], &r[i])
+	}
+	total := 0
+	for a := 1; a <= m; a++ {
+		for b := a; b <= m; b++ {
+			valid := false
+			ok := true
+			for i := 0; i < n; i++ {
+				start := a
+				if l[i] > start {
+					start = l[i]
+				}
+				end := b
+				if r[i] < end {
+					end = r[i]
+				}
+				length := end - start + 1
+				if start > end {
+					length = 0
+				}
+				if length > 0 {
+					valid = true
+				}
+				if length%2 == 0 {
+					if length != 0 {
+						ok = false
+						break
+					}
+				}
+			}
+			if ok && valid {
+				total += b - a + 1
+			}
+		}
+	}
+	fmt.Println(total)
+}


### PR DESCRIPTION
## Summary
- implement a simple brute force solution for problem 799F

## Testing
- `gofmt -w 0-999/700-799/790-799/799/799F.go`

------
https://chatgpt.com/codex/tasks/task_e_6881b70f4cec83248e8dbace9d1ef3d1