### PR TITLE
Add verifiers for contest 569

### DIFF
--- a/0-999/500-599/560-569/569/verifierA.go
+++ b/0-999/500-599/560-569/569/verifierA.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(T, S, q int) string {
+	cur := S
+	count := 0
+	for cur < T {
+		cur *= q
+		count++
+	}
+	return fmt.Sprint(count)
+}
+
+func buildInput(T, S, q int) string {
+	return fmt.Sprintf("%d %d %d\n", T, S, q)
+}
+
+func randomCase(rng *rand.Rand) (int, int, int) {
+	T := rng.Intn(100000-2) + 2
+	S := rng.Intn(T-1) + 1
+	q := rng.Intn(10000-2) + 2
+	return T, S, q
+}
+
+func runCase(bin string, T, S, q int) error {
+	input := buildInput(T, S, q)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	exp := expected(T, S, q)
+	if out != exp {
+		return fmt.Errorf("expected %s got %s", exp, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := [][3]int{
+		{5, 1, 2},
+		{5, 4, 2},
+		{100000, 1, 10000},
+		{100000, 99999, 2},
+		{7, 4, 3},
+	}
+	for len(cases) < 105 {
+		T, S, q := randomCase(rng)
+		cases = append(cases, [3]int{T, S, q})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc[0], tc[1], tc[2]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInput(tc[0], tc[1], tc[2]))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/500-599/560-569/569/verifierB.go
+++ b/0-999/500-599/560-569/569/verifierB.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n   int
+	arr []int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func minimalChanges(tc testCase) int {
+	seen := make(map[int]struct{})
+	for _, v := range tc.arr {
+		if v >= 1 && v <= tc.n {
+			seen[v] = struct{}{}
+		}
+	}
+	return tc.n - len(seen)
+}
+
+func parseOutput(out string, n int) ([]int, error) {
+	fields := strings.Fields(out)
+	if len(fields) != n {
+		return nil, fmt.Errorf("expected %d numbers got %d", n, len(fields))
+	}
+	res := make([]int, n)
+	for i, f := range fields {
+		var x int
+		if _, err := fmt.Sscan(f, &x); err != nil {
+			return nil, fmt.Errorf("bad integer %q", f)
+		}
+		res[i] = x
+	}
+	return res, nil
+}
+
+func isPermutation(arr []int, n int) bool {
+	seen := make([]bool, n+1)
+	for _, v := range arr {
+		if v < 1 || v > n || seen[v] {
+			return false
+		}
+		seen[v] = true
+	}
+	return true
+}
+
+func runCase(bin string, tc testCase) error {
+	input := buildInput(tc)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	ans, err := parseOutput(out, tc.n)
+	if err != nil {
+		return err
+	}
+	if !isPermutation(ans, tc.n) {
+		return fmt.Errorf("output is not a permutation")
+	}
+	changes := 0
+	for i := 0; i < tc.n; i++ {
+		if ans[i] != tc.arr[i] {
+			changes++
+		}
+	}
+	if changes != minimalChanges(tc) {
+		return fmt.Errorf("expected %d changes, got %d", minimalChanges(tc), changes)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		if rng.Float64() < 0.5 {
+			arr[i] = rng.Intn(n) + 1
+		} else {
+			arr[i] = rng.Intn(1000) + n + 1
+		}
+	}
+	return testCase{n: n, arr: arr}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, testCase{n: 3, arr: []int{1, 2, 3}})
+	cases = append(cases, testCase{n: 3, arr: []int{1, 1, 1}})
+	cases = append(cases, testCase{n: 5, arr: []int{1, 2, 2, 3, 3}})
+	cases = append(cases, testCase{n: 3, arr: []int{4, 5, 6}})
+	cases = append(cases, testCase{n: 1, arr: []int{1}})
+	for len(cases) < 105 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for contest 569
- verifiers execute any binary or Go file and check output for over 100 test cases each
- cases include deterministic edge tests and randomized ones

## Testing
- `go build ./0-999/500-599/560-569/569/verifierA.go`
- `go build ./0-999/500-599/560-569/569/verifierB.go`


------
https://chatgpt.com/codex/tasks/task_e_6883388181148324997ac9427cf64b5c