### PR TITLE
Add Go solution for 792A

### DIFF
--- a/0-999/700-799/790-799/792/792A.go
+++ b/0-999/700-799/790-799/792/792A.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	sort.Ints(a)
+	minDiff := a[1] - a[0]
+	count := 1
+	for i := 1; i < n-1; i++ {
+		diff := a[i+1] - a[i]
+		if diff < minDiff {
+			minDiff = diff
+			count = 1
+		} else if diff == minDiff {
+			count++
+		}
+	}
+	fmt.Printf("%d %d\n", minDiff, count)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 792A

## Testing
- `go run 0-999/700-799/790-799/792/792A.go <<EOF
2
1 3
EOF`
- `go run 0-999/700-799/790-799/792/792A.go <<EOF
5
4 2 1 6 5
EOF`
- `go vet 0-999/700-799/790-799/792/792A.go`


------
https://chatgpt.com/codex/tasks/task_e_6881bf46e63c8324af48543b33a95824