### PR TITLE
Add Go solution for CF 1294D

### DIFF
--- a/1000-1999/1200-1299/1290-1299/1294/1294D.go
+++ b/1000-1999/1200-1299/1290-1299/1294/1294D.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+func main() {
+    in := bufio.NewReader(os.Stdin)
+    out := bufio.NewWriter(os.Stdout)
+    defer out.Flush()
+
+    var q, x int
+    fmt.Fscan(in, &q, &x)
+    cnt := make([]int, x)
+    mex := 0
+    for i := 0; i < q; i++ {
+        var y int
+        fmt.Fscan(in, &y)
+        cnt[y%x]++
+        for cnt[mex%x] > 0 {
+            cnt[mex%x]--
+            mex++
+        }
+        fmt.Fprintln(out, mex)
+    }
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1294D (MEX maximizing)

## Testing
- `go build ./1000-1999/1200-1299/1290-1299/1294/1294D.go`

------
https://chatgpt.com/codex/tasks/task_e_6882bc662b1c8324b738e03694b8045e