### PR TITLE
Add solution verifiers for contest 540

### DIFF
--- a/0-999/500-599/540-549/540/verifierA.go
+++ b/0-999/500-599/540-549/540/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n int, s, t string) string {
+	total := 0
+	for i := 0; i < n; i++ {
+		a := int(s[i] - '0')
+		b := int(t[i] - '0')
+		diff := a - b
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > 5 {
+			diff = 10 - diff
+		}
+		total += diff
+	}
+	return fmt.Sprint(total)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	sb := make([]byte, n)
+	tb := make([]byte, n)
+	for i := 0; i < n; i++ {
+		sb[i] = byte(rng.Intn(10)) + '0'
+		tb[i] = byte(rng.Intn(10)) + '0'
+	}
+	s := string(sb)
+	t := string(tb)
+	input := fmt.Sprintf("%d\n%s\n%s\n", n, s, t)
+	expected := solveCase(n, s, t)
+	return input, expected
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		inp, expect := genCase(rng)
+		got, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\n got: %s\ninput:\n%s", i+1, expect, got, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/500-599/540-549/540/verifierB.go
+++ b/0-999/500-599/540-549/540/verifierB.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type caseB struct {
+	n, k, p, x, y int
+	arr           []int
+	input         string
+	exist         bool
+}
+
+func computeSolution(n, k, p, x, y int, arr []int) (bool, []int) {
+	sum := 0
+	for _, v := range arr {
+		sum += v
+	}
+	nNew := n - k
+	if sum+nNew > x {
+		return false, nil
+	}
+	cur := x - (sum + nNew)
+	b := make([]int, nNew)
+	for i := 0; i < nNew; i++ {
+		if cur >= y-1 {
+			b[i] = y
+			cur -= y - 1
+		} else {
+			b[i] = 1
+		}
+	}
+	all := append(append([]int(nil), arr...), b...)
+	sort.Ints(all)
+	if all[n/2] < y || all[n-1] > p {
+		return false, nil
+	}
+	return true, b
+}
+
+func genCase(rng *rand.Rand) caseB {
+	n := rng.Intn(49)*2 + 1 // odd between 1 and 99
+	k := rng.Intn(n)
+	p := rng.Intn(20) + 1
+	x := rng.Intn(n*p-n+1) + n
+	y := rng.Intn(p) + 1
+	arr := make([]int, k)
+	for i := 0; i < k; i++ {
+		arr[i] = rng.Intn(p) + 1
+	}
+	var bldr strings.Builder
+	fmt.Fprintf(&bldr, "%d %d %d %d %d\n", n, k, p, x, y)
+	for i := 0; i < k; i++ {
+		if i > 0 {
+			bldr.WriteByte(' ')
+		}
+		fmt.Fprintf(&bldr, "%d", arr[i])
+	}
+	if k > 0 {
+		bldr.WriteByte('\n')
+	}
+	input := bldr.String()
+	exist, _ := computeSolution(n, k, p, x, y, arr)
+	return caseB{n, k, p, x, y, arr, input, exist}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func validate(c caseB, out string) error {
+	out = strings.TrimSpace(out)
+	if out == "-1" {
+		if c.exist {
+			return fmt.Errorf("solution exists but candidate printed -1")
+		}
+		return nil
+	}
+	if !c.exist {
+		return fmt.Errorf("no solution exists but candidate produced one")
+	}
+	tokens := strings.Fields(out)
+	if len(tokens) != c.n-c.k {
+		return fmt.Errorf("expected %d numbers, got %d", c.n-c.k, len(tokens))
+	}
+	b := make([]int, c.n-c.k)
+	for i, t := range tokens {
+		v, err := strconv.Atoi(t)
+		if err != nil {
+			return fmt.Errorf("invalid integer: %v", err)
+		}
+		if v < 1 || v > c.p {
+			return fmt.Errorf("mark out of range")
+		}
+		b[i] = v
+	}
+	all := append(append([]int(nil), c.arr...), b...)
+	total := 0
+	for _, v := range all {
+		total += v
+	}
+	sort.Ints(all)
+	if total > c.x {
+		return fmt.Errorf("total sum exceeds limit")
+	}
+	if all[c.n/2] < c.y {
+		return fmt.Errorf("median below required")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		c := genCase(rng)
+		got, err := run(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := validate(c, got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/500-599/540-549/540/verifierC.go
+++ b/0-999/500-599/540-549/540/verifierC.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type caseC struct {
+	input    string
+	expected string
+}
+
+func solveCase(n, m int, grid [][]byte, r1, c1, r2, c2 int) string {
+	visited := make([][]bool, n)
+	for i := range visited {
+		visited[i] = make([]bool, m)
+	}
+	type pt struct{ x, y int }
+	q := []pt{{r1, c1}}
+	visited[r1][c1] = true
+	dirs := []pt{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for h := 0; h < len(q); h++ {
+		p := q[h]
+		for _, d := range dirs {
+			nx, ny := p.x+d.x, p.y+d.y
+			if nx < 0 || nx >= n || ny < 0 || ny >= m {
+				continue
+			}
+			if visited[nx][ny] {
+				continue
+			}
+			if grid[nx][ny] == '.' || (nx == r2 && ny == c2) {
+				visited[nx][ny] = true
+				q = append(q, pt{nx, ny})
+			}
+		}
+	}
+	if !visited[r2][c2] {
+		return "NO"
+	}
+	cnt := 0
+	dirs = []pt{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	for _, d := range dirs {
+		nx, ny := r2+d.x, c2+d.y
+		if nx < 0 || nx >= n || ny < 0 || ny >= m {
+			continue
+		}
+		if grid[nx][ny] == '.' || (nx == r1 && ny == c1) {
+			cnt++
+		}
+	}
+	if r1 == r2 && c1 == c2 {
+		if cnt >= 1 {
+			return "YES"
+		}
+		return "NO"
+	}
+	if grid[r2][c2] == 'X' {
+		return "YES"
+	}
+	if cnt >= 2 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func genCase(rng *rand.Rand) caseC {
+	n := rng.Intn(9) + 1
+	m := rng.Intn(9) + 1
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = '.'
+			} else {
+				row[j] = 'X'
+			}
+		}
+		grid[i] = row
+	}
+	r1 := rng.Intn(n)
+	c1 := rng.Intn(m)
+	grid[r1][c1] = 'X'
+	r2 := rng.Intn(n)
+	c2 := rng.Intn(m)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		b.WriteString(string(grid[i]))
+		b.WriteByte('\n')
+	}
+	fmt.Fprintf(&b, "%d %d\n%d %d\n", r1+1, c1+1, r2+1, c2+1)
+	expected := solveCase(n, m, grid, r1, c1, r2, c2)
+	return caseC{b.String(), expected}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		c := genCase(rng)
+		got, err := run(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != c.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\ngot: %s\ninput:\n%s", i+1, c.expected, got, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/500-599/540-549/540/verifierD.go
+++ b/0-999/500-599/540-549/540/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type key struct{ r, s, p int }
+
+var memo map[key]float64
+
+func prob(r, s, p int) float64 {
+	if r == 0 {
+		return 0
+	}
+	if p == 0 {
+		return 1
+	}
+	if s == 0 {
+		return 0
+	}
+	k := key{r, s, p}
+	if v, ok := memo[k]; ok {
+		return v
+	}
+	rs := float64(r * s)
+	sp := float64(s * p)
+	pr := float64(p * r)
+	total := rs + sp + pr
+	d := (pr / total) * prob(r-1, s, p)
+	d += (rs / total) * prob(r, s-1, p)
+	d += (sp / total) * prob(r, s, p-1)
+	memo[k] = d
+	return d
+}
+
+func solveCase(r, s, p int) string {
+	memo = make(map[key]float64)
+	rProb := prob(r, s, p)
+	memo = make(map[key]float64)
+	sProb := prob(s, p, r)
+	memo = make(map[key]float64)
+	pProb := prob(p, r, s)
+	return fmt.Sprintf("%.9f %.9f %.9f", rProb, sProb, pProb)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	r := rng.Intn(10) + 1
+	s := rng.Intn(10) + 1
+	p := rng.Intn(10) + 1
+	input := fmt.Sprintf("%d %d %d\n", r, s, p)
+	expected := solveCase(r, s, p)
+	return input, expected
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		inp, expect := genCase(rng)
+		got, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\ngot: %s\ninput:%s", i+1, expect, got, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/500-599/540-549/540/verifierE.go
+++ b/0-999/500-599/540-549/540/verifierE.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type pair struct{ a, b int64 }
+
+// BIT Fenwick tree
+type BIT struct {
+	n int
+	t []int64
+}
+
+func NewBIT(n int) *BIT { return &BIT{n, make([]int64, n+1)} }
+func (b *BIT) Add(i int, v int64) {
+	for i <= b.n {
+		b.t[i] += v
+		i += i & -i
+	}
+}
+func (b *BIT) Sum(i int) int64 {
+	var s int64
+	for i > 0 {
+		s += b.t[i]
+		i -= i & -i
+	}
+	return s
+}
+
+func solveCase(pairs []pair) int64 {
+	all := make([]int64, 0, len(pairs)*2)
+	for _, p := range pairs {
+		all = append(all, p.a, p.b)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i] < all[j] })
+	uniq := all[:0]
+	for i, v := range all {
+		if i == 0 || v != all[i-1] {
+			uniq = append(uniq, v)
+		}
+	}
+	all = uniq
+	k := len(all)
+	pos2idx := make(map[int64]int, k)
+	for i, v := range all {
+		pos2idx[v] = i
+	}
+	M := make([]int, k)
+	for i := 0; i < k; i++ {
+		M[i] = i
+	}
+	for _, p := range pairs {
+		ia := pos2idx[p.a]
+		ib := pos2idx[p.b]
+		M[ia], M[ib] = M[ib], M[ia]
+	}
+	bit := NewBIT(k)
+	var invSS int64
+	for i := 0; i < k; i++ {
+		v := M[i]
+		seen := int64(i)
+		sum := bit.Sum(v + 1)
+		invSS += seen - sum
+		bit.Add(v+1, 1)
+	}
+	var sumA, sumB int64
+	for i := 0; i < k; i++ {
+		pi := all[i]
+		vi := all[M[i]]
+		if vi > pi+1 {
+			a := pi + 1
+			b := vi - 1
+			tot := b - a + 1
+			l := sort.Search(k, func(j int) bool { return all[j] >= a })
+			r := sort.Search(k, func(j int) bool { return all[j] > b }) - 1
+			var cnt int64
+			if r >= l {
+				cnt = int64(r - l + 1)
+			}
+			sumA += tot - cnt
+		}
+		if vi < pi-1 {
+			a := vi + 1
+			b := pi - 1
+			tot := b - a + 1
+			l := sort.Search(k, func(j int) bool { return all[j] >= a })
+			r := sort.Search(k, func(j int) bool { return all[j] > b }) - 1
+			var cnt int64
+			if r >= l {
+				cnt = int64(r - l + 1)
+			}
+			sumB += tot - cnt
+		}
+	}
+	return invSS + sumA + sumB
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	pairs := make([]pair, n)
+	for i := 0; i < n; i++ {
+		a := int64(rng.Intn(200) + 1)
+		b := int64(rng.Intn(200) + 1)
+		if a == b {
+			if a == 1 {
+				b = 2
+			} else {
+				b = a - 1
+			}
+		}
+		pairs[i] = pair{a, b}
+	}
+	var bld strings.Builder
+	fmt.Fprintf(&bld, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&bld, "%d %d\n", pairs[i].a, pairs[i].b)
+	}
+	ans := solveCase(pairs)
+	return bld.String(), fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		inp, expect := genCase(rng)
+		got, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\ngot: %s\ninput:\n%s", i+1, expect, got, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}


### PR DESCRIPTION
## Summary
- added Go verifiers for all problems of contest 540
- verifiers generate 100 random tests and check candidate solutions

## Testing
- `go run 0-999/500-599/540-549/540/verifierA.go 0-999/500-599/540-549/540/binA`
- `go run 0-999/500-599/540-549/540/verifierB.go 0-999/500-599/540-549/540/binB`
- `go run 0-999/500-599/540-549/540/verifierC.go 0-999/500-599/540-549/540/binC`
- `go run 0-999/500-599/540-549/540/verifierD.go 0-999/500-599/540-549/540/binD`
- `go run 0-999/500-599/540-549/540/verifierE.go 0-999/500-599/540-549/540/binE`


------
https://chatgpt.com/codex/tasks/task_e_688328a2e9f083248b50562e2943688a