### PR TITLE
Add Go solution for 1796A

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1796/1796A.go
+++ b/1000-1999/1700-1799/1790-1799/1796/1796A.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+
+	base := "FBFFBFFB"
+	pattern := strings.Repeat(base, 20)
+
+	for ; t > 0; t-- {
+		var k int
+		var s string
+		fmt.Fscan(reader, &k, &s)
+		if strings.Contains(pattern, s) {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem A in contest 1796

## Testing
- `gofmt -w 1000-1999/1700-1799/1790-1799/1796/1796A.go`
- `go build 1000-1999/1700-1799/1790-1799/1796/1796A.go`

------
https://chatgpt.com/codex/tasks/task_e_68822e83364083249ce0a027047a9ad6