### PR TITLE
Add Go solution for 1703C

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1703/1703C.go
+++ b/1000-1999/1700-1799/1700-1709/1703/1703C.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		for i := 0; i < n; i++ {
+			var b int
+			var s string
+			fmt.Fscan(in, &b, &s)
+			for _, ch := range s {
+				if ch == 'U' {
+					a[i] = (a[i] + 9) % 10
+				} else if ch == 'D' {
+					a[i] = (a[i] + 1) % 10
+				}
+			}
+		}
+		for i, x := range a {
+			if i > 0 {
+				out.WriteByte(' ')
+			}
+			fmt.Fprint(out, x)
+		}
+		out.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1703C

## Testing
- `go build 1000-1999/1700-1799/1700-1709/1703/1703C.go`
- `go run 1000-1999/1700-1799/1700-1709/1703/1703C.go < /tmp/input2.txt`

------
https://chatgpt.com/codex/tasks/task_e_6881df9cd6408324a8b2fe3d4420ffd0