### PR TITLE
Add Go verifiers for contest 504

### DIFF
--- a/0-999/500-599/500-509/504/504A.go
+++ b/0-999/500-599/500-509/504/504A.go
@@ -1,0 +1,6 @@
+package main
+
+func main() {
+	var x int
+	_ = 1 / x
+}

--- a/0-999/500-599/500-509/504/verifierA.go
+++ b/0-999/500-599/500-509/504/verifierA.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type Test struct {
+	n     int
+	deg   []int
+	s     []int
+	edges [][2]int
+	input string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(10) + 1
+	edges := make([][2]int, 0, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges = append(edges, [2]int{i, p})
+	}
+	deg := make([]int, n)
+	s := make([]int, n)
+	for _, e := range edges {
+		a, b := e[0], e[1]
+		deg[a]++
+		deg[b]++
+		s[a] ^= b
+		s[b] ^= a
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", deg[i], s[i]))
+	}
+	return Test{n: n, deg: deg, s: s, edges: edges, input: sb.String()}
+}
+
+func checkOutput(t Test, out string) error {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	m, err := strconv.Atoi(strings.TrimSpace(scanner.Text()))
+	if err != nil {
+		return fmt.Errorf("invalid m: %v", err)
+	}
+	edges := make([][2]int, 0, m)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 2 {
+			return fmt.Errorf("invalid edge line")
+		}
+		a, err1 := strconv.Atoi(fields[0])
+		b, err2 := strconv.Atoi(fields[1])
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("invalid numbers")
+		}
+		edges = append(edges, [2]int{a, b})
+	}
+	if len(edges) != m {
+		return fmt.Errorf("edge count mismatch")
+	}
+	deg := make([]int, t.n)
+	s := make([]int, t.n)
+	for _, e := range edges {
+		a, b := e[0], e[1]
+		if a < 0 || a >= t.n || b < 0 || b >= t.n || a == b {
+			return fmt.Errorf("invalid edge values")
+		}
+		deg[a]++
+		deg[b]++
+		s[a] ^= b
+		s[b] ^= a
+	}
+	for i := 0; i < t.n; i++ {
+		if deg[i] != t.deg[i] || s[i] != t.s[i] {
+			return fmt.Errorf("degree/xor mismatch")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := checkOutput(t, out); err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%s\noutput:\n%s\n", i+1, err, t.input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/500-599/500-509/504/verifierB.go
+++ b/0-999/500-599/500-509/504/verifierB.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func fact(n int) int {
+	f := 1
+	for i := 2; i <= n; i++ {
+		f *= i
+	}
+	return f
+}
+
+func ord(p []int) int {
+	n := len(p)
+	used := make([]bool, n)
+	res := 0
+	f := fact(n - 1)
+	for i := 0; i < n; i++ {
+		cnt := 0
+		for j := 0; j < p[i]; j++ {
+			if !used[j] {
+				cnt++
+			}
+		}
+		res += cnt * f
+		used[p[i]] = true
+		if i < n-1 {
+			f /= n - 1 - i
+		}
+	}
+	return res
+}
+
+func permFromIndex(n, idx int) []int {
+	nums := make([]int, n)
+	for i := 0; i < n; i++ {
+		nums[i] = i
+	}
+	res := make([]int, n)
+	f := fact(n - 1)
+	for i := 0; i < n; i++ {
+		pos := 0
+		if f > 0 {
+			pos = idx / f
+			idx %= f
+		}
+		res[i] = nums[pos]
+		nums = append(nums[:pos], nums[pos+1:]...)
+		if i < n-1 {
+			f /= n - 1 - i
+		}
+	}
+	return res
+}
+
+func genTest(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(6) + 1
+	p := rng.Perm(n)
+	q := rng.Perm(n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range q {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	idx := (ord(p) + ord(q)) % fact(n)
+	expect := permFromIndex(n, idx)
+	return sb.String(), expect
+}
+
+func check(out string, expect []int) error {
+	fields := strings.Fields(out)
+	if len(fields) != len(expect) {
+		return fmt.Errorf("expected %d numbers", len(expect))
+	}
+	seen := make(map[int]bool)
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("invalid number")
+		}
+		if v < 0 || v >= len(expect) || seen[v] {
+			return fmt.Errorf("invalid permutation")
+		}
+		if v != expect[i] {
+			return fmt.Errorf("wrong result")
+		}
+		seen[v] = true
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genTest(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(out, exp); err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%soutput:\n%s\n", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/500-599/500-509/504/verifierC.go
+++ b/0-999/500-599/500-509/504/verifierC.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func isPalindrome(arr []int) bool {
+	n := len(arr)
+	for i := 0; i < n/2; i++ {
+		if arr[i] != arr[n-1-i] {
+			return false
+		}
+	}
+	return true
+}
+
+func permute(arr []int, f func([]int) bool) bool {
+	var rec func(int) bool
+	rec = func(i int) bool {
+		if i == len(arr) {
+			tmp := make([]int, len(arr))
+			copy(tmp, arr)
+			if f(tmp) {
+				return true
+			}
+			return false
+		}
+		for j := i; j < len(arr); j++ {
+			arr[i], arr[j] = arr[j], arr[i]
+			if rec(i + 1) {
+				return true
+			}
+			arr[i], arr[j] = arr[j], arr[i]
+		}
+		return false
+	}
+	return rec(0)
+}
+
+func possible(a []int, l, r int) bool {
+	sub := append([]int(nil), a[l:r]...)
+	return permute(sub, func(p []int) bool {
+		b := append([]int(nil), a...)
+		copy(b[l:r], p)
+		return isPalindrome(b)
+	})
+}
+
+func brute(a []int) int {
+	n := len(a)
+	cnt := 0
+	for l := 0; l < n; l++ {
+		for r := l; r < n; r++ {
+			if possible(a, l, r+1) {
+				cnt++
+			}
+		}
+	}
+	return cnt
+}
+
+func genTest(rng *rand.Rand) (string, int) {
+	n := rng.Intn(5) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(3) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	exp := brute(a)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genTest(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil || val != exp {
+			fmt.Printf("test %d failed: expected %d got %s\ninput:\n%s\n", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/500-599/500-509/504/verifierD.go
+++ b/0-999/500-599/500-509/504/verifierD.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func canRepresent(nums []int, target int) (bool, []int) {
+	m := len(nums)
+	bestMask := -1
+	for mask := 1; mask < (1 << m); mask++ {
+		xor := 0
+		for i := 0; i < m; i++ {
+			if mask&(1<<i) != 0 {
+				xor ^= nums[i]
+			}
+		}
+		if xor == target {
+			bestMask = mask
+			break
+		}
+	}
+	if bestMask == -1 {
+		return false, nil
+	}
+	idx := []int{}
+	for i := 0; i < m; i++ {
+		if bestMask&(1<<i) != 0 {
+			idx = append(idx, i)
+		}
+	}
+	return true, idx
+}
+
+func genTest(rng *rand.Rand) (string, []int) {
+	m := rng.Intn(8) + 1
+	nums := make([]int, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		nums[i] = rng.Intn(256)
+		sb.WriteString(fmt.Sprintf("%d\n", nums[i]))
+	}
+	return sb.String(), nums
+}
+
+func check(out string, nums []int) error {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for i, x := range nums {
+		if !scanner.Scan() {
+			return fmt.Errorf("not enough lines")
+		}
+		fields := strings.Fields(scanner.Text())
+		k, err := strconv.Atoi(fields[0])
+		if err != nil {
+			return fmt.Errorf("invalid k")
+		}
+		if k == 0 {
+			ok, _ := canRepresent(nums[:i], x)
+			if ok {
+				return fmt.Errorf("representation exists but got 0")
+			}
+			continue
+		}
+		if len(fields)-1 != k {
+			return fmt.Errorf("invalid number of indices")
+		}
+		mask := 0
+		xor := 0
+		for j := 0; j < k; j++ {
+			idx, err := strconv.Atoi(fields[1+j])
+			if err != nil || idx < 0 || idx >= i || (mask&(1<<idx)) != 0 {
+				return fmt.Errorf("bad index")
+			}
+			mask |= 1 << idx
+			xor ^= nums[idx]
+		}
+		if xor != x {
+			return fmt.Errorf("wrong xor")
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, nums := genTest(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(out, nums); err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%soutput:\n%s\n", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/500-599/500-509/504/verifierE.go
+++ b/0-999/500-599/500-509/504/verifierE.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func pathStr(adj [][]int, labels string, u, v int) string {
+	n := len(adj)
+	parent := make([]int, n)
+	for i := range parent {
+		parent[i] = -1
+	}
+	queue := []int{u}
+	parent[u] = u
+	for len(queue) > 0 {
+		x := queue[0]
+		queue = queue[1:]
+		if x == v {
+			break
+		}
+		for _, y := range adj[x] {
+			if parent[y] == -1 {
+				parent[y] = x
+				queue = append(queue, y)
+			}
+		}
+	}
+	path := []int{v}
+	for path[len(path)-1] != u {
+		path = append(path, parent[path[len(path)-1]])
+	}
+	for i := 0; i < len(path)/2; i++ {
+		path[i], path[len(path)-1-i] = path[len(path)-1-i], path[i]
+	}
+	var sb strings.Builder
+	for _, x := range path {
+		sb.WriteByte(labels[x])
+	}
+	return sb.String()
+}
+
+func lcp(a, b string) int {
+	i := 0
+	for i < len(a) && i < len(b) && a[i] == b[i] {
+		i++
+	}
+	return i
+}
+
+func genTest(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(5) + 1
+	adj := make([][]int, n)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		adj[i] = append(adj[i], p)
+		adj[p] = append(adj[p], i)
+	}
+	letters := make([]byte, n)
+	for i := 0; i < n; i++ {
+		letters[i] = byte('a' + rng.Intn(3))
+	}
+	m := rng.Intn(5) + 1
+	queries := make([][4]int, m)
+	for i := 0; i < m; i++ {
+		for j := 0; j < 4; j++ {
+			queries[i][j] = rng.Intn(n)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	sb.WriteString(string(letters) + "\n")
+	for i := 1; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", i+1, adj[i][0]+1))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		a, b, c, d := queries[i][0]+1, queries[i][1]+1, queries[i][2]+1, queries[i][3]+1
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", a, b, c, d))
+	}
+	answers := make([]int, m)
+	for i, q := range queries {
+		s1 := pathStr(adj, string(letters), q[0], q[1])
+		s2 := pathStr(adj, string(letters), q[2], q[3])
+		answers[i] = lcp(s1, s2)
+	}
+	return sb.String(), answers
+}
+
+func check(out string, ans []int) error {
+	fields := strings.Fields(out)
+	if len(fields) != len(ans) {
+		return fmt.Errorf("expected %d numbers", len(ans))
+	}
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil || v != ans[i] {
+			return fmt.Errorf("wrong answer")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, ans := genTest(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(out, ans); err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%soutput:\n%s\n", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` through `verifierE.go` for contest 504 with 100 random tests each
- provide sample crashing solution `504A.go` for runtime error checks

## Testing
- `go build 0-999/500-599/500-509/504/verifierA.go`
- `go build 0-999/500-599/500-509/504/verifierB.go`
- `go build 0-999/500-599/500-509/504/verifierC.go`
- `go build 0-999/500-599/500-509/504/verifierD.go`
- `go build 0-999/500-599/500-509/504/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_688314ef67dc8324be1af00e193b2e42