### PR TITLE
Add Go solution for 1709B

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1709/1709B.go
+++ b/1000-1999/1700-1799/1700-1709/1709/1709B.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return
+	}
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+
+	prefixRight := make([]int64, n)
+	for i := 1; i < n; i++ {
+		diff := a[i-1] - a[i]
+		if diff > 0 {
+			prefixRight[i] = prefixRight[i-1] + diff
+		} else {
+			prefixRight[i] = prefixRight[i-1]
+		}
+	}
+
+	prefixLeft := make([]int64, n)
+	for i := n - 2; i >= 0; i-- {
+		diff := a[i+1] - a[i]
+		if diff > 0 {
+			prefixLeft[i] = prefixLeft[i+1] + diff
+		} else {
+			prefixLeft[i] = prefixLeft[i+1]
+		}
+	}
+
+	for ; m > 0; m-- {
+		var s, t int
+		fmt.Fscan(in, &s, &t)
+		if s < t {
+			fmt.Fprintln(out, prefixRight[t-1]-prefixRight[s-1])
+		} else {
+			fmt.Fprintln(out, prefixLeft[t-1]-prefixLeft[s-1])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement 1709B solution in Go

## Testing
- `go build 1000-1999/1700-1799/1700-1709/1709/1709B.go`


------
https://chatgpt.com/codex/tasks/task_e_6881e78e5014832483d73b5e5854a8e8