### PR TITLE
Add Go solution for 1250B

### DIFF
--- a/1000-1999/1200-1299/1250-1259/1250/1250B.go
+++ b/1000-1999/1200-1299/1250-1259/1250/1250B.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n, k int
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+	teams := make([]int, k)
+	for i := 0; i < n; i++ {
+		var t int
+		fmt.Fscan(in, &t)
+		teams[t-1]++
+	}
+	sort.Ints(teams)
+	best := int64(^uint64(0) >> 1)
+	maxPair := 0
+	for pairs := 0; pairs <= k/2; pairs++ {
+		if pairs > 0 {
+			sum := teams[pairs-1] + teams[k-pairs]
+			if sum > maxPair {
+				maxPair = sum
+			}
+		}
+		rides := k - pairs
+		largest := 0
+		if pairs <= k-pairs-1 {
+			largest = teams[k-pairs-1]
+		}
+		cap := largest
+		if maxPair > cap {
+			cap = maxPair
+		}
+		cost := int64(rides) * int64(cap)
+		if cost < best {
+			best = cost
+		}
+	}
+	fmt.Println(best)
+}


### PR DESCRIPTION
## Summary
- implement bus cost minimization for contest 1250B

## Testing
- `go build 1000-1999/1200-1299/1250-1259/1250/1250B.go`
- `echo -e "6 3\n1 2 2 3 1 3" | go run 1000-1999/1200-1299/1250-1259/1250/1250B.go`
- `echo -e "5 2\n1 1 1 2 2" | go run 1000-1999/1200-1299/1250-1259/1250/1250B.go`


------
https://chatgpt.com/codex/tasks/task_e_6882d01e1d388324a5c161b45adabd47