### PR TITLE
Add Go solution for 1243B1

### DIFF
--- a/1000-1999/1200-1299/1240-1249/1243/1243B1.go
+++ b/1000-1999/1200-1299/1240-1249/1243/1243B1.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var T int
+	if _, err := fmt.Fscan(reader, &T); err != nil {
+		return
+	}
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var s, t string
+		fmt.Fscan(reader, &s)
+		fmt.Fscan(reader, &t)
+
+		mism := make([]int, 0, 2)
+		for i := 0; i < n; i++ {
+			if s[i] != t[i] {
+				mism = append(mism, i)
+			}
+		}
+
+		if len(mism) == 2 && s[mism[0]] == s[mism[1]] && t[mism[0]] == t[mism[1]] {
+			fmt.Fprintln(writer, "Yes")
+		} else {
+			fmt.Fprintln(writer, "No")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem B1 in the 1243 directory

## Testing
- `go run 1000-1999/1200-1299/1240-1249/1243/1243B1.go <<EOF
1
2
aa
bb
EOF`
- `go build 1000-1999/1200-1299/1240-1249/1243/1243B1.go`
- `go vet 1000-1999/1200-1299/1240-1249/1243/1243B1.go`


------
https://chatgpt.com/codex/tasks/task_e_68828d4a92088324b7e427538feebba2