### PR TITLE
Add Go solution for 1743C

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1743/1743C.go
+++ b/1000-1999/1700-1799/1740-1749/1743/1743C.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var s string
+		fmt.Fscan(reader, &s)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		ans := 0
+		best := 0
+		for i := 0; i < n; i++ {
+			if s[i] == '0' {
+				best = a[i]
+			} else {
+				ans += a[i]
+				if best > a[i] {
+					ans += best - a[i]
+					best = a[i]
+				}
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 1743C

## Testing
- `go build 1000-1999/1700-1799/1740-1749/1743/1743C.go`
- `go run 1000-1999/1700-1799/1740-1749/1743/1743C.go < /tmp/input.txt`

------
https://chatgpt.com/codex/tasks/task_e_68820bfcdf1c8324b2f71a904a49355f