### PR TITLE
Add Go solution for CF 1741A

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1741/1741A.go
+++ b/1000-1999/1700-1799/1740-1749/1741/1741A.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var a, b string
+		fmt.Fscan(reader, &a, &b)
+		la := len(a)
+		lb := len(b)
+		ca := a[la-1]
+		cb := b[lb-1]
+		rank := func(c byte) int {
+			if c == 'S' {
+				return 0
+			}
+			if c == 'M' {
+				return 1
+			}
+			return 2 // 'L'
+		}
+		ra := rank(ca)
+		rb := rank(cb)
+		if ra != rb {
+			if ra > rb {
+				fmt.Fprintln(writer, ">")
+			} else {
+				fmt.Fprintln(writer, "<")
+			}
+			continue
+		}
+		if ca == 'M' {
+			fmt.Fprintln(writer, "=")
+			continue
+		}
+		if ca == 'S' {
+			if la == lb {
+				fmt.Fprintln(writer, "=")
+			} else if la < lb {
+				fmt.Fprintln(writer, ">")
+			} else {
+				fmt.Fprintln(writer, "<")
+			}
+		} else { // 'L'
+			if la == lb {
+				fmt.Fprintln(writer, "=")
+			} else if la > lb {
+				fmt.Fprintln(writer, ">")
+			} else {
+				fmt.Fprintln(writer, "<")
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `1741A` (Compare T-Shirt Sizes)

## Testing
- `go vet 1000-1999/1700-1799/1740-1749/1741/1741A.go`
- `go run 1000-1999/1700-1799/1740-1749/1741/1741A.go <<EOF
1
M L
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688210eb688c8324a36b5e3b6879682f