### PR TITLE
Add initial Go solution for 1793E

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1793/1793E.go
+++ b/1000-1999/1700-1799/1790-1799/1793/1793E.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	sort.Ints(a)
+
+	var q int
+	fmt.Fscan(in, &q)
+	// precompute prefix array for binary search bounds
+	for ; q > 0; q-- {
+		var k int
+		fmt.Fscan(in, &k)
+		l, r := 0, n
+		for l < r {
+			m := (l + r + 1) / 2
+			if feasible(a, n, m, k) {
+				l = m
+			} else {
+				r = m - 1
+			}
+		}
+		fmt.Fprintln(out, l)
+	}
+}
+
+func feasible(a []int, n, t, k int) bool {
+	// check if it is possible to satisfy t smallest requirements using at most k groups
+	groups := 0
+	filler := 0
+	i := t
+	for i > 0 {
+		groups++
+		need := a[i-1]
+		if i >= need {
+			i -= need
+		} else {
+			filler += need - i
+			i = 0
+		}
+	}
+	if groups > k {
+		return false
+	}
+	if filler > n-t {
+		return false
+	}
+	return n-t-filler >= k-groups
+}


### PR DESCRIPTION
## Summary
- add Go solution file `1793E.go` implementing a feasible approach for problem E

## Testing
- `gofmt -w 1000-1999/1700-1799/1790-1799/1793/1793E.go`


------
https://chatgpt.com/codex/tasks/task_e_688227f003bc8324b95e8de014df94d0