### PR TITLE
Add 1987E Go solution

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1987/1987E.go
+++ b/1000-1999/1900-1999/1980-1989/1987/1987E.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var (
+	g [][]int
+	a []int64
+)
+
+func dfs(v int) (int64, int64) {
+	if len(g[v]) == 0 {
+		return a[v], 0
+	}
+	var total, cost int64
+	for _, u := range g[v] {
+		s, c := dfs(u)
+		total += s
+		cost += c
+	}
+	if total < a[v] {
+		diff := a[v] - total
+		cost += diff
+		total += diff
+	}
+	return total + a[v], cost
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	if _, err := fmt.Fscan(in, &T); err != nil {
+		return
+	}
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a = make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		g = make([][]int, n)
+		for i := 1; i < n; i++ {
+			var p int
+			fmt.Fscan(in, &p)
+			g[p-1] = append(g[p-1], i)
+		}
+		_, ans := dfs(0)
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solver for 1987E using DFS on the tree
- minimal operations computed with recursive accumulation

## Testing
- `go run 1000-1999/1900-1999/1980-1989/1987/verifierE.go ./1987E`


------
https://chatgpt.com/codex/tasks/task_e_6882dee8a1b88324a19d1750808cda3b