### PR TITLE
Add contest 537 verifiers

### DIFF
--- a/0-999/500-599/530-539/537/verifierA.go
+++ b/0-999/500-599/530-539/537/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const targetA = "CODEFORCES"
+
+func expectedAnswerA(s string) string {
+	n := len(s)
+	m := len(targetA)
+	if n < m {
+		return "NO"
+	}
+	for i := 0; i <= m; i++ {
+		if s[:i] == targetA[:i] && s[n-(m-i):] == targetA[i:] {
+			return "YES"
+		}
+	}
+	return "NO"
+}
+
+func generateCaseA(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('A' + rng.Intn(26))
+	}
+	if string(b) == targetA {
+		b[0] = 'Z'
+	}
+	return string(b)
+}
+
+func runCaseA(bin, s string) error {
+	input := s + "\n"
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedAnswerA(s)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := generateCaseA(rng)
+		if err := runCaseA(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/537/verifierB.go
+++ b/0-999/500-599/530-539/537/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswerB(s string) string {
+	digits := make([]int, len(s))
+	maxd := 0
+	for i, c := range []byte(s) {
+		d := int(c - '0')
+		digits[i] = d
+		if d > maxd {
+			maxd = d
+		}
+	}
+	results := make([]int, 0, maxd)
+	for k := 0; k < maxd; k++ {
+		num := 0
+		for i := range digits {
+			num *= 10
+			if digits[i] > 0 {
+				num++
+				digits[i]--
+			}
+		}
+		results = append(results, num)
+	}
+	nums := make([]string, len(results))
+	for i, v := range results {
+		nums[i] = fmt.Sprint(v)
+	}
+	return fmt.Sprintf("%d\n%s", maxd, strings.Join(nums, " "))
+}
+
+func generateCaseB(rng *rand.Rand) string {
+	n := rng.Intn(12) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('0' + rng.Intn(10))
+	}
+	if b[0] == '0' {
+		b[0] = '1'
+	}
+	return string(b)
+}
+
+func runCaseB(bin, num string) error {
+	input := num + "\n"
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedAnswerB(num)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		num := generateCaseB(rng)
+		if err := runCaseB(bin, num); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, num)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/537/verifierC.go
+++ b/0-999/500-599/530-539/537/verifierC.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type note struct{ d, h int }
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func expectedAnswerC(n int, notes []note) (string, int) {
+	ans := notes[0].h + (notes[0].d - 1)
+	for i := 0; i < len(notes)-1; i++ {
+		d1, h1 := notes[i].d, notes[i].h
+		d2, h2 := notes[i+1].d, notes[i+1].h
+		dist := d2 - d1
+		diff := abs(h2 - h1)
+		if diff > dist {
+			return "IMPOSSIBLE", 0
+		}
+		cand := max(h1, h2) + (dist-diff)/2
+		if cand > ans {
+			ans = cand
+		}
+	}
+	last := notes[len(notes)-1]
+	if last.h+(n-last.d) > ans {
+		ans = last.h + (n - last.d)
+	}
+	return "OK", ans
+}
+
+func generateCaseC(rng *rand.Rand) (int, []note) {
+	n := rng.Intn(30) + 1
+	m := rng.Intn(n) + 1
+	ds := rand.Perm(n)[:m]
+	sort.Ints(ds)
+	notes := make([]note, m)
+	for i, d := range ds {
+		notes[i] = note{d + 1, rng.Intn(20)}
+	}
+	return n, notes
+}
+
+func runCaseC(bin string, n int, notes []note) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(notes)))
+	for _, nt := range notes {
+		sb.WriteString(fmt.Sprintf("%d %d\n", nt.d, nt.h))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	status, ans := expectedAnswerC(n, notes)
+	var expected string
+	if status == "IMPOSSIBLE" {
+		expected = "IMPOSSIBLE"
+	} else {
+		expected = fmt.Sprint(ans)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, notes := generateCaseC(rng)
+		if err := runCaseC(bin, n, notes); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/537/verifierD.go
+++ b/0-999/500-599/530-539/537/verifierD.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswerD(board [][]byte) string {
+	n := len(board)
+	size := 2*n - 1
+	center := n - 1
+	valid := make([][]bool, size)
+	for i := range valid {
+		valid[i] = make([]bool, size)
+		for j := range valid[i] {
+			valid[i][j] = true
+		}
+	}
+	valid[center][center] = false
+	for dx := -center; dx <= center; dx++ {
+		for dy := -center; dy <= center; dy++ {
+			kx := dx + center
+			ky := dy + center
+			if kx == center && ky == center {
+				continue
+			}
+			ok := true
+			for i := 0; i < n && ok; i++ {
+				for j := 0; j < n; j++ {
+					if board[i][j] != 'o' {
+						continue
+					}
+					ii := i + dx
+					jj := j + dy
+					if ii >= 0 && ii < n && jj >= 0 && jj < n {
+						if board[ii][jj] == '.' {
+							ok = false
+							break
+						}
+					}
+				}
+			}
+			valid[kx][ky] = ok
+		}
+	}
+	got := make([][]byte, n)
+	for i := range got {
+		got[i] = make([]byte, n)
+		for j := range got[i] {
+			got[i][j] = '.'
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if board[i][j] == 'o' {
+				got[i][j] = 'o'
+				for dx := -center; dx <= center; dx++ {
+					for dy := -center; dy <= center; dy++ {
+						kx := dx + center
+						ky := dy + center
+						if !valid[kx][ky] {
+							continue
+						}
+						ii := i + dx
+						jj := j + dy
+						if ii >= 0 && ii < n && jj >= 0 && jj < n {
+							if got[ii][jj] == '.' {
+								got[ii][jj] = 'x'
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if board[i][j] == 'x' && got[i][j] != 'x' {
+				return "NO"
+			}
+			if board[i][j] == '.' && got[i][j] == 'x' {
+				return "NO"
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	for dx := -center; dx <= center; dx++ {
+		for dy := -center; dy <= center; dy++ {
+			kx := dx + center
+			ky := dy + center
+			if kx == center && ky == center {
+				sb.WriteByte('o')
+			} else if valid[kx][ky] {
+				sb.WriteByte('x')
+			} else {
+				sb.WriteByte('.')
+			}
+		}
+		if dx != center {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func generateCaseD(rng *rand.Rand) [][]byte {
+	n := rng.Intn(4) + 1
+	board := make([][]byte, n)
+	hasO := false
+	for i := range board {
+		board[i] = make([]byte, n)
+		for j := range board[i] {
+			r := rng.Intn(3)
+			switch r {
+			case 0:
+				board[i][j] = '.'
+			case 1:
+				board[i][j] = 'x'
+			case 2:
+				board[i][j] = 'o'
+				hasO = true
+			}
+		}
+	}
+	if !hasO {
+		board[0][0] = 'o'
+	}
+	return board
+}
+
+func runCaseD(bin string, board [][]byte) error {
+	var sb strings.Builder
+	n := len(board)
+	sb.WriteString(fmt.Sprint(n, "\n"))
+	for _, row := range board {
+		sb.WriteString(string(row))
+		sb.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := strings.TrimSpace(expectedAnswerD(board))
+	if got != expected {
+		return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		board := generateCaseD(rng)
+		if err := runCaseD(bin, board); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/537/verifierE.go
+++ b/0-999/500-599/530-539/537/verifierE.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswerE(n int, edges [][2]int) string {
+	children := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		children[u] = append(children[u], v)
+	}
+	depth := make([]int, n+1)
+	queue := []int{1}
+	for i := 0; i < len(queue); i++ {
+		u := queue[i]
+		for _, v := range children[u] {
+			depth[v] = depth[u] + 1
+			queue = append(queue, v)
+		}
+	}
+	stack := []int{1}
+	order := make([]int, 0, n)
+	for len(stack) > 0 {
+		u := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, u)
+		for _, v := range children[u] {
+			stack = append(stack, v)
+		}
+	}
+	need1 := make([]int, n+1)
+	need2 := make([]int, n+1)
+	m := 0
+	for i := len(order) - 1; i >= 0; i-- {
+		u := order[i]
+		if len(children[u]) == 0 {
+			need1[u] = 1
+			need2[u] = 1
+			m++
+		} else if depth[u]%2 == 0 {
+			mn1 := n + 5
+			sum2 := 0
+			for _, v := range children[u] {
+				if need1[v] < mn1 {
+					mn1 = need1[v]
+				}
+				sum2 += need2[v]
+			}
+			need1[u] = mn1
+			need2[u] = sum2
+		} else {
+			sum1 := 0
+			mn2 := n + 5
+			for _, v := range children[u] {
+				sum1 += need1[v]
+				if need2[v] < mn2 {
+					mn2 = need2[v]
+				}
+			}
+			need1[u] = sum1
+			need2[u] = mn2
+		}
+	}
+	maxRes := m - need1[1] + 1
+	minRes := need2[1]
+	return fmt.Sprintf("%d %d", maxRes, minRes)
+}
+
+func generateCaseE(rng *rand.Rand) (int, [][2]int) {
+	n := rng.Intn(10) + 1
+	edges := make([][2]int, 0, n-1)
+	for v := 2; v <= n; v++ {
+		p := rng.Intn(v-1) + 1
+		edges = append(edges, [2]int{p, v})
+	}
+	return n, edges
+}
+
+func runCaseE(bin string, n int, edges [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprint(n, "\n"))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedAnswerE(n, edges)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, edges := generateCaseE(rng)
+		if err := runCaseE(bin, n, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/537/verifierF.go
+++ b/0-999/500-599/530-539/537/verifierF.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswerF(a []int64) string {
+	n := len(a) - 1
+	ans := make([]int, n)
+	const K = 350
+	smallK := K
+	if smallK > n-1 {
+		smallK = n - 1
+	}
+	for k := 1; k <= smallK; k++ {
+		cnt := 0
+		for j := 1; ; j++ {
+			l := k*(j-1) + 2
+			if l > n {
+				break
+			}
+			r := k*j + 1
+			if r > n {
+				r = n
+			}
+			pj := a[j]
+			for v := l; v <= r; v++ {
+				if a[v] < pj {
+					cnt++
+				}
+			}
+		}
+		ans[k] = cnt
+	}
+	diff := make([]int, n+2)
+	for u := 2; u <= n; u++ {
+		x := u - 2
+		maxP := x/(smallK+1) + 1
+		if maxP > u-1 {
+			maxP = u - 1
+		}
+		for p := 1; p <= maxP; p++ {
+			if a[p] <= a[u] {
+				continue
+			}
+			var L, R int
+			if p == 1 {
+				L = x + 1
+				R = n - 1
+			} else {
+				L = x/p + 1
+				R = x / (p - 1)
+			}
+			if L <= smallK {
+				L = smallK + 1
+			}
+			if L > R || L > n-1 {
+				continue
+			}
+			if R > n-1 {
+				R = n - 1
+			}
+			diff[L]++
+			diff[R+1]--
+		}
+	}
+	cur := 0
+	for k := smallK + 1; k <= n-1; k++ {
+		cur += diff[k]
+		ans[k] = cur
+	}
+	var sb strings.Builder
+	for k := 1; k <= n-1; k++ {
+		if k > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(ans[k]))
+	}
+	return sb.String()
+}
+
+func generateCaseF(rng *rand.Rand) []int64 {
+	n := rng.Intn(30) + 2
+	a := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = int64(rng.Intn(100) - 50)
+	}
+	return a
+}
+
+func runCaseF(bin string, a []int64) error {
+	var sb strings.Builder
+	n := len(a) - 1
+	sb.WriteString(fmt.Sprint(n, "\n"))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedAnswerF(a)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		a := generateCaseF(rng)
+		if err := runCaseF(bin, a); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/537/verifierG.go
+++ b/0-999/500-599/530-539/537/verifierG.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func abs64(a int64) int64 {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+type record struct {
+	t int64
+	x int64
+	y int64
+}
+
+func expectedAnswerG(l int64, recs []record) string {
+	type Occ struct{ c0, x0, y0 int64 }
+	occ := make(map[int64]*Occ, len(recs))
+	var dxGlobal, dyGlobal int64
+	var hasDX, hasDY bool
+	for _, r := range recs {
+		c := r.t / l
+		mod := r.t % l
+		if o, ok := occ[mod]; !ok {
+			occ[mod] = &Occ{c0: c, x0: r.x, y0: r.y}
+		} else {
+			d := c - o.c0
+			dx := r.x - o.x0
+			dy := r.y - o.y0
+			if d <= 0 || dx%d != 0 || dy%d != 0 {
+				return "NO"
+			}
+			vx := dx / d
+			vy := dy / d
+			if !hasDX {
+				dxGlobal = vx
+				hasDX = true
+			} else if dxGlobal != vx {
+				return "NO"
+			}
+			if !hasDY {
+				dyGlobal = vy
+				hasDY = true
+			} else if dyGlobal != vy {
+				return "NO"
+			}
+		}
+	}
+	if !hasDX {
+		dxGlobal = 0
+	}
+	if !hasDY {
+		dyGlobal = 0
+	}
+	type P struct {
+		idx  int
+		x, y int64
+	}
+	fps := []P{{idx: 0, x: 0, y: 0}}
+	for r, o := range occ {
+		sx := o.x0 - o.c0*dxGlobal
+		sy := o.y0 - o.c0*dyGlobal
+		if r == 0 {
+			if sx != 0 || sy != 0 {
+				return "NO"
+			}
+			continue
+		}
+		fps = append(fps, P{idx: int(r), x: sx, y: sy})
+	}
+	fps = append(fps, P{idx: int(l), x: dxGlobal, y: dyGlobal})
+	sort.Slice(fps, func(i, j int) bool { return fps[i].idx < fps[j].idx })
+	res := make([]byte, l)
+	for i := 0; i+1 < len(fps); i++ {
+		a := fps[i]
+		b := fps[i+1]
+		dt := b.idx - a.idx
+		dx := b.x - a.x
+		dy := b.y - a.y
+		D := abs64(dx) + abs64(dy)
+		if D > int64(dt) || (int64(dt)-D)%2 != 0 {
+			return "NO"
+		}
+		pos := a.idx
+		if dx > 0 {
+			for k := int64(0); k < dx; k++ {
+				res[pos] = 'R'
+				pos++
+			}
+		} else if dx < 0 {
+			for k := int64(0); k < -dx; k++ {
+				res[pos] = 'L'
+				pos++
+			}
+		}
+		if dy > 0 {
+			for k := int64(0); k < dy; k++ {
+				res[pos] = 'U'
+				pos++
+			}
+		} else if dy < 0 {
+			for k := int64(0); k < -dy; k++ {
+				res[pos] = 'D'
+				pos++
+			}
+		}
+		rem := dt - int(D)
+		for k := 0; k < rem; k += 2 {
+			res[pos] = 'L'
+			res[pos+1] = 'R'
+			pos += 2
+		}
+	}
+	return string(res)
+}
+
+func generateCaseG(rng *rand.Rand) (int, int64, []record) {
+	n := rng.Intn(5) + 1
+	l := int64(rng.Intn(10) + 1)
+	recs := make([]record, n)
+	var t int64
+	for i := 0; i < n; i++ {
+		t += int64(rng.Intn(int(l*3)) + 1)
+		x := int64(rng.Intn(11) - 5)
+		y := int64(rng.Intn(11) - 5)
+		recs[i] = record{t, x, y}
+	}
+	return n, int64(l), recs
+}
+
+func runCaseG(bin string, n int, l int64, recs []record) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, l))
+	for _, r := range recs {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", r.t, r.x, r.y))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedAnswerG(l, recs)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, l, recs := generateCaseG(rng)
+		if err := runCaseG(bin, n, l, recs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/530-539/537/verifierH.go
+++ b/0-999/500-599/530-539/537/verifierH.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type pair struct{ u, v int }
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expectedAnswerH(t, T int64, li, ri []int64, edges []pair) string {
+	n := len(li)
+	g := make([][]int, n)
+	for _, e := range edges {
+		g[e.u] = append(g[e.u], e.v)
+		g[e.v] = append(g[e.v], e.u)
+	}
+	color := make([]int, n)
+	comp := make([]int, n)
+	var compCol0, compCol1 [][]int
+	for i := 0; i < n; i++ {
+		if comp[i] != 0 {
+			continue
+		}
+		q := []int{i}
+		comp[i] = len(compCol0) + 1
+		color[i] = 0
+		col0 := []int{i}
+		col1 := []int{}
+		for k := 0; k < len(q); k++ {
+			u := q[k]
+			for _, v := range g[u] {
+				if comp[v] == 0 {
+					comp[v] = comp[u]
+					color[v] = color[u] ^ 1
+					if color[v] == 0 {
+						col0 = append(col0, v)
+					} else {
+						col1 = append(col1, v)
+					}
+					q = append(q, v)
+				} else {
+					if comp[v] == comp[u] && color[v] == color[u] {
+						return "IMPOSSIBLE"
+					}
+				}
+			}
+		}
+		compCol0 = append(compCol0, col0)
+		compCol1 = append(compCol1, col1)
+	}
+	C := len(compCol0)
+	type CI struct {
+		LA, RA, LB, RB int64
+		idx            int
+	}
+	cis := make([]CI, C)
+	for i := 0; i < C; i++ {
+		LA, RA := int64(0), int64(1e18)
+		for _, u := range compCol0[i] {
+			if li[u] > LA {
+				LA = li[u]
+			}
+			if ri[u] < RA {
+				RA = ri[u]
+			}
+		}
+		LB, RB := int64(0), int64(1e18)
+		for _, u := range compCol1[i] {
+			if li[u] > LB {
+				LB = li[u]
+			}
+			if ri[u] < RB {
+				RB = ri[u]
+			}
+		}
+		if LA > RA || LB > RB {
+			return "IMPOSSIBLE"
+		}
+		cis[i] = CI{LA, RA, LB, RB, i}
+	}
+	sort.Slice(cis, func(i, j int) bool { return cis[i].LA-cis[i].LB < cis[j].LA-cis[j].LB })
+	const INF = int64(1e18)
+	prefLA := make([]int64, C+1)
+	prefLB := make([]int64, C+1)
+	prefRA := make([]int64, C+1)
+	prefRB := make([]int64, C+1)
+	prefRA[0], prefRB[0] = INF, INF
+	for i := 1; i <= C; i++ {
+		c := cis[i-1]
+		if prefLA[i-1] > c.LA {
+			prefLA[i] = prefLA[i-1]
+		} else {
+			prefLA[i] = c.LA
+		}
+		if prefLB[i-1] > c.LB {
+			prefLB[i] = prefLB[i-1]
+		} else {
+			prefLB[i] = c.LB
+		}
+		if prefRA[i-1] < c.RA {
+			prefRA[i] = prefRA[i-1]
+		} else {
+			prefRA[i] = c.RA
+		}
+		if prefRB[i-1] < c.RB {
+			prefRB[i] = prefRB[i-1]
+		} else {
+			prefRB[i] = c.RB
+		}
+	}
+	sufLA := make([]int64, C+2)
+	sufLB := make([]int64, C+2)
+	sufRA := make([]int64, C+2)
+	sufRB := make([]int64, C+2)
+	sufRA[C+1], sufRB[C+1] = INF, INF
+	for i := C; i >= 1; i-- {
+		c := cis[i-1]
+		if sufLA[i+1] > c.LA {
+			sufLA[i] = sufLA[i+1]
+		} else {
+			sufLA[i] = c.LA
+		}
+		if sufLB[i+1] > c.LB {
+			sufLB[i] = sufLB[i+1]
+		} else {
+			sufLB[i] = c.LB
+		}
+		if sufRA[i+1] < c.RA {
+			sufRA[i] = sufRA[i+1]
+		} else {
+			sufRA[i] = c.RA
+		}
+		if sufRB[i+1] < c.RB {
+			sufRB[i] = sufRB[i+1]
+		} else {
+			sufRB[i] = c.RB
+		}
+	}
+	var bestK int = -1
+	var outL1, outL2 int64
+	for k := 0; k <= C; k++ {
+		L1 := max64(prefLA[k], sufLB[k+1])
+		R1 := min64(prefRA[k], sufRB[k+1])
+		L2 := max64(prefLB[k], sufLA[k+1])
+		R2 := min64(prefRB[k], sufRA[k+1])
+		if L1 > R1 || L2 > R2 {
+			continue
+		}
+		if L1+L2 > T || R1+R2 < t {
+			continue
+		}
+		bestK = k
+		outL1 = L1
+		outL2 = L2
+		break
+	}
+	if bestK < 0 {
+		return "IMPOSSIBLE"
+	}
+	n1 := outL1
+	n2 := outL2
+	if n1+n2 < t {
+		delta := t - (n1 + n2)
+		add := min64(delta, min64(prefRA[bestK], sufRB[bestK+1])-n1)
+		n1 += add
+		delta -= add
+		add = min64(delta, min64(prefRB[bestK], sufRA[bestK+1])-n2)
+		n2 += add
+		delta -= add
+	}
+	ans := make([]byte, n)
+	for i := 0; i < n; i++ {
+		ans[i] = '1'
+	}
+	for idx := 0; idx < bestK; idx++ {
+		ci := cis[idx]
+		for _, u := range compCol0[ci.idx] {
+			ans[u] = '1'
+		}
+		for _, u := range compCol1[ci.idx] {
+			ans[u] = '2'
+		}
+	}
+	for idx := bestK; idx < C; idx++ {
+		ci := cis[idx]
+		for _, u := range compCol0[ci.idx] {
+			ans[u] = '2'
+		}
+		for _, u := range compCol1[ci.idx] {
+			ans[u] = '1'
+		}
+	}
+	return fmt.Sprintf("POSSIBLE\n%d %d\n%s", n1, n2, string(ans))
+}
+
+func generateCaseH(rng *rand.Rand) (int64, int64, []int64, []int64, []pair) {
+	t := int64(rng.Intn(5) + 1)
+	T := t + int64(rng.Intn(5))
+	n := rng.Intn(5) + 1
+	m := rng.Intn(n)
+	li := make([]int64, n)
+	ri := make([]int64, n)
+	for i := 0; i < n; i++ {
+		l := int64(rng.Intn(5))
+		r := l + int64(rng.Intn(5))
+		li[i] = l
+		ri[i] = r
+	}
+	edges := make([]pair, 0, m)
+	seen := map[pair]bool{}
+	for len(edges) < m {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		p := pair{u, v}
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		edges = append(edges, p)
+	}
+	return t, T, li, ri, edges
+}
+
+func runCaseH(bin string, t, T int64, li, ri []int64, edges []pair) error {
+	var sb strings.Builder
+	n := len(li)
+	sb.WriteString(fmt.Sprintf("%d %d\n", t, T))
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", li[i], ri[i]))
+	}
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u+1, e.v+1))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := strings.TrimSpace(expectedAnswerH(t, T, li, ri, edges))
+	if got != expected {
+		return fmt.Errorf("expected\n%s\n\ngot\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t, T, li, ri, edges := generateCaseH(rng)
+		if err := runCaseH(bin, t, T, li, ri, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 537 problems A–H
- verifiers generate random tests and check a binary's output

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go build verifierD.go`


------
https://chatgpt.com/codex/tasks/task_e_688326fe54dc8324ba81bae9e48ed97f