### PR TITLE
Add Go solution for problem 1793F

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1793/1793F.go
+++ b/1000-1999/1700-1799/1790-1799/1793/1793F.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, q int
+	if _, err := fmt.Fscan(in, &n, &q); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	for ; q > 0; q-- {
+		var l, r int
+		fmt.Fscan(in, &l, &r)
+		l--
+		seg := append([]int(nil), a[l:r]...)
+		sort.Ints(seg)
+		ans := seg[1] - seg[0]
+		for i := 2; i < len(seg); i++ {
+			d := seg[i] - seg[i-1]
+			if d < ans {
+				ans = d
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem F in contest 1793

## Testing
- `gofmt -w 1000-1999/1700-1799/1790-1799/1793/1793F.go`


------
https://chatgpt.com/codex/tasks/task_e_6882287c156c8324b086592599a23116