### PR TITLE
Add Go solution for 1971C

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1971/1971C.go
+++ b/1000-1999/1900-1999/1970-1979/1971/1971C.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func between(a, b, x int) bool {
+	if x == a || x == b {
+		return false
+	}
+	cur := a
+	for {
+		cur = cur%12 + 1
+		if cur == x {
+			return true
+		}
+		if cur == b {
+			break
+		}
+	}
+	return false
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a, b, c, d int
+		fmt.Fscan(reader, &a, &b, &c, &d)
+		abC := between(a, b, c)
+		abD := between(a, b, d)
+		cdA := between(c, d, a)
+		cdB := between(c, d, b)
+		if abC != abD && cdA != cdB {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement 1971C.go to determine if two chords on a 12-hour clock intersect
- use a helper `between` to detect clockwise ordering of endpoints
- verified correctness with provided verifier

## Testing
- `go build 1000-1999/1900-1999/1970-1979/1971/1971C.go`
- `go run 1000-1999/1900-1999/1970-1979/1971/verifierC.go ./1971C`

------
https://chatgpt.com/codex/tasks/task_e_6882f81c846c8324835ea8a2d0dc32f1