### PR TITLE
Add Go solution for problem 793D

### DIFF
--- a/0-999/700-799/790-799/793/793D.go
+++ b/0-999/700-799/790-799/793/793D.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+type Edge struct{to int; w int}
+
+func solve(reader *bufio.Reader, writer *bufio.Writer){
+    var n,k int
+    if _, err := fmt.Fscan(reader, &n, &k); err != nil {
+        return
+    }
+    var m int
+    fmt.Fscan(reader, &m)
+    adj := make([][]Edge, n+1)
+    for i:=0;i<m;i++{
+        var u,v,c int
+        fmt.Fscan(reader,&u,&v,&c)
+        adj[u]=append(adj[u],Edge{v,c})
+    }
+    // state encoding
+    Np := n+2
+    encode := func(L,R,pos int) int {
+        return ((L*Np+R)*n + (pos-1))
+    }
+    decode := func(code int)(L,R,pos int){
+        pos = code% n +1
+        code/=n
+        R = code%Np
+        L = code/Np
+        return
+    }
+    const INF int64 = 1<<60
+    dpPrev := map[int]int64{}
+    for i:=1;i<=n;i++{
+        idx := encode(0,n+1,i)
+        dpPrev[idx]=0
+    }
+    for step:=1; step<k; step++{
+        dpNext := map[int]int64{}
+        for idx,cost := range dpPrev {
+            L,R,pos := decode(idx)
+            for _,e := range adj[pos]{
+                next := e.to
+                if next<=L || next>=R || next==pos {continue}
+                var newL,newR int
+                if next>pos {
+                    newL = pos
+                    newR = R
+                }else{
+                    newL = L
+                    newR = pos
+                }
+                nidx := encode(newL,newR,next)
+                nc := cost + int64(e.w)
+                if old,ok := dpNext[nidx]; !ok || nc<old{
+                    dpNext[nidx]=nc
+                }
+            }
+        }
+        dpPrev = dpNext
+        if len(dpPrev)==0 {break}
+    }
+    ans := INF
+    for _,cost := range dpPrev{
+        if cost<ans{ ans=cost }
+    }
+    if ans==INF{ fmt.Fprintln(writer,-1) } else { fmt.Fprintln(writer,ans) }
+}
+
+func main(){
+    reader := bufio.NewReader(os.Stdin)
+    writer := bufio.NewWriter(os.Stdout)
+    solve(reader,writer)
+    writer.Flush()
+}


### PR DESCRIPTION
## Summary
- implement solution for problem D in contest 793

## Testing
- `go build 0-999/700-799/790-799/793/793D.go`
- `echo '7 4
4
1 6 2
6 2 2
2 4 2
2 7 1
' | go run 793D.go`
- `echo '4 3
4
2 1 2
1 3 2
3 4 2
4 1 1
' | go run 793D.go`


------
https://chatgpt.com/codex/tasks/task_e_6881bb712f548324857b1d4fa41d8007