### PR TITLE
Add Go solution for 777B

### DIFF
--- a/0-999/700-799/770-779/777/777B.go
+++ b/0-999/700-799/770-779/777/777B.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	var sherlock, moriarty string
+	fmt.Fscan(in, &sherlock)
+	fmt.Fscan(in, &moriarty)
+
+	var freq1 [10]int
+	var freq2 [10]int
+	for i := 0; i < n; i++ {
+		d := moriarty[i] - '0'
+		freq1[d]++
+		freq2[d]++
+	}
+
+	minFlicks := 0
+	for i := 0; i < n; i++ {
+		d := int(sherlock[i] - '0')
+		j := d
+		for j < 10 && freq1[j] == 0 {
+			j++
+		}
+		if j < 10 {
+			freq1[j]--
+		} else {
+			minFlicks++
+			for k := 0; k < 10; k++ {
+				if freq1[k] > 0 {
+					freq1[k]--
+					break
+				}
+			}
+		}
+	}
+
+	maxFlickSherlock := 0
+	for i := 0; i < n; i++ {
+		d := int(sherlock[i] - '0')
+		j := d + 1
+		for j < 10 && freq2[j] == 0 {
+			j++
+		}
+		if j < 10 {
+			freq2[j]--
+			maxFlickSherlock++
+		} else {
+			for k := 0; k < 10; k++ {
+				if freq2[k] > 0 {
+					freq2[k]--
+					break
+				}
+			}
+		}
+	}
+
+	out := bufio.NewWriter(os.Stdout)
+	fmt.Fprintln(out, minFlicks)
+	fmt.Fprintln(out, maxFlickSherlock)
+	out.Flush()
+}


### PR DESCRIPTION
## Summary
- implement `777B.go`, a Greedy solution for Game of Credit Cards

## Testing
- `go build 0-999/700-799/770-779/777/777B.go`
- `echo -e "3\n123\n321" | go run 0-999/700-799/770-779/777/777B.go`

------
https://chatgpt.com/codex/tasks/task_e_6881d692e27483248c5312cacba2a5a4