### PR TITLE
Add Go solution verifiers for contest 530

### DIFF
--- a/0-999/500-599/530-539/530/verifierA.go
+++ b/0-999/500-599/530-539/530/verifierA.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(a, b, c float64) []float64 {
+	d := b*b - 4*a*c
+	sqrtD := math.Sqrt(d)
+	x1 := (-b - sqrtD) / (2 * a)
+	x2 := (-b + sqrtD) / (2 * a)
+	if d == 0 {
+		return []float64{x1}
+	}
+	if x1 > x2 {
+		x1, x2 = x2, x1
+	}
+	return []float64{x1, x2}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		var a, b, c int
+		for {
+			a = rng.Intn(21) - 10
+			if a != 0 {
+				break
+			}
+		}
+		b = rng.Intn(21) - 10
+		c = rng.Intn(21) - 10
+		for float64(b*b-4*a*c) < 0 {
+			for {
+				a = rng.Intn(21) - 10
+				if a != 0 {
+					break
+				}
+			}
+			b = rng.Intn(21) - 10
+			c = rng.Intn(21) - 10
+		}
+		input := fmt.Sprintf("%d %d %d\n", a, b, c)
+		want := expected(float64(a), float64(b), float64(c))
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != len(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\n", i+1, len(want), len(fields))
+			os.Exit(1)
+		}
+		for j, f := range fields {
+			got, err := strconv.ParseFloat(f, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: invalid float output\n", i+1)
+				os.Exit(1)
+			}
+			diff := math.Abs(got - want[j])
+			tol := 1e-4 * math.Max(1, math.Abs(want[j]))
+			if diff > tol {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %.10f got %.10f\n", i+1, want[j], got)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/530/verifierB.go
+++ b/0-999/500-599/530-539/530/verifierB.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(s string) string {
+	n := len(s)
+	first := []rune(s[:n/2])
+	second := []rune(s[n/2:])
+	for i, j := 0, len(first)-1; i < j; i, j = i+1, j-1 {
+		first[i], first[j] = first[j], first[i]
+	}
+	for i, j := 0, len(second)-1; i < j; i, j = i+1, j-1 {
+		second[i], second[j] = second[j], second[i]
+	}
+	return string(first) + string(second)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	for i := 0; i < 100; i++ {
+		n := (rng.Intn(10) + 1) * 2
+		runes := make([]rune, n)
+		for j := 0; j < n; j++ {
+			runes[j] = letters[rng.Intn(len(letters))]
+		}
+		s := string(runes)
+		input := s + "\n"
+		want := expected(s)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, want, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/530/verifierC.go
+++ b/0-999/500-599/530-539/530/verifierC.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type pair struct{ X, Y int }
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(a, b, c int) string {
+	sols := []pair{}
+	for x := 1; a*x < c; x++ {
+		rem := c - a*x
+		if rem%b == 0 {
+			y := rem / b
+			if y >= 1 {
+				sols = append(sols, pair{x, y})
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d", len(sols))
+	for _, p := range sols {
+		sb.WriteByte('\n')
+		fmt.Fprintf(&sb, "%d %d", p.X, p.Y)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		a := rng.Intn(20) + 1
+		b := rng.Intn(20) + 1
+		c := rng.Intn(20) + 1
+		input := fmt.Sprintf("%d %d %d\n", a, b, c)
+		want := expected(a, b, c)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\n", i+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/530/verifierD.go
+++ b/0-999/500-599/530-539/530/verifierD.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(intervals [][2]int) string {
+	removed := make([]bool, 1001)
+	for _, iv := range intervals {
+		a, b := iv[0], iv[1]
+		if a < 1 {
+			a = 1
+		}
+		if b > 1000 {
+			b = 1000
+		}
+		for j := a; j <= b; j++ {
+			removed[j] = true
+		}
+	}
+	var res []int
+	for i := 1; i <= 1000; i++ {
+		if !removed[i] {
+			res = append(res, i)
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d", len(res))
+	for _, v := range res {
+		fmt.Fprintf(&sb, " %d", v)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10)
+		intervals := make([][2]int, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			a := rng.Intn(1000) + 1
+			b := a + rng.Intn(1000-a+1)
+			intervals[j] = [2]int{a, b}
+			fmt.Fprintf(&sb, "%d %d\n", a, b)
+		}
+		input := sb.String()
+		want := expected(intervals)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, want, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/530/verifierE.go
+++ b/0-999/500-599/530-539/530/verifierE.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func check(nums []int64, d int64) bool {
+	sum := big.NewInt(0)
+	prod := big.NewInt(1)
+	for _, v := range nums {
+		if v <= 0 || v > 1_000_000 {
+			return false
+		}
+		sum.Add(sum, big.NewInt(v))
+		prod.Mul(prod, big.NewInt(v))
+	}
+	diff := big.NewInt(0).Sub(prod, sum)
+	return diff.Cmp(big.NewInt(d)) == 0
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(9) + 2
+		d := rng.Intn(100)
+		input := fmt.Sprintf("%d %d\n", n, d)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != n {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers, got %d\n", i+1, n, len(fields))
+			os.Exit(1)
+		}
+		nums := make([]int64, n)
+		prev := int64(-1)
+		for j, f := range fields {
+			v, err := strconv.ParseInt(f, 10, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: invalid integer\n", i+1)
+				os.Exit(1)
+			}
+			if j > 0 && v < prev {
+				fmt.Fprintf(os.Stderr, "case %d failed: numbers not non-decreasing\n", i+1)
+				os.Exit(1)
+			}
+			prev = v
+			nums[j] = v
+		}
+		if !check(nums, int64(d)) {
+			fmt.Fprintf(os.Stderr, "case %d failed: numbers do not satisfy condition\n", i+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/530/verifierF.go
+++ b/0-999/500-599/530-539/530/verifierF.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(xs, ys []int) int {
+	n := len(xs) - 1
+	reachable := make([]bool, n+1)
+	for i := 1; i <= 10; i++ {
+		visited := make([]bool, n+1)
+		q := []int{0}
+		visited[0] = true
+		for head := 0; head < len(q); head++ {
+			u := q[head]
+			for v := 1; v <= n; v++ {
+				if visited[v] {
+					continue
+				}
+				if xs[u] == xs[v] && abs(ys[u]-ys[v]) == i || ys[u] == ys[v] && abs(xs[u]-xs[v]) == i {
+					visited[v] = true
+					q = append(q, v)
+				}
+			}
+		}
+		for v := 1; v <= n; v++ {
+			if visited[v] {
+				reachable[v] = true
+			}
+		}
+	}
+	maxD := 0
+	for i := 1; i <= n; i++ {
+		if reachable[i] {
+			d := abs(xs[i]) + abs(ys[i])
+			if d > maxD {
+				maxD = d
+			}
+		}
+	}
+	return maxD
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		xs := make([]int, n+1)
+		ys := make([]int, n+1)
+		used := make(map[[2]int]bool)
+		for j := 1; j <= n; j++ {
+			for {
+				x := rng.Intn(11) - 5
+				y := rng.Intn(11) - 5
+				if x == 0 && y == 0 {
+					continue
+				}
+				if !used[[2]int{x, y}] {
+					used[[2]int{x, y}] = true
+					xs[j] = x
+					ys[j] = y
+					break
+				}
+			}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 1; j <= n; j++ {
+			fmt.Fprintf(&sb, "%d %d\n", xs[j], ys[j])
+		}
+		input := sb.String()
+		xs[0], ys[0] = 0, 0
+		want := expected(xs, ys)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil || got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, want, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/530/verifierG.go
+++ b/0-999/500-599/530-539/530/verifierG.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(s, t string) int {
+	n, m := len(s), len(t)
+	dp := make([][]int, n+1)
+	for i := range dp {
+		dp[i] = make([]int, m+1)
+	}
+	for i := 1; i <= n; i++ {
+		dp[i][0] = dp[i-1][0] + int(s[i-1]-'a'+1)
+	}
+	for j := 1; j <= m; j++ {
+		dp[0][j] = dp[0][j-1] + int(t[j-1]-'a'+1)
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			costDel := dp[i-1][j] + int(s[i-1]-'a'+1)
+			costIns := dp[i][j-1] + int(t[j-1]-'a'+1)
+			diff := int(s[i-1] - t[j-1])
+			if diff < 0 {
+				diff = -diff
+			}
+			costSub := dp[i-1][j-1] + diff
+			best := costDel
+			if costIns < best {
+				best = costIns
+			}
+			if costSub < best {
+				best = costSub
+			}
+			dp[i][j] = best
+		}
+	}
+	return dp[n][m]
+}
+
+func randString(rng *rand.Rand, n int) string {
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		s := randString(rng, rng.Intn(5)+1)
+		t := randString(rng, rng.Intn(5)+1)
+		input := fmt.Sprintf("%s\n%s\n", s, t)
+		want := expected(s, t)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil || got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, want, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/530/verifierH.go
+++ b/0-999/500-599/530-539/530/verifierH.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(xs, ys []int) float64 {
+	n := len(xs)
+	maxX, maxY := 0, 0
+	for i := 0; i < n; i++ {
+		if xs[i] > maxX {
+			maxX = xs[i]
+		}
+		if ys[i] > maxY {
+			maxY = ys[i]
+		}
+	}
+	best := math.Inf(1)
+	for A := maxX + 1; ; A++ {
+		B := 0
+		for i := 0; i < n; i++ {
+			num := A * ys[i]
+			den := A - xs[i]
+			b := num / den
+			if num%den != 0 {
+				b++
+			}
+			if b > B {
+				B = b
+			}
+		}
+		area := float64(A*B) / 2.0
+		if area < best {
+			best = area
+		}
+		if float64(A*maxY)/2.0 > best {
+			break
+		}
+	}
+	return best
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		xs := make([]int, n)
+		ys := make([]int, n)
+		for j := 0; j < n; j++ {
+			xs[j] = rng.Intn(5) + 1
+			ys[j] = rng.Intn(5) + 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d %d\n", xs[j], ys[j])
+		}
+		input := sb.String()
+		want := expected(xs, ys)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseFloat(strings.TrimSpace(out), 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid output\n", i+1)
+			os.Exit(1)
+		}
+		if math.Abs(got-want) > 1e-4*math.Max(1, math.Abs(want)) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.6f got %s\n", i+1, want, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/530/verifierI.go
+++ b/0-999/500-599/530-539/530/verifierI.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, groups [][]int) []int {
+	adj := make([][]bool, n)
+	for i := range adj {
+		adj[i] = make([]bool, n)
+	}
+	for _, g := range groups {
+		for i := 0; i < len(g); i++ {
+			for j := i + 1; j < len(g); j++ {
+				u, v := g[i], g[j]
+				adj[u][v] = true
+				adj[v][u] = true
+			}
+		}
+	}
+	xs := make([]int, n)
+	var dfs func(int, int) bool
+	dfs = func(i, C int) bool {
+		if i == n {
+			return true
+		}
+		for v := 1; v <= C; v++ {
+			ok := true
+			for j := 0; j < i; j++ {
+				if xs[j] == v && adj[i][j] {
+					ok = false
+					break
+				}
+			}
+			if !ok {
+				continue
+			}
+			xs[i] = v
+			if dfs(i+1, C) {
+				return true
+			}
+			xs[i] = 0
+		}
+		return false
+	}
+	for C := 1; C <= n; C++ {
+		for i := range xs {
+			xs[i] = 0
+		}
+		if dfs(0, C) {
+			res := append([]int(nil), xs...)
+			return res
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for caseIdx := 0; caseIdx < 100; caseIdx++ {
+		n := rng.Intn(5) + 2
+		k := rng.Intn(n) + 1
+		groups := make([][]int, k)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for i := 0; i < k; i++ {
+			m := rng.Intn(n-1) + 2
+			perm := rng.Perm(n)
+			group := make([]int, m)
+			for j := 0; j < m; j++ {
+				group[j] = perm[j]
+			}
+			groups[i] = group
+			fmt.Fprintf(&sb, "%d", m)
+			for _, idx := range group {
+				fmt.Fprintf(&sb, " %d", idx+1)
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		want := expected(n, groups)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", caseIdx+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != n {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d values got %d\n", caseIdx+1, n, len(fields))
+			os.Exit(1)
+		}
+		got := make([]int, n)
+		for i, f := range fields {
+			v, err := strconv.Atoi(f)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: invalid int\n", caseIdx+1)
+				os.Exit(1)
+			}
+			got[i] = v
+		}
+		for i := 0; i < n; i++ {
+			if got[i] != want[i] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %v got %v\n", caseIdx+1, want, got)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for problems A-I of Codeforces contest 530
- each verifier generates 100 deterministic tests and runs a provided binary
- verifiers support either compiled binaries or `.go` sources

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`

------
https://chatgpt.com/codex/tasks/task_e_68832329c4608324bb31f2664632e1fd