### PR TITLE
Add Go solution for 1299C

### DIFF
--- a/1000-1999/1200-1299/1290-1299/1299/1299C.go
+++ b/1000-1999/1200-1299/1290-1299/1299/1299C.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type segment struct {
+	sum int64
+	cnt int
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	segs := make([]segment, 0, n)
+	for i := 0; i < n; i++ {
+		var v int64
+		fmt.Fscan(in, &v)
+		segs = append(segs, segment{sum: v, cnt: 1})
+		for len(segs) >= 2 {
+			m := len(segs)
+			a := segs[m-2]
+			b := segs[m-1]
+			if a.sum*int64(b.cnt) > b.sum*int64(a.cnt) {
+				segs[m-2].sum += b.sum
+				segs[m-2].cnt += b.cnt
+				segs = segs[:m-1]
+			} else {
+				break
+			}
+		}
+	}
+	for _, s := range segs {
+		avg := float64(s.sum) / float64(s.cnt)
+		for i := 0; i < s.cnt; i++ {
+			fmt.Fprintf(out, "%.10f\n", avg)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement algorithm for Codeforces problem 1299C (water tanks redistribution)
- maintain segments with non-decreasing averages and output results with high precision

## Testing
- `gofmt -w 1000-1999/1200-1299/1290-1299/1299/1299C.go`
- `go build 1000-1999/1200-1299/1290-1299/1299/1299C.go`
- `go vet 1000-1999/1200-1299/1290-1299/1299/1299C.go`


------
https://chatgpt.com/codex/tasks/task_e_6882b84a43ec8324993f2dad2f27d086