### PR TITLE
Add Go solution for 1902A

### DIFF
--- a/1000-1999/1900-1999/1900-1909/1902/1902A.go
+++ b/1000-1999/1900-1999/1900-1909/1902/1902A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(in, &n, &s)
+		zero := false
+		for i := 0; i < len(s); i++ {
+			if s[i] == '0' {
+				zero = true
+				break
+			}
+		}
+		if zero {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1902A.go` with simple check for a '0'

## Testing
- `gofmt -w 1000-1999/1900-1999/1900-1909/1902/1902A.go`

------
https://chatgpt.com/codex/tasks/task_e_6882e7204de08324a8cff4634809e13e