### PR TITLE
Add Go solution for 1972B

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1972/1972B.go
+++ b/1000-1999/1900-1999/1970-1979/1972/1972B.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(in, &n)
+		fmt.Fscan(in, &s)
+		cnt := 0
+		for i := 0; i < len(s); i++ {
+			if s[i] == 'U' {
+				cnt++
+			}
+		}
+		if cnt%2 == 1 {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go solution for contest 1972 problem B

## Testing
- `go run 1000-1999/1900-1999/1970-1979/1972/1972B.go <<EOF
3
5
UUDUD
5
UDDUD
2
UU
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6882f40049fc83249bba5c055ae7952b