### PR TITLE
Add 1275C Go solution

### DIFF
--- a/1000-1999/1200-1299/1270-1279/1275/1275C.go
+++ b/1000-1999/1200-1299/1270-1279/1275/1275C.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	fmt.Fscan(reader, &n)
+	digits := []int64{0, 1, 3, 4}
+	for i := 0; i < n; i++ {
+		var pos int64
+		fmt.Fscan(reader, &pos)
+		var sum int64
+		for j := 0; j < 25; j++ {
+			sum += digits[pos%4]
+			pos /= 4
+		}
+		fmt.Fprintln(writer, sum)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1275C

## Testing
- `go vet 1000-1999/1200-1299/1270-1279/1275/1275C.go`
- `go build 1000-1999/1200-1299/1270-1279/1275/1275C.go`
- `echo -e "5\n0\n1\n3\n5\n8\n" | go run 1000-1999/1200-1299/1270-1279/1275/1275C.go`

------
https://chatgpt.com/codex/tasks/task_e_688288a2909083249d3f1b86c7abb78d