### PR TITLE
Add Go solution for 1777B

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1777/1777B.go
+++ b/1000-1999/1700-1799/1770-1779/1777/1777B.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 1e9 + 7
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	ns := make([]int, t)
+	maxN := 0
+	for i := 0; i < t; i++ {
+		fmt.Fscan(reader, &ns[i])
+		if ns[i] > maxN {
+			maxN = ns[i]
+		}
+	}
+
+	fact := make([]int64, maxN+1)
+	fact[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+
+	for _, n := range ns {
+		ans := fact[n] * int64(n) % mod * int64(n-1) % mod
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for Problem B in the 1777 folder

## Testing
- `go build 1000-1999/1700-1799/1770-1779/1777/1777B.go`

------
https://chatgpt.com/codex/tasks/task_e_6881f355ea2c832492bdb7c2106d3c80