### PR TITLE
Add Go solution stub for 1734F

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1734/1734F.go
+++ b/1000-1999/1700-1799/1730-1739/1734/1734F.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/bits"
+	"os"
+)
+
+func thueMorse(x uint64) uint64 {
+	return uint64(bits.OnesCount64(x) & 1)
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var n, m uint64
+		fmt.Fscan(in, &n, &m)
+		var ans uint64
+		for i := uint64(0); i < m; i++ {
+			if thueMorse(i)^thueMorse(i+n) == 1 {
+				ans++
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a simple Go program for problem F of contest 1734

## Testing
- `gofmt -w 1000-1999/1700-1799/1730-1739/1734/1734F.go`

------
https://chatgpt.com/codex/tasks/task_e_688218dd9b5c832495b9ba6e5e381cf4