### PR TITLE
Add Go solution for 1903D2

### DIFF
--- a/1000-1999/1900-1999/1900-1909/1903/1903D2.go
+++ b/1000-1999/1900-1999/1900-1909/1903/1903D2.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func solveQuery(a []int64, k int64) int64 {
+	n := len(a)
+	cur := make([]int64, n)
+	copy(cur, a)
+	var ans int64
+	for bit := 60; bit >= 0; bit-- {
+		var cost int64
+		limit := int64(1) << (bit + 1)
+		half := int64(1) << bit
+		for i := 0; i < n; i++ {
+			if (cur[i]>>bit)&1 == 0 {
+				rem := cur[i] % limit
+				cost += half - rem
+			}
+		}
+		if cost <= k {
+			k -= cost
+			ans |= half
+			for i := 0; i < n; i++ {
+				if (cur[i]>>bit)&1 == 0 {
+					rem := cur[i] % limit
+					cur[i] += half - rem
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, q int
+	if _, err := fmt.Fscan(in, &n, &q); err != nil {
+		return
+	}
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &arr[i])
+	}
+	for ; q > 0; q-- {
+		var k int64
+		fmt.Fscan(in, &k)
+		res := solveQuery(arr, k)
+		fmt.Fprintln(out, res)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a naive solver for problem D2 of contest 1903

## Testing
- `gofmt -w 1000-1999/1900-1999/1900-1909/1903/1903D2.go`


------
https://chatgpt.com/codex/tasks/task_e_6882e8c4f48c8324b8cd58212e0e4323