### PR TITLE
Add Go solution for problem 1249B1

### DIFF
--- a/1000-1999/1200-1299/1240-1249/1249/1249B1.go
+++ b/1000-1999/1200-1299/1240-1249/1249/1249B1.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var q int
+	fmt.Fscan(in, &q)
+	for ; q > 0; q-- {
+		var n int
+		fmt.Fscan(in, &n)
+		p := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &p[i])
+			p[i]--
+		}
+
+		ans := make([]int, n)
+		visited := make([]bool, n)
+		for i := 0; i < n; i++ {
+			if visited[i] {
+				continue
+			}
+			curr := i
+			cycle := []int{}
+			for !visited[curr] {
+				visited[curr] = true
+				cycle = append(cycle, curr)
+				curr = p[curr]
+			}
+			length := len(cycle)
+			for _, idx := range cycle {
+				ans[idx] = length
+			}
+		}
+
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				fmt.Fprint(out, " ")
+			}
+			fmt.Fprint(out, ans[i])
+		}
+		fmt.Fprintln(out)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for Books Exchange (easy)

## Testing
- `go build 1000-1999/1200-1299/1240-1249/1249/1249B1.go`
- `go vet 1000-1999/1200-1299/1240-1249/1249/1249B1.go`
- `echo -e "1\n5\n5 1 2 4 3" | go run 1000-1999/1200-1299/1240-1249/1249/1249B1.go`

------
https://chatgpt.com/codex/tasks/task_e_68828ba5e5fc8324917a10de56a8bec7