### PR TITLE
Add Go solution for 1746D

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1746/1746D.go
+++ b/1000-1999/1700-1799/1740-1749/1746/1746D.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+var (
+	g [][]int
+	s []int64
+)
+
+func dfs(u int, k int64) (int64, int64) {
+	val := k * s[u]
+	if len(g[u]) == 0 {
+		return val, s[u]
+	}
+	m := int64(len(g[u]))
+	base := k / m
+	rem := int(k % m)
+	diffs := make([]int64, len(g[u]))
+	for i, v := range g[u] {
+		childVal, childDiff := dfs(v, base)
+		val += childVal
+		diffs[i] = childDiff
+	}
+	sort.Slice(diffs, func(i, j int) bool { return diffs[i] > diffs[j] })
+	for i := 0; i < rem; i++ {
+		val += diffs[i]
+	}
+	delta := s[u] + diffs[rem]
+	return val, delta
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var n int
+		var k int64
+		fmt.Fscan(in, &n, &k)
+		g = make([][]int, n)
+		p := make([]int, n)
+		for i := 1; i < n; i++ {
+			fmt.Fscan(in, &p[i])
+			p[i]--
+			g[p[i]] = append(g[p[i]], i)
+		}
+		s = make([]int64, n)
+		for i := range s {
+			fmt.Fscan(in, &s[i])
+		}
+		ans, _ := dfs(0, k)
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1746D using DFS with greedy distribution

## Testing
- `go build 1000-1999/1700-1799/1740-1749/1746/1746D.go`
- `go run 1000-1999/1700-1799/1740-1749/1746/1746D.go < /tmp/input2.txt`

------
https://chatgpt.com/codex/tasks/task_e_68820da1e2a08324a5ae62cafa96a64c