### PR TITLE
Add Go verifiers for contest 526

### DIFF
--- a/0-999/500-599/520-529/526/verifierA.go
+++ b/0-999/500-599/520-529/526/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveA(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return ""
+	}
+	var s string
+	fmt.Fscan(in, &s)
+	good := false
+	for d := 1; d*4 < n && !good; d++ {
+		for i := 0; i+4*d < n; i++ {
+			ok := true
+			for k := 0; k < 5; k++ {
+				if s[i+k*d] != '*' {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				good = true
+				break
+			}
+		}
+	}
+	if good {
+		return "yes"
+	}
+	return "no"
+}
+
+func genTestA(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '*'
+		} else {
+			b[i] = '.'
+		}
+	}
+	return fmt.Sprintf("%d\n%s\n", n, string(b))
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestA(rng)
+		expect := solveA(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/520-529/526/verifierB.go
+++ b/0-999/500-599/520-529/526/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func solveB(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return ""
+	}
+	size := 1 << (n + 1)
+	a := make([]int, size)
+	for i := 2; i < size; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	dp := make([]int, size)
+	var res int64
+	for i := size/2 - 1; i >= 1; i-- {
+		left, right := 2*i, 2*i+1
+		sL := a[left] + dp[left]
+		sR := a[right] + dp[right]
+		if sL > sR {
+			res += int64(sL - sR)
+			sR = sL
+		} else {
+			res += int64(sR - sL)
+			sL = sR
+		}
+		dp[i] = sL
+	}
+	return fmt.Sprint(res)
+}
+
+func genTestB(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	size := 1 << (n + 1)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d\n", n)
+	for i := 2; i < size; i++ {
+		if i > 2 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprintf(&buf, "%d", rng.Intn(100)+1)
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestB(rng)
+		expect := solveB(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/520-529/526/verifierC.go
+++ b/0-999/500-599/520-529/526/verifierC.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveC(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var C, Hr, Hb, Wr, Wb int64
+	if _, err := fmt.Fscan(in, &C, &Hr, &Hb, &Wr, &Wb); err != nil {
+		return ""
+	}
+	w1, h1 := Wr, Hr
+	w2, h2 := Wb, Hb
+	if w1 > w2 {
+		w1, w2 = w2, w1
+		h1, h2 = h2, h1
+	}
+	limit := int64(math.Sqrt(float64(C))) + 1
+	var maxJoy int64
+	maxX := min64(C/w1, limit)
+	for x := int64(0); x <= maxX; x++ {
+		rem := C - x*w1
+		y := rem / w2
+		joy := x*h1 + y*h2
+		if joy > maxJoy {
+			maxJoy = joy
+		}
+	}
+	maxY := min64(C/w2, limit)
+	for y := int64(0); y <= maxY; y++ {
+		rem := C - y*w2
+		x := rem / w1
+		joy := x*h1 + y*h2
+		if joy > maxJoy {
+			maxJoy = joy
+		}
+	}
+	return fmt.Sprint(maxJoy)
+}
+
+func genTestC(rng *rand.Rand) string {
+	C := rng.Int63n(1000) + 1
+	Hr := rng.Int63n(100) + 1
+	Hb := rng.Int63n(100) + 1
+	Wr := rng.Int63n(100) + 1
+	Wb := rng.Int63n(100) + 1
+	return fmt.Sprintf("%d %d %d %d %d\n", C, Hr, Hb, Wr, Wb)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestC(rng)
+		expect := solveC(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/520-529/526/verifierD.go
+++ b/0-999/500-599/520-529/526/verifierD.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveD(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n, k int
+	if _, err := fmt.Fscan(reader, &n, &k); err != nil {
+		return ""
+	}
+	var tmp string
+	fmt.Fscan(reader, &tmp)
+	s := []byte(tmp)
+	z := make([]int, n)
+	z[0] = n
+	l, r := 0, 0
+	for i := 1; i < n; i++ {
+		if i <= r {
+			k0 := r - i + 1
+			if z[i-l] < k0 {
+				z[i] = z[i-l]
+			} else {
+				z[i] = k0
+			}
+		}
+		for i+z[i] < n && s[z[i]] == s[i+z[i]] {
+			z[i]++
+		}
+		if i+z[i]-1 > r {
+			l = i
+			r = i + z[i] - 1
+		}
+	}
+	diff := make([]int, n+2)
+	for L := 1; L < n; L++ {
+		l64 := int64(k) * int64(L)
+		if l64 <= int64(n) && int64(z[L]) >= l64 {
+			r64 := int64(z[L]) + int64(L)
+			maxR := int64(k+1) * int64(L)
+			if r64 > maxR {
+				r64 = maxR
+			}
+			if r64 > int64(n) {
+				r64 = int64(n)
+			}
+			lpos := int(l64)
+			rpos := int(r64)
+			if lpos <= rpos {
+				diff[lpos]++
+				diff[rpos+1]--
+			}
+		}
+		if int64(k-1)*int64(L) <= int64(z[L]) {
+			pos := k * L
+			if pos <= n {
+				diff[pos]++
+				diff[pos+1]--
+			}
+		}
+	}
+	res := make([]byte, n)
+	cur := 0
+	for i := 1; i <= n; i++ {
+		cur += diff[i]
+		if cur > 0 {
+			res[i-1] = '1'
+		} else {
+			res[i-1] = '0'
+		}
+	}
+	return string(res)
+}
+
+func genTestD(rng *rand.Rand) string {
+	n := rng.Intn(50) + 1
+	k := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(2))
+	}
+	sb.Write(b)
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestD(rng)
+		expect := solveD(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/520-529/526/verifierE.go
+++ b/0-999/500-599/520-529/526/verifierE.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveECase(a []int64, b int64) int {
+	n := len(a)
+	arr := make([]int64, 2*n)
+	copy(arr, a)
+	for i := 0; i < n; i++ {
+		arr[n+i] = a[i]
+	}
+	r := make([]int, 2*n)
+	var sum int64
+	j := 0
+	for i := 0; i < 2*n; i++ {
+		for j < 2*n && sum+arr[j] <= b {
+			sum += arr[j]
+			j++
+		}
+		r[i] = j
+		sum -= arr[i]
+	}
+	dq := make([]int, 0, n+2)
+	head := 0
+	cur := 0
+	dq = append(dq, cur)
+	for cur < n {
+		cur = r[cur]
+		dq = append(dq, cur)
+	}
+	ans := len(dq) - head - 1
+	for s := 1; s < n; s++ {
+		for head < len(dq) && dq[head] < s {
+			head++
+		}
+		last := dq[len(dq)-1]
+		for last < s+n {
+			last = r[last]
+			dq = append(dq, last)
+		}
+		cnt := len(dq) - head - 1
+		if cnt < ans {
+			ans = cnt
+		}
+	}
+	return ans
+}
+
+func solveE(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n, q int
+	fmt.Fscan(reader, &n, &q)
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+	}
+	var sb strings.Builder
+	for qi := 0; qi < q; qi++ {
+		var b int64
+		fmt.Fscan(reader, &b)
+		res := solveECase(arr, b)
+		if qi > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fmt.Sprint(res))
+	}
+	return sb.String()
+}
+
+func genTestE(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	q := rng.Intn(5) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(20) + 1)
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d %d\n", n, q)
+	for i, v := range arr {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprintf(&buf, "%d", v)
+	}
+	buf.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		fmt.Fprintf(&buf, "%d\n", rng.Intn(40)+1)
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestE(rng)
+		expect := solveE(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/520-529/526/verifierF.go
+++ b/0-999/500-599/520-529/526/verifierF.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveF(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(in, &n)
+	rows := make([]int, n)
+	for i := 0; i < n; i++ {
+		var r, c int
+		fmt.Fscan(in, &r, &c)
+		rows[r-1] = c
+	}
+	ans := 0
+	for i := 0; i < n; i++ {
+		minVal := rows[i]
+		maxVal := rows[i]
+		for j := i; j < n; j++ {
+			if rows[j] < minVal {
+				minVal = rows[j]
+			}
+			if rows[j] > maxVal {
+				maxVal = rows[j]
+			}
+			if maxVal-minVal == j-i {
+				ans++
+			}
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func genTestF(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	cols := rng.Perm(n)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&buf, "%d %d\n", i+1, cols[i]+1)
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestF(rng)
+		expect := solveF(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/520-529/526/verifierG.go
+++ b/0-999/500-599/520-529/526/verifierG.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type edge struct{ to, w int }
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveG(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n, q int
+	fmt.Fscan(in, &n, &q)
+	adj := make([][]edge, n)
+	for i := 0; i < n-1; i++ {
+		var u, v, w int
+		fmt.Fscan(in, &u, &v, &w)
+		u--
+		v--
+		adj[u] = append(adj[u], edge{v, w})
+		adj[v] = append(adj[v], edge{u, w})
+	}
+	down1 := make([]int, n)
+	down2 := make([]int, n)
+	child1 := make([]int, n)
+	up := make([]int, n)
+	parent := make([]int, n)
+	var dfs1 func(int, int)
+	dfs1 = func(u, p int) {
+		parent[u] = p
+		down1[u], down2[u] = 0, 0
+		for _, e := range adj[u] {
+			v, w := e.to, e.w
+			if v == p {
+				continue
+			}
+			dfs1(v, u)
+			d := down1[v] + w
+			if d > down1[u] {
+				down2[u], down1[u] = down1[u], d
+				child1[u] = v
+			} else if d > down2[u] {
+				down2[u] = d
+			}
+		}
+	}
+	var dfs2 func(int, int)
+	dfs2 = func(u, p int) {
+		for _, e := range adj[u] {
+			v, w := e.to, e.w
+			if v == p {
+				continue
+			}
+			viaUp := up[u] + w
+			viaSib := 0
+			if child1[u] == v {
+				viaSib = down2[u] + w
+			} else {
+				viaSib = down1[u] + w
+			}
+			up[v] = maxInt(viaUp, viaSib)
+			dfs2(v, u)
+		}
+	}
+	dfs1(0, -1)
+	up[0] = 0
+	dfs2(0, -1)
+	D1 := make([]int, n)
+	D2 := make([]int, n)
+	Bs := make([][]int64, n)
+	PBs := make([][]int64, n)
+	for u := 0; u < n; u++ {
+		var ds []int
+		ds = append(ds, up[u])
+		for _, e := range adj[u] {
+			v, w := e.to, e.w
+			if v == parent[u] {
+				continue
+			}
+			ds = append(ds, down1[v]+w)
+		}
+		a, b := 0, 0
+		for _, d := range ds {
+			if d > a {
+				b = a
+				a = d
+			} else if d > b {
+				b = d
+			}
+		}
+		D1[u], D2[u] = a, b
+		remA, remB := 1, 1
+		var bs []int64
+		for _, d := range ds {
+			if d == a && remA > 0 {
+				remA--
+				continue
+			}
+			if d == b && remB > 0 {
+				remB--
+				continue
+			}
+			bs = append(bs, int64(d))
+		}
+		if len(bs) > 1 {
+			for i := 0; i < len(bs); i++ {
+				for j := i + 1; j < len(bs); j++ {
+					if bs[j] > bs[i] {
+						bs[i], bs[j] = bs[j], bs[i]
+					}
+				}
+			}
+		}
+		Bs[u] = bs
+		ps := make([]int64, len(bs)+1)
+		for i := 0; i < len(bs); i++ {
+			ps[i+1] = ps[i] + bs[i]
+		}
+		PBs[u] = ps
+	}
+	var x, y, ansPrev int64
+	var out strings.Builder
+	for i := 0; i < q; i++ {
+		fmt.Fscan(in, &x, &y)
+		if i > 0 {
+			x = ((x + ansPrev - 1) % int64(n)) + 1
+			y = ((y + ansPrev - 1) % int64(n)) + 1
+		}
+		u := int(x - 1)
+		k := int(y) - 1
+		if k < 0 {
+			k = 0
+		}
+		if k > len(PBs[u])-1 {
+			k = len(PBs[u]) - 1
+		}
+		ans := int64(D1[u] + D2[u])
+		if k > 0 {
+			ans += PBs[u][k]
+		}
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		out.WriteString(fmt.Sprint(ans))
+		ansPrev = ans
+	}
+	return out.String()
+}
+
+func genTestG(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	q := rng.Intn(5) + 1
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d %d\n", n, q)
+	parent := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		w := rng.Intn(10) + 1
+		parent[i] = p
+		fmt.Fprintf(&buf, "%d %d %d\n", p, i, w)
+	}
+	for i := 0; i < q; i++ {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(n) + 1
+		fmt.Fprintf(&buf, "%d %d\n", x, y)
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestG(rng)
+		expect := solveG(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 526 problems A–G
- each verifier generates 100 random test cases and checks a given binary

## Testing
- `go build 0-999/500-599/520-529/526/verifierA.go` *(fails: no output yet)*

------
https://chatgpt.com/codex/tasks/task_e_688320f9648c832482b1ca87450d2e0d