### PR TITLE
Add Go solution for 1753A1 problem

### DIFF
--- a/1000-1999/1700-1799/1750-1759/1753/1753A1.go
+++ b/1000-1999/1700-1799/1750-1759/1753/1753A1.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		if n%2 == 1 {
+			fmt.Fprintln(writer, -1)
+			continue
+		}
+		segments := make([][2]int, 0, n)
+		for i := 0; i < n; i += 2 {
+			if arr[i] == arr[i+1] {
+				segments = append(segments, [2]int{i + 1, i + 2})
+			} else {
+				segments = append(segments, [2]int{i + 1, i + 1})
+				segments = append(segments, [2]int{i + 2, i + 2})
+			}
+		}
+		fmt.Fprintln(writer, len(segments))
+		for _, seg := range segments {
+			fmt.Fprintln(writer, seg[0], seg[1])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `problemA1.txt`

## Testing
- `go build 1000-1999/1700-1799/1750-1759/1753/1753A1.go`
- `go run 1000-1999/1700-1799/1750-1759/1753/1753A1.go <<EOF`
  (tested with multiple cases)
  `EOF`

------
https://chatgpt.com/codex/tasks/task_e_6882579b5f508324a69a4dfc4d087339