### PR TITLE
Add solution for 1760D

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1760/1760D.go
+++ b/1000-1999/1700-1799/1760-1769/1760/1760D.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		// compress consecutive duplicates
+		b := make([]int, 0, n)
+		for i := 0; i < n; i++ {
+			if i == 0 || arr[i] != arr[i-1] {
+				b = append(b, arr[i])
+			}
+		}
+		m := len(b)
+		idx := 0
+		for idx+1 < m && b[idx] > b[idx+1] {
+			idx++
+		}
+		for idx+1 < m && b[idx] < b[idx+1] {
+			idx++
+		}
+		if idx == m-1 {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 1760D in Go

## Testing
- `gofmt -w 1000-1999/1700-1799/1760-1769/1760/1760D.go`

------
https://chatgpt.com/codex/tasks/task_e_6882469f29b08324ad457d3672c22c6f