### PR TITLE
Add Go solution for 784C

### DIFF
--- a/0-999/700-799/780-789/784/784C.go
+++ b/0-999/700-799/780-789/784/784C.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	maxVal := 0
+	last := 0
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(reader, &x)
+		if x > maxVal {
+			maxVal = x
+		}
+		last = x
+	}
+	fmt.Println(maxVal ^ last)
+}


### PR DESCRIPTION
## Summary
- implement solution for INTERCALC (784C)

## Testing
- `go run 0-999/700-799/780-789/784/784C.go < sample.in`

------
https://chatgpt.com/codex/tasks/task_e_6881c1be683483248fc02e69f1c20cef