### PR TITLE
Add solution verifiers for contest 524

### DIFF
--- a/0-999/500-599/520-529/524/verifierA.go
+++ b/0-999/500-599/520-529/524/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "524A.go")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("build ref failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runProg(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(5) + 2
+		ids := make([]int64, n)
+		used := map[int64]bool{}
+		for i := 0; i < n; i++ {
+			for {
+				v := rng.Int63n(100) + 1
+				if !used[v] {
+					used[v] = true
+					ids[i] = v
+					break
+				}
+			}
+		}
+		// generate all pairs
+		var pairs [][2]int64
+		for i := 0; i < n; i++ {
+			for j := i + 1; j < n; j++ {
+				pairs = append(pairs, [2]int64{ids[i], ids[j]})
+			}
+		}
+		rng.Shuffle(len(pairs), func(i, j int) { pairs[i], pairs[j] = pairs[j], pairs[i] })
+		m := rng.Intn(len(pairs)) + 1
+		k := rng.Intn(101)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", m, k)
+		for i := 0; i < m; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", pairs[i][0], pairs[i][1])
+		}
+		tests[t] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		expOut, err1 := runProg("./"+ref, tc)
+		if err1 != nil {
+			fmt.Printf("reference solution runtime error on test %d: %v\n", i+1, err1)
+			return
+		}
+		gotOut, err2 := runProg(target, tc)
+		if err2 != nil {
+			fmt.Printf("target runtime error on test %d: %v\n", i+1, err2)
+			return
+		}
+		if strings.TrimSpace(expOut) != strings.TrimSpace(gotOut) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc, expOut, gotOut)
+			return
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/520-529/524/verifierB.go
+++ b/0-999/500-599/520-529/524/verifierB.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "524B.go")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("build ref failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runProg(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(2))
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			w := rng.Intn(20) + 1
+			h := rng.Intn(20) + 1
+			fmt.Fprintf(&sb, "%d %d\n", w, h)
+		}
+		tests[t] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		expOut, err1 := runProg("./"+ref, tc)
+		if err1 != nil {
+			fmt.Printf("reference solution runtime error on test %d: %v\n", i+1, err1)
+			return
+		}
+		gotOut, err2 := runProg(target, tc)
+		if err2 != nil {
+			fmt.Printf("target runtime error on test %d: %v\n", i+1, err2)
+			return
+		}
+		if strings.TrimSpace(expOut) != strings.TrimSpace(gotOut) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc, expOut, gotOut)
+			return
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/520-529/524/verifierC.go
+++ b/0-999/500-599/520-529/524/verifierC.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "524C.go")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("build ref failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runProg(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(3))
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(4) + 1
+		k := rng.Intn(20) + 1
+		den := make([]int, n)
+		used := map[int]bool{}
+		for i := 0; i < n; i++ {
+			for {
+				v := rng.Intn(50) + 1
+				if !used[v] {
+					used[v] = true
+					den[i] = v
+					break
+				}
+			}
+		}
+		sort.Ints(den)
+		q := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for _, v := range den {
+			fmt.Fprintf(&sb, "%d ", v)
+		}
+		sb.WriteByte('\n')
+		fmt.Fprintf(&sb, "%d\n", q)
+		for i := 0; i < q; i++ {
+			x := rng.Intn(200) + 1
+			fmt.Fprintf(&sb, "%d\n", x)
+		}
+		tests[t] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		expOut, err1 := runProg("./"+ref, tc)
+		if err1 != nil {
+			fmt.Printf("reference solution runtime error on test %d: %v\n", i+1, err1)
+			return
+		}
+		gotOut, err2 := runProg(target, tc)
+		if err2 != nil {
+			fmt.Printf("target runtime error on test %d: %v\n", i+1, err2)
+			return
+		}
+		if strings.TrimSpace(expOut) != strings.TrimSpace(gotOut) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc, expOut, gotOut)
+			return
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/520-529/524/verifierD.go
+++ b/0-999/500-599/520-529/524/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "524D.go")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("build ref failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runProg(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func formatTime(sec int) string {
+	h := sec / 3600
+	m := (sec % 3600) / 60
+	s := sec % 60
+	return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(4))
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(8) + 2
+		M := rng.Intn(n) + 1
+		T := rng.Intn(10) + 1
+		times := make([]int, n)
+		for i := 0; i < n; i++ {
+			times[i] = rng.Intn(24 * 3600)
+		}
+		sort.Ints(times)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, M, T)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%s\n", formatTime(times[i]))
+		}
+		tests[t] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		expOut, err1 := runProg("./"+ref, tc)
+		if err1 != nil {
+			fmt.Printf("reference solution runtime error on test %d: %v\n", i+1, err1)
+			return
+		}
+		gotOut, err2 := runProg(target, tc)
+		if err2 != nil {
+			fmt.Printf("target runtime error on test %d: %v\n", i+1, err2)
+			return
+		}
+		if strings.TrimSpace(expOut) != strings.TrimSpace(gotOut) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc, expOut, gotOut)
+			return
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/520-529/524/verifierE.go
+++ b/0-999/500-599/520-529/524/verifierE.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "524E.go")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("build ref failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runProg(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(5))
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		maxk := n * m
+		if maxk > 15 {
+			maxk = 15
+		}
+		k := rng.Intn(maxk) + 1
+		q := rng.Intn(5) + 1
+		used := map[[2]int]bool{}
+		rooks := make([][2]int, k)
+		for i := 0; i < k; i++ {
+			for {
+				x := rng.Intn(n) + 1
+				y := rng.Intn(m) + 1
+				p := [2]int{x, y}
+				if !used[p] {
+					used[p] = true
+					rooks[i] = p
+					break
+				}
+			}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d\n", n, m, k, q)
+		for _, p := range rooks {
+			fmt.Fprintf(&sb, "%d %d\n", p[0], p[1])
+		}
+		for i := 0; i < q; i++ {
+			x1 := rng.Intn(n) + 1
+			x2 := rng.Intn(n) + 1
+			if x1 > x2 {
+				x1, x2 = x2, x1
+			}
+			y1 := rng.Intn(m) + 1
+			y2 := rng.Intn(m) + 1
+			if y1 > y2 {
+				y1, y2 = y2, y1
+			}
+			fmt.Fprintf(&sb, "%d %d %d %d\n", x1, y1, x2, y2)
+		}
+		tests[t] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		expOut, err1 := runProg("./"+ref, tc)
+		if err1 != nil {
+			fmt.Printf("reference solution runtime error on test %d: %v\n", i+1, err1)
+			return
+		}
+		gotOut, err2 := runProg(target, tc)
+		if err2 != nil {
+			fmt.Printf("target runtime error on test %d: %v\n", i+1, err2)
+			return
+		}
+		if strings.TrimSpace(expOut) != strings.TrimSpace(gotOut) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc, expOut, gotOut)
+			return
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/520-529/524/verifierF.go
+++ b/0-999/500-599/520-529/524/verifierF.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "524F.go")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("build ref failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runProg(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(6))
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(20) + 1
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('(')
+			} else {
+				sb.WriteByte(')')
+			}
+		}
+		sb.WriteByte('\n')
+		tests[t] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	target := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		expOut, err1 := runProg("./"+ref, tc)
+		if err1 != nil {
+			fmt.Printf("reference solution runtime error on test %d: %v\n", i+1, err1)
+			return
+		}
+		gotOut, err2 := runProg(target, tc)
+		if err2 != nil {
+			fmt.Printf("target runtime error on test %d: %v\n", i+1, err2)
+			return
+		}
+		if strings.TrimSpace(expOut) != strings.TrimSpace(gotOut) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc, expOut, gotOut)
+			return
+		}
+	}
+	fmt.Println("OK")
+}


### PR DESCRIPTION
## Summary
- added verifierA.go..verifierF.go in `524` directory
- each verifier compiles the reference solution and runs 100 pseudo-random tests
- program reports runtime errors and wrong answers

## Testing
- `go vet verifierA.go` *(passes)*
- `go vet verifierB.go` *(passes)*
- `go vet verifierC.go` *(passes)*
- `go vet verifierD.go` *(passes)*
- `go vet verifierE.go` *(passes)*
- `go vet verifierF.go` *(passes)*

------
https://chatgpt.com/codex/tasks/task_e_68831fe1adec8324b489c5ae9cd70aab