### PR TITLE
Add Go solution for Codeforces 1700A

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1700/1700A.go
+++ b/1000-1999/1700-1799/1700-1709/1700/1700A.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, m int64
+		fmt.Fscan(in, &n, &m)
+		ans := m*(m+1)/2 + m*(n*(n+1)/2-1)
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problemA in contest 1700
- compute minimal path cost with closed-form formula

## Testing
- `go build 1000-1999/1700-1799/1700-1709/1700/1700A.go`
- `go run 1000-1999/1700-1799/1700-1709/1700/1700A.go <<EOF
3
1 1
2 3
3 3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6881ead83690832489ae646730b3358b