### PR TITLE
Add Go solution for problem 1932C

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1932/1932C.go
+++ b/1000-1999/1900-1999/1930-1939/1932/1932C.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(reader, &n, &m)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		var s string
+		fmt.Fscan(reader, &s)
+		removed := make([]int, n)
+		l, r := 0, n-1
+		for i := 0; i < n; i++ {
+			if s[i] == 'L' {
+				removed[i] = a[l]
+				l++
+			} else {
+				removed[i] = a[r]
+				r--
+			}
+		}
+		ans := make([]int, n)
+		prod := 1 % m
+		for i := n - 1; i >= 0; i-- {
+			prod = (prod * removed[i]) % m
+			ans[i] = prod
+		}
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				fmt.Fprint(writer, " ")
+			}
+			fmt.Fprint(writer, ans[i])
+		}
+		fmt.Fprintln(writer)
+	}
+}


### PR DESCRIPTION
## Summary
- add solution 1932C.go implementing reverse processing with prefix removals

## Testing
- `go vet 1000-1999/1900-1999/1930-1939/1932/1932C.go`
- `go build 1000-1999/1900-1999/1930-1939/1932/1932C.go`

------
https://chatgpt.com/codex/tasks/task_e_68834b62f9bc832491850c83d9c375b2