### PR TITLE
Add Go verifiers for contest 527

### DIFF
--- a/0-999/500-599/520-529/527/verifierA.go
+++ b/0-999/500-599/520-529/527/verifierA.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// solve computes expected result for problem A
+func solve(a, b int64) int64 {
+	var ships int64
+	for b != 0 {
+		ships += a / b
+		a, b = b, a%b
+	}
+	return ships
+}
+
+// generateTests returns at least 100 deterministic test cases
+func generateTests() [][2]int64 {
+	rnd := rand.New(rand.NewSource(1))
+	tests := make([][2]int64, 0, 110)
+	// some boundary cases
+	tests = append(tests, [2]int64{2, 1})
+	tests = append(tests, [2]int64{1000000000000, 1})
+	tests = append(tests, [2]int64{1000000000000, 999999999999})
+	// random cases
+	for len(tests) < 100 {
+		a := rnd.Int63n(1_000_000_000_000-2) + 2
+		b := rnd.Int63n(a-1) + 1
+		tests = append(tests, [2]int64{a, b})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t[0], t[1])
+		expected := fmt.Sprintf("%d\n", solve(t[0], t[1]))
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		err := cmd.Run()
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		want := strings.TrimSpace(expected)
+		if got != want {
+			fmt.Printf("test %d failed\ninput: %sexpected: %s\n got: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/0-999/500-599/520-529/527/verifierB.go
+++ b/0-999/500-599/520-529/527/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	n int
+	s string
+	t string
+}
+
+func solve(n int, s, t string) string {
+	type pair struct {
+		i    int
+		s, t byte
+	}
+	ms := make([]pair, 0)
+	for i := 0; i < n; i++ {
+		if s[i] != t[i] {
+			ms = append(ms, pair{i, s[i], t[i]})
+		}
+	}
+	cnt := len(ms)
+	var pos [26][26]int
+	for k, p := range ms {
+		pos[p.s-'a'][p.t-'a'] = k + 1
+	}
+	for _, p := range ms {
+		if opp := pos[p.t-'a'][p.s-'a']; opp != 0 {
+			return fmt.Sprintf("%d\n%d %d\n", cnt-2, p.i+1, ms[opp-1].i+1)
+		}
+	}
+	for _, p := range ms {
+		row := p.t - 'a'
+		for c := 0; c < 26; c++ {
+			if pos[row][c] != 0 {
+				j := pos[row][c] - 1
+				return fmt.Sprintf("%d\n%d %d\n", cnt-1, p.i+1, ms[j].i+1)
+			}
+		}
+	}
+	return fmt.Sprintf("%d\n-1 -1\n", cnt)
+}
+
+func generateTests() []testCase {
+	rnd := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 0, 100)
+	for len(tests) < 100 {
+		n := rnd.Intn(20) + 1
+		b1 := make([]byte, n)
+		b2 := make([]byte, n)
+		for i := 0; i < n; i++ {
+			b1[i] = byte('a' + rnd.Intn(26))
+			b2[i] = byte('a' + rnd.Intn(26))
+		}
+		tests = append(tests, testCase{n, string(b1), string(b2)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d\n%s\n%s\n", tc.n, tc.s, tc.t)
+		expected := solve(tc.n, tc.s, tc.t)
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		want := strings.TrimSpace(expected)
+		if got != want {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/0-999/500-599/520-529/527/verifierC.go
+++ b/0-999/500-599/520-529/527/verifierC.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type cut struct {
+	t byte
+	x int
+}
+
+type testCase struct {
+	w, h int
+	cuts []cut
+}
+
+func solve(tc testCase) string {
+	v := []int{0, tc.w}
+	h := []int{0, tc.h}
+	out := make([]int64, len(tc.cuts))
+	for i, c := range tc.cuts {
+		if c.t == 'V' {
+			v = append(v, c.x)
+			sort.Ints(v)
+		} else {
+			h = append(h, c.x)
+			sort.Ints(h)
+		}
+		maxW := 0
+		for j := 1; j < len(v); j++ {
+			if v[j]-v[j-1] > maxW {
+				maxW = v[j] - v[j-1]
+			}
+		}
+		maxH := 0
+		for j := 1; j < len(h); j++ {
+			if h[j]-h[j-1] > maxH {
+				maxH = h[j] - h[j-1]
+			}
+		}
+		out[i] = int64(maxW) * int64(maxH)
+	}
+	var buf strings.Builder
+	for _, v := range out {
+		fmt.Fprintln(&buf, v)
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+func generateTests() []testCase {
+	rnd := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 0, 100)
+	for len(tests) < 100 {
+		w := rnd.Intn(50) + 2
+		h := rnd.Intn(50) + 2
+		n := rnd.Intn(10) + 1
+		cuts := make([]cut, 0, n)
+		vset := map[int]bool{0: true, w: true}
+		hset := map[int]bool{0: true, h: true}
+		for len(cuts) < n {
+			if rnd.Intn(2) == 0 {
+				x := rnd.Intn(w-1) + 1
+				if !vset[x] {
+					vset[x] = true
+					cuts = append(cuts, cut{'V', x})
+				}
+			} else {
+				y := rnd.Intn(h-1) + 1
+				if !hset[y] {
+					hset[y] = true
+					cuts = append(cuts, cut{'H', y})
+				}
+			}
+		}
+		tests = append(tests, testCase{w, h, cuts})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", tc.w, tc.h, len(tc.cuts))
+		for _, c := range tc.cuts {
+			fmt.Fprintf(&sb, "%c %d\n", c.t, c.x)
+		}
+		input := sb.String()
+		expected := solve(tc)
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		want := strings.TrimSpace(expected)
+		if got != want {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\n got:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/0-999/500-599/520-529/527/verifierD.go
+++ b/0-999/500-599/520-529/527/verifierD.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type point struct {
+	x int64
+	w int64
+}
+
+type testCase struct {
+	points []point
+}
+
+func solve(tc testCase) string {
+	intervals := make([][2]int64, len(tc.points))
+	for i, p := range tc.points {
+		intervals[i][0] = p.x - p.w
+		intervals[i][1] = p.x + p.w
+	}
+	sort.Slice(intervals, func(i, j int) bool {
+		if intervals[i][1] != intervals[j][1] {
+			return intervals[i][1] < intervals[j][1]
+		}
+		return intervals[i][0] < intervals[j][0]
+	})
+	count := 0
+	lastR := int64(-1 << 62)
+	for _, iv := range intervals {
+		if iv[0] >= lastR {
+			count++
+			lastR = iv[1]
+		}
+	}
+	return fmt.Sprintf("%d", count)
+}
+
+func generateTests() []testCase {
+	rnd := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 0, 100)
+	for len(tests) < 100 {
+		n := rnd.Intn(20) + 1
+		used := map[int64]bool{}
+		pts := make([]point, 0, n)
+		for len(pts) < n {
+			x := int64(rnd.Intn(200))
+			if used[x] {
+				continue
+			}
+			used[x] = true
+			w := int64(rnd.Intn(50) + 1)
+			pts = append(pts, point{x, w})
+		}
+		tests = append(tests, testCase{pts})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", len(tc.points))
+		for _, p := range tc.points {
+			fmt.Fprintf(&sb, "%d %d\n", p.x, p.w)
+		}
+		input := sb.String()
+		expected := solve(tc)
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		want := strings.TrimSpace(expected)
+		if got != want {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/0-999/500-599/520-529/527/verifierE.go
+++ b/0-999/500-599/520-529/527/verifierE.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type edge struct{ u, v int }
+
+type testCase struct {
+	n     int
+	edges []edge
+}
+
+func solve(tc testCase) string {
+	n := tc.n
+	adj := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		adj[i] = -1
+	}
+	apr := make([]int, n+1)
+	tem := []int{}
+	to := []int{}
+	nxt := []int{}
+	vis := []bool{}
+	vise := []bool{}
+	cntege := 0
+	var addDir func(u, v int)
+	addDir = func(u, v int) {
+		e := len(to)
+		to = append(to, v)
+		nxt = append(nxt, adj[u])
+		adj[u] = e
+		vis = append(vis, false)
+		vise = append(vise, false)
+	}
+	addEdge := func(u, v int) {
+		addDir(u, v)
+		addDir(v, u)
+		cntege++
+	}
+	for _, e := range tc.edges {
+		addEdge(e.u, e.v)
+		apr[e.u]++
+		apr[e.v]++
+	}
+	for i := 1; i <= n; i++ {
+		if apr[i]%2 != 0 {
+			tem = append(tem, i)
+		}
+	}
+	for i := 0; i < len(tem); i += 2 {
+		if i+1 < len(tem) {
+			addEdge(tem[i], tem[i+1])
+		} else {
+			addEdge(tem[i], tem[i])
+		}
+	}
+	iter := make([]int, n+1)
+	copy(iter, adj)
+	nodeSt := []int{1}
+	edgeSt := []int{-1}
+	res := []int{}
+	for len(nodeSt) > 0 {
+		v := nodeSt[len(nodeSt)-1]
+		if iter[v] != -1 {
+			e := iter[v]
+			iter[v] = nxt[e]
+			if vis[e] {
+				continue
+			}
+			vis[e] = true
+			vis[e^1] = true
+			nodeSt = append(nodeSt, to[e])
+			edgeSt = append(edgeSt, e)
+		} else {
+			nodeSt = nodeSt[:len(nodeSt)-1]
+			e := edgeSt[len(edgeSt)-1]
+			edgeSt = edgeSt[:len(edgeSt)-1]
+			if e != -1 {
+				res = append(res, e)
+			}
+		}
+	}
+	z := 0
+	for _, e := range res {
+		z++
+		if z%2 == 1 {
+			vise[e] = true
+		} else {
+			vise[e^1] = true
+		}
+	}
+	if cntege%2 != 0 {
+		addDir(1, 1)
+		e2 := len(to)
+		addDir(1, 1)
+		cntege++
+		vise[e2] = true
+	}
+	var sb strings.Builder
+	fmt.Fprintln(&sb, cntege)
+	for u := 1; u <= n; u++ {
+		for e := adj[u]; e != -1; e = nxt[e] {
+			if vise[e] {
+				fmt.Fprintf(&sb, "%d %d\n", u, to[e])
+			}
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateTests() []testCase {
+	rnd := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 0, 100)
+	for len(tests) < 100 {
+		n := rnd.Intn(6) + 2
+		m := rnd.Intn(8) + 1
+		edges := make([]edge, m)
+		for i := 0; i < m; i++ {
+			u := rnd.Intn(n) + 1
+			v := rnd.Intn(n) + 1
+			edges[i] = edge{u, v}
+		}
+		tests = append(tests, testCase{n, edges})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", tc.n, len(tc.edges))
+		for _, e := range tc.edges {
+			fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+		}
+		input := sb.String()
+		expected := solve(tc)
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		want := strings.TrimSpace(expected)
+		if got != want {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\n got:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add solution verifiers `verifierA.go` through `verifierE.go` for contest 527
- each verifier generates 100 deterministic test cases and checks output

## Testing
- `go build 0-999/500-599/520-529/527/verifierA.go`
- `go build 0-999/500-599/520-529/527/verifierB.go`
- `go build 0-999/500-599/520-529/527/verifierC.go`
- `go build 0-999/500-599/520-529/527/verifierD.go`
- `go build 0-999/500-599/520-529/527/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_6883218651688324b4ffb1eec10ecdde