### PR TITLE
Add Go verifiers for contest 591

### DIFF
--- a/0-999/500-599/590-599/591/verifierA.go
+++ b/0-999/500-599/590-599/591/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	l int
+	p int
+	q int
+}
+
+func generateTests() []testCase {
+	tests := []testCase{
+		{1, 1, 1},
+		{1000, 500, 500},
+		{1000, 1, 500},
+		{500, 500, 1},
+		{999, 123, 456},
+	}
+	rng := rand.New(rand.NewSource(1))
+	for len(tests) < 100 {
+		l := rng.Intn(1000) + 1
+		p := rng.Intn(500) + 1
+		q := rng.Intn(500) + 1
+		tests = append(tests, testCase{l, p, q})
+	}
+	return tests
+}
+
+func solve(tc testCase) float64 {
+	return float64(tc.p) * float64(tc.l) / float64(tc.p+tc.q)
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func equal(a, b float64) bool {
+	diff := math.Abs(a - b)
+	return diff <= 1e-4*math.Max(1, math.Abs(b))
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d\n%d\n%d\n", tc.l, tc.p, tc.q)
+		gotStr, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var got float64
+		if _, err := fmt.Sscanf(gotStr, "%f", &got); err != nil {
+			fmt.Fprintf(os.Stderr, "cannot parse output on test %d: %v\noutput: %s\n", i+1, err, gotStr)
+			os.Exit(1)
+		}
+		exp := solve(tc)
+		if !equal(got, exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected: %.6f\ngot: %.6f\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/500-599/590-599/591/verifierB.go
+++ b/0-999/500-599/590-599/591/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	n    int
+	m    int
+	name string
+	ops  [][2]byte
+}
+
+func generateTests() []testCase {
+	tests := []testCase{
+		{1, 1, "a", [][2]byte{{'a', 'b'}}},
+		{3, 2, "abc", [][2]byte{{'a', 'b'}, {'b', 'c'}}},
+	}
+	rng := rand.New(rand.NewSource(2))
+	for len(tests) < 100 {
+		n := rng.Intn(20) + 1
+		m := rng.Intn(20) + 1
+		nameBytes := make([]byte, n)
+		for i := 0; i < n; i++ {
+			nameBytes[i] = byte('a' + rng.Intn(26))
+		}
+		ops := make([][2]byte, m)
+		for i := 0; i < m; i++ {
+			ops[i][0] = byte('a' + rng.Intn(26))
+			ops[i][1] = byte('a' + rng.Intn(26))
+		}
+		tests = append(tests, testCase{n, m, string(nameBytes), ops})
+	}
+	return tests
+}
+
+func solve(tc testCase) string {
+	mapping := [26]byte{}
+	for i := 0; i < 26; i++ {
+		mapping[i] = byte('a' + i)
+	}
+	for _, op := range tc.ops {
+		x := op[0]
+		y := op[1]
+		for j := 0; j < 26; j++ {
+			if mapping[j] == x {
+				mapping[j] = y
+			} else if mapping[j] == y {
+				mapping[j] = x
+			}
+		}
+	}
+	bytes := []byte(tc.name)
+	for i := 0; i < len(bytes); i++ {
+		bytes[i] = mapping[bytes[i]-'a']
+	}
+	return string(bytes)
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var input strings.Builder
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.m)
+		input.WriteString(tc.name)
+		input.WriteByte('\n')
+		for _, op := range tc.ops {
+			fmt.Fprintf(&input, "%c %c\n", op[0], op[1])
+		}
+		got, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		exp := solve(tc)
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input.String(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for contest 591
- each verifier generates 100 test cases and checks a provided binary

## Testing
- `go run verifierA.go ./591A`
- `go run verifierB.go ./591B`


------
https://chatgpt.com/codex/tasks/task_e_6883448bda288324a3ea0ac9058e24ba