### PR TITLE
Add Go solution for 1209A

### DIFF
--- a/1000-1999/1200-1299/1200-1209/1209/1209A.go
+++ b/1000-1999/1200-1299/1200-1209/1209/1209A.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+	}
+	sort.Ints(arr)
+	used := make([]bool, n)
+	var colors int
+	for i := 0; i < n; i++ {
+		if used[i] {
+			continue
+		}
+		colors++
+		for j := i; j < n; j++ {
+			if !used[j] && arr[j]%arr[i] == 0 {
+				used[j] = true
+			}
+		}
+	}
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	fmt.Fprint(writer, colors)
+}


### PR DESCRIPTION
## Summary
- implement solution for Paint the Numbers in `1209A.go`

## Testing
- `go vet 1000-1999/1200-1299/1200-1209/1209/1209A.go`
- `go build 1000-1999/1200-1299/1200-1209/1209/1209A.go`


------
https://chatgpt.com/codex/tasks/task_e_688276d4f10c8324ba5d1a521e66c40f