### PR TITLE
Add Go solution for problem 1243A

### DIFF
--- a/1000-1999/1200-1299/1240-1249/1243/1243A.go
+++ b/1000-1999/1200-1299/1240-1249/1243/1243A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var T int
+	if _, err := fmt.Fscan(reader, &T); err != nil {
+		return
+	}
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		sort.Sort(sort.Reverse(sort.IntSlice(arr)))
+		ans := 0
+		for i := 0; i < n; i++ {
+			if arr[i] >= i+1 {
+				ans = i + 1
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 1243 problem A

## Testing
- `go build 1000-1999/1200-1299/1240-1249/1243/1243A.go`
- `go vet 1000-1999/1200-1299/1240-1249/1243/1243A.go`


------
https://chatgpt.com/codex/tasks/task_e_68832487f6888324976cbcb6ea68dd45