### PR TITLE
Add solution verifiers for CF contest 541

### DIFF
--- a/0-999/500-599/540-549/541/verifierA.go
+++ b/0-999/500-599/540-549/541/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const reference = "541A.go"
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		vids := make([][2]int, n)
+		for j := 0; j < n; j++ {
+			l := rng.Intn(10)
+			r := l + rng.Intn(5)
+			vids[j] = [2]int{l, r}
+		}
+		chans := make([]struct{ a, b, c int }, m)
+		for j := 0; j < m; j++ {
+			a := rng.Intn(10)
+			b := a + rng.Intn(5)
+			c := rng.Intn(5) + 1
+			chans[j] = struct{ a, b, c int }{a, b, c}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j := 0; j < n; j++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", vids[j][0], vids[j][1]))
+		}
+		for j := 0; j < m; j++ {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", chans[j].a, chans[j].b, chans[j].c))
+		}
+		input := sb.String()
+		exp, err := run(reference, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/540-549/541/verifierB.go
+++ b/0-999/500-599/540-549/541/verifierB.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Fenwick struct {
+	n int
+	t []int
+}
+
+func NewFenwick(n int) *Fenwick {
+	return &Fenwick{n: n, t: make([]int, n+1)}
+}
+
+func (f *Fenwick) Add(i, v int) {
+	for i <= f.n {
+		f.t[i] += v
+		i += i & -i
+	}
+}
+
+func (f *Fenwick) Sum(i int) int {
+	s := 0
+	for i > 0 {
+		s += f.t[i]
+		i -= i & -i
+	}
+	return s
+}
+
+func expected(n int, R int64, ducks [][2]int64) string {
+	type interval struct{ l, r int64 }
+	intervals := make([]interval, 0, n)
+	for i := 0; i < n; i++ {
+		hi, ti := ducks[i][0], ducks[i][1]
+		if ti < 0 {
+			continue
+		}
+		l := hi
+		if l < 0 {
+			l = 0
+		}
+		intervals = append(intervals, interval{l, ti})
+	}
+	if len(intervals) == 0 {
+		return "0"
+	}
+	sort.Slice(intervals, func(i, j int) bool { return intervals[i].r < intervals[j].r })
+	m := len(intervals)
+	rArr := make([]int64, m+1)
+	llist := make([]struct {
+		l   int64
+		idx int
+	}, m)
+	for i := 1; i <= m; i++ {
+		rArr[i] = intervals[i-1].r
+		llist[i-1] = struct {
+			l   int64
+			idx int
+		}{intervals[i-1].l, i}
+	}
+	sort.Slice(llist, func(i, j int) bool { return llist[i].l < llist[j].l })
+	fw := NewFenwick(m)
+	count := make([]int, m+1)
+	ptr := 0
+	for i := 1; i <= m; i++ {
+		ri := rArr[i]
+		for ptr < m && llist[ptr].l <= ri {
+			fw.Add(llist[ptr].idx, 1)
+			ptr++
+		}
+		count[i] = fw.Sum(m) - fw.Sum(i-1)
+	}
+	p := make([]int, m+1)
+	for i := 1; i <= m; i++ {
+		val := rArr[i] - R
+		k := sort.Search(m, func(j int) bool { return rArr[j+1] > val })
+		p[i] = k
+	}
+	dp := make([]int64, m+1)
+	for i := 1; i <= m; i++ {
+		without := dp[i-1]
+		with := dp[p[i]] + int64(count[i])
+		if without > with {
+			dp[i] = without
+		} else {
+			dp[i] = with
+		}
+	}
+	return fmt.Sprintf("%d", dp[m])
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		R := int64(rng.Intn(5) + 1)
+		ducks := make([][2]int64, n)
+		for j := 0; j < n; j++ {
+			h := int64(rng.Intn(11) - 5)
+			t := h + int64(rng.Intn(6)+1)
+			ducks[j] = [2]int64{h, t}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, R))
+		for j := 0; j < n; j++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", ducks[j][0], ducks[j][1]))
+		}
+		input := sb.String()
+		exp := expected(n, R, ducks)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/540-549/541/verifierC.go
+++ b/0-999/500-599/540-549/541/verifierC.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int64) int64 {
+	return a / gcd(a, b) * b
+}
+
+func expected(n int, f []int) string {
+	for i := range f {
+		f[i]--
+	}
+	indeg := make([]int, n)
+	for i := 0; i < n; i++ {
+		indeg[f[i]]++
+	}
+	inCycle := make([]bool, n)
+	for i := range inCycle {
+		inCycle[i] = true
+	}
+	queue := make([]int, 0)
+	for i := 0; i < n; i++ {
+		if indeg[i] == 0 {
+			queue = append(queue, i)
+		}
+	}
+	for idx := 0; idx < len(queue); idx++ {
+		u := queue[idx]
+		inCycle[u] = false
+		v := f[u]
+		indeg[v]--
+		if indeg[v] == 0 {
+			queue = append(queue, v)
+		}
+	}
+	visited := make([]bool, n)
+	L := int64(1)
+	for i := 0; i < n; i++ {
+		if inCycle[i] && !visited[i] {
+			v := i
+			cnt := int64(0)
+			for {
+				visited[v] = true
+				cnt++
+				v = f[v]
+				if v == i {
+					break
+				}
+			}
+			L = lcm(L, cnt)
+		}
+	}
+	depth := make([]int, n)
+	var calc func(int) int
+	calc = func(u int) int {
+		if inCycle[u] {
+			return 0
+		}
+		if depth[u] != 0 {
+			return depth[u]
+		}
+		depth[u] = calc(f[u]) + 1
+		return depth[u]
+	}
+	maxd := 0
+	for i := 0; i < n; i++ {
+		d := calc(i)
+		if d > maxd {
+			maxd = d
+		}
+	}
+	var k int64
+	if maxd == 0 {
+		k = L
+	} else {
+		t := (int64(maxd) + L - 1) / L
+		if t < 1 {
+			t = 1
+		}
+		k = t * L
+	}
+	return fmt.Sprintf("%d", k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		f := make([]int, n)
+		for j := 0; j < n; j++ {
+			f[j] = rng.Intn(n) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", f[j]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(n, append([]int(nil), f...))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/540-549/541/verifierD.go
+++ b/0-999/500-599/540-549/541/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func J(x int64) int64 {
+	sum := int64(0)
+	for k := int64(1); k*k <= x; k++ {
+		if x%k == 0 {
+			if gcd(k, x/k) == 1 {
+				sum += k
+			}
+			d := x / k
+			if d != k && gcd(d, x/d) == 1 {
+				sum += d
+			}
+		}
+	}
+	return sum
+}
+
+func expected(A int64) string {
+	cnt := int64(0)
+	for x := int64(1); x <= 2000; x++ {
+		if J(x) == A {
+			cnt++
+		}
+	}
+	return fmt.Sprintf("%d", cnt)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		var A int64
+		if rng.Intn(3) == 0 {
+			A = int64(rng.Intn(2000) + 1)
+		} else {
+			x := int64(rng.Intn(2000) + 1)
+			A = J(x)
+		}
+		input := fmt.Sprintf("%d\n", A)
+		exp := expected(A)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/540-549/541/verifierE.go
+++ b/0-999/500-599/540-549/541/verifierE.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m int, edges [][2]int) string {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	visited := make([]bool, n)
+	color := make([]int, n)
+	dist := make([]int, n)
+	queue := make([]int, n)
+	total := 0
+	for i := 0; i < n; i++ {
+		if visited[i] {
+			continue
+		}
+		comp := []int{}
+		head, tail := 0, 0
+		queue[tail] = i
+		tail++
+		visited[i] = true
+		color[i] = 0
+		comp = append(comp, i)
+		ok := true
+		for head < tail && ok {
+			u := queue[head]
+			head++
+			for _, v := range adj[u] {
+				if !visited[v] {
+					visited[v] = true
+					color[v] = 1 - color[u]
+					queue[tail] = v
+					tail++
+					comp = append(comp, v)
+				} else if color[v] == color[u] {
+					ok = false
+					break
+				}
+			}
+		}
+		if !ok {
+			return "-1"
+		}
+		for _, u := range comp {
+			dist[u] = -1
+		}
+		start := comp[0]
+		dist[start] = 0
+		head, tail = 0, 0
+		queue[tail] = start
+		tail++
+		far := start
+		for head < tail {
+			u := queue[head]
+			head++
+			for _, v := range adj[u] {
+				if dist[v] == -1 {
+					dist[v] = dist[u] + 1
+					queue[tail] = v
+					tail++
+				}
+			}
+			if dist[u] > dist[far] {
+				far = u
+			}
+		}
+		for _, u := range comp {
+			dist[u] = -1
+		}
+		dist[far] = 0
+		head, tail = 0, 0
+		queue[tail] = far
+		tail++
+		diam := 0
+		for head < tail {
+			u := queue[head]
+			head++
+			for _, v := range adj[u] {
+				if dist[v] == -1 {
+					dist[v] = dist[u] + 1
+					queue[tail] = v
+					tail++
+				}
+			}
+			if dist[u] > diam {
+				diam = dist[u]
+			}
+		}
+		total += diam
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		maxEdges := n * (n - 1) / 2
+		m := rng.Intn(maxEdges + 1)
+		edgeSet := make(map[[2]int]struct{})
+		edges := make([][2]int, 0, m)
+		for len(edges) < m {
+			u := rng.Intn(n)
+			v := rng.Intn(n)
+			if u == v {
+				continue
+			}
+			if u > v {
+				u, v = v, u
+			}
+			key := [2]int{u, v}
+			if _, ok := edgeSet[key]; ok {
+				continue
+			}
+			edgeSet[key] = struct{}{}
+			edges = append(edges, key)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+		}
+		input := sb.String()
+		exp := expected(n, m, edges)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/540-549/541/verifierF.go
+++ b/0-999/500-599/540-549/541/verifierF.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, T int, tasks []struct{ t, q int }) string {
+	buckets := make([][]int, T)
+	for _, task := range tasks {
+		L := T - task.t
+		if L < 0 {
+			continue
+		}
+		buckets[L] = append(buckets[L], task.q)
+	}
+	prefs := make([][]int, T)
+	for d := 0; d < T; d++ {
+		b := buckets[d]
+		sort.Slice(b, func(i, j int) bool { return b[i] > b[j] })
+		pref := make([]int, len(b)+1)
+		for i, v := range b {
+			pref[i+1] = pref[i] + v
+		}
+		prefs[d] = pref
+	}
+	const neg = -1000000000
+	prev := make([]int, n+1)
+	for i := range prev {
+		prev[i] = neg
+	}
+	prev[1] = 0
+	for d := 0; d < T; d++ {
+		next := make([]int, n+1)
+		for i := range next {
+			next[i] = neg
+		}
+		pref := prefs[d]
+		m := len(pref) - 1
+		for s := 0; s <= n; s++ {
+			base := prev[s]
+			if base < 0 {
+				continue
+			}
+			maxTake := m
+			if s < maxTake {
+				maxTake = s
+			}
+			for x := 0; x <= maxTake; x++ {
+				profit := base + pref[x]
+				newSlots := (s - x) * 2
+				if newSlots > n {
+					newSlots = n
+				}
+				if profit > next[newSlots] {
+					next[newSlots] = profit
+				}
+			}
+		}
+		prev = next
+	}
+	ans := 0
+	for _, v := range prev {
+		if v > ans {
+			ans = v
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		T := rng.Intn(10) + 1
+		tasks := make([]struct{ t, q int }, n)
+		for j := 0; j < n; j++ {
+			t := rng.Intn(T) + 1
+			q := rng.Intn(10) + 1
+			tasks[j] = struct{ t, q int }{t, q}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, T))
+		for _, task := range tasks {
+			sb.WriteString(fmt.Sprintf("%d %d\n", task.t, task.q))
+		}
+		input := sb.String()
+		exp := expected(n, T, tasks)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–F of contest 541
- verifiers generate 100 random tests each
- verifierA uses the official 541A.go for expected output
- other verifiers compute expected results directly

## Testing
- `go build verifierA.go && ./verifierA 541A.go`
- `go build verifierB.go && ./verifierB 541B.go`


------
https://chatgpt.com/codex/tasks/task_e_6883292ec9288324bbc2e0c98edf286d