### PR TITLE
Add Go solution for 1981 problem B

### DIFF
--- a/1000-1999/1900-1999/1980-1989/1981/1981B.go
+++ b/1000-1999/1900-1999/1980-1989/1981/1981B.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func rangeOr(l, r int64) int64 {
+	res := r
+	for i := 0; i < 61; i++ {
+		if l>>i < r>>i {
+			res |= 1 << i
+		}
+	}
+	return res
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m int64
+		fmt.Fscan(in, &n, &m)
+		l := n - m
+		if l < 0 {
+			l = 0
+		}
+		r := n + m
+		ans := rangeOr(l, r)
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement problem B solution in Go for contest 1981
- algorithm uses range OR of numbers `n-m` to `n+m`
- added file `1981B.go` with standard input/output handling

## Testing
- `go run verifierB.go ./1981B_solution`

------
https://chatgpt.com/codex/tasks/task_e_6882dd43dbfc8324b46e40e4dc7e8539