### PR TITLE
Add Go solution for 1721B Deadly Laser

### DIFF
--- a/1000-1999/1700-1799/1720-1729/1721/1721B.go
+++ b/1000-1999/1700-1799/1720-1729/1721/1721B.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m, sx, sy, d int
+		fmt.Fscan(in, &n, &m, &sx, &sy, &d)
+		path1 := (sx-1 > d) && (m-sy > d)
+		path2 := (sy-1 > d) && (n-sx > d)
+		if path1 || path2 {
+			fmt.Fprintln(out, n+m-2)
+		} else {
+			fmt.Fprintln(out, -1)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add missing Go solution for problem 1721B

## Testing
- `go build 1000-1999/1700-1799/1720-1729/1721/1721B.go`

------
https://chatgpt.com/codex/tasks/task_e_68825f8cd4a88324b251733fd83fd15b