### PR TITLE
Add naive Go solution for 773E

### DIFF
--- a/0-999/700-799/770-779/773/773E.go
+++ b/0-999/700-799/770-779/773/773E.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &arr[i])
+	}
+
+	prefix := make([]int, 0, n)
+	for k := 0; k < n; k++ {
+		// insert arr[k] into prefix keeping it sorted
+		x := arr[k]
+		idx := sort.SearchInts(prefix, x)
+		prefix = append(prefix, 0)
+		copy(prefix[idx+1:], prefix[idx:])
+		prefix[idx] = x
+
+		rating := 0
+		for _, v := range prefix {
+			if v > rating {
+				rating++
+			} else if v < rating {
+				rating--
+			}
+		}
+
+		if k > 0 {
+			fmt.Fprint(out, " ")
+		}
+		fmt.Fprint(out, rating)
+	}
+	fmt.Fprintln(out)
+}


### PR DESCRIPTION
## Summary
- implement a Go program for problemE

## Testing
- `gofmt -w 0-999/700-799/770-779/773/773E.go`

------
https://chatgpt.com/codex/tasks/task_e_6881d995d7c88324960f09912393f258