### PR TITLE
Add Go solution for 1741C

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1741/1741C.go
+++ b/1000-1999/1700-1799/1740-1749/1741/1741C.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := range a {
+			fmt.Fscan(reader, &a[i])
+		}
+
+		prefix := make([]int, n+1)
+		pos := make(map[int]int, n+1)
+		pos[0] = 0
+		for i := 0; i < n; i++ {
+			prefix[i+1] = prefix[i] + a[i]
+			pos[prefix[i+1]] = i + 1
+		}
+
+		ans := n
+		for i := 1; i <= n; i++ {
+			target := prefix[i]
+			last := i
+			maxLen := i
+			valid := true
+			for last < n {
+				needed := prefix[last] + target
+				idx, ok := pos[needed]
+				if !ok {
+					valid = false
+					break
+				}
+				segLen := idx - last
+				if segLen > maxLen {
+					maxLen = segLen
+				}
+				last = idx
+			}
+			if valid && last == n {
+				if maxLen < ans {
+					ans = maxLen
+				}
+			}
+		}
+
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 1741C in Go

## Testing
- `go build 1000-1999/1700-1799/1740-1749/1741/1741C.go`
- `./1741C <<EOF
1
6
55 45 30 30 40 100
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688210a540888324b711fc77f5b1a56a