### PR TITLE
Add Go solution for 1244F majority chip game

### DIFF
--- a/1000-1999/1200-1299/1240-1249/1244/1244F.go
+++ b/1000-1999/1200-1299/1240-1249/1244/1244F.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	var k int64
+	if _, err := fmt.Fscan(reader, &n, &k); err != nil {
+		return
+	}
+	var s string
+	fmt.Fscan(reader, &s)
+
+	b := []byte(s)
+	stable := make([]bool, n)
+	dist := make([]int64, n)
+	for i := range dist {
+		dist[i] = -1
+	}
+	anyStable := false
+	for i := 0; i < n; i++ {
+		prev := (i - 1 + n) % n
+		next := (i + 1) % n
+		if b[i] == b[prev] || b[i] == b[next] {
+			stable[i] = true
+			anyStable = true
+		}
+	}
+	if !anyStable {
+		if k%2 == 1 {
+			for i := 0; i < n; i++ {
+				if b[i] == 'W' {
+					b[i] = 'B'
+				} else {
+					b[i] = 'W'
+				}
+			}
+		}
+		fmt.Fprintln(writer, string(b))
+		return
+	}
+
+	// BFS from stable positions
+	q := make([]int, 0)
+	for i := 0; i < n; i++ {
+		if stable[i] {
+			dist[i] = 0
+			q = append(q, i)
+		}
+	}
+	head := 0
+	for head < len(q) {
+		cur := q[head]
+		head++
+		for _, nb := range []int{(cur - 1 + n) % n, (cur + 1) % n} {
+			if dist[nb] == -1 {
+				dist[nb] = dist[cur] + 1
+				b[nb] = b[cur]
+				q = append(q, nb)
+			}
+		}
+	}
+
+	orig := []byte(s)
+	res := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if dist[i] != -1 && dist[i] <= k {
+			res[i] = b[i]
+		} else {
+			if k%2 == 0 {
+				res[i] = orig[i]
+			} else {
+				if orig[i] == 'W' {
+					res[i] = 'B'
+				} else {
+					res[i] = 'W'
+				}
+			}
+		}
+	}
+	fmt.Fprintln(writer, string(res))
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem F in contest 1244
- follow BFS approach from stable cells

## Testing
- `go vet 1000-1999/1200-1299/1240-1249/1244/1244F.go`
- `go build 1000-1999/1200-1299/1240-1249/1244/1244F.go`


------
https://chatgpt.com/codex/tasks/task_e_68828e6330848324a5b0d00b29c1acea