### PR TITLE
Add Go solution for 1791C

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1791/1791C.go
+++ b/1000-1999/1700-1799/1790-1799/1791/1791C.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(in, &n)
+		fmt.Fscan(in, &s)
+		l, r := 0, n-1
+		for l < r && s[l] != s[r] {
+			l++
+			r--
+		}
+		if r < l {
+			fmt.Fprintln(out, 0)
+		} else {
+			fmt.Fprintln(out, r-l+1)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add solution for contest 1791 problem C `Prepend and Append`

## Testing
- `go run 1000-1999/1700-1799/1790-1799/1791/1791C.go << EOF`
  `1`
  `1`
  `0`
  `EOF`

------
https://chatgpt.com/codex/tasks/task_e_68822c98383c8324b38fce8c920503f6