### PR TITLE
Add Go solution for 1791G1

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1791/1791G1.go
+++ b/1000-1999/1700-1799/1790-1799/1791/1791G1.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var c int64
+		fmt.Fscan(in, &n, &c)
+		costs := make([]int64, n)
+		for i := 0; i < n; i++ {
+			var a int64
+			fmt.Fscan(in, &a)
+			costs[i] = a + int64(i+1)
+		}
+		sort.Slice(costs, func(i, j int) bool { return costs[i] < costs[j] })
+		count := 0
+		for _, v := range costs {
+			if c >= v {
+				c -= v
+				count++
+			} else {
+				break
+			}
+		}
+		fmt.Fprintln(out, count)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for Teleporters (Easy Version) problem 1791G1

## Testing
- `go build 1000-1999/1700-1799/1790-1799/1791/1791G1.go`


------
https://chatgpt.com/codex/tasks/task_e_68822b40cec483249e3d1ace57cc4e99