### PR TITLE
Add Go verifiers for contest 508

### DIFF
--- a/0-999/500-599/500-509/508/verifierA.go
+++ b/0-999/500-599/500-509/508/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveA(n, m, k int, moves [][2]int) int {
+	grid := make([][]bool, n+2)
+	for i := range grid {
+		grid[i] = make([]bool, m+2)
+	}
+	for t := 1; t <= k; t++ {
+		r := moves[t-1][0]
+		c := moves[t-1][1]
+		grid[r][c] = true
+		for dr := -1; dr <= 0; dr++ {
+			for dc := -1; dc <= 0; dc++ {
+				x := r + dr
+				y := c + dc
+				if x >= 1 && x+1 <= n && y >= 1 && y+1 <= m {
+					if grid[x][y] && grid[x+1][y] && grid[x][y+1] && grid[x+1][y+1] {
+						return t
+					}
+				}
+			}
+		}
+	}
+	return 0
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(20) + 1
+	k := rng.Intn(100) + 1
+	moves := make([][2]int, k)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < k; i++ {
+		r := rng.Intn(n) + 1
+		c := rng.Intn(m) + 1
+		moves[i] = [2]int{r, c}
+		sb.WriteString(fmt.Sprintf("%d %d\n", r, c))
+	}
+	expect := solveA(n, m, k, moves)
+	return sb.String(), expect
+}
+
+func runCase(bin, input string, expected int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(outStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(bin, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/508/verifierB.go
+++ b/0-999/500-599/500-509/508/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(s string) string {
+	n := len(s)
+	last := s[n-1]
+	earliest := -1
+	latestGreater := -1
+	for i := 0; i < n-1; i++ {
+		c := s[i]
+		if (c-'0')%2 == 0 {
+			if c < last && earliest == -1 {
+				earliest = i
+			}
+			if c > last {
+				latestGreater = i
+			}
+		}
+	}
+	idx := -1
+	if earliest != -1 {
+		idx = earliest
+	} else if latestGreater != -1 {
+		idx = latestGreater
+	} else {
+		return "-1"
+	}
+	b := []byte(s)
+	b[idx], b[n-1] = b[n-1], b[idx]
+	if b[0] == '0' {
+		return "-1"
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	length := rng.Intn(18) + 2
+	digits := make([]byte, length)
+	digits[0] = byte(rng.Intn(9)+1) + '0'
+	for i := 1; i < length-1; i++ {
+		digits[i] = byte(rng.Intn(10)) + '0'
+	}
+	odd := []byte{'1', '3', '5', '7', '9'}
+	digits[length-1] = odd[rng.Intn(len(odd))]
+	s := string(digits)
+	expect := solveB(s)
+	return s + "\n", expect
+}
+
+func runCase(bin string, input string, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(bin, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/508/verifierC.go
+++ b/0-999/500-599/500-509/508/verifierC.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveC(m, t, r int, w []int) int {
+	const offset = 300
+	const size = 1000
+	used := make([]bool, size)
+	total := 0
+	for _, wi := range w {
+		cnt := 0
+		for s := wi - t; s <= wi-1; s++ {
+			idx := s + offset
+			if idx >= 0 && idx < size && used[idx] {
+				cnt++
+			}
+		}
+		if cnt >= r {
+			continue
+		}
+		need := r - cnt
+		for s := wi - 1; s >= wi-t && need > 0; s-- {
+			idx := s + offset
+			if idx >= 0 && idx < size && !used[idx] {
+				used[idx] = true
+				total++
+				need--
+			}
+		}
+		if need > 0 {
+			return -1
+		}
+	}
+	return total
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	m := rng.Intn(10) + 1
+	t := rng.Intn(10) + 1
+	r := rng.Intn(t) + 1
+	w := make([]int, m)
+	cur := rng.Intn(50) + 1
+	for i := 0; i < m; i++ {
+		cur += rng.Intn(5) + 1
+		w[i] = cur
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", m, t, r))
+	for i, v := range w {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	expect := solveC(m, t, r, w)
+	return sb.String(), expect
+}
+
+func runCase(bin, input string, expected int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(outStr)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(bin, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/508/verifierD.go
+++ b/0-999/500-599/500-509/508/verifierD.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(n int, subs []string) (bool, string) {
+	const maxv = 200 * 200
+	graph := make([][]int, maxv)
+	indeg := make([]int, maxv)
+	outdeg := make([]int, maxv)
+	for _, s := range subs {
+		u1 := int(s[0])*200 + int(s[1])
+		u2 := int(s[1])*200 + int(s[2])
+		graph[u1] = append(graph[u1], u2)
+		outdeg[u1]++
+		indeg[u2]++
+	}
+	start := -1
+	cntPos := 0
+	cntNeg := 0
+	for i := 0; i < maxv; i++ {
+		diff := outdeg[i] - indeg[i]
+		if diff == 1 {
+			start = i
+			cntPos++
+		} else if diff == -1 {
+			cntNeg++
+		} else if diff != 0 {
+			if diff > 1 || diff < -1 {
+				return false, ""
+			}
+		}
+	}
+	if !(cntPos == cntNeg && (cntPos == 0 || cntPos == 1)) {
+		return false, ""
+	}
+	if start == -1 {
+		for i := 0; i < maxv; i++ {
+			if outdeg[i] > 0 {
+				start = i
+				break
+			}
+		}
+	}
+	if start == -1 {
+		return false, ""
+	}
+	stack := []int{start}
+	var path []int
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		if len(graph[v]) > 0 {
+			nxt := graph[v][len(graph[v])-1]
+			graph[v] = graph[v][:len(graph[v])-1]
+			stack = append(stack, nxt)
+		} else {
+			stack = stack[:len(stack)-1]
+			path = append(path, v)
+		}
+	}
+	if len(path) != n+1 {
+		return false, ""
+	}
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+	ans := make([]byte, 0, n+2)
+	ans = append(ans, byte(path[0]/200))
+	for _, v := range path {
+		ans = append(ans, byte(v%200))
+	}
+	return true, string(ans)
+}
+
+func validD(ans string, subs []string) bool {
+	if len(ans) != len(subs)+2 {
+		return false
+	}
+	cnt := make(map[string]int)
+	for _, s := range subs {
+		cnt[s]++
+	}
+	for i := 0; i+3 <= len(ans); i++ {
+		sub := ans[i : i+3]
+		if cnt[sub] == 0 {
+			return false
+		}
+		cnt[sub]--
+	}
+	for _, c := range cnt {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func generateCase(rng *rand.Rand) (string, []string, bool) {
+	n := rng.Intn(18) + 2
+	subs := make([]string, n)
+	chars := []byte("abcXYZ012")
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		b := []byte{chars[rng.Intn(len(chars))], chars[rng.Intn(len(chars))], chars[rng.Intn(len(chars))]}
+		subs[i] = string(b)
+		sb.WriteString(subs[i])
+		sb.WriteByte('\n')
+	}
+	ok, _ := solveD(n, subs)
+	return sb.String(), subs, ok
+}
+
+func runCase(bin, input string, subs []string, expected bool) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	output := strings.TrimSpace(out.String())
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	first := scanner.Text()
+	if !expected {
+		if strings.ToUpper(first) != "NO" {
+			return fmt.Errorf("expected NO got %s", first)
+		}
+		return nil
+	}
+	if strings.ToUpper(first) != "YES" {
+		return fmt.Errorf("expected YES got %s", first)
+	}
+	if !scanner.Scan() {
+		return fmt.Errorf("missing sequence")
+	}
+	ans := scanner.Text()
+	if !validD(ans, subs) {
+		return fmt.Errorf("invalid sequence %s", ans)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, subs, ok := generateCase(rng)
+		if err := runCase(bin, input, subs, ok); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/500-509/508/verifierE.go
+++ b/0-999/500-599/500-509/508/verifierE.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(n int, l, r []int) (bool, string) {
+	dp := make([][]bool, n+2)
+	choice := make([][]int, n+2)
+	for i := 0; i <= n+1; i++ {
+		dp[i] = make([]bool, n+2)
+		choice[i] = make([]int, n+2)
+	}
+	for i := 1; i <= n+1; i++ {
+		dp[i][i-1] = true
+	}
+	for length := 1; length <= n; length++ {
+		for i := 1; i+length-1 <= n; i++ {
+			j := i + length - 1
+			tmin := l[i] / 2
+			tmax := (r[i] - 1) / 2
+			if tmin < 0 {
+				tmin = 0
+			}
+			if tmax > j-i {
+				tmax = j - i
+			}
+			for t := tmin; t <= tmax; t++ {
+				if dp[i+1][i+t] && dp[i+t+1][j] {
+					dp[i][j] = true
+					choice[i][j] = t
+					break
+				}
+			}
+		}
+	}
+	if !dp[1][n] {
+		return false, ""
+	}
+	buf := make([]byte, 0, 2*n)
+	var build func(i, j int)
+	build = func(i, j int) {
+		if i > j {
+			return
+		}
+		t := choice[i][j]
+		buf = append(buf, '(')
+		build(i+1, i+t)
+		buf = append(buf, ')')
+		build(i+t+1, j)
+	}
+	build(1, n)
+	return true, string(buf)
+}
+
+func checkSequence(seq string, n int, l, r []int) bool {
+	if len(seq) != 2*n {
+		return false
+	}
+	posStack := []int{}
+	idxStack := []int{}
+	openID := 0
+	for i := 0; i < len(seq); i++ {
+		ch := seq[i]
+		if ch == '(' {
+			openID++
+			if openID > n {
+				return false
+			}
+			posStack = append(posStack, i)
+			idxStack = append(idxStack, openID)
+		} else if ch == ')' {
+			if len(posStack) == 0 {
+				return false
+			}
+			pos := posStack[len(posStack)-1]
+			idx := idxStack[len(idxStack)-1]
+			posStack = posStack[:len(posStack)-1]
+			idxStack = idxStack[:len(idxStack)-1]
+			dist := i - pos
+			if dist < l[idx] || dist > r[idx] {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return len(posStack) == 0 && openID == n
+}
+
+func generateCase(rng *rand.Rand) (string, []int, []int, bool) {
+	n := rng.Intn(6) + 1
+	l := make([]int, n+1)
+	r := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		li := rng.Intn(2*n-1) + 1
+		ri := li + rng.Intn(2*n-li)
+		l[i] = li
+		r[i] = ri
+	}
+	ok, _ := solveE(n, l, r)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", l[i], r[i]))
+	}
+	return sb.String(), l, r, ok
+}
+
+func runCase(bin, input string, l, r []int, expected bool) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	output := strings.TrimSpace(out.String())
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	first := scanner.Text()
+	if !expected {
+		if first != "IMPOSSIBLE" {
+			return fmt.Errorf("expected IMPOSSIBLE got %s", first)
+		}
+		return nil
+	}
+	if first == "IMPOSSIBLE" {
+		return fmt.Errorf("expected sequence got IMPOSSIBLE")
+	}
+	seq := first
+	if !checkSequence(seq, len(l)-1, l, r) {
+		return fmt.Errorf("invalid sequence %s", seq)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, l, r, ok := generateCase(rng)
+		if err := runCase(bin, input, l, r, ok); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`, `verifierB.go`, `verifierC.go`, `verifierD.go`, `verifierE.go` for contest 508
- verifiers execute a supplied binary on 100 random tests
- include reference solutions in Go to compute expected results and validate outputs

## Testing
- `go run verifierA.go ./508A`
- `go run verifierB.go ./508B`
- `go run verifierC.go ./508C`
- `go run verifierD.go ./508D`
- `go run verifierE.go ./508E`


------
https://chatgpt.com/codex/tasks/task_e_6883171fc07c832489591370d0360718