### PR TITLE
Add verifier programs for CF contest 581

### DIFF
--- a/0-999/500-599/580-589/581/verifierA.go
+++ b/0-999/500-599/580-589/581/verifierA.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func gen() string {
+	a := rand.Intn(100) + 1
+	b := rand.Intn(100) + 1
+	return fmt.Sprintf("%d %d\n", a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./_refA.bin"
+	if err := exec.Command("go", "build", "-o", ref, "581A.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 1; i <= 100; i++ {
+		input := gen()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/581/verifierB.go
+++ b/0-999/500-599/580-589/581/verifierB.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func gen() string {
+	n := rand.Intn(100) + 1
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", rand.Int63n(1000000000)+1)
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./_refB.bin"
+	if err := exec.Command("go", "build", "-o", ref, "581B.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 1; i <= 100; i++ {
+		input := gen()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/581/verifierC.go
+++ b/0-999/500-599/580-589/581/verifierC.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func gen() string {
+	n := rand.Intn(100) + 1
+	k := rand.Intn(10000)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", rand.Intn(101))
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./_refC.bin"
+	if err := exec.Command("go", "build", "-o", ref, "581C.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 1; i <= 100; i++ {
+		input := gen()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/581/verifierD.go
+++ b/0-999/500-599/580-589/581/verifierD.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func gen() string {
+	a1 := rand.Intn(100) + 1
+	b1 := rand.Intn(100) + 1
+	a2 := rand.Intn(100) + 1
+	b2 := rand.Intn(100) + 1
+	a3 := rand.Intn(100) + 1
+	b3 := rand.Intn(100) + 1
+	return fmt.Sprintf("%d %d %d %d %d %d\n", a1, b1, a2, b2, a3, b3)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./_refD.bin"
+	if err := exec.Command("go", "build", "-o", ref, "581D.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 1; i <= 100; i++ {
+		input := gen()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/581/verifierE.go
+++ b/0-999/500-599/580-589/581/verifierE.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func gen() string {
+	e := rand.Intn(1000) + 1
+	s := rand.Intn(100) + 1
+	n := rand.Intn(5) + 1
+	m := rand.Intn(5) + 1
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %d %d %d\n", e, s, n, m)
+	used := make(map[int]bool)
+	for i := 0; i < n; i++ {
+		var x int
+		for {
+			x = rand.Intn(2*e) - e
+			if !used[x] {
+				used[x] = true
+				break
+			}
+		}
+		t := rand.Intn(3) + 1
+		fmt.Fprintf(&b, "%d %d\n", t, x)
+	}
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		f := rand.Intn(e*2) - e
+		if f >= e {
+			f = e - 1
+		}
+		fmt.Fprintf(&b, "%d", f)
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./_refE.bin"
+	if err := exec.Command("go", "build", "-o", ref, "581E.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 1; i <= 100; i++ {
+		input := gen()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/581/verifierF.go
+++ b/0-999/500-599/580-589/581/verifierF.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func gen() string {
+	n := rand.Intn(20) + 2
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		fmt.Fprintf(&b, "%d %d\n", p, i)
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./_refF.bin"
+	if err := exec.Command("go", "build", "-o", ref, "581F.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 1; i <= 100; i++ {
+		input := gen()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verification scripts for contest 581 problems A–F
- each verifier builds the official Go solution and checks a provided binary against 100 random test cases

## Testing
- `go build 0-999/500-599/580-589/581/verifierA.go`
- `go build 0-999/500-599/580-589/581/verifierB.go`
- `go build 0-999/500-599/580-589/581/verifierC.go`
- `go build 0-999/500-599/580-589/581/verifierD.go`
- `go build 0-999/500-599/580-589/581/verifierE.go`
- `go build 0-999/500-599/580-589/581/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68833f12aac88324b2f20fc7be93e15b