### PR TITLE
Add verifiers for contest 571

### DIFF
--- a/0-999/500-599/570-579/571/verifierA.go
+++ b/0-999/500-599/570-579/571/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := filepath.Join(os.TempDir(), "oracleA")
+	cmd := exec.Command("go", "build", "-o", exe, "571A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runCase(bin, oracle, input string) error {
+	// run oracle
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) string {
+	a := rng.Intn(30) + 1
+	b := rng.Intn(30) + 1
+	c := rng.Intn(30) + 1
+	l := rng.Intn(30)
+	return fmt.Sprintf("%d %d %d %d\n", a, b, c, l)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/571/verifierB.go
+++ b/0-999/500-599/570-579/571/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := filepath.Join(os.TempDir(), "oracleB")
+	cmd := exec.Command("go", "build", "-o", exe, "571B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(9) + 2 // 2..10
+	k := rng.Intn(n-1) + 1
+	if k > 5 {
+		k = 5
+		if k >= n {
+			k = n - 1
+		}
+	}
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(41) - 20
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/571/verifierC.go
+++ b/0-999/500-599/570-579/571/verifierC.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := filepath.Join(os.TempDir(), "oracleC")
+	cmd := exec.Command("go", "build", "-o", exe, "571C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) string {
+	nc := rng.Intn(3) + 1 // number of clauses
+	n := rng.Intn(4) + 1  // number of variables
+	// prepare slices
+	clauses := make([][]int, nc)
+	for i := 1; i <= n; i++ {
+		occ := rng.Intn(2) + 1 // 1 or 2 occurrences
+		cats := rng.Perm(nc)[:occ]
+		for _, c := range cats {
+			val := i
+			if rng.Intn(2) == 0 {
+				val = -val
+			}
+			clauses[c] = append(clauses[c], val)
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", nc, n)
+	for _, cl := range clauses {
+		fmt.Fprintf(&sb, "%d", len(cl))
+		for _, v := range cl {
+			fmt.Fprintf(&sb, " %d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/571/verifierD.go
+++ b/0-999/500-599/570-579/571/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := filepath.Join(os.TempDir(), "oracleD")
+	cmd := exec.Command("go", "build", "-o", exe, "571D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	hasQ := false
+	ops := []string{"U", "M", "A", "Z", "Q"}
+	for i := 0; i < m; i++ {
+		op := ops[rng.Intn(len(ops))]
+		switch op {
+		case "U", "M":
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "%s %d %d\n", op, a, b)
+		case "A":
+			x := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "%s %d\n", op, x)
+		case "Z":
+			y := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "%s %d\n", op, y)
+		case "Q":
+			hasQ = true
+			q := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "%s %d\n", op, q)
+		}
+	}
+	if !hasQ {
+		q := rng.Intn(n) + 1
+		fmt.Fprintf(&sb, "Q %d\n", q)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/571/verifierE.go
+++ b/0-999/500-599/570-579/571/verifierE.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := filepath.Join(os.TempDir(), "oracleE")
+	cmd := exec.Command("go", "build", "-o", exe, "571E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runCase(bin, oracle, input string) error {
+	cmdO := exec.Command(oracle)
+	cmdO.Stdin = strings.NewReader(input)
+	var outO bytes.Buffer
+	cmdO.Stdout = &outO
+	if err := cmdO.Run(); err != nil {
+		return fmt.Errorf("oracle runtime error: %v", err)
+	}
+	expected := strings.TrimSpace(outO.String())
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errb.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		a := rng.Intn(20) + 1
+		b := rng.Intn(10) + 1
+		fmt.Fprintf(&sb, "%d %d\n", a, b)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 571 problems A–E
- each verifier builds the reference solution and checks 100 randomized cases

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68833999bb4c83249fbb9b60374e1921