### PR TITLE
Add Go solution for 1946A

### DIFF
--- a/1000-1999/1900-1999/1940-1949/1946/1946A.go
+++ b/1000-1999/1900-1999/1940-1949/1946/1946A.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+		m := (n - 1) / 2
+		target := a[m] + 1
+		var ops int64
+		for i := m; i < n; i++ {
+			if a[i] < target {
+				ops += target - a[i]
+			}
+		}
+		fmt.Fprintln(out, ops)
+	}
+}


### PR DESCRIPTION
## Summary
- implement 1946A solution in Go

## Testing
- `go build 1000-1999/1900-1999/1940-1949/1946/1946A.go`
- ran sample inputs with the built binary

------
https://chatgpt.com/codex/tasks/task_e_68833ecca4cc8324b0c2a30d2e872703