### PR TITLE
Add solution verifiers for contest 580

### DIFF
--- a/0-999/500-599/580-589/580/verifierA.go
+++ b/0-999/500-599/580-589/580/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solve(nums []int) int {
+	maxLen, currLen := 0, 0
+	prev := 0
+	for i, x := range nums {
+		if i == 0 || x >= prev {
+			currLen++
+		} else {
+			currLen = 1
+		}
+		if currLen > maxLen {
+			maxLen = currLen
+		}
+		prev = x
+	}
+	return maxLen
+}
+
+func buildCase(nums []int) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(nums)))
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	ans := solve(nums)
+	return testCase{input: sb.String(), expected: fmt.Sprintf("%d\n", ans)}
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 1
+	nums := make([]int, n)
+	for i := range nums {
+		nums[i] = rng.Intn(1000)
+	}
+	return buildCase(nums)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{
+		buildCase([]int{1}),
+		buildCase([]int{1, 2, 3}),
+		buildCase([]int{3, 2, 1}),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/580/verifierB.go
+++ b/0-999/500-599/580-589/580/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+type friend struct {
+	money  int64
+	factor int64
+}
+
+func solveCase(friends []friend, d int64) int64 {
+	sort.Slice(friends, func(i, j int) bool { return friends[i].money < friends[j].money })
+	var best, cur int64
+	l := 0
+	for r := 0; r < len(friends); r++ {
+		cur += friends[r].factor
+		for l <= r && friends[r].money-friends[l].money >= d {
+			cur -= friends[l].factor
+			l++
+		}
+		if cur > best {
+			best = cur
+		}
+	}
+	return best
+}
+
+func buildCase(friends []friend, d int64) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", len(friends), d))
+	for _, f := range friends {
+		sb.WriteString(fmt.Sprintf("%d %d\n", f.money, f.factor))
+	}
+	ans := solveCase(append([]friend(nil), friends...), d)
+	return testCase{input: sb.String(), expected: fmt.Sprintf("%d\n", ans)}
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 1
+	d := int64(rng.Intn(20) + 1)
+	friends := make([]friend, n)
+	for i := range friends {
+		friends[i].money = int64(rng.Intn(100))
+		friends[i].factor = int64(rng.Intn(100))
+	}
+	return buildCase(friends, d)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []testCase{
+		buildCase([]friend{{10, 5}}, 1),
+		buildCase([]friend{{1, 1}, {2, 2}, {3, 3}}, 5),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/580/verifierC.go
+++ b/0-999/500-599/580-589/580/verifierC.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(n, m int, cats []int, edges [][2]int) int {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	type node struct{ v, cnt int }
+	stack := []node{{1, cats[1]}}
+	visited := make([]bool, n+1)
+	visited[1] = true
+	ans := 0
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if cur.cnt > m {
+			continue
+		}
+		isLeaf := true
+		for _, to := range adj[cur.v] {
+			if !visited[to] {
+				visited[to] = true
+				nextCnt := 0
+				if cats[to] == 1 {
+					nextCnt = cur.cnt + 1
+				}
+				stack = append(stack, node{to, nextCnt})
+				isLeaf = false
+			}
+		}
+		if isLeaf {
+			ans++
+		}
+	}
+	return ans
+}
+
+func buildCase(n, m int, cats []int, edges [][2]int) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", cats[i]))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	ans := solveCase(n, m, cats, edges)
+	return testCase{input: sb.String(), expected: fmt.Sprintf("%d\n", ans)}
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 2
+	m := rng.Intn(n) + 1
+	cats := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		cats[i] = rng.Intn(2)
+	}
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	return buildCase(n, m, cats, edges)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cats := []int{0, 1, 1}
+	edges := [][2]int{{1, 2}, {1, 3}}
+	cases := []testCase{
+		buildCase(3, 1, cats, edges),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/580/verifierD.go
+++ b/0-999/500-599/580-589/580/verifierD.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(a []int64, bonus [][]int64, m int) int64 {
+	n := len(a)
+	maxMask := 1 << n
+	dp := make([][]int64, maxMask)
+	for i := range dp {
+		dp[i] = make([]int64, n)
+		for j := range dp[i] {
+			dp[i][j] = -1
+		}
+	}
+	for i := 0; i < n; i++ {
+		dp[1<<i][i] = a[i]
+	}
+	var ans int64
+	for mask := 0; mask < maxMask; mask++ {
+		cnt := bits.OnesCount(uint(mask))
+		if cnt > m {
+			continue
+		}
+		for last := 0; last < n; last++ {
+			val := dp[mask][last]
+			if val < 0 {
+				continue
+			}
+			if cnt == m {
+				if val > ans {
+					ans = val
+				}
+				continue
+			}
+			for next := 0; next < n; next++ {
+				if mask&(1<<next) != 0 {
+					continue
+				}
+				newMask := mask | 1<<next
+				nv := val + a[next] + bonus[last][next]
+				if nv > dp[newMask][next] {
+					dp[newMask][next] = nv
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func buildCase(a []int64, bonus [][]int64, m int) testCase {
+	n := len(a)
+	var sb strings.Builder
+	k := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if bonus[i][j] != 0 {
+				k++
+			}
+		}
+	}
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if bonus[i][j] != 0 {
+				sb.WriteString(fmt.Sprintf("%d %d %d\n", i+1, j+1, bonus[i][j]))
+			}
+		}
+	}
+	ans := solveCase(a, bonus, m)
+	return testCase{input: sb.String(), expected: fmt.Sprintf("%d\n", ans)}
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 2
+	m := rng.Intn(n) + 1
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = int64(rng.Intn(10))
+	}
+	bonus := make([][]int64, n)
+	for i := range bonus {
+		bonus[i] = make([]int64, n)
+		for j := range bonus[i] {
+			if i != j && rng.Intn(4) == 0 {
+				bonus[i][j] = int64(rng.Intn(5))
+			}
+		}
+	}
+	return buildCase(a, bonus, m)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	a := []int64{1, 1}
+	bonus := [][]int64{{0, 1}, {0, 0}}
+	cases := []testCase{buildCase(a, bonus, 2)}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/580/verifierE.go
+++ b/0-999/500-599/580-589/580/verifierE.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	mod1 int64 = 1000000007
+	mod2 int64 = 1000000009
+	base int64 = 911382323
+)
+
+var (
+	pow1  []int64
+	pow2  []int64
+	ones1 []int64
+	ones2 []int64
+)
+
+type Hash struct {
+	h1, h2 int64
+	len    int
+}
+
+type SegTree struct {
+	n    int
+	h1   []int64
+	h2   []int64
+	lazy []int
+}
+
+func NewSegTree(arr []int) *SegTree {
+	n := len(arr) - 1
+	size := 4 * n
+	st := &SegTree{
+		n:    n,
+		h1:   make([]int64, size),
+		h2:   make([]int64, size),
+		lazy: make([]int, size),
+	}
+	for i := range st.lazy {
+		st.lazy[i] = -1
+	}
+	st.build(1, 1, n, arr)
+	return st
+}
+
+func (st *SegTree) build(node, l, r int, arr []int) {
+	if l == r {
+		v := int64(arr[l] + 1)
+		st.h1[node] = v
+		st.h2[node] = v
+		return
+	}
+	mid := (l + r) >> 1
+	st.build(node<<1, l, mid, arr)
+	st.build(node<<1|1, mid+1, r, arr)
+	st.pull(node, l, r)
+}
+
+func (st *SegTree) apply(node, l, r, c int) {
+	length := r - l + 1
+	v := int64(c + 1)
+	st.h1[node] = v * ones1[length] % mod1
+	st.h2[node] = v * ones2[length] % mod2
+	st.lazy[node] = c
+}
+
+func (st *SegTree) push(node, l, r int) {
+	if st.lazy[node] != -1 && l != r {
+		mid := (l + r) >> 1
+		c := st.lazy[node]
+		st.apply(node<<1, l, mid, c)
+		st.apply(node<<1|1, mid+1, r, c)
+		st.lazy[node] = -1
+	}
+}
+
+func (st *SegTree) pull(node, l, r int) {
+	left, right := node<<1, node<<1|1
+	mid := (l + r) >> 1
+	lenR := r - mid
+	st.h1[node] = (st.h1[left]*pow1[lenR] + st.h1[right]) % mod1
+	st.h2[node] = (st.h2[left]*pow2[lenR] + st.h2[right]) % mod2
+}
+
+func (st *SegTree) Update(node, l, r, ql, qr, c int) {
+	if ql <= l && r <= qr {
+		st.apply(node, l, r, c)
+		return
+	}
+	st.push(node, l, r)
+	mid := (l + r) >> 1
+	if ql <= mid {
+		st.Update(node<<1, l, mid, ql, qr, c)
+	}
+	if qr > mid {
+		st.Update(node<<1|1, mid+1, r, ql, qr, c)
+	}
+	st.pull(node, l, r)
+}
+
+func merge(a, b Hash) Hash {
+	if a.len == 0 {
+		return b
+	}
+	if b.len == 0 {
+		return a
+	}
+	return Hash{
+		h1:  (a.h1*pow1[b.len] + b.h1) % mod1,
+		h2:  (a.h2*pow2[b.len] + b.h2) % mod2,
+		len: a.len + b.len,
+	}
+}
+
+func (st *SegTree) Query(node, l, r, ql, qr int) Hash {
+	if ql > qr {
+		return Hash{0, 0, 0}
+	}
+	if ql <= l && r <= qr {
+		return Hash{st.h1[node], st.h2[node], r - l + 1}
+	}
+	st.push(node, l, r)
+	mid := (l + r) >> 1
+	if qr <= mid {
+		return st.Query(node<<1, l, mid, ql, qr)
+	}
+	if ql > mid {
+		return st.Query(node<<1|1, mid+1, r, ql, qr)
+	}
+	leftHash := st.Query(node<<1, l, mid, ql, qr)
+	rightHash := st.Query(node<<1|1, mid+1, r, ql, qr)
+	return merge(leftHash, rightHash)
+}
+
+func solve(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+	defer writer.Flush()
+
+	var n, m, k int
+	if _, err := fmt.Fscan(reader, &n, &m, &k); err != nil {
+		return ""
+	}
+	var str string
+	fmt.Fscan(reader, &str)
+
+	pow1 = make([]int64, n+2)
+	pow2 = make([]int64, n+2)
+	ones1 = make([]int64, n+2)
+	ones2 = make([]int64, n+2)
+	pow1[0], pow2[0] = 1, 1
+	for i := 1; i <= n+1; i++ {
+		pow1[i] = pow1[i-1] * base % mod1
+		pow2[i] = pow2[i-1] * base % mod2
+	}
+	for i := 1; i <= n+1; i++ {
+		ones1[i] = (ones1[i-1]*base + 1) % mod1
+		ones2[i] = (ones2[i-1]*base + 1) % mod2
+	}
+
+	arr := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		arr[i] = int(str[i-1] - '0')
+	}
+	st := NewSegTree(arr)
+
+	total := m + k
+	for ; total > 0; total-- {
+		var tp int
+		fmt.Fscan(reader, &tp)
+		if tp == 1 {
+			var l, r, c int
+			fmt.Fscan(reader, &l, &r, &c)
+			st.Update(1, 1, n, l, r, c)
+		} else {
+			var l, r, d int
+			fmt.Fscan(reader, &l, &r, &d)
+			if l > r-d {
+				fmt.Fprintln(writer, "YES")
+				continue
+			}
+			h1 := st.Query(1, 1, n, l, r-d)
+			h2 := st.Query(1, 1, n, l+d, r)
+			if h1.h1 == h2.h1 && h1.h2 == h2.h2 {
+				fmt.Fprintln(writer, "YES")
+			} else {
+				fmt.Fprintln(writer, "NO")
+			}
+		}
+	}
+	writer.Flush()
+	return buf.String()
+}
+
+func buildCase(n, m, k int, str string, ops []string) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	sb.WriteString(str)
+	sb.WriteByte('\n')
+	for _, op := range ops {
+		sb.WriteString(op)
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	return testCase{input: input, expected: solve(input)}
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(3) + 1
+	k := rng.Intn(3) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	str := sb.String()
+	var ops []string
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		c := rng.Intn(2)
+		ops = append(ops, fmt.Sprintf("1 %d %d %d", l, r, c))
+	}
+	for i := 0; i < k; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		d := 0
+		if r-l > 0 {
+			d = rng.Intn(r - l)
+		}
+		ops = append(ops, fmt.Sprintf("2 %d %d %d", l, r, d))
+	}
+	rng.Shuffle(len(ops), func(i, j int) { ops[i], ops[j] = ops[j], ops[i] })
+	return buildCase(n, m, k, str, ops)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	ops := []string{"1 1 1 1", "2 1 1 0"}
+	cases := []testCase{buildCase(1, 1, 1, "0", ops)}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` – runs 100+ test cases for 580A
- add `verifierB.go` – runs 100+ test cases for 580B
- add `verifierC.go` – runs 100+ test cases for 580C
- add `verifierD.go` – runs 100+ test cases for 580D
- add `verifierE.go` – runs 100+ test cases for 580E

## Testing
- `gofmt -w 0-999/500-599/580-589/580/verifierA.go 0-999/500-599/580-589/580/verifierB.go 0-999/500-599/580-589/580/verifierC.go 0-999/500-599/580-589/580/verifierD.go 0-999/500-599/580-589/580/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_68833e86929c8324911d32cb263251e9