### PR TITLE
Add Go solution for problem 1765M

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1765/1765M.go
+++ b/1000-1999/1700-1799/1760-1769/1765/1765M.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		spf := int64(-1)
+		for i := int64(2); i*i <= n; i++ {
+			if n%i == 0 {
+				spf = i
+				break
+			}
+		}
+		if spf == -1 {
+			fmt.Fprintln(writer, 1, n-1)
+		} else {
+			a := n / spf
+			fmt.Fprintln(writer, a, n-a)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `1765M`

## Testing
- `go build 1000-1999/1700-1799/1760-1769/1765/1765M.go`


------
https://chatgpt.com/codex/tasks/task_e_68824a2ec6c083249b4729773b28b590