### PR TITLE
Add Go solution for 1272C

### DIFF
--- a/1000-1999/1200-1299/1270-1279/1272/1272C.go
+++ b/1000-1999/1200-1299/1270-1279/1272/1272C.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, k int
+	if _, err := fmt.Fscan(reader, &n, &k); err != nil {
+		return
+	}
+	var s string
+	fmt.Fscan(reader, &s)
+	allowed := make(map[byte]bool)
+	for i := 0; i < k; i++ {
+		var ch string
+		fmt.Fscan(reader, &ch)
+		allowed[ch[0]] = true
+	}
+
+	var cur int64
+	var ans int64
+	for i := 0; i < n; i++ {
+		if allowed[s[i]] {
+			cur++
+		} else {
+			ans += cur * (cur + 1) / 2
+			cur = 0
+		}
+	}
+	ans += cur * (cur + 1) / 2
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement solution for problem C in contest 1272 using Go

## Testing
- `go build 1000-1999/1200-1299/1270-1279/1272/1272C.go`

------
https://chatgpt.com/codex/tasks/task_e_68828789f69c8324a8d2723edaf1fc94