### PR TITLE
Add placeholder solution for 1273A

### DIFF
--- a/1000-1999/1200-1299/1270-1279/1273/1273A.go
+++ b/1000-1999/1200-1299/1270-1279/1273/1273A.go
@@ -1,0 +1,10 @@
+package main
+
+// Placeholder solution for Codeforces 1273A.
+// The original problem statement is unavailable in this repository.
+// Please replace this file with an actual implementation once the
+// statement is provided.
+
+func main() {
+    // TODO: implement solution once problem statement is known
+}


### PR DESCRIPTION
## Summary
- add a placeholder Go file for problem 1273A since the statement is missing

## Testing
- `go vet` *(fails: no packages to vet)*


------
https://chatgpt.com/codex/tasks/task_e_688323fbecf48324aedd02f6dfd44dbd