### PR TITLE
Add Go solution for 1234B2

### DIFF
--- a/1000-1999/1200-1299/1230-1239/1234/1234B2.go
+++ b/1000-1999/1200-1299/1230-1239/1234/1234B2.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"container/list"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, k int
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+
+	present := make(map[int]*list.Element)
+	lst := list.New()
+
+	for i := 0; i < n; i++ {
+		var id int
+		fmt.Fscan(in, &id)
+		if _, ok := present[id]; ok {
+			continue
+		}
+		if lst.Len() == k {
+			backElem := lst.Back()
+			backID := backElem.Value.(int)
+			lst.Remove(backElem)
+			delete(present, backID)
+		}
+		elem := lst.PushFront(id)
+		present[id] = elem
+	}
+
+	fmt.Fprintln(out, lst.Len())
+	first := true
+	for e := lst.Front(); e != nil; e = e.Next() {
+		if !first {
+			fmt.Fprint(out, " ")
+		}
+		fmt.Fprint(out, e.Value.(int))
+		first = false
+	}
+	if lst.Len() > 0 {
+		fmt.Fprintln(out)
+	}
+}


### PR DESCRIPTION
## Summary
- implement problem 1234B2 in Go
- maintain most recent conversations with a list+map

## Testing
- `go build 1000-1999/1200-1299/1230-1239/1234/1234B2.go`
- `echo -e '8 2\n1 2 3 3 1 1 2 2' | go run 1000-1999/1200-1299/1230-1239/1234/1234B2.go`
- `echo -e '5 3\n1 2 1 3 1' | go run 1000-1999/1200-1299/1230-1239/1234/1234B2.go`


------
https://chatgpt.com/codex/tasks/task_e_688298cc4e4083248bdeeacc39970279