### PR TITLE
Add Go verifiers for contest 558

### DIFF
--- a/0-999/500-599/550-559/558/verifierA.go
+++ b/0-999/500-599/550-559/558/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func expectedAnswer(n int, trees [][2]int) int {
+	left := make([][2]int, 0, n)
+	right := make([][2]int, 0, n)
+	for _, t := range trees {
+		if t[0] < 0 {
+			left = append(left, t)
+		} else {
+			right = append(right, t)
+		}
+	}
+	sort.Slice(left, func(i, j int) bool { return left[i][0] > left[j][0] })
+	sort.Slice(right, func(i, j int) bool { return right[i][0] < right[j][0] })
+	k := len(left)
+	if len(right) < k {
+		k = len(right)
+	}
+	sum := 0
+	for i := 0; i < k; i++ {
+		sum += left[i][1] + right[i][1]
+	}
+	if len(left) > len(right) && len(left) > k {
+		sum += left[k][1]
+	} else if len(right) > len(left) && len(right) > k {
+		sum += right[k][1]
+	}
+	return sum
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	trees := make([][2]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := rng.Intn(201) - 100
+		if x == 0 {
+			x = 1
+		}
+		a := rng.Intn(100) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, a))
+		trees[i] = [2]int{x, a}
+	}
+	expect := expectedAnswer(n, trees)
+	return testCase{input: sb.String(), expected: fmt.Sprint(expect)}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/558/verifierB.go
+++ b/0-999/500-599/550-559/558/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type pair struct {
+	v   int
+	idx int
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func expectedAnswer(a []int) (int, int) {
+	n := len(a)
+	arr := make([]pair, n)
+	for i, v := range a {
+		arr[i] = pair{v, i}
+	}
+	sort.Slice(arr, func(i, j int) bool {
+		if arr[i].v != arr[j].v {
+			return arr[i].v < arr[j].v
+		}
+		return arr[i].idx < arr[j].idx
+	})
+	maxCount := 1
+	retL, retR := 0, 0
+	l := 0
+	r := 0
+	for r < n {
+		if arr[l].v == arr[r].v {
+			r++
+		} else {
+			count := r - l
+			if count > maxCount || (count == maxCount && arr[r-1].idx-arr[l].idx < arr[retR].idx-arr[retL].idx) {
+				maxCount = count
+				retL = l
+				retR = r - 1
+			}
+			l = r
+		}
+	}
+	if r-l > maxCount || (r-l == maxCount && arr[r-1].idx-arr[l].idx < arr[retR].idx-arr[retL].idx) {
+		retL = l
+		retR = r - 1
+	}
+	return arr[retL].idx + 1, arr[retR].idx + 1
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(20) + 1
+		sb.WriteString(fmt.Sprintf("%d ", arr[i]))
+	}
+	sb.WriteString("\n")
+	l, r := expectedAnswer(arr)
+	return testCase{input: sb.String(), expected: fmt.Sprintf("%d %d", l, r)}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/558/verifierC.go
+++ b/0-999/500-599/550-559/558/verifierC.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const maxVal = 200000
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func expectedAnswer(a []int) int {
+	dist := make([]int, maxVal+1)
+	cnt := make([]int, maxVal+1)
+	for _, v := range a {
+		visited := make(map[int]bool)
+		val := v
+		j := 0
+		for val > 0 {
+			x := val
+			k := 0
+			for x <= maxVal {
+				if !visited[x] {
+					dist[x] += j + k
+					cnt[x]++
+					visited[x] = true
+				}
+				x <<= 1
+				k++
+			}
+			val >>= 1
+			j++
+		}
+		if !visited[0] {
+			dist[0] += j
+			cnt[0]++
+		}
+	}
+	ans := int(^uint(0) >> 1)
+	n := len(a)
+	for x := 0; x <= maxVal; x++ {
+		if cnt[x] == n && dist[x] < ans {
+			ans = dist[x]
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(1000) + 1
+		sb.WriteString(fmt.Sprintf("%d ", arr[i]))
+	}
+	sb.WriteString("\n")
+	expect := expectedAnswer(arr)
+	return testCase{input: sb.String(), expected: fmt.Sprint(expect)}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/558/verifierD.go
+++ b/0-999/500-599/550-559/558/verifierD.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type interval struct {
+	l, r int64
+}
+
+func intersect(arr []interval, seg interval) []interval {
+	res := make([]interval, 0, len(arr))
+	for _, in := range arr {
+		l := in.l
+		if seg.l > l {
+			l = seg.l
+		}
+		r := in.r
+		if seg.r < r {
+			r = seg.r
+		}
+		if l <= r {
+			res = append(res, interval{l, r})
+		}
+	}
+	return res
+}
+
+func subtract(arr []interval, seg interval) []interval {
+	res := make([]interval, 0, len(arr)+1)
+	for _, in := range arr {
+		if seg.r < in.l || seg.l > in.r {
+			res = append(res, in)
+			continue
+		}
+		if seg.l > in.l {
+			res = append(res, interval{in.l, seg.l - 1})
+		}
+		if seg.r < in.r {
+			res = append(res, interval{seg.r + 1, in.r})
+		}
+	}
+	return res
+}
+
+func expectedAnswer(h int, queries [][4]int64) string {
+	allowed := []interval{{1 << (h - 1), (1 << h) - 1}}
+	for _, q := range queries {
+		i := q[0]
+		L := q[1]
+		R := q[2]
+		ans := q[3]
+		shift := uint(h - int(i))
+		seg := interval{L << shift, ((R + 1) << shift) - 1}
+		if ans == 1 {
+			allowed = intersect(allowed, seg)
+		} else {
+			allowed = subtract(allowed, seg)
+		}
+	}
+	if len(allowed) == 0 {
+		return "Game cheated!"
+	}
+	if len(allowed) == 1 && allowed[0].l == allowed[0].r {
+		return fmt.Sprint(allowed[0].l)
+	}
+	count := 0
+	var val int64
+	for _, in := range allowed {
+		if in.l == in.r {
+			count++
+			val = in.l
+		} else {
+			return "Data not sufficient!"
+		}
+	}
+	if count == 1 {
+		return fmt.Sprint(val)
+	}
+	return "Data not sufficient!"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	h := rng.Intn(10) + 1
+	q := rng.Intn(10)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", h, q))
+	queries := make([][4]int64, q)
+	for i := 0; i < q; i++ {
+		level := rng.Intn(h) + 1
+		L := int64(rng.Intn(1<<level-1) + (1 << (level - 1)))
+		R := int64(rng.Intn(int((1<<level)-1-int(L)+1)) + int(L))
+		ans := rng.Intn(2)
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", level, L, R, ans))
+		queries[i] = [4]int64{int64(level), L, R, int64(ans)}
+	}
+	expected := expectedAnswer(h, queries)
+	return sb.String(), expected
+}
+
+func runCase(bin string, tcInput, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tcInput)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(bin, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/550-559/558/verifierE.go
+++ b/0-999/500-599/550-559/558/verifierE.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const alpha = 26
+
+var trees [alpha][]int
+var lazy [alpha][]int
+
+func push(c, node, l, r int) {
+	if lazy[c][node] != -1 {
+		val := lazy[c][node]
+		trees[c][node] = (r - l + 1) * val
+		if l != r {
+			lazy[c][node*2] = val
+			lazy[c][node*2+1] = val
+		}
+		lazy[c][node] = -1
+	}
+}
+
+func update(c, node, l, r, ql, qr, val int) {
+	push(c, node, l, r)
+	if ql > r || qr < l {
+		return
+	}
+	if ql <= l && r <= qr {
+		lazy[c][node] = val
+		push(c, node, l, r)
+		return
+	}
+	mid := (l + r) / 2
+	update(c, node*2, l, mid, ql, qr, val)
+	update(c, node*2+1, mid+1, r, ql, qr, val)
+	trees[c][node] = trees[c][node*2] + trees[c][node*2+1]
+}
+
+func query(c, node, l, r, ql, qr int) int {
+	push(c, node, l, r)
+	if ql > r || qr < l {
+		return 0
+	}
+	if ql <= l && r <= qr {
+		return trees[c][node]
+	}
+	mid := (l + r) / 2
+	return query(c, node*2, l, mid, ql, qr) + query(c, node*2+1, mid+1, r, ql, qr)
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func expectedAnswer(n int, s string, queries [][3]int) string {
+	for i := 0; i < alpha; i++ {
+		trees[i] = make([]int, 4*(n+2))
+		lazy[i] = make([]int, 4*(n+2))
+		for j := range lazy[i] {
+			lazy[i][j] = -1
+		}
+	}
+	for i, ch := range s {
+		c := int(ch - 'a')
+		update(c, 1, 1, n, i+1, i+1, 1)
+	}
+	for _, q := range queries {
+		l := q[0]
+		r := q[1]
+		k := q[2]
+		if l > r {
+			l, r = r, l
+		}
+		cnt := make([]int, alpha)
+		for c := 0; c < alpha; c++ {
+			cnt[c] = query(c, 1, 1, n, l, r)
+			if cnt[c] > 0 {
+				update(c, 1, 1, n, l, r, 0)
+			}
+		}
+		idx := l
+		if k == 1 {
+			for c := 0; c < alpha; c++ {
+				if cnt[c] > 0 {
+					update(c, 1, 1, n, idx, idx+cnt[c]-1, 1)
+					idx += cnt[c]
+				}
+			}
+		} else {
+			for c := alpha - 1; c >= 0; c-- {
+				if cnt[c] > 0 {
+					update(c, 1, 1, n, idx, idx+cnt[c]-1, 1)
+					idx += cnt[c]
+				}
+			}
+		}
+	}
+	out := make([]byte, n)
+	for i := 1; i <= n; i++ {
+		for c := 0; c < alpha; c++ {
+			if query(c, 1, 1, n, i, i) > 0 {
+				out[i-1] = byte('a' + c)
+				break
+			}
+		}
+	}
+	return string(out)
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	q := rng.Intn(10)
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	s := string(b)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	sb.WriteString(fmt.Sprintf("%s\n", s))
+	queries := make([][3]int, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n) + 1
+		if l > r {
+			l, r = r, l
+		}
+		k := rng.Intn(2)
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", l, r, k))
+		queries[i] = [3]int{l, r, k}
+	}
+	expect := expectedAnswer(n, s, queries)
+	return testCase{input: sb.String(), expected: expect}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.expected {
+		return fmt.Errorf("expected %s got %s", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new solution verifiers for Codeforces contest 558
- verifiers cover problems A through E with 100 random test cases each

## Testing
- `go build 0-999/500-599/550-559/558/verifierA.go`
- `go build 0-999/500-599/550-559/558/verifierB.go`
- `go build 0-999/500-599/550-559/558/verifierC.go`
- `go build 0-999/500-599/550-559/558/verifierD.go`
- `go build 0-999/500-599/550-559/558/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_6883327c893c8324a642dc31eb08d4f5