### PR TITLE
Add Go solution for Codeforces 1248B

### DIFF
--- a/1000-1999/1200-1299/1240-1249/1248/1248B.go
+++ b/1000-1999/1200-1299/1240-1249/1248/1248B.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	fmt.Fscan(in, &n)
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &arr[i])
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	var x, y int64
+	for i := 0; i < n/2; i++ {
+		x += arr[i]
+	}
+	for i := n / 2; i < n; i++ {
+		y += arr[i]
+	}
+	res := x*x + y*y
+	fmt.Fprintln(out, res)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1248B

## Testing
- `gofmt -w 1000-1999/1200-1299/1240-1249/1248/1248B.go`
- `go build 1000-1999/1200-1299/1240-1249/1248/1248B.go`

------
https://chatgpt.com/codex/tasks/task_e_68828c7830308324b116f4c9d20aaacd