### PR TITLE
Add verifiers for contest 525

### DIFF
--- a/0-999/500-599/520-529/525/verifierA.go
+++ b/0-999/500-599/520-529/525/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int, s string) string {
+	keys := make([]int, 26)
+	bought := 0
+	for i := 0; i < n-1; i++ {
+		k := s[2*i] - 'a'
+		d := s[2*i+1] - 'A'
+		keys[k]++
+		if keys[d] > 0 {
+			keys[d]--
+		} else {
+			bought++
+		}
+	}
+	return fmt.Sprintf("%d", bought)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(30) + 2
+	var b strings.Builder
+	for i := 0; i < (n-1)*2; i += 2 {
+		key := byte('a' + rng.Intn(26))
+		door := byte('A' + rng.Intn(26))
+		b.WriteByte(key)
+		b.WriteByte(door)
+	}
+	input := fmt.Sprintf("%d\n%s\n", n, b.String())
+	expect := solveCase(n, b.String())
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/520-529/525/verifierB.go
+++ b/0-999/500-599/520-529/525/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(s string, ops []int) string {
+	b := []byte(s)
+	n := len(b)
+	for _, a := range ops {
+		l := a - 1
+		r := n - a
+		for l < r {
+			b[l], b[r] = b[r], b[l]
+			l++
+			r--
+		}
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 2
+	m := rng.Intn(20) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('a' + rng.Intn(26)))
+	}
+	s := sb.String()
+	ops := make([]int, m)
+	for i := 0; i < m; i++ {
+		ops[i] = rng.Intn(n/2) + 1
+	}
+	// build input
+	var input strings.Builder
+	input.WriteString(s)
+	input.WriteByte('\n')
+	input.WriteString(strconv.Itoa(m))
+	input.WriteByte('\n')
+	for i, v := range ops {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(strconv.Itoa(v))
+	}
+	input.WriteByte('\n')
+	expect := solveCase(s, ops)
+	return input.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/520-529/525/verifierC.go
+++ b/0-999/500-599/520-529/525/verifierC.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(sticks []int) string {
+	sort.Slice(sticks, func(i, j int) bool { return sticks[i] > sticks[j] })
+	sides := make([]int, 0, len(sticks)/2)
+	for i := 0; i < len(sticks)-1; {
+		if sticks[i]-sticks[i+1] <= 1 {
+			sides = append(sides, sticks[i+1])
+			i += 2
+		} else {
+			i++
+		}
+	}
+	var area int64
+	for i := 0; i+1 < len(sides); i += 2 {
+		area += int64(sides[i]) * int64(sides[i+1])
+	}
+	return fmt.Sprintf("%d", area)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(30) + 1
+	sticks := make([]int, n)
+	for i := range sticks {
+		sticks[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i, v := range sticks {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	expect := solveCase(append([]int(nil), sticks...))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/520-529/525/verifierD.go
+++ b/0-999/500-599/520-529/525/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, m int, grid [][]byte) string {
+	visited := make([][]bool, n)
+	for i := range visited {
+		visited[i] = make([]bool, m)
+	}
+	dirs := [][2]int{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
+	for r := 0; r < n; r++ {
+		for c := 0; c < m; c++ {
+			if grid[r][c] == '.' && !visited[r][c] {
+				stack := [][2]int{{r, c}}
+				visited[r][c] = true
+				minr, maxr := r, r
+				minc, maxc := c, c
+				for len(stack) > 0 {
+					x := stack[len(stack)-1]
+					stack = stack[:len(stack)-1]
+					cr, cc := x[0], x[1]
+					if cr < minr {
+						minr = cr
+					}
+					if cr > maxr {
+						maxr = cr
+					}
+					if cc < minc {
+						minc = cc
+					}
+					if cc > maxc {
+						maxc = cc
+					}
+					for _, d := range dirs {
+						nr, nc := cr+d[0], cc+d[1]
+						if nr >= 0 && nr < n && nc >= 0 && nc < m && !visited[nr][nc] && grid[nr][nc] == '.' {
+							visited[nr][nc] = true
+							stack = append(stack, [2]int{nr, nc})
+						}
+					}
+				}
+				for i := minr; i <= maxr; i++ {
+					for j := minc; j <= maxc; j++ {
+						grid[i][j] = '.'
+					}
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.Write(grid[i])
+		sb.WriteByte('\n')
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(6) + 1
+	grid := make([][]byte, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = '.'
+			} else {
+				row[j] = '*'
+			}
+		}
+		grid[i] = append([]byte(nil), row...)
+		sb.Write(row)
+		sb.WriteByte('\n')
+	}
+	expect := solveCase(n, m, grid)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/520-529/525/verifierE.go
+++ b/0-999/500-599/520-529/525/verifierE.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func factorialMap(limit int64) map[int64]int64 {
+	facts := make(map[int64]int64)
+	facts[0] = 1
+	facts[1] = 1
+	v := int64(1)
+	for i := int64(2); ; i++ {
+		v *= i
+		if v > limit {
+			break
+		}
+		facts[i] = v
+		if i >= 20 {
+			break
+		}
+	}
+	return facts
+}
+
+func dfs(a []int64, pos int, sum int64, used, k int, S int64, facts map[int64]int64) int64 {
+	if sum > S || used > k {
+		return 0
+	}
+	if pos == len(a) {
+		if sum == S {
+			return 1
+		}
+		return 0
+	}
+	res := dfs(a, pos+1, sum, used, k, S, facts)
+	res += dfs(a, pos+1, sum+a[pos], used, k, S, facts)
+	if used < k {
+		if f, ok := facts[a[pos]]; ok {
+			res += dfs(a, pos+1, sum+f, used+1, k, S, facts)
+		}
+	}
+	return res
+}
+
+func solveCase(n, k int, S int64, a []int64) string {
+	facts := factorialMap(S)
+	ans := dfs(a, 0, 0, 0, k, S, facts)
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	k := rng.Intn(n + 1)
+	a := make([]int64, n)
+	sum := int64(0)
+	for i := range a {
+		a[i] = int64(rng.Intn(10) + 1)
+		sum += a[i]
+	}
+	S := int64(rng.Intn(int(sum)+50) + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, k, S))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	expect := solveCase(n, k, S, a)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 525
- each verifier generates 100 random test cases and runs a candidate solution

## Testing
- `go run 0-999/500-599/520-529/525/verifierA.go ./525A_bin`
- `go run 0-999/500-599/520-529/525/verifierB.go ./525B_bin`
- `go run 0-999/500-599/520-529/525/verifierC.go ./525C_bin`
- `go run 0-999/500-599/520-529/525/verifierD.go ./525D_bin`
- `go run 0-999/500-599/520-529/525/verifierE.go ./525E_bin`


------
https://chatgpt.com/codex/tasks/task_e_6883206d5f008324888d4859c13ed60d