### PR TITLE
Add Go solution for 1285B

### DIFF
--- a/1000-1999/1200-1299/1280-1289/1285/1285B.go
+++ b/1000-1999/1200-1299/1280-1289/1285/1285B.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+
+		total := int64(0)
+		for _, v := range a {
+			total += v
+		}
+
+		curr := int64(0)
+		maxPref := int64(-1 << 63)
+		for i := 0; i < n-1; i++ {
+			curr += a[i]
+			if curr > maxPref {
+				maxPref = curr
+			}
+			if curr < 0 {
+				curr = 0
+			}
+		}
+
+		curr = 0
+		maxSuff := int64(-1 << 63)
+		for i := n - 1; i >= 1; i-- {
+			curr += a[i]
+			if curr > maxSuff {
+				maxSuff = curr
+			}
+			if curr < 0 {
+				curr = 0
+			}
+		}
+
+		if total > maxPref && total > maxSuff {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1285B `Just Eat It!`

## Testing
- `go build 1000-1999/1200-1299/1280-1289/1285/1285B.go`


------
https://chatgpt.com/codex/tasks/task_e_688269afb0b48324a25acbb7303881f7