### PR TITLE
Add Go verifiers for contest 575

### DIFF
--- a/0-999/500-599/570-579/575/verifierA.go
+++ b/0-999/500-599/570-579/575/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refA_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "575A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	K := rand.Int63n(20)
+	P := rand.Int63n(1000) + 1
+	N := rand.Intn(3) + 1
+	base := make([]int64, N)
+	for i := 0; i < N; i++ {
+		base[i] = rand.Int63n(P) + 1
+	}
+	M := rand.Intn(3)
+	lines := fmt.Sprintf("%d %d\n%d\n", K, P, N)
+	for i := 0; i < N; i++ {
+		lines += fmt.Sprintf("%d ", base[i])
+	}
+	lines = strings.TrimSpace(lines) + "\n"
+	lines += fmt.Sprintf("%d\n", M)
+	for i := 0; i < M; i++ {
+		j := rand.Int63n(K+int64(N)) + int64(N)
+		v := rand.Int63n(P) + 1
+		lines += fmt.Sprintf("%d %d\n", j, v)
+	}
+	return lines
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%s\nactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/570-579/575/verifierB.go
+++ b/0-999/500-599/570-579/575/verifierB.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refB_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "575B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(4) + 2
+	edges := make([][3]int, n-1)
+	for i := 1; i <= n-1; i++ {
+		a := i
+		b := i + 1
+		x := rand.Intn(2)
+		edges[i-1] = [3]int{a, b, x}
+	}
+	K := rand.Intn(5) + 1
+	path := make([]int, K)
+	for i := 0; i < K; i++ {
+		path[i] = rand.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", K))
+	for i, v := range path {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%s\nactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/570-579/575/verifierC.go
+++ b/0-999/500-599/570-579/575/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refC_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "575C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(3) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(10)))
+			if j+1 < n {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(10)))
+			if j+1 < n {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%s\nactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/570-579/575/verifierD.go
+++ b/0-999/500-599/570-579/575/verifierD.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() string {
+	ref := "refD_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "575D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin string) (string, error) {
+	c := exec.Command(bin)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	exp, err := run(ref)
+	if err != nil {
+		fmt.Println("reference failed:", err)
+		return
+	}
+	for i := 0; i < 100; i++ {
+		got, err := run(bin)
+		if err != nil {
+			fmt.Printf("binary failed on iteration %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on iteration %d\nexpected:%s\nactual:%s\n", i, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/570-579/575/verifierE.go
+++ b/0-999/500-599/570-579/575/verifierE.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refE_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "575E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := rand.Intn(100)
+		y := rand.Intn(100)
+		d := rand.Intn(50)
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", x, y, d))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%s\nactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/570-579/575/verifierF.go
+++ b/0-999/500-599/570-579/575/verifierF.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refF_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "575F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(4) + 1
+	x := rand.Intn(20)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+	for i := 0; i < n; i++ {
+		l := rand.Intn(20)
+		r := l + rand.Intn(10)
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%s\nactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/570-579/575/verifierG.go
+++ b/0-999/500-599/570-579/575/verifierG.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refG_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "575G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(4) + 2
+	m := rand.Intn(6) + n - 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		a := rand.Intn(n)
+		b := rand.Intn(n)
+		for b == a {
+			b = rand.Intn(n)
+		}
+		l := rand.Intn(10)
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", a, b, l))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%s\nactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/570-579/575/verifierH.go
+++ b/0-999/500-599/570-579/575/verifierH.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refH_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "575H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(50)
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:%sexpected:%sactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/500-599/570-579/575/verifierI.go
+++ b/0-999/500-599/570-579/575/verifierI.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() string {
+	ref := "refI_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "575I.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("failed to build reference: %v\n%s", err, string(out)))
+	}
+	return ref
+}
+
+func run(bin, input string) (string, error) {
+	c := exec.Command(bin)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &out
+	err := c.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	N := rand.Intn(4) + 1
+	Q := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", N, Q))
+	for i := 0; i < Q; i++ {
+		tp := rand.Intn(2) + 1
+		sb.WriteString(fmt.Sprintf("%d ", tp))
+		if tp == 1 {
+			dir := rand.Intn(4) + 1
+			x := rand.Intn(N) + 1
+			y := rand.Intn(N) + 1
+			l := rand.Intn(3) + 1
+			sb.WriteString(fmt.Sprintf("%d %d %d %d\n", dir, x, y, l))
+		} else {
+			x := rand.Intn(N) + 1
+			y := rand.Intn(N) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	ref := buildRef()
+	defer os.Remove(ref)
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			return
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("binary failed on case %d: %v\n", i, err)
+			return
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on case %d\ninput:\n%s\nexpected:%s\nactual:%s\n", i, input, exp, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–I of contest 575
- each verifier builds the reference solution, generates 100 random test cases and checks a target binary

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go verifierH.go verifierI.go`


------
https://chatgpt.com/codex/tasks/task_e_68833bca182c8324aad1ff1df571ef16