### PR TITLE
Add Go solution for 1901B

### DIFF
--- a/1000-1999/1900-1999/1900-1909/1901/1901B.go
+++ b/1000-1999/1900-1999/1900-1909/1901/1901B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func solve(reader *bufio.Reader, writer *bufio.Writer) {
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	c := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &c[i])
+	}
+	var segments int64
+	var prev int64
+	for i := 0; i < n; i++ {
+		if c[i] > prev {
+			segments += c[i] - prev
+		}
+		prev = c[i]
+	}
+	fmt.Fprintln(writer, segments-1)
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var t int
+	fmt.Fscan(reader, &t)
+	for i := 0; i < t; i++ {
+		solve(reader, writer)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solver for problem 1901B

## Testing
- `go run 1000-1999/1900-1999/1900-1909/1901/1901B.go <<EOF`
  `3
4
1 2 2 1
2
3 5
2
2 2
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6882eb8221808324a24706777f294094