### PR TITLE
Add verifiers for contest 550

### DIFF
--- a/0-999/500-599/550-559/550/verifierA.go
+++ b/0-999/500-599/550-559/550/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func containsNonOverlap(s, p1, p2 string) bool {
+	n := len(s)
+	for i := 0; i+len(p1) <= n; i++ {
+		if s[i:i+len(p1)] == p1 {
+			for j := i + len(p1); j+len(p2) <= n; j++ {
+				if s[j:j+len(p2)] == p2 {
+					return true
+				}
+			}
+			break
+		}
+	}
+	return false
+}
+
+func expected(s string) string {
+	if containsNonOverlap(s, "AB", "BA") || containsNonOverlap(s, "BA", "AB") {
+		return "YES"
+	}
+	return "NO"
+}
+
+func randString(rng *rand.Rand, n int) string {
+	letters := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	s := randString(rng, n)
+	input := s + "\n"
+	exp := expected(s)
+	return input, exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/550/verifierB.go
+++ b/0-999/500-599/550-559/550/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, l, r, x int, c []int) string {
+	count := 0
+	for mask := 0; mask < (1 << n); mask++ {
+		if bitsOnes(mask) < 2 {
+			continue
+		}
+		sum := 0
+		minv := 1<<31 - 1
+		maxv := 0
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) != 0 {
+				v := c[i]
+				sum += v
+				if v < minv {
+					minv = v
+				}
+				if v > maxv {
+					maxv = v
+				}
+			}
+		}
+		if sum >= l && sum <= r && maxv-minv >= x {
+			count++
+		}
+	}
+	return fmt.Sprintf("%d", count)
+}
+
+func bitsOnes(x int) int {
+	c := 0
+	for x > 0 {
+		c += x & 1
+		x >>= 1
+	}
+	return c
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	l := rng.Intn(50)
+	r := l + rng.Intn(50) + 1
+	x := rng.Intn(20) + 1
+	c := make([]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", n, l, r, x)
+	for i := 0; i < n; i++ {
+		c[i] = rng.Intn(40) + 1
+		fmt.Fprintf(&sb, "%d ", c[i])
+	}
+	sb.WriteString("\n")
+	input := sb.String()
+	exp := expected(n, l, r, x, c)
+	return input, exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/550/verifierC.go
+++ b/0-999/500-599/550-559/550/verifierC.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(s string) string {
+	for i := 0; i < 1000; i += 8 {
+		cand := strconv.Itoa(i)
+		k := 0
+		for j := 0; j < len(s) && k < len(cand); j++ {
+			if s[j] == cand[k] {
+				k++
+			}
+		}
+		if k == len(cand) {
+			return fmt.Sprintf("YES\n%s", cand)
+		}
+	}
+	return "NO"
+}
+
+func randDigits(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('0' + rng.Intn(10))
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(18) + 1
+	s := randDigits(rng, n)
+	input := s + "\n"
+	exp := expected(s)
+	return input, exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/550/verifierD.go
+++ b/0-999/500-599/550-559/550/verifierD.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(k int) string {
+	if k%2 == 0 {
+		return "NO"
+	}
+	n := 4*k - 2
+	m := 2*((k-1)+(k-1)*(k-1)+((k-1)/2)) + 1
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	goFunc := func(start, limit, n int) {
+		for i := start; i < limit; i += 2 {
+			fmt.Fprintf(&sb, "%d %d\n", i, i+1)
+			for j := 0; j < n-1; j++ {
+				fmt.Fprintf(&sb, "%d %d\n", i, limit+j)
+				fmt.Fprintf(&sb, "%d %d\n", i+1, limit+j)
+			}
+		}
+		for i := limit; i < limit+n-1; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", i, limit+n-1)
+		}
+	}
+	goFunc(1, k, k)
+	goFunc(2*k, 3*k-1, k)
+	fmt.Fprintf(&sb, "%d %d\n", 2*k-1, 4*k-2)
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	k := rng.Intn(10) + 1
+	input := fmt.Sprintf("%d\n", k)
+	exp := expected(k)
+	return input, exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/550/verifierE.go
+++ b/0-999/500-599/550-559/550/verifierE.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(a []int) string {
+	n := len(a)
+	if a[n-1] != 0 {
+		return "NO"
+	}
+	flag := -1
+	for i := 0; i < n-1; i++ {
+		if a[i] == 0 {
+			flag = i
+			break
+		}
+	}
+	if flag == n-2 {
+		return "NO"
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	if flag >= 0 {
+		if flag > 0 {
+			sb.WriteString("(")
+			for i := 0; i < flag-1; i++ {
+				fmt.Fprintf(&sb, "%d->", a[i])
+			}
+			fmt.Fprintf(&sb, "%d)->", a[flag-1])
+		}
+		sb.WriteString("(0)->(")
+		for i := flag + 1; i < n-1; i++ {
+			fmt.Fprintf(&sb, "%d->", a[i])
+		}
+		fmt.Fprintf(&sb, "%d)", a[n-2])
+		sb.WriteString("->0")
+	} else {
+		for i := 0; i < n-1; i++ {
+			fmt.Fprintf(&sb, "%d->", a[i])
+		}
+		sb.WriteString("0")
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(2)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteString("\n")
+	input := sb.String()
+	exp := expected(a)
+	return input, exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 550 problems A–E

## Testing
- `go run verifierA.go ./550A`
- `go run verifierB.go ./550B`
- `go run verifierC.go ./550C`
- `go run verifierD.go ./550D`
- `go run verifierE.go ./550E`

------
https://chatgpt.com/codex/tasks/task_e_68832e1cbb288324b2507dba60b20e3c