### PR TITLE
Add Go verifiers for contest 505

### DIFF
--- a/0-999/500-599/500-509/505/verifierA.go
+++ b/0-999/500-599/500-509/505/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isPal(s string) bool {
+	i, j := 0, len(s)-1
+	for i < j {
+		if s[i] != s[j] {
+			return false
+		}
+		i++
+		j--
+	}
+	return true
+}
+
+func possibleInsertions(s string) []string {
+	results := []string{}
+	for pos := 0; pos <= len(s); pos++ {
+		for ch := 'a'; ch <= 'z'; ch++ {
+			t := s[:pos] + string(ch) + s[pos:]
+			if isPal(t) {
+				results = append(results, t)
+			}
+		}
+	}
+	return results
+}
+
+func verifyOutput(s, out string) bool {
+	out = strings.TrimSpace(out)
+	if out == "NA" {
+		return len(possibleInsertions(s)) == 0
+	}
+	if len(out) != len(s)+1 {
+		return false
+	}
+	if !isPal(out) {
+		return false
+	}
+	for i := 0; i <= len(s); i++ {
+		if out[:i]+out[i+1:] == s {
+			return true
+		}
+	}
+	return false
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		l := rng.Intn(10) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('a' + rng.Intn(26))
+		}
+		s := string(b)
+		input := s + "\n"
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if !verifyOutput(s, out) {
+			fmt.Fprintf(os.Stderr, "case %d failed: wrong output %s\ninput:%s", i+1, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/505/verifierB.go
+++ b/0-999/500-599/500-509/505/verifierB.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type dsu struct {
+	p []int
+}
+
+func newDSU(n int) *dsu {
+	d := &dsu{p: make([]int, n+1)}
+	for i := 1; i <= n; i++ {
+		d.p[i] = i
+	}
+	return d
+}
+
+func (d *dsu) find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *dsu) union(a, b int) {
+	fa, fb := d.find(a), d.find(b)
+	if fa != fb {
+		d.p[fa] = fb
+	}
+}
+
+func expected(n int, edges [][3]int, queries [][2]int) []int {
+	// colors from 1..m maybe
+	maxColor := 0
+	for _, e := range edges {
+		if e[2] > maxColor {
+			maxColor = e[2]
+		}
+	}
+	comps := make([]*dsu, maxColor+1)
+	for c := 1; c <= maxColor; c++ {
+		comps[c] = newDSU(n)
+	}
+	for _, e := range edges {
+		comps[e[2]].union(e[0], e[1])
+	}
+	res := make([]int, len(queries))
+	for i, q := range queries {
+		cnt := 0
+		for c := 1; c <= maxColor; c++ {
+			if comps[c].find(q[0]) == comps[c].find(q[1]) {
+				cnt++
+			}
+		}
+		res[i] = cnt
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tc := 0; tc < 100; tc++ {
+		n := rng.Intn(5) + 2
+		m := rng.Intn(6) + 1
+		used := map[[3]int]struct{}{}
+		edges := make([][3]int, 0, m)
+		for len(edges) < m {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			if a == b {
+				continue
+			}
+			c := rng.Intn(m) + 1
+			key := [3]int{a, b, c}
+			if _, ok := used[key]; ok {
+				continue
+			}
+			used[key] = struct{}{}
+			edges = append(edges, [3]int{a, b, c})
+		}
+		q := rng.Intn(5) + 1
+		queries := make([][2]int, q)
+		for i := 0; i < q; i++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			for u == v {
+				v = rng.Intn(n) + 1
+			}
+			queries[i] = [2]int{u, v}
+		}
+		// build input string
+		input := fmt.Sprintf("%d %d\n", n, m)
+		for _, e := range edges {
+			input += fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2])
+		}
+		input += fmt.Sprintf("%d\n", q)
+		for _, qu := range queries {
+			input += fmt.Sprintf("%d %d\n", qu[0], qu[1])
+		}
+		expect := expected(n, edges, queries)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tc+1, err, input)
+			os.Exit(1)
+		}
+		parts := strings.Fields(out)
+		if len(parts) != len(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", tc+1, len(expect), len(parts), input)
+			os.Exit(1)
+		}
+		for i, exp := range expect {
+			if parts[i] != fmt.Sprintf("%d", exp) {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", tc+1, exp, parts[i], input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/505/verifierC.go
+++ b/0-999/500-599/500-509/505/verifierC.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func expected(n, d int, positions []int) int {
+	gems := map[int]int{}
+	maxPos := 0
+	for _, p := range positions {
+		gems[p]++
+		if p > maxPos {
+			maxPos = p
+		}
+	}
+	memo := make(map[[2]int]int)
+	var dfs func(pos, jump int) int
+	dfs = func(pos, jump int) int {
+		key := [2]int{pos, jump}
+		if v, ok := memo[key]; ok {
+			return v
+		}
+		best := 0
+		for delta := -1; delta <= 1; delta++ {
+			nj := jump + delta
+			if nj <= 0 {
+				continue
+			}
+			np := pos + nj
+			if np > maxPos {
+				continue
+			}
+			val := gems[np] + dfs(np, nj)
+			if val > best {
+				best = val
+			}
+		}
+		memo[key] = best
+		return best
+	}
+	return gems[d] + dfs(d, d)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tc := 0; tc < 100; tc++ {
+		n := rng.Intn(8) + 1
+		d := rng.Intn(10) + 1
+		positions := make([]int, n)
+		for i := 0; i < n; i++ {
+			positions[i] = d + rng.Intn(20)
+		}
+		sort.Ints(positions)
+		input := fmt.Sprintf("%d %d\n", n, d)
+		for _, p := range positions {
+			input += fmt.Sprintf("%d\n", p)
+		}
+		exp := expected(n, d, positions)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tc+1, err, input)
+			os.Exit(1)
+		}
+		if out != fmt.Sprintf("%d", exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", tc+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/505/verifierD.go
+++ b/0-999/500-599/500-509/505/verifierD.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int, pairs [][2]int) int {
+	reach := make([][]bool, n+1)
+	for i := range reach {
+		reach[i] = make([]bool, n+1)
+		if i > 0 {
+			reach[i][i] = true
+		}
+	}
+	for _, p := range pairs {
+		reach[p[0]][p[1]] = true
+	}
+	// transitive closure
+	for k := 1; k <= n; k++ {
+		for i := 1; i <= n; i++ {
+			if reach[i][k] {
+				for j := 1; j <= n; j++ {
+					if reach[k][j] {
+						reach[i][j] = true
+					}
+				}
+			}
+		}
+	}
+	comp := make([]int, n+1)
+	for i := range comp {
+		comp[i] = -1
+	}
+	cid := 0
+	for v := 1; v <= n; v++ {
+		if comp[v] != -1 {
+			continue
+		}
+		// BFS
+		queue := []int{v}
+		comp[v] = cid
+		for len(queue) > 0 {
+			x := queue[0]
+			queue = queue[1:]
+			for y := 1; y <= n; y++ {
+				if comp[y] == -1 && reach[x][y] && reach[y][x] {
+					comp[y] = cid
+					queue = append(queue, y)
+				}
+			}
+		}
+		cid++
+	}
+	C := cid
+	size := make([]int, C)
+	for i := 1; i <= n; i++ {
+		size[comp[i]]++
+	}
+	closureC := make([][]bool, C)
+	for i := range closureC {
+		closureC[i] = make([]bool, C)
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= n; j++ {
+			if reach[i][j] && comp[i] != comp[j] {
+				closureC[comp[i]][comp[j]] = true
+			}
+		}
+	}
+	// transitive closure on components already satisfied due to previous step
+	// compute transitive reduction edge count
+	edgeCnt := 0
+	for i := 0; i < C; i++ {
+		for j := 0; j < C; j++ {
+			if i == j || !closureC[i][j] {
+				continue
+			}
+			redundant := false
+			for k := 0; k < C; k++ {
+				if k != i && k != j && closureC[i][k] && closureC[k][j] {
+					redundant = true
+					break
+				}
+			}
+			if !redundant {
+				edgeCnt++
+			}
+		}
+	}
+	ans := edgeCnt
+	for i := 0; i < C; i++ {
+		if size[i] > 1 {
+			ans += size[i]
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tc := 0; tc < 100; tc++ {
+		n := rng.Intn(6) + 2
+		maxEdges := n * (n - 1)
+		limit := 8
+		if maxEdges < limit {
+			limit = maxEdges
+		}
+		m := rng.Intn(limit) + 1
+		used := map[[2]int]struct{}{}
+		pairs := make([][2]int, 0, m)
+		for len(pairs) < m {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			if a == b {
+				continue
+			}
+			p := [2]int{a, b}
+			if _, ok := used[p]; ok {
+				continue
+			}
+			used[p] = struct{}{}
+			pairs = append(pairs, p)
+		}
+		input := fmt.Sprintf("%d %d\n", n, m)
+		for _, p := range pairs {
+			input += fmt.Sprintf("%d %d\n", p[0], p[1])
+		}
+		exp := expected(n, pairs)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tc+1, err, input)
+			os.Exit(1)
+		}
+		if out != fmt.Sprintf("%d", exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", tc+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/505/verifierE.go
+++ b/0-999/500-599/500-509/505/verifierE.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Item struct {
+	id int
+	ai int64
+}
+
+type MaxHeap []Item
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i].ai > h[j].ai }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(Item)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+func expected(n, m, k int, p int64, hArr, aArr []int64) int64 {
+	hi := int64(0)
+	for i := 0; i < n; i++ {
+		endH := hArr[i] + aArr[i]*int64(m)
+		if endH > hi {
+			hi = endH
+		}
+	}
+	can := func(H int64) bool {
+		events := make([][]int, m+2)
+		times := make([]int, n)
+		for i := 0; i < n; i++ {
+			var t0 int
+			if hArr[i] > H {
+				t0 = 1
+			} else {
+				t0 = int((H-hArr[i])/aArr[i]) + 2
+			}
+			if t0 <= m {
+				events[t0] = append(events[t0], i)
+			}
+		}
+		hq := &MaxHeap{}
+		heap.Init(hq)
+		for d := 1; d <= m; d++ {
+			for _, idx := range events[d] {
+				heap.Push(hq, Item{id: idx, ai: aArr[idx]})
+			}
+			for j := 0; j < k; j++ {
+				if hq.Len() == 0 {
+					break
+				}
+				it := heap.Pop(hq).(Item)
+				id := it.id
+				times[id]++
+				hStart := hArr[id] + aArr[id]*int64(d) - int64(times[id])*p
+				var tnext int
+				if hStart > H {
+					tnext = d + 1
+				} else {
+					tnext = d + int((H-hStart)/aArr[id]) + 2
+				}
+				if tnext <= m {
+					events[tnext] = append(events[tnext], id)
+				}
+			}
+			if hq.Len() > 0 {
+				return false
+			}
+		}
+		return true
+	}
+	lo := int64(-1)
+	for lo+1 < hi {
+		mid := (lo + hi) / 2
+		if can(mid) {
+			hi = mid
+		} else {
+			lo = mid
+		}
+	}
+	return hi
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tc := 0; tc < 100; tc++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		k := rng.Intn(4) + 1
+		p := int64(rng.Intn(20) + 1)
+		hArr := make([]int64, n)
+		aArr := make([]int64, n)
+		for i := 0; i < n; i++ {
+			hArr[i] = int64(rng.Intn(20))
+			aArr[i] = int64(rng.Intn(10) + 1)
+		}
+		input := fmt.Sprintf("%d %d %d %d\n", n, m, k, p)
+		for i := 0; i < n; i++ {
+			input += fmt.Sprintf("%d %d\n", hArr[i], aArr[i])
+		}
+		exp := expected(n, m, k, p, hArr, aArr)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tc+1, err, input)
+			os.Exit(1)
+		}
+		if out != fmt.Sprintf("%d", exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", tc+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add randomized verifiers for problems A–E of contest 505
- cover 100 random cases in each verifier
- ensure generator for verifierD avoids infinite loops

## Testing
- `go run verifierA.go ./solA` ✅
- `go run verifierB.go ./solB` ✅
- `go run verifierC.go ./solC` ✅
- `go run verifierD.go ./solD` ✅
- `go run verifierE.go ./solE` ✅

------
https://chatgpt.com/codex/tasks/task_e_6883157bbff08324b8f8de863aa2f0c9