### PR TITLE
Add Go solution for 1775E

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1775/1775E.go
+++ b/1000-1999/1700-1799/1770-1779/1775/1775E.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		prefix := int64(0)
+		maxPref := int64(0)
+		minPref := int64(0)
+		for i := 0; i < n; i++ {
+			var x int64
+			fmt.Fscan(reader, &x)
+			prefix += x
+			if prefix > maxPref {
+				maxPref = prefix
+			}
+			if prefix < minPref {
+				minPref = prefix
+			}
+		}
+		fmt.Fprintln(writer, maxPref-minPref)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem E using prefix sum range

## Testing
- `gofmt -w 1000-1999/1700-1799/1770-1779/1775/1775E.go`


------
https://chatgpt.com/codex/tasks/task_e_6881f052a1c08324a735032d75269c27