### PR TITLE
Add Go solution for 1268B

### DIFF
--- a/1000-1999/1200-1299/1260-1269/1268/1268B.go
+++ b/1000-1999/1200-1299/1260-1269/1268/1268B.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	fmt.Fscan(in, &n)
+
+	var sum int64
+	diff := 0
+	for i := 1; i <= n; i++ {
+		var a int64
+		fmt.Fscan(in, &a)
+		sum += a
+		if a&1 == 1 {
+			if i&1 == 1 {
+				diff++
+			} else {
+				diff--
+			}
+		}
+	}
+	if diff < 0 {
+		diff = -diff
+	}
+	ans := (sum - int64(diff)) / 2
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 1268B using chessboard parity method

## Testing
- `go vet 1000-1999/1200-1299/1260-1269/1268/1268B.go`
- `go build 1000-1999/1200-1299/1260-1269/1268/1268B.go`
- `echo -e "5\n3 2 2 2 1\n" | go run 1000-1999/1200-1299/1260-1269/1268/1268B.go`

------
https://chatgpt.com/codex/tasks/task_e_6882b0e5984083248966b10567825f71