### PR TITLE
Add Go solution for 1221A

### DIFF
--- a/1000-1999/1200-1299/1220-1229/1221/1221A.go
+++ b/1000-1999/1200-1299/1220-1229/1221/1221A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var q int
+	if _, err := fmt.Fscan(in, &q); err != nil {
+		return
+	}
+	for ; q > 0; q-- {
+		var n int
+		fmt.Fscan(in, &n)
+		sum := 0
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(in, &x)
+			if x <= 2048 {
+				sum += x
+			}
+		}
+		if sum >= 2048 {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1221A

## Testing
- `go run 1000-1999/1200-1299/1220-1229/1221/1221A.go <<EOF`
  `1`
  `1`
  `2048`
  `EOF`
- `go run 1000-1999/1200-1299/1220-1229/1221/1221A.go <<EOF`
  `2`
  `3`
  `1024 1024 1`
  `4`
  `2048 2048 4 4`
  `EOF`

------
https://chatgpt.com/codex/tasks/task_e_6882d783a0948324a4d7986f69327c0c