### PR TITLE
Add Go verifiers for contest 518

### DIFF
--- a/0-999/500-599/510-519/518/verifierA.go
+++ b/0-999/500-599/510-519/518/verifierA.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s, t string) string {
+	// compute next lexicographical string after s
+	n := len(s)
+	next := []byte(s)
+	i := n - 1
+	for ; i >= 0; i-- {
+		if next[i] != 'z' {
+			next[i]++
+			break
+		}
+		next[i] = 'a'
+	}
+	if i < 0 {
+		return "No such string"
+	}
+	res := string(next)
+	if res < t {
+		return res
+	}
+	return "No such string"
+}
+
+func generateCase(rng *rand.Rand) (string, string, string) {
+	n := rng.Intn(10) + 1
+	s := make([]byte, n)
+	for i := 0; i < n; i++ {
+		s[i] = byte('a' + rng.Intn(26))
+	}
+	// generate t greater than s
+	t := make([]byte, n)
+	copy(t, s)
+	pos := rng.Intn(n)
+	// ensure some position increases
+	if t[pos] < 'z' {
+		t[pos] = byte(int(t[pos]) + 1 + rng.Intn(int('z'-t[pos])))
+	} else {
+		j := pos
+		for j >= 0 && t[j] == 'z' {
+			j--
+		}
+		if j >= 0 {
+			t[j] = byte(int(t[j]) + 1 + rng.Intn(int('z'-t[j])))
+		} else {
+			// all z, append 'a'
+			t = append(t, 'a')
+			n++
+		}
+	}
+	for i := pos + 1; i < n && i < len(t); i++ {
+		t[i] = byte('a' + rng.Intn(26))
+	}
+	return string(s), string(t), expected(string(s), string(t))
+}
+
+func runCase(bin, s, t, exp string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	input := fmt.Sprintf("%s\n%s\n", s, t)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []struct{ s, t, exp string }{
+		{"a", "c", expected("a", "c")},
+		{"aaaa", "zzzz", expected("aaaa", "zzzz")},
+		{"az", "ba", expected("az", "ba")},
+	}
+	for i := 0; i < 100; i++ {
+		s, t, e := generateCase(rng)
+		cases = append(cases, struct{ s, t, exp string }{s, t, e})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc.s, tc.t, tc.exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n%s\n", i+1, err, tc.s, tc.t)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/518/verifierB.go
+++ b/0-999/500-599/510-519/518/verifierB.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s, t string) string {
+	var cntLow [26]int
+	var cntUp [26]int
+	for _, ch := range t {
+		if ch >= 'a' && ch <= 'z' {
+			cntLow[ch-'a']++
+		} else if ch >= 'A' && ch <= 'Z' {
+			cntUp[ch-'A']++
+		}
+	}
+	yay := 0
+	whoops := 0
+	unmatched := make([]rune, 0, len(s))
+	for _, ch := range s {
+		if ch >= 'a' && ch <= 'z' {
+			idx := ch - 'a'
+			if cntLow[idx] > 0 {
+				yay++
+				cntLow[idx]--
+			} else {
+				unmatched = append(unmatched, ch)
+			}
+		} else {
+			idx := ch - 'A'
+			if cntUp[idx] > 0 {
+				yay++
+				cntUp[idx]--
+			} else {
+				unmatched = append(unmatched, ch)
+			}
+		}
+	}
+	for _, ch := range unmatched {
+		if ch >= 'a' && ch <= 'z' {
+			idx := ch - 'a'
+			if cntUp[idx] > 0 {
+				whoops++
+				cntUp[idx]--
+			}
+		} else {
+			idx := ch - 'A'
+			if cntLow[idx] > 0 {
+				whoops++
+				cntLow[idx]--
+			}
+		}
+	}
+	return fmt.Sprintf("%d %d", yay, whoops)
+}
+
+func generateCase(rng *rand.Rand) (string, string, string) {
+	n := rng.Intn(20) + 1
+	m := n + rng.Intn(20)
+	sbS := make([]byte, n)
+	sbT := make([]byte, m)
+	letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	for i := 0; i < n; i++ {
+		sbS[i] = letters[rng.Intn(len(letters))]
+	}
+	for i := 0; i < m; i++ {
+		sbT[i] = letters[rng.Intn(len(letters))]
+	}
+	s := string(sbS)
+	t := string(sbT)
+	return s, t, expected(s, t)
+}
+
+func runCase(bin, s, t, exp string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	input := fmt.Sprintf("%s\n%s\n", s, t)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []struct{ s, t, exp string }{}
+	for i := 0; i < 100; i++ {
+		s, t, e := generateCase(rng)
+		cases = append(cases, struct{ s, t, exp string }{s, t, e})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc.s, tc.t, tc.exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n%s\n", i+1, err, tc.s, tc.t)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/518/verifierC.go
+++ b/0-999/500-599/510-519/518/verifierC.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, m, k int, a []int, b []int) string {
+	pos := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		pos[a[i-1]] = i
+	}
+	result := int64(0)
+	for _, app := range b {
+		p := pos[app]
+		screen := (p-1)/k + 1
+		result += int64(screen)
+		if p > 1 {
+			prev := a[p-2]
+			a[p-2], a[p-1] = a[p-1], a[p-2]
+			pos[app] = p - 1
+			pos[prev] = p
+		}
+	}
+	return fmt.Sprintf("%d", result)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	if m > 20 {
+		m = 20
+	}
+	k := rng.Intn(n) + 1
+	// permutation a
+	perm := rng.Perm(n)
+	a := make([]int, n)
+	for i, v := range perm {
+		a[i] = v + 1
+	}
+	b := make([]int, m)
+	for i := 0; i < m; i++ {
+		b[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	exp := expected(n, m, k, append([]int(nil), a...), append([]int(nil), b...))
+	return input, exp
+}
+
+func runCase(bin, input, exp string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/518/verifierD.go
+++ b/0-999/500-599/510-519/518/verifierD.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int, p float64, t int) string {
+	dp := make([]float64, n+1)
+	dp[0] = 1.0
+	for timeStep := 1; timeStep <= t; timeStep++ {
+		dp[n] += p * dp[n-1]
+		for i := n - 1; i > 0; i-- {
+			dp[i] = p*dp[i-1] + (1-p)*dp[i]
+		}
+		dp[0] *= (1 - p)
+	}
+	ans := 0.0
+	for i := 0; i <= n; i++ {
+		ans += float64(i) * dp[i]
+	}
+	return fmt.Sprintf("%.10f", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	t := rng.Intn(20) + 1
+	p := rng.Float64()
+	p = float64(int(p*100)) / 100.0
+	input := fmt.Sprintf("%d %.2f %d\n", n, p, t)
+	exp := expected(n, p, t)
+	return input, exp
+}
+
+func runCase(bin, input, exp string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/518/verifierE.go
+++ b/0-999/500-599/510-519/518/verifierE.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "518E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) (string, string, error) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if rng.Intn(3) == 0 {
+			sb.WriteString("? ")
+		} else {
+			sb.WriteString(fmt.Sprintf("%d ", rng.Intn(11)-5))
+		}
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	return input, "", nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, _, _ := generateCase(rng)
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/510-519/518/verifierF.go
+++ b/0-999/500-599/510-519/518/verifierF.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "518F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	m := rng.Intn(5) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if rng.Intn(3) == 0 {
+				sb.WriteByte('#')
+			} else {
+				sb.WriteByte('.')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verification programs in Go for contest 518 problems A–F
- each verifier generates at least 100 random test cases
- verifiers A–D implement expected answers directly
- verifiers E and F compile the reference Go solution as an oracle before running cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `./verifierA ./solA` (after building `solA` from `518A.go`)


------
https://chatgpt.com/codex/tasks/task_e_68831c98ce2883248c19f92fac2c3cfe