### PR TITLE
Add Go verifiers for contest 543

### DIFF
--- a/0-999/500-599/540-549/543/verifierA.go
+++ b/0-999/500-599/540-549/543/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(n, m, b, mod int, a []int) int {
+	dp := make([][]int, m+1)
+	for i := range dp {
+		dp[i] = make([]int, b+1)
+	}
+	dp[0][0] = 1
+	for _, ai := range a {
+		for j := 1; j <= m; j++ {
+			for k := ai; k <= b; k++ {
+				dp[j][k] += dp[j-1][k-ai]
+				if dp[j][k] >= mod {
+					dp[j][k] -= mod
+				}
+			}
+		}
+	}
+	result := 0
+	for k := 0; k <= b; k++ {
+		result += dp[m][k]
+		if result >= mod {
+			result -= mod
+		}
+	}
+	return result
+}
+
+func genTestA() (string, int) {
+	n := rand.Intn(4) + 1
+	m := rand.Intn(5) + 1
+	b := rand.Intn(5) + 1
+	mod := 1000000007
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(b + 1)
+	}
+	input := fmt.Sprintf("%d %d %d %d\n", n, m, b, mod)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", a[i])
+	}
+	input += "\n"
+	expected := solveA(n, m, b, mod, a)
+	return input, expected
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 1; t <= 100; t++ {
+		input, expected := genTestA()
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(output) != fmt.Sprintf("%d", expected) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected: %d\nGot: %s\n", t, input, expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/500-599/540-549/543/verifierB.go
+++ b/0-999/500-599/540-549/543/verifierB.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ a, b int }
+
+func bfs(src int, adj [][]int) []int {
+	n := len(adj)
+	const inf = int(1e9)
+	dist := make([]int, n)
+	for i := range dist {
+		dist[i] = inf
+	}
+	dist[src] = 0
+	q := []int{src}
+	for i := 0; i < len(q); i++ {
+		u := q[i]
+		for _, v := range adj[u] {
+			if dist[v] > dist[u]+1 {
+				dist[v] = dist[u] + 1
+				q = append(q, v)
+			}
+		}
+	}
+	return dist
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveB(n int, edges []pair, s1, t1, l1, s2, t2, l2 int) int {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		a, b := e.a, e.b
+		adj[a] = append(adj[a], b)
+		adj[b] = append(adj[b], a)
+	}
+	dist := make([][]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = bfs(i, adj)
+	}
+	if dist[s1][t1] > l1 || dist[s2][t2] > l2 {
+		return -1
+	}
+	ans := dist[s1][t1] + dist[s2][t2]
+	for u := 0; u < n; u++ {
+		for v := 0; v < n; v++ {
+			d := dist[u][v]
+			d1 := dist[s1][u] + d + dist[v][t1]
+			if d1 > l1 {
+				continue
+			}
+			d2 := dist[s2][u] + d + dist[v][t2]
+			if d2 <= l2 {
+				ans = min(ans, d1+d2-d)
+			}
+			d2 = dist[s2][v] + d + dist[u][t2]
+			if d2 <= l2 {
+				ans = min(ans, d1+d2-d)
+			}
+		}
+	}
+	m := len(edges)
+	return m - ans
+}
+
+func genTestB() (string, int) {
+	n := rand.Intn(5) + 2 //2..6
+	// create random connected graph
+	edges := make([]pair, 0)
+	for i := 1; i < n; i++ {
+		p := rand.Intn(i)
+		edges = append(edges, pair{i, p})
+	}
+	extra := rand.Intn(n)
+	edgeSet := map[pair]bool{}
+	for _, e := range edges {
+		if e.a > e.b {
+			e.a, e.b = e.b, e.a
+		}
+		edgeSet[e] = true
+	}
+	for k := 0; k < extra; k++ {
+		for {
+			a := rand.Intn(n)
+			b := rand.Intn(n)
+			if a == b {
+				continue
+			}
+			e := pair{a, b}
+			if e.a > e.b {
+				e.a, e.b = e.b, e.a
+			}
+			if edgeSet[e] {
+				continue
+			}
+			edgeSet[e] = true
+			edges = append(edges, pair{a, b})
+			break
+		}
+	}
+	s1 := rand.Intn(n)
+	t1 := rand.Intn(n)
+	s2 := rand.Intn(n)
+	t2 := rand.Intn(n)
+	l1 := rand.Intn(n) + 1
+	l2 := rand.Intn(n) + 1
+	input := fmt.Sprintf("%d %d\n", n, len(edges))
+	for _, e := range edges {
+		input += fmt.Sprintf("%d %d\n", e.a+1, e.b+1)
+	}
+	input += fmt.Sprintf("%d %d %d\n", s1+1, t1+1, l1)
+	input += fmt.Sprintf("%d %d %d\n", s2+1, t2+1, l2)
+	expected := solveB(n, edges, s1, t1, l1, s2, t2, l2)
+	return input, expected
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 1; t <= 100; t++ {
+		input, expected := genTestB()
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(output) != fmt.Sprintf("%d", expected) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected: %d\nGot: %s\n", t, input, expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/500-599/540-549/543/verifierC.go
+++ b/0-999/500-599/540-549/543/verifierC.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(n, m int, s []string, a [][]int) int {
+	cols := m * 26
+	cost := make([][]int, n)
+	for i := 0; i < n; i++ {
+		cost[i] = make([]int, cols)
+	}
+	for j := 0; j < m; j++ {
+		for c := 0; c < 26; c++ {
+			fid := j*26 + c
+			sum := 0
+			cc := byte('a' + c)
+			for i := 0; i < n; i++ {
+				if s[i][j] == cc {
+					sum += a[i][j]
+				}
+			}
+			for i := 0; i < n; i++ {
+				cur := sum
+				if s[i][j] == cc {
+					cur -= a[i][j]
+				} else {
+					cur += a[i][j]
+				}
+				cost[i][fid] = cur
+			}
+		}
+	}
+	const INF = int(1 << 60)
+	u := make([]int, n+1)
+	v := make([]int, cols+1)
+	p := make([]int, cols+1)
+	way := make([]int, cols+1)
+	for i := 1; i <= n; i++ {
+		p[0] = i
+		j0 := 0
+		minv := make([]int, cols+1)
+		used := make([]bool, cols+1)
+		for j := 0; j <= cols; j++ {
+			minv[j] = INF
+		}
+		for {
+			used[j0] = true
+			i0 := p[j0]
+			delta := INF
+			j1 := 0
+			for j := 1; j <= cols; j++ {
+				if !used[j] {
+					cur := cost[i0-1][j-1] - u[i0] - v[j]
+					if cur < minv[j] {
+						minv[j] = cur
+						way[j] = j0
+					}
+					if minv[j] < delta {
+						delta = minv[j]
+						j1 = j
+					}
+				}
+			}
+			for j := 0; j <= cols; j++ {
+				if used[j] {
+					u[p[j]] += delta
+					v[j] -= delta
+				} else {
+					minv[j] -= delta
+				}
+			}
+			j0 = j1
+			if p[j0] == 0 {
+				break
+			}
+		}
+		for {
+			j1 := way[j0]
+			p[j0] = p[j1]
+			j0 = j1
+			if j0 == 0 {
+				break
+			}
+		}
+	}
+	assignment := make([]int, n)
+	for j := 1; j <= cols; j++ {
+		if p[j] > 0 {
+			assignment[p[j]-1] = j - 1
+		}
+	}
+	ans := 0
+	for i := 0; i < n; i++ {
+		ans += cost[i][assignment[i]]
+	}
+	return ans
+}
+
+func genRandomString(m int) string {
+	b := make([]byte, m)
+	for i := 0; i < m; i++ {
+		b[i] = byte('a' + rand.Intn(3))
+	}
+	return string(b)
+}
+
+func genTestC() (string, int) {
+	n := rand.Intn(3) + 1
+	m := rand.Intn(3) + 1
+	s := make([]string, n)
+	for i := 0; i < n; i++ {
+		s[i] = genRandomString(m)
+	}
+	a := make([][]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			a[i][j] = rand.Intn(10)
+		}
+	}
+	input := fmt.Sprintf("%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		input += s[i] + "\n"
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", a[i][j])
+		}
+		input += "\n"
+	}
+	expected := solveC(n, m, s, a)
+	return input, expected
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 1; t <= 100; t++ {
+		input, expected := genTestC()
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(output) != fmt.Sprintf("%d", expected) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected: %d\nGot: %s\n", t, input, expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/500-599/540-549/543/verifierD.go
+++ b/0-999/500-599/540-549/543/verifierD.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modD = 1000000007
+
+func solveD(parents []int) []int {
+	n := len(parents) + 1
+	adj := make([][]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := parents[i-2]
+		adj[p] = append(adj[p], i)
+		adj[i] = append(adj[i], p)
+	}
+	dpDown := make([]int64, n+1)
+	dpUp := make([]int64, n+1)
+	ans := make([]int64, n+1)
+
+	var dfs1 func(u, p int)
+	dfs1 = func(u, p int) {
+		prod := int64(1)
+		for _, v := range adj[u] {
+			if v == p {
+				continue
+			}
+			dfs1(v, u)
+			prod = prod * (dpDown[v] + 1) % modD
+		}
+		dpDown[u] = prod
+	}
+	var dfs2 func(u, p int)
+	dfs2 = func(u, p int) {
+		deg := len(adj[u])
+		f := make([]int64, deg)
+		for i, v := range adj[u] {
+			if v == p {
+				f[i] = dpUp[u] + 1
+			} else {
+				f[i] = dpDown[v] + 1
+			}
+		}
+		pre := make([]int64, deg+1)
+		suf := make([]int64, deg+1)
+		pre[0] = 1
+		for i := 0; i < deg; i++ {
+			pre[i+1] = pre[i] * f[i] % modD
+		}
+		suf[deg] = 1
+		for i := deg - 1; i >= 0; i-- {
+			suf[i] = suf[i+1] * f[i] % modD
+		}
+		ans[u] = pre[deg]
+		for i, v := range adj[u] {
+			if v == p {
+				continue
+			}
+			dpUp[v] = pre[i] * suf[i+1] % modD
+			dfs2(v, u)
+		}
+	}
+
+	dfs1(1, 0)
+	dfs2(1, 0)
+	res := make([]int, n)
+	for i := 1; i <= n; i++ {
+		res[i-1] = int(ans[i] % modD)
+	}
+	return res
+}
+
+func genTestD() (string, string) {
+	n := rand.Intn(8) + 2 // at least 2
+	parents := make([]int, n-1)
+	for i := 2; i <= n; i++ {
+		parents[i-2] = rand.Intn(i-1) + 1
+	}
+	input := fmt.Sprintf("%d\n", n)
+	for i := 2; i <= n; i++ {
+		if i > 2 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", parents[i-2])
+	}
+	input += "\n"
+	ans := solveD(parents)
+	expected := ""
+	for i, v := range ans {
+		if i > 0 {
+			expected += " "
+		}
+		expected += fmt.Sprintf("%d", v)
+	}
+	return input, expected
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 1; t <= 100; t++ {
+		input, expected := genTestD()
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(output) != expected {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected: %s\nGot: %s\n", t, input, expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/500-599/540-549/543/verifierE.go
+++ b/0-999/500-599/540-549/543/verifierE.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type SegTree struct {
+	n    int
+	minv []int
+	lazy []int
+}
+
+func NewSegTree(n int) *SegTree {
+	size := 1
+	for size < n {
+		size <<= 1
+	}
+	minv := make([]int, size*2)
+	lazy := make([]int, size*2)
+	return &SegTree{n: n, minv: minv, lazy: lazy}
+}
+
+func (st *SegTree) apply(p, v int) {
+	st.minv[p] += v
+	st.lazy[p] += v
+}
+
+func (st *SegTree) push(p int) {
+	if st.lazy[p] != 0 {
+		st.apply(p*2, st.lazy[p])
+		st.apply(p*2+1, st.lazy[p])
+		st.lazy[p] = 0
+	}
+}
+
+func (st *SegTree) pull(p int) {
+	if st.minv[p*2] < st.minv[p*2+1] {
+		st.minv[p] = st.minv[p*2]
+	} else {
+		st.minv[p] = st.minv[p*2+1]
+	}
+}
+
+func (st *SegTree) updateRange(p, l, r, ql, qr, v int) {
+	if ql > r || qr < l {
+		return
+	}
+	if ql <= l && r <= qr {
+		st.apply(p, v)
+		return
+	}
+	st.push(p)
+	m := (l + r) >> 1
+	st.updateRange(p*2, l, m, ql, qr, v)
+	st.updateRange(p*2+1, m+1, r, ql, qr, v)
+	st.pull(p)
+}
+
+func (st *SegTree) queryMin(p, l, r, ql, qr int) int {
+	if ql > r || qr < l {
+		return 1 << 60
+	}
+	if ql <= l && r <= qr {
+		return st.minv[p]
+	}
+	st.push(p)
+	m := (l + r) >> 1
+	a := st.queryMin(p*2, l, m, ql, qr)
+	b := st.queryMin(p*2+1, m+1, r, ql, qr)
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveE(n, m int, a []int, qs [][3]int) []int {
+	W := n - m + 1
+	if W < 1 {
+		W = 1
+	}
+	type P struct{ v, idx int }
+	ps := make([]P, n)
+	for j := 0; j < n; j++ {
+		ps[j] = P{v: a[j], idx: j}
+	}
+	sort.Slice(ps, func(i, j int) bool { return ps[i].v < ps[j].v })
+	st := NewSegTree(W)
+	p := 0
+	curQ := 0
+	prevAns := 0
+	res := make([]int, len(qs))
+	for i, q := range qs {
+		qi := q[2] ^ prevAns
+		if qi > curQ {
+			for p < n && ps[p].v < qi {
+				j := ps[p].idx
+				l := j - m + 1
+				if l < 0 {
+					l = 0
+				}
+				r := j
+				if r >= W {
+					r = W - 1
+				}
+				if l <= r {
+					st.updateRange(1, 0, st.n-1, l, r, 1)
+				}
+				p++
+			}
+		} else if qi < curQ {
+			for p > 0 && ps[p-1].v >= qi {
+				p--
+				j := ps[p].idx
+				l := j - m + 1
+				if l < 0 {
+					l = 0
+				}
+				r := j
+				if r >= W {
+					r = W - 1
+				}
+				if l <= r {
+					st.updateRange(1, 0, st.n-1, l, r, -1)
+				}
+			}
+		}
+		curQ = qi
+		li := q[0]
+		ri := q[1]
+		if ri >= W {
+			ri = W - 1
+		}
+		ans := st.queryMin(1, 0, st.n-1, li, ri)
+		if ans < 0 {
+			ans = 0
+		}
+		res[i] = ans
+		prevAns = ans
+	}
+	return res
+}
+
+func genTestE() (string, string) {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(n) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rand.Intn(10)
+	}
+	s := rand.Intn(5) + 1
+	qs := make([][3]int, s)
+	for i := 0; i < s; i++ {
+		l := rand.Intn(n)
+		r := rand.Intn(n)
+		if l > r {
+			l, r = r, l
+		}
+		x := rand.Intn(10)
+		qs[i] = [3]int{l, r, x}
+	}
+	input := fmt.Sprintf("%d %d\n", n, m)
+	for i := range a {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", a[i])
+	}
+	input += "\n"
+	input += fmt.Sprintf("%d\n", s)
+	for i := 0; i < s; i++ {
+		input += fmt.Sprintf("%d %d %d\n", qs[i][0]+1, qs[i][1]+1, qs[i][2])
+	}
+	res := solveE(n, m, a, qs)
+	expected := ""
+	for i, v := range res {
+		if i > 0 {
+			expected += " "
+		}
+		expected += fmt.Sprintf("%d", v)
+	}
+	return input, expected
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 1; t <= 100; t++ {
+		input, expected := genTestE()
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(output) != expected {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected: %s\nGot: %s\n", t, input, expected, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for contest 543 (problems A–E)
- each verifier generates over a hundred random tests and checks a binary

## Testing
- `go build 0-999/500-599/540-549/543/verifierA.go`
- `go build 0-999/500-599/540-549/543/verifierB.go`
- `go build 0-999/500-599/540-549/543/verifierC.go`
- `go build 0-999/500-599/540-549/543/verifierD.go`
- `go build 0-999/500-599/540-549/543/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68832a4711a88324bf5dec00261f8617