### PR TITLE
Add Go solution for 755C

### DIFF
--- a/0-999/700-799/750-759/755/755C.go
+++ b/0-999/700-799/750-759/755/755C.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type DSU struct {
+	parent []int
+}
+
+func NewDSU(n int) *DSU {
+	p := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		p[i] = i
+	}
+	return &DSU{parent: p}
+}
+
+func (d *DSU) Find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.Find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) Union(x, y int) {
+	fx := d.Find(x)
+	fy := d.Find(y)
+	if fx != fy {
+		d.parent[fx] = fy
+	}
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	dsu := NewDSU(n)
+	for i := 1; i <= n; i++ {
+		var p int
+		fmt.Fscan(reader, &p)
+		dsu.Union(i, p)
+	}
+
+	seen := make(map[int]struct{})
+	for i := 1; i <= n; i++ {
+		seen[dsu.Find(i)] = struct{}{}
+	}
+	fmt.Fprintln(writer, len(seen))
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 755C

## Testing
- `go build 0-999/700-799/750-759/755/755C.go`
- `go vet ./...` *(fails: "pattern ./...: directory prefix . does not contain main module or its selected dependencies")*

------
https://chatgpt.com/codex/tasks/task_e_6881c96bc1948324aab1b322a9d040f1