### PR TITLE
Add Go solution for problem 1978B

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1978/1978B.go
+++ b/1000-1999/1900-1999/1970-1979/1978/1978B.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, a, b int64
+		fmt.Fscan(reader, &n, &a, &b)
+		maxk := n
+		if b < maxk {
+			maxk = b
+		}
+		var result int64
+		if b <= a {
+			result = n * a
+		} else {
+			k := b - a
+			if k > maxk {
+				k = maxk
+			}
+			best := k*b - k*(k-1)/2 + (n-k)*a
+			last := maxk*b - maxk*(maxk-1)/2 + (n-maxk)*a
+			if last > best {
+				best = last
+			}
+			result = best
+		}
+		fmt.Fprintln(writer, result)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 1978 problem B

## Testing
- `go build 1978B.go`
- `go run verifierB.go ./solB`

------
https://chatgpt.com/codex/tasks/task_e_6882f677752c83248d38361d783872d9