### PR TITLE
Add Go solution for problem 1900B

### DIFF
--- a/1000-1999/1900-1999/1900-1909/1900/1900B.go
+++ b/1000-1999/1900-1999/1900-1909/1900/1900B.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var a, b, c int
+		fmt.Fscan(reader, &a, &b, &c)
+		one := 0
+		two := 0
+		three := 0
+		if b%2 == c%2 {
+			one = 1
+		}
+		if a%2 == c%2 {
+			two = 1
+		}
+		if a%2 == b%2 {
+			three = 1
+		}
+		fmt.Fprintf(writer, "%d %d %d\n", one, two, three)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for contest 1900 problem B

## Testing
- `go build 1000-1999/1900-1999/1900-1909/1900/1900B.go`
- `printf '3\n1 1 1\n1 2 3\n2 2 2\n' | go run 1000-1999/1900-1999/1900-1909/1900/1900B.go`

------
https://chatgpt.com/codex/tasks/task_e_6882f373e5388324bfe0f6c3bbbad27e