### PR TITLE
Add Go solution for 1767D

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1767/1767D.go
+++ b/1000-1999/1700-1799/1760-1769/1767/1767D.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	var s string
+	fmt.Fscan(reader, &s)
+
+	ones := 0
+	zeros := 0
+	for _, ch := range s {
+		if ch == '1' {
+			ones++
+		} else {
+			zeros++
+		}
+	}
+
+	N := 1 << n
+	L := 1 << ones
+	R := N - (1 << zeros) + 1
+
+	for i := L; i <= R; i++ {
+		if i > L {
+			fmt.Fprint(writer, " ")
+		}
+		fmt.Fprint(writer, i)
+	}
+	fmt.Fprintln(writer)
+}


### PR DESCRIPTION
## Summary
- add Go solution for `1767D`

## Testing
- `go vet 1000-1999/1700-1799/1760-1769/1767/1767D.go`
- `go build 1000-1999/1700-1799/1760-1769/1767/1767D.go`


------
https://chatgpt.com/codex/tasks/task_e_688244fa81708324b2f952f36d4ebe5f