### PR TITLE
Add Go solution for problem 1736A

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1736/1736A.go
+++ b/1000-1999/1700-1799/1730-1739/1736/1736A.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		b := make([]int, n)
+		cntA, cntB := 0, 0
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+			if a[i] == 1 {
+				cntA++
+			}
+		}
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &b[i])
+			if b[i] == 1 {
+				cntB++
+			}
+		}
+		mism := 0
+		for i := 0; i < n; i++ {
+			if a[i] != b[i] {
+				mism++
+			}
+		}
+		diff := cntA - cntB
+		if diff < 0 {
+			diff = -diff
+		}
+		ans := mism
+		if diff+1 < ans {
+			ans = diff + 1
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for 1736A (Make A Equal to B)

## Testing
- `go build 1000-1999/1700-1799/1730-1739/1736/1736A.go`
- `./1736A <<EOF
1
2
1 0
0 0
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68821c6dc50883248fe61f9769fc0d3b