### PR TITLE
Add Go solution for Problem 1795B

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1795/1795B.go
+++ b/1000-1999/1700-1799/1790-1799/1795/1795B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(in, &n, &k)
+		left, right := false, false
+		for i := 0; i < n; i++ {
+			var l, r int
+			fmt.Fscan(in, &l, &r)
+			if l == k {
+				left = true
+			}
+			if r == k {
+				right = true
+			}
+		}
+		if left && right {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1795B.go`
- simple check for segments starting and ending at `k`

## Testing
- `gofmt -w ./1000-1999/1700-1799/1790-1799/1795/1795B.go`
- `go build ./1000-1999/1700-1799/1790-1799/1795/1795B.go`


------
https://chatgpt.com/codex/tasks/task_e_688225788fc08324afeecd316fdf080f