### PR TITLE
Add Go solution for 1730C

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1730/1730C.go
+++ b/1000-1999/1700-1799/1730-1739/1730/1730C.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		res := solve(s)
+		fmt.Fprintln(writer, res)
+	}
+}
+
+func solve(s string) string {
+	n := len(s)
+	digits := []byte(s)
+	minRight := byte('9')
+	for i := n - 1; i >= 0; i-- {
+		orig := digits[i]
+		if orig > minRight && orig < '9' {
+			digits[i] = orig + 1
+		}
+		if orig < minRight {
+			minRight = orig
+		}
+	}
+	sort.Slice(digits, func(i, j int) bool { return digits[i] < digits[j] })
+	return string(digits)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem C in contest 1730

## Testing
- `go build 1000-1999/1700-1799/1730-1739/1730/1730C.go`


------
https://chatgpt.com/codex/tasks/task_e_688221e8cf2c8324b9acac1e4c81e815