### PR TITLE
Add Go solution for 1737B

### DIFF
--- a/1000-1999/1700-1799/1730-1739/1737/1737B.go
+++ b/1000-1999/1700-1799/1730-1739/1737/1737B.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func countLuxury(n int64) int64 {
+	if n <= 0 {
+		return 0
+	}
+	m := int64(math.Sqrt(float64(n)))
+	for (m+1)*(m+1) <= n { // ensure floor sqrt
+		m++
+	}
+	for m*m > n {
+		m--
+	}
+	ans := (m - 1) * 3
+	if m*m <= n {
+		ans++
+	}
+	if m*m+m <= n {
+		ans++
+	}
+	if m*m+2*m <= n {
+		ans++
+	}
+	return ans
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var l, r int64
+		fmt.Fscan(in, &l, &r)
+		fmt.Fprintln(out, countLuxury(r)-countLuxury(l-1))
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 1737B (Ela and luxury numbers)

## Testing
- `go build 1000-1999/1700-1799/1730-1739/1737/1737B.go`


------
https://chatgpt.com/codex/tasks/task_e_6882238decdc83249fccd789a4b8b221