### PR TITLE
Add Go solution for 796A

### DIFF
--- a/0-999/700-799/790-799/796/796A.go
+++ b/0-999/700-799/790-799/796/796A.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, m, k int
+	if _, err := fmt.Fscan(reader, &n, &m, &k); err != nil {
+		return
+	}
+	houses := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &houses[i])
+	}
+
+	const inf = int(1e9)
+	ans := inf
+	for i, cost := range houses {
+		if cost != 0 && cost <= k {
+			dist := abs(i+1-m) * 10
+			if dist < ans {
+				ans = dist
+			}
+		}
+	}
+
+	fmt.Fprintln(writer, ans)
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}


### PR DESCRIPTION
## Summary
- implement solver for problem 796A

## Testing
- `gofmt -w 0-999/700-799/790-799/796/796A.go`
- `go build 0-999/700-799/790-799/796/796A.go`

------
https://chatgpt.com/codex/tasks/task_e_6881bae524e48324b1d7f8ebe82e6c55