### PR TITLE
Add Go solution for 1772A

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1772/1772A.go
+++ b/1000-1999/1700-1799/1770-1779/1772/1772A.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		// expression is of form a+b where a and b are digits
+		if len(s) >= 3 {
+			a := int(s[0] - '0')
+			b := int(s[2] - '0')
+			fmt.Fprintln(writer, a+b)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem A of contest 1772

## Testing
- `go build 1000-1999/1700-1799/1770-1779/1772/1772A.go`
- `echo -e "3\n1+1\n2+3\n0+9" | ./1772A`

------
https://chatgpt.com/codex/tasks/task_e_6881f1f756d0832491cccfc9c2465be8