### PR TITLE
Add Go solution for 1719A

### DIFF
--- a/1000-1999/1700-1799/1710-1719/1719/1719A.go
+++ b/1000-1999/1700-1799/1710-1719/1719/1719A.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m int64
+		fmt.Fscan(in, &n, &m)
+		if (n+m)%2 == 0 {
+			fmt.Fprintln(out, "Tonya")
+		} else {
+			fmt.Fprintln(out, "Burenka")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add implementation for `1719A.go`

## Testing
- `go vet 1000-1999/1700-1799/1710-1719/1719/1719A.go`
- `go build 1000-1999/1700-1799/1710-1719/1719/1719A.go`


------
https://chatgpt.com/codex/tasks/task_e_6882378e7e448324ba0421432d640869