### PR TITLE
Add Go solution for 1933C

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1933/1933C.go
+++ b/1000-1999/1900-1999/1930-1939/1933/1933C.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var a, b, l int
+		fmt.Fscan(in, &a, &b, &l)
+		kset := make(map[int]struct{})
+		for powA := 1; powA <= l; {
+			for powB := 1; powA*powB <= l; {
+				if l%(powA*powB) == 0 {
+					k := l / (powA * powB)
+					kset[k] = struct{}{}
+				}
+				if powB > l/b {
+					break
+				}
+				powB *= b
+			}
+			if powA > l/a {
+				break
+			}
+			powA *= a
+		}
+		fmt.Fprintln(out, len(kset))
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1933C.go` to compute distinct possible `k` values
- use nested loops over powers of `a` and `b`

## Testing
- `go build 1000-1999/1900-1999/1930-1939/1933/1933C.go`
- `go run 1000-1999/1900-1999/1930-1939/1933/1933C.go < /tmp/input.txt`

------
https://chatgpt.com/codex/tasks/task_e_6883481a66c48324a158b3acc14172c2