### PR TITLE
Add Go verifiers for contest 545

### DIFF
--- a/0-999/500-599/540-549/545/verifierA.go
+++ b/0-999/500-599/540-549/545/verifierA.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveA(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([][]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			fmt.Fscan(reader, &a[i][j])
+		}
+	}
+	good := make([]int, 0)
+	for i := 0; i < n; i++ {
+		ok := true
+		for j := 0; j < n; j++ {
+			if i == j {
+				continue
+			}
+			if a[i][j] == 1 || a[i][j] == 3 {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			good = append(good, i+1)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(len(good)))
+	if len(good) > 0 {
+		sb.WriteByte('\n')
+		for idx, v := range good {
+			if idx > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+	} else {
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func genTests() []string {
+	rand.Seed(1)
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(8) + 2 // between 2 and 9
+		matrix := make([][]int, n)
+		for i := 0; i < n; i++ {
+			matrix[i] = make([]int, n)
+		}
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				if i == j {
+					matrix[i][j] = -1
+				} else if j < i {
+					// ensure symmetry
+					v := matrix[j][i]
+					switch v {
+					case 1:
+						matrix[i][j] = 2
+					case 2:
+						matrix[i][j] = 1
+					default:
+						matrix[i][j] = v
+					}
+				} else {
+					r := rand.Intn(4) // 0..3
+					matrix[i][j] = r
+					switch r {
+					case 0:
+						matrix[j][i] = 0
+					case 1:
+						matrix[j][i] = 2
+					case 2:
+						matrix[j][i] = 1
+					case 3:
+						matrix[j][i] = 3
+					}
+				}
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintln(n))
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(strconv.Itoa(matrix[i][j]))
+			}
+			sb.WriteByte('\n')
+		}
+		tests = append(tests, strings.TrimSpace(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierA <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		expected := solveA(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/540-549/545/verifierB.go
+++ b/0-999/500-599/540-549/545/verifierB.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveB(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var s, t string
+	fmt.Fscan(reader, &s)
+	fmt.Fscan(reader, &t)
+	if len(s) != len(t) {
+		return "impossible"
+	}
+	diff := 0
+	for i := range s {
+		if s[i] != t[i] {
+			diff++
+		}
+	}
+	if diff%2 == 1 {
+		return "impossible"
+	}
+	res := make([]byte, len(s))
+	pickFromT := false
+	for i := range s {
+		if s[i] == t[i] {
+			res[i] = s[i]
+		} else {
+			if pickFromT {
+				res[i] = t[i]
+			} else {
+				res[i] = s[i]
+			}
+			pickFromT = !pickFromT
+		}
+	}
+	return string(res)
+}
+
+func genTests() []string {
+	rand.Seed(2)
+	tests := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		var s, t strings.Builder
+		for j := 0; j < n; j++ {
+			s.WriteByte(byte('0' + rand.Intn(2)))
+			t.WriteByte(byte('0' + rand.Intn(2)))
+		}
+		tests = append(tests, s.String()+"\n"+t.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierB <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		reader := bufio.NewReader(strings.NewReader(tc))
+		var s, t string
+		fmt.Fscan(reader, &s)
+		fmt.Fscan(reader, &t)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		diff := 0
+		for k := range s {
+			if s[k] != t[k] {
+				diff++
+			}
+		}
+		if diff%2 == 1 {
+			if strings.TrimSpace(got) != "impossible" {
+				fmt.Printf("test %d failed expected impossible, got %s\n", i+1, got)
+				os.Exit(1)
+			}
+			continue
+		}
+		ans := strings.TrimSpace(got)
+		if len(ans) != len(s) {
+			fmt.Printf("test %d failed length mismatch\n", i+1)
+			os.Exit(1)
+		}
+		d1 := 0
+		d2 := 0
+		for k := range ans {
+			if ans[k] != '0' && ans[k] != '1' {
+				fmt.Printf("test %d failed invalid character\n", i+1)
+				os.Exit(1)
+			}
+			if ans[k] != s[k] {
+				d1++
+			}
+			if ans[k] != t[k] {
+				d2++
+			}
+		}
+		if d1 != d2 || d1 != diff/2 {
+			fmt.Printf("test %d failed distances mismatch\n", i+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/540-549/545/verifierC.go
+++ b/0-999/500-599/540-549/545/verifierC.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveC(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(reader, &n)
+	xs := make([]int64, n)
+	hs := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &xs[i], &hs[i])
+	}
+	if n == 1 {
+		return "1"
+	}
+	ans := 1
+	last := xs[0]
+	for i := 1; i < n-1; i++ {
+		if xs[i]-hs[i] > last {
+			ans++
+			last = xs[i]
+		} else if xs[i]+hs[i] < xs[i+1] {
+			ans++
+			last = xs[i] + hs[i]
+		} else {
+			last = xs[i]
+		}
+	}
+	ans++
+	return strconv.Itoa(ans)
+}
+
+func genTests() []string {
+	rand.Seed(3)
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		xs := make([]int64, n)
+		hs := make([]int64, n)
+		pos := int64(0)
+		for i := 0; i < n; i++ {
+			pos += int64(rand.Intn(5) + 1)
+			xs[i] = pos
+			hs[i] = int64(rand.Intn(5) + 1)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintln(n))
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintln(xs[i], hs[i]))
+		}
+		tests = append(tests, strings.TrimSpace(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierC <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		expected := solveC(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/540-549/545/verifierD.go
+++ b/0-999/500-599/540-549/545/verifierD.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveD(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(reader, &n)
+	times := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &times[i])
+	}
+	sortSlice(times)
+	var sum int64
+	count := 0
+	for _, t := range times {
+		if sum <= t {
+			count++
+			sum += t
+		}
+	}
+	return strconv.Itoa(count)
+}
+
+func sortSlice(a []int64) {
+	if len(a) < 2 {
+		return
+	}
+	quickSort(a, 0, len(a)-1)
+}
+
+func quickSort(a []int64, l, r int) {
+	if l >= r {
+		return
+	}
+	p := a[(l+r)/2]
+	i, j := l, r
+	for i <= j {
+		for a[i] < p {
+			i++
+		}
+		for a[j] > p {
+			j--
+		}
+		if i <= j {
+			a[i], a[j] = a[j], a[i]
+			i++
+			j--
+		}
+	}
+	if l < j {
+		quickSort(a, l, j)
+	}
+	if i < r {
+		quickSort(a, i, r)
+	}
+}
+
+func genTests() []string {
+	rand.Seed(4)
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintln(n))
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d ", rand.Int63n(20)+1))
+		}
+		tests = append(tests, strings.TrimSpace(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierD <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		expected := solveD(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/540-549/545/verifierE.go
+++ b/0-999/500-599/540-549/545/verifierE.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Edge struct {
+	to int
+	w  int64
+	id int
+}
+
+type Item struct {
+	node int
+	dist int64
+	idx  int
+}
+
+type PQ []*Item
+
+func (pq PQ) Len() int           { return len(pq) }
+func (pq PQ) Less(i, j int) bool { return pq[i].dist < pq[j].dist }
+func (pq PQ) Swap(i, j int)      { pq[i], pq[j] = pq[j], pq[i]; pq[i].idx = i; pq[j].idx = j }
+
+func (pq *PQ) Push(x interface{}) {
+	n := len(*pq)
+	it := x.(*Item)
+	it.idx = n
+	*pq = append(*pq, it)
+}
+
+func (pq *PQ) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	it := old[n-1]
+	*pq = old[:n-1]
+	return it
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveE(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var n, m int
+	fmt.Fscan(reader, &n, &m)
+	graph := make([][]Edge, n+1)
+	edges := make([][3]int64, m)
+	for i := 0; i < m; i++ {
+		var u, v int
+		var w int64
+		fmt.Fscan(reader, &u, &v, &w)
+		edges[i] = [3]int64{int64(u), int64(v), w}
+		graph[u] = append(graph[u], Edge{to: v, w: w, id: i + 1})
+		graph[v] = append(graph[v], Edge{to: u, w: w, id: i + 1})
+	}
+	var start int
+	fmt.Fscan(reader, &start)
+	const INF = int64(1) << 62
+	dist := make([]int64, n+1)
+	for i := range dist {
+		dist[i] = INF
+	}
+	dist[start] = 0
+	visited := make([]bool, n+1)
+	pq := &PQ{}
+	heap.Push(pq, &Item{node: start, dist: 0})
+	for pq.Len() > 0 {
+		it := heap.Pop(pq).(*Item)
+		u := it.node
+		if visited[u] {
+			continue
+		}
+		visited[u] = true
+		for _, e := range graph[u] {
+			if dist[e.to] > dist[u]+e.w {
+				dist[e.to] = dist[u] + e.w
+				heap.Push(pq, &Item{node: e.to, dist: dist[e.to]})
+			}
+		}
+	}
+	res := make([]int, 0, n-1)
+	var total int64
+	for v := 1; v <= n; v++ {
+		if v == start {
+			continue
+		}
+		bestW := INF
+		bestID := 0
+		for _, e := range graph[v] {
+			if dist[v] == dist[e.to]+e.w && e.w < bestW {
+				bestW = e.w
+				bestID = e.id
+			}
+		}
+		total += bestW
+		res = append(res, bestID)
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.FormatInt(total, 10))
+	sb.WriteByte('\n')
+	for i, id := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(id))
+	}
+	return sb.String()
+}
+
+func genTests() []string {
+	rand.Seed(5)
+	tests := make([]string, 0, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 2
+		maxM := n * (n - 1) / 2
+		m := (n - 1) + rand.Intn(maxM-(n-1)+1) // ensure connectivity
+		type pair struct{ u, v int }
+		used := make(map[pair]bool)
+		edges := make([][3]int64, 0, m)
+		// first create a random tree to ensure connectivity
+		for i := 2; i <= n; i++ {
+			v := rand.Intn(i-1) + 1
+			w := rand.Int63n(9) + 1
+			edges = append(edges, [3]int64{int64(i), int64(v), w})
+			used[pair{i, v}] = true
+			used[pair{v, i}] = true
+		}
+		// add remaining edges
+		for len(edges) < m {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			if u == v || used[pair{u, v}] {
+				continue
+			}
+			w := rand.Int63n(9) + 1
+			edges = append(edges, [3]int64{int64(u), int64(v), w})
+			used[pair{u, v}] = true
+			used[pair{v, u}] = true
+		}
+		start := rand.Intn(n) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+		}
+		sb.WriteString(fmt.Sprintf("%d", start))
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierE <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		expected := solveE(tc)
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers `verifierA.go`..`verifierE.go` under contest 545
- each verifier generates ~100 random tests and validates a provided binary

## Testing
- `go run 0-999/500-599/540-549/545/verifierA.go 0-999/500-599/540-549/545/solutionA`
- `go run 0-999/500-599/540-549/545/verifierB.go 0-999/500-599/540-549/545/solutionB`
- `go run 0-999/500-599/540-549/545/verifierC.go 0-999/500-599/540-549/545/solutionC`
- `go run 0-999/500-599/540-549/545/verifierD.go 0-999/500-599/540-549/545/solutionD`
- `go run 0-999/500-599/540-549/545/verifierE.go 0-999/500-599/540-549/545/solutionE`


------
https://chatgpt.com/codex/tasks/task_e_68832b5f04308324bc36248b60743541