### PR TITLE
Add Go solution for problem 773A

### DIFF
--- a/0-999/700-799/770-779/773/773A.go
+++ b/0-999/700-799/770-779/773/773A.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func ceilDiv(a, b int64) int64 {
+	if a%b == 0 {
+		return a / b
+	}
+	return a/b + 1
+}
+
+func max(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var x, y, p, q int64
+		fmt.Fscan(in, &x, &y, &p, &q)
+
+		if p == q {
+			if x == y {
+				fmt.Fprintln(out, 0)
+			} else {
+				fmt.Fprintln(out, -1)
+			}
+			continue
+		}
+		if p == 0 {
+			if x == 0 {
+				fmt.Fprintln(out, 0)
+			} else {
+				fmt.Fprintln(out, -1)
+			}
+			continue
+		}
+
+		k := max(ceilDiv(x, p), max(ceilDiv(y, q), ceilDiv(y-x, q-p)))
+		ans := q*k - y
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement minimal submissions calculation in Go
- handle edge cases when desired success ratio is 0 or 1

## Testing
- `go build 0-999/700-799/770-779/773/773A.go`
- `go vet 0-999/700-799/770-779/773/773A.go`


------
https://chatgpt.com/codex/tasks/task_e_6881daf46a6c8324b44c08add2bf9aa0