### PR TITLE
Add Go solution for 1780E

### DIFF
--- a/1000-1999/1700-1799/1780-1789/1780/1780E.go
+++ b/1000-1999/1700-1799/1780-1789/1780/1780E.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func countDistinct(l, r int64) int64 {
+	if r-l <= 0 {
+		return 0
+	}
+	diff := r - l
+	res := int64(0)
+	// gcd values >= l
+	start := l
+	end := r / 2
+	if end > diff {
+		end = diff
+	}
+	if end >= start {
+		res += end - start + 1
+	}
+	// gcd values < l
+	maxG := l - 1
+	if maxG > diff {
+		maxG = diff
+	}
+	g := int64(1)
+	for g <= maxG {
+		k := (l - 1) / g
+		var nextG int64
+		if k == 0 {
+			nextG = maxG
+		} else {
+			nextG = (l - 1) / k
+			if nextG > maxG {
+				nextG = maxG
+			}
+		}
+		upper := r / (k + 2)
+		if upper >= g {
+			if upper > nextG {
+				upper = nextG
+			}
+			res += upper - g + 1
+		}
+		g = nextG + 1
+	}
+	return res
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var l, r int64
+		fmt.Fscan(in, &l, &r)
+		ans := countDistinct(l, r)
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `countDistinct` to count distinct gcd values among edges in range
- handle cases in O(sqrt(l)) by grouping intervals based on floor division
- include CLI for multiple test cases

## Testing
- `go build 1000-1999/1700-1799/1780-1789/1780/1780E.go`

------
https://chatgpt.com/codex/tasks/task_e_6881fed7df6c8324876a70f0acb0a121