### PR TITLE
Add Go solution for 1740B

### DIFF
--- a/1000-1999/1700-1799/1740-1749/1740/1740B.go
+++ b/1000-1999/1700-1799/1740-1749/1740/1740B.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var sumWidth int64
+		var maxHeight int64
+		for i := 0; i < n; i++ {
+			var a, b int64
+			fmt.Fscan(reader, &a, &b)
+			if a > b {
+				a, b = b, a
+			}
+			sumWidth += a
+			if b > maxHeight {
+				maxHeight = b
+			}
+		}
+		perimeter := 2 * (sumWidth + maxHeight)
+		fmt.Fprintln(writer, perimeter)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1740B.go` for problem B in the 1740 set

## Testing
- `go build 1000-1999/1700-1799/1740-1749/1740/1740B.go`

------
https://chatgpt.com/codex/tasks/task_e_6882131c86e0832483ba2494a41fb8d8