### PR TITLE
Add Go solution for 1704B

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1704/1704B.go
+++ b/1000-1999/1700-1799/1700-1709/1704/1704B.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var x int64
+		fmt.Fscan(reader, &n, &x)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		l, r := a[0]-x, a[0]+x
+		changes := 0
+		for i := 1; i < n; i++ {
+			nl, nr := a[i]-x, a[i]+x
+			if nl > r || nr < l {
+				changes++
+				l, r = nl, nr
+			} else {
+				if nl > l {
+					l = nl
+				}
+				if nr < r {
+					r = nr
+				}
+			}
+		}
+		fmt.Fprintln(writer, changes)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for problem 1704B

## Testing
- `go build 1000-1999/1700-1799/1700-1709/1704/1704B.go`
- `go vet 1000-1999/1700-1799/1700-1709/1704/1704B.go`

------
https://chatgpt.com/codex/tasks/task_e_6881e18768808324b1ed880ec5dad940