### PR TITLE
Add Go solution for 1948B

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1948/1948B.go
+++ b/1000-1999/1900-1999/1940-1949/1948/1948B.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func nondecreasing(nums []int) bool {
+	for i := 1; i < len(nums); i++ {
+		if nums[i] < nums[i-1] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		if _, err := fmt.Fscan(reader, &n); err != nil {
+			return
+		}
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		lastDigit := -1
+		for i := 0; i < n; i++ {
+			if a[i] < 10 {
+				lastDigit = i
+			}
+		}
+		possible := false
+		for pos := lastDigit + 1; pos <= n; pos++ {
+			digits := make([]int, 0, pos*2)
+			for i := 0; i < pos; i++ {
+				if a[i] >= 10 {
+					digits = append(digits, a[i]/10, a[i]%10)
+				} else {
+					digits = append(digits, a[i])
+				}
+			}
+			if !nondecreasing(digits) {
+				continue
+			}
+			good := true
+			for i := pos + 1; i < n; i++ {
+				if a[i] < a[i-1] {
+					good = false
+					break
+				}
+			}
+			if good {
+				possible = true
+				break
+			}
+		}
+		if possible {
+			writer.WriteString("YES\n")
+		} else {
+			writer.WriteString("NO\n")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem B of contest 1948

## Testing
- `go build 1000-1999/1900-1999/1940-1949/1948/1948B.go`
- `go vet 1000-1999/1900-1999/1940-1949/1948/1948B.go`


------
https://chatgpt.com/codex/tasks/task_e_68833b84093483249422455568df2d14