### PR TITLE
Add Go solution for 1260C

### DIFF
--- a/1000-1999/1200-1299/1260-1269/1260/1260C.go
+++ b/1000-1999/1200-1299/1260-1269/1260/1260C.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var r, b, k int64
+		fmt.Fscan(in, &r, &b, &k)
+		if r > b {
+			r, b = b, r
+		}
+		g := gcd(r, b)
+		r /= g
+		b /= g
+		if r > b {
+			r, b = b, r
+		}
+		// maximum possible run length of the larger color
+		maxRun := (b + r - 2) / r
+		if maxRun >= k {
+			fmt.Fprintln(out, "REBEL")
+		} else {
+			fmt.Fprintln(out, "OBEY")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1260C

## Testing
- `go run 1000-1999/1200-1299/1260-1269/1260/1260C.go <<EOF
2
3 5 2
4 6 2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6882ad560b888324a89830d36ae8d546