### PR TITLE
Add Go solution for CF 1760B

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1760/1760B.go
+++ b/1000-1999/1700-1799/1760-1769/1760/1760B.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+func main() {
+    in := bufio.NewReader(os.Stdin)
+    var t int
+    if _, err := fmt.Fscan(in, &t); err != nil {
+        return
+    }
+    for ; t > 0; t-- {
+        var n int
+        var s string
+        fmt.Fscan(in, &n)
+        fmt.Fscan(in, &s)
+        maxCh := byte('a')
+        for i := 0; i < n; i++ {
+            if s[i] > maxCh {
+                maxCh = s[i]
+            }
+        }
+        fmt.Println(int(maxCh - 'a' + 1))
+    }
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem B in contest 1760

## Testing
- `go build 1000-1999/1700-1799/1760-1769/1760/1760B.go`

------
https://chatgpt.com/codex/tasks/task_e_688247b84db8832497a52d11b7798302