### PR TITLE
Add verifiers for contest 522

### DIFF
--- a/0-999/500-599/520-529/522/verifierA.go
+++ b/0-999/500-599/520-529/522/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomCase(s string) string {
+	var sb strings.Builder
+	for _, ch := range s {
+		if rand.Intn(2) == 0 {
+			sb.WriteByte(byte(strings.ToLower(string(ch))[0]))
+		} else {
+			sb.WriteByte(byte(strings.ToUpper(string(ch))[0]))
+		}
+	}
+	return sb.String()
+}
+
+type testCaseA struct {
+	input    string
+	expected int
+}
+
+func computeA(events [][2]string) int {
+	depths := map[string]int{"polycarp": 1}
+	maxDepth := 1
+	for _, ev := range events {
+		l1 := strings.ToLower(ev[0])
+		l2 := strings.ToLower(ev[1])
+		d := depths[l2] + 1
+		depths[l1] = d
+		if d > maxDepth {
+			maxDepth = d
+		}
+	}
+	return maxDepth
+}
+
+func generateCaseA() testCaseA {
+	n := rand.Intn(20) + 1 // 1..20
+	names := []string{"polycarp"}
+	events := make([][2]string, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("user%d", i+1)
+		parent := names[rand.Intn(len(names))]
+		events[i] = [2]string{randomCase(name), randomCase(parent)}
+		names = append(names, name)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, ev := range events {
+		sb.WriteString(fmt.Sprintf("%s reposted %s\n", ev[0], ev[1]))
+	}
+	return testCaseA{input: sb.String(), expected: computeA(events)}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		tc := generateCaseA()
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, tc.input)
+			os.Exit(1)
+		}
+		var val int
+		if _, err := fmt.Sscan(out, &val); err != nil || val != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %s\ninput:\n%s", i, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/520-529/522/verifierB.go
+++ b/0-999/500-599/520-529/522/verifierB.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCaseB struct {
+	input    string
+	expected []int64
+}
+
+func computeB(w, h []int64) []int64 {
+	n := len(w)
+	sumW := int64(0)
+	for _, v := range w {
+		sumW += v
+	}
+	var maxH, secondH int64
+	idxMax := 0
+	for i, hi := range h {
+		if hi > maxH {
+			secondH = maxH
+			maxH = hi
+			idxMax = i
+		} else if hi > secondH {
+			secondH = hi
+		}
+	}
+	res := make([]int64, n)
+	for i := 0; i < n; i++ {
+		curH := maxH
+		if i == idxMax {
+			curH = secondH
+		}
+		res[i] = (sumW - w[i]) * curH
+	}
+	return res
+}
+
+func generateCaseB() testCaseB {
+	n := rand.Intn(9) + 2 // 2..10
+	w := make([]int64, n)
+	h := make([]int64, n)
+	for i := 0; i < n; i++ {
+		w[i] = int64(rand.Intn(1000) + 1)
+		h[i] = int64(rand.Intn(1000) + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", w[i], h[i]))
+	}
+	return testCaseB{input: sb.String(), expected: computeB(w, h)}
+}
+
+func parseInt64s(s string) ([]int64, error) {
+	parts := strings.Fields(s)
+	vals := make([]int64, len(parts))
+	for i, p := range parts {
+		v, err := strconv.ParseInt(p, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		vals[i] = v
+	}
+	return vals, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		tc := generateCaseB()
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, tc.input)
+			os.Exit(1)
+		}
+		vals, err := parseInt64s(out)
+		if err != nil || len(vals) != len(tc.expected) {
+			fmt.Fprintf(os.Stderr, "case %d: invalid output\ninput:\n%s", i, tc.input)
+			os.Exit(1)
+		}
+		for j, v := range vals {
+			if v != tc.expected[j] {
+				fmt.Fprintf(os.Stderr, "case %d: expected %v got %v\ninput:\n%s", i, tc.expected, vals, tc.input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/520-529/522/verifierC.go
+++ b/0-999/500-599/520-529/522/verifierC.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCaseC struct {
+	input    string
+	expected string
+}
+
+func computeC(m, k int, a []int, events [][2]int) string {
+	cnt := make([]int, k+1)
+	unknown := 0
+	for _, ev := range events {
+		ti, _ := ev[0], ev[1]
+		if ti > 0 && ti <= k {
+			cnt[ti]++
+		} else {
+			unknown++
+		}
+	}
+	var sb strings.Builder
+	for i := 1; i <= k; i++ {
+		if cnt[i]+unknown >= a[i] {
+			sb.WriteByte('Y')
+		} else {
+			sb.WriteByte('N')
+		}
+	}
+	return sb.String()
+}
+
+func generateCaseC() testCaseC {
+	m := rand.Intn(4) + 2 // 2..5
+	k := rand.Intn(4) + 1 // 1..5
+	a := make([]int, k+1)
+	sum := 0
+	for i := 1; i <= k; i++ {
+		a[i] = rand.Intn(3) + 1
+		sum += a[i]
+	}
+	if sum < m {
+		a[1] += m - sum
+		sum = m
+	}
+	events := make([][2]int, m-1)
+	for i := 0; i < m-1; i++ {
+		ti := rand.Intn(k + 1)
+		ri := rand.Intn(2)
+		events[i] = [2]int{ti, ri}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", m, k))
+	for i := 1; i <= k; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for _, ev := range events {
+		sb.WriteString(fmt.Sprintf("%d %d\n", ev[0], ev[1]))
+	}
+	return testCaseC{input: sb.String(), expected: computeC(m, k, a, events)}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		tc := generateCaseC()
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, tc.input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d: expected %s got %s\ninput:\n%s", i, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/520-529/522/verifierD.go
+++ b/0-999/500-599/520-529/522/verifierD.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCaseD struct {
+	input    string
+	expected []int
+}
+
+func computeD(n int, arr []int, queries [][2]int) []int {
+	res := make([]int, len(queries))
+	for qi, q := range queries {
+		l, r := q[0]-1, q[1]-1
+		last := make(map[int]int)
+		best := n + 1
+		for i := l; i <= r; i++ {
+			v := arr[i]
+			if p, ok := last[v]; ok {
+				if i-p < best {
+					best = i - p
+				}
+			}
+			last[v] = i
+		}
+		if best == n+1 {
+			res[qi] = -1
+		} else {
+			res[qi] = best
+		}
+	}
+	return res
+}
+
+func generateCaseD() testCaseD {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rand.Intn(7) - 3 // values -3..3
+	}
+	queries := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		l := rand.Intn(n) + 1
+		r := rand.Intn(n-l+1) + l
+		queries[i] = [2]int{l, r}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for _, q := range queries {
+		sb.WriteString(fmt.Sprintf("%d %d\n", q[0], q[1]))
+	}
+	return testCaseD{input: sb.String(), expected: computeD(n, arr, queries)}
+}
+
+func parseInts(s string) ([]int, error) {
+	parts := strings.Fields(s)
+	vals := make([]int, len(parts))
+	for i, p := range parts {
+		v, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, err
+		}
+		vals[i] = v
+	}
+	return vals, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 1; i <= 100; i++ {
+		tc := generateCaseD()
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, tc.input)
+			os.Exit(1)
+		}
+		vals, err := parseInts(out)
+		if err != nil || len(vals) != len(tc.expected) {
+			fmt.Fprintf(os.Stderr, "case %d: invalid output\ninput:\n%s", i, tc.input)
+			os.Exit(1)
+		}
+		for j, v := range vals {
+			if v != tc.expected[j] {
+				fmt.Fprintf(os.Stderr, "case %d: expected %v got %v\ninput:\n%s", i, tc.expected, vals, tc.input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces contest 522 problems A–D
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`


------
https://chatgpt.com/codex/tasks/task_e_68831ec933b8832482b7ea90014a9112