### PR TITLE
Add Go solution for 1907D

### DIFF
--- a/1000-1999/1900-1999/1900-1909/1907/1907D.go
+++ b/1000-1999/1900-1999/1900-1909/1907/1907D.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func canComplete(segs [][2]int, k int) bool {
+	low, high := 0, 0
+	for _, seg := range segs {
+		l, r := seg[0], seg[1]
+		if low-k > l {
+			l = low - k
+		}
+		if high+k < r {
+			r = high + k
+		}
+		if l > r {
+			return false
+		}
+		low, high = l, r
+	}
+	return true
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		segs := make([][2]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &segs[i][0], &segs[i][1])
+		}
+
+		lo, hi := 0, int(1e9)
+		for lo < hi {
+			mid := (lo + hi) / 2
+			if canComplete(segs, mid) {
+				hi = mid
+			} else {
+				lo = mid + 1
+			}
+		}
+		fmt.Fprintln(writer, lo)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 1907D

## Testing
- `go build 1000-1999/1900-1999/1900-1909/1907/1907D.go`
- `echo -e '1\n3\n3 8\n10 18\n6 11\n' | go run 1000-1999/1900-1999/1900-1909/1907/1907D.go`


------
https://chatgpt.com/codex/tasks/task_e_6882f143db748324b2a21d21ad8855e9