### PR TITLE
Add Go solution for 1266B

### DIFF
--- a/1000-1999/1200-1299/1260-1269/1266/1266B.go
+++ b/1000-1999/1200-1299/1260-1269/1266/1266B.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var x int64
+		fmt.Fscan(reader, &x)
+		if x >= 15 && x%14 >= 1 && x%14 <= 6 {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1266B.go` for the "Dice Tower" problem

## Testing
- `go build 1000-1999/1200-1299/1260-1269/1266/1266B.go`


------
https://chatgpt.com/codex/tasks/task_e_6882b2d063d88324856154b035f20d51