### PR TITLE
Add Go solution for CF problem 774G

### DIFF
--- a/0-999/700-799/770-779/774/774G.go
+++ b/0-999/700-799/770-779/774/774G.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func extendedGCD(a, b int64) (int64, int64, int64) {
+	if b == 0 {
+		return a, 1, 0
+	}
+	g, x1, y1 := extendedGCD(b, a%b)
+	return g, y1, x1 - (a/b)*y1
+}
+
+func ceilDiv(a, b int64) int64 {
+	if b < 0 {
+		a, b = -a, -b
+	}
+	if a >= 0 {
+		return (a + b - 1) / b
+	}
+	return a / b
+}
+
+func floorDiv(a, b int64) int64 {
+	if b < 0 {
+		a, b = -a, -b
+	}
+	if a >= 0 {
+		return a / b
+	}
+	return -((-a + b - 1) / b)
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var a, h, w int64
+	if _, err := fmt.Fscan(reader, &a, &h, &w); err != nil {
+		return
+	}
+
+	if h < a || w < a {
+		fmt.Fprintln(writer, -1)
+		return
+	}
+
+	A := h + a
+	B := w + a
+	C := w - h
+
+	g, x0, y0 := extendedGCD(A, B)
+	if C%g != 0 {
+		fmt.Fprintln(writer, -1)
+		return
+	}
+
+	factor := C / g
+	m0 := x0 * factor
+	n0 := -y0 * factor
+
+	Bdiv := B / g
+	Adiv := A / g
+
+	lowN := ceilDiv(1-n0, Adiv)
+	highN := floorDiv(h/a-n0, Adiv)
+	lowM := ceilDiv(1-m0, Bdiv)
+	highM := floorDiv(w/a-m0, Bdiv)
+
+	low := lowN
+	if lowM > low {
+		low = lowM
+	}
+	high := highN
+	if highM < high {
+		high = highM
+	}
+
+	if low > high {
+		fmt.Fprintln(writer, -1)
+		return
+	}
+
+	t := high
+	n := n0 + Adiv*t
+	_ = m0 + Bdiv*t // m value not needed explicitly
+	x := float64(h-n*a) / float64(n+1)
+	fmt.Fprintf(writer, "%.10f\n", x)
+}


### PR DESCRIPTION
## Summary
- implement `774G.go` solving grid placement problem using extended Euclid
- choose largest feasible solution parameter to minimize `x`

## Testing
- `go build 0-999/700-799/770-779/774/774G.go`
- `echo '2 18 13' | go run 0-999/700-799/770-779/774/774G.go`
- `echo '2 3 10' | go run 0-999/700-799/770-779/774/774G.go`

------
https://chatgpt.com/codex/tasks/task_e_6881dd254b5c8324ade0fc63ed28d14a