### PR TITLE
Add Go solution for problem 1903C

### DIFF
--- a/1000-1999/1900-1999/1900-1909/1903/1903C.go
+++ b/1000-1999/1900-1999/1900-1909/1903/1903C.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		var sum int64
+		for i := 0; i < n; i++ {
+			sum += a[i]
+		}
+		ans := sum
+		var suffix int64
+		for i := n - 1; i > 0; i-- {
+			suffix += a[i]
+			if suffix > 0 {
+				ans += suffix
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add `1903C.go` implementing the algorithm from problem statement

## Testing
- `go build 1000-1999/1900-1999/1900-1909/1903/1903C.go`
- `printf '2\n6\n1 -3 7 -6 2 5\n4\n2 9 -5 -3\n' | go run 1000-1999/1900-1999/1900-1909/1903/1903C.go`

------
https://chatgpt.com/codex/tasks/task_e_6882e7f29d308324b916daa6854390f7