### PR TITLE
Add Go solution for problem 776E

### DIFF
--- a/0-999/700-799/770-779/776/776E.go
+++ b/0-999/700-799/770-779/776/776E.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod = 1000000007
+
+// phi computes Euler's totient of n.
+func phi(n int64) int64 {
+	result := n
+	m := n
+	for i := int64(2); i*i <= m; i++ {
+		if m%i == 0 {
+			for m%i == 0 {
+				m /= i
+			}
+			result = result / i * (i - 1)
+		}
+	}
+	if m > 1 {
+		result = result / m * (m - 1)
+	}
+	return result
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, k int64
+	fmt.Fscan(in, &n, &k)
+	// For any k >= 1, Fk(n) equals phi(n)
+	ans := phi(n) % mod
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement solution for problem E of 776
- compute Euler's totient of `n` which equals `Fk(n)` for any `k ≥ 1`

## Testing
- `go build 0-999/700-799/770-779/776/776E.go`


------
https://chatgpt.com/codex/tasks/task_e_6881d46167d4832490dcbfcebab9571f