### PR TITLE
Add Go solution for Codeforces 780A

### DIFF
--- a/0-999/700-799/780-789/780/780A.go
+++ b/0-999/700-799/780-789/780/780A.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	table := make(map[int]bool)
+	current := 0
+	maxCount := 0
+	for i := 0; i < 2*n; i++ {
+		var x int
+		fmt.Fscan(reader, &x)
+		if table[x] {
+			delete(table, x)
+			current--
+		} else {
+			table[x] = true
+			current++
+			if current > maxCount {
+				maxCount = current
+			}
+		}
+	}
+	fmt.Fprintln(writer, maxCount)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 780A

## Testing
- `gofmt -w 0-999/700-799/780-789/780/780A.go`


------
https://chatgpt.com/codex/tasks/task_e_6881c77f59788324b95e0f1375214adf