### PR TITLE
Add Go solution for 1766A

### DIFF
--- a/1000-1999/1700-1799/1760-1769/1766/1766A.go
+++ b/1000-1999/1700-1799/1760-1769/1766/1766A.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		pow := 1
+		for pow*10 <= n {
+			pow *= 10
+		}
+		digits := 0
+		for tmp := n; tmp > 0; tmp /= 10 {
+			digits++
+		}
+		ans := 9*(digits-1) + n/pow
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1766A

## Testing
- `go build 1000-1999/1700-1799/1760-1769/1766/1766A.go`


------
https://chatgpt.com/codex/tasks/task_e_68831df718e083248b9d4e7212472962