### PR TITLE
Add Go solution for Codeforces 1703F

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1703/1703F.go
+++ b/1000-1999/1700-1799/1700-1709/1703/1703F.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		pre := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			pre[i] = pre[i-1]
+			if a[i] < i {
+				pre[i]++
+			}
+		}
+		var ans int64
+		for j := 1; j <= n; j++ {
+			if a[j] < j {
+				idx := a[j] - 1
+				if idx >= 0 {
+					if idx > n {
+						idx = n
+					}
+					ans += int64(pre[idx])
+				}
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add implementation for problem 1703F

## Testing
- `go build 1000-1999/1700-1799/1700-1709/1703/1703F.go`

------
https://chatgpt.com/codex/tasks/task_e_6881df10cb0c832491e33a0aed5ef93b