### PR TITLE
Add Go solution for 751B

### DIFF
--- a/0-999/700-799/750-759/751/751B.go
+++ b/0-999/700-799/750-759/751/751B.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, d int
+	fmt.Fscan(in, &n, &d)
+	cities := make(map[int]struct{}, n)
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(in, &x)
+		cities[x] = struct{}{}
+	}
+
+	count := 0
+	for x := range cities {
+		if _, ok := cities[x+d]; ok {
+			count++
+		}
+	}
+	fmt.Fprintln(out, count)
+}


### PR DESCRIPTION
## Summary
- implement solution to problem 751B using a map to count city pairs at distance `d`

## Testing
- `gofmt -w 0-999/700-799/750-759/751/751B.go`
- `go build 0-999/700-799/750-759/751/751B.go`


------
https://chatgpt.com/codex/tasks/task_e_6881cea0a0e88324a63bed885b978bda