### PR TITLE
Add Go solution for 1735A

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1735/1735A.go
+++ b/1000-1999/1700-1799/1730-1739/1735/1735A.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		if n < 6 {
+			fmt.Fprintln(writer, 0)
+			continue
+		}
+		fmt.Fprintln(writer, (n-6)/3)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1735A.go` solution

## Testing
- `go build -o /tmp/1735A.bin 1000-1999/1700-1799/1730-1739/1735/1735A.go`

------
https://chatgpt.com/codex/tasks/task_e_68821851494c8324aedcd66203bb7062