### PR TITLE
Add Go solution for 1748B

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1748/1748B.go
+++ b/1000-1999/1700-1799/1740-1749/1748/1748B.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var s string
+		fmt.Fscan(reader, &s)
+		ans := 0
+		for i := 0; i < n; i++ {
+			freq := [10]int{}
+			distinct := 0
+			maxFreq := 0
+			for j := i; j < n && j < i+100; j++ {
+				d := s[j] - '0'
+				if freq[d] == 0 {
+					distinct++
+				}
+				freq[d]++
+				if freq[d] > maxFreq {
+					maxFreq = freq[d]
+				}
+				if maxFreq <= distinct {
+					ans++
+				}
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement algorithm to count diverse substrings for 1748B
- add Go source file `1748B.go`

## Testing
- `go build 1000-1999/1700-1799/1740-1749/1748/1748B.go`

------
https://chatgpt.com/codex/tasks/task_e_68820d156f4c8324b0317f7d58d6644e