### PR TITLE
Add naive 1784C solver in Go

### DIFF
--- a/1000-1999/1700-1799/1780-1789/1784/1784C.go
+++ b/1000-1999/1700-1799/1780-1789/1784/1784C.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// calcCost computes minimal number of type1 spells needed for given prefix array.
+// This is a naive O(n^2) implementation derived from the problem statement.
+func calcCost(arr []int) int {
+	b := append([]int(nil), arr...)
+	sort.Ints(b)
+	n := len(b)
+	best := int(1 << 60)
+	for L := 0; L <= n+1; L++ {
+		idx := 0
+		costPre := 0
+		feasible := true
+		for v := 1; v < L; v++ {
+			for idx < n && b[idx] < v {
+				idx++
+			}
+			if idx == n {
+				feasible = false
+				break
+			}
+			costPre += b[idx] - v
+			idx++
+		}
+		if !feasible {
+			break
+		}
+		cost := costPre
+		for j := idx; j < n; j++ {
+			if b[j] == L {
+				cost += 1
+			} else if b[j] > L {
+				cost += b[j] - L
+			}
+		}
+		if cost < best {
+			best = cost
+		}
+	}
+	return best
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		prefix := make([]int, 0, n)
+		for i := 0; i < n; i++ {
+			prefix = append(prefix, a[i])
+			ans := calcCost(prefix)
+			if i > 0 {
+				fmt.Fprint(out, " ")
+			}
+			fmt.Fprint(out, ans)
+		}
+		fmt.Fprintln(out)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a simple (quadratic) Go solution for `problemC`

## Testing
- `go build 1000-1999/1700-1799/1780-1789/1784/1784C.go`


------
https://chatgpt.com/codex/tasks/task_e_6882070f544083248499a548069eef8a