### PR TITLE
Add Go solution for 780B

### DIFF
--- a/0-999/700-799/780-789/780/780B.go
+++ b/0-999/700-799/780-789/780/780B.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	x := make([]float64, n)
+	v := make([]float64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &x[i])
+	}
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &v[i])
+	}
+
+	ok := func(t float64) bool {
+		left := -1e18
+		right := 1e18
+		for i := 0; i < n; i++ {
+			l := x[i] - v[i]*t
+			r := x[i] + v[i]*t
+			if l > left {
+				left = l
+			}
+			if r < right {
+				right = r
+			}
+		}
+		return left <= right
+	}
+
+	lo, hi := 0.0, 1e9
+	for iter := 0; iter < 100; iter++ {
+		mid := (lo + hi) / 2
+		if ok(mid) {
+			hi = mid
+		} else {
+			lo = mid
+		}
+	}
+	fmt.Printf("%.10f\n", hi)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 780B using binary search on time

## Testing
- `gofmt -w 0-999/700-799/780-789/780/780B.go`
- `go build 0-999/700-799/780-789/780/780B.go`


------
https://chatgpt.com/codex/tasks/task_e_6881c73926f483248c18c5f1d3cb0c5b