### PR TITLE
Add Go solution for 1786A1

### DIFF
--- a/1000-1999/1700-1799/1780-1789/1786/1786A1.go
+++ b/1000-1999/1700-1799/1780-1789/1786/1786A1.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var T int
+	if _, err := fmt.Fscan(reader, &T); err != nil {
+		return
+	}
+	for ; T > 0; T-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		a, b := int64(0), int64(0)
+		i := int64(1)
+		for n > 0 {
+			take := i
+			if take > n {
+				take = n
+			}
+			if i%4 == 1 || i%4 == 0 {
+				a += take
+			} else {
+				b += take
+			}
+			n -= take
+			i++
+		}
+		fmt.Fprintf(writer, "%d %d\n", a, b)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1786A1

## Testing
- `go build 1000-1999/1700-1799/1780-1789/1786/1786A1.go`

------
https://chatgpt.com/codex/tasks/task_e_68820497e4e08324aba38ba38d47f913