### PR TITLE
Add Go solution for 1948D

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1948/1948D.go
+++ b/1000-1999/1900-1999/1940-1949/1948/1948D.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		b := []byte(s)
+		n := len(b)
+		result := 0
+		for k := n / 2; k >= 1; k-- {
+			run := 0
+			found := false
+			for i := n - k - 1; i >= 0; i-- {
+				c1 := b[i]
+				c2 := b[i+k]
+				if c1 == c2 || c1 == '?' || c2 == '?' {
+					run++
+					if run >= k {
+						result = 2 * k
+						found = true
+						break
+					}
+				} else {
+					run = 0
+				}
+			}
+			if found {
+				break
+			}
+		}
+		fmt.Fprintln(writer, result)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1948D (tandem repeat search)

## Testing
- `go build 1000-1999/1900-1999/1940-1949/1948/1948D.go`
- `go run 1000-1999/1900-1999/1940-1949/1948/1948D.go <<EOF
1
a??a
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68833953a8408324a2183bd511f15547