### PR TITLE
Add Go solution for 1209B

### DIFF
--- a/1000-1999/1200-1299/1200-1209/1209/1209B.go
+++ b/1000-1999/1200-1299/1200-1209/1209/1209B.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(reader, &n)
+	var s string
+	fmt.Fscan(reader, &s)
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i], &b[i])
+	}
+
+	state := make([]int, n)
+	cur := 0
+	for i := 0; i < n; i++ {
+		if s[i] == '1' {
+			state[i] = 1
+			cur++
+		}
+	}
+
+	maxOn := cur
+	for t := 1; t <= 1000; t++ {
+		for i := 0; i < n; i++ {
+			if t >= b[i] && (t-b[i])%a[i] == 0 {
+				if state[i] == 1 {
+					state[i] = 0
+					cur--
+				} else {
+					state[i] = 1
+					cur++
+				}
+			}
+		}
+		if cur > maxOn {
+			maxOn = cur
+		}
+	}
+
+	fmt.Println(maxOn)
+}


### PR DESCRIPTION
## Summary
- implement problem 1209B solution in Go

## Testing
- `go run 1000-1999/1200-1299/1200-1209/1209/1209B.go <<EOF
2
01
2 1
2 1
EOF`
- `go run 1000-1999/1200-1299/1200-1209/1209/1209B.go <<EOF
3
101
2 3
1 2
1 1
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6882768edfd0832483c41ce51580db7e