### PR TITLE
Add Go solution for problem 1256D

### DIFF
--- a/1000-1999/1200-1299/1250-1259/1256/1256D.go
+++ b/1000-1999/1200-1299/1250-1259/1256/1256D.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var q int
+	fmt.Fscan(reader, &q)
+	for ; q > 0; q-- {
+		var n int
+		var k int64
+		fmt.Fscan(reader, &n, &k)
+		var s string
+		fmt.Fscan(reader, &s)
+
+		zeroIdx := make([]int, 0)
+		for i := 0; i < n; i++ {
+			if s[i] == '0' {
+				zeroIdx = append(zeroIdx, i)
+			}
+		}
+		res := make([]byte, n)
+		for i := 0; i < n; i++ {
+			res[i] = '1'
+		}
+		pos := 0
+		for _, idx := range zeroIdx {
+			dist := idx - pos
+			shift := int64(dist)
+			if shift > k {
+				shift = k
+			}
+			final := idx - int(shift)
+			res[final] = '0'
+			k -= shift
+			pos++
+		}
+		fmt.Fprintln(writer, string(res))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for 1256D

## Testing
- `gofmt -w 1000-1999/1200-1299/1250-1259/1256/1256D.go`

------
https://chatgpt.com/codex/tasks/task_e_6882c9d194a8832490384452ec9dd955