### PR TITLE
Add Go solution for 1298C

### DIFF
--- a/1000-1999/1200-1299/1290-1299/1298/1298C.go
+++ b/1000-1999/1200-1299/1290-1299/1298/1298C.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	var s string
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	fmt.Fscan(reader, &s)
+	ans := 0
+	cnt := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == 'x' {
+			cnt++
+			if cnt >= 3 {
+				ans++
+			}
+		} else {
+			cnt = 0
+		}
+	}
+	writer := bufio.NewWriter(os.Stdout)
+	fmt.Fprintln(writer, ans)
+	writer.Flush()
+}


### PR DESCRIPTION
## Summary
- add solution `1298C.go` for problem C of contest 1298

## Testing
- `gofmt -w 1000-1999/1200-1299/1290-1299/1298/1298C.go`
- `go build 1000-1999/1200-1299/1290-1299/1298/1298C.go`

------
https://chatgpt.com/codex/tasks/task_e_6882b962bc9c8324a1c85e9fcb6074f1