### PR TITLE
Add naive Go solution for 1268E

### DIFF
--- a/1000-1999/1200-1299/1260-1269/1268/1268E.go
+++ b/1000-1999/1200-1299/1260-1269/1268/1268E.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type Edge struct {
+	to int
+	w  int
+}
+
+type State struct {
+	v    int
+	last int
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return
+	}
+	g := make([][]Edge, n+1)
+	for i := 1; i <= m; i++ {
+		var a, b int
+		fmt.Fscan(reader, &a, &b)
+		g[a] = append(g[a], Edge{to: b, w: i})
+		g[b] = append(g[b], Edge{to: a, w: i})
+	}
+
+	ans := make([]int, n+1)
+	for start := 1; start <= n; start++ {
+		visited := make([]bool, n+1)
+		q := make([]State, 0)
+		q = append(q, State{v: start, last: 0})
+		visited[start] = true
+		for len(q) > 0 {
+			cur := q[0]
+			q = q[1:]
+			for _, e := range g[cur.v] {
+				if e.w > cur.last && !visited[e.to] {
+					visited[e.to] = true
+					ans[start]++
+					q = append(q, State{v: e.to, last: e.w})
+				}
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			fmt.Fprint(writer, " ")
+		}
+		fmt.Fprint(writer, ans[i])
+	}
+	fmt.Fprintln(writer)
+}


### PR DESCRIPTION
## Summary
- implement a basic Go solver for problem 1268E

## Testing
- `go build ./1000-1999/1200-1299/1260-1269/1268/1268E.go`

------
https://chatgpt.com/codex/tasks/task_e_6882b013567c83249bbd8a791f45c427