### PR TITLE
Add Go solution for 1203E

### DIFF
--- a/1000-1999/1200-1299/1200-1209/1203/1203E.go
+++ b/1000-1999/1200-1299/1200-1209/1203/1203E.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+
+	sort.Ints(a)
+
+	const maxW = 150001
+	used := make([]bool, maxW+2)
+	ans := 0
+
+	for _, w := range a {
+		if w-1 > 0 && !used[w-1] {
+			used[w-1] = true
+			ans++
+		} else if w <= maxW && !used[w] {
+			used[w] = true
+			ans++
+		} else if w+1 <= maxW && !used[w+1] {
+			used[w+1] = true
+			ans++
+		}
+	}
+
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement greedy solution for `1203E - Boxers`

## Testing
- `go build 1000-1999/1200-1299/1200-1209/1203/1203E.go`


------
https://chatgpt.com/codex/tasks/task_e_68827f98a2548324bc31378a1c740399