### PR TITLE
Add solution for 1765E in Go

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1765/1765E.go
+++ b/1000-1999/1700-1799/1760-1769/1765/1765E.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, a, b int
+		fmt.Fscan(reader, &n, &a, &b)
+		if a > b {
+			fmt.Fprintln(writer, 1)
+		} else {
+			ans := (n + a - 1) / a
+			if ans < 1 {
+				ans = 1
+			}
+			fmt.Fprintln(writer, ans)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 1765 problem E

## Testing
- `go build 1000-1999/1700-1799/1760-1769/1765/1765E.go`


------
https://chatgpt.com/codex/tasks/task_e_68824bd385d08324919856f87a23bee1