### PR TITLE
Add Go solution for 1768D

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1768/1768D.go
+++ b/1000-1999/1700-1799/1760-1769/1768/1768D.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		p := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(reader, &p[i])
+		}
+		visited := make([]bool, n+1)
+		cycleID := make([]int, n+1)
+		cid := 0
+		for i := 1; i <= n; i++ {
+			if !visited[i] {
+				cid++
+				j := i
+				for !visited[j] {
+					visited[j] = true
+					cycleID[j] = cid
+					j = p[j]
+				}
+			}
+		}
+		base := n - cid
+		same := false
+		for i := 1; i < n; i++ {
+			if cycleID[i] == cycleID[i+1] {
+				same = true
+				break
+			}
+		}
+		ans := base + 1
+		if same {
+			ans = base - 1
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solver for problem 1768D
- compute cycle count of the permutation and adjust for adjacent cycle pairs

## Testing
- `go build 1000-1999/1700-1799/1760-1769/1768/1768D.go`


------
https://chatgpt.com/codex/tasks/task_e_688240988a7c83248989b364fef43e7b