### PR TITLE
Add Go solution for 1779C

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1779/1779C.go
+++ b/1000-1999/1700-1799/1770-1779/1779/1779C.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bufio"
+	"container/heap"
+	"fmt"
+	"os"
+)
+
+type MaxHeap []int
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := *h
+	x := old[len(old)-1]
+	*h = old[:len(old)-1]
+	return x
+}
+
+func solve(n, m int, a []int) int {
+	ops := 0
+	// process right side (indices m..n-1) => original positions m+1..n
+	cur := 0
+	right := &MaxHeap{}
+	heap.Init(right)
+	for i := m; i < n; i++ {
+		v := a[i]
+		if v < 0 {
+			heap.Push(right, -v)
+		}
+		cur += v
+		if cur < 0 {
+			x := heap.Pop(right).(int)
+			cur += 2 * x
+			ops++
+		}
+	}
+	// process left side (indices m-1 down to 1) => positions m..2
+	cur = 0
+	left := &MaxHeap{}
+	heap.Init(left)
+	for i := m - 1; i > 0; i-- {
+		v := a[i]
+		if v > 0 {
+			heap.Push(left, v)
+		}
+		cur += v
+		if cur > 0 {
+			x := heap.Pop(left).(int)
+			cur -= 2 * x
+			ops++
+		}
+	}
+	return ops
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(reader, &n, &m)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		fmt.Fprintln(writer, solve(n, m, arr))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1779C using priority queues to greedily flip signs

## Testing
- `go build 1000-1999/1700-1799/1770-1779/1779/1779C.go`

------
https://chatgpt.com/codex/tasks/task_e_6881f6e57a08832480b4dd0da483fe59