### PR TITLE
Add Go solution for 1283A

### DIFF
--- a/1000-1999/1200-1299/1280-1289/1283/1283A.go
+++ b/1000-1999/1200-1299/1280-1289/1283/1283A.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var h, m int
+		fmt.Fscan(reader, &h, &m)
+		remaining := 24*60 - (h*60 + m)
+		fmt.Fprintln(writer, remaining)
+	}
+}


### PR DESCRIPTION
## Summary
- implement problem A for contest 1283 in Go

## Testing
- `go run 1000-1999/1200-1299/1280-1289/1283/1283A.go <<EOF
2
23 59
0 1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68826c26d67c8324a67fc4f9b5013a55