### PR TITLE
Add Go verifiers for CF contest 552

### DIFF
--- a/0-999/500-599/550-559/552/verifierA.go
+++ b/0-999/500-599/550-559/552/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n     int
+	rects [][4]int
+}
+
+func expected(t Test) int {
+	total := 0
+	for _, r := range t.rects {
+		width := r[2] - r[0] + 1
+		height := r[3] - r[1] + 1
+		total += width * height
+	}
+	return total
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1
+	rects := make([][4]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		x1 := rng.Intn(100) + 1
+		x2 := rng.Intn(100) + 1
+		if x1 > x2 {
+			x1, x2 = x2, x1
+		}
+		y1 := rng.Intn(100) + 1
+		y2 := rng.Intn(100) + 1
+		if y1 > y2 {
+			y1, y2 = y2, y1
+		}
+		rects[i] = [4]int{x1, y1, x2, y2}
+		fmt.Fprintf(&sb, "%d %d %d %d\n", x1, y1, x2, y2)
+	}
+	return sb.String(), expected(Test{n, rects})
+}
+
+func runCase(bin, input string, exp int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/552/verifierB.go
+++ b/0-999/500-599/550-559/552/verifierB.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int64) int64 {
+	var ans int64
+	var digit int64 = 1
+	var start int64 = 1
+	for start*10 <= n {
+		ans += (start*10 - start) * digit
+		digit++
+		start *= 10
+	}
+	ans += (n - start + 1) * digit
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000) + 1
+	exp := expected(n)
+	input := fmt.Sprintf("%d\n", n)
+	return input, fmt.Sprintf("%d", exp)
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/552/verifierC.go
+++ b/0-999/500-599/550-559/552/verifierC.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(w, m int64) string {
+	for m > 0 {
+		r := m % w
+		if r == 0 || r == 1 {
+			m /= w
+		} else if r == w-1 {
+			m = m/w + 1
+		} else {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	w := rng.Int63n(1_000_000_000-1) + 2
+	m := rng.Int63n(1_000_000_000) + 1
+	exp := expected(w, m)
+	input := fmt.Sprintf("%d %d\n", w, m)
+	return input, exp
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/552/verifierD.go
+++ b/0-999/500-599/550-559/552/verifierD.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Point struct{ x, y int }
+
+func gcd(a, b int) int {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		a = -a
+	}
+	return a
+}
+
+func expected(points []Point) int64 {
+	n := len(points)
+	if n < 3 {
+		return 0
+	}
+	total := int64(n) * int64(n-1) * int64(n-2) / 6
+	var deg int64
+	for i := 0; i < n; i++ {
+		mp := make(map[[2]int]int)
+		xi, yi := points[i].x, points[i].y
+		for j := 0; j < n; j++ {
+			if i == j {
+				continue
+			}
+			dx := points[j].x - xi
+			dy := points[j].y - yi
+			g := gcd(dx, dy)
+			dx /= g
+			dy /= g
+			if dx < 0 || (dx == 0 && dy < 0) {
+				dx = -dx
+				dy = -dy
+			}
+			mp[[2]int{dx, dy}]++
+		}
+		for _, c := range mp {
+			if c >= 2 {
+				deg += int64(c * (c - 1) / 2)
+			}
+		}
+	}
+	deg /= 3
+	return total - deg
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	pts := make([]Point, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		x := rng.Intn(201) - 100
+		y := rng.Intn(201) - 100
+		pts[i] = Point{x, y}
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	exp := expected(pts)
+	return sb.String(), fmt.Sprintf("%d", exp)
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/552/verifierE.go
+++ b/0-999/500-599/550-559/552/verifierE.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func evalExpr(digits []*big.Int, ops []byte) *big.Int {
+	if len(digits) == 0 {
+		return big.NewInt(0)
+	}
+	cur := new(big.Int).Set(digits[0])
+	res := big.NewInt(0)
+	for i, op := range ops {
+		if op == '+' {
+			res.Add(res, cur)
+			cur = new(big.Int).Set(digits[i+1])
+		} else {
+			cur.Mul(cur, digits[i+1])
+		}
+	}
+	res.Add(res, cur)
+	return res
+}
+
+func evalWithParen(digits []*big.Int, ops []byte, l, r int) *big.Int {
+	mid := evalExpr(digits[l:r+1], ops[l:r])
+	newDigits := make([]*big.Int, 0, len(digits)-(r-l))
+	newDigits = append(newDigits, digits[:l]...)
+	newDigits = append(newDigits, mid)
+	if r+1 < len(digits) {
+		newDigits = append(newDigits, digits[r+1:]...)
+	}
+	newOps := make([]byte, 0, len(ops)-(r-l))
+	newOps = append(newOps, ops[:l]...)
+	if r < len(ops) {
+		newOps = append(newOps, ops[r])
+		if r+1 < len(ops) {
+			newOps = append(newOps, ops[r+1:]...)
+		}
+	}
+	return evalExpr(newDigits, newOps)
+}
+
+func expected(expr string) string {
+	n := (len(expr) + 1) / 2
+	digits := make([]*big.Int, n)
+	ops := make([]byte, 0, n-1)
+	for i := 0; i < len(expr); i++ {
+		if i%2 == 0 {
+			digits[i/2] = big.NewInt(int64(expr[i] - '0'))
+		} else {
+			ops = append(ops, expr[i])
+		}
+	}
+	starts := []int{0}
+	ends := []int{n - 1}
+	for i, op := range ops {
+		if op == '*' {
+			starts = append(starts, i+1)
+			ends = append(ends, i)
+		}
+	}
+	maxVal := big.NewInt(0)
+	for _, l := range starts {
+		for _, r := range ends {
+			if l > r {
+				continue
+			}
+			val := evalWithParen(digits, ops, l, r)
+			if val.Cmp(maxVal) > 0 {
+				maxVal = val
+			}
+		}
+	}
+	return maxVal.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	digitsCount := rng.Intn(9) + 1
+	var sb strings.Builder
+	starCnt := 0
+	for i := 0; i < digitsCount; i++ {
+		if i > 0 {
+			var op byte
+			if starCnt >= 15 {
+				op = '+'
+			} else {
+				if rng.Intn(2) == 0 {
+					op = '+'
+				} else {
+					op = '*'
+					starCnt++
+				}
+			}
+			sb.WriteByte(op)
+		}
+		sb.WriteByte(byte(rng.Intn(9) + '1'))
+	}
+	expr := sb.String()
+	return expr + "\n", expected(expr)
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers `verifierA.go` to `verifierE.go` for contest 552
- each verifier runs 100 randomized test cases against a provided binary
- verifiers compute expected results using reference algorithms

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_68832f33e4d483248af5e58ea7657edf