### PR TITLE
Add Go solution for 1741E

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1741/1741E.go
+++ b/1000-1999/1700-1799/1740-1749/1741/1741E.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func solve(b []int) bool {
+	n := len(b)
+	dp := make([]bool, n+1)
+	dp[0] = true
+	for i := 0; i < n; i++ {
+		if dp[i] && i+b[i]+1 <= n {
+			dp[i+b[i]+1] = true
+		}
+		if i-b[i] >= 0 && dp[i-b[i]] {
+			dp[i+1] = true
+		}
+	}
+	return dp[n]
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		b := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &b[i])
+		}
+		if solve(b) {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `solve` and main for problem 1741E (Sending a Sequence Over the Network)

## Testing
- `go build 1000-1999/1700-1799/1740-1749/1741/1741E.go`
- `go run 1000-1999/1700-1799/1740-1749/1741/1741E.go <<EOF
1
5
1 2 3 4 5
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68820f8ccf2083248507aefc3a6935d1