### PR TITLE
Add Go solution for CF 1718A2

### DIFF
--- a/1000-1999/1700-1799/1710-1719/1718/1718A2.go
+++ b/1000-1999/1700-1799/1710-1719/1718/1718A2.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		pre := 0
+		dp := make([]int, n+1)
+		mp := map[int]int{0: 0}
+		for i := 1; i <= n; i++ {
+			pre ^= a[i-1]
+			dp[i] = dp[i-1]
+			if v, ok := mp[pre]; ok {
+				if dp[i] < v+1 {
+					dp[i] = v + 1
+				}
+			}
+			if mpv, ok := mp[pre]; !ok || mpv < dp[i] {
+				mp[pre] = dp[i]
+			}
+		}
+		fmt.Fprintln(out, n-dp[n])
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem A2 in contest 1718

## Testing
- `go vet 1000-1999/1700-1799/1710-1719/1718/1718A2.go`
- `go run 1000-1999/1700-1799/1710-1719/1718/1718A2.go <<EOF
2
4
1 2 3 0
3
1 1 1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688235a3041c832489c77c4a33597907