### PR TITLE
Add Go solution for 1211C

### DIFF
--- a/1000-1999/1200-1299/1210-1219/1211/1211C.go
+++ b/1000-1999/1200-1299/1210-1219/1211/1211C.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+type day struct {
+	a int64
+	b int64
+	c int64
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	var k int64
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+	days := make([]day, n)
+	var minNeed, maxPossible int64
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &days[i].a, &days[i].b, &days[i].c)
+		minNeed += days[i].a
+		maxPossible += days[i].b
+	}
+	if k < minNeed || k > maxPossible {
+		fmt.Fprintln(out, -1)
+		return
+	}
+
+	totalCost := int64(0)
+	for i := 0; i < n; i++ {
+		totalCost += days[i].a * days[i].c
+		days[i].b -= days[i].a
+	}
+	remaining := k - minNeed
+	sort.Slice(days, func(i, j int) bool { return days[i].c < days[j].c })
+	for _, d := range days {
+		if remaining == 0 {
+			break
+		}
+		take := d.b
+		if take > remaining {
+			take = remaining
+		}
+		totalCost += take * d.c
+		remaining -= take
+	}
+	fmt.Fprintln(out, totalCost)
+}


### PR DESCRIPTION
## Summary
- implement greedy solution for contest 1211 problem C

## Testing
- `go build -o /tmp/1211C.out 1211C.go`

------
https://chatgpt.com/codex/tasks/task_e_6882a67d09688324aadfa01610948d25