### PR TITLE
Add Go solution for 1765 Problem K

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1765/1765K.go
+++ b/1000-1999/1700-1799/1760-1769/1765/1765K.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	fmt.Fscan(reader, &n)
+
+	var total int64
+	const inf int64 = 1<<63 - 1
+	minDiag := inf
+
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			var x int64
+			fmt.Fscan(reader, &x)
+			total += x
+			if j == n-1-i && x < minDiag {
+				minDiag = x
+			}
+		}
+	}
+
+	fmt.Fprintln(writer, total-minDiag)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for 1765 problem K

## Testing
- `go build 1000-1999/1700-1799/1760-1769/1765/1765K.go`


------
https://chatgpt.com/codex/tasks/task_e_68824b0136f08324b8bccc0171d39d9b