### PR TITLE
Add Go solution for 1740D

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1740/1740D.go
+++ b/1000-1999/1700-1799/1740-1749/1740/1740D.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, m, k int
+		fmt.Fscan(in, &n, &m, &k)
+		a := make([]int, k)
+		for i := 0; i < k; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		capacity := n*m - 2
+		stored := make([]bool, k+1)
+		count := 0
+		p := 0
+		ok := true
+		for target := k; target >= 1 && ok; target-- {
+			if stored[target] {
+				stored[target] = false
+				count--
+			} else {
+				for p < k && a[p] != target {
+					stored[a[p]] = true
+					count++
+					if count > capacity {
+						ok = false
+						break
+					}
+					p++
+				}
+				if !ok {
+					break
+				}
+				if p == k {
+					ok = false
+					break
+				}
+				p++ // deposit target directly
+			}
+		}
+		if ok {
+			fmt.Fprintln(out, "YA")
+		} else {
+			fmt.Fprintln(out, "TIDAK")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem D using greedy simulation and capacity checks

## Testing
- `gofmt -w 1000-1999/1700-1799/1740-1749/1740/1740D.go`


------
https://chatgpt.com/codex/tasks/task_e_68821203f6188324b6b37826ded374c0