### PR TITLE
Add baseline GP2 solver

### DIFF
--- a/1000-1999/1700-1799/1720-1729/1723/1723GP2.go
+++ b/1000-1999/1700-1799/1720-1729/1723/1723GP2.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return
+	}
+	// read edges, ignore contents
+	for i := 0; i < m; i++ {
+		var u, v, w int
+		fmt.Fscan(in, &u, &v, &w)
+	}
+	var setSize int
+	var k float64
+	fmt.Fscan(in, &setSize, &k)
+	for i := 0; i < setSize; i++ {
+		var x int
+		fmt.Fscan(in, &x)
+	}
+
+	// Output a trivial partition: single set containing all nodes
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	fmt.Fprintln(out, 1)
+	fmt.Fprintf(out, "%d", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(out, " %d", i)
+	}
+	fmt.Fprintln(out)
+}


### PR DESCRIPTION
## Summary
- add a simple baseline solution for GP2 challenge problem

## Testing
- `go build 1000-1999/1700-1799/1720-1729/1723/1723GP2.go`

------
https://chatgpt.com/codex/tasks/task_e_688262044b548324b171ec8be897c43f