### PR TITLE
Add Go solution for 1971G

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1971/1971G.go
+++ b/1000-1999/1900-1999/1970-1979/1971/1971G.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		groups := make(map[int][]int)
+		vals := make(map[int][]int)
+		for i, v := range a {
+			g := v >> 2
+			groups[g] = append(groups[g], i)
+			vals[g] = append(vals[g], v)
+		}
+		for g := range groups {
+			idxs := groups[g]
+			vs := vals[g]
+			sort.Ints(vs)
+			for j, idx := range idxs {
+				a[idx] = vs[j]
+			}
+		}
+		for i, v := range a {
+			if i > 0 {
+				fmt.Fprint(out, " ")
+			}
+			fmt.Fprint(out, v)
+		}
+		fmt.Fprintln(out)
+	}
+}


### PR DESCRIPTION
## Summary
- add `1971G.go` implementing lexicographically minimal array under xor-based swaps

## Testing
- `go run verifierG.go /tmp/1971G`

------
https://chatgpt.com/codex/tasks/task_e_6882f7d611448324b2f9cb10c9b3949f