### PR TITLE
Add Go verifiers for contest 579

### DIFF
--- a/0-999/500-599/570-579/579/verifierA.go
+++ b/0-999/500-599/570-579/579/verifierA.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// expected computes the number of set bits in x.
+func expected(x int) int {
+	count := 0
+	for x > 0 {
+		if x&1 == 1 {
+			count++
+		}
+		x >>= 1
+	}
+	return count
+}
+
+// runBinary runs the provided binary with given input and returns trimmed stdout.
+func runBinary(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	tests := []int{}
+	for i := 1; i <= 100; i++ {
+		tests = append(tests, i)
+	}
+	extra := []int{101, 123, 234, 345, 456, 567, 678, 789, 890, 901,
+		1000, 1234, 2048, 4096, 8192, 16384, 32768, 65536,
+		99999, 100000, 500000, 999999, 1000000, 1234567, 7654321,
+		9999999, 12345678, 50000000, 100000000, 200000000, 500000000, 1000000000}
+	tests = append(tests, extra...)
+
+	for idx, x := range tests {
+		exp := expected(x)
+		output, err := runBinary(binary, fmt.Sprintf("%d\n", x))
+		if err != nil {
+			fmt.Printf("Test %d (x=%d) runtime error: %v\n", idx+1, x, err)
+			os.Exit(1)
+		}
+		if output != fmt.Sprintf("%d", exp) {
+			fmt.Printf("Test %d (x=%d) failed: expected %d, got %s\n", idx+1, x, exp, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(tests))
+}

--- a/0-999/500-599/570-579/579/verifierB.go
+++ b/0-999/500-599/570-579/579/verifierB.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type Test struct {
+	n   int
+	mat [][]int
+}
+
+func generateTests() []Test {
+	var tests []Test
+	for t := 0; t < 100; t++ {
+		rand.Seed(int64(t + 1))
+		n := rand.Intn(4) + 2 // n in [2,5], so 2n in [4,10]
+		m := 2 * n
+		total := m * (m - 1) / 2
+		perm := rand.Perm(total)
+		idx := 0
+		mat := make([][]int, m+1)
+		for i := range mat {
+			mat[i] = make([]int, m+1)
+		}
+		for i := 2; i <= m; i++ {
+			for j := 1; j < i; j++ {
+				mat[i][j] = perm[idx] + 1
+				idx++
+			}
+		}
+		tests = append(tests, Test{n: n, mat: mat})
+	}
+	return tests
+}
+
+func solve(n int, mat [][]int) []int {
+	m := 2 * n
+	type Pair struct{ i, j, v int }
+	var pairs []Pair
+	for i := 2; i <= m; i++ {
+		for j := 1; j < i; j++ {
+			pairs = append(pairs, Pair{i, j, mat[i][j]})
+		}
+	}
+	sort.Slice(pairs, func(a, b int) bool { return pairs[a].v > pairs[b].v })
+	res := make([]int, m+1)
+	for _, p := range pairs {
+		if res[p.i] == 0 && res[p.j] == 0 {
+			res[p.i] = p.j
+			res[p.j] = p.i
+		}
+	}
+	return res[1:]
+}
+
+func (t Test) input() string {
+	var b strings.Builder
+	m := 2 * t.n
+	b.WriteString(fmt.Sprintf("%d\n", t.n))
+	for i := 2; i <= m; i++ {
+		for j := 1; j < i; j++ {
+			b.WriteString(fmt.Sprintf("%d ", t.mat[i][j]))
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func runBinary(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func intsToString(arr []int) string {
+	var b strings.Builder
+	for i, v := range arr {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprintf("%d", v))
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+
+	tests := generateTests()
+	for idx, t := range tests {
+		exp := intsToString(solve(t.n, t.mat))
+		output, err := runBinary(binary, t.input())
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if output != exp {
+			fmt.Printf("Test %d failed:\nInput:\n%sExpected: %s\nGot: %s\n", idx+1, t.input(), exp, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` for problem A
- add `verifierB.go` for problem B
- each verifier runs 100+ generated test cases against a provided binary

## Testing
- `go run verifierA.go ./579A_bin`
- `go run verifierB.go ./579B_bin`


------
https://chatgpt.com/codex/tasks/task_e_68833dfa77748324a94da5f8ade8e4de