### PR TITLE
Add verifiers for CF519

### DIFF
--- a/0-999/500-599/510-519/519/verifierA.go
+++ b/0-999/500-599/510-519/519/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+	"unicode"
+)
+
+func solveBoard(input string) string {
+	lines := strings.Split(strings.TrimSpace(input), "\n")
+	weights := map[rune]int{'Q': 9, 'R': 5, 'B': 3, 'N': 3, 'P': 1}
+	white, black := 0, 0
+	for _, line := range lines {
+		for _, r := range line {
+			if r == '.' {
+				continue
+			}
+			w := weights[unicode.ToUpper(r)]
+			if unicode.IsUpper(r) {
+				white += w
+			} else {
+				black += w
+			}
+		}
+	}
+	if white > black {
+		return "White"
+	} else if black > white {
+		return "Black"
+	}
+	return "Draw"
+}
+
+func generateCase(rng *rand.Rand) string {
+	pieces := []byte{'.', 'Q', 'q', 'R', 'r', 'B', 'b', 'N', 'n', 'P', 'p', 'K', 'k'}
+	var sb strings.Builder
+	for i := 0; i < 8; i++ {
+		for j := 0; j < 8; j++ {
+			sb.WriteByte(pieces[rng.Intn(len(pieces))])
+		}
+		if i < 7 {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input + "\n")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		inp := generateCase(rng)
+		exp := solveBoard(inp)
+		if err := runCase(bin, inp, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/519/verifierB.go
+++ b/0-999/500-599/510-519/519/verifierB.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(input string) string {
+	reader := strings.NewReader(input)
+	var n int
+	fmt.Fscan(reader, &n)
+	sumA, sumB, sumC := int64(0), int64(0), int64(0)
+	for i := 0; i < n; i++ {
+		var x int64
+		fmt.Fscan(reader, &x)
+		sumA += x
+	}
+	for i := 0; i < n-1; i++ {
+		var x int64
+		fmt.Fscan(reader, &x)
+		sumB += x
+	}
+	for i := 0; i < n-2; i++ {
+		var x int64
+		fmt.Fscan(reader, &x)
+		sumC += x
+	}
+	missing1 := sumA - sumB
+	missing2 := sumB - sumC
+	return fmt.Sprintf("%d %d", missing1, missing2)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = rng.Int63n(20)
+	}
+	b := append([]int64(nil), a...)
+	idx := rng.Intn(len(b))
+	b = append(b[:idx], b[idx+1:]...)
+	c := append([]int64(nil), b...)
+	idx2 := rng.Intn(len(c))
+	c = append(c[:idx2], c[idx2+1:]...)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range c {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		inp := generateCase(rng)
+		exp := solveCase(inp)
+		if err := runCase(bin, inp, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/519/verifierC.go
+++ b/0-999/500-599/510-519/519/verifierC.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(input string) string {
+	reader := strings.NewReader(input)
+	var n, m int64
+	fmt.Fscan(reader, &n, &m)
+	total := (n + m) / 3
+	ans := total
+	if n < ans {
+		ans = n
+	}
+	if m < ans {
+		ans = m
+	}
+	return fmt.Sprint(ans)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	m := rng.Intn(100) + 1
+	return fmt.Sprintf("%d %d\n", n, m)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		inp := generateCase(rng)
+		exp := solveCase(inp)
+		if err := runCase(bin, inp, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/519/verifierD.go
+++ b/0-999/500-599/510-519/519/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(input string) string {
+	reader := strings.NewReader(input)
+	weights := make([]int64, 26)
+	for i := 0; i < 26; i++ {
+		fmt.Fscan(reader, &weights[i])
+	}
+	var s string
+	fmt.Fscan(reader, &s)
+	n := len(s)
+	prefix := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		prefix[i] = prefix[i-1] + weights[s[i-1]-'a']
+	}
+	cnt := make([]map[int64]int64, 26)
+	for i := range cnt {
+		cnt[i] = make(map[int64]int64)
+	}
+	var ans int64
+	for i := 1; i <= n; i++ {
+		c := s[i-1] - 'a'
+		target := prefix[i-1]
+		if v, ok := cnt[c][target]; ok {
+			ans += v
+		}
+		cnt[c][prefix[i]]++
+	}
+	return fmt.Sprint(ans)
+}
+
+func generateCase(rng *rand.Rand) string {
+	weights := make([]int64, 26)
+	for i := 0; i < 26; i++ {
+		weights[i] = rng.Int63n(5) + 1
+	}
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	for i := 0; i < 26; i++ {
+		fmt.Fprintf(&sb, "%d ", weights[i])
+	}
+	sb.WriteByte('\n')
+	letters := make([]byte, n)
+	for i := range letters {
+		letters[i] = byte('a' + rng.Intn(26))
+	}
+	sb.WriteString(string(letters))
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		inp := generateCase(rng)
+		exp := solveCase(inp)
+		if err := runCase(bin, inp, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/519/verifierE.go
+++ b/0-999/500-599/510-519/519/verifierE.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(input string) string {
+	in := strings.NewReader(input)
+	var n int
+	fmt.Fscan(in, &n)
+	adj := make([][]int, n+1)
+	for i := 0; i < n-1; i++ {
+		var u, v int
+		fmt.Fscan(in, &u, &v)
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	const LOG = 18
+	parent := make([][]int, LOG)
+	for i := range parent {
+		parent[i] = make([]int, n+1)
+	}
+	depth := make([]int, n+1)
+	order := make([]int, 0, n)
+	q := []int{1}
+	parent[0][1] = 0
+	depth[1] = 0
+	for idx := 0; idx < len(q); idx++ {
+		u := q[idx]
+		order = append(order, u)
+		for _, v := range adj[u] {
+			if v == parent[0][u] {
+				continue
+			}
+			parent[0][v] = u
+			depth[v] = depth[u] + 1
+			q = append(q, v)
+		}
+	}
+	sz := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		sz[i] = 1
+	}
+	for i := len(order) - 1; i > 0; i-- {
+		u := order[i]
+		p := parent[0][u]
+		sz[p] += sz[u]
+	}
+	for k := 1; k < LOG; k++ {
+		for v := 1; v <= n; v++ {
+			parent[k][v] = parent[k-1][parent[k-1][v]]
+		}
+	}
+	lca := func(u, v int) int {
+		if depth[u] < depth[v] {
+			u, v = v, u
+		}
+		dd := depth[u] - depth[v]
+		for k := 0; k < LOG; k++ {
+			if dd>>k&1 == 1 {
+				u = parent[k][u]
+			}
+		}
+		if u == v {
+			return u
+		}
+		for k := LOG - 1; k >= 0; k-- {
+			if parent[k][u] != parent[k][v] {
+				u = parent[k][u]
+				v = parent[k][v]
+			}
+		}
+		return parent[0][u]
+	}
+	jump := func(u, d int) int {
+		for k := 0; k < LOG && u != 0; k++ {
+			if d>>k&1 == 1 {
+				u = parent[k][u]
+			}
+		}
+		return u
+	}
+	var m int
+	fmt.Fscan(in, &m)
+	var out strings.Builder
+	for i := 0; i < m; i++ {
+		var x, y int
+		fmt.Fscan(in, &x, &y)
+		if x == y {
+			fmt.Fprintf(&out, "%d\n", n)
+			continue
+		}
+		w := lca(x, y)
+		d := depth[x] + depth[y] - 2*depth[w]
+		if d&1 == 1 {
+			fmt.Fprintf(&out, "0\n")
+			continue
+		}
+		k := d / 2
+		var c int
+		dx := depth[x] - depth[w]
+		if k <= dx {
+			c = jump(x, k)
+		} else {
+			rem := k - dx
+			c = jump(y, depth[y]-depth[w]-rem)
+		}
+		var nx int
+		if lca(c, x) == c {
+			nx = jump(x, depth[x]-depth[c]-1)
+		} else {
+			nx = parent[0][c]
+		}
+		var ny int
+		if lca(c, y) == c {
+			ny = jump(y, depth[y]-depth[c]-1)
+		} else {
+			ny = parent[0][c]
+		}
+		var sx, sy int
+		if parent[0][nx] == c {
+			sx = sz[nx]
+		} else {
+			sx = n - sz[c]
+		}
+		if parent[0][ny] == c {
+			sy = sz[ny]
+		} else {
+			sy = n - sz[c]
+		}
+		ans := n - sx - sy
+		fmt.Fprintf(&out, "%d\n", ans)
+	}
+	return strings.TrimRight(out.String(), "\n")
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 2
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{i, p}
+	}
+	m := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	fmt.Fprintf(&sb, "%d\n", m)
+	for i := 0; i < m; i++ {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(n) + 1
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	return sb.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		inp := generateCase(rng)
+		exp := solveCase(inp)
+		if err := runCase(bin, inp, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go – generates 100 chess board tests for problem A
- add verifierB.go – random integer arrays tests for problem B
- add verifierC.go – random n and m checks for problem C
- add verifierD.go – random weights and strings for problem D
- add verifierE.go – random tree and query tests for problem E

## Testing
- `go build 0-999/500-599/510-519/519/verifierA.go`
- `go build 0-999/500-599/510-519/519/verifierB.go`
- `go build 0-999/500-599/510-519/519/verifierC.go`
- `go build 0-999/500-599/510-519/519/verifierD.go`
- `go build 0-999/500-599/510-519/519/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68831d24e4a48324b5747a749b0dc0f3