### PR TITLE
Add Go solution for 1216E2

### DIFF
--- a/1000-1999/1200-1299/1210-1219/1216/1216E2.go
+++ b/1000-1999/1200-1299/1210-1219/1216/1216E2.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func sumLen(n int64) int64 {
+	var res int64
+	var pow10 int64 = 1
+	var d int64 = 1
+	for pow10 <= n {
+		nxt := pow10*10 - 1
+		if nxt > n {
+			nxt = n
+		}
+		res += (nxt - pow10 + 1) * d
+		pow10 *= 10
+		d++
+	}
+	return res
+}
+
+func sumXLen(n int64) int64 {
+	var res int64
+	var pow10 int64 = 1
+	var d int64 = 1
+	for pow10 <= n {
+		nxt := pow10*10 - 1
+		if nxt > n {
+			nxt = n
+		}
+		cnt := nxt - pow10 + 1
+		res += d * (pow10 + nxt) * cnt / 2
+		pow10 *= 10
+		d++
+	}
+	return res
+}
+
+func prefix(n int64) int64 {
+	if n <= 0 {
+		return 0
+	}
+	return (n+1)*sumLen(n) - sumXLen(n)
+}
+
+func digitInRange(n, k int64) int {
+	var pow10 int64 = 1
+	var d int64 = 1
+	for {
+		nxt := pow10*10 - 1
+		if nxt > n {
+			nxt = n
+		}
+		cnt := nxt - pow10 + 1
+		total := cnt * d
+		if k > total {
+			k -= total
+		} else {
+			idx := (k - 1) / d
+			num := pow10 + idx
+			pos := (k - 1) % d
+			str := strconv.FormatInt(num, 10)
+			return int(str[pos] - '0')
+		}
+		if nxt == n {
+			break
+		}
+		pow10 *= 10
+		d++
+	}
+	return 0
+}
+
+func query(k int64) int {
+	l, r := int64(1), int64(1e9)
+	for l < r {
+		m := (l + r) / 2
+		if prefix(m) >= k {
+			r = m
+		} else {
+			l = m + 1
+		}
+	}
+	n := l
+	k -= prefix(n - 1)
+	return digitInRange(n, k)
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var q int
+	fmt.Fscan(reader, &q)
+	for ; q > 0; q-- {
+		var k int64
+		fmt.Fscan(reader, &k)
+		ans := query(k)
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem E2 (Number of Digits hard version)
- uses prefix calculations and binary search to find the k-th digit

## Testing
- `go run 1000-1999/1200-1299/1210-1219/1216/1216E2.go <<EOF
5
1
3
20
38
56
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6882a4929ed08324b1bf455ca5dc6ed5