### PR TITLE
Add Go solution for CF 1734C

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1734/1734C.go
+++ b/1000-1999/1700-1799/1730-1739/1734/1734C.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var s string
+		fmt.Fscan(reader, &s)
+		cost := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			for j := i; j <= n; j += i {
+				if s[j-1] == '1' {
+					break
+				}
+				if cost[j] == 0 {
+					cost[j] = i
+				}
+			}
+		}
+		ans := 0
+		for i := 1; i <= n; i++ {
+			if s[i-1] == '0' {
+				ans += cost[i]
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1734C.go` solving problem C in Go

## Testing
- `go build 1000-1999/1700-1799/1730-1739/1734/1734C.go`
- `./a.out < /tmp/test.in` (custom sample)

------
https://chatgpt.com/codex/tasks/task_e_68821923c31483249d30e381f555be18