### PR TITLE
Add Go solution for 1973 Problem B

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1973/1973B.go
+++ b/1000-1999/1900-1999/1970-1979/1973/1973B.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func loneliness(a []int) int {
+	n := len(a)
+	maxGap := 0
+	for bit := 0; bit < 20; bit++ {
+		last := 0
+		appear := false
+		for i := 0; i < n; i++ {
+			if (a[i]>>bit)&1 == 1 {
+				appear = true
+				gap := i + 1 - last - 1
+				if gap > maxGap {
+					maxGap = gap
+				}
+				last = i + 1
+			}
+		}
+		if appear {
+			gap := n + 1 - last - 1
+			if gap > maxGap {
+				maxGap = gap
+			}
+		}
+	}
+	return maxGap + 1
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		fmt.Fprintln(out, loneliness(a))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `1973/problemB.txt`
- algorithm scans each bit position to find maximal gap between set bits and outputs `maxGap + 1`

## Testing
- `go run verifierB.go ./1973/1973B.bin`


------
https://chatgpt.com/codex/tasks/task_e_6882f55edc048324837ad0fe49b8cf57