### PR TITLE
Add Go solution for 1743D

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1743/1743D.go
+++ b/1000-1999/1700-1799/1740-1749/1743/1743D.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	var s string
+	fmt.Fscan(in, &n)
+	fmt.Fscan(in, &s)
+
+	// Trim leading zeros
+	i := 0
+	for i < len(s) && s[i] == '0' {
+		i++
+	}
+	if i == len(s) {
+		fmt.Fprintln(out, 0)
+		return
+	}
+	t := s[i:]
+	best := t
+	l := len(t)
+	maxShift := 20
+	if l < maxShift {
+		maxShift = l
+	}
+	for shift := 1; shift <= maxShift; shift++ {
+		prefix := t[:l-shift]
+		cand := []byte(t)
+		for j := shift; j < l; j++ {
+			if prefix[j-shift] == '1' {
+				cand[j] = '1'
+			}
+		}
+		cs := string(cand)
+		if len(cs) > len(best) || cs > best {
+			best = cs
+		}
+	}
+	fmt.Fprintln(out, best)
+}


### PR DESCRIPTION
## Summary
- add `1743D.go` implementing a binary string OR algorithm

## Testing
- `go build 1000-1999/1700-1799/1740-1749/1743/1743D.go`


------
https://chatgpt.com/codex/tasks/task_e_68820b2aadb08324987c29e7a7630040