### PR TITLE
Add verifiers for contest 567

### DIFF
--- a/0-999/500-599/560-569/567/verifierA.go
+++ b/0-999/500-599/560-569/567/verifierA.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	n     int
+	xs    []int64
+	input string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(20) + 2 // 2..21
+	xs := make([]int64, n)
+	cur := int64(rng.Intn(10) - 5)
+	for i := 0; i < n; i++ {
+		cur += int64(rng.Intn(10) + 1) // ensure strictly increasing
+		xs[i] = cur
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(xs[i], 10))
+	}
+	sb.WriteByte('\n')
+	return Test{n: n, xs: xs, input: sb.String()}
+}
+
+func solve(t Test) string {
+	n := t.n
+	xs := t.xs
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		var minDist, maxDist int64
+		if i == 0 {
+			minDist = xs[1] - xs[0]
+			maxDist = xs[n-1] - xs[0]
+		} else if i == n-1 {
+			minDist = xs[n-1] - xs[n-2]
+			maxDist = xs[n-1] - xs[0]
+		} else {
+			left := xs[i] - xs[i-1]
+			right := xs[i+1] - xs[i]
+			if left < right {
+				minDist = left
+			} else {
+				minDist = right
+			}
+			distFirst := xs[i] - xs[0]
+			distLast := xs[n-1] - xs[i]
+			if distFirst > distLast {
+				maxDist = distFirst
+			} else {
+				maxDist = distLast
+			}
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", minDist, maxDist))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/500-599/560-569/567/verifierB.go
+++ b/0-999/500-599/560-569/567/verifierB.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Event struct {
+	op string
+	id int
+}
+
+type Test struct {
+	events []Event
+	input  string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(90) + 10 // 10..99
+	inside := make(map[int]bool)
+	used := make(map[int]bool)
+	nextID := 1
+	events := make([]Event, 0, n)
+	// initial random inside people
+	initial := rng.Intn(5)
+	for i := 0; i < initial; i++ {
+		id := nextID
+		nextID++
+		inside[id] = true
+	}
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 { // add
+			id := nextID
+			if len(inside) > 0 && rng.Intn(2) == 0 {
+				// maybe reuse an old id not inside
+				for candidate := range used {
+					if !inside[candidate] {
+						id = candidate
+						break
+					}
+				}
+			}
+			used[id] = true
+			inside[id] = true
+			events = append(events, Event{"+", id})
+		} else { // remove
+			var id int
+			if len(inside) > 0 && rng.Intn(3) != 0 {
+				// remove someone inside
+				for k := range inside {
+					id = k
+					break
+				}
+				delete(inside, id)
+			} else {
+				id = nextID
+				nextID++
+				used[id] = true
+				// event implies he was inside before log
+			}
+			events = append(events, Event{"-", id})
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(events)))
+	for _, e := range events {
+		sb.WriteString(fmt.Sprintf("%s %d\n", e.op, e.id))
+	}
+	return Test{events: events, input: sb.String()}
+}
+
+func solve(t Test) string {
+	inside := make(map[int]bool)
+	cur := 0
+	ans := 0
+	for _, e := range t.events {
+		if e.op == "+" {
+			inside[e.id] = true
+			cur++
+			if cur > ans {
+				ans = cur
+			}
+		} else {
+			if inside[e.id] {
+				delete(inside, e.id)
+				cur--
+			} else {
+				ans++
+			}
+		}
+	}
+	return strconv.Itoa(ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s got:%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/500-599/560-569/567/verifierC.go
+++ b/0-999/500-599/560-569/567/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	n     int
+	k     int64
+	arr   []int64
+	input string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(20) + 1
+	k := int64(rng.Intn(5) + 1)
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(10) + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(arr[i], 10))
+	}
+	sb.WriteByte('\n')
+	return Test{n: n, k: k, arr: arr, input: sb.String()}
+}
+
+func solve(t Test) string {
+	left := make(map[int64]int64)
+	right := make(map[int64]int64)
+	for _, v := range t.arr {
+		right[v]++
+	}
+	var ans int64
+	for _, v := range t.arr {
+		right[v]--
+		if v%t.k == 0 {
+			ans += left[v/t.k] * right[v*t.k]
+		}
+		left[v]++
+	}
+	return strconv.FormatInt(ans, 10)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s got:%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/500-599/560-569/567/verifierD.go
+++ b/0-999/500-599/560-569/567/verifierD.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	n     int
+	k     int
+	a     int
+	shots []int
+	input string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(50) + 5
+	a := rng.Intn(n/2) + 1
+	maxShips := (n + 1) / (a + 1)
+	k := rng.Intn(maxShips) + 1
+	m := rng.Intn(50) + 1
+	shots := make([]int, m)
+	for i := 0; i < m; i++ {
+		shots[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n%d\n", n, k, a, m))
+	for i, s := range shots {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(s))
+	}
+	sb.WriteByte('\n')
+	return Test{n: n, k: k, a: a, shots: shots, input: sb.String()}
+}
+
+func calc(len, a int) int {
+	if len < 0 {
+		return 0
+	}
+	return (len + 1) / (a + 1)
+}
+
+// solver replicates 567D.go
+func solve(t Test) string {
+	// use ordered set as []int slice for simplicity
+	cuts := []int{0, t.n + 1}
+	total := calc(t.n, t.a)
+	for i, x := range t.shots {
+		// find position to insert
+		idx := 0
+		for idx < len(cuts) && cuts[idx] < x {
+			idx++
+		}
+		prev := cuts[idx-1]
+		next := cuts[idx]
+		total -= calc(next-prev-1, t.a)
+		total += calc(x-prev-1, t.a)
+		total += calc(next-x-1, t.a)
+		// insert x maintaining order if not already present
+		inserted := false
+		if cuts[idx-1] != x && cuts[idx] != x {
+			cuts = append(cuts, 0)
+			copy(cuts[idx+1:], cuts[idx:])
+			cuts[idx] = x
+			inserted = true
+		}
+		if total < t.k {
+			return strconv.Itoa(i + 1)
+		}
+		if !inserted {
+			// duplicate shot, but still after result check
+		}
+	}
+	return "-1"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s got:%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/500-599/560-569/567/verifierE.go
+++ b/0-999/500-599/560-569/567/verifierE.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Edge struct {
+	to  int
+	w   int64
+	idx int
+}
+
+type Item struct {
+	v    int
+	dist int64
+}
+
+type MinHeap []Item
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i].dist < h[j].dist }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(Item)) }
+func (h *MinHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
+}
+
+const INF int64 = 1 << 60
+
+func dijkstra(start int, adj [][]Edge) []int64 {
+	n := len(adj) - 1
+	dist := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = INF
+	}
+	pq := &MinHeap{}
+	heap.Init(pq)
+	dist[start] = 0
+	heap.Push(pq, Item{v: start, dist: 0})
+	for pq.Len() > 0 {
+		cur := heap.Pop(pq).(Item)
+		if cur.dist != dist[cur.v] {
+			continue
+		}
+		for _, e := range adj[cur.v] {
+			nd := cur.dist + e.w
+			if nd < dist[e.to] {
+				dist[e.to] = nd
+				heap.Push(pq, Item{v: e.to, dist: nd})
+			}
+		}
+	}
+	return dist
+}
+
+func solve(t Test) string {
+	n := t.n
+	adj := make([][]Edge, n+1)
+	radj := make([][]Edge, n+1)
+	for i, e := range t.edges {
+		a, b, w := int(e[0]), int(e[1]), e[2]
+		adj[a] = append(adj[a], Edge{to: b, w: w, idx: i})
+		radj[b] = append(radj[b], Edge{to: a, w: w, idx: i})
+	}
+	distS := dijkstra(t.s, adj)
+	distT := dijkstra(t.t, radj)
+	L := distS[t.t]
+	dag := make([][]Edge, n+1)
+	revDag := make([][]Edge, n+1)
+	for _, e := range t.edges {
+		u, v, w := int(e[0]), int(e[1]), e[2]
+		if distS[u] != INF && distT[v] != INF && distS[u]+w+distT[v] == L {
+			dag[u] = append(dag[u], Edge{to: v, w: w})
+			revDag[v] = append(revDag[v], Edge{to: u, w: w})
+		}
+	}
+	order := make([]int, n)
+	for i := 0; i < n; i++ {
+		order[i] = i + 1
+	}
+	sort.Slice(order, func(i, j int) bool { return distS[order[i]] < distS[order[j]] })
+	f := make([]*big.Int, n+1)
+	for i := 1; i <= n; i++ {
+		f[i] = big.NewInt(0)
+	}
+	f[t.s].SetInt64(1)
+	for _, u := range order {
+		for _, e := range dag[u] {
+			f[e.to].Add(f[e.to], f[u])
+		}
+	}
+	revOrder := make([]int, n)
+	copy(revOrder, order)
+	for i, j := 0, n-1; i < j; i, j = i+1, j-1 {
+		revOrder[i], revOrder[j] = revOrder[j], revOrder[i]
+	}
+	g := make([]*big.Int, n+1)
+	for i := 1; i <= n; i++ {
+		g[i] = big.NewInt(0)
+	}
+	g[t.t].SetInt64(1)
+	for _, u := range revOrder {
+		for _, e := range revDag[u] {
+			g[e.to].Add(g[e.to], g[u])
+		}
+	}
+	total := new(big.Int).Set(f[t.t])
+	var sb strings.Builder
+	for _, e := range t.edges {
+		u, v, w := int(e[0]), int(e[1]), e[2]
+		if distS[u] == INF || distT[v] == INF {
+			sb.WriteString("NO\n")
+			continue
+		}
+		pathLen := distS[u] + w + distT[v]
+		if pathLen == L {
+			prod := new(big.Int).Mul(f[u], g[v])
+			if prod.Cmp(total) == 0 {
+				sb.WriteString("YES\n")
+				continue
+			}
+		}
+		T := L - distS[u] - distT[v]
+		if T > 1 {
+			newW := T - 1
+			if newW >= 1 && newW < w {
+				sb.WriteString("CAN " + strconv.FormatInt(w-newW, 10) + "\n")
+				continue
+			}
+		}
+		sb.WriteString("NO\n")
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+type Test struct {
+	n     int
+	s     int
+	t     int
+	edges [][3]int64
+	input string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(4) + 2 // 2..5
+	s := 1
+	t := n
+	edges := make([][3]int64, 0)
+	// ensure a path chain 1->2->...->n
+	for i := 1; i < n; i++ {
+		edges = append(edges, [3]int64{int64(i), int64(i + 1), int64(rng.Intn(5) + 1)})
+	}
+	mExtra := rng.Intn(5)
+	for i := 0; i < mExtra; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a == b {
+			if a < n {
+				b = a + 1
+			} else {
+				b = a - 1
+			}
+		}
+		w := int64(rng.Intn(5) + 1)
+		edges = append(edges, [3]int64{int64(a), int64(b), w})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, len(edges), s, t))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+	}
+	return Test{n: n, s: s, t: t, edges: edges, input: sb.String()}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/500-599/560-569/567/verifierF.go
+++ b/0-999/500-599/560-569/567/verifierF.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Constraint struct {
+	x  int
+	op string
+	y  int
+}
+
+type Test struct {
+	n           int
+	constraints []Constraint
+	input       string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(6)
+	cons := make([]Constraint, k)
+	ops := []string{"=", "<", ">", "<=", ">="}
+	for i := 0; i < k; i++ {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(n) + 1
+		op := ops[rng.Intn(len(ops))]
+		cons[i] = Constraint{x: x, op: op, y: y}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for _, c := range cons {
+		sb.WriteString(fmt.Sprintf("%d %s %d\n", c.x, c.op, c.y))
+	}
+	return Test{n: n, constraints: cons, input: sb.String()}
+}
+
+func check(seq []int, cons []Constraint) bool {
+	for _, c := range cons {
+		vx := seq[c.x-1]
+		vy := seq[c.y-1]
+		switch c.op {
+		case "=":
+			if vx != vy {
+				return false
+			}
+		case "<":
+			if !(vx < vy) {
+				return false
+			}
+		case ">":
+			if !(vx > vy) {
+				return false
+			}
+		case "<=":
+			if !(vx <= vy) {
+				return false
+			}
+		case ">=":
+			if !(vx >= vy) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func dfs(i int, n int, a []int, cons []Constraint, count *int64) {
+	if i > n {
+		left := make([]int, 0, 2*n)
+		for v := 1; v <= n; v++ {
+			for j := 0; j < a[v]; j++ {
+				left = append(left, v)
+			}
+		}
+		right := make([]int, 0, 2*n)
+		for v := n; v >= 1; v-- {
+			for j := 0; j < 2-a[v]; j++ {
+				right = append(right, v)
+			}
+		}
+		seq := append(left, right...)
+		if check(seq, cons) {
+			*count++
+		}
+		return
+	}
+	for t := 0; t <= 2; t++ {
+		a[i] = t
+		dfs(i+1, n, a, cons, count)
+	}
+}
+
+func solve(t Test) string {
+	a := make([]int, t.n+1)
+	var cnt int64
+	dfs(1, t.n, a, t.constraints, &cnt)
+	return strconv.FormatInt(cnt, 10)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s got:%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}


### PR DESCRIPTION
## Summary
- add Go verification programs for problems A–F of contest 567
- each verifier generates 100 random tests and compares output with reference solver

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go run verifierA.go ./567A_bin`
- `go run verifierB.go ./567B_bin`


------
https://chatgpt.com/codex/tasks/task_e_68833769714c8324a561a5e9a58370aa