### PR TITLE
Add Go solution for 1971F

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1971/1971F.go
+++ b/1000-1999/1900-1999/1970-1979/1971/1971F.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func countInside(R int) int64 {
+	if R <= 0 {
+		return 0
+	}
+	r2 := int64(R) * int64(R)
+	var cnt int64
+	for x := 0; int64(x)*int64(x) < r2; x++ {
+		remain := r2 - int64(x*x) - 1
+		if remain < 0 {
+			remain = 0
+		}
+		y := int64(math.Sqrt(float64(remain)))
+		if x == 0 {
+			cnt += 2*y + 1
+		} else {
+			cnt += 2 * (2*y + 1)
+		}
+	}
+	return cnt
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var r int
+		fmt.Fscan(in, &r)
+		ans := countInside(r+1) - countInside(r)
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem F in contest 1971
- count lattice points in an annulus using integer math
- add basic test via verifierF.go (all tests passed)

## Testing
- `go run 1000-1999/1900-1999/1970-1979/1971/verifierF.go /tmp/1971F.bin`

------
https://chatgpt.com/codex/tasks/task_e_6882f79020648324af2c20bea978b8d4