### PR TITLE
Add Go solution for 1250F

### DIFF
--- a/1000-1999/1200-1299/1250-1259/1250/1250F.go
+++ b/1000-1999/1200-1299/1250-1259/1250/1250F.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	best := int(1<<31 - 1)
+	for i := 1; i*i <= n; i++ {
+		if n%i == 0 {
+			j := n / i
+			p := 2 * (i + j)
+			if p < best {
+				best = p
+			}
+		}
+	}
+	fmt.Fprintln(writer, best)
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem 1250F to compute the minimal perimeter of an integer-sided rectangle with area exactly `n`

## Testing
- `go build 1000-1999/1200-1299/1250-1259/1250/1250F.go`


------
https://chatgpt.com/codex/tasks/task_e_6882cf4bcd8483248d8ba4e97b1477f3