### PR TITLE
Add Go solution for 1700D River Locks

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1700/1700D.go
+++ b/1000-1999/1700-1799/1700-1709/1700/1700D.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	fmt.Fscan(in, &n)
+	pref := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		var x int64
+		fmt.Fscan(in, &x)
+		pref[i] = pref[i-1] + x
+	}
+
+	maxTime := int64(0)
+	for i := 1; i <= n; i++ {
+		t := (pref[i] + int64(i) - 1) / int64(i)
+		if t > maxTime {
+			maxTime = t
+		}
+	}
+
+	var q int
+	fmt.Fscan(in, &q)
+	for ; q > 0; q-- {
+		var t int64
+		fmt.Fscan(in, &t)
+		if t < maxTime {
+			fmt.Fprintln(out, -1)
+		} else {
+			k := (pref[n] + t - 1) / t
+			fmt.Fprintln(out, k)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1700D.go` solving River Locks

## Testing
- `go build 1000-1999/1700-1799/1700-1709/1700/1700D.go`


------
https://chatgpt.com/codex/tasks/task_e_6881ea05749c8324b569057bf7d9a12e