### PR TITLE
Add Go solution for problem 1765N

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1765/1765N.go
+++ b/1000-1999/1700-1799/1760-1769/1765/1765N.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var T int
+	if _, err := fmt.Fscan(in, &T); err != nil {
+		return
+	}
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	for ; T > 0; T-- {
+		var x string
+		var k int
+		fmt.Fscan(in, &x)
+		fmt.Fscan(in, &k)
+		n := len(x)
+		L := n - k
+		positions := make([][]int, 10)
+		for i, c := range x {
+			d := int(c - '0')
+			positions[d] = append(positions[d], i)
+		}
+		ptr := make([]int, 10)
+		res := make([]byte, 0, L)
+		start := 0
+		for j := 0; j < L; j++ {
+			end := n - (L - j)
+			digitStart := 0
+			if j == 0 {
+				digitStart = 1
+			}
+			chosenDigit := -1
+			chosenIndex := -1
+			for d := digitStart; d <= 9; d++ {
+				p := ptr[d]
+				for p < len(positions[d]) && positions[d][p] < start {
+					p++
+				}
+				ptr[d] = p
+				if p < len(positions[d]) {
+					idx := positions[d][p]
+					if idx <= end {
+						chosenDigit = d
+						chosenIndex = idx
+						break
+					}
+				}
+			}
+			res = append(res, byte(chosenDigit+'0'))
+			start = chosenIndex + 1
+		}
+		fmt.Fprintln(writer, string(res))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem N in 1765
- algorithm selects smallest subsequence without leading zeros

## Testing
- `go build 1000-1999/1700-1799/1760-1769/1765/1765N.go`
- `echo -e "3\n1010\n1\n1010\n2\n100\n1" | go run 1000-1999/1700-1799/1760-1769/1765/1765N.go`
- `echo -e "1\n10\n1" | go run 1000-1999/1700-1799/1760-1769/1765/1765N.go`


------
https://chatgpt.com/codex/tasks/task_e_68824a74e8a48324afb536989f2602c9