### PR TITLE
Add verifiers for contest 520

### DIFF
--- a/0-999/500-599/520-529/520/verifierA.go
+++ b/0-999/500-599/520-529/520/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n int
+	s string
+}
+
+func generateCase(rng *rand.Rand) (string, testCaseA) {
+	n := rng.Intn(100) + 1
+	letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	s := sb.String()
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	return input, testCaseA{n: n, s: s}
+}
+
+func expected(tc testCaseA) string {
+	seen := [26]bool{}
+	for i := 0; i < tc.n; i++ {
+		ch := tc.s[i]
+		if ch >= 'a' && ch <= 'z' {
+			seen[ch-'a'] = true
+		} else if ch >= 'A' && ch <= 'Z' {
+			seen[ch-'A'] = true
+		}
+	}
+	for i := 0; i < 26; i++ {
+		if !seen[i] {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func runCase(bin string, input string, tc testCaseA) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := expected(tc)
+	if got != want {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		if err := runCase(bin, input, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/520-529/520/verifierB.go
+++ b/0-999/500-599/520-529/520/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n int
+	m int
+}
+
+func generateCase(rng *rand.Rand) (string, testCaseB) {
+	n := rng.Intn(10000) + 1
+	m := rng.Intn(10000) + 1
+	input := fmt.Sprintf("%d %d\n", n, m)
+	return input, testCaseB{n: n, m: m}
+}
+
+func expected(tc testCaseB) int {
+	n, m := tc.n, tc.m
+	if n >= m {
+		return n - m
+	}
+	steps := 0
+	for m > n {
+		if m%2 == 0 {
+			m /= 2
+		} else {
+			m++
+		}
+		steps++
+	}
+	return steps + n - m
+}
+
+func runCase(bin string, input string, tc testCaseB) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	want := expected(tc)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		if err := runCase(bin, input, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/520-529/520/verifierC.go
+++ b/0-999/500-599/520-529/520/verifierC.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modC = 1000000007
+
+type testCaseC struct {
+	n int
+	s string
+}
+
+func generateCase(rng *rand.Rand) (string, testCaseC) {
+	n := rng.Intn(100) + 1
+	letters := []byte{'A', 'C', 'G', 'T'}
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = letters[rng.Intn(4)]
+	}
+	s := string(b)
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	return input, testCaseC{n: n, s: s}
+}
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	a %= modC
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % modC
+		}
+		a = a * a % modC
+		e >>= 1
+	}
+	return res
+}
+
+func expected(tc testCaseC) int64 {
+	cnt := make(map[byte]int)
+	for i := 0; i < tc.n; i++ {
+		cnt[tc.s[i]]++
+	}
+	maxCnt := 0
+	for _, c := range []byte{'A', 'C', 'G', 'T'} {
+		if cnt[c] > maxCnt {
+			maxCnt = cnt[c]
+		}
+	}
+	letters := 0
+	for _, c := range []byte{'A', 'C', 'G', 'T'} {
+		if cnt[c] == maxCnt {
+			letters++
+		}
+	}
+	return modPow(int64(letters), int64(tc.n))
+}
+
+func runCase(bin string, input string, tc testCaseC) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	var got int64
+	if _, err := fmt.Sscan(gotStr, &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	want := expected(tc)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		if err := runCase(bin, input, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/520-529/520/verifierD.go
+++ b/0-999/500-599/520-529/520/verifierD.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modD = 1000000009
+
+type testCaseD struct {
+	m  int
+	xs []int
+	ys []int
+}
+
+func generateCase(rng *rand.Rand) (string, testCaseD) {
+	m := rng.Intn(8) + 1
+	xs := make([]int, m)
+	ys := make([]int, m)
+	pos := map[[2]int]bool{}
+	xs[0], ys[0] = 0, 0
+	pos[[2]int{0, 0}] = true
+	for i := 1; i < m; i++ {
+		for {
+			base := rng.Intn(i) // pick existing cube index
+			bx, by := xs[base], ys[base]
+			dx := rng.Intn(3) - 1 // -1,0,1
+			x := bx + dx
+			y := by + 1
+			if pos[[2]int{x, y}] {
+				continue
+			}
+			// ensure at least one supporter exists (bx,by)
+			xs[i] = x
+			ys[i] = y
+			pos[[2]int{x, y}] = true
+			break
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", m)
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", xs[i], ys[i])
+	}
+	return sb.String(), testCaseD{m: m, xs: xs, ys: ys}
+}
+
+// heaps
+
+type MinHeap []int
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MinHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+type MaxHeap []int
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+func expected(tc testCaseD) int64 {
+	m := tc.m
+	xs := tc.xs
+	ys := tc.ys
+	idx := make(map[uint64]int, m)
+	for i := 0; i < m; i++ {
+		key := (uint64(xs[i]) << 32) | uint64(uint32(ys[i]))
+		idx[key] = i
+	}
+	supporters := make([][]int, m)
+	dependents := make([][]int, m)
+	supportCount := make([]int, m)
+	for i := 0; i < m; i++ {
+		x, y := xs[i], ys[i]
+		for dx := -1; dx <= 1; dx++ {
+			key := (uint64(x+dx) << 32) | uint64(uint32(y-1))
+			if j, ok := idx[key]; ok {
+				supporters[i] = append(supporters[i], j)
+			}
+		}
+		supportCount[i] = len(supporters[i])
+		for _, j := range supporters[i] {
+			dependents[j] = append(dependents[j], i)
+		}
+	}
+	inSet := make([]bool, m)
+	removed := make([]bool, m)
+	var minh MinHeap
+	var maxh MaxHeap
+	heap.Init(&minh)
+	heap.Init(&maxh)
+	for i := 0; i < m; i++ {
+		ok := true
+		for _, u := range dependents[i] {
+			if supportCount[u] < 2 {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			inSet[i] = true
+			heap.Push(&minh, i)
+			heap.Push(&maxh, i)
+		}
+	}
+	seq := make([]int, 0, m)
+	for t := 0; t < m; t++ {
+		var v int
+		if t%2 == 0 {
+			for {
+				top := heap.Pop(&maxh).(int)
+				if !removed[top] && inSet[top] {
+					v = top
+					break
+				}
+			}
+		} else {
+			for {
+				top := heap.Pop(&minh).(int)
+				if !removed[top] && inSet[top] {
+					v = top
+					break
+				}
+			}
+		}
+		removed[v] = true
+		inSet[v] = false
+		seq = append(seq, v)
+		for _, u := range dependents[v] {
+			if supportCount[u] >= 2 {
+				supportCount[u]--
+				if supportCount[u] == 1 {
+					for _, w := range supporters[u] {
+						if !removed[w] {
+							if inSet[w] {
+								inSet[w] = false
+							}
+							break
+						}
+					}
+				}
+			}
+		}
+		for _, w := range supporters[v] {
+			if removed[w] || inSet[w] {
+				continue
+			}
+			ok := true
+			for _, u := range dependents[w] {
+				if supportCount[u] < 2 {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				inSet[w] = true
+				heap.Push(&minh, w)
+				heap.Push(&maxh, w)
+			}
+		}
+	}
+	var res int64
+	for i := 0; i < m; i++ {
+		res = (res*int64(m) + int64(seq[i])) % modD
+	}
+	return res
+}
+
+func runCase(bin string, input string, tc testCaseD) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	var got int64
+	if _, err := fmt.Sscan(gotStr, &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	want := expected(tc)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		if err := runCase(bin, input, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/520-529/520/verifierE.go
+++ b/0-999/500-599/520-529/520/verifierE.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modE = 1000000007
+
+type testCaseE struct {
+	n int
+	k int
+	s string
+}
+
+func generateCase(rng *rand.Rand) (string, testCaseE) {
+	n := rng.Intn(7) + 1
+	k := rng.Intn(n)
+	digits := make([]byte, n)
+	for i := 0; i < n; i++ {
+		digits[i] = byte(rng.Intn(10)) + '0'
+	}
+	s := string(digits)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n%s\n", n, k, s)
+	return sb.String(), testCaseE{n: n, k: k, s: s}
+}
+
+func evalExpression(parts []string) int64 {
+	var sum int64
+	for _, p := range parts {
+		var v int64
+		for i := 0; i < len(p); i++ {
+			v = v*10 + int64(p[i]-'0')
+		}
+		sum += v
+	}
+	return sum
+}
+
+func expected(tc testCaseE) int64 {
+	n, k := tc.n, tc.k
+	indices := make([]int, 0, k)
+	var best int64
+	var count int64
+	var dfs func(pos int)
+	dfs = func(pos int) {
+		if len(indices) == k {
+			parts := make([]string, 0, k+1)
+			last := 0
+			for _, idx := range indices {
+				parts = append(parts, tc.s[last:idx])
+				last = idx
+			}
+			parts = append(parts, tc.s[last:])
+			val := evalExpression(parts)
+			if val > best {
+				best = val
+				count = 1
+			} else if val == best {
+				count++
+			}
+			return
+		}
+		if pos >= n-1 {
+			return
+		}
+		// choose no plus at pos
+		dfs(pos + 1)
+		// add plus after pos
+		indices = append(indices, pos+1)
+		dfs(pos + 1)
+		indices = indices[:len(indices)-1]
+	}
+	dfs(0)
+	return best % modE
+}
+
+func runCase(bin string, input string, tc testCaseE) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	var got int64
+	if _, err := fmt.Sscan(gotStr, &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	want := expected(tc)
+	if got%modE != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		if err := runCase(bin, input, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 520
- each verifier generates 100 random tests and checks any binary

## Testing
- `go run verifierA.go ./solA`


------
https://chatgpt.com/codex/tasks/task_e_68831db0f540832483a7b095562c372b