### PR TITLE
Add Go solution for problem 784F

### DIFF
--- a/0-999/700-799/780-789/784/784F.go
+++ b/0-999/700-799/780-789/784/784F.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+	}
+	sort.Ints(arr)
+	for i, v := range arr {
+		if i > 0 {
+			fmt.Fprint(writer, " ")
+		}
+		fmt.Fprint(writer, v)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go program `784F.go` to sort an array of ticket prices

## Testing
- `go build 0-999/700-799/780-789/784/784F.go`
- `echo '5 4 2 5 1 3' | ./784F`

------
https://chatgpt.com/codex/tasks/task_e_6881c178349c83249228779061c7e165