### PR TITLE
Add Go solution for 1288C

### DIFF
--- a/1000-1999/1200-1299/1280-1289/1288/1288C.go
+++ b/1000-1999/1200-1299/1280-1289/1288/1288C.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 1000000007
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return
+	}
+
+	maxN := n + 2*m
+	fact := make([]int64, maxN+1)
+	invFact := make([]int64, maxN+1)
+	fact[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invFact[maxN] = modPow(fact[maxN], mod-2)
+	for i := maxN; i > 0; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % mod
+	}
+
+	comb := func(n, k int) int64 {
+		if k < 0 || k > n {
+			return 0
+		}
+		return fact[n] * invFact[k] % mod * invFact[n-k] % mod
+	}
+
+	ans := comb(n+2*m-1, 2*m)
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1288C

## Testing
- `go run 1000-1999/1200-1299/1280-1289/1288/1288C.go <<EOF
2 2
EOF`
- `go run 1000-1999/1200-1299/1280-1289/1288/1288C.go <<EOF
3 3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68826cb3236483249e6922168cddfab4