### PR TITLE
Add Go verifiers for Codeforces contest 592

### DIFF
--- a/0-999/500-599/590-599/592/verifierA.go
+++ b/0-999/500-599/590-599/592/verifierA.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(board []string) string {
+	minA := 8
+	minB := 8
+	for c := 0; c < 8; c++ {
+		for r := 0; r < 8; r++ {
+			ch := board[r][c]
+			if ch == 'W' {
+				if r < minA {
+					minA = r
+				}
+				break
+			} else if ch == 'B' {
+				break
+			}
+		}
+		for r := 7; r >= 0; r-- {
+			ch := board[r][c]
+			if ch == 'B' {
+				steps := 7 - r
+				if steps < minB {
+					minB = steps
+				}
+				break
+			} else if ch == 'W' {
+				break
+			}
+		}
+	}
+	if minA <= minB {
+		return "A"
+	}
+	return "B"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	board := make([]string, 8)
+	countW, countB := 0, 0
+	for r := 0; r < 8; r++ {
+		row := make([]byte, 8)
+		for c := 0; c < 8; c++ {
+			if r == 0 {
+				row[c] = '.'
+			} else if r == 7 {
+				row[c] = '.'
+			} else {
+				v := rng.Intn(3)
+				if v == 0 {
+					row[c] = '.'
+				} else if v == 1 {
+					row[c] = 'W'
+					countW++
+				} else {
+					row[c] = 'B'
+					countB++
+				}
+			}
+		}
+		board[r] = string(row)
+	}
+	if countW == 0 {
+		board[1] = "W" + board[1][1:]
+	}
+	if countB == 0 {
+		board[6] = "B" + board[6][1:]
+	}
+	var sb strings.Builder
+	for _, row := range board {
+		sb.WriteString(row)
+		sb.WriteByte('\n')
+	}
+	exp := expected(board)
+	return sb.String(), exp
+}
+
+func runCase(exe, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/590-599/592/verifierB.go
+++ b/0-999/500-599/590-599/592/verifierB.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int64) string {
+	if n < 2 {
+		return "0"
+	}
+	ans := (n - 2) * (n - 2)
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(100000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	return input, expected(n)
+}
+
+func runCase(exe, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/590-599/592/verifierC.go
+++ b/0-999/500-599/590-599/592/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b uint64) uint64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func min(a, b uint64) uint64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expected(t, w, b uint64) string {
+	if w > b {
+		w, b = b, w
+	}
+	g := gcd(w, b)
+	l := b / g
+	var L uint64
+	if l > 0 && w > t/l {
+		L = t + 1
+	} else {
+		L = l * w
+		if L > t {
+			L = t + 1
+		}
+	}
+	q := t / L
+	r := t % L
+	num := q*w + min(r, w-1)
+	den := t
+	g2 := gcd(num, den)
+	return fmt.Sprintf("%d/%d", num/g2, den/g2)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := uint64(rng.Int63n(1_000_000_000_000) + 1)
+	w := uint64(rng.Int63n(1_000_000) + 1)
+	b := uint64(rng.Int63n(1_000_000) + 1)
+	input := fmt.Sprintf("%d %d %d\n", t, w, b)
+	return input, expected(t, w, b)
+}
+
+func runCase(exe, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/590-599/592/verifierD.go
+++ b/0-999/500-599/590-599/592/verifierD.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(n int, edges [][2]int, specials []int) (int, int) {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	special := make([]bool, n+1)
+	for _, s := range specials {
+		special[s] = true
+	}
+	cnt := 0
+	var dfs func(u, p int) bool
+	dfs = func(u, p int) bool {
+		need := special[u]
+		for _, v := range adj[u] {
+			if v == p {
+				continue
+			}
+			if dfs(v, u) {
+				cnt++
+				need = true
+			}
+		}
+		return need
+	}
+	dfs(specials[0], 0)
+	bfs := func(start int) (int, []int) {
+		dist := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			dist[i] = -1
+		}
+		q := []int{start}
+		dist[start] = 0
+		far := start
+		maxd := 0
+		for head := 0; head < len(q); head++ {
+			u := q[head]
+			if special[u] {
+				if dist[u] > maxd || (dist[u] == maxd && u < far) {
+					far = u
+					maxd = dist[u]
+				}
+			}
+			for _, v := range adj[u] {
+				if dist[v] == -1 {
+					dist[v] = dist[u] + 1
+					q = append(q, v)
+				}
+			}
+		}
+		return far, dist
+	}
+	far1, _ := bfs(specials[0])
+	far2, dist2 := bfs(far1)
+	d := dist2[far2]
+	startCity := far1
+	if far2 < startCity {
+		startCity = far2
+	}
+	time := 2*cnt - d
+	return startCity, time
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{i, p}
+	}
+	m := rng.Intn(n) + 1
+	perm := rng.Perm(n)
+	specials := make([]int, m)
+	for i := 0; i < m; i++ {
+		specials[i] = perm[i] + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	for i, s := range specials {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(s))
+	}
+	sb.WriteByte('\n')
+	start, tm := expected(n, edges, specials)
+	out := fmt.Sprintf("%d\n%d", start, tm)
+	return sb.String(), out
+}
+
+func runCase(exe, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/590-599/592/verifierE.go
+++ b/0-999/500-599/590-599/592/verifierE.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(n int, c, d int64, arr [][2]int64) int64 {
+	angles := make([]float64, n)
+	twoPi := 2 * math.Pi
+	for i := 0; i < n; i++ {
+		x := float64(arr[i][0] - c)
+		y := float64(arr[i][1] - d)
+		ang := math.Atan2(y, x)
+		if ang < 0 {
+			ang += twoPi
+		}
+		angles[i] = ang
+	}
+	sort.Float64s(angles)
+	ext := make([]float64, 2*n)
+	copy(ext, angles)
+	for i := 0; i < n; i++ {
+		ext[i+n] = angles[i] + twoPi
+	}
+	var bad int64
+	j := 0
+	eps := 1e-12
+	for i := 0; i < n; i++ {
+		if j < i+1 {
+			j = i + 1
+		}
+		for j < i+n && ext[j]-ext[i] <= math.Pi+eps {
+			j++
+		}
+		m := j - i - 1
+		if m >= 2 {
+			bad += int64(m*(m-1)) / 2
+		}
+	}
+	total := int64(n) * int64(n-1) * int64(n-2) / 6
+	good := total - bad
+	return good
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(30) + 3
+	c := int64(rng.Intn(1000) + 1)
+	d := int64(rng.Intn(1000) + 1)
+	data := make([][2]int64, n)
+	for i := 0; i < n; i++ {
+		r := int64(rng.Intn(1000) + 1)
+		w := int64(rng.Intn(1000) + 1)
+		if r == c && w == d {
+			r++
+		}
+		data[i] = [2]int64{r, w}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, c, d))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", data[i][0], data[i][1]))
+	}
+	ans := expected(n, c, d, data)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func runCase(exe, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new Go verifiers for problems A–E of contest 592
- each verifier generates 100 random test cases and checks a provided binary
- verifiers allow passing either a compiled binary or a `.go` source file

## Testing
- `go run verifierA.go ./592A_bin` *(passed)*
- `go run verifierB.go ./592B_bin` *(passed)*


------
https://chatgpt.com/codex/tasks/task_e_68834517f52c8324830f14ff59d369d4