### PR TITLE
Add Go solution for Codeforces 1987D

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1987/1987D.go
+++ b/1000-1999/1900-1999/1980-1989/1987/1987D.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		sort.Ints(a)
+		prev := -1
+		left, right := 0, n-1
+		eaten := 0
+		for left <= right {
+			for left <= right && a[left] <= prev {
+				left++
+			}
+			if left > right {
+				break
+			}
+			prev = a[left]
+			left++
+			eaten++
+			if left <= right {
+				right--
+			}
+		}
+		fmt.Fprintln(writer, eaten)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem D of contest 1987
- the solution sorts the cakes by tastiness and simulates optimal play with two pointers

## Testing
- `go build -o /tmp/1987D.bin 1000-1999/1900-1999/1980-1989/1987/1987D.go && go run 1000-1999/1900-1999/1980-1989/1987/verifierD.go /tmp/1987D.bin`

------
https://chatgpt.com/codex/tasks/task_e_6882df2ec7788324915e7dedb5268fbf