### PR TITLE
Add naive Go solution for 1949E

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1949/1949E.go
+++ b/1000-1999/1900-1999/1940-1949/1949/1949E.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, k int
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+	h := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &h[i])
+	}
+
+	bestX, bestY := 1, k-1
+	bestTime := math.Inf(1)
+	for x := 1; x <= k-1; x++ {
+		y := k - x
+		var hits int64
+		for _, v := range h {
+			hits += (v + int64(x) - 1) / int64(x)
+		}
+		t := float64(hits) / float64(y)
+		if t < bestTime {
+			bestTime = t
+			bestX, bestY = x, y
+		}
+	}
+
+	fmt.Fprintf(out, "%d %d\n", bestX, bestY)
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem E of contest 1949

## Testing
- `go vet 1000-1999/1900-1999/1940-1949/1949/1949E.go`
- `go build 1000-1999/1900-1999/1940-1949/1949/1949E.go`

------
https://chatgpt.com/codex/tasks/task_e_68833723464083248d05300cfe1b39c8