### PR TITLE
Add Go solution for problem 1777A

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1777/1777A.go
+++ b/1000-1999/1700-1799/1770-1779/1777/1777A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		runs := 1
+		prev := arr[0] % 2
+		for i := 1; i < n; i++ {
+			cur := arr[i] % 2
+			if cur != prev {
+				runs++
+				prev = cur
+			}
+		}
+		ops := n - runs
+		fmt.Fprintln(writer, ops)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a solution for [problemA](1000-1999/1700-1799/1770-1779/1777/problemA.txt)
- use run counting to determine minimal operations

## Testing
- `gofmt -w 1000-1999/1700-1799/1770-1779/1777/1777A.go`

------
https://chatgpt.com/codex/tasks/task_e_6881f39bfc8c8324aa86d2034263c8d2