### PR TITLE
Add Go solution for 1237B Balanced Tunnel

### DIFF
--- a/1000-1999/1200-1299/1230-1239/1237/1237B.go
+++ b/1000-1999/1200-1299/1230-1239/1237/1237B.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	enter := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &enter[i])
+	}
+	exit := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &exit[i])
+	}
+
+	exitIndex := make(map[int]int, n)
+	for i, v := range exit {
+		exitIndex[v] = i
+	}
+
+	maxPos := -1
+	fined := 0
+	for _, car := range enter {
+		pos := exitIndex[car]
+		if pos > maxPos {
+			maxPos = pos
+		} else {
+			fined++
+		}
+	}
+
+	fmt.Fprintln(writer, fined)
+}


### PR DESCRIPTION
## Summary
- implement `1237B.go` for Balanced Tunnel

## Testing
- `go build 1000-1999/1200-1299/1230-1239/1237/1237B.go`

------
https://chatgpt.com/codex/tasks/task_e_6882927f08288324a006c7f7ebb1fd58