### PR TITLE
Add verifiers for contest 572

### DIFF
--- a/0-999/500-599/570-579/572/verifierA.go
+++ b/0-999/500-599/570-579/572/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type caseA struct {
+	nA, nB int
+	k, m   int
+	A, B   []int
+}
+
+func genCase(rng *rand.Rand) caseA {
+	nA := rng.Intn(20) + 1
+	nB := rng.Intn(20) + 1
+	k := rng.Intn(nA) + 1
+	m := rng.Intn(nB) + 1
+	A := make([]int, nA)
+	cur := rng.Intn(41) - 20
+	for i := 0; i < nA; i++ {
+		cur += rng.Intn(5)
+		A[i] = cur
+	}
+	B := make([]int, nB)
+	cur = rng.Intn(41) - 20
+	for i := 0; i < nB; i++ {
+		cur += rng.Intn(5)
+		B[i] = cur
+	}
+	return caseA{nA, nB, k, m, A, B}
+}
+
+func expected(tc caseA) string {
+	if tc.A[tc.k-1] < tc.B[tc.nB-tc.m] {
+		return "YES"
+	}
+	return "NO"
+}
+
+func formatInput(tc caseA) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.nA, tc.nB))
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.k, tc.m))
+	for i, v := range tc.A {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.B {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin string, tc caseA) error {
+	input := formatInput(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	ans := strings.ToUpper(fields[0])
+	if ans != "YES" && ans != "NO" {
+		return fmt.Errorf("expected YES or NO, got %s", fields[0])
+	}
+	if ans != expected(tc) {
+		return fmt.Errorf("expected %s got %s", expected(tc), ans)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, formatInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/572/verifierB.go
+++ b/0-999/500-599/570-579/572/verifierB.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type order struct {
+	dir   string
+	price int
+	qty   int
+}
+
+type caseB struct {
+	n      int
+	s      int
+	orders []order
+}
+
+func genCase(rng *rand.Rand) caseB {
+	n := rng.Intn(20) + 1
+	s := rng.Intn(5) + 1
+	orders := make([]order, n)
+	for i := 0; i < n; i++ {
+		dir := "B"
+		if rng.Intn(2) == 0 {
+			dir = "S"
+		}
+		var price int
+		if dir == "B" {
+			price = rng.Intn(40) + 1
+		} else {
+			price = rng.Intn(50) + 50
+		}
+		qty := rng.Intn(20) + 1
+		orders[i] = order{dir, price, qty}
+	}
+	return caseB{n, s, orders}
+}
+
+func formatInput(tc caseB) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.s))
+	for _, ord := range tc.orders {
+		sb.WriteString(fmt.Sprintf("%s %d %d\n", ord.dir, ord.price, ord.qty))
+	}
+	return sb.String()
+}
+
+func expected(tc caseB) []string {
+	buy := make(map[int]int)
+	sell := make(map[int]int)
+	for _, o := range tc.orders {
+		if o.dir == "B" {
+			buy[o.price] += o.qty
+		} else {
+			sell[o.price] += o.qty
+		}
+	}
+	buyPrices := make([]int, 0, len(buy))
+	for p := range buy {
+		buyPrices = append(buyPrices, p)
+	}
+	sellPrices := make([]int, 0, len(sell))
+	for p := range sell {
+		sellPrices = append(sellPrices, p)
+	}
+	sort.Ints(buyPrices)
+	sort.Ints(sellPrices)
+	res := make([]string, 0)
+	limitSell := tc.s
+	if limitSell > len(sellPrices) {
+		limitSell = len(sellPrices)
+	}
+	for i := limitSell - 1; i >= 0; i-- {
+		p := sellPrices[i]
+		res = append(res, fmt.Sprintf("S %d %d", p, sell[p]))
+	}
+	limitBuy := tc.s
+	if limitBuy > len(buyPrices) {
+		limitBuy = len(buyPrices)
+	}
+	for i := len(buyPrices) - 1; i >= len(buyPrices)-limitBuy; i-- {
+		p := buyPrices[i]
+		res = append(res, fmt.Sprintf("B %d %d", p, buy[p]))
+	}
+	return res
+}
+
+func runCase(bin string, tc caseB) error {
+	input := formatInput(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expectedLines := expected(tc)
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(out.String())))
+	gotLines := make([]string, 0)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			gotLines = append(gotLines, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to read output: %v", err)
+	}
+	if len(gotLines) != len(expectedLines) {
+		return fmt.Errorf("expected %d lines got %d", len(expectedLines), len(gotLines))
+	}
+	for i, exp := range expectedLines {
+		fields := strings.Fields(gotLines[i])
+		var dir string
+		var price, qty int
+		if len(fields) != 3 {
+			return fmt.Errorf("bad line %d: %q", i+1, gotLines[i])
+		}
+		if _, err := fmt.Sscan(gotLines[i], &dir, &price, &qty); err != nil {
+			return fmt.Errorf("bad numbers on line %d: %v", i+1, err)
+		}
+		eFields := strings.Fields(exp)
+		eDir := eFields[0]
+		var ePrice, eQty int
+		fmt.Sscan(exp, &eDir, &ePrice, &eQty)
+		if dir != eDir || price != ePrice || qty != eQty {
+			return fmt.Errorf("line %d expected '%s' got '%s'", i+1, exp, gotLines[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, formatInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` and `verifierB.go` for contest 572
- each verifier runs 100 random tests against a provided binary

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`

------
https://chatgpt.com/codex/tasks/task_e_68833a262fb48324b9ff82390a5e737d