### PR TITLE
Add Go verifiers for contest 509

### DIFF
--- a/0-999/500-599/500-509/509/verifierA.go
+++ b/0-999/500-599/500-509/509/verifierA.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n int) string {
+	dp := make([][]int, n+1)
+	for i := 0; i <= n; i++ {
+		dp[i] = make([]int, n+1)
+	}
+	for i := 1; i <= n; i++ {
+		dp[i][1] = 1
+		dp[1][i] = 1
+	}
+	for i := 2; i <= n; i++ {
+		for j := 2; j <= n; j++ {
+			dp[i][j] = dp[i-1][j] + dp[i][j-1]
+		}
+	}
+	return fmt.Sprint(dp[n][n])
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("%d\n", n)
+	expected := solve(n)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/509/verifierB.go
+++ b/0-999/500-599/500-509/509/verifierB.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, k  int
+	piles []int
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(8) + 1
+	piles := make([]int, n)
+	for i := range piles {
+		piles[i] = rng.Intn(20) + 1
+	}
+	return testCase{n: n, k: k, piles: piles}
+}
+
+func possible(tc testCase) bool {
+	mini, maxi := tc.piles[0], tc.piles[0]
+	for _, v := range tc.piles {
+		if v < mini {
+			mini = v
+		}
+		if v > maxi {
+			maxi = v
+		}
+	}
+	return maxi-mini <= tc.k
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+	for i, v := range tc.piles {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	first := strings.TrimSpace(scanner.Text())
+	poss := possible(tc)
+	if first == "NO" {
+		if poss {
+			return fmt.Errorf("should be YES")
+		}
+		if scanner.Scan() {
+			return fmt.Errorf("extra output after NO")
+		}
+		return nil
+	}
+	if first != "YES" {
+		return fmt.Errorf("expected YES or NO")
+	}
+	if !poss {
+		return fmt.Errorf("should be NO")
+	}
+	counts := make([][]int, tc.n)
+	for i := 0; i < tc.n; i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("not enough lines")
+		}
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != tc.piles[i] {
+			return fmt.Errorf("pile %d expected %d numbers got %d", i+1, tc.piles[i], len(fields))
+		}
+		cnt := make([]int, tc.k)
+		for _, f := range fields {
+			val, err := strconv.Atoi(f)
+			if err != nil {
+				return fmt.Errorf("bad number: %v", err)
+			}
+			if val < 1 || val > tc.k {
+				return fmt.Errorf("color out of range")
+			}
+			cnt[val-1]++
+		}
+		counts[i] = cnt
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	for c := 0; c < tc.k; c++ {
+		minC, maxC := counts[0][c], counts[0][c]
+		for i := 1; i < tc.n; i++ {
+			if counts[i][c] < minC {
+				minC = counts[i][c]
+			}
+			if counts[i][c] > maxC {
+				maxC = counts[i][c]
+			}
+		}
+		if maxC-minC > 1 {
+			return fmt.Errorf("color difference >1 for color %d", c+1)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/509/verifierC.go
+++ b/0-999/500-599/500-509/509/verifierC.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveSequence(b []int) []string {
+	prev := "0"
+	res := make([]string, len(b))
+	for i, bi := range b {
+		L := len(prev)
+		found := ""
+		ps := make([]int, L+1)
+		for j := 0; j < L; j++ {
+			ps[j+1] = ps[j] + int(prev[j]-'0')
+		}
+		for pos := L - 1; pos >= 0 && found == ""; pos-- {
+			orig := int(prev[pos] - '0')
+			for d := orig + 1; d <= 9; d++ {
+				sumPre := ps[pos] + d
+				rem := bi - sumPre
+				remPos := L - pos - 1
+				if rem < 0 || rem > 9*remPos {
+					continue
+				}
+				t := make([]byte, L)
+				copy(t, []byte(prev))
+				t[pos] = byte('0' + d)
+				for k := pos + 1; k < L; k++ {
+					after := L - k - 1
+					x := rem - 9*after
+					if x < 0 {
+						x = 0
+					}
+					if x > 9 {
+						x = 9
+					}
+					t[k] = byte('0' + x)
+					rem -= x
+				}
+				found = string(t)
+				break
+			}
+		}
+		if found != "" {
+			prev = found
+		} else {
+			needLen := bi / 9
+			if bi%9 != 0 {
+				needLen++
+			}
+			newLen := needLen
+			if newLen <= len(prev) {
+				newLen = len(prev) + 1
+			}
+			rem := bi
+			t := make([]byte, newLen)
+			for k := 0; k < newLen; k++ {
+				remPos := newLen - k - 1
+				minD := 0
+				if k == 0 {
+					minD = 1
+				}
+				x := rem - 9*remPos
+				if x < minD {
+					x = minD
+				}
+				if x > 9 {
+					x = 9
+				}
+				t[k] = byte('0' + x)
+				rem -= x
+			}
+			prev = string(t)
+		}
+		res[i] = prev
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) []int {
+	n := rng.Intn(5) + 1
+	b := make([]int, n)
+	for i := range b {
+		b[i] = rng.Intn(27) + 1
+	}
+	return b
+}
+
+func runCase(bin string, b []int) error {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(len(b)))
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotLines := strings.Fields(strings.TrimSpace(out.String()))
+	expect := solveSequence(b)
+	if len(gotLines) != len(expect) {
+		return fmt.Errorf("expected %d lines got %d", len(expect), len(gotLines))
+	}
+	for i, ex := range expect {
+		if gotLines[i] != ex {
+			return fmt.Errorf("line %d expected %s got %s", i+1, ex, gotLines[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		b := generateCase(rng)
+		if err := runCase(bin, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/509/verifierD.go
+++ b/0-999/500-599/500-509/509/verifierD.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func checkSolution(n, m int, w [][]int64) bool {
+	b := make([]int64, m)
+	for j := 0; j < m; j++ {
+		b[j] = w[0][j]
+	}
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = w[i][0] - b[0]
+	}
+	gcd := func(a, b int64) int64 {
+		for b != 0 {
+			a, b = b, a%b
+		}
+		return a
+	}
+	abs := func(x int64) int64 {
+		if x < 0 {
+			return -x
+		}
+		return x
+	}
+	var g int64
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			g = gcd(g, abs(w[i][j]-a[i]-b[j]))
+		}
+	}
+	if g == 0 {
+		g = 1000000001
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if g <= w[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func runCase(bin string, w [][]int64) error {
+	n := len(w)
+	m := len(w[0])
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(w[i][j], 10))
+		}
+		sb.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	first := strings.TrimSpace(scanner.Text())
+	possible := checkSolution(n, m, w)
+	if first == "NO" {
+		if possible {
+			return fmt.Errorf("should be YES")
+		}
+		if scanner.Scan() {
+			return fmt.Errorf("extra output after NO")
+		}
+		return nil
+	}
+	if first != "YES" {
+		return fmt.Errorf("expected YES or NO")
+	}
+	if !possible {
+		return fmt.Errorf("should be NO")
+	}
+	if !scanner.Scan() {
+		return fmt.Errorf("missing k")
+	}
+	k, err := strconv.ParseInt(strings.TrimSpace(scanner.Text()), 10, 64)
+	if err != nil {
+		return fmt.Errorf("bad k: %v", err)
+	}
+	if k <= 0 {
+		return fmt.Errorf("k must be positive")
+	}
+	if !scanner.Scan() {
+		return fmt.Errorf("missing a line")
+	}
+	fields := strings.Fields(scanner.Text())
+	if len(fields) != n {
+		return fmt.Errorf("expected %d numbers for a", n)
+	}
+	a := make([]int64, n)
+	for i, f := range fields {
+		val, err := strconv.ParseInt(f, 10, 64)
+		if err != nil {
+			return fmt.Errorf("bad a: %v", err)
+		}
+		a[i] = val
+	}
+	if !scanner.Scan() {
+		return fmt.Errorf("missing b line")
+	}
+	fields = strings.Fields(scanner.Text())
+	if len(fields) != m {
+		return fmt.Errorf("expected %d numbers for b", m)
+	}
+	b := make([]int64, m)
+	for i, f := range fields {
+		val, err := strconv.ParseInt(f, 10, 64)
+		if err != nil {
+			return fmt.Errorf("bad b: %v", err)
+		}
+		b[i] = val
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if ((a[i]+b[j])%k+k)%k != w[i][j] {
+				return fmt.Errorf("wrong matrix value at %d,%d", i+1, j+1)
+			}
+		}
+	}
+	return nil
+}
+
+func generateMatrix(rng *rand.Rand) [][]int64 {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	k := rng.Int63n(1000) + 2
+	a := make([]int64, n)
+	b := make([]int64, m)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Int63n(k)
+	}
+	for j := 0; j < m; j++ {
+		b[j] = rng.Int63n(k)
+	}
+	w := make([][]int64, n)
+	for i := 0; i < n; i++ {
+		w[i] = make([]int64, m)
+		for j := 0; j < m; j++ {
+			w[i][j] = (a[i] + b[j]) % k
+		}
+	}
+	if rng.Intn(2) == 0 {
+		// invalidate
+		i := rng.Intn(n)
+		j := rng.Intn(m)
+		w[i][j] = (w[i][j] + 1) % k
+		if w[i][j] == (a[i]+b[j])%k {
+			w[i][j] = (w[i][j] + 1) % k
+		}
+	}
+	return w
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		w := generateMatrix(rng)
+		if err := runCase(bin, w); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/509/verifierE.go
+++ b/0-999/500-599/500-509/509/verifierE.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isVowel(c byte) bool {
+	switch c {
+	case 'I', 'E', 'A', 'O', 'U', 'Y':
+		return true
+	}
+	return false
+}
+
+func solvePrettiness(s string) string {
+	n := len(s)
+	pref := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		pref[i] = pref[i-1]
+		if isVowel(s[i-1]) {
+			pref[i]++
+		}
+	}
+	prev := float64(pref[n])
+	ret := prev
+	for l := 2; l <= n; l++ {
+		delta := float64(pref[n-l+1] - pref[l-1])
+		ans := prev + delta
+		ret += ans / float64(l)
+		prev = ans
+	}
+	return fmt.Sprintf("%.8f", ret)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	b := make([]byte, n)
+	letters := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	for i := 0; i < n; i++ {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func runCase(bin, input string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input + "\n")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := solvePrettiness(input)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := generateCase(rng)
+		if err := runCase(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/509/verifierF.go
+++ b/0-999/500-599/500-509/509/verifierF.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+func solveTree(b []int) string {
+	n := len(b) - 1
+	if n <= 1 {
+		return "1"
+	}
+	m := n - 1
+	breakChild := make([]bool, m)
+	for i := 1; i < m; i++ {
+		if b[i+2] < b[i+1] {
+			breakChild[i] = true
+		}
+	}
+	dpPrev := make([]int, m+2)
+	dpPrev[1] = 1
+	for i := 1; i < m; i++ {
+		pre := make([]int, i+2)
+		for k := 1; k <= i; k++ {
+			pre[k] = pre[k-1] + dpPrev[k]
+			if pre[k] >= MOD {
+				pre[k] -= MOD
+			}
+		}
+		dpCurr := make([]int, m+2)
+		for k := 1; k <= i+1; k++ {
+			if breakChild[i] {
+				if k-1 >= 1 {
+					dpCurr[k] = pre[k-1]
+				}
+			} else {
+				if k > i {
+					dpCurr[k] = pre[i]
+				} else {
+					dpCurr[k] = pre[k]
+				}
+			}
+		}
+		dpPrev = dpCurr
+	}
+	ans := 0
+	for k := 1; k <= m; k++ {
+		ans += dpPrev[k]
+		if ans >= MOD {
+			ans -= MOD
+		}
+	}
+	return strconv.Itoa(ans)
+}
+
+func generateCase(rng *rand.Rand) []int {
+	n := rng.Intn(6) + 1
+	b := make([]int, n+1)
+	perm := rand.Perm(n)
+	for i := 0; i < n; i++ {
+		b[i+1] = perm[i] + 1
+	}
+	b[0] = 0
+	if b[1] != 1 {
+		idx := 1
+		for i := 1; i <= n; i++ {
+			if b[i] == 1 {
+				idx = i
+				break
+			}
+		}
+		b[1], b[idx] = b[idx], b[1]
+	}
+	return b
+}
+
+func runCase(bin string, b []int) error {
+	var sb strings.Builder
+	n := len(b) - 1
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(b[i]))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := solveTree(b)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		b := generateCase(rng)
+		if err := runCase(bin, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 509 problems A–F
- each verifier runs 100 random cases
- verifiers check arbitrary binaries via command line

## Testing
- `go build 0-999/500-599/500-509/509/verifierA.go`
- `go build 0-999/500-599/500-509/509/verifierB.go`
- `go build 0-999/500-599/500-509/509/verifierC.go`
- `go build 0-999/500-599/500-509/509/verifierD.go`
- `go build 0-999/500-599/500-509/509/verifierE.go`
- `go build 0-999/500-599/500-509/509/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688317abd45483249db16f4b56f20d1b