### PR TITLE
Add Go solution for 1772E Permutation Game

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1772/1772E.go
+++ b/1000-1999/1700-1799/1770-1779/1772/1772E.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+		}
+		asc, desc := 0, 0
+		for i := 0; i < n; i++ {
+			if arr[i] == i+1 {
+				asc++
+			}
+			if arr[i] == n-i {
+				desc++
+			}
+		}
+		if asc > desc {
+			fmt.Fprintln(out, "First")
+		} else if desc > asc {
+			fmt.Fprintln(out, "Second")
+		} else {
+			fmt.Fprintln(out, "Tie")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem E in contest 1772

## Testing
- `go build 1000-1999/1700-1799/1770-1779/1772/1772E.go`
- `go run 1000-1999/1700-1799/1770-1779/1772/1772E.go < /tmp/input.txt`

------
https://chatgpt.com/codex/tasks/task_e_6881f124fc2883248fc06af2c51d89b5