### PR TITLE
Add Go solution for problem 1200E

### DIFF
--- a/1000-1999/1200-1299/1200-1209/1200/1200E.go
+++ b/1000-1999/1200-1299/1200-1209/1200/1200E.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func prefixFunction(s string) []int {
+	pi := make([]int, len(s))
+	for i := 1; i < len(s); i++ {
+		j := pi[i-1]
+		for j > 0 && s[i] != s[j] {
+			j = pi[j-1]
+		}
+		if s[i] == s[j] {
+			j++
+		}
+		pi[i] = j
+	}
+	return pi
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	fmt.Fscan(reader, &n)
+	if n <= 0 {
+		return
+	}
+
+	var res string
+	fmt.Fscan(reader, &res)
+
+	for i := 1; i < n; i++ {
+		var w string
+		fmt.Fscan(reader, &w)
+		l := len(w)
+		if len(res) < l {
+			l = len(res)
+		}
+		tail := res[len(res)-l:]
+		s := w + "#" + tail
+		pi := prefixFunction(s)
+		overlap := pi[len(s)-1]
+		res += w[overlap:]
+	}
+
+	fmt.Fprint(writer, res)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1200E (Compress Words)

## Testing
- `go build 1000-1999/1200-1299/1200-1209/1200/1200E.go`


------
https://chatgpt.com/codex/tasks/task_e_688277a757c48324a7ef42035cbb891e