### PR TITLE
Add preliminary Go solution for 1776C

### DIFF
--- a/1000-1999/1700-1799/1770-1779/1776/1776C.go
+++ b/1000-1999/1700-1799/1770-1779/1776/1776C.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := range a {
+		fmt.Fscan(in, &a[i])
+	}
+	sort.Slice(a, func(i, j int) bool { return a[i] > a[j] })
+
+	l := m
+	for _, d := range a {
+		if d > l {
+			fmt.Println("Bernardo")
+			return
+		}
+		if d <= l/2 {
+			l -= d
+		} else {
+			l /= 2
+		}
+	}
+	fmt.Println("Alessia")
+}


### PR DESCRIPTION
## Summary
- implement a basic solver for problem C in contest 1776

## Testing
- `go build ./1000-1999/1700-1799/1770-1779/1776/1776C.go`

------
https://chatgpt.com/codex/tasks/task_e_6881fc61786c83249f2196a709640cb3