### PR TITLE
Add solution for 1977C

### DIFF
--- a/1000-1999/1900-1999/1970-1979/1977/1977C.go
+++ b/1000-1999/1900-1999/1970-1979/1977/1977C.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const limit int64 = 1_000_000_000
+const infLCM int64 = limit + 1
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func lcmCap(a, b int64) int64 {
+	if a == infLCM || b == infLCM {
+		return infLCM
+	}
+	g := gcd(a, b)
+	a /= g
+	res := a * b
+	if res > infLCM {
+		return infLCM
+	}
+	return res
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	arr := make([]int64, n)
+	present := make(map[int64]bool)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+		present[arr[i]] = true
+	}
+
+	dp := make(map[int64]int)
+	for _, x := range arr {
+		next := make(map[int64]int)
+		if next[x] < 1 {
+			next[x] = 1
+		}
+		for l, lLen := range dp {
+			nl := lcmCap(l, x)
+			if lLen+1 > next[nl] {
+				next[nl] = lLen + 1
+			}
+		}
+		for l, lLen := range next {
+			if lLen > dp[l] {
+				dp[l] = lLen
+			}
+		}
+	}
+
+	ans := 0
+	for l, lLen := range dp {
+		if l > limit || !present[l] {
+			if lLen > ans {
+				ans = lLen
+			}
+		}
+	}
+
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem C in `1977`
- dynamic programming over LCMs with saturation to 1e9+1

## Testing
- `go build -o solver 1977C.go && go run verifierC.go ./solver`

------
https://chatgpt.com/codex/tasks/task_e_6882f8a893c88324a7f8bbb82a0e4f57