### PR TITLE
Add solution for 1932B

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1932/1932B.go
+++ b/1000-1999/1900-1999/1930-1939/1932/1932B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		var year int64 = 1
+		var signYear int64
+		for i := 0; i < n; i++ {
+			ai := a[i]
+			if year%ai == 0 {
+				signYear = year
+			} else {
+				signYear = (year + ai - 1) / ai * ai
+			}
+			year = signYear + 1
+		}
+		fmt.Fprintln(out, signYear)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem B in contest 1932

## Testing
- `go build 1000-1999/1900-1999/1930-1939/1932/1932B.go`
- `echo -e "1\n6\n3 2 4 5 9 18" | go run 1000-1999/1900-1999/1930-1939/1932/1932B.go`

------
https://chatgpt.com/codex/tasks/task_e_68834bef1bac83248ce482634dab49e4