### PR TITLE
Add Go solution for 1983A

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1983/1983A.go
+++ b/1000-1999/1900-1999/1980-1989/1983/1983A.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		for i := 1; i <= n; i++ {
+			if i > 1 {
+				fmt.Fprint(out, " ")
+			}
+			fmt.Fprint(out, i)
+		}
+		fmt.Fprintln(out)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem A from contest 1983

## Testing
- `go vet 1000-1999/1900-1999/1980-1989/1983/1983A.go`
- `go build 1000-1999/1900-1999/1980-1989/1983/1983A.go`


------
https://chatgpt.com/codex/tasks/task_e_6882e1ecb1b08324828aefc44a867776