### PR TITLE
Add solution for 1779H

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1779/1779H.go
+++ b/1000-1999/1700-1799/1770-1779/1779/1779H.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+type Player struct {
+	val int64
+	idx int
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	vals := make([]int64, n)
+	var total int64
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &vals[i])
+		total += vals[i]
+	}
+	players := make([]Player, n)
+	for i := 0; i < n; i++ {
+		players[i] = Player{vals[i], i}
+	}
+	sort.Slice(players, func(i, j int) bool { return players[i].val > players[j].val })
+	var pref int64
+	k := 0
+	half := total / 2
+	for k < n {
+		pref += players[k].val
+		k++
+		if pref >= half {
+			break
+		}
+	}
+	res := make([]byte, n)
+	for i := 0; i < n; i++ {
+		res[i] = '0'
+	}
+	for i := 0; i < k; i++ {
+		res[players[i].idx] = '1'
+	}
+	fmt.Fprintln(writer, string(res))
+}


### PR DESCRIPTION
## Summary
- implement a solution for problem H in round 1779

## Testing
- `gofmt -w 1000-1999/1700-1799/1770-1779/1779/1779H.go`


------
https://chatgpt.com/codex/tasks/task_e_6881f5cd064c8324a981ac73bac7efe7