### PR TITLE
Add Go solution for 1765D

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1765/1765D.go
+++ b/1000-1999/1700-1799/1760-1769/1765/1765D.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	var m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return
+	}
+	a := make([]int, n)
+	var sum int64
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+		sum += int64(a[i])
+	}
+	sort.Ints(a)
+	i, j := 0, n-1
+	wait := 0
+	for i < j {
+		if a[i]+a[j] <= m {
+			i++
+			j--
+		} else {
+			wait++
+			j--
+		}
+	}
+	ans := sum + int64(wait) + 1
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement solution for problem D in contest 1765

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*
- `go build ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68824c19b3988324a6e0782e7befa0a9