### PR TITLE
Add go solution for 1212A

### DIFF
--- a/1000-1999/1200-1299/1210-1219/1212/1212A.go
+++ b/1000-1999/1200-1299/1210-1219/1212/1212A.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int64
+	var k int
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+	for i := 0; i < k; i++ {
+		if n%10 == 0 {
+			n /= 10
+		} else {
+			n--
+		}
+	}
+	fmt.Fprintln(out, n)
+}


### PR DESCRIPTION
## Summary
- implement a solution for `problemA.txt` under `1212`
- solution repeatedly decreases or divides by 10 according to the spec

## Testing
- `gofmt -w 1000-1999/1200-1299/1210-1219/1212/1212A.go`

------
https://chatgpt.com/codex/tasks/task_e_68829dff928c83248eec6bb7d2b8da8e