### PR TITLE
Add Go solution for 1786B

### DIFF
--- a/1000-1999/1700-1799/1780-1789/1786/1786B.go
+++ b/1000-1999/1700-1799/1780-1789/1786/1786B.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+func main() {
+    reader := bufio.NewReader(os.Stdin)
+    writer := bufio.NewWriter(os.Stdout)
+    defer writer.Flush()
+
+    var t int
+    if _, err := fmt.Fscan(reader, &t); err != nil {
+        return
+    }
+    for ; t > 0; t-- {
+        var n int
+        var w, h int64
+        fmt.Fscan(reader, &n, &w, &h)
+        a := make([]int64, n)
+        b := make([]int64, n)
+        for i := 0; i < n; i++ {
+            fmt.Fscan(reader, &a[i])
+        }
+        for i := 0; i < n; i++ {
+            fmt.Fscan(reader, &b[i])
+        }
+        lower := int64(-1 << 60)
+        upper := int64(1 << 60)
+        for i := 0; i < n; i++ {
+            l := (b[i] + h) - (a[i] + w)
+            r := (b[i] - h) - (a[i] - w)
+            if l > lower {
+                lower = l
+            }
+            if r < upper {
+                upper = r
+            }
+        }
+        if lower <= upper {
+            fmt.Fprintln(writer, "YES")
+        } else {
+            fmt.Fprintln(writer, "NO")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement solution for problemB in `1786B.go`
- uses interval intersection logic to find feasible shift

## Testing
- `go build 1000-1999/1700-1799/1780-1789/1786/1786B.go`
- `go vet 1000-1999/1700-1799/1780-1789/1786/1786B.go`


------
https://chatgpt.com/codex/tasks/task_e_688204de629483248d29b64e4edb1920