### PR TITLE
Add Go solution for problem 1906M

### DIFF
--- a/1000-1999/1900-1999/1900-1909/1906/1906M.go
+++ b/1000-1999/1900-1999/1900-1909/1906/1906M.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func possible(a []int64, k int64) bool {
+	var sum int64
+	for _, v := range a {
+		if v > 2*k {
+			sum += 2 * k
+		} else {
+			sum += v
+		}
+		if sum >= 3*k {
+			return true
+		}
+	}
+	return sum >= 3*k
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	fmt.Fscan(in, &n)
+	a := make([]int64, n)
+	var total int64
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+		total += a[i]
+	}
+
+	l, r := int64(0), total/3
+	for l < r {
+		m := (l + r + 1) / 2
+		if possible(a, m) {
+			l = m
+		} else {
+			r = m - 1
+		}
+	}
+	fmt.Fprintln(out, l)
+}


### PR DESCRIPTION
## Summary
- implement solution for problem M of contest 1906
- use binary search to maximize count of nonintersecting triangles

## Testing
- `go build 1000-1999/1900-1999/1900-1909/1906/1906M.go`

------
https://chatgpt.com/codex/tasks/task_e_6882ec0e60448324b41f7481ec7f12e0