### PR TITLE
Add verifiers for Codeforces 532

### DIFF
--- a/0-999/500-599/530-539/532/verifierA.go
+++ b/0-999/500-599/530-539/532/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := r.Intn(5) + 1
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d\n", n)
+		for i := 1; i <= n; i++ {
+			fmt.Fprintf(&b, "%d ", r.Intn(10)+1)
+		}
+		b.WriteByte('\n')
+		for i := 0; i < n-1; i++ {
+			a := r.Intn(i+1) + 1
+			bNode := i + 2
+			fmt.Fprintf(&b, "%d %d\n", a, bNode)
+		}
+		k := r.Intn(n) + 1
+		fmt.Fprintf(&b, "%d\n", k)
+		for i := 0; i < k; i++ {
+			fmt.Fprintf(&b, "%d ", r.Intn(10)+1)
+		}
+		b.WriteByte('\n')
+		tests = append(tests, b.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialA"
+	if err := exec.Command("go", "build", "-o", official, "532A.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/530-539/532/verifierB.go
+++ b/0-999/500-599/530-539/532/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(2))
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := r.Intn(5) + 1
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d\n", n)
+		for i := 1; i <= n; i++ {
+			if i == 1 {
+				fmt.Fprintf(&b, "-1 %d\n", r.Intn(20)+1)
+			} else {
+				p := r.Intn(i-1) + 1
+				fmt.Fprintf(&b, "%d %d\n", p, r.Intn(20)+1)
+			}
+		}
+		tests = append(tests, b.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialB"
+	if err := exec.Command("go", "build", "-o", official, "532B.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/530-539/532/verifierC.go
+++ b/0-999/500-599/530-539/532/verifierC.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(3))
+	tests := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		xp := r.Intn(20)
+		yp := r.Intn(20)
+		xv := r.Intn(20)
+		yv := r.Intn(20)
+		tests = append(tests, fmt.Sprintf("%d %d %d %d\n", xp, yp, xv, yv))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialC"
+	if err := exec.Command("go", "build", "-o", official, "532C.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/530-539/532/verifierD.go
+++ b/0-999/500-599/530-539/532/verifierD.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(4))
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := r.Intn(3) + 1
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d\n", n)
+		x := make([]int, n+2)
+		x[0] = 0
+		for i := 1; i <= n+1; i++ {
+			x[i] = x[i-1] + r.Intn(5) + 1
+			fmt.Fprintf(&b, "%d ", x[i])
+		}
+		b.WriteByte('\n')
+		for i := 1; i <= n; i++ {
+			fmt.Fprintf(&b, "%d ", r.Intn(5)+1)
+		}
+		b.WriteByte('\n')
+		tests = append(tests, b.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialD"
+	if err := exec.Command("go", "build", "-o", official, "532D.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/530-539/532/verifierE.go
+++ b/0-999/500-599/530-539/532/verifierE.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + r.Intn(3))
+	}
+	return string(b)
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(5))
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := r.Intn(6) + 1
+		s := randString(r, n)
+		tstr := randString(r, n)
+		tests = append(tests, fmt.Sprintf("%d\n%s\n%s\n", n, s, tstr))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialE"
+	if err := exec.Command("go", "build", "-o", official, "532E.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/530-539/532/verifierF.go
+++ b/0-999/500-599/530-539/532/verifierF.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + r.Intn(3))
+	}
+	return string(b)
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(6))
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := r.Intn(8) + 1
+		m := r.Intn(n) + 1
+		s := randString(r, n)
+		tstr := randString(r, m)
+		tests = append(tests, fmt.Sprintf("%d %d\n%s\n%s\n", n, m, s, tstr))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialF"
+	if err := exec.Command("go", "build", "-o", official, "532F.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems of contest 532
- verifiers compile official solution and run 100 randomized tests

## Testing
- `go build verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`
- `go run verifierA.go ./solA`
- `go run verifierC.go ./solC`


------
https://chatgpt.com/codex/tasks/task_e_68832441ebcc8324862441bf12fa57ee