### PR TITLE
Add Go solution for 1738H

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1738/1738H.go
+++ b/1000-1999/1700-1799/1730-1739/1738/1738H.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func isPalindrome(b []byte) bool {
+	i, j := 0, len(b)-1
+	for i < j {
+		if b[i] != b[j] {
+			return false
+		}
+		i++
+		j--
+	}
+	return true
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var q int
+	fmt.Fscan(in, &q)
+
+	queue := make([]byte, 0)
+	for ; q > 0; q-- {
+		var op string
+		fmt.Fscan(in, &op)
+		if op == "push" {
+			var c string
+			fmt.Fscan(in, &c)
+			queue = append(queue, c[0])
+		} else if op == "pop" {
+			if len(queue) > 0 {
+				queue = queue[1:]
+			}
+		}
+		seen := make(map[string]struct{})
+		for i := 0; i < len(queue); i++ {
+			for j := i; j < len(queue); j++ {
+				if isPalindrome(queue[i : j+1]) {
+					seen[string(queue[i:j+1])] = struct{}{}
+				}
+			}
+		}
+		fmt.Fprintln(out, len(seen))
+	}
+}


### PR DESCRIPTION
## Summary
- add a new Go solution `1738H.go`
- implement a naive approach to count distinct palindromic substrings after each queue operation

## Testing
- `gofmt -w 1000-1999/1700-1799/1730-1739/1738/1738H.go`


------
https://chatgpt.com/codex/tasks/task_e_68821e58e3ac8324a12b0971894463e1