### PR TITLE
Add Go solution for 1774C

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1774/1774C.go
+++ b/1000-1999/1700-1799/1770-1779/1774/1774C.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		var s string
+		fmt.Fscan(in, &s)
+		t1 := make([]int, n)
+		t0 := make([]int, n)
+		for i := 1; i < n; i++ {
+			if s[i-1] == '1' {
+				t1[i] = t1[i-1] + 1
+			} else {
+				t1[i] = 0
+			}
+			if s[i-1] == '0' {
+				t0[i] = t0[i-1] + 1
+			} else {
+				t0[i] = 0
+			}
+		}
+		for i := 1; i < n; i++ {
+			x := i + 1
+			ans := x - t1[i] - t0[i]
+			if i > 1 {
+				out.WriteByte(' ')
+			}
+			fmt.Fprint(out, ans)
+		}
+		out.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem C in 1774
- count trailing ones and zeros for each prefix of `s` to derive number of possible winners

## Testing
- `go build 1000-1999/1700-1799/1770-1779/1774/1774C.go`

------
https://chatgpt.com/codex/tasks/task_e_6881efc6545c83248be0473090634c18