### PR TITLE
Add Go solution for problem 1725A

### DIFF
--- a/1000-1999/1700-1799/1720-1729/1725/1725A.go
+++ b/1000-1999/1700-1799/1720-1729/1725/1725A.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, m int64
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return
+	}
+	var ans int64
+	if m == 1 {
+		ans = n - 1
+	} else {
+		ans = n * (m - 1)
+	}
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for 1725A counting tight dominoes

## Testing
- `go build 1000-1999/1700-1799/1720-1729/1725/1725A.go`

------
https://chatgpt.com/codex/tasks/task_e_688267389bac8324bf42794a9e1125ca