### PR TITLE
Add Go solution for 1708A

### DIFF
--- a/1000-1999/1700-1799/1700-1709/1708/1708A.go
+++ b/1000-1999/1700-1799/1700-1709/1708/1708A.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		g := a[0]
+		for i := 1; i < n; i++ {
+			g = gcd(g, a[i])
+		}
+		if g == a[0] {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1708A.go` for problem A (Difference Operations)

## Testing
- `go vet 1000-1999/1700-1799/1700-1709/1708/1708A.go`
- `go build 1000-1999/1700-1799/1700-1709/1708/1708A.go`


------
https://chatgpt.com/codex/tasks/task_e_6881ee67f400832497ba02891effc72c