### PR TITLE
Add Go solution for problem 1295A

### DIFF
--- a/1000-1999/1200-1299/1290-1299/1295/1295A.go
+++ b/1000-1999/1200-1299/1290-1299/1295/1295A.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		if n%2 == 1 {
+			fmt.Fprint(out, "7")
+			n -= 3
+		}
+		for i := 0; i < n; i += 2 {
+			fmt.Fprint(out, "1")
+		}
+		fmt.Fprintln(out)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem A in contest 1295
- use greedy approach of preferring digit `1` with special handling for odd `n`

## Testing
- `go build 1000-1999/1200-1299/1290-1299/1295/1295A.go`

------
https://chatgpt.com/codex/tasks/task_e_6882c081b7f88324be6ed408fed0f863