### PR TITLE
Add Go solution for Codeforces 1251B

### DIFF
--- a/1000-1999/1200-1299/1250-1259/1251/1251B.go
+++ b/1000-1999/1200-1299/1250-1259/1251/1251B.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var q int
+	if _, err := fmt.Fscan(reader, &q); err != nil {
+		return
+	}
+	for ; q > 0; q-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		oddLen := 0
+		totalOnes := 0
+		for i := 0; i < n; i++ {
+			var s string
+			fmt.Fscan(reader, &s)
+			if len(s)%2 == 1 {
+				oddLen++
+			}
+			for j := 0; j < len(s); j++ {
+				if s[j] == '1' {
+					totalOnes++
+				}
+			}
+		}
+		if oddLen > 0 || totalOnes%2 == 0 {
+			fmt.Fprintln(writer, n)
+		} else {
+			fmt.Fprintln(writer, n-1)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1251B.go` solution

## Testing
- `go build 1000-1999/1200-1299/1250-1259/1251/1251B.go`


------
https://chatgpt.com/codex/tasks/task_e_6882c87324ec8324a45706cfd72aaa80