### PR TITLE
Add Go solution for 1714C

### DIFF
--- a/1000-1999/1700-1799/1710-1719/1714/1714C.go
+++ b/1000-1999/1700-1799/1710-1719/1714/1714C.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s int
+		fmt.Fscan(reader, &s)
+		var digits []int
+		for d := 9; d >= 1; d-- {
+			if s >= d {
+				digits = append(digits, d)
+				s -= d
+			}
+		}
+		for i := len(digits) - 1; i >= 0; i-- {
+			fmt.Fprint(writer, digits[i])
+		}
+		fmt.Fprintln(writer)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1714C.go` to solve problem C in contest 1714

## Testing
- `gofmt -w ./1000-1999/1700-1799/1710-1719/1714/1714C.go`


------
https://chatgpt.com/codex/tasks/task_e_68823f800a408324b79ab9f682cb9a6a