### PR TITLE
Add Go solution for 1717D

### DIFF
--- a/1000-1999/1700-1799/1710-1719/1717/1717D.go
+++ b/1000-1999/1700-1799/1710-1719/1717/1717D.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 1e9 + 7
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, k int
+	if _, err := fmt.Fscan(reader, &n, &k); err != nil {
+		return
+	}
+	if k > n {
+		k = n
+	}
+	fact := make([]int64, n+1)
+	invFact := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invFact[n] = modPow(fact[n], mod-2)
+	for i := n; i >= 1; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % mod
+	}
+	ans := int64(0)
+	for i := 0; i <= k; i++ {
+		ans = (ans + fact[n]*invFact[i]%mod*invFact[n-i]%mod) % mod
+	}
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1717D
- compute binomial sum up to `min(k,n)` using factorials and modular inverses

## Testing
- `go run 1000-1999/1700-1799/1710-1719/1717/1717D.go << EOF
2 1
EOF`
- `go run 1000-1999/1700-1799/1710-1719/1717/1717D.go << EOF
3 2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6882381a7f388324a1ab74cce94ee8d7