### PR TITLE
Add contest 557 verifiers

### DIFF
--- a/0-999/500-599/550-559/557/verifierA.go
+++ b/0-999/500-599/550-559/557/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// solveA implements the logic from 557A.go for a single test case.
+func solveA(n, min1, max1, min2, max2, min3, max3 int) (int, int, int) {
+	if n < 0 {
+		return 0, 0, 0
+	}
+	x1 := max1
+	if t := n - min2 - min3; t < x1 {
+		x1 = t
+	}
+	if x1 < min1 {
+		x1 = min1
+	}
+	remaining := n - x1
+	x2 := max2
+	if t := remaining - min3; t < x2 {
+		x2 = t
+	}
+	if x2 < min2 {
+		x2 = min2
+	}
+	x3 := n - x1 - x2
+	return x1, x2, x3
+}
+
+func genCase() (string, string) {
+	// generate random but small test case fulfilling constraints
+	for {
+		min1 := rand.Intn(10) + 1
+		max1 := min1 + rand.Intn(10)
+		min2 := rand.Intn(10) + 1
+		max2 := min2 + rand.Intn(10)
+		min3 := rand.Intn(10) + 1
+		max3 := min3 + rand.Intn(10)
+		minTotal := min1 + min2 + min3
+		maxTotal := max1 + max2 + max3
+		if minTotal > maxTotal {
+			continue
+		}
+		n := rand.Intn(maxTotal-minTotal+1) + minTotal
+		if n < 3 {
+			continue
+		}
+		x1, x2, x3 := solveA(n, min1, max1, min2, max2, min3, max3)
+		input := fmt.Sprintf("%d\n%d %d\n%d %d\n%d %d\n", n, min1, max1, min2, max2, min3, max3)
+		output := fmt.Sprintf("%d %d %d", x1, x2, x3)
+		return input, output
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input, expected := genCase()
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/550-559/557/verifierB.go
+++ b/0-999/500-599/550-559/557/verifierB.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func solveB(n int, w int64, cups []int64) float64 {
+	sort.Slice(cups, func(i, j int) bool { return cups[i] < cups[j] })
+	a1 := float64(cups[0])
+	mid := float64(cups[n])
+	res := 0.0
+	if a1*2 <= mid {
+		res = a1 * float64(n) * 3
+	} else {
+		res = mid * 1.5 * float64(n)
+	}
+	mw := float64(w)
+	if res > mw {
+		res = mw
+	}
+	return res
+}
+
+func genCase() (string, float64) {
+	n := rand.Intn(5) + 1
+	w := rand.Int63n(1000) + 1
+	cups := make([]int64, 2*n)
+	for i := range cups {
+		cups[i] = rand.Int63n(1000) + 1
+	}
+	res := solveB(n, w, append([]int64(nil), cups...))
+	input := fmt.Sprintf("%d %d\n", n, w)
+	for i, v := range cups {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	return input, res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input, expected := genCase()
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		gotStr := strings.TrimSpace(out.String())
+		var got float64
+		if _, err := fmt.Sscan(gotStr, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: failed to parse output\n", i+1)
+			os.Exit(1)
+		}
+		if math.Abs(got-expected) > 1e-6*math.Max(1.0, math.Abs(expected)) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected: %.7f\ngot: %s\n", i+1, input, expected, gotStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/550-559/557/verifierC.go
+++ b/0-999/500-599/550-559/557/verifierC.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type group struct {
+	length int
+	costs  []int
+}
+
+func sumSmallest(freq []int, k int) int {
+	if k <= 0 {
+		return 0
+	}
+	sum := 0
+	for cost := 1; cost < len(freq) && k > 0; cost++ {
+		if freq[cost] > 0 {
+			take := freq[cost]
+			if take > k {
+				take = k
+			}
+			sum += take * cost
+			k -= take
+		}
+	}
+	return sum
+}
+
+func solveC(n int, legs []struct{ l, d int }) int {
+	sort.Slice(legs, func(i, j int) bool { return legs[i].l < legs[j].l })
+	groups := make([]group, 0)
+	for i := 0; i < n; {
+		j := i
+		for j < n && legs[j].l == legs[i].l {
+			j++
+		}
+		g := group{length: legs[i].l, costs: make([]int, j-i)}
+		for k := i; k < j; k++ {
+			g.costs[k-i] = legs[k].d
+		}
+		groups = append(groups, g)
+		i = j
+	}
+	m := len(groups)
+	suffixCost := make([]int, m+1)
+	for i := m - 1; i >= 0; i-- {
+		sum := 0
+		for _, v := range groups[i].costs {
+			sum += v
+		}
+		suffixCost[i] = suffixCost[i+1] + sum
+	}
+	freq := make([]int, 201)
+	prefixCost := 0
+	countShorter := 0
+	ans := int(^uint(0) >> 1)
+	for idx, g := range groups {
+		sort.Ints(g.costs)
+		c := len(g.costs)
+		prefixGroup := make([]int, c+1)
+		for i := 0; i < c; i++ {
+			prefixGroup[i+1] = prefixGroup[i] + g.costs[i]
+		}
+		groupTotal := prefixGroup[c]
+		costLonger := suffixCost[idx+1]
+		for x := 1; x <= c; x++ {
+			keepOthers := x - 1
+			if keepOthers > countShorter {
+				keepOthers = countShorter
+			}
+			costKeepOthers := sumSmallest(freq, keepOthers)
+			costRemoveShorter := prefixCost - costKeepOthers
+			costRemoveGroup := groupTotal - prefixGroup[x]
+			total := costLonger + costRemoveShorter + costRemoveGroup
+			if total < ans {
+				ans = total
+			}
+		}
+		for _, v := range g.costs {
+			freq[v]++
+		}
+		prefixCost += groupTotal
+		countShorter += c
+	}
+	if ans < 0 {
+		ans = 0
+	}
+	return ans
+}
+
+func genCase() (string, int) {
+	n := rand.Intn(10) + 1
+	legs := make([]struct{ l, d int }, n)
+	for i := 0; i < n; i++ {
+		legs[i].l = rand.Intn(10) + 1
+	}
+	for i := 0; i < n; i++ {
+		legs[i].d = rand.Intn(200) + 1
+	}
+	res := solveC(n, append([]struct{ l, d int }{}, legs...))
+	input := fmt.Sprintf("%d\n", n)
+	for i, v := range legs {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v.l)
+	}
+	input += "\n"
+	for i, v := range legs {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v.d)
+	}
+	input += "\n"
+	return input, res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input, expected := genCase()
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		gotStr := strings.TrimSpace(out.String())
+		var got int
+		if _, err := fmt.Sscan(gotStr, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: failed to parse output\n", i+1)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected: %d\ngot: %s\n", i+1, input, expected, gotStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/550-559/557/verifierD.go
+++ b/0-999/500-599/550-559/557/verifierD.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveD(n, m int, edges [][2]int) (int, int64) {
+	g := make([][]int, n)
+	for _, e := range edges {
+		a, b := e[0], e[1]
+		g[a] = append(g[a], b)
+		g[b] = append(g[b], a)
+	}
+	color := make([]int8, n)
+	for i := range color {
+		color[i] = -1
+	}
+	var t int
+	var ways int64
+	var bipartitePairs int64
+	queue := make([]int, 0, n)
+	for v := 0; v < n; v++ {
+		if color[v] != -1 {
+			continue
+		}
+		queue = queue[:0]
+		queue = append(queue, v)
+		color[v] = 0
+		cnt := [2]int64{1, 0}
+		isBip := true
+		for head := 0; head < len(queue); head++ {
+			u := queue[head]
+			for _, to := range g[u] {
+				if color[to] == -1 {
+					color[to] = color[u] ^ 1
+					cnt[color[to]]++
+					queue = append(queue, to)
+				} else if color[to] == color[u] {
+					isBip = false
+				}
+			}
+		}
+		if !isBip {
+			return 0, 1
+		}
+		bipartitePairs += cnt[0]*(cnt[0]-1)/2 + cnt[1]*(cnt[1]-1)/2
+	}
+	if bipartitePairs > 0 {
+		t = 1
+		ways = bipartitePairs
+	} else if m > 0 {
+		t = 2
+		ways = int64(m) * int64(n-2)
+	} else {
+		t = 3
+		ways = int64(n) * int64(n-1) * int64(n-2) / 6
+	}
+	return t, ways
+}
+
+func genCase() (string, int, int64) {
+	n := rand.Intn(6) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rand.Intn(maxEdges + 1)
+	edges := make([][2]int, 0, m)
+	used := make(map[[2]int]bool)
+	for len(edges) < m {
+		a := rand.Intn(n)
+		b := rand.Intn(n)
+		if a == b {
+			continue
+		}
+		if a > b {
+			a, b = b, a
+		}
+		e := [2]int{a, b}
+		if used[e] {
+			continue
+		}
+		used[e] = true
+		edges = append(edges, e)
+	}
+	t, ways := solveD(n, len(edges), edges)
+	input := fmt.Sprintf("%d %d\n", n, len(edges))
+	for _, e := range edges {
+		input += fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1)
+	}
+	return input, t, ways
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input, et, ew := genCase()
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var gt int
+		var gw int64
+		if _, err := fmt.Fscan(strings.NewReader(out.String()), &gt, &gw); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: failed to parse output\n", i+1)
+			os.Exit(1)
+		}
+		if gt != et || gw != ew {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected: %d %d\ngot: %d %d\n", i+1, input, et, ew, gt, gw)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/550-559/557/verifierE.go
+++ b/0-999/500-599/550-559/557/verifierE.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func solveE(s string, k int) string {
+	n := len(s)
+	dp := make([][]bool, n)
+	for i := range dp {
+		dp[i] = make([]bool, n)
+	}
+	for l := 1; l <= n; l++ {
+		for i := 0; i+l-1 < n; i++ {
+			j := i + l - 1
+			if l == 1 {
+				dp[i][j] = true
+			} else if l == 2 {
+				dp[i][j] = s[i] == s[j]
+			} else if s[i] == s[j] && (l <= 4 || dp[i+2][j-2]) {
+				dp[i][j] = true
+			}
+		}
+	}
+	substrs := make([]string, 0)
+	for i := 0; i < n; i++ {
+		for j := i; j < n; j++ {
+			if dp[i][j] {
+				substrs = append(substrs, s[i:j+1])
+			}
+		}
+	}
+	sort.Strings(substrs)
+	if k-1 < len(substrs) {
+		return substrs[k-1]
+	}
+	return ""
+}
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rand.Intn(2))
+	}
+	return string(b)
+}
+
+func genCase() (string, string) {
+	n := rand.Intn(6) + 1
+	s := randString(n)
+	maxSub := n * (n + 1) / 2
+	k := rand.Intn(maxSub) + 1
+	res := solveE(s, k)
+	input := fmt.Sprintf("%s\n%d\n", s, k)
+	return input, res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input, expected := genCase()
+		cmd := exec.Command(binary)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for contest 557 problems A–E
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`

------
https://chatgpt.com/codex/tasks/task_e_688331f06664832499b577f1b5e5851e