### PR TITLE
Add Go solution for problem 1942A

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1942/1942A.go
+++ b/1000-1999/1900-1999/1940-1949/1942/1942A.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(in, &n, &k)
+		if k == n {
+			for i := 0; i < n; i++ {
+				if i > 0 {
+					fmt.Fprint(out, " ")
+				}
+				fmt.Fprint(out, 1)
+			}
+			fmt.Fprintln(out)
+			continue
+		}
+		if k == 1 {
+			for i := 1; i <= n; i++ {
+				if i > 1 {
+					fmt.Fprint(out, " ")
+				}
+				fmt.Fprint(out, i)
+			}
+			fmt.Fprintln(out)
+			continue
+		}
+		fmt.Fprintln(out, -1)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1942A.go` with direct logic to construct an array with exactly `k` sorted cyclic shifts

## Testing
- `gofmt -w 1000-1999/1900-1999/1940-1949/1942/1942A.go`
- `go build 1000-1999/1900-1999/1940-1949/1942/1942A.go`
- `go vet 1000-1999/1900-1999/1940-1949/1942/1942A.go`


------
https://chatgpt.com/codex/tasks/task_e_688331aaf7b4832493e6a4e90467b34f