### PR TITLE
Add verifiers for Codeforces 594

### DIFF
--- a/0-999/500-599/590-599/594/verifierA.go
+++ b/0-999/500-599/590-599/594/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveA(a []int) int {
+	sort.Ints(a)
+	half := len(a) / 2
+	ans := a[half] - a[0]
+	for i := 1; i < half; i++ {
+		if d := a[i+half] - a[i]; d < ans {
+			ans = d
+		}
+	}
+	return ans
+}
+
+func run(binary string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(50)*2 + 2 // even between 2 and 100
+		seen := map[int]bool{}
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			v := rand.Intn(1000000)
+			for seen[v] {
+				v = rand.Intn(1000000)
+			}
+			seen[v] = true
+			arr[i] = v
+		}
+		input := fmt.Sprintf("%d\n", n)
+		for i, v := range arr {
+			if i > 0 {
+				input += " "
+			}
+			input += strconv.Itoa(v)
+		}
+		input += "\n"
+		expected := strconv.Itoa(solveA(append([]int{}, arr...)))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Println("test", t, "runtime error:", err)
+			fmt.Println("output:", got)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Println("test", t, "failed")
+			fmt.Println("input:\n" + input)
+			fmt.Println("expected:", expected, "got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/590-599/594/verifierB.go
+++ b/0-999/500-599/590-599/594/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveOne(r, v float64, s, f int) float64 {
+	d := float64(f - s)
+	e := d / r
+	b := e - 2*math.Pi
+	if b < 0 {
+		b = 0
+	}
+	for i := 0; i < 50; i++ {
+		mid := 0.5 * (b + e)
+		t := math.Sin(mid * 0.5)
+		if t < 0 {
+			t = -t
+		}
+		t = r*mid + 2*r*t
+		if t < d {
+			b = mid
+		} else {
+			e = mid
+		}
+	}
+	return b * r / v
+}
+
+func solveB(n int, r, v int, segs [][2]int) []string {
+	res := make([]string, n)
+	rf := float64(r)
+	vf := float64(v)
+	for i := 0; i < n; i++ {
+		t := solveOne(rf, vf, segs[i][0], segs[i][1])
+		res[i] = fmt.Sprintf("%.10f", t)
+	}
+	return res
+}
+
+func run(binary, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(2)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		r := rand.Intn(9) + 1
+		v := rand.Intn(9) + 1
+		segs := make([][2]int, n)
+		for i := 0; i < n; i++ {
+			s := rand.Intn(50)
+			f := s + rand.Intn(50) + 1
+			segs[i] = [2]int{s, f}
+		}
+		input := fmt.Sprintf("%d %d %d\n", n, r, v)
+		for i, sg := range segs {
+			input += fmt.Sprintf("%d %d", sg[0], sg[1])
+			if i+1 < n {
+				input += "\n"
+			} else {
+				input += "\n"
+			}
+		}
+		expectedLines := solveB(n, r, v, segs)
+		expected := strings.Join(expectedLines, "\n")
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Println("test", t, "runtime error:", err)
+			fmt.Println("output:", got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Println("test", t, "failed")
+			fmt.Println("input:\n" + input)
+			fmt.Println("expected:\n" + expected)
+			fmt.Println("got:\n" + got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/590-599/594/verifierC.go
+++ b/0-999/500-599/590-599/594/verifierC.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type rect struct {
+	x1, y1, x2, y2 int64
+}
+
+type pair struct {
+	val int64
+	id  int
+}
+
+func solveC(recs []rect, k int) int64 {
+	n := len(recs)
+	centersX := make([]pair, n)
+	centersY := make([]pair, n)
+	for i := 0; i < n; i++ {
+		cx := recs[i].x1 + recs[i].x2
+		cy := recs[i].y1 + recs[i].y2
+		centersX[i] = pair{val: cx, id: i}
+		centersY[i] = pair{val: cy, id: i}
+	}
+	sort.Slice(centersX, func(i, j int) bool { return centersX[i].val < centersX[j].val })
+	sort.Slice(centersY, func(i, j int) bool { return centersY[i].val < centersY[j].val })
+	best := int64(1<<63 - 1)
+	for a := 0; a <= k; a++ {
+		for b := 0; b <= k; b++ {
+			for c := 0; c <= k; c++ {
+				for d := 0; d <= k; d++ {
+					removed := make(map[int]struct{})
+					for i := 0; i < a && i < n; i++ {
+						removed[centersX[i].id] = struct{}{}
+					}
+					for i := 0; i < b && i < n; i++ {
+						removed[centersX[n-1-i].id] = struct{}{}
+					}
+					for i := 0; i < c && i < n; i++ {
+						removed[centersY[i].id] = struct{}{}
+					}
+					for i := 0; i < d && i < n; i++ {
+						removed[centersY[n-1-i].id] = struct{}{}
+					}
+					if len(removed) > k {
+						continue
+					}
+					li := 0
+					for li < n {
+						if _, ok := removed[centersX[li].id]; !ok {
+							break
+						}
+						li++
+					}
+					ri := n - 1
+					for ri >= 0 {
+						if _, ok := removed[centersX[ri].id]; !ok {
+							break
+						}
+						ri--
+					}
+					lj := 0
+					for lj < n {
+						if _, ok := removed[centersY[lj].id]; !ok {
+							break
+						}
+						lj++
+					}
+					rj := n - 1
+					for rj >= 0 {
+						if _, ok := removed[centersY[rj].id]; !ok {
+							break
+						}
+						rj--
+					}
+					if li > ri || lj > rj {
+						continue
+					}
+					dx := centersX[ri].val - centersX[li].val
+					dy := centersY[rj].val - centersY[lj].val
+					w := dx / 2
+					if dx%2 != 0 {
+						w++
+					}
+					h := dy / 2
+					if dy%2 != 0 {
+						h++
+					}
+					if w < 1 {
+						w = 1
+					}
+					if h < 1 {
+						h = 1
+					}
+					area := w * h
+					if area < best {
+						best = area
+					}
+				}
+			}
+		}
+	}
+	if best == int64(1<<63-1) {
+		best = 1
+	}
+	return best
+}
+
+func run(binary, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 1
+		k := rand.Intn(n + 1)
+		recs := make([]rect, n)
+		for i := 0; i < n; i++ {
+			x1 := int64(rand.Intn(10))
+			y1 := int64(rand.Intn(10))
+			x2 := x1 + int64(rand.Intn(5)+1)
+			y2 := y1 + int64(rand.Intn(5)+1)
+			recs[i] = rect{x1, y1, x2, y2}
+		}
+		input := fmt.Sprintf("%d %d\n", n, k)
+		for i, r := range recs {
+			input += fmt.Sprintf("%d %d %d %d", r.x1, r.y1, r.x2, r.y2)
+			if i+1 < n {
+				input += "\n"
+			} else {
+				input += "\n"
+			}
+		}
+		expected := fmt.Sprintf("%d", solveC(recs, k))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Println("test", t, "runtime error:", err)
+			fmt.Println("output:", got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Println("test", t, "failed")
+			fmt.Println("input:\n" + input)
+			fmt.Println("expected:", expected)
+			fmt.Println("got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/590-599/594/verifierD.go
+++ b/0-999/500-599/590-599/594/verifierD.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func phi(x int64) int64 {
+	if x == 0 {
+		return 0
+	}
+	res := x
+	i := int64(2)
+	for i*i <= x {
+		if x%i == 0 {
+			for x%i == 0 {
+				x /= i
+			}
+			res = res / i * (i - 1)
+		}
+		i++
+	}
+	if x > 1 {
+		res = res / x * (x - 1)
+	}
+	return res
+}
+
+func solveD(a []int, queries [][2]int) []int64 {
+	res := make([]int64, len(queries))
+	for qi, q := range queries {
+		l, r := q[0]-1, q[1]-1
+		prod := int64(1)
+		factors := make(map[int64]int)
+		for i := l; i <= r; i++ {
+			x := a[i]
+			v := int64(x)
+			prod = (prod * v) % mod
+			xx := x
+			for p := 2; p*p <= xx; p++ {
+				if xx%p == 0 {
+					c := 0
+					for xx%p == 0 {
+						xx /= p
+						c++
+					}
+					factors[int64(p)] += c
+				}
+			}
+			if xx > 1 {
+				factors[int64(xx)]++
+			}
+		}
+		phiVal := int64(1)
+		for p, e := range factors {
+			pe := int64(1)
+			for i := 0; i < e-1; i++ {
+				pe = (pe * p) % mod
+			}
+			phiVal = phiVal * ((pe * (p - 1)) % mod) % mod
+		}
+		res[qi] = phiVal % mod
+	}
+	return res
+}
+
+func run(binary, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(4)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 1
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rand.Intn(10) + 1
+		}
+		qnum := rand.Intn(5) + 1
+		queries := make([][2]int, qnum)
+		for i := 0; i < qnum; i++ {
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			queries[i] = [2]int{l, r}
+		}
+		input := fmt.Sprintf("%d\n", n)
+		for i, v := range a {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		input += fmt.Sprintf("%d\n", qnum)
+		for i, q := range queries {
+			input += fmt.Sprintf("%d %d", q[0], q[1])
+			if i+1 < qnum {
+				input += "\n"
+			} else {
+				input += "\n"
+			}
+		}
+		expectedVals := solveD(a, queries)
+		expectedParts := make([]string, len(expectedVals))
+		for i, v := range expectedVals {
+			expectedParts[i] = fmt.Sprintf("%d", v%mod)
+		}
+		expected := strings.Join(expectedParts, "\n")
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Println("test", t, "runtime error:", err)
+			fmt.Println("output:\n" + got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Println("test", t, "failed")
+			fmt.Println("input:\n" + input)
+			fmt.Println("expected:\n" + expected)
+			fmt.Println("got:\n" + got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/0-999/500-599/590-599/594/verifierE.go
+++ b/0-999/500-599/590-599/594/verifierE.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func reverseString(str string) string {
+	b := []byte(str)
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}
+
+func minString(a, b string) string {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveE(s string, k int) string {
+	memo := make(map[[2]int]string)
+	var dfs func(int, int) string
+	dfs = func(pos, k int) string {
+		if pos == len(s) {
+			return ""
+		}
+		if k == 1 {
+			rem := s[pos:]
+			rev := reverseString(rem)
+			if rem < rev {
+				return rem
+			}
+			return rev
+		}
+		key := [2]int{pos, k}
+		if v, ok := memo[key]; ok {
+			return v
+		}
+		best := ""
+		n := len(s)
+		for i := pos + 1; i <= n; i++ {
+			if k-1 > n-i {
+				continue
+			}
+			part := s[pos:i]
+			rest := dfs(i, k-1)
+			best = minString(best, part+rest)
+			best = minString(best, reverseString(part)+rest)
+		}
+		memo[key] = best
+		return best
+	}
+	return dfs(0, k)
+}
+
+func run(binary, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(6) + 1
+		b := make([]rune, n)
+		for i := range b {
+			b[i] = letters[rand.Intn(len(letters))]
+		}
+		s := string(b)
+		k := rand.Intn(n) + 1
+		input := fmt.Sprintf("%s\n%d\n", s, k)
+		expected := solveE(s, k)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Println("test", t, "runtime error:", err)
+			fmt.Println("output:\n" + got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Println("test", t, "failed")
+			fmt.Println("input:\n" + input)
+			fmt.Println("expected:\n" + expected)
+			fmt.Println("got:\n" + got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 594 problems A–E
- generate 100 random test cases per problem
- fix unused import in verifier B

## Testing
- `go build 0-999/500-599/590-599/594/verifierA.go`
- `go build 0-999/500-599/590-599/594/verifierB.go`
- `go build 0-999/500-599/590-599/594/verifierC.go`
- `go build 0-999/500-599/590-599/594/verifierD.go`
- `go build 0-999/500-599/590-599/594/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68834630235c83248e62e4367a504725