### PR TITLE
Add Go solution for Codeforces 1791E

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1791/1791E.go
+++ b/1000-1999/1700-1799/1790-1799/1791/1791E.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int64, n)
+		var negCount int
+		hasZero := false
+		var sumAbs int64
+		var minAbs int64 = 1<<63 - 1
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+			if arr[i] < 0 {
+				negCount++
+			}
+			if arr[i] == 0 {
+				hasZero = true
+			}
+			v := arr[i]
+			if v < 0 {
+				v = -v
+			}
+			sumAbs += v
+			if v < minAbs {
+				minAbs = v
+			}
+		}
+		if negCount%2 == 1 && !hasZero {
+			sumAbs -= 2 * minAbs
+		}
+		fmt.Fprintln(writer, sumAbs)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution to problem E for contest 1791

## Testing
- `go build 1000-1999/1700-1799/1790-1799/1791/1791E.go`

------
https://chatgpt.com/codex/tasks/task_e_68822bc5dc808324b72609ffc377185f