### PR TITLE
Add Go solution for 774E

### DIFF
--- a/0-999/700-799/770-779/774/774E.go
+++ b/0-999/700-799/770-779/774/774E.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var s string
+	if _, err := fmt.Fscan(reader, &s); err != nil {
+		return
+	}
+	var m int64
+	if _, err := fmt.Fscan(reader, &m); err != nil {
+		return
+	}
+	n := len(s)
+	// Precompute prefix values for s+s
+	t := s + s
+	pref := make([]int64, 2*n+1)
+	for i := 0; i < 2*n; i++ {
+		d := int64(t[i] - '0')
+		pref[i+1] = (pref[i]*10 + d) % m
+	}
+	// pow10n = 10^n mod m
+	pow10n := int64(1)
+	for i := 0; i < n; i++ {
+		pow10n = (pow10n * 10) % m
+	}
+	minRem := int64(-1)
+	for i := 0; i < n; i++ {
+		if s[i] == '0' {
+			continue
+		}
+		val := (pref[i+n] - (pref[i]*pow10n)%m + m) % m
+		if minRem == -1 || val < minRem {
+			minRem = val
+		}
+	}
+	fmt.Println(minRem)
+}


### PR DESCRIPTION
## Summary
- add a Go solution for problemE in contest 774

## Testing
- `go run 0-999/700-799/770-779/774/774E.go <<EOF
521
3
EOF`
- `go run 0-999/700-799/770-779/774/774E.go <<EOF
1001
5
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6881dc52e6b88324b89e190d8db44811