### PR TITLE
Add naive solution for 1799G

### DIFF
--- a/1000-1999/1700-1799/1790-1799/1799/1799G.go
+++ b/1000-1999/1700-1799/1790-1799/1799/1799G.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const MOD int = 998244353
+
+var n int
+var c []int
+var team []int
+var ans int
+
+func dfs(idx int, rem []int) {
+	if idx == n {
+		ans = (ans + 1) % MOD
+		return
+	}
+	for j := 0; j < n; j++ {
+		if team[idx] == team[j] { // can't vote for same team
+			continue
+		}
+		if rem[j] == 0 {
+			continue
+		}
+		rem[j]--
+		dfs(idx+1, rem)
+		rem[j]++
+	}
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Fscan(reader, &n)
+	c = make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &c[i])
+	}
+	team = make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &team[i])
+		team[i]--
+	}
+	rem := make([]int, n)
+	copy(rem, c)
+	dfs(0, rem)
+	writer := bufio.NewWriter(os.Stdout)
+	fmt.Fprintln(writer, ans)
+	writer.Flush()
+}


### PR DESCRIPTION
## Summary
- add a naive recursive solver for problem G of contest 1799

## Testing
- `gofmt -w 1000-1999/1700-1799/1790-1799/1799/1799G.go`


------
https://chatgpt.com/codex/tasks/task_e_6882329fba008324ba9150b977b89125