### PR TITLE
Add Go verifiers for contest 568

### DIFF
--- a/0-999/500-599/560-569/568/verifierA.go
+++ b/0-999/500-599/560-569/568/verifierA.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const N = 2000000
+
+var piCount []int
+var rubCount []int
+
+func isPalindrome(n int) bool {
+	rev := 0
+	tmp := n
+	for tmp > 0 {
+		rev = rev*10 + tmp%10
+		tmp /= 10
+	}
+	return rev == n
+}
+
+func initCounts() {
+	primes := make([]bool, N+1)
+	for i := 2; i <= N; i++ {
+		primes[i] = true
+	}
+	for i := 2; i*i <= N; i++ {
+		if primes[i] {
+			for j := i * i; j <= N; j += i {
+				primes[j] = false
+			}
+		}
+	}
+	piCount = make([]int, N+1)
+	rubCount = make([]int, N+1)
+	for i := 1; i <= N; i++ {
+		piCount[i] = piCount[i-1]
+		rubCount[i] = rubCount[i-1]
+		if primes[i] {
+			piCount[i]++
+		}
+		if isPalindrome(i) {
+			rubCount[i]++
+		}
+	}
+}
+
+func solveCase(p, q int) string {
+	ans := -1
+	for n := 1; n <= N; n++ {
+		if piCount[n]*q <= rubCount[n]*p {
+			ans = n
+		}
+	}
+	if ans == -1 {
+		return "Palindromic tree is better than splay tree\n"
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+type testCase struct {
+	p, q     int
+	expected string
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	q := rng.Intn(10000) + 1
+	maxP := q * 42
+	if maxP > 10000 {
+		maxP = 10000
+	}
+	minP := (q + 41) / 42
+	if minP < 1 {
+		minP = 1
+	}
+	if minP > maxP {
+		minP = maxP
+	}
+	p := rng.Intn(maxP-minP+1) + minP
+	return testCase{p: p, q: q, expected: solveCase(p, q)}
+}
+
+func runCase(bin string, tc testCase) error {
+	input := fmt.Sprintf("%d %d\n", tc.p, tc.q)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(tc.expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(tc.expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	initCounts()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	// deterministic edge cases
+	edges := []struct{ p, q int }{{1, 42}, {42, 1}, {1, 1}, {2, 3}, {10000, 10000}}
+	for _, e := range edges {
+		cases = append(cases, testCase{p: e.p, q: e.q, expected: solveCase(e.p, e.q)})
+	}
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %d %d\n", i+1, err, tc.p, tc.q)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/560-569/568/verifierB.go
+++ b/0-999/500-599/560-569/568/verifierB.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+const maxN = 100
+
+var fact [maxN + 1]int64
+var invFact [maxN + 1]int64
+var bell [maxN + 1]int64
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func initPrecalc() {
+	fact[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fact[i] = fact[i-1] * int64(i) % MOD
+	}
+	invFact[maxN] = modPow(fact[maxN], MOD-2)
+	for i := maxN; i > 0; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % MOD
+	}
+
+	comb := func(n, k int) int64 {
+		if k < 0 || k > n {
+			return 0
+		}
+		return fact[n] * invFact[k] % MOD * invFact[n-k] % MOD
+	}
+
+	bell[0] = 1
+	for i := 0; i < maxN; i++ {
+		sum := int64(0)
+		for k := 0; k <= i; k++ {
+			sum = (sum + comb(i, k)*bell[k]) % MOD
+		}
+		bell[i+1] = sum
+	}
+}
+
+func solveCase(n int) string {
+	comb := func(n, k int) int64 {
+		if k < 0 || k > n {
+			return 0
+		}
+		return fact[n] * invFact[k] % MOD * invFact[n-k] % MOD
+	}
+	ans := int64(0)
+	for m := 0; m < n; m++ {
+		ans = (ans + comb(n, m)*bell[m]) % MOD
+	}
+	return fmt.Sprintf("%d\n", ans%MOD)
+}
+
+type testCase struct {
+	n        int
+	expected string
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(maxN-1) + 1
+	return testCase{n: n, expected: solveCase(n)}
+}
+
+func runCase(bin string, tc testCase) error {
+	input := fmt.Sprintf("%d\n", tc.n)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(tc.expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(tc.expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	initPrecalc()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	edges := []int{1, 2, 3, 10, 20, 50, 100}
+	for _, e := range edges {
+		if e <= maxN {
+			cases = append(cases, testCase{n: e, expected: solveCase(e)})
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %d\n", i+1, err, tc.n)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/560-569/568/verifierC.go
+++ b/0-999/500-599/560-569/568/verifierC.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type rule struct {
+	p1 int
+	t1 byte
+	p2 int
+	t2 byte
+}
+
+type testCase struct {
+	typeStr  string
+	n        int
+	rules    []rule
+	s        string
+	expected string
+}
+
+func letterTypeMap(typeStr string) []byte {
+	m := make([]byte, len(typeStr))
+	for i, ch := range typeStr {
+		if ch == 'V' {
+			m[i] = 'V'
+		} else {
+			m[i] = 'C'
+		}
+	}
+	return m
+}
+
+func checkWord(word []byte, ltypes []byte, rules []rule) bool {
+	for _, r := range rules {
+		if (ltypes[int(word[r.p1]-'a')] == r.t1) && (ltypes[int(word[r.p2]-'a')] != r.t2) {
+			return false
+		}
+	}
+	return true
+}
+
+func bruteForce(typeStr string, n int, rules []rule, s string) string {
+	l := len(typeStr)
+	letters := make([]byte, l)
+	for i := 0; i < l; i++ {
+		letters[i] = byte('a' + i)
+	}
+	ltypes := letterTypeMap(typeStr)
+	best := ""
+	word := make([]byte, n)
+	var dfs func(pos int, greater bool) bool
+	dfs = func(pos int, greater bool) bool {
+		if pos == n {
+			if checkWord(word, ltypes, rules) {
+				best = string(word)
+				return true
+			}
+			return false
+		}
+		start := byte('a')
+		if !greater {
+			start = s[pos]
+		}
+		for ch := start; ch < byte('a')+byte(l); ch++ {
+			word[pos] = ch
+			if dfs(pos+1, greater || ch > s[pos]) {
+				return true
+			}
+		}
+		return false
+	}
+	if dfs(0, false) {
+		return best + "\n"
+	}
+	return "-1\n"
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	l := rng.Intn(3) + 1
+	typeStr := make([]byte, l)
+	for i := 0; i < l; i++ {
+		if rng.Intn(2) == 0 {
+			typeStr[i] = 'V'
+		} else {
+			typeStr[i] = 'C'
+		}
+	}
+	n := rng.Intn(4) + 1
+	maxRules := n
+	rcount := rng.Intn(maxRules + 1)
+	rules := make([]rule, rcount)
+	for i := 0; i < rcount; i++ {
+		p1 := rng.Intn(n)
+		p2 := rng.Intn(n)
+		t1 := byte('V')
+		if rng.Intn(2) == 0 {
+			t1 = 'C'
+		}
+		t2 := byte('V')
+		if rng.Intn(2) == 0 {
+			t2 = 'C'
+		}
+		rules[i] = rule{p1: p1, t1: t1, p2: p2, t2: t2}
+	}
+	letters := make([]byte, l)
+	for i := 0; i < l; i++ {
+		letters[i] = byte('a' + i)
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rng.Intn(l)])
+	}
+	s := sb.String()
+	expected := bruteForce(string(typeStr), n, rules, s)
+	return testCase{typeStr: string(typeStr), n: n, rules: rules, s: s, expected: expected}
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString(tc.typeStr)
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, len(tc.rules)))
+	for _, r := range tc.rules {
+		sb.WriteString(fmt.Sprintf("%d %c %d %c\n", r.p1+1, r.t1, r.p2+1, r.t2))
+	}
+	sb.WriteString(tc.s)
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(tc.expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(tc.expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/560-569/568/verifierD.go
+++ b/0-999/500-599/560-569/568/verifierD.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type line struct {
+	a, b, c int
+}
+
+type testCase struct {
+	n, k     int
+	lines    []line
+	expected string
+}
+
+func intersection(l1, l2 line) (float64, float64, bool) {
+	det := float64(l1.a*l2.b - l2.a*l1.b)
+	if math.Abs(det) < 1e-9 {
+		return 0, 0, false
+	}
+	x := float64(l1.b*l2.c-l2.b*l1.c) / det
+	y := float64(l1.c*l2.a-l2.c*l1.a) / float64(l1.b*l2.a-l1.a*l2.b)
+	return x, y, true
+}
+
+func buildCandidates(lines []line) []int {
+	n := len(lines)
+	all := make([]int, 0)
+	for i := 0; i < n; i++ {
+		all = append(all, 1<<i) // sign on road i only
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			x, y, ok := intersection(lines[i], lines[j])
+			if !ok {
+				continue
+			}
+			mask := (1 << i) | (1 << j)
+			for t := 0; t < n; t++ {
+				if t == i || t == j {
+					continue
+				}
+				if math.Abs(float64(lines[t].a)*x+float64(lines[t].b)*y+float64(lines[t].c)) < 1e-6 {
+					mask |= 1 << t
+				}
+			}
+			all = append(all, mask)
+		}
+	}
+	// remove duplicates
+	uniq := make(map[int]bool)
+	res := make([]int, 0, len(all))
+	for _, m := range all {
+		if !uniq[m] {
+			uniq[m] = true
+			res = append(res, m)
+		}
+	}
+	return res
+}
+
+func checkPossible(n, k int, lines []line) bool {
+	cand := buildCandidates(lines)
+	target := (1 << n) - 1
+	var dfs func(idx, used int, mask int) bool
+	dfs = func(idx, used int, mask int) bool {
+		if mask == target && used <= k {
+			return true
+		}
+		if used >= k || idx == len(cand) {
+			return false
+		}
+		if dfs(idx+1, used, mask) {
+			return true
+		}
+		return dfs(idx+1, used+1, mask|cand[idx])
+	}
+	return dfs(0, 0, 0)
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(3) + 1
+	lines := make([]line, n)
+	for i := 0; i < n; i++ {
+		for {
+			a := rng.Intn(5) - 2
+			b := rng.Intn(5) - 2
+			c := rng.Intn(5) - 2
+			if a != 0 || b != 0 {
+				lines[i] = line{a, b, c}
+				break
+			}
+		}
+	}
+	ans := "NO\n"
+	if checkPossible(n, k, lines) {
+		ans = "YES"
+	}
+	return testCase{n: n, k: k, lines: lines, expected: ans}
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+	for _, ln := range tc.lines {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", ln.a, ln.b, ln.c))
+	}
+	input := sb.String()
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outFirst := strings.Fields(out.String())
+	if len(outFirst) == 0 {
+		return fmt.Errorf("no output")
+	}
+	got := strings.ToUpper(outFirst[0])
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/560-569/568/verifierE.go
+++ b/0-999/500-599/560-569/568/verifierE.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n        int
+	a        []int
+	b        []int
+	expected string
+}
+
+func lisLength(arr []int) int {
+	d := make([]int, len(arr))
+	length := 0
+	for _, v := range arr {
+		i := sort.Search(length, func(i int) bool { return d[i] >= v })
+		d[i] = v
+		if i == length {
+			length++
+		}
+	}
+	return length
+}
+
+func bruteForceFill(a []int, b []int) []int {
+	// indexes of gaps
+	gaps := []int{}
+	for i, v := range a {
+		if v == -1 {
+			gaps = append(gaps, i)
+		}
+	}
+	used := make([]bool, len(b))
+	bestLen := -1
+	var best []int
+
+	var dfs func(idx int)
+	dfs = func(idx int) {
+		if idx == len(gaps) {
+			tmp := make([]int, len(a))
+			copy(tmp, a)
+			cur := lisLength(tmp)
+			if cur > bestLen {
+				bestLen = cur
+				best = append([]int(nil), tmp...)
+			}
+			return
+		}
+		for i := 0; i < len(b); i++ {
+			if used[i] {
+				continue
+			}
+			used[i] = true
+			a[gaps[idx]] = b[i]
+			dfs(idx + 1)
+			used[i] = false
+			a[gaps[idx]] = -1
+		}
+	}
+	dfs(0)
+	if best == nil {
+		best = make([]int, len(a))
+		copy(best, a)
+		for i := range best {
+			if best[i] == -1 {
+				best[i] = b[0]
+			}
+		}
+	}
+	return best
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	a := make([]int, n)
+	gaps := 0
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			a[i] = -1
+			gaps++
+		} else {
+			a[i] = rng.Intn(10) + 1
+		}
+	}
+	m := gaps + rng.Intn(3)
+	if m == 0 {
+		m = 1
+	}
+	b := make([]int, m)
+	for i := 0; i < m; i++ {
+		b[i] = rng.Intn(10) + 1
+	}
+	filled := bruteForceFill(append([]int(nil), a...), b)
+	var sb strings.Builder
+	for i, v := range filled {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return testCase{n: n, a: a, b: b, expected: sb.String()}
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.b)))
+	for i, v := range tc.b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(tc.expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(tc.expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go-based solution verifiers for contest 568 problems A–E
- each verifier generates at least 100 random cases and checks candidate binaries
- verifiers use brute-force or simplified reference solutions to validate output

## Testing
- `go build 0-999/500-599/560-569/568/verifierA.go`
- `go build 0-999/500-599/560-569/568/verifierB.go`
- `go build 0-999/500-599/560-569/568/verifierC.go`
- `go build 0-999/500-599/560-569/568/verifierD.go`
- `go build 0-999/500-599/560-569/568/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_688337f56d4c83249f8a8f0b1cb1c471