### PR TITLE
Add Go solution for 1236B

### DIFF
--- a/1000-1999/1200-1299/1230-1239/1236/1236B.go
+++ b/1000-1999/1200-1299/1230-1239/1236/1236B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 1_000_000_007
+
+func modPow(a, n int64) int64 {
+	res := int64(1)
+	for n > 0 {
+		if n&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		n >>= 1
+	}
+	return res
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, m int64
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return
+	}
+	val := modPow(2, m) - 1
+	if val < 0 {
+		val += mod
+	}
+	ans := modPow(val, n)
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for contest 1236 problem B
- fast modular exponentiation of `(2^m - 1)^n` modulo `1e9+7`

## Testing
- `go build 1000-1999/1200-1299/1230-1239/1236/1236B.go`
- `go vet 1000-1999/1200-1299/1230-1239/1236/1236B.go`


------
https://chatgpt.com/codex/tasks/task_e_688294afe9148324b6698a4cb050fccd