### PR TITLE
Add Go verifiers for contest 588

### DIFF
--- a/0-999/500-599/580-589/588/verifierA.go
+++ b/0-999/500-599/580-589/588/verifierA.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(a, p []int64) string {
+	minPrice := int64(1 << 60)
+	var total int64
+	for i := range a {
+		if p[i] < minPrice {
+			minPrice = p[i]
+		}
+		total += minPrice * a[i]
+	}
+	return fmt.Sprintf("%d\n", total)
+}
+
+func genCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	a := make([]int64, n)
+	pr := make([]int64, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(100) + 1)
+		pr[i] = int64(rng.Intn(100) + 1)
+		fmt.Fprintf(&sb, "%d %d\n", a[i], pr[i])
+	}
+	return sb.String(), solveA(a, pr)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseA(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/588/verifierB.go
+++ b/0-999/500-599/580-589/588/verifierB.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(n int64) string {
+	ans := int64(1)
+	for i := int64(2); i*i <= n; i++ {
+		if n%i == 0 {
+			ans *= i
+			for n%i == 0 {
+				n /= i
+			}
+		}
+	}
+	if n > 1 {
+		ans *= n
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func genCaseB(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000) + 1
+	return fmt.Sprintf("%d\n", n), solveB(n)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseB(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` for contest 588 problem A
- add `verifierB.go` for contest 588 problem B

## Testing
- `go run 0-999/500-599/580-589/588/verifierA.go 0-999/500-599/580-589/588/588A`
- `go run 0-999/500-599/580-589/588/verifierB.go 0-999/500-599/580-589/588/588B`


------
https://chatgpt.com/codex/tasks/task_e_688342e7cf448324b29ac6201f0655e1