### PR TITLE
Add Go solution for 784B

### DIFF
--- a/0-999/700-799/780-789/784/784B.go
+++ b/0-999/700-799/780-789/784/784B.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int64
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	var res int64
+	if n%2 == 0 {
+		res = n / 2
+	} else {
+		res = -((n + 1) / 2)
+	}
+	fmt.Print(res)
+}


### PR DESCRIPTION
## Summary
- add solution for problem B in contest 784

## Testing
- `go run 0-999/700-799/780-789/784/784B.go <<EOF
5
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6881c2049c2c832493c20d0a01638375