### PR TITLE
Add Go solution for problem 1712A

### DIFF
--- a/1000-1999/1700-1799/1710-1719/1712/1712A.go
+++ b/1000-1999/1700-1799/1710-1719/1712/1712A.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		p := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &p[i])
+		}
+		ans := 0
+		for i := 0; i < k; i++ {
+			if p[i] > k {
+				ans++
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1712A.go` with buffered IO
- count elements greater than `k` in the first `k` positions to determine minimal swaps

## Testing
- `go build 1000-1999/1700-1799/1710-1719/1712/1712A.go`

------
https://chatgpt.com/codex/tasks/task_e_68823cc2e8488324bc33fe1cbb4d4037