### PR TITLE
Add Go solution for 1702D

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1702/1702D.go
+++ b/1000-1999/1700-1799/1700-1709/1702/1702D.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var w string
+		fmt.Fscan(reader, &w)
+		var p int
+		fmt.Fscan(reader, &p)
+
+		freq := make([]int, 26)
+		total := 0
+		for _, ch := range w {
+			idx := int(ch - 'a')
+			freq[idx]++
+			total += idx + 1
+		}
+
+		keep := make([]int, 26)
+		copy(keep, freq)
+
+		for c := 25; c >= 0 && total > p; c-- {
+			for keep[c] > 0 && total > p {
+				keep[c]--
+				total -= c + 1
+			}
+		}
+
+		res := make([]byte, 0, len(w))
+		for _, ch := range w {
+			idx := int(ch - 'a')
+			if keep[idx] > 0 {
+				res = append(res, byte(ch))
+				keep[idx]--
+			}
+		}
+		fmt.Fprintln(writer, string(res))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem D of contest 1702

## Testing
- `gofmt -w 1000-1999/1700-1799/1700-1709/1702/1702D.go`
- `go build 1000-1999/1700-1799/1700-1709/1702/1702D.go`


------
https://chatgpt.com/codex/tasks/task_e_6881e51715f88324b43f012cdac8e244