### PR TITLE
Add Go solution for problem 785A

### DIFF
--- a/0-999/700-799/780-789/785/785A.go
+++ b/0-999/700-799/780-789/785/785A.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	total := 0
+	for i := 0; i < n; i++ {
+		var s string
+		fmt.Fscan(reader, &s)
+		switch s {
+		case "Tetrahedron":
+			total += 4
+		case "Cube":
+			total += 6
+		case "Octahedron":
+			total += 8
+		case "Dodecahedron":
+			total += 12
+		case "Icosahedron":
+			total += 20
+		}
+	}
+	fmt.Fprintln(writer, total)
+}


### PR DESCRIPTION
## Summary
- implement solution for contest 785 problem A

## Testing
- `go run 0-999/700-799/780-789/785/785A.go <<EOF
4
Icosahedron
Cube
Tetrahedron
Dodecahedron
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6881c0a5b3488324877c81e6e5db2386