### PR TITLE
Add 1790A Go solution

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1790/1790A.go
+++ b/1000-1999/1700-1799/1790-1799/1790/1790A.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const piDigits = "314159265358979323846264338327"
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		count := 0
+		for i := 0; i < len(s) && i < len(piDigits); i++ {
+			if s[i] == piDigits[i] {
+				count++
+			} else {
+				break
+			}
+		}
+		fmt.Fprintln(writer, count)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1790A `Polycarp and the Day of Pi`

## Testing
- `go build 1000-1999/1700-1799/1790-1799/1790/1790A.go`
- `echo -e "1\n314159265358979323846264338327" | go run 1000-1999/1700-1799/1790-1799/1790/1790A.go`


------
https://chatgpt.com/codex/tasks/task_e_68823186e3488324826258a67e0335bd