### PR TITLE
Add Go verifiers for CF514 problems

### DIFF
--- a/0-999/500-599/510-519/514/verifierA.go
+++ b/0-999/500-599/510-519/514/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(s string) string {
+	b := []byte(s)
+	for i := 0; i < len(b); i++ {
+		inv := '9' - b[i] + '0'
+		if inv < b[i] {
+			if i == 0 && inv == '0' {
+				continue
+			}
+			b[i] = inv
+		}
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) string {
+	length := rng.Intn(18) + 1
+	var sb strings.Builder
+	sb.WriteByte(byte(rng.Intn(9)+1) + '0')
+	for i := 1; i < length; i++ {
+		sb.WriteByte(byte(rng.Intn(10)) + '0')
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// Deterministic cases
+	cases := []string{
+		"9\n", "5\n", "4\n", "4545\n", "909\n", "123456789\n", "9000\n",
+		"8\n", "1111\n", "9876543210\n",
+	}
+	for idx, in := range cases {
+		exp := expected(strings.TrimSpace(in))
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: %v\ninput:\n%s", idx+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: expected %s got %s\ninput:\n%s", idx+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+
+	// Random cases
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp := expected(strings.TrimSpace(in))
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/514/verifierB.go
+++ b/0-999/500-599/510-519/514/verifierB.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func expected(n int, x0, y0 int, pts [][2]int) string {
+	dirs := make(map[[2]int]struct{})
+	for _, p := range pts {
+		dx := p[0] - x0
+		dy := p[1] - y0
+		g := gcd(abs(dx), abs(dy))
+		dx /= g
+		dy /= g
+		if dx < 0 || (dx == 0 && dy < 0) {
+			dx = -dx
+			dy = -dy
+		}
+		dirs[[2]int{dx, dy}] = struct{}{}
+	}
+	return fmt.Sprintf("%d", len(dirs))
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	x0 := rng.Intn(21) - 10
+	y0 := rng.Intn(21) - 10
+	pts := make([][2]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x0, y0))
+	for i := 0; i < n; i++ {
+		x := rng.Intn(21) - 10
+		y := rng.Intn(21) - 10
+		pts[i] = [2]int{x, y}
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	expect := expected(n, x0, y0, pts)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// deterministic cases
+	fixed := []struct {
+		n      int
+		x0, y0 int
+		pts    [][2]int
+	}{
+		{1, 0, 0, [][2]int{{1, 1}}},
+		{3, 0, 0, [][2]int{{1, 0}, {2, 0}, {3, 0}}},
+		{3, 1, 1, [][2]int{{2, 2}, {0, 0}, {3, 1}}},
+	}
+	for idx, f := range fixed {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", f.n, f.x0, f.y0))
+		for _, p := range f.pts {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+		}
+		exp := expected(f.n, f.x0, f.y0, f.pts)
+		out, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: expected %s got %s\ninput:\n%s", idx+1, exp, out, sb.String())
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/514/verifierC.go
+++ b/0-999/500-599/510-519/514/verifierC.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(memory []string, queries []string) string {
+	var sb strings.Builder
+	for _, q := range queries {
+		found := false
+		for _, m := range memory {
+			if len(m) != len(q) {
+				continue
+			}
+			diff := 0
+			for i := 0; i < len(q) && diff <= 1; i++ {
+				if q[i] != m[i] {
+					diff++
+				}
+			}
+			if diff == 1 {
+				found = true
+				break
+			}
+		}
+		if found {
+			sb.WriteString("YES\n")
+		} else {
+			sb.WriteString("NO\n")
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	memory := make([]string, n)
+	for i := 0; i < n; i++ {
+		memory[i] = randString(rng)
+	}
+	queries := make([]string, m)
+	for i := 0; i < m; i++ {
+		queries[i] = randString(rng)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, s := range memory {
+		sb.WriteString(s + "\n")
+	}
+	for _, s := range queries {
+		sb.WriteString(s + "\n")
+	}
+	expect := expected(memory, queries)
+	return sb.String(), expect
+}
+
+func randString(rng *rand.Rand) string {
+	l := rng.Intn(5) + 1
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte(rng.Intn(3)) + 'a'
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// deterministic edge cases
+	mem := []string{"a", "b"}
+	queries := []string{"c", "aa"}
+	in := "2 2\na\nb\nc\naa\n"
+	exp := expected(mem, queries)
+	out, err := runCandidate(bin, in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "edge case failed: %v\n", err)
+		os.Exit(1)
+	}
+	if out != exp {
+		fmt.Fprintf(os.Stderr, "edge case failed: expected %s got %s\n", exp, out)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/514/verifierD.go
+++ b/0-999/500-599/510-519/514/verifierD.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m int, k int64, a [][]int64) string {
+	bestLen := 0
+	best := make([]int64, m)
+	for l := 0; l < n; l++ {
+		maxCol := make([]int64, m)
+		for r := l; r < n; r++ {
+			for j := 0; j < m; j++ {
+				if a[r][j] > maxCol[j] {
+					maxCol[j] = a[r][j]
+				}
+			}
+			sum := int64(0)
+			for j := 0; j < m; j++ {
+				sum += maxCol[j]
+			}
+			if sum <= k {
+				if r-l+1 > bestLen {
+					bestLen = r - l + 1
+					copy(best, maxCol)
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", best[i]))
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	k := int64(rng.Intn(1000))
+	a := make([][]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		a[i] = make([]int64, m)
+		for j := 0; j < m; j++ {
+			v := int64(rng.Intn(1000))
+			a[i][j] = v
+			sb.WriteString(fmt.Sprintf("%d", v))
+			if j+1 < m {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	expect := expected(n, m, k, a)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// simple edge case
+	in := "1 1 5\n3\n"
+	exp := "3"
+	out, err := runCandidate(bin, in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "edge case failed: %v\n", err)
+		os.Exit(1)
+	}
+	if out != exp {
+		fmt.Fprintf(os.Stderr, "edge case failed: expected %s got %s\n", exp, out)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/514/verifierE.go
+++ b/0-999/500-599/510-519/514/verifierE.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, x int64, d []int64) string {
+	counts := make([]int64, x+1)
+	counts[0] = 1
+	for dist := int64(0); dist <= x; dist++ {
+		c := counts[dist]
+		if c == 0 {
+			continue
+		}
+		for _, step := range d {
+			nd := dist + step
+			if nd <= x {
+				counts[nd] = (counts[nd] + c) % MOD
+			}
+		}
+	}
+	sum := int64(0)
+	for i := int64(0); i <= x; i++ {
+		sum = (sum + counts[i]) % MOD
+	}
+	return fmt.Sprintf("%d", sum%MOD)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	x := int64(rng.Intn(10) + 1)
+	d := make([]int64, n)
+	for i := 0; i < n; i++ {
+		d[i] = int64(rng.Intn(3) + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", d[i]))
+	}
+	sb.WriteByte('\n')
+	expect := expected(n, x, d)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// simple edge case
+	in := "1 1\n1\n"
+	exp := "2"
+	out, err := runCandidate(bin, in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "edge case failed: %v\n", err)
+		os.Exit(1)
+	}
+	if out != exp {
+		fmt.Fprintf(os.Stderr, "edge case failed: expected %s got %s\n", exp, out)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone verifiers for Codeforces contest 514 (A–E)
- each verifier runs deterministic and 100 random test cases
- can run against any binary or Go source with `go run verifierX.go /path/to/binary`

## Testing
- `go build 0-999/500-599/510-519/514/verifierA.go`
- `go build 0-999/500-599/510-519/514/verifierB.go`
- `go build 0-999/500-599/510-519/514/verifierC.go`
- `go build 0-999/500-599/510-519/514/verifierD.go`
- `go build 0-999/500-599/510-519/514/verifierE.go`
- `./verifierA 0-999/500-599/510-519/514/514A.go`

------
https://chatgpt.com/codex/tasks/task_e_68831a687cec8324abf5c396024cf2e6