### PR TITLE
Add Go solution for 1211B

### DIFF
--- a/1000-1999/1200-1299/1210-1219/1211/1211B.go
+++ b/1000-1999/1200-1299/1210-1219/1211/1211B.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+
+	var ans int64
+	for i := 0; i < n; i++ {
+		if a[i] == 0 {
+			continue
+		}
+		candidate := int64(i+1) + int64(n)*(a[i]-1)
+		if candidate > ans {
+			ans = candidate
+		}
+	}
+
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problemB in contest 1211

## Testing
- `go build 1000-1999/1200-1299/1210-1219/1211/1211B.go`

------
https://chatgpt.com/codex/tasks/task_e_6882a6c327d08324b9890149679c2285