### PR TITLE
Add Go solution for 1239A

### DIFF
--- a/1000-1999/1200-1299/1230-1239/1239/1239A.go
+++ b/1000-1999/1200-1299/1230-1239/1239/1239A.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return
+	}
+
+	const mod int = 1000000007
+	maxVal := n
+	if m > maxVal {
+		maxVal = m
+	}
+	dp := make([]int, maxVal+2)
+	dp[1] = 2
+	if maxVal >= 2 {
+		dp[2] = 4
+	}
+	for i := 3; i <= maxVal; i++ {
+		dp[i] = (dp[i-1] + dp[i-2]) % mod
+	}
+
+	ans := (dp[n] + dp[m] - 2) % mod
+	if ans < 0 {
+		ans += mod
+	}
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement solution for problemA from the 1239 contest

## Testing
- `go run /tmp/1239A.go <<EOF
2 3
EOF`
- `go run /tmp/1239A.go <<EOF
3 5
EOF`


------
https://chatgpt.com/codex/tasks/task_e_688291204f348324990efa79b821f8b8