### PR TITLE
Add Go solution for 1275B

### DIFF
--- a/1000-1999/1200-1299/1270-1279/1275/1275B.go
+++ b/1000-1999/1200-1299/1270-1279/1275/1275B.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type commit struct {
+	author int
+	hash   string
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+
+	stack := make([]commit, 0, n)
+	for i := 0; i < n; i++ {
+		var dev int
+		var h string
+		fmt.Fscan(in, &dev, &h)
+		if len(stack) > 0 {
+			last := stack[len(stack)-1]
+			if last.author != dev {
+				// review the last unreviewed commit
+				stack = stack[:len(stack)-1]
+			}
+		}
+		stack = append(stack, commit{author: dev, hash: h})
+	}
+
+	for _, c := range stack {
+		fmt.Fprintln(out, c.hash)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for 1275B using a stack to track unreviewed commits

## Testing
- `go build 1000-1999/1200-1299/1270-1279/1275/1275B.go`
- `go vet 1000-1999/1200-1299/1270-1279/1275/1275B.go`


------
https://chatgpt.com/codex/tasks/task_e_688288e9559c83249820c844e63e1562