### PR TITLE
Add Go solution for problem 1237E

### DIFF
--- a/1000-1999/1200-1299/1230-1239/1237/1237E.go
+++ b/1000-1999/1200-1299/1230-1239/1237/1237E.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const limit = 1000000
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	valid := make(map[int]struct{})
+	a := 1
+	step := 0
+	for a <= limit {
+		valid[a] = struct{}{}
+		if a+1 <= limit {
+			valid[a+1] = struct{}{}
+		}
+		if step%2 == 0 {
+			a = 2*a + 2
+		} else {
+			a = 2*a + 1
+		}
+		step++
+	}
+
+	if _, ok := valid[n]; ok {
+		fmt.Fprintln(writer, 1)
+	} else {
+		fmt.Fprintln(writer, 0)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for `problemE.txt`
- use recurrence to generate numbers with valid striped BSTs

## Testing
- `go build 1000-1999/1200-1299/1230-1239/1237/1237E.go`

------
https://chatgpt.com/codex/tasks/task_e_6882916678088324adfa3b51ca00900c