### PR TITLE
Add Go verifiers for contest 546

### DIFF
--- a/0-999/500-599/540-549/546/verifierA.go
+++ b/0-999/500-599/540-549/546/verifierA.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(k, n, w int) string {
+	total := k * w * (w + 1) / 2
+	need := total - n
+	if need < 0 {
+		need = 0
+	}
+	return fmt.Sprintf("%d", need)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	k := rng.Intn(1000) + 1
+	w := rng.Intn(1000) + 1
+	n := rng.Intn(1000000000)
+	input := fmt.Sprintf("%d %d %d\n", k, n, w)
+	return input, solve(k, n, w)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/540-549/546/verifierB.go
+++ b/0-999/500-599/540-549/546/verifierB.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solve(a []int) string {
+	sort.Ints(a)
+	ans := 0
+	for i := 1; i < len(a); i++ {
+		if a[i] <= a[i-1] {
+			diff := a[i-1] + 1 - a[i]
+			ans += diff
+			a[i] = a[i-1] + 1
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	return input, solve(append([]int(nil), a...))
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/540-549/546/verifierC.go
+++ b/0-999/500-599/540-549/546/verifierC.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n int, p1, p2 []int) string {
+	seen := make(map[string]struct{})
+	rounds := 0
+	for {
+		state := encode(p1, p2)
+		if _, ok := seen[state]; ok {
+			return "-1"
+		}
+		seen[state] = struct{}{}
+		if len(p1) == 0 {
+			return fmt.Sprintf("%d 2", rounds)
+		}
+		if len(p2) == 0 {
+			return fmt.Sprintf("%d 1", rounds)
+		}
+		rounds++
+		c1 := p1[0]
+		c2 := p2[0]
+		p1 = p1[1:]
+		p2 = p2[1:]
+		if c1 > c2 {
+			p1 = append(p1, c2, c1)
+		} else {
+			p2 = append(p2, c1, c2)
+		}
+	}
+}
+
+func encode(a, b []int) string {
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('|')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(9) + 2
+	perm := rng.Perm(n)
+	k1 := rng.Intn(n-1) + 1
+	k2 := n - k1
+	p1 := make([]int, k1)
+	p2 := make([]int, k2)
+	copy(p1, perm[:k1])
+	copy(p2, perm[k1:])
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	sb.WriteString(fmt.Sprintf("%d ", k1))
+	for i, v := range p1 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d ", k2))
+	for i, v := range p2 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	// convert to 1-based deck values for solver as well
+	p1sol := make([]int, k1)
+	p2sol := make([]int, k2)
+	for i := range p1 {
+		p1sol[i] = p1[i] + 1
+	}
+	for i := range p2 {
+		p2sol[i] = p2[i] + 1
+	}
+	exp := solve(n, p1sol, p2sol)
+	return input, exp
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/540-549/546/verifierD.go
+++ b/0-999/500-599/540-549/546/verifierD.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const maxLimit = 500000
+
+var spf []int
+var bigOmega []int
+var pref []int64
+
+func precompute() {
+	spf = make([]int, maxLimit+1)
+	for i := 2; i <= maxLimit; i++ {
+		if spf[i] == 0 {
+			for j := i; j <= maxLimit; j += i {
+				if spf[j] == 0 {
+					spf[j] = i
+				}
+			}
+		}
+	}
+	bigOmega = make([]int, maxLimit+1)
+	pref = make([]int64, maxLimit+1)
+	for i := 2; i <= maxLimit; i++ {
+		p := spf[i]
+		bigOmega[i] = bigOmega[i/p] + 1
+		pref[i] = pref[i-1] + int64(bigOmega[i])
+	}
+}
+
+func solve(a, b int) string {
+	return fmt.Sprintf("%d", pref[a]-pref[b])
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	a := rng.Intn(maxLimit-1) + 1
+	b := rng.Intn(a) // ensures b < a
+	input := fmt.Sprintf("1\n%d %d\n", a, b)
+	return input, solve(a, b)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	precompute()
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/540-549/546/verifierE.go
+++ b/0-999/500-599/540-549/546/verifierE.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Edge for Dinic
+type Edge struct {
+	to, cap, rev int
+}
+
+// Dinic structure
+type Dinic struct {
+	N     int
+	G     [][]Edge
+	level []int
+	iter  []int
+}
+
+func NewDinic(n int) *Dinic {
+	g := make([][]Edge, n)
+	return &Dinic{N: n, G: g, level: make([]int, n), iter: make([]int, n)}
+}
+
+func (d *Dinic) AddEdge(u, v, c int) {
+	d.G[u] = append(d.G[u], Edge{to: v, cap: c, rev: len(d.G[v])})
+	d.G[v] = append(d.G[v], Edge{to: u, cap: 0, rev: len(d.G[u]) - 1})
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func (d *Dinic) bfs(s int) {
+	for i := range d.level {
+		d.level[i] = -1
+	}
+	q := make([]int, 0, d.N)
+	d.level[s] = 0
+	q = append(q, s)
+	for i := 0; i < len(q); i++ {
+		v := q[i]
+		for _, e := range d.G[v] {
+			if e.cap > 0 && d.level[e.to] < 0 {
+				d.level[e.to] = d.level[v] + 1
+				q = append(q, e.to)
+			}
+		}
+	}
+}
+
+func (d *Dinic) dfs(v, t, f int) int {
+	if v == t {
+		return f
+	}
+	for ; d.iter[v] < len(d.G[v]); d.iter[v]++ {
+		e := &d.G[v][d.iter[v]]
+		if e.cap > 0 && d.level[v] < d.level[e.to] {
+			ret := d.dfs(e.to, t, min(f, e.cap))
+			if ret > 0 {
+				e.cap -= ret
+				d.G[e.to][e.rev].cap += ret
+				return ret
+			}
+		}
+	}
+	return 0
+}
+
+func (d *Dinic) MaxFlow(s, t int) int {
+	flow := 0
+	const INF = int(1e9)
+	for {
+		d.bfs(s)
+		if d.level[t] < 0 {
+			break
+		}
+		for i := range d.iter {
+			d.iter[i] = 0
+		}
+		for {
+			f := d.dfs(s, t, INF)
+			if f == 0 {
+				break
+			}
+			flow += f
+		}
+	}
+	return flow
+}
+
+func solveCase(n, m int, A, B []int, edges [][2]int) (bool, [][]int) {
+	sumA := 0
+	sumB := 0
+	for i := 0; i < n; i++ {
+		sumA += A[i]
+		sumB += B[i]
+	}
+	if sumA != sumB {
+		return false, nil
+	}
+	s := 0
+	t := 2*n + 1
+	d := NewDinic(2*n + 2)
+	for i := 0; i < n; i++ {
+		d.AddEdge(s, i+1, A[i])
+		d.AddEdge(i+1, i+1+n, A[i])
+		d.AddEdge(i+1+n, t, B[i])
+	}
+	const INF = int(1e9)
+	for _, e := range edges {
+		x, y := e[0], e[1]
+		d.AddEdge(x, y+n, INF)
+		d.AddEdge(y, x+n, INF)
+	}
+	if d.MaxFlow(s, t) != sumA {
+		return false, nil
+	}
+	ans := make([][]int, n)
+	for i := range ans {
+		ans[i] = make([]int, n)
+	}
+	for u := 1; u <= n; u++ {
+		for _, e := range d.G[u] {
+			if e.to >= n+1 && e.to <= n+n {
+				j := e.to - (n + 1)
+				revCap := d.G[e.to][e.rev].cap
+				ans[u-1][j] = revCap
+			}
+		}
+	}
+	return true, ans
+}
+
+func generateCase(rng *rand.Rand) (string, bool, []int, []int, map[[2]int]struct{}) {
+	n := rng.Intn(5) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	edgeSet := make(map[[2]int]struct{})
+	for len(edgeSet) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		edgeSet[[2]int{u, v}] = struct{}{}
+	}
+	edges := make([][2]int, 0, len(edgeSet))
+	for e := range edgeSet {
+		edges = append(edges, e)
+	}
+	A := make([]int, n)
+	B := make([]int, n)
+	for i := 0; i < n; i++ {
+		A[i] = rng.Intn(5)
+		B[i] = rng.Intn(5)
+	}
+	if rng.Intn(2) == 0 {
+		sumA, sumB := 0, 0
+		for _, v := range A {
+			sumA += v
+		}
+		for _, v := range B {
+			sumB += v
+		}
+		diff := sumA - sumB
+		B[n-1] += diff
+		if B[n-1] < 0 {
+			B[n-1] = 0
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for i, v := range A {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range B {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	input := sb.String()
+	ok, _ := solveCase(n, len(edges), A, B, edges)
+	return input, ok, A, B, edgeSet
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func checkOutput(out string, n int, A, B []int, edges map[[2]int]struct{}, expectOK bool) error {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) == 0 {
+		return fmt.Errorf("empty output")
+	}
+	first := strings.TrimSpace(lines[0])
+	if first == "NO" {
+		if expectOK {
+			return fmt.Errorf("expected YES got NO")
+		}
+		if len(lines) != 1 {
+			return fmt.Errorf("extra output after NO")
+		}
+		return nil
+	}
+	if first != "YES" {
+		return fmt.Errorf("first line must be YES or NO")
+	}
+	if !expectOK {
+		return fmt.Errorf("expected NO got YES")
+	}
+	if len(lines) != n+1 {
+		return fmt.Errorf("expected %d lines, got %d", n+1, len(lines))
+	}
+	matrix := make([][]int, n)
+	for i := 0; i < n; i++ {
+		parts := strings.Fields(lines[i+1])
+		if len(parts) != n {
+			return fmt.Errorf("line %d should have %d numbers", i+1, n)
+		}
+		row := make([]int, n)
+		for j, p := range parts {
+			val, err := strconv.Atoi(p)
+			if err != nil || val < 0 {
+				return fmt.Errorf("invalid number at (%d,%d)", i+1, j+1)
+			}
+			row[j] = val
+		}
+		matrix[i] = row
+	}
+	for i := 0; i < n; i++ {
+		sumOut := 0
+		sumIn := 0
+		for j := 0; j < n; j++ {
+			sumOut += matrix[i][j]
+			sumIn += matrix[j][i]
+			if i != j && matrix[i][j] > 0 {
+				p := [2]int{i + 1, j + 1}
+				if p[0] > p[1] {
+					p[0], p[1] = p[1], p[0]
+				}
+				if _, ok := edges[p]; !ok {
+					return fmt.Errorf("edge %d-%d not allowed", i+1, j+1)
+				}
+			}
+		}
+		if sumOut != A[i] {
+			return fmt.Errorf("out sum mismatch for city %d", i+1)
+		}
+		if sumIn != B[i] {
+			return fmt.Errorf("in sum mismatch for city %d", i+1)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, ok, A, B, edges := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if err := checkOutput(out, len(A), A, B, edges, ok); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to run 100 random tests for Soldier and Bananas
- add verifierB.go for badge increments
- add verifierC.go for the card game simulator
- add verifierD.go for bigOmega queries
- add verifierE.go with max-flow solver and output validator

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68832beb530c8324ae147730243f4e89