### PR TITLE
Add solution for problem 770B

### DIFF
--- a/0-999/700-799/770-779/770/770B.go
+++ b/0-999/700-799/770-779/770/770B.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func digitSumStr(s string) int {
+	sum := 0
+	for i := 0; i < len(s); i++ {
+		sum += int(s[i] - '0')
+	}
+	return sum
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var s string
+	if _, err := fmt.Fscan(in, &s); err != nil {
+		return
+	}
+	x, _ := strconv.ParseInt(s, 10, 64)
+	best := x
+	bestSum := digitSumStr(s)
+
+	for i := 0; i < len(s); i++ {
+		if s[i] == '0' {
+			continue
+		}
+		t := s[:i] + string(s[i]-1) + strings.Repeat("9", len(s)-i-1)
+		num, _ := strconv.ParseInt(t, 10, 64)
+		if num <= 0 {
+			continue
+		}
+		sum := digitSumStr(t)
+		if sum > bestSum || (sum == bestSum && num > best) {
+			best = num
+			bestSum = sum
+		}
+	}
+	fmt.Println(best)
+}


### PR DESCRIPTION
## Summary
- implement `770B.go` for problem B in contest 770
- compute candidate numbers by decreasing a digit and filling trailing digits with `9`

## Testing
- `go build ./0-999/700-799/770-779/770/770B.go`
- `echo 1234 | go run ./0-999/700-799/770-779/770/770B.go` (prints `999`)
- `echo 987 | go run ./0-999/700-799/770-779/770/770B.go` (prints `899`)
- `echo 1000 | go run ./0-999/700-799/770-779/770/770B.go` (prints `999`)


------
https://chatgpt.com/codex/tasks/task_e_6881d764cbc08324a584ae56ab702eb5