### PR TITLE
Add Go solution for 1945D

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1945/1945D.go
+++ b/1000-1999/1900-1999/1940-1949/1945/1945D.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var (
+	in  = bufio.NewReader(os.Stdin)
+	out = bufio.NewWriter(os.Stdout)
+)
+
+func main() {
+	defer out.Flush()
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		solve()
+	}
+}
+
+func solve() {
+	var n, m int
+	fmt.Fscan(in, &n, &m)
+	a := make([]int64, n+1)
+	b := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(in, &b[i])
+	}
+	pref := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		pref[i] = pref[i-1] + b[i]
+	}
+
+	dp := make([]int64, n+2)
+	best := pref[n] // dp[n+1] = 0
+	for j := n; j >= 1; j-- {
+		dp[j] = a[j] - pref[j] + best
+		if v := dp[j] + pref[j-1]; v < best {
+			best = v
+		}
+	}
+	ans := dp[1]
+	for i := 1; i <= m; i++ {
+		if dp[i] < ans {
+			ans = dp[i]
+		}
+	}
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- implement solution for problem D in Go
- compute minimal bribery cost using DP and prefix sums

## Testing
- `go build 1000-1999/1900-1999/1940-1949/1945/1945D.go`


------
https://chatgpt.com/codex/tasks/task_e_6883323676ac8324ad78da5b9751418b