### PR TITLE
Add Go verifiers for contest 570

### DIFF
--- a/0-999/500-599/570-579/570/verifierA.go
+++ b/0-999/500-599/570-579/570/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m int, votes [][]int) int {
+	wins := make([]int, n)
+	for i := 0; i < m; i++ {
+		bestCand := 0
+		bestVotes := votes[i][0]
+		for j := 1; j < n; j++ {
+			if votes[i][j] > bestVotes {
+				bestVotes = votes[i][j]
+				bestCand = j
+			}
+		}
+		wins[bestCand]++
+	}
+	winner := 0
+	for i := 1; i < n; i++ {
+		if wins[i] > wins[winner] {
+			winner = i
+		}
+	}
+	return winner + 1
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		votes := make([][]int, m)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for r := 0; r < m; r++ {
+			votes[r] = make([]int, n)
+			for c := 0; c < n; c++ {
+				v := rng.Intn(21)
+				votes[r][c] = v
+				fmt.Fprintf(&sb, "%d ", v)
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		want := expected(n, m, votes)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil || got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, want, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/570/verifierB.go
+++ b/0-999/500-599/570-579/570/verifierB.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m int) int {
+	if m == 1 {
+		if n == 1 {
+			return 1
+		}
+		return 2
+	}
+	if m == n {
+		return n - 1
+	}
+	if m-1 >= n-m {
+		return m - 1
+	}
+	return m + 1
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		m := rng.Intn(n) + 1
+		input := fmt.Sprintf("%d %d\n", n, m)
+		want := expected(n, m)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil || got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, want, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/570/verifierC.go
+++ b/0-999/500-599/570-579/570/verifierC.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type query struct {
+	x  int
+	ch byte
+}
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, s []byte, qs []query) string {
+	pairs := 0
+	for i := 0; i < n-1; i++ {
+		if s[i] == '.' && s[i+1] == '.' {
+			pairs++
+		}
+	}
+	var sb strings.Builder
+	for idx, q := range qs {
+		if s[q.x] != q.ch {
+			if s[q.x] == '.' {
+				if q.x > 0 && s[q.x-1] == '.' {
+					pairs--
+				}
+				if q.x+1 < n && s[q.x+1] == '.' {
+					pairs--
+				}
+			}
+			s[q.x] = q.ch
+			if s[q.x] == '.' {
+				if q.x > 0 && s[q.x-1] == '.' {
+					pairs++
+				}
+				if q.x+1 < n && s[q.x+1] == '.' {
+					pairs++
+				}
+			}
+		}
+		if idx > 0 {
+			sb.WriteByte('\n')
+		}
+		fmt.Fprintf(&sb, "%d", pairs)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	letters := []byte("abc.")
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 2
+		m := rng.Intn(8) + 1
+		s := make([]byte, n)
+		for j := 0; j < n; j++ {
+			s[j] = letters[rng.Intn(len(letters))]
+		}
+		qs := make([]query, m)
+		for j := 0; j < m; j++ {
+			qs[j] = query{rng.Intn(n), letters[rng.Intn(len(letters))]}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		sb.Write(s)
+		sb.WriteByte('\n')
+		for _, q := range qs {
+			fmt.Fprintf(&sb, "%d %c\n", q.x+1, q.ch)
+		}
+		input := sb.String()
+		want := expected(n, append([]byte(nil), s...), qs)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\n", i+1, want, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/570/verifierD.go
+++ b/0-999/500-599/570-579/570/verifierD.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type query struct {
+	v int
+	h int
+}
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildTree(n int, parents []int) [][]int {
+	g := make([][]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := parents[i-2]
+		g[p] = append(g[p], i)
+	}
+	return g
+}
+
+func isAncestor(parents []int, v, u int) bool {
+	for u != 0 {
+		if u == v {
+			return true
+		}
+		if u == 1 {
+			break
+		}
+		u = parents[u-2]
+	}
+	return v == 1 && u == 1
+}
+
+func expected(n int, parents []int, letters string, qs []query) string {
+	g := buildTree(n, parents)
+	depth := make([]int, n+1)
+	depth[1] = 1
+	stack := []int{1}
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, u := range g[v] {
+			depth[u] = depth[v] + 1
+			stack = append(stack, u)
+		}
+	}
+	var sb strings.Builder
+	for idx, q := range qs {
+		counts := make([]int, 26)
+		for u := 1; u <= n; u++ {
+			if depth[u] == q.h && isAncestor(parents, q.v, u) {
+				counts[letters[u-1]-'a']++
+			}
+		}
+		odd := 0
+		for _, c := range counts {
+			if c%2 == 1 {
+				odd++
+			}
+		}
+		if idx > 0 {
+			sb.WriteByte('\n')
+		}
+		if odd <= 1 {
+			sb.WriteString("Yes")
+		} else {
+			sb.WriteString("No")
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	lettersArr := []byte("abcde")
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(7) + 1
+		m := rng.Intn(7) + 1
+		parents := make([]int, n-1)
+		for j := 2; j <= n; j++ {
+			parents[j-2] = rng.Intn(j-1) + 1
+		}
+		letters := make([]byte, n)
+		for j := 0; j < n; j++ {
+			letters[j] = lettersArr[rng.Intn(len(lettersArr))]
+		}
+		qs := make([]query, m)
+		for j := 0; j < m; j++ {
+			qs[j] = query{rng.Intn(n) + 1, rng.Intn(n) + 1}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for j := 0; j < n-1; j++ {
+			fmt.Fprintf(&sb, "%d ", parents[j])
+		}
+		if n > 1 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(string(letters))
+		sb.WriteByte('\n')
+		for _, q := range qs {
+			fmt.Fprintf(&sb, "%d %d\n", q.v, q.h)
+		}
+		input := sb.String()
+		want := expected(n, parents, string(letters), qs)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\n", i+1, want, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/570/verifierE.go
+++ b/0-999/500-599/570-579/570/verifierE.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const MOD = 1000000007
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func countPalPaths(grid [][]byte) int {
+	n := len(grid)
+	m := len(grid[0])
+	path := make([]byte, n+m-1)
+	var cnt int
+	var dfs func(r, c, idx int)
+	dfs = func(r, c, idx int) {
+		path[idx] = grid[r][c]
+		if r == n-1 && c == m-1 {
+			if isPalindrome(path) {
+				cnt++
+			}
+			return
+		}
+		if r+1 < n {
+			dfs(r+1, c, idx+1)
+		}
+		if c+1 < m {
+			dfs(r, c+1, idx+1)
+		}
+	}
+	dfs(0, 0, 0)
+	return cnt % MOD
+}
+
+func isPalindrome(s []byte) bool {
+	i, j := 0, len(s)-1
+	for i < j {
+		if s[i] != s[j] {
+			return false
+		}
+		i++
+		j--
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	letters := []byte("ab")
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 2
+		m := rng.Intn(4) + 2
+		grid := make([][]byte, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for r := 0; r < n; r++ {
+			row := make([]byte, m)
+			for c := 0; c < m; c++ {
+				row[c] = letters[rng.Intn(len(letters))]
+			}
+			grid[r] = row
+			sb.Write(row)
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		want := countPalPaths(grid)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscanf(out, "%d", &got); err != nil || got%MOD != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, want, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 570 problems A–E
- each verifier runs 100 randomized tests
- verifiers can run any binary and support Go sources via `go run`

## Testing
- `go run 0-999/500-599/570-579/570/verifierA.go /tmp/570A_bin`
- `go run 0-999/500-599/570-579/570/verifierB.go /tmp/570B_bin`
- `go run 0-999/500-599/570-579/570/verifierC.go /tmp/570C_bin`
- `go run 0-999/500-599/570-579/570/verifierD.go /tmp/570D_bin`
- `go run 0-999/500-599/570-579/570/verifierE.go /tmp/570E_bin`


------
https://chatgpt.com/codex/tasks/task_e_6883390db2108324b35bcf5510263976