### PR TITLE
Add Go verifiers for contest 582

### DIFF
--- a/0-999/500-599/580-589/582/verifierA.go
+++ b/0-999/500-599/580-589/582/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+// generateCase builds a random array and returns the input string and
+// the sorted gcd table for validation along with n.
+func generateCase(rng *rand.Rand) (string, []int, int) {
+	n := rng.Intn(4) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(20) + 1
+	}
+	table := make([]int, 0, n*n)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			table = append(table, gcd(arr[i], arr[j]))
+		}
+	}
+	rng.Shuffle(len(table), func(i, j int) { table[i], table[j] = table[j], table[i] })
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range table {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+
+	sorted := append([]int(nil), table...)
+	sort.Ints(sorted)
+	return sb.String(), sorted, n
+}
+
+func runCase(bin string, input string, expect []int, n int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != n {
+		return fmt.Errorf("expected %d numbers got %d", n, len(fields))
+	}
+	arr := make([]int, n)
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("invalid integer %q", f)
+		}
+		arr[i] = v
+	}
+	table := make([]int, 0, n*n)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			table = append(table, gcd(arr[i], arr[j]))
+		}
+	}
+	sort.Ints(table)
+	for i := range table {
+		if table[i] != expect[i] {
+			return fmt.Errorf("wrong answer")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect, n := generateCase(rng)
+		if err := runCase(bin, input, expect, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/582/verifierB.go
+++ b/0-999/500-599/580-589/582/verifierB.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "582B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	T := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(300) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, T))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(prog, input string) (string, error) {
+	cmd := exec.Command(prog)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, oracle, input string) error {
+	got, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	expect, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/582/verifierC.go
+++ b/0-999/500-599/580-589/582/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "582C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(20) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(prog, input string) (string, error) {
+	cmd := exec.Command(prog)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, oracle, input string) error {
+	got, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	expect, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/582/verifierD.go
+++ b/0-999/500-599/580-589/582/verifierD.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "582D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+var primes = []int{2, 3, 5, 7, 11, 13, 17, 19, 23}
+
+func generateCase(rng *rand.Rand) string {
+	p := primes[rng.Intn(len(primes))]
+	alpha := rng.Intn(5) + 1
+	A := rng.Int63n(1000000)
+	return fmt.Sprintf("%d %d\n%d\n", p, alpha, A)
+}
+
+func run(prog, input string) (string, error) {
+	cmd := exec.Command(prog)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, oracle, input string) error {
+	got, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	expect, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/582/verifierE.go
+++ b/0-999/500-599/580-589/582/verifierE.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "582E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+var vars = []byte{'A', 'B', 'C', 'D', 'a', 'b', 'c', 'd', '?'}
+var ops = []byte{'&', '|', '?'}
+
+func genExpr(rng *rand.Rand, depth int) string {
+	if depth == 0 || rng.Intn(3) == 0 {
+		return string(vars[rng.Intn(len(vars))])
+	}
+	left := genExpr(rng, depth-1)
+	right := genExpr(rng, depth-1)
+	op := ops[rng.Intn(len(ops))]
+	return "(" + left + ")" + string(op) + "(" + right + ")"
+}
+
+func generateCase(rng *rand.Rand) string {
+	expr := genExpr(rng, 3)
+	n := rng.Intn(4)
+	var sb strings.Builder
+	sb.WriteString(expr + "\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	seen := make(map[string]bool)
+	for i := 0; i < n; {
+		a := rng.Intn(2)
+		b := rng.Intn(2)
+		c := rng.Intn(2)
+		d := rng.Intn(2)
+		key := fmt.Sprintf("%d%d%d%d", a, b, c, d)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		e := rng.Intn(2)
+		fmt.Fprintf(&sb, "%d %d %d %d %d\n", a, b, c, d, e)
+		i++
+	}
+	return sb.String()
+}
+
+func run(prog, input string) (string, error) {
+	cmd := exec.Command(prog)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, oracle, input string) error {
+	got, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	expect, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 582 problems A–E
- each verifier generates 100 random test cases
- verifiers B–E compile an oracle from the reference solutions and compare output
- verifierA checks gcd table validity directly

## Testing
- `go build 0-999/500-599/580-589/582/verifierA.go`
- `go build 0-999/500-599/580-589/582/verifierB.go`
- `go build 0-999/500-599/580-589/582/verifierC.go`
- `go build 0-999/500-599/580-589/582/verifierD.go`
- `go build 0-999/500-599/580-589/582/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68833f9ecde08324a5652f4993708fe6