### PR TITLE
Add verifier programs for contest 584

### DIFF
--- a/0-999/500-599/580-589/584/verifierA.go
+++ b/0-999/500-599/580-589/584/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n, t int) string {
+	if n == 1 && t == 10 {
+		return "-1"
+	}
+	if t == 10 {
+		return "1" + strings.Repeat("0", n-1)
+	}
+	return strings.Repeat(fmt.Sprint(t), n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// predetermined edge cases
+	cases := []struct{ n, t int }{
+		{1, 10}, {1, 2}, {2, 10}, {3, 10}, {10, 3},
+	}
+	for i := 0; i < 95; i++ {
+		n := rng.Intn(100) + 1
+		t := rng.Intn(9) + 2 // 2..10
+		cases = append(cases, struct{ n, t int }{n, t})
+	}
+	for idx, tc := range cases {
+		input := fmt.Sprintf("%d %d\n", tc.n, tc.t)
+		expect := solve(tc.n, tc.t)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", idx+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/584/verifierB.go
+++ b/0-999/500-599/580-589/584/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func powmod(base, exp int64) int64 {
+	res := int64(1)
+	base %= mod
+	for exp > 0 {
+		if exp&1 == 1 {
+			res = res * base % mod
+		}
+		base = base * base % mod
+		exp >>= 1
+	}
+	return res
+}
+
+func solve(n int64) int64 {
+	total := powmod(3, 3*n)
+	bad := powmod(7, n)
+	ans := (total - bad) % mod
+	if ans < 0 {
+		ans += mod
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := make([]int64, 0, 100)
+	// deterministic cases
+	for i := int64(1); i <= 5; i++ {
+		cases = append(cases, i)
+	}
+	for len(cases) < 100 {
+		cases = append(cases, rng.Int63n(100000)+1)
+	}
+
+	for idx, n := range cases {
+		input := fmt.Sprintf("%d\n", n)
+		expect := solve(n)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output %q\n", idx+1, out)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:%s", idx+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/584/verifierC.go
+++ b/0-999/500-599/580-589/584/verifierC.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func note(x, y byte) byte {
+	for z := byte('a'); z <= 'z'; z++ {
+		if z != x && z != y {
+			return z
+		}
+	}
+	return 'a'
+}
+
+func solve(s1, s2 string, t int) (string, bool) {
+	n := len(s1)
+	eq := 0
+	for i := 0; i < n; i++ {
+		if s1[i] == s2[i] {
+			eq++
+		}
+	}
+	dif := n - eq
+	sdMin := t - dif
+	if sdMin < 0 {
+		sdMin = 0
+	}
+	half := (dif + 1) / 2
+	sdMax := t - half
+	if sdMax > eq {
+		sdMax = eq
+	}
+	if sdMin > sdMax {
+		return "", false
+	}
+	sd := sdMin
+	tPrime := t - sd
+	db := 2*tPrime - dif
+
+	ans := make([]byte, n)
+	c := 0
+	for i := 0; i < n; i++ {
+		if s1[i] != s2[i] {
+			if c < db {
+				ans[i] = note(s1[i], s2[i])
+			} else {
+				if c%2 == 1 {
+					ans[i] = s1[i]
+				} else {
+					ans[i] = s2[i]
+				}
+			}
+			c++
+		}
+	}
+	c = 0
+	for i := 0; i < n; i++ {
+		if s1[i] == s2[i] {
+			if c < sd {
+				ans[i] = byte('a' + (s1[i]-'a'+1)%26)
+			} else {
+				ans[i] = s1[i]
+			}
+			c++
+		}
+	}
+	return string(ans), true
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func diff(a, b string) int {
+	cnt := 0
+	for i := range a {
+		if a[i] != b[i] {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type tc struct {
+		n      int
+		t      int
+		s1, s2 string
+	}
+	cases := make([]tc, 0, 100)
+	// some edge cases
+	cases = append(cases, tc{1, 0, "a", "a"})
+	cases = append(cases, tc{1, 1, "a", "b"})
+	cases = append(cases, tc{2, 1, "aa", "aa"})
+
+	for len(cases) < 100 {
+		n := rng.Intn(20) + 1
+		t := rng.Intn(n + 1)
+		var b1, b2 strings.Builder
+		for i := 0; i < n; i++ {
+			b1.WriteByte(byte('a' + rng.Intn(26)))
+			b2.WriteByte(byte('a' + rng.Intn(26)))
+		}
+		cases = append(cases, tc{n, t, b1.String(), b2.String()})
+	}
+
+	for idx, tc := range cases {
+		input := fmt.Sprintf("%d %d\n%s\n%s\n", tc.n, tc.t, tc.s1, tc.s2)
+		expect, ok := solve(tc.s1, tc.s2, tc.t)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if !ok {
+			if out != "-1" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected -1 got %s\ninput:%s", idx+1, out, input)
+				os.Exit(1)
+			}
+			continue
+		}
+		if out == "-1" {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected string got -1\ninput:%s", idx+1, input)
+			os.Exit(1)
+		}
+		if len(out) != tc.n {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected length %d got %d\n", idx+1, tc.n, len(out))
+			os.Exit(1)
+		}
+		if diff(tc.s1, out) != tc.t || diff(tc.s2, out) != tc.t {
+			fmt.Fprintf(os.Stderr, "case %d failed: output doesn't differ by t\ninput:%soutput:%s\n", idx+1, input, out)
+			os.Exit(1)
+		}
+		if expect != out {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", idx+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/584/verifierD.go
+++ b/0-999/500-599/580-589/584/verifierD.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isPrime(x int64) bool {
+	if x < 2 {
+		return false
+	}
+	for i := int64(2); i*i <= x; i++ {
+		if x%i == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func solve(n int64) (int, []int64) {
+	var a, b int64
+	for i := n; i >= 2; i-- {
+		if isPrime(i) {
+			a = i
+			break
+		}
+	}
+	for i := int64(2); i <= n; i++ {
+		if !isPrime(i) {
+			continue
+		}
+		sum := a + i
+		if sum != n && !isPrime(n-sum) {
+			continue
+		}
+		b = i
+		break
+	}
+	if a == n {
+		return 1, []int64{a}
+	} else if a+b == n {
+		return 2, []int64{a, b}
+	}
+	return 3, []int64{a, b, n - (a + b)}
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseOutput(out string) (int, []int64, error) {
+	reader := strings.NewReader(out)
+	var k int
+	if _, err := fmt.Fscan(reader, &k); err != nil {
+		return 0, nil, fmt.Errorf("cannot parse k: %v", err)
+	}
+	res := make([]int64, k)
+	for i := 0; i < k; i++ {
+		if _, err := fmt.Fscan(reader, &res[i]); err != nil {
+			return 0, nil, fmt.Errorf("cannot parse value: %v", err)
+		}
+	}
+	return k, res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := make([]int64, 0, 100)
+	for i := int64(3); i <= 11; i += 2 {
+		cases = append(cases, i)
+	}
+	for len(cases) < 100 {
+		n := rng.Int63n(99999) + 3
+		if n%2 == 0 {
+			n++
+		}
+		cases = append(cases, n)
+	}
+
+	for idx, n := range cases {
+		input := fmt.Sprintf("%d\n", n)
+		expK, expVals := solve(n)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		k, vals, err := parseOutput(out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d output parse error: %v\noutput:%s", idx+1, err, out)
+			os.Exit(1)
+		}
+		if k != len(vals) {
+			fmt.Fprintf(os.Stderr, "case %d failed: k=%d len(vals)=%d\n", idx+1, k, len(vals))
+			os.Exit(1)
+		}
+		if k != expK {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected k=%d got %d\n", idx+1, expK, k)
+			os.Exit(1)
+		}
+		for i := 0; i < k; i++ {
+			if vals[i] != expVals[i] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %v got %v\n", idx+1, expVals, vals)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/584/verifierE.go
+++ b/0-999/500-599/580-589/584/verifierE.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func compute(n int, p, s []int) (int64, [][2]int) {
+	pp := make([]int, n+1)
+	ps := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		pp[p[i-1]] = i
+		ps[s[i-1]] = i
+	}
+	ppos := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		ppos[i] = ps[p[i-1]]
+	}
+	var mc int64
+	for x := 1; x <= n; x++ {
+		diff := int64(pp[x] - ps[x])
+		if diff < 0 {
+			diff = -diff
+		}
+		mc += diff
+	}
+	swaps := make([][2]int, 0)
+	for {
+		flag := false
+		for x := 1; x <= n; x++ {
+			if ppos[x] >= x+1 {
+				for y := ppos[x]; y > x; y-- {
+					if ppos[y] <= x {
+						ppos[x], ppos[y] = ppos[y], ppos[x]
+						swaps = append(swaps, [2]int{x, y})
+						flag = true
+						break
+					}
+				}
+			}
+		}
+		if !flag {
+			break
+		}
+	}
+	return mc / 2, swaps
+}
+
+func apply(n int, p []int, swaps [][2]int) []int {
+	arr := make([]int, n)
+	copy(arr, p)
+	for _, sw := range swaps {
+		i, j := sw[0]-1, sw[1]-1
+		arr[i], arr[j] = arr[j], arr[i]
+	}
+	return arr
+}
+
+func parseOutput(out string, kExpected int) (int64, [][2]int, error) {
+	reader := strings.NewReader(out)
+	var cost int64
+	var k int
+	if _, err := fmt.Fscan(reader, &cost); err != nil {
+		return 0, nil, fmt.Errorf("cannot parse cost: %v", err)
+	}
+	if _, err := fmt.Fscan(reader, &k); err != nil {
+		return 0, nil, fmt.Errorf("cannot parse k: %v", err)
+	}
+	swaps := make([][2]int, k)
+	for i := 0; i < k; i++ {
+		if _, err := fmt.Fscan(reader, &swaps[i][0], &swaps[i][1]); err != nil {
+			return 0, nil, fmt.Errorf("cannot parse swap: %v", err)
+		}
+	}
+	return cost, swaps, nil
+}
+
+func permutations(n int, rng *rand.Rand) ([]int, []int) {
+	p := rng.Perm(n)
+	s := rng.Perm(n)
+	for i := range p {
+		p[i]++
+		s[i]++
+	}
+	return p, s
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type tc struct {
+		n    int
+		p, s []int
+	}
+	cases := make([]tc, 0, 100)
+	cases = append(cases, tc{2, []int{1, 2}, []int{2, 1}})
+	for len(cases) < 100 {
+		n := rng.Intn(10) + 2
+		p, s := permutations(n, rng)
+		cases = append(cases, tc{n, p, s})
+	}
+
+	for idx, tc := range cases {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for i, v := range tc.p {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		for i, v := range tc.s {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expCost, _ := compute(tc.n, tc.p, tc.s)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		cost, swaps, err := parseOutput(out, -1)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d parse error: %v\noutput:%s", idx+1, err, out)
+			os.Exit(1)
+		}
+		var swapCost int64
+		for _, sw := range swaps {
+			if sw[0] < 1 || sw[0] > tc.n || sw[1] < 1 || sw[1] > tc.n || sw[0] == sw[1] {
+				fmt.Fprintf(os.Stderr, "case %d invalid swap %v\n", idx+1, sw)
+				os.Exit(1)
+			}
+			swapCost += int64(math.Abs(float64(sw[0] - sw[1])))
+		}
+		final := apply(tc.n, tc.p, swaps)
+		for i, v := range final {
+			if v != tc.s[i] {
+				fmt.Fprintf(os.Stderr, "case %d permutation mismatch\n", idx+1)
+				os.Exit(1)
+			}
+		}
+		if swapCost != cost {
+			fmt.Fprintf(os.Stderr, "case %d cost mismatch reported %d actual %d\n", idx+1, cost, swapCost)
+			os.Exit(1)
+		}
+		if cost != expCost {
+			fmt.Fprintf(os.Stderr, "case %d minimal cost mismatch expected %d got %d\n", idx+1, expCost, cost)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go solution verifiers for contest 584 problems A–E
- each verifier generates 100+ test cases and checks a provided binary or Go file

## Testing
- `go build 0-999/500-599/580-589/584/verifierA.go`
- `./verifierA 584A.go`


------
https://chatgpt.com/codex/tasks/task_e_688340b70f5c83248dbe44b762dde941