### PR TITLE
Add Go solution for 1705B

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1705/1705B.go
+++ b/1000-1999/1700-1799/1700-1709/1705/1705B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		last := n - 1
+		for last >= 0 && a[last] == 0 {
+			last--
+		}
+		var ans int64
+		for i := 0; i < last; i++ {
+			ans += a[i]
+			if a[i] == 0 {
+				ans++
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1705B

## Testing
- `go build 1000-1999/1700-1799/1700-1709/1705/1705B.go`


------
https://chatgpt.com/codex/tasks/task_e_6881e3b8ad0c832480ec403afa7f3836