### PR TITLE
Add Go solution for 787A

### DIFF
--- a/0-999/700-799/780-789/787/787A.go
+++ b/0-999/700-799/780-789/787/787A.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var a, b int
+	if _, err := fmt.Fscan(reader, &a, &b); err != nil {
+		return
+	}
+	var c, d int
+	if _, err := fmt.Fscan(reader, &c, &d); err != nil {
+		return
+	}
+
+	// iterate over Rick's scream times and check when Morty matches
+	// upper bound large enough for given constraints
+	for t := b; t <= 100000; t += a {
+		if t >= d && (t-d)%c == 0 {
+			fmt.Println(t)
+			return
+		}
+	}
+	fmt.Println(-1)
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problemA.txt for problem 787A

## Testing
- `go run 0-999/700-799/780-789/787/787A.go <<EOF
1 2
3 4
EOF`
- `go vet 0-999/700-799/780-789/787/787A.go`


------
https://chatgpt.com/codex/tasks/task_e_6881c54e5d948324bf85ccc58b3fd30e