### PR TITLE
Add solution verifiers for contest 559

### DIFF
--- a/0-999/500-599/550-559/559/verifierA.go
+++ b/0-999/500-599/550-559/559/verifierA.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	a [6]int
+}
+
+func solveCase(a [6]int) int {
+	s := a[0] + a[1] + a[2]
+	return s*s - a[0]*a[0] - a[2]*a[2] - a[4]*a[4]
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	exp := solveCase(tc.a)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	cases := make([]testCase, 100)
+	for i := range cases {
+		for j := 0; j < 6; j++ {
+			cases[i].a[j] = rand.Intn(1000) + 1
+		}
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/559/verifierB.go
+++ b/0-999/500-599/550-559/559/verifierB.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	a, b string
+}
+
+func canonical(s string) string {
+	if len(s)%2 == 1 {
+		return s
+	}
+	mid := len(s) / 2
+	left := canonical(s[:mid])
+	right := canonical(s[mid:])
+	if left < right {
+		return left + right
+	}
+	return right + left
+}
+
+func solveCase(a, b string) string {
+	if canonical(a) == canonical(b) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runCase(bin string, tc testCase) error {
+	input := tc.a + "\n" + tc.b + "\n"
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCase(tc.a, tc.b)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(2)
+	cases := make([]testCase, 100)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	for i := range cases {
+		n := rand.Intn(20) + 1
+		var sb1, sb2 strings.Builder
+		for j := 0; j < n; j++ {
+			sb1.WriteRune(letters[rand.Intn(len(letters))])
+			sb2.WriteRune(letters[rand.Intn(len(letters))])
+		}
+		cases[i] = testCase{sb1.String(), sb2.String()}
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/559/verifierC.go
+++ b/0-999/500-599/550-559/559/verifierC.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type Point struct{ x, y int }
+
+type testCase struct {
+	h, w  int
+	cells []Point
+}
+
+const mod int64 = 1000000007
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func comb(n, k int, fact, invFact []int64) int64 {
+	if k < 0 || k > n {
+		return 0
+	}
+	return fact[n] * invFact[k] % mod * invFact[n-k] % mod
+}
+
+func solveCase(h, w int, cells []Point) int64 {
+	n := len(cells)
+	pts := append([]Point(nil), cells...)
+	pts = append(pts, Point{h, w})
+	sort.Slice(pts, func(i, j int) bool {
+		if pts[i].x == pts[j].x {
+			return pts[i].y < pts[j].y
+		}
+		return pts[i].x < pts[j].x
+	})
+	maxN := h + w
+	fact := make([]int64, maxN+1)
+	invFact := make([]int64, maxN+1)
+	fact[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invFact[maxN] = modPow(fact[maxN], mod-2)
+	for i := maxN; i > 0; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % mod
+	}
+	dp := make([]int64, n+1)
+	for i := 0; i <= n; i++ {
+		p := pts[i]
+		dp[i] = comb(p.x+p.y-2, p.x-1, fact, invFact)
+		for j := 0; j < i; j++ {
+			q := pts[j]
+			if q.x <= p.x && q.y <= p.y {
+				ways := dp[j] * comb(p.x-q.x+p.y-q.y, p.x-q.x, fact, invFact) % mod
+				dp[i] = (dp[i] - ways + mod) % mod
+			}
+		}
+	}
+	return dp[n]
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", tc.h, tc.w, len(tc.cells))
+	for _, c := range tc.cells {
+		fmt.Fprintf(&sb, "%d %d\n", c.x, c.y)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	exp := solveCase(tc.h, tc.w, tc.cells)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	cases := make([]testCase, 100)
+	for i := range cases {
+		h := rand.Intn(10) + 2
+		w := rand.Intn(10) + 2
+		n := rand.Intn(5)
+		mp := make(map[Point]bool)
+		for len(mp) < n {
+			p := Point{rand.Intn(h) + 1, rand.Intn(w) + 1}
+			if p.x == h && p.y == w {
+				continue
+			}
+			if p.x == 1 && p.y == 1 {
+				continue
+			}
+			mp[p] = true
+		}
+		cells := make([]Point, 0, len(mp))
+		for p := range mp {
+			cells = append(cells, p)
+		}
+		cases[i] = testCase{h, w, cells}
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/559/verifierD.go
+++ b/0-999/500-599/550-559/559/verifierD.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	magic = 49
+	D     = 105
+)
+
+type Point struct{ x, y int }
+
+type testCase struct{ pts []Point }
+
+var half [D]float64
+var two [D]float64
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveCase(p []Point) float64 {
+	n := len(p)
+	half[0], two[0] = 1.0, 1.0
+	for i := 1; i < D; i++ {
+		half[i] = half[i-1] / 2.0
+		two[i] = two[i-1] * 2.0
+	}
+	area, border := 0.0, 0.0
+	var z float64
+	if n <= 50 {
+		z = two[n] - 1.0 - float64(n) - float64(n*(n-1)/2)
+	}
+	for i := 0; i < n; i++ {
+		for j0 := i + 1; j0 <= min(i+n-2, i+magic); j0++ {
+			var now float64
+			if n > 50 {
+				now = half[j0-i+1]
+			} else {
+				now = two[n-(j0-i+1)] - 1.0
+				now = now / z
+			}
+			jj := j0 % n
+			dx := p[i].x - p[jj].x
+			if dx < 0 {
+				dx = -dx
+			}
+			dy := p[i].y - p[jj].y
+			if dy < 0 {
+				dy = -dy
+			}
+			line := gcd(dx, dy)
+			border += float64(line) * now
+			cross := float64(p[i].x)*float64(p[jj].y) - float64(p[i].y)*float64(p[jj].x)
+			area += 0.5 * now * cross
+		}
+	}
+	return area - border/2.0 + 1.0
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(tc.pts))
+	for _, pt := range tc.pts {
+		fmt.Fprintf(&sb, "%d %d\n", pt.x, pt.y)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	exp := solveCase(tc.pts)
+	if math.Abs(got-exp) > 1e-6 {
+		return fmt.Errorf("expected %.6f got %.6f", exp, got)
+	}
+	return nil
+}
+
+func genPolygon(n, r, ox, oy int) []Point {
+	pts := make([]Point, n)
+	for i := 0; i < n; i++ {
+		angle := 2 * math.Pi * float64(i) / float64(n)
+		x := ox + int(math.Round(float64(r)*math.Cos(angle)))
+		y := oy + int(math.Round(float64(r)*math.Sin(angle)))
+		pts[i] = Point{x, y}
+	}
+	return pts
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(4)
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rand.Intn(5) + 3
+		r := rand.Intn(20) + 5
+		ox := rand.Intn(20) - 10
+		oy := rand.Intn(20) - 10
+		cases[i] = testCase{genPolygon(n, r, ox, oy)}
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/559/verifierE.go
+++ b/0-999/500-599/550-559/559/verifierE.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type interval struct{ l, r int }
+
+type light struct{ a, l int }
+
+type testCase struct{ lights []light }
+
+func addInterval(ints []interval, iv interval) []interval {
+	n := len(ints)
+	pos := sort.Search(n, func(i int) bool { return ints[i].l >= iv.l })
+	ints = append(ints, interval{})
+	copy(ints[pos+1:], ints[pos:])
+	ints[pos] = iv
+
+	res := make([]interval, 0, len(ints))
+	for _, it := range ints {
+		if len(res) == 0 || res[len(res)-1].r < it.l {
+			res = append(res, it)
+		} else if res[len(res)-1].r < it.r {
+			res[len(res)-1].r = it.r
+		}
+	}
+	return res
+}
+
+func length(ints []interval) int {
+	sum := 0
+	for _, it := range ints {
+		sum += it.r - it.l
+	}
+	return sum
+}
+
+func copyIntervals(ints []interval) []interval {
+	res := make([]interval, len(ints))
+	copy(res, ints)
+	return res
+}
+
+func solveCase(lights []light) int {
+	sort.Slice(lights, func(i, j int) bool { return lights[i].a < lights[j].a })
+	intervals := []interval{}
+	for _, lt := range lights {
+		north := interval{lt.a, lt.a + lt.l}
+		south := interval{lt.a - lt.l, lt.a}
+		intsNorth := addInterval(copyIntervals(intervals), north)
+		lenNorth := length(intsNorth)
+		intsSouth := addInterval(copyIntervals(intervals), south)
+		lenSouth := length(intsSouth)
+		if lenNorth >= lenSouth {
+			intervals = intsNorth
+		} else {
+			intervals = intsSouth
+		}
+	}
+	return length(intervals)
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(tc.lights))
+	for _, lt := range tc.lights {
+		fmt.Fprintf(&sb, "%d %d\n", lt.a, lt.l)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	exp := solveCase(tc.lights)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	cases := make([]testCase, 100)
+	for i := range cases {
+		n := rand.Intn(10) + 1
+		ls := make([]light, n)
+		for j := range ls {
+			ls[j] = light{rand.Intn(100), rand.Intn(20) + 1}
+		}
+		cases[i] = testCase{ls}
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for hexagon triangles problem
- add verifierB.go for string equivalence
- add verifierC.go for grid paths with obstacles
- add verifierD.go for randomizer polygon expectation
- add verifierE.go for spotlight coverage

## Testing
- `go run 0-999/500-599/550-559/559/verifierA.go ./559A`
- `go run 0-999/500-599/550-559/559/verifierB.go ./559B`
- `go run 0-999/500-599/550-559/559/verifierC.go ./559C`
- `go run 0-999/500-599/550-559/559/verifierD.go ./559D`
- `go run 0-999/500-599/550-559/559/verifierE.go ./559E`


------
https://chatgpt.com/codex/tasks/task_e_68833308a1308324a21f9dcd3d386afe