### PR TITLE
Add Go solution for 1933A

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1933/1933A.go
+++ b/1000-1999/1900-1999/1930-1939/1933/1933A.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		sum := 0
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(in, &x)
+			if x < 0 {
+				sum -= x
+			} else {
+				sum += x
+			}
+		}
+		fmt.Fprintln(out, sum)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for contest 1933 problem A

## Testing
- `go vet 1000-1999/1900-1999/1930-1939/1933/1933A.go`
- `go build 1000-1999/1900-1999/1930-1939/1933/1933A.go`


------
https://chatgpt.com/codex/tasks/task_e_688349329e7483249f5dd4f915daaf1f