### PR TITLE
Add Go solution for Codeforces 1760A

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1760/1760A.go
+++ b/1000-1999/1700-1799/1760-1769/1760/1760A.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a, b, c int
+		fmt.Fscan(in, &a, &b, &c)
+		nums := []int{a, b, c}
+		sort.Ints(nums)
+		fmt.Fprintln(out, nums[1])
+	}
+}


### PR DESCRIPTION
## Summary
- implement problem A solution in Go for contest 1760

## Testing
- `go build 1000-1999/1700-1799/1760-1769/1760/1760A.go`
- `go run 1000-1999/1700-1799/1760-1769/1760/1760A.go` with sample input

------
https://chatgpt.com/codex/tasks/task_e_688247fdd49c8324bf80558b69f3f673