### PR TITLE
Add Go solution for 1942C1

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1942/1942C1.go
+++ b/1000-1999/1900-1999/1940-1949/1942/1942C1.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, x, y int
+		fmt.Fscan(in, &n, &x, &y)
+		for i := 0; i < x; i++ {
+			var tmp int
+			fmt.Fscan(in, &tmp)
+		}
+		if x < 3 {
+			fmt.Fprintln(out, 0)
+		} else {
+			fmt.Fprintln(out, x-2)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for 1942C1

## Testing
- `go build 1000-1999/1900-1999/1940-1949/1942/1942C1.go`
- `echo "1\n6 4 0\n1 3 4 5" | go run 1000-1999/1900-1999/1940-1949/1942/1942C1.go`


------
https://chatgpt.com/codex/tasks/task_e_6883016c8d9c8324a4df992a3c15de0a