### PR TITLE
Add Go solution for 1794C

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1794/1794C.go
+++ b/1000-1999/1700-1799/1790-1799/1794/1794C.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+
+		prefix := make([]float64, n+1)
+		for i := 1; i <= n; i++ {
+			prefix[i] = prefix[i-1] + math.Log(float64(a[i-1]))
+		}
+		logFact := make([]float64, n+1)
+		for i := 1; i <= n; i++ {
+			logFact[i] = logFact[i-1] + math.Log(float64(i))
+		}
+
+		ans := make([]int, n)
+		d := 0
+		for k := 1; k <= n; k++ {
+			for d < k {
+				scoreD := prefix[k] - prefix[k-d] - logFact[d]
+				scoreD1 := prefix[k] - prefix[k-(d+1)] - logFact[d+1]
+				if scoreD1 >= scoreD-1e-12 {
+					d++
+				} else {
+					break
+				}
+			}
+			ans[k-1] = d
+		}
+
+		for i, v := range ans {
+			if i > 0 {
+				fmt.Fprint(out, " ")
+			}
+			fmt.Fprint(out, v)
+		}
+		fmt.Fprintln(out)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem C in contest 1794

## Testing
- `go run 1000-1999/1700-1799/1790-1799/1794/1794C.go < /tmp/input.txt`
- `go run 1000-1999/1700-1799/1790-1799/1794/1794C.go < /tmp/inp`


------
https://chatgpt.com/codex/tasks/task_e_688229daae408324b3c0814847a0f09b