### PR TITLE
Add Go solution for 784A

### DIFF
--- a/0-999/700-799/780-789/784/784A.go
+++ b/0-999/700-799/780-789/784/784A.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var a int
+	if _, err := fmt.Fscan(in, &a); err != nil {
+		return
+	}
+	seq := []int{4, 22, 27, 58, 85, 94, 121, 166, 202, 265, 274, 319, 346, 355, 378, 382, 391, 438, 454, 483, 517, 526, 535, 562, 576, 588, 627, 634, 636, 645}
+	if a >= 1 && a <= len(seq) {
+		fmt.Println(seq[a-1])
+	}
+}


### PR DESCRIPTION
## Summary
- implement 784A solution in Go

## Testing
- `go vet 0-999/700-799/780-789/784/784A.go`
- `go build 0-999/700-799/780-789/784/784A.go`
- `echo 3 | go run 0-999/700-799/780-789/784/784A.go`

------
https://chatgpt.com/codex/tasks/task_e_6881c24aea0c83249024c1d8bd28935d