### PR TITLE
Add Go solution for 1286F

### DIFF
--- a/1000-1999/1200-1299/1280-1289/1286/1286F.go
+++ b/1000-1999/1200-1299/1280-1289/1286/1286F.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var (
+	n    int
+	a    []int64
+	memo map[int]int
+	full int
+)
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func dfs(mask int) int {
+	if mask == full {
+		return 0
+	}
+	if v, ok := memo[mask]; ok {
+		return v
+	}
+	// find first unpaired index
+	i := 0
+	for ; i < n; i++ {
+		if mask>>i&1 == 0 {
+			break
+		}
+	}
+	best := dfs(mask | 1<<i) // leave i unmatched
+	for j := i + 1; j < n; j++ {
+		if mask>>j&1 == 0 && abs(a[i]-a[j]) == 1 {
+			val := 1 + dfs(mask|1<<i|1<<j)
+			if val > best {
+				best = val
+			}
+		}
+	}
+	memo[mask] = best
+	return best
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Fscan(reader, &n)
+	a = make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	full = (1 << n) - 1
+	memo = make(map[int]int)
+	pairs := dfs(0)
+	ans := n - pairs
+	fmt.Println(ans)
+}


### PR DESCRIPTION
## Summary
- implement a solver for 1286F using DP over subsets
- pair numbers with difference 1 to minimize operations

## Testing
- `go build 1000-1999/1200-1299/1280-1289/1286/1286F.go`
- `printf "3\n1 4 5\n" | go run 1000-1999/1200-1299/1280-1289/1286/1286F.go`

------
https://chatgpt.com/codex/tasks/task_e_68826e9dfca88324a2e7878258a7d958