### PR TITLE
Add Go solution for 1768B

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1768/1768B.go
+++ b/1000-1999/1700-1799/1760-1769/1768/1768B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(in, &n, &k)
+		p := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &p[i])
+		}
+		expected := 1
+		for _, v := range p {
+			if v == expected {
+				expected++
+			}
+		}
+		m := expected - 1
+		remaining := n - m
+		if remaining <= 0 {
+			fmt.Fprintln(out, 0)
+		} else {
+			ans := (remaining + k - 1) / k
+			fmt.Fprintln(out, ans)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for contest 1768 problem B

## Testing
- `gofmt -w 1000-1999/1700-1799/1760-1769/1768/1768B.go`


------
https://chatgpt.com/codex/tasks/task_e_68824124e4d083248ee3db881515da5b