### PR TITLE
Add Go solution for 1214A

### DIFF
--- a/1000-1999/1200-1299/1210-1219/1214/1214A.go
+++ b/1000-1999/1200-1299/1210-1219/1214/1214A.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, d, e int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	fmt.Fscan(in, &d)
+	fmt.Fscan(in, &e)
+	e *= 5
+	ans := n
+	for i := 0; i <= n; i += e {
+		rem := (n - i) % d
+		if rem < ans {
+			ans = rem
+		}
+	}
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- add Go solution for contest 1214 problem A

## Testing
- `go run 1000-1999/1200-1299/1210-1219/1214/1214A.go <<EOF
100
30
30
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68829a2a41988324b82a8992dca47679