### PR TITLE
Add Go solution for 1228A

### DIFF
--- a/1000-1999/1200-1299/1220-1229/1228/1228A.go
+++ b/1000-1999/1200-1299/1220-1229/1228/1228A.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+)
+
+func uniqueDigits(x int) bool {
+	seen := [10]bool{}
+	if x == 0 {
+		seen[0] = true
+		return true
+	}
+	for x > 0 {
+		d := x % 10
+		if seen[d] {
+			return false
+		}
+		seen[d] = true
+		x /= 10
+	}
+	return true
+}
+
+func main() {
+	var l, r int
+	if _, err := fmt.Scan(&l, &r); err != nil {
+		return
+	}
+	for x := l; x <= r; x++ {
+		if uniqueDigits(x) {
+			fmt.Println(x)
+			return
+		}
+	}
+	fmt.Println(-1)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1228A

## Testing
- `go run 1000-1999/1200-1299/1220-1229/1228/1228A.go << EOF
123 130
EOF`
- `go run 1000-1999/1200-1299/1220-1229/1228/1228A.go << EOF
989 991
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6882d8e1f48483248769f5457fa33b46