### PR TITLE
Add Go solution for 1260B

### DIFF
--- a/1000-1999/1200-1299/1260-1269/1260/1260B.go
+++ b/1000-1999/1200-1299/1260-1269/1260/1260B.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a, b int64
+		fmt.Fscan(reader, &a, &b)
+		if (a+b)%3 != 0 {
+			fmt.Fprintln(writer, "NO")
+			continue
+		}
+		if a > 2*b || b > 2*a {
+			fmt.Fprintln(writer, "NO")
+		} else {
+			fmt.Fprintln(writer, "YES")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1260B

## Testing
- `go run 1000-1999/1200-1299/1260-1269/1260/1260B.go <<EOF
1
6 9
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6882ad9c1e588324b314cc964827a998