### PR TITLE
Add Go solution for 1298D bus passenger counts

### DIFF
--- a/1000-1999/1200-1299/1290-1299/1298/1298D.go
+++ b/1000-1999/1200-1299/1290-1299/1298/1298D.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	var w int64
+	if _, err := fmt.Fscan(reader, &n, &w); err != nil {
+		return
+	}
+
+	prefix := int64(0)
+	minPref := int64(0)
+	maxPref := int64(0)
+	for i := 0; i < n; i++ {
+		var x int64
+		fmt.Fscan(reader, &x)
+		prefix += x
+		if prefix < minPref {
+			minPref = prefix
+		}
+		if prefix > maxPref {
+			maxPref = prefix
+		}
+	}
+
+	low := int64(0)
+	if -minPref > low {
+		low = -minPref
+	}
+	high := w - maxPref
+	if high > w {
+		high = w
+	}
+
+	ans := int64(0)
+	if high >= low {
+		ans = high - low + 1
+	}
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement solution for `problemD.txt`

## Testing
- `go build 1000-1999/1200-1299/1290-1299/1298/1298D.go`

------
https://chatgpt.com/codex/tasks/task_e_6882b91ce06c8324845397687650986d