### PR TITLE
Add Go solution for 1244B

### DIFF
--- a/1000-1999/1200-1299/1240-1249/1244/1244B.go
+++ b/1000-1999/1200-1299/1240-1249/1244/1244B.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		var s string
+		fmt.Fscan(in, &s)
+		ans := n
+		for i := 0; i < n; i++ {
+			if s[i] == '1' {
+				left := i + 1
+				right := n - i
+				if left > right {
+					if 2*left > ans {
+						ans = 2 * left
+					}
+				} else {
+					if 2*right > ans {
+						ans = 2 * right
+					}
+				}
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add solution `1244B.go` implementing greedy approach from string indices

## Testing
- `go vet 1000-1999/1200-1299/1240-1249/1244/1244B.go`
- `go build 1000-1999/1200-1299/1240-1249/1244/1244B.go`


------
https://chatgpt.com/codex/tasks/task_e_68828ea922888324a681955ceff9201b