### PR TITLE
Add Go solution for 1700C

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1700/1700C.go
+++ b/1000-1999/1700-1799/1700-1709/1700/1700C.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+
+		var pos, neg int64
+		for i := 1; i < n; i++ {
+			diff := a[i] - a[i-1]
+			if diff > 0 {
+				pos += diff
+			} else {
+				neg += -diff
+			}
+		}
+		ans := pos + neg + int64(math.Abs(float64(a[0]-neg)))
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem C in contest 1700

## Testing
- `go build 1000-1999/1700-1799/1700-1709/1700/1700C.go`

------
https://chatgpt.com/codex/tasks/task_e_6881ea91b75c83248dd1e996c0d9cc50