### PR TITLE
Add Go solution for 1790D

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1790/1790D.go
+++ b/1000-1999/1700-1799/1790-1799/1790/1790D.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		freq := make(map[int]int, n)
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			freq[x]++
+		}
+		keys := make([]int, 0, len(freq))
+		for k := range freq {
+			keys = append(keys, k)
+		}
+		sort.Ints(keys)
+		total := 0
+		active := 0
+		prev := 0
+		first := true
+		for _, k := range keys {
+			if first {
+				first = false
+			} else if k != prev+1 {
+				active = 0
+			}
+			need := freq[k] - active
+			if need > 0 {
+				total += need
+			}
+			active = freq[k]
+			prev = k
+		}
+		fmt.Fprintln(writer, total)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1790D

## Testing
- `go build ./1000-1999/1700-1799/1790-1799/1790/1790D.go`

------
https://chatgpt.com/codex/tasks/task_e_6882306e3d4c832491a03c2ccdc7340a