### PR TITLE
Add Go solution for 1750A

### DIFF
--- a/1000-1999/1700-1799/1750-1759/1750/1750A.go
+++ b/1000-1999/1700-1799/1750-1759/1750/1750A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		if arr[0] == 1 {
+			fmt.Fprintln(writer, "Yes")
+		} else {
+			fmt.Fprintln(writer, "No")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1750A

## Testing
- `go build 1000-1999/1700-1799/1750-1759/1750/1750A.go`
- `go vet 1000-1999/1700-1799/1750-1759/1750/1750A.go`


------
https://chatgpt.com/codex/tasks/task_e_6882545186548324936ee12559135b8b