### PR TITLE
Add Go solution for 1732D1

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1732/1732D1.go
+++ b/1000-1999/1700-1799/1730-1739/1732/1732D1.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var q int
+	if _, err := fmt.Fscan(reader, &q); err != nil {
+		return
+	}
+
+	set := make(map[int64]struct{})
+	set[0] = struct{}{}
+	next := make(map[int64]int64)
+
+	for i := 0; i < q; i++ {
+		var op string
+		fmt.Fscan(reader, &op)
+		if op == "+" {
+			var x int64
+			fmt.Fscan(reader, &x)
+			set[x] = struct{}{}
+		} else if op == "?" {
+			var k int64
+			fmt.Fscan(reader, &k)
+			v := next[k]
+			for {
+				if _, found := set[v]; !found {
+					fmt.Fprintln(writer, v)
+					next[k] = v
+					break
+				}
+				v += k
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for `problemD1.txt`
- add `1732D1.go` with efficient k-mex logic

## Testing
- `go build 1000-1999/1700-1799/1730-1739/1732/1732D1.go`
- `echo -e "5\n+ 1\n+ 2\n? 1\n+ 4\n? 2" | go run 1000-1999/1700-1799/1730-1739/1732/1732D1.go`

------
https://chatgpt.com/codex/tasks/task_e_68821738b29483249f8f414f41851376