### PR TITLE
Add solution for 784D

### DIFF
--- a/0-999/700-799/780-789/784/784D.go
+++ b/0-999/700-799/780-789/784/784D.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var s string
+	fmt.Fscan(in, &s)
+	ok := true
+	for i := 0; i < len(s)/2; i++ {
+		if s[i] != s[len(s)-1-i] {
+			ok = false
+			break
+		}
+	}
+	if ok {
+		fmt.Println("Yes")
+	} else {
+		fmt.Println("No")
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for the 784D task

## Testing
- `go build 0-999/700-799/780-789/784/784D.go`


------
https://chatgpt.com/codex/tasks/task_e_6881c13206608324b5489b6e5b984f0c