### PR TITLE
Add Go solution for 1238A

### DIFF
--- a/1000-1999/1200-1299/1230-1239/1238/1238A.go
+++ b/1000-1999/1200-1299/1230-1239/1238/1238A.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var x, y int64
+		fmt.Fscan(reader, &x, &y)
+		if x-y == 1 {
+			fmt.Fprintln(writer, "NO")
+		} else {
+			fmt.Fprintln(writer, "YES")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1238A.go` for Prime Subtraction problem

## Testing
- `go build 1000-1999/1200-1299/1230-1239/1238/1238A.go`


------
https://chatgpt.com/codex/tasks/task_e_688296e0bd148324b546d04936535b7d