### PR TITLE
Add Go verifiers for contest 587

### DIFF
--- a/0-999/500-599/580-589/587/verifierA.go
+++ b/0-999/500-599/580-589/587/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(weights []int) int {
+	maxW := 0
+	for _, w := range weights {
+		if w > maxW {
+			maxW = w
+		}
+	}
+	cnt := make([]int, maxW+70)
+	for _, w := range weights {
+		cnt[w]++
+	}
+	for i := 0; i < len(cnt)-1; i++ {
+		pairs := cnt[i] / 2
+		if pairs > 0 {
+			cnt[i+1] += pairs
+			cnt[i] %= 2
+		}
+	}
+	steps := 0
+	for _, c := range cnt {
+		steps += c
+	}
+	return steps
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		n := rng.Intn(20) + 1
+		weights := make([]int, n)
+		for i := 0; i < n; i++ {
+			weights[i] = rng.Intn(60)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, w := range weights {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", w))
+		}
+		sb.WriteString("\n")
+		input := sb.String()
+		expectedStr := fmt.Sprintf("%d", expected(weights))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedStr {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, expectedStr, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/587/verifierB.go
+++ b/0-999/500-599/580-589/587/verifierB.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "587B.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(20) + 1
+		l := rng.Int63n(500) + 1
+		if int64(n)*int64(k) > 1000000 {
+			k = 1
+		}
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(1000)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, l, k))
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteString("\n")
+		input := sb.String()
+		expected, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error running reference: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/587/verifierC.go
+++ b/0-999/500-599/580-589/587/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "587C.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		n := rng.Intn(8) + 2
+		m := rng.Intn(n) + 1
+		q := rng.Intn(5) + 1
+		edges := make([][2]int, n-1)
+		for i := 2; i <= n; i++ {
+			p := rng.Intn(i-1) + 1
+			edges[i-2] = [2]int{p, i}
+		}
+		people := make([]int, m)
+		for i := 0; i < m; i++ {
+			people[i] = rng.Intn(n) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		for i, c := range people {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", c))
+		}
+		sb.WriteString("\n")
+		for i := 0; i < q; i++ {
+			v := rng.Intn(n) + 1
+			u := rng.Intn(n) + 1
+			a := rng.Intn(5) + 1
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", v, u, a))
+		}
+		input := sb.String()
+		expected, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error running reference: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/587/verifierD.go
+++ b/0-999/500-599/580-589/587/verifierD.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "587D.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		n := rng.Intn(5) + 2
+		m := rng.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < m; i++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			for v == u {
+				v = rng.Intn(n) + 1
+			}
+			color := rng.Intn(3) + 1
+			t := rng.Intn(10) + 1
+			sb.WriteString(fmt.Sprintf("%d %d %d %d\n", u, v, color, t))
+		}
+		input := sb.String()
+		expected, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error running reference: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/587/verifierE.go
+++ b/0-999/500-599/580-589/587/verifierE.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "587E.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		n := rng.Intn(6) + 1
+		q := rng.Intn(6) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(32)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteString("\n")
+		for i := 0; i < q; i++ {
+			t := rng.Intn(2) + 1
+			if t == 1 {
+				l := rng.Intn(n) + 1
+				r := rng.Intn(n-l+1) + l
+				k := rng.Intn(32)
+				sb.WriteString(fmt.Sprintf("1 %d %d %d\n", l, r, k))
+			} else {
+				l := rng.Intn(n) + 1
+				r := rng.Intn(n-l+1) + l
+				sb.WriteString(fmt.Sprintf("2 %d %d\n", l, r))
+			}
+		}
+		input := sb.String()
+		expected, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error running reference: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/580-589/587/verifierF.go
+++ b/0-999/500-599/580-589/587/verifierF.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "587F.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		n := rng.Intn(4) + 1
+		q := rng.Intn(4) + 1
+		strs := make([]string, n)
+		for i := 0; i < n; i++ {
+			strs[i] = randString(rng, rng.Intn(5)+1)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		for i := 0; i < n; i++ {
+			sb.WriteString(strs[i])
+			if i+1 < n {
+				sb.WriteByte('\n')
+			} else {
+				sb.WriteByte('\n')
+			}
+		}
+		for i := 0; i < q; i++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			k := rng.Intn(n) + 1
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", l, r, k))
+		}
+		input := sb.String()
+		expected, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error running reference: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", caseNum+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", caseNum+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A-F of contest 587
- each verifier generates 100 random tests and compares results with the reference solutions
- verifiers handle both binaries and Go source files via a `--` argument check

## Testing
- `go run verifierA.go -- 587A.go`
- `go run verifierB.go -- 587B.go`
- `go run verifierC.go -- 587C.go`
- `go run verifierE.go -- 587E.go`
- `go run verifierF.go -- 587F.go`

------
https://chatgpt.com/codex/tasks/task_e_6883425b565c8324b60ad22d98cec024