### PR TITLE
Add Go solution for 1703B

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1703/1703B.go
+++ b/1000-1999/1700-1799/1700-1709/1703/1703B.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(in, &n, &s)
+		seen := make(map[byte]bool)
+		for i := 0; i < n; i++ {
+			seen[s[i]] = true
+		}
+		ans := n + len(seen)
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solver for 1703B

## Testing
- `go build 1000-1999/1700-1799/1700-1709/1703/1703B.go`

------
https://chatgpt.com/codex/tasks/task_e_6881dfe2e4b083248d92b8e13516f056