### PR TITLE
Add Go solution for problem 1285D

### DIFF
--- a/1000-1999/1200-1299/1280-1289/1285/1285D.go
+++ b/1000-1999/1200-1299/1280-1289/1285/1285D.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func solve(arr []int, bit int) int {
+	if bit < 0 || len(arr) <= 1 {
+		return 0
+	}
+	mask := 1 << bit
+	var left, right []int
+	for _, v := range arr {
+		if v&mask == 0 {
+			left = append(left, v)
+		} else {
+			right = append(right, v)
+		}
+	}
+	if len(left) == 0 {
+		return solve(right, bit-1)
+	}
+	if len(right) == 0 {
+		return solve(left, bit-1)
+	}
+	a := solve(left, bit-1)
+	b := solve(right, bit-1)
+	if a < b {
+		return mask + a
+	}
+	return mask + b
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+	}
+
+	ans := solve(arr, 30)
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem D in 1285 directory

## Testing
- `go build 1000-1999/1200-1299/1280-1289/1285/1285D.go`
- `echo -e "1\n0\n" | go run 1000-1999/1200-1299/1280-1289/1285/1285D.go`
- `echo -e "2\n0 1\n" | go run 1000-1999/1200-1299/1280-1289/1285/1285D.go`
- `echo -e "3\n1 2 3\n" | go run 1000-1999/1200-1299/1280-1289/1285/1285D.go`


------
https://chatgpt.com/codex/tasks/task_e_6882692374408324818903edd8ff63a7