### PR TITLE
Add Go solution for 1776H

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1776/1776H.go
+++ b/1000-1999/1700-1799/1770-1779/1776/1776H.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func LISLength(arr []int) int {
+	d := make([]int, 0, len(arr))
+	for _, v := range arr {
+		i := sort.Search(len(d), func(i int) bool { return d[i] >= v })
+		if i == len(d) {
+			d = append(d, v)
+		} else {
+			d[i] = v
+		}
+	}
+	return len(d)
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		pos := make([]int, n+1)
+		for i, v := range a {
+			pos[v] = i
+		}
+		b := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &b[i])
+			b[i] = pos[b[i]]
+		}
+		lis := LISLength(b)
+		fmt.Fprintln(writer, n-lis)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem H of contest 1776

## Testing
- `go build 1000-1999/1700-1799/1770-1779/1776/1776H.go`

------
https://chatgpt.com/codex/tasks/task_e_6881fb8dfbf48324a13401a6f1a3fd76