### PR TITLE
Add Go solution for 1933B

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1933/1933B.go
+++ b/1000-1999/1900-1999/1930-1939/1933/1933B.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		sum := 0
+		c1, c2 := 0, 0
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			sum += x
+			switch x % 3 {
+			case 1:
+				c1++
+			case 2:
+				c2++
+			}
+		}
+		mod := sum % 3
+		ans := 0
+		if mod == 1 {
+			if c1 >= 1 {
+				ans = 1
+			} else {
+				ans = 2
+			}
+		} else if mod == 2 {
+			if c2 >= 1 {
+				ans = 1
+			} else {
+				ans = 2
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add `1933B.go` with a solution for problem B in contest 1933

## Testing
- `go run 1000-1999/1900-1999/1930-1939/1933/1933B.go << EOF
1
4
2 2 5 4
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688348a6887083248f2d761036401403