### PR TITLE
Add Go solution for 1730A

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1730/1730A.go
+++ b/1000-1999/1700-1799/1730-1739/1730/1730A.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		solve(reader, writer)
+	}
+}
+
+func solve(reader *bufio.Reader, writer *bufio.Writer) {
+	var n, c int
+	fmt.Fscan(reader, &n, &c)
+	counts := make(map[int]int)
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(reader, &x)
+		counts[x]++
+	}
+	ans := 0
+	for _, cnt := range counts {
+		if cnt < c {
+			ans += cnt
+		} else {
+			ans += c
+		}
+	}
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1730A

## Testing
- `go run 1000-1999/1700-1799/1730-1739/1730/1730A.go <<EOF
1
4 2
1 2 2 3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6882222f1c9c83248d5e49f7b84b6721