### PR TITLE
Add Go verifiers for contest 598

### DIFF
--- a/0-999/500-599/590-599/598/verifierA.go
+++ b/0-999/500-599/590-599/598/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedA(n int64) int64 {
+	total := n * (n + 1) / 2
+	var sum int64
+	for p := int64(1); p <= n; p <<= 1 {
+		sum += p
+	}
+	return total - 2*sum
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	var out strings.Builder
+	sb.WriteString(strconv.Itoa(t) + "\n")
+	for i := 0; i < t; i++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		sb.WriteString(strconv.FormatInt(n, 10))
+		sb.WriteByte('\n')
+		out.WriteString(strconv.FormatInt(expectedA(n), 10))
+		out.WriteByte('\n')
+	}
+	return sb.String(), out.String()
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected\n%s\ngot\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/590-599/598/verifierB.go
+++ b/0-999/500-599/590-599/598/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func applyQueries(s []byte, queries [][3]int) string {
+	for _, q := range queries {
+		l, r, k := q[0], q[1], q[2]
+		l--
+		length := r - l
+		k %= length
+		if k > 0 {
+			tmp := append([]byte(nil), s[l:r]...)
+			copy(s[l:r], append(tmp[length-k:], tmp[:length-k]...))
+		}
+	}
+	return string(s)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	s := string(b)
+	m := rng.Intn(20) + 1
+	queries := make([][3]int, m)
+	var sb strings.Builder
+	sb.WriteString(s + "\n")
+	sb.WriteString(strconv.Itoa(m) + "\n")
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		k := rng.Intn(1000) + 1
+		queries[i] = [3]int{l, r, k}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", l, r, k))
+	}
+	expected := applyQueries([]byte(s), queries)
+	return sb.String(), expected + "\n"
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/590-599/598/verifierC.go
+++ b/0-999/500-599/590-599/598/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type vec struct {
+	idx   int
+	x, y  int
+	angle float64
+}
+
+func expectedC(v []vec) (int, int) {
+	n := len(v)
+	for i := range v {
+		v[i].angle = math.Atan2(float64(v[i].y), float64(v[i].x))
+	}
+	sort.Slice(v, func(i, j int) bool { return v[i].angle < v[j].angle })
+	ans1, ans2 := v[0].idx, v[n-1].idx
+	minDiff := v[0].angle + 2*math.Pi - v[n-1].angle
+	for i := 0; i < n-1; i++ {
+		diff := v[i+1].angle - v[i].angle
+		if diff < minDiff {
+			minDiff = diff
+			ans1 = v[i].idx
+			ans2 = v[i+1].idx
+		}
+	}
+	return ans1, ans2
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(18) + 2
+	vectors := make([]vec, n)
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n) + "\n")
+	for i := 0; i < n; i++ {
+		x := rng.Intn(2001) - 1000
+		y := rng.Intn(2001) - 1000
+		if x == 0 && y == 0 {
+			x = 1
+		}
+		vectors[i] = vec{idx: i + 1, x: x, y: y}
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	a, b := expectedC(append([]vec(nil), vectors...))
+	out := fmt.Sprintf("%d %d\n", a, b)
+	return sb.String(), out
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/590-599/598/verifierD.go
+++ b/0-999/500-599/590-599/598/verifierD.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type pair struct{ x, y int }
+
+func expectedD(grid [][]byte, queries []pair) []int {
+	n, m := len(grid), len(grid[0])
+	comp := make([][]int, n)
+	for i := range comp {
+		comp[i] = make([]int, m)
+	}
+	pictures := []int{0}
+	compID := 0
+	dirs := []int{-1, 0, 1, 0, -1}
+
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] != '.' || comp[i][j] != 0 {
+				continue
+			}
+			compID++
+			queue := []pair{{i, j}}
+			comp[i][j] = compID
+			pics := 0
+			for head := 0; head < len(queue); head++ {
+				cur := queue[head]
+				x, y := cur.x, cur.y
+				for d := 0; d < 4; d++ {
+					nx := x + dirs[d]
+					ny := y + dirs[d+1]
+					if nx < 0 || nx >= n || ny < 0 || ny >= m {
+						continue
+					}
+					if grid[nx][ny] == '*' {
+						pics++
+					} else if comp[nx][ny] == 0 {
+						comp[nx][ny] = compID
+						queue = append(queue, pair{nx, ny})
+					}
+				}
+			}
+			pictures = append(pictures, pics)
+		}
+	}
+
+	res := make([]int, len(queries))
+	for i, q := range queries {
+		res[i] = pictures[comp[q.x][q.y]]
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 3
+	m := rng.Intn(6) + 3
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if i == 0 || j == 0 || i == n-1 || j == m-1 {
+				row[j] = '*'
+			} else if rng.Intn(4) == 0 {
+				row[j] = '*'
+			} else {
+				row[j] = '.'
+			}
+		}
+		grid[i] = row
+	}
+	k := rng.Intn(min(n*m, 5)) + 1
+	queries := make([]pair, k)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]) + "\n")
+	}
+	empties := make([]pair, 0)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '.' {
+				empties = append(empties, pair{i, j})
+			}
+		}
+	}
+	if len(empties) == 0 {
+		empties = append(empties, pair{1, 1})
+		grid[1][1] = '.'
+	}
+	for i := 0; i < k; i++ {
+		p := empties[rng.Intn(len(empties))]
+		queries[i] = p
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.x+1, p.y+1))
+	}
+	ans := expectedD(grid, queries)
+	var out strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		out.WriteString(strconv.Itoa(v))
+	}
+	out.WriteByte('\n')
+	return sb.String(), out.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected\n%s\ngot\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/590-599/598/verifierE.go
+++ b/0-999/500-599/590-599/598/verifierE.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	maxN = 31
+	maxK = 51
+)
+
+var dp [maxN][maxN][maxK]int
+var vis [maxN][maxN][maxK]bool
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solve(n, m, k int) int {
+	if k == 0 || k == n*m {
+		return 0
+	}
+	if vis[n][m][k] {
+		return dp[n][m][k]
+	}
+	vis[n][m][k] = true
+	ans := 1<<31 - 1
+	for i := 1; i <= n/2; i++ {
+		maxK1 := min(k, i*m)
+		for k1 := 0; k1 <= maxK1; k1++ {
+			if k1 > i*m || k-k1 > (n-i)*m {
+				continue
+			}
+			cost := m*m + solve(i, m, k1) + solve(n-i, m, k-k1)
+			if cost < ans {
+				ans = cost
+			}
+		}
+	}
+	for j := 1; j <= m/2; j++ {
+		maxK1 := min(k, j*n)
+		for k1 := 0; k1 <= maxK1; k1++ {
+			if k1 > j*n || k-k1 > n*(m-j) {
+				continue
+			}
+			cost := n*n + solve(n, j, k1) + solve(n, m-j, k-k1)
+			if cost < ans {
+				ans = cost
+			}
+		}
+	}
+	dp[n][m][k] = ans
+	return ans
+}
+
+func expectedE(cases [][3]int) []int {
+	// reset vis each call
+	for i := 0; i < maxN; i++ {
+		for j := 0; j < maxN; j++ {
+			for k := 0; k < maxK; k++ {
+				vis[i][j][k] = false
+			}
+		}
+	}
+	res := make([]int, len(cases))
+	for i, c := range cases {
+		res[i] = solve(c[0], c[1], c[2])
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(3) + 1
+	cases := make([][3]int, t)
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(t) + "\n")
+	for i := 0; i < t; i++ {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		k := rng.Intn(min(n*m, 30)) + 1
+		cases[i] = [3]int{n, m, k}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	}
+	ans := expectedE(cases)
+	var out strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		out.WriteString(strconv.Itoa(v))
+	}
+	out.WriteByte('\n')
+	return sb.String(), out.String()
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected\n%s\ngot\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/500-599/590-599/598/verifierF.go
+++ b/0-999/500-599/590-599/598/verifierF.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const eps = 1e-9
+
+type Point struct{ x, y float64 }
+
+func sub(a, b Point) Point         { return Point{a.x - b.x, a.y - b.y} }
+func add(a, b Point) Point         { return Point{a.x + b.x, a.y + b.y} }
+func mul(a Point, t float64) Point { return Point{a.x * t, a.y * t} }
+func dot(a, b Point) float64       { return a.x*b.x + a.y*b.y }
+func cross(a, b Point) float64     { return a.x*b.y - a.y*b.x }
+
+func onSegment(p, a, b Point) bool {
+	if math.Abs(cross(sub(b, a), sub(p, a))) > eps {
+		return false
+	}
+	return dot(sub(p, a), sub(p, b)) <= eps
+}
+
+func pointInPoly(p Point, poly []Point) bool {
+	n := len(poly)
+	for i := 0; i < n; i++ {
+		a := poly[i]
+		b := poly[(i+1)%n]
+		if onSegment(p, a, b) {
+			return true
+		}
+	}
+	wn := 0
+	for i := 0; i < n; i++ {
+		a := poly[i]
+		b := poly[(i+1)%n]
+		if a.y <= p.y {
+			if b.y > p.y && cross(sub(b, a), sub(p, a)) > eps {
+				wn++
+			}
+		} else {
+			if b.y <= p.y && cross(sub(b, a), sub(p, a)) < -eps {
+				wn--
+			}
+		}
+	}
+	return wn != 0
+}
+
+func intersectionLength(poly []Point, p0, p1 Point) float64 {
+	d := sub(p1, p0)
+	l := math.Hypot(d.x, d.y)
+	dir := Point{d.x / l, d.y / l}
+	var ts []float64
+	n := len(poly)
+	for i := 0; i < n; i++ {
+		a := poly[i]
+		b := poly[(i+1)%n]
+		da := sub(b, a)
+		denom := cross(d, da)
+		if math.Abs(denom) < eps {
+			if math.Abs(cross(d, sub(a, p0))) < eps {
+				t1 := dot(sub(a, p0), dir)
+				t2 := dot(sub(b, p0), dir)
+				if t2 < t1 {
+					t1, t2 = t2, t1
+				}
+				ts = append(ts, t1, t2)
+			}
+			continue
+		}
+		t := cross(sub(a, p0), da) / denom
+		s := cross(sub(a, p0), d) / denom
+		if s >= -eps && s <= 1+eps {
+			ts = append(ts, t)
+		}
+	}
+	if len(ts) == 0 {
+		return 0
+	}
+	sort.Float64s(ts)
+	uniq := []float64{ts[0]}
+	for i := 1; i < len(ts); i++ {
+		if math.Abs(ts[i]-ts[i-1]) > eps {
+			uniq = append(uniq, ts[i])
+		}
+	}
+	res := 0.0
+	for i := 0; i+1 < len(uniq); i++ {
+		tmid := (uniq[i] + uniq[i+1]) / 2
+		pt := add(p0, mul(dir, tmid))
+		if pointInPoly(pt, poly) {
+			res += uniq[i+1] - uniq[i]
+		}
+	}
+	return res * l
+}
+
+func expectedF(poly []Point, lines [][2]Point) []float64 {
+	ans := make([]float64, len(lines))
+	for i, ln := range lines {
+		ans[i] = intersectionLength(poly, ln[0], ln[1])
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 3
+	m := rng.Intn(5) + 1
+	poly := make([]Point, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		x := rng.Float64()*20 - 10
+		y := rng.Float64()*20 - 10
+		poly[i] = Point{x, y}
+		sb.WriteString(fmt.Sprintf("%.2f %.2f\n", x, y))
+	}
+	lines := make([][2]Point, m)
+	for i := 0; i < m; i++ {
+		x1 := rng.Float64()*20 - 10
+		y1 := rng.Float64()*20 - 10
+		x2 := rng.Float64()*20 - 10
+		y2 := rng.Float64()*20 - 10
+		lines[i] = [2]Point{{x1, y1}, {x2, y2}}
+		sb.WriteString(fmt.Sprintf("%.2f %.2f %.2f %.2f\n", x1, y1, x2, y2))
+	}
+	ans := expectedF(poly, lines)
+	var out strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		out.WriteString(fmt.Sprintf("%.10f", v))
+	}
+	out.WriteByte('\n')
+	return sb.String(), out.String()
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotLines := strings.Fields(strings.TrimSpace(out.String()))
+	expLines := strings.Fields(strings.TrimSpace(expected))
+	if len(gotLines) != len(expLines) {
+		return fmt.Errorf("wrong number of lines")
+	}
+	for i := range gotLines {
+		g, err1 := strconv.ParseFloat(gotLines[i], 64)
+		e, err2 := strconv.ParseFloat(expLines[i], 64)
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("parse error")
+		}
+		if math.Abs(g-e) > 1e-6*math.Max(1, math.Abs(e)) {
+			return fmt.Errorf("expected %.10f got %.10f", e, g)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA..F.go to test solutions for all problems in contest 598
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go build 0-999/500-599/590-599/598/verifierA.go`


------
https://chatgpt.com/codex/tasks/task_e_688348608bc883249670de1b15bb953c