### PR TITLE
Add Go solution for 1934B

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1934/1934B.go
+++ b/1000-1999/1900-1999/1930-1939/1934/1934B.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	coins := []int{1, 3, 6, 10, 15}
+	const maxBase = 29
+	const inf = int(1e9)
+	dp := make([]int, maxBase+1)
+	for i := 1; i <= maxBase; i++ {
+		dp[i] = inf
+		for _, c := range coins {
+			if i >= c && dp[i-c]+1 < dp[i] {
+				dp[i] = dp[i-c] + 1
+			}
+		}
+	}
+
+	var t, n int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		fmt.Fscan(in, &n)
+		if n < 15 {
+			fmt.Fprintln(out, dp[n])
+			continue
+		}
+		r := (n-15)%15 + 15
+		ans := (n - r) / 15
+		ans += dp[r]
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem B (1934)

## Testing
- `go build 1000-1999/1900-1999/1930-1939/1934/1934B.go`
- `go vet 1000-1999/1900-1999/1930-1939/1934/1934B.go`


------
https://chatgpt.com/codex/tasks/task_e_688343bac25c8324872026c2070a9d64