### PR TITLE
Add Go solution for 1743A

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1743/1743A.go
+++ b/1000-1999/1700-1799/1740-1749/1743/1743A.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(in, &x)
+		}
+		k := 10 - n
+		ans := 3 * k * (k - 1)
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solver for problem 1743A

## Testing
- `go build 1000-1999/1700-1799/1740-1749/1743/1743A.go`


------
https://chatgpt.com/codex/tasks/task_e_68820c4301308324b6eabd0a301137ef