### PR TITLE
Add Go solution verifiers for Codeforces contest 576

### DIFF
--- a/0-999/500-599/570-579/576/verifierA.go
+++ b/0-999/500-599/570-579/576/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "576A.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(1000) + 1
+		tests[i] = fmt.Sprintf("%d\n", n)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		expToks := strings.Fields(exp)
+		outToks := strings.Fields(out)
+		if len(expToks) != len(outToks) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+		for i := range expToks {
+			if expToks[i] != outToks[i] {
+				fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/576/verifierB.go
+++ b/0-999/500-599/570-579/576/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "576B.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rand.Seed(2)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		p := rand.Perm(n)
+		for j := range p {
+			p[j]++
+		}
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range p {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/576/verifierC.go
+++ b/0-999/500-599/570-579/576/verifierC.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "576C.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rand.Seed(3)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50) + 1
+		type pt struct{ x, y int }
+		seen := make(map[pt]bool)
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			var x, y int
+			for {
+				x = rand.Intn(1000)
+				y = rand.Intn(1000)
+				if !seen[pt{x, y}] {
+					seen[pt{x, y}] = true
+					break
+				}
+			}
+			sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/576/verifierD.go
+++ b/0-999/500-599/570-579/576/verifierD.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refD_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "576D.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rand.Seed(4)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(6) + 2
+		m := rand.Intn(8) + 1
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j := 0; j < m; j++ {
+			a := rand.Intn(n) + 1
+			b := rand.Intn(n) + 1
+			d := rand.Intn(20)
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", a, b, d))
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/570-579/576/verifierE.go
+++ b/0-999/500-599/570-579/576/verifierE.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "576E.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rand.Seed(5)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(8) + 2
+		m := rand.Intn(10) + 1
+		k := rand.Intn(3) + 1
+		q := rand.Intn(10) + 1
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, k, q))
+		type edge struct{ a, b int }
+		used := make(map[edge]bool)
+		for j := 0; j < m; j++ {
+			var a, b int
+			for {
+				a = rand.Intn(n) + 1
+				b = rand.Intn(n) + 1
+				if a != b && !used[edge{a, b}] && !used[edge{b, a}] {
+					used[edge{a, b}] = true
+					break
+				}
+			}
+			sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+		}
+		for j := 0; j < q; j++ {
+			e := rand.Intn(m) + 1
+			c := rand.Intn(k) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", e, c))
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for each problem of contest 576
- each verifier builds the corresponding reference solution and runs 100 random tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_68833c56312c8324ae6cd9aecaae1555