### PR TITLE
Add Go solution for 1733A

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1733/1733A.go
+++ b/1000-1999/1700-1799/1730-1739/1733/1733A.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+
+		sum := 0
+		for r := 0; r < k; r++ {
+			maxVal := 0
+			for i := r; i < n; i += k {
+				if a[i] > maxVal {
+					maxVal = a[i]
+				}
+			}
+			sum += maxVal
+		}
+		fmt.Fprintln(writer, sum)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem A in 1733

## Testing
- `GO111MODULE=off go run 1000-1999/1700-1799/1730-1739/1733/1733A.go <<'EOF'
1
5 3
5 4 3 1 2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68821a3c9ebc832481b80d3cb31783ed