### PR TITLE
Add Go solution for 1204D1

### DIFF
--- a/1000-1999/1200-1299/1200-1209/1204/1204D1.go
+++ b/1000-1999/1200-1299/1200-1209/1204/1204D1.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var s string
+	if _, err := fmt.Fscan(reader, &s); err != nil {
+		return
+	}
+
+	n := len(s)
+	res := []byte(s)
+	stack := make([]int, 0)
+	for i := 0; i < n; i++ {
+		if s[i] == '1' {
+			stack = append(stack, i)
+		} else {
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		}
+	}
+	for _, idx := range stack {
+		res[idx] = '0'
+	}
+	fmt.Fprintln(writer, string(res))
+}


### PR DESCRIPTION
## Summary
- implement Kirk and a Binary String (easy version) solution

## Testing
- `go build 1000-1999/1200-1299/1200-1209/1204/1204D1.go`
- `echo 1110 | go run 1000-1999/1200-1299/1200-1209/1204/1204D1.go`

------
https://chatgpt.com/codex/tasks/task_e_68827ec655e483249175d0f412e7c3a2