### PR TITLE
Add Go solution for problem 1225B2

### DIFF
--- a/1000-1999/1200-1299/1220-1229/1225/1225B2.go
+++ b/1000-1999/1200-1299/1220-1229/1225/1225B2.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k, d int
+		fmt.Fscan(reader, &n, &k, &d)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		freq := make(map[int]int)
+		distinct := 0
+		for i := 0; i < d; i++ {
+			v := arr[i]
+			if freq[v] == 0 {
+				distinct++
+			}
+			freq[v]++
+		}
+		ans := distinct
+		for i := d; i < n; i++ {
+			rm := arr[i-d]
+			freq[rm]--
+			if freq[rm] == 0 {
+				delete(freq, rm)
+				distinct--
+			}
+			v := arr[i]
+			if freq[v] == 0 {
+				distinct++
+			}
+			freq[v]++
+			if distinct < ans {
+				ans = distinct
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add `1225B2.go` implementing sliding window solution for minimum distinct shows in any segment

## Testing
- `go build 1000-1999/1200-1299/1220-1229/1225/1225B2.go`
- `go vet 1000-1999/1200-1299/1220-1229/1225/1225B2.go`


------
https://chatgpt.com/codex/tasks/task_e_6882d43a4aa88324ada7c866d01bec41