### PR TITLE
Add Go verifiers for contest 507

### DIFF
--- a/0-999/500-599/500-509/507/verifierA.go
+++ b/0-999/500-599/500-509/507/verifierA.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type TestA struct {
+	n int
+	k int
+	a []int
+}
+
+func generateTests() []TestA {
+	rand.Seed(1)
+	tests := make([]TestA, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(50)
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rand.Intn(10) + 1
+		}
+		tests[i] = TestA{n, k, a}
+	}
+	return tests
+}
+
+func maxLearn(n, k int, a []int) int {
+	type pair struct{ v, idx int }
+	p := make([]pair, n)
+	for i := 0; i < n; i++ {
+		p[i] = pair{a[i], i + 1}
+	}
+	sort.Slice(p, func(i, j int) bool { return p[i].v < p[j].v })
+	ans := 0
+	for i := 0; i < n; i++ {
+		if k >= p[i].v {
+			k -= p[i].v
+			ans++
+		} else {
+			break
+		}
+	}
+	return ans
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.n, t.k)
+		for j, v := range t.a {
+			if j > 0 {
+				input += " "
+			}
+			input += strconv.Itoa(v)
+		}
+		input += "\n"
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		// parse output
+		scanner := bufio.NewScanner(strings.NewReader(got))
+		if !scanner.Scan() {
+			fmt.Printf("test %d: no output\n", i+1)
+			os.Exit(1)
+		}
+		mStr := strings.TrimSpace(scanner.Text())
+		m, err := strconv.Atoi(mStr)
+		if err != nil {
+			fmt.Printf("test %d: invalid integer output\n", i+1)
+			os.Exit(1)
+		}
+		idxs := []int{}
+		if scanner.Scan() {
+			parts := strings.Fields(scanner.Text())
+			for _, p := range parts {
+				val, _ := strconv.Atoi(p)
+				idxs = append(idxs, val)
+			}
+		}
+		if len(idxs) != m {
+			fmt.Printf("test %d: expected %d indices, got %d\n", i+1, m, len(idxs))
+			os.Exit(1)
+		}
+		used := make(map[int]bool)
+		sum := 0
+		for _, idx := range idxs {
+			if idx < 1 || idx > t.n {
+				fmt.Printf("test %d: index %d out of range\n", i+1, idx)
+				os.Exit(1)
+			}
+			if used[idx] {
+				fmt.Printf("test %d: duplicate index %d\n", i+1, idx)
+				os.Exit(1)
+			}
+			used[idx] = true
+			sum += t.a[idx-1]
+		}
+		if sum > t.k {
+			fmt.Printf("test %d: sum %d exceeds k %d\n", i+1, sum, t.k)
+			os.Exit(1)
+		}
+		expectedM := maxLearn(t.n, t.k, t.a)
+		if m != expectedM {
+			fmt.Printf("test %d: expected m=%d got %d\n", i+1, expectedM, m)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/500-599/500-509/507/verifierB.go
+++ b/0-999/500-599/500-509/507/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type TestB struct {
+	r  int64
+	x1 int64
+	y1 int64
+	x2 int64
+	y2 int64
+}
+
+func generateTests() []TestB {
+	rand.Seed(2)
+	tests := make([]TestB, 100)
+	for i := range tests {
+		r := rand.Int63n(1000) + 1
+		x1 := rand.Int63n(2001) - 1000
+		y1 := rand.Int63n(2001) - 1000
+		x2 := rand.Int63n(2001) - 1000
+		y2 := rand.Int63n(2001) - 1000
+		tests[i] = TestB{r, x1, y1, x2, y2}
+	}
+	return tests
+}
+
+func expected(t TestB) int64 {
+	dx := float64(t.x1 - t.x2)
+	dy := float64(t.y1 - t.y2)
+	dist := math.Hypot(dx, dy)
+	maxMove := 2 * float64(t.r)
+	return int64(math.Ceil(dist / maxMove))
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d %d %d %d\n", t.r, t.x1, t.y1, t.x2, t.y2)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(strings.TrimSpace(got), 10, 64)
+		if err != nil {
+			fmt.Printf("test %d: invalid output\n", i+1)
+			os.Exit(1)
+		}
+		exp := expected(t)
+		if val != exp {
+			fmt.Printf("test %d: expected %d got %d\n", i+1, exp, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/500-599/500-509/507/verifierC.go
+++ b/0-999/500-599/500-509/507/verifierC.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type TestC struct {
+	h int
+	n int64
+}
+
+func generateTests() []TestC {
+	rand.Seed(3)
+	tests := make([]TestC, 100)
+	for i := range tests {
+		h := rand.Intn(25) + 1
+		maxN := int64(1) << h
+		n := rand.Int63n(maxN) + 1
+		tests[i] = TestC{h, n}
+	}
+	return tests
+}
+
+func expected(t TestC) int64 {
+	h := t.h
+	n := t.n
+	var ans int64
+	dir := 0
+	for i := h; i > 0; i-- {
+		half := int64(1) << (i - 1)
+		if (n <= half && dir == 0) || (n > half && dir == 1) {
+			ans += 1
+			dir ^= 1
+		} else {
+			ans += int64(1) << i
+		}
+		if n > half {
+			n -= half
+		}
+	}
+	return ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.h, t.n)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(strings.TrimSpace(got), 10, 64)
+		if err != nil {
+			fmt.Printf("test %d: invalid output\n", i+1)
+			os.Exit(1)
+		}
+		exp := expected(t)
+		if val != exp {
+			fmt.Printf("test %d: expected %d got %d\n", i+1, exp, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/500-599/500-509/507/verifierD.go
+++ b/0-999/500-599/500-509/507/verifierD.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type TestD struct {
+	n int
+	k int
+	m int
+}
+
+func generateTests() []TestD {
+	rand.Seed(4)
+	tests := make([]TestD, 100)
+	for i := range tests {
+		n := rand.Intn(5) + 1
+		k := rand.Intn(9) + 2
+		m := rand.Intn(1000) + 1
+		tests[i] = TestD{n, k, m}
+	}
+	return tests
+}
+
+func expected(t TestD) int {
+	n, k, m := t.n, t.k, t.m
+	pow10 := make([]int, n)
+	pow10[0] = 1 % k
+	for i := 1; i < n; i++ {
+		pow10[i] = pow10[i-1] * 10 % k
+	}
+	dpCurr := make([][2]int, k)
+	dpNext := make([][2]int, k)
+	dpCurr[0][0] = 1 % m
+	for i := 0; i < n; i++ {
+		for r := 0; r < k; r++ {
+			dpNext[r][0] = 0
+			dpNext[r][1] = 0
+		}
+		start := 0
+		if i+1 == n {
+			start = 1
+		}
+		for r := 0; r < k; r++ {
+			for flag := 0; flag < 2; flag++ {
+				v := dpCurr[r][flag]
+				if v == 0 {
+					continue
+				}
+				for d := start; d <= 9; d++ {
+					newR := (d*pow10[i] + r) % k
+					newFlag := flag
+					if flag == 0 && newR == 0 && d != 0 {
+						newFlag = 1
+					}
+					dpNext[newR][newFlag] += v
+					if dpNext[newR][newFlag] >= m {
+						dpNext[newR][newFlag] %= m
+					}
+				}
+			}
+		}
+		dpCurr, dpNext = dpNext, dpCurr
+	}
+	ans := 0
+	for r := 0; r < k; r++ {
+		ans += dpCurr[r][1]
+		if ans >= m {
+			ans %= m
+		}
+	}
+	return ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d %d\n", t.n, t.k, t.m)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(strings.TrimSpace(got))
+		if err != nil {
+			fmt.Printf("test %d: invalid output\n", i+1)
+			os.Exit(1)
+		}
+		exp := expected(t)
+		if val != exp {
+			fmt.Printf("test %d: expected %d got %d\n", i+1, exp, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/500-599/500-509/507/verifierE.go
+++ b/0-999/500-599/500-509/507/verifierE.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type edge struct{ u, v, z int }
+
+// Test case structure
+type TestE struct {
+	n     int
+	m     int
+	edges []edge
+}
+
+func generateTests() []TestE {
+	rand.Seed(5)
+	tests := make([]TestE, 100)
+	for i := range tests {
+		n := rand.Intn(6) + 2 // 2..7
+		maxExtra := n*(n-1)/2 - (n - 1)
+		extra := rand.Intn(maxExtra + 1)
+		m := (n - 1) + extra
+		edges := make([]edge, 0, m)
+		// create tree to ensure connectivity
+		for v := 2; v <= n; v++ {
+			u := rand.Intn(v-1) + 1
+			z := rand.Intn(2)
+			edges = append(edges, edge{u, v, z})
+		}
+		// add extra edges
+		pairs := make([][2]int, 0)
+		for a := 1; a <= n; a++ {
+			for b := a + 1; b <= n; b++ {
+				skip := false
+				for _, e := range edges {
+					if (e.u == a && e.v == b) || (e.u == b && e.v == a) {
+						skip = true
+						break
+					}
+				}
+				if !skip {
+					pairs = append(pairs, [2]int{a, b})
+				}
+			}
+		}
+		rand.Shuffle(len(pairs), func(i, j int) { pairs[i], pairs[j] = pairs[j], pairs[i] })
+		for i2 := 0; i2 < extra && i2 < len(pairs); i2++ {
+			p := pairs[i2]
+			z := rand.Intn(2)
+			edges = append(edges, edge{p[0], p[1], z})
+		}
+		tests[i] = TestE{n, len(edges), edges}
+	}
+	return tests
+}
+
+// Implementation of reference algorithm from 507E.go
+const inf = int64(1e18)
+const cFijo = int64(1000000)
+
+type Edge struct {
+	to int
+	z  int
+}
+
+type Item struct {
+	node int
+	dist int64
+}
+
+type PQ []Item
+
+func (pq PQ) Len() int            { return len(pq) }
+func (pq PQ) Less(i, j int) bool  { return pq[i].dist < pq[j].dist }
+func (pq PQ) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PQ) Push(x interface{}) { *pq = append(*pq, x.(Item)) }
+func (pq *PQ) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	it := old[n-1]
+	*pq = old[:n-1]
+	return it
+}
+
+func expected(t TestE) string {
+	N := t.n
+	M := t.m
+	g := make([][]Edge, N)
+	edges := make([]edge, 0, M)
+	rotos := 0
+	for _, e := range t.edges {
+		u, v, z := e.u-1, e.v-1, e.z
+		g[u] = append(g[u], Edge{v, z})
+		g[v] = append(g[v], Edge{u, z})
+		edges = append(edges, e)
+		if z == 0 {
+			rotos++
+		}
+	}
+	dist := make([]int64, N)
+	parent := make([]int, N)
+	for i := 0; i < N; i++ {
+		dist[i] = inf
+		parent[i] = -1
+	}
+	dist[0] = 0
+	pq := &PQ{}
+	heap.Init(pq)
+	heap.Push(pq, Item{0, 0})
+	for pq.Len() > 0 {
+		it := heap.Pop(pq).(Item)
+		u := it.node
+		d := it.dist
+		if d != dist[u] {
+			continue
+		}
+		for _, e := range g[u] {
+			cost := cFijo
+			if e.z == 0 {
+				cost++
+			}
+			nd := d + cost
+			v := e.to
+			if nd < dist[v] {
+				dist[v] = nd
+				parent[v] = u
+				heap.Push(pq, Item{v, nd})
+			}
+		}
+	}
+	pathMap := make(map[[2]int]bool)
+	zMap := make(map[[2]int]int)
+	for _, e := range edges {
+		u, v := e.u-1, e.v-1
+		key := [2]int{min(u, v), max(u, v)}
+		zMap[key] = e.z
+	}
+	brokenInPath := 0
+	pathLen := 0
+	cur := N - 1
+	for parent[cur] != -1 {
+		p := parent[cur]
+		key := [2]int{min(p, cur), max(p, cur)}
+		pathMap[key] = true
+		if zMap[key] == 0 {
+			brokenInPath++
+		}
+		pathLen++
+		cur = p
+	}
+	ops := M - rotos - pathLen + 2*brokenInPath
+	var buf strings.Builder
+	buf.WriteString(fmt.Sprintf("%d\n", ops))
+	for _, e := range edges {
+		u, v, z := e.u-1, e.v-1, e.z
+		key := [2]int{min(u, v), max(u, v)}
+		if pathMap[key] {
+			if z == 0 {
+				buf.WriteString(fmt.Sprintf("%d %d 1\n", u+1, v+1))
+			}
+		} else {
+			if z == 1 {
+				buf.WriteString(fmt.Sprintf("%d %d 0\n", u+1, v+1))
+			}
+		}
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildInput(t TestE) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.m))
+	for _, e := range t.edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.u, e.v, e.z))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := buildInput(t)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		exp := expected(t)
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("test %d failed\nexpected:\n%s\ngot:\n%s\n", i+1, exp, strings.TrimSpace(got))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go, verifierB.go, verifierC.go, verifierD.go and verifierE.go to check solutions for contest 507
- each verifier runs 100 randomized tests using reference logic
- verifiers execute an arbitrary binary and report mismatches or runtime errors

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`


------
https://chatgpt.com/codex/tasks/task_e_68831693ff108324b1f5302125cdb4b8