### PR TITLE
Add Go solution for 1249C1

### DIFF
--- a/1000-1999/1200-1299/1240-1249/1249/1249C1.go
+++ b/1000-1999/1200-1299/1240-1249/1249/1249C1.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func nextGood(n int64) int64 {
+	for {
+		t := n
+		good := true
+		for t > 0 {
+			if t%3 == 2 {
+				good = false
+				break
+			}
+			t /= 3
+		}
+		if good {
+			return n
+		}
+		n++
+	}
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var q int
+	if _, err := fmt.Fscan(reader, &q); err != nil {
+		return
+	}
+	for ; q > 0; q-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		fmt.Fprintln(writer, nextGood(n))
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1249C1

## Testing
- `go vet 1000-1999/1200-1299/1240-1249/1249/1249C1.go`
- `go build 1000-1999/1200-1299/1240-1249/1249/1249C1.go`


------
https://chatgpt.com/codex/tasks/task_e_68828b19a0bc8324abb5a5bb7e47b42b