### PR TITLE
Add Go solution for 1770A

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1770/1770A.go
+++ b/1000-1999/1700-1799/1770-1779/1770/1770A.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(reader, &n, &m)
+		nums := make([]int, n+m)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &nums[i])
+		}
+		for i := 0; i < m; i++ {
+			fmt.Fscan(reader, &nums[n+i])
+		}
+		sort.Slice(nums, func(i, j int) bool { return nums[i] > nums[j] })
+		sum := 0
+		for i := 0; i < n && i < len(nums); i++ {
+			sum += nums[i]
+		}
+		fmt.Fprintln(writer, sum)
+	}
+}


### PR DESCRIPTION
## Summary
- implement 1770A solution in Go

## Testing
- `go build 1000-1999/1700-1799/1770-1779/1770/1770A.go`


------
https://chatgpt.com/codex/tasks/task_e_6881f587d984832481d7849c4f80c31f