### PR TITLE
Add Go solution for problem 1717A

### DIFF
--- a/1000-1999/1700-1799/1710-1719/1717/1717A.go
+++ b/1000-1999/1700-1799/1710-1719/1717/1717A.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		ans := n + 2*(n/2) + 2*(n/3)
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 1717 problem A

## Testing
- `go vet 1000-1999/1700-1799/1710-1719/1717/1717A.go`
- `go build 1000-1999/1700-1799/1710-1719/1717/1717A.go`


------
https://chatgpt.com/codex/tasks/task_e_688238a6e388832499bae792884e9dc8