### PR TITLE
Add Go solution for 1265E

### DIFF
--- a/1000-1999/1200-1299/1260-1269/1265/1265E.go
+++ b/1000-1999/1200-1299/1260-1269/1265/1265E.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const MOD int64 = 998244353
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	a %= MOD
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		b >>= 1
+	}
+	return res
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+
+	inv100 := modPow(100, MOD-2)
+	prefix := int64(1)
+	sumPrefix := int64(0)
+	for i := 0; i < n; i++ {
+		var p int64
+		fmt.Fscan(in, &p)
+		sumPrefix = (sumPrefix + prefix) % MOD
+		q := p * inv100 % MOD
+		prefix = prefix * q % MOD
+	}
+
+	ans := sumPrefix * modPow(prefix, MOD-2) % MOD
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- implement `1265E.go` for Beautiful Mirrors

## Testing
- `go build 1000-1999/1200-1299/1260-1269/1265/1265E.go`
- `echo -e "1\n50" | go run 1000-1999/1200-1299/1260-1269/1265/1265E.go`
- `echo -e "3\n50 60 80" | go run 1000-1999/1200-1299/1260-1269/1265/1265E.go`


------
https://chatgpt.com/codex/tasks/task_e_6882abf7751c832480801bc8a05b1ead