### PR TITLE
Add Go solution for problem 1293A

### DIFF
--- a/1000-1999/1200-1299/1290-1299/1293/1293A.go
+++ b/1000-1999/1200-1299/1290-1299/1293/1293A.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, s, k int
+		fmt.Fscan(reader, &n, &s, &k)
+		closed := make(map[int]bool, k)
+		for i := 0; i < k; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			closed[x] = true
+		}
+		// since k <= 1000, checking up to k+100 is enough
+		ans := 0
+		for {
+			lower := s - ans
+			upper := s + ans
+			okLower := lower >= 1 && !closed[lower]
+			okUpper := upper <= n && !closed[upper]
+			if okLower || okUpper {
+				fmt.Fprintln(writer, ans)
+				break
+			}
+			ans++
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1293A.go` with solver for ConneR and the A.R.C. Markland-N

## Testing
- `gofmt -w 1000-1999/1200-1299/1290-1299/1293/1293A.go`

------
https://chatgpt.com/codex/tasks/task_e_6882bd3867b883248f5daf708684ead7