### PR TITLE
Add Go solution for 1257C Dominated Subarray

### DIFF
--- a/1000-1999/1200-1299/1250-1259/1257/1257C.go
+++ b/1000-1999/1200-1299/1250-1259/1257/1257C.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var T int
+	if _, err := fmt.Fscan(reader, &T); err != nil {
+		return
+	}
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		last := make(map[int]int)
+		best := n + 10
+		for i, v := range arr {
+			if prev, ok := last[v]; ok {
+				if i-prev+1 < best {
+					best = i - prev + 1
+				}
+			}
+			last[v] = i
+		}
+		if best > n {
+			fmt.Fprintln(writer, -1)
+		} else {
+			fmt.Fprintln(writer, best)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1257C

## Testing
- `go build ./1000-1999/1200-1299/1250-1259/1257/1257C.go`
- `printf "1\n5\n1 2 3 2 2\n" | go run 1000-1999/1200-1299/1250-1259/1257/1257C.go`

------
https://chatgpt.com/codex/tasks/task_e_6882cc027d408324bfeab46d6ed84add