### PR TITLE
Add Go solution for problem 1772B

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1772/1772B.go
+++ b/1000-1999/1700-1799/1770-1779/1772/1772B.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a, b, c, d int
+		fmt.Fscan(reader, &a, &b)
+		fmt.Fscan(reader, &c, &d)
+		ok := false
+		for i := 0; i < 4; i++ {
+			if a < b && c < d && a < c && b < d {
+				ok = true
+				break
+			}
+			// rotate 90 degrees clockwise
+			a, b, c, d = c, a, d, b
+		}
+		if ok {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `1772B` (Matrix rotations)

## Testing
- `go build 1000-1999/1700-1799/1770-1779/1772/1772B.go`
- `printf '3\n1 2\n3 4\n1 4\n3 2\n3 1\n4 2\n' | go run 1000-1999/1700-1799/1770-1779/1772/1772B.go`


------
https://chatgpt.com/codex/tasks/task_e_6881f1b18ef88324acbf2b221bfdc9f6