### PR TITLE
Add Go solution for 1744A

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1744/1744A.go
+++ b/1000-1999/1700-1799/1740-1749/1744/1744A.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		var s string
+		fmt.Fscan(reader, &s)
+		mp := make(map[int]byte)
+		ok := true
+		for i := 0; i < n && ok; i++ {
+			ch := s[i]
+			if v, exists := mp[a[i]]; exists {
+				if v != ch {
+					ok = false
+				}
+			} else {
+				mp[a[i]] = ch
+			}
+		}
+		if ok {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `1744A.go` implementing Number Replacement

## Testing
- `go build 1000-1999/1700-1799/1740-1749/1744/1744A.go`

------
https://chatgpt.com/codex/tasks/task_e_68820a9e668c8324bcafb8d160cca9cb