### PR TITLE
Add Go solution for 1907B

### DIFF
--- a/1000-1999/1900-1999/1900-1909/1907/1907B.go
+++ b/1000-1999/1900-1999/1900-1909/1907/1907B.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		lowerSkip := 0
+		upperSkip := 0
+		result := make([]byte, 0, len(s))
+		for i := len(s) - 1; i >= 0; i-- {
+			c := s[i]
+			if c == 'b' {
+				lowerSkip++
+			} else if c == 'B' {
+				upperSkip++
+			} else if c >= 'a' && c <= 'z' {
+				if lowerSkip > 0 {
+					lowerSkip--
+				} else {
+					result = append(result, c)
+				}
+			} else { // uppercase letter
+				if upperSkip > 0 {
+					upperSkip--
+				} else {
+					result = append(result, c)
+				}
+			}
+		}
+		for i := len(result) - 1; i >= 0; i-- {
+			writer.WriteByte(result[i])
+		}
+		writer.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1907B.go` solution that simulates unusual backspaces

## Testing
- `go vet ./1000-1999/1900-1999/1900-1909/1907/1907B.go`
- `go run 1907B.go` with custom input

------
https://chatgpt.com/codex/tasks/task_e_6882f21548b883249c0ff693f6fcfa9b