### PR TITLE
Add 1941C Go solution

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1941/1941C.go
+++ b/1000-1999/1900-1999/1940-1949/1941/1941C.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	if _, err := fmt.Fscan(in, &T); err != nil {
+		return
+	}
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(in, &n)
+		var s string
+		fmt.Fscan(in, &s)
+		ans := 0
+		for i := 0; i < n; {
+			if i+4 < n && s[i:i+5] == "mapie" {
+				ans++
+				i += 5
+			} else if i+2 < n && (s[i:i+3] == "pie" || s[i:i+3] == "map") {
+				ans++
+				i += 3
+			} else {
+				i++
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem C from contest 1941

## Testing
- `go build 1000-1999/1900-1999/1940-1949/1941/1941C.go`
- `go vet 1000-1999/1900-1999/1940-1949/1941/1941C.go`


------
https://chatgpt.com/codex/tasks/task_e_688341893a6083248799ac9b1966fb8e