### PR TITLE
Add Go solution for 1765B

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1765/1765B.go
+++ b/1000-1999/1700-1799/1760-1769/1765/1765B.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(reader, &n, &s)
+		pos := 0
+		double := false
+		ok := true
+		for pos < n {
+			if double {
+				if pos+1 >= n || s[pos] != s[pos+1] {
+					ok = false
+					break
+				}
+				pos += 2
+			} else {
+				pos++
+			}
+			double = !double
+		}
+		if pos != n {
+			ok = false
+		}
+		if ok {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement a solver for problemB in contest 1765

## Testing
- `go run 1765B.go <<EOF
4
4
ossu
2
aa
3
abb
4
qwe
EOF`
- `go build 1765B.go`


------
https://chatgpt.com/codex/tasks/task_e_68824cec0c6483249171e7718b0d86f3