### PR TITLE
Add Go solution for problem 1225C

### DIFF
--- a/1000-1999/1200-1299/1220-1229/1225/1225C.go
+++ b/1000-1999/1200-1299/1220-1229/1225/1225C.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/bits"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, p int64
+	if _, err := fmt.Fscan(reader, &n, &p); err != nil {
+		return
+	}
+
+	for k := int64(1); k <= 60; k++ {
+		s := n - p*k
+		if s <= 0 {
+			continue
+		}
+		if s < k {
+			continue
+		}
+		if int64(bits.OnesCount64(uint64(s))) <= k {
+			fmt.Fprintln(writer, k)
+			return
+		}
+	}
+	fmt.Fprintln(writer, -1)
+}


### PR DESCRIPTION
## Summary
- implement `1225C.go` solving p-binary representation problem

## Testing
- `go build 1000-1999/1200-1299/1220-1229/1225/1225C.go`

------
https://chatgpt.com/codex/tasks/task_e_6882d3adf2d48324994124e8b332c1ef