### PR TITLE
Add Go solution for problem 1774B

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1774/1774B.go
+++ b/1000-1999/1700-1799/1770-1779/1774/1774B.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m, k int
+		fmt.Fscan(reader, &n, &m, &k)
+		maxCount := 0
+		countMax := 0
+		for i := 0; i < m; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			if x > maxCount {
+				maxCount = x
+				countMax = 1
+			} else if x == maxCount {
+				countMax++
+			}
+		}
+		// condition derived from scheduling theory
+		// minimal length to place all occurrences without conflicts
+		if int64(maxCount-1)*int64(k)+int64(countMax) <= int64(n) {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1774B.go` for problem B in contest 1774
- use scheduling based check to verify counts

## Testing
- `go build ./1000-1999/1700-1799/1770-1779/1774/1774B.go`
- `go vet ./1000-1999/1700-1799/1770-1779/1774/1774B.go`


------
https://chatgpt.com/codex/tasks/task_e_6881f00c6b088324a876598ab98c05d4