### PR TITLE
Add Go solution for 1722B

### DIFF
--- a/1000-1999/1700-1799/1720-1729/1722/1722B.go
+++ b/1000-1999/1700-1799/1720-1729/1722/1722B.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		s1 := make([]byte, n)
+		s2 := make([]byte, n)
+		fmt.Fscan(reader, &s1)
+		fmt.Fscan(reader, &s2)
+		ok := true
+		for i := 0; i < n; i++ {
+			a := s1[i] == 'R'
+			b := s2[i] == 'R'
+			if a != b {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solver for problem 1722B

## Testing
- `go build 1000-1999/1700-1799/1720-1729/1722/1722B.go`
- `go run 1000-1999/1700-1799/1720-1729/1722/1722B.go << EOF
3
3
RBR
BBB
2
RG
GB
3
GGG
BBB
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688263a8e7e8832486462195f81113f6