### PR TITLE
Add Go solution for Codeforces 779B

### DIFF
--- a/0-999/700-799/770-779/779/779B.go
+++ b/0-999/700-799/770-779/779/779B.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var nStr string
+	var k int
+	if _, err := fmt.Fscan(reader, &nStr, &k); err != nil {
+		return
+	}
+	zeroCount := 0
+	removed := 0
+	for i := len(nStr) - 1; i >= 0 && zeroCount < k; i-- {
+		if nStr[i] == '0' {
+			zeroCount++
+		} else {
+			removed++
+		}
+	}
+	if zeroCount < k {
+		fmt.Println(len(nStr) - 1)
+	} else {
+		fmt.Println(removed)
+	}
+}


### PR DESCRIPTION
## Summary
- Implemented a Go solution for problem 779B
- Added file `779B.go` under contest directory `0-999/700-799/770-779/779`

## Testing
- `go run 0-999/700-799/770-779/779/779B.go <<EOF
30020 3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6881d7f1b158832486f9c53536f2d225