### PR TITLE
Add Go solution for 1776A

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1776/1776A.go
+++ b/1000-1999/1700-1799/1770-1779/1776/1776A.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		prev := 0
+		walks := 0
+		for i := 0; i < n; i++ {
+			diff := a[i] - prev
+			walks += diff / 120
+			prev = a[i]
+		}
+		diff := 1440 - prev
+		walks += diff / 120
+		if walks >= 2 {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 1776 problem A

## Testing
- `go build 1000-1999/1700-1799/1770-1779/1776/1776A.go`
- `cat <<EOF | go run 1000-1999/1700-1799/1770-1779/1776/1776A.go
1
12
100 200 300 400 600 700 800 900 1100 1200 1300 1400
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6881fcec87a0832497e21c4ec0989089