### PR TITLE
Add solution verifiers for contest 534

### DIFF
--- a/0-999/500-599/530-539/534/verifierA.go
+++ b/0-999/500-599/530-539/534/verifierA.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func checkCase(n int, out string) error {
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("cannot parse k")
+	}
+	fields = fields[1:]
+	if len(fields) != k {
+		return fmt.Errorf("expected %d numbers, got %d", k, len(fields))
+	}
+	seq := make([]int, k)
+	used := make(map[int]bool)
+	for i := 0; i < k; i++ {
+		v, err := strconv.Atoi(fields[i])
+		if err != nil {
+			return fmt.Errorf("bad number")
+		}
+		if v < 1 || v > n {
+			return fmt.Errorf("value %d out of range", v)
+		}
+		if used[v] {
+			return fmt.Errorf("duplicate value %d", v)
+		}
+		used[v] = true
+		seq[i] = v
+	}
+	for i := 0; i+1 < k; i++ {
+		if abs(seq[i]-seq[i+1]) == 1 {
+			return fmt.Errorf("adjacent numbers %d and %d differ by 1", seq[i], seq[i+1])
+		}
+	}
+	expected := n
+	if n == 1 || n == 2 {
+		expected = 1
+	} else if n == 3 {
+		expected = 2
+	}
+	if k != expected {
+		return fmt.Errorf("expected k=%d got %d", expected, k)
+	}
+	if n >= 4 && len(used) != n {
+		return fmt.Errorf("not all students used")
+	}
+	return nil
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5000) + 1
+		input := fmt.Sprintf("%d\n", n)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := checkCase(n, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%soutput:%s\n", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/534/verifierB.go
+++ b/0-999/500-599/530-539/534/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(v1, v2, t, d int) int {
+	total := 0
+	for i := 0; i < t; i++ {
+		maxFromStart := v1 + i*d
+		maxFromEnd := v2 + (t-1-i)*d
+		if maxFromStart < maxFromEnd {
+			total += maxFromStart
+		} else {
+			total += maxFromEnd
+		}
+	}
+	return total
+}
+
+func check(v1, v2, t, d int, out string) error {
+	val, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("cannot parse output")
+	}
+	exp := expected(v1, v2, t, d)
+	if val != exp {
+		return fmt.Errorf("expected %d got %d", exp, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		v1 := rng.Intn(100) + 1
+		v2 := rng.Intn(100) + 1
+		t := rng.Intn(99) + 2
+		d := rng.Intn(11)
+		input := fmt.Sprintf("%d %d\n%d %d\n", v1, v2, t, d)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := check(v1, v2, t, d, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%soutput:%s\n", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/534/verifierC.go
+++ b/0-999/500-599/530-539/534/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, A int64, d []int64) []int64 {
+	sumd := int64(0)
+	for _, v := range d {
+		sumd += v
+	}
+	sumMinExcl := int64(n - 1)
+	res := make([]int64, n)
+	for i := 0; i < n; i++ {
+		low := A - (sumd - d[i])
+		if low < 1 {
+			low = 1
+		}
+		high := A - sumMinExcl
+		if high > d[i] {
+			high = d[i]
+		}
+		var possible int64
+		if low > high {
+			possible = 0
+		} else {
+			possible = high - low + 1
+		}
+		res[i] = d[i] - possible
+	}
+	return res
+}
+
+func check(n int, out string, exp []int64) error {
+	fields := strings.Fields(out)
+	if len(fields) != n {
+		return fmt.Errorf("expected %d numbers, got %d", n, len(fields))
+	}
+	for i := 0; i < n; i++ {
+		val, err := strconv.ParseInt(fields[i], 10, 64)
+		if err != nil {
+			return fmt.Errorf("bad number")
+		}
+		if val != exp[i] {
+			return fmt.Errorf("expected %d got %d at pos %d", exp[i], val, i+1)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		d := make([]int64, n)
+		for j := 0; j < n; j++ {
+			d[j] = int64(rng.Intn(6) + 1) // dice faces 1..6 to keep numbers small
+		}
+		sumd := int64(0)
+		for _, v := range d {
+			sumd += v
+		}
+		A := int64(rng.Intn(int(sumd-int64(n)+1)) + n) // ensure n <= A <= sumd
+		exp := expected(n, A, d)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, A))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(d[j]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := check(n, out, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%soutput:%s\n", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/534/verifierD.go
+++ b/0-999/500-599/530-539/534/verifierD.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refD")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "534D.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(20) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(n)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(arr[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/534/verifierE.go
+++ b/0-999/500-599/530-539/534/verifierE.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refE")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "534E.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(10) + 2
+		a := make([]int, n)
+		cur := 0
+		for i := 0; i < n; i++ {
+			cur += rng.Intn(5) + 1
+			a[i] = cur
+		}
+		m := rng.Intn(10) + 1
+		b := make([]int, m)
+		for i := 0; i < m; i++ {
+			b[i] = rng.Intn(n) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(a[i]))
+		}
+		sb.WriteString("\n")
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+		for i := 0; i < m; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(b[i]))
+		}
+		sb.WriteString("\n")
+		input := sb.String()
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:%sexpected:%sactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/534/verifierF.go
+++ b/0-999/500-599/530-539/534/verifierF.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func countSegments(line string) int {
+	cnt := 0
+	prev := '.'
+	for i := 0; i < len(line); i++ {
+		if line[i] == '*' && prev != '*' {
+			cnt++
+		}
+		prev = line[i]
+	}
+	return cnt
+}
+
+func checkBoard(out string, n, m int, rowSeg []int, colSeg []int) error {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != n {
+		return fmt.Errorf("expected %d lines, got %d", n, len(lines))
+	}
+	board := make([]string, n)
+	for i := 0; i < n; i++ {
+		if len(lines[i]) != m {
+			return fmt.Errorf("line %d length %d expected %d", i+1, len(lines[i]), m)
+		}
+		for j := 0; j < m; j++ {
+			if lines[i][j] != '.' && lines[i][j] != '*' {
+				return fmt.Errorf("invalid character")
+			}
+		}
+		board[i] = lines[i]
+		if countSegments(board[i]) != rowSeg[i] {
+			return fmt.Errorf("row %d segments mismatch", i+1)
+		}
+	}
+	for j := 0; j < m; j++ {
+		col := make([]byte, n)
+		for i := 0; i < n; i++ {
+			col[i] = board[i][j]
+		}
+		if countSegments(string(col)) != colSeg[j] {
+			return fmt.Errorf("column %d segments mismatch", j+1)
+		}
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, []int, []int) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(20) + 1
+	board := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		board[i] = make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				board[i][j] = '.'
+			} else {
+				board[i][j] = '*'
+			}
+		}
+	}
+	row := make([]int, n)
+	for i := 0; i < n; i++ {
+		row[i] = countSegments(string(board[i]))
+	}
+	col := make([]int, m)
+	for j := 0; j < m; j++ {
+		colLine := make([]byte, n)
+		for i := 0; i < n; i++ {
+			colLine[i] = board[i][j]
+		}
+		col[j] = countSegments(string(colLine))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(row[i]))
+	}
+	sb.WriteByte('\n')
+	for j := 0; j < m; j++ {
+		if j > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(col[j]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), row, col
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input, row, col := generateCase(rng)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		nmc := strings.Fields(input)
+		n, _ := strconv.Atoi(nmc[0])
+		m, _ := strconv.Atoi(nmc[1])
+		if err := checkBoard(out, n, m, row, col); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%soutput:%s\n", t+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 534
- each verifier runs 100 randomized tests
- reference implementations are used where needed

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6883255a28808324b188ed3ab9a9fd13