### PR TITLE
Add verifiers for contest 603

### DIFF
--- a/0-999/600-699/600-609/603/verifierA.go
+++ b/0-999/600-699/600-609/603/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int, s string) int {
+	transitions := 0
+	equalCnt := 0
+	for i := 0; i+1 < n; i++ {
+		if s[i] != s[i+1] {
+			transitions++
+		} else {
+			equalCnt++
+		}
+	}
+	delta := 0
+	if equalCnt >= 2 {
+		delta = 2
+	} else if equalCnt == 1 {
+		delta = 1
+	}
+	return transitions + delta + 1
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	s := sb.String()
+	input := fmt.Sprintf("%d %s\n", n, s)
+	exp := fmt.Sprintf("%d", expected(n, s))
+	return input, exp
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/600-609/603/verifierB.go
+++ b/0-999/600-699/600-609/603/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func modPow(a, b int64) int64 {
+	a %= mod
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func solveCase(p, k int64) int64 {
+	if k == 0 {
+		return modPow(p, p-1)
+	}
+	if k == 1 {
+		return modPow(p, p)
+	}
+	visited := make([]bool, p)
+	var cycles int64
+	for i := int64(1); i < p; i++ {
+		if !visited[i] {
+			cycles++
+			j := i
+			for !visited[j] {
+				visited[j] = true
+				j = (j * k) % p
+			}
+		}
+	}
+	return modPow(p, cycles)
+}
+
+var primes = []int64{3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	p := primes[rng.Intn(len(primes))]
+	k := rng.Int63n(p)
+	input := fmt.Sprintf("%d %d\n", p, k)
+	exp := fmt.Sprintf("%d", solveCase(p, k))
+	return input, exp
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/600-609/603/verifierC.go
+++ b/0-999/600-699/600-609/603/verifierC.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func grundyOdd(x int64) int {
+	switch x {
+	case 0:
+		return 0
+	case 1:
+		return 1
+	case 2:
+		return 0
+	case 3:
+		return 1
+	case 4:
+		return 2
+	}
+	if x%2 == 1 {
+		return 0
+	}
+	g := grundyOdd(x / 2)
+	if g == 1 {
+		return 2
+	}
+	return 1
+}
+
+func grundyEven(x int64) int {
+	if x == 1 {
+		return 1
+	}
+	if x == 2 {
+		return 2
+	}
+	if x%2 == 1 {
+		return 0
+	}
+	g := grundyEven(x / 2)
+	if g == 1 {
+		return 2
+	}
+	return 1
+}
+
+func solveCase(n int, k int64, arr []int64) string {
+	res := 0
+	for _, a := range arr {
+		var g int
+		if k%2 == 0 {
+			g = grundyEven(a)
+		} else {
+			g = grundyOdd(a)
+		}
+		res ^= g
+	}
+	if res != 0 {
+		return "Kevin"
+	}
+	return "Nicky"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	k := int64(rng.Intn(10) + 1)
+	arr := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(20) + 1)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(arr[i]))
+	}
+	sb.WriteByte('\n')
+	expected := solveCase(n, k, arr)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/600-609/603/verifierD.go
+++ b/0-999/600-699/600-609/603/verifierD.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type line struct {
+	a, b, c int64
+}
+
+type point struct {
+	x, y, s int64
+}
+
+func abs(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func gcd(a, b int64) int64 {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solveCase(n int, lines []line) int64 {
+	pts := make([]point, n)
+	for i, l := range lines {
+		pts[i] = point{x: l.a * l.c, y: l.b * l.c, s: l.a*l.a + l.b*l.b}
+	}
+	var ans int64
+	for i := 0; i < n; i++ {
+		xi, yi, si := pts[i].x, pts[i].y, pts[i].s
+		dup := 0
+		slopes := make(map[[2]int64]int)
+		for j := i + 1; j < n; j++ {
+			xj, yj, sj := pts[j].x, pts[j].y, pts[j].s
+			dx := xj*si - xi*sj
+			dy := yj*si - yi*sj
+			if dx == 0 && dy == 0 {
+				dup++
+				continue
+			}
+			g := gcd(abs(dx), abs(dy))
+			dx /= g
+			dy /= g
+			if dx < 0 || (dx == 0 && dy < 0) {
+				dx = -dx
+				dy = -dy
+			}
+			slopes[[2]int64{dx, dy}]++
+		}
+		for _, m := range slopes {
+			ans += int64(m*(m-1)/2) + int64(dup*m)
+		}
+		ans += int64(dup * (dup - 1) / 2)
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 3
+	lines := make([]line, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		a := int64(rng.Intn(11) - 5)
+		b := int64(rng.Intn(11) - 5)
+		for a == 0 && b == 0 {
+			a = int64(rng.Intn(11) - 5)
+			b = int64(rng.Intn(11) - 5)
+		}
+		c := int64(rng.Intn(11) - 5)
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", a, b, c))
+		lines[i] = line{a: a, b: b, c: c}
+	}
+	expected := fmt.Sprintf("%d", solveCase(n, lines))
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/600-609/603/verifierE.go
+++ b/0-999/600-699/600-609/603/verifierE.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	u, v int
+	w    int64
+}
+
+type DSU struct {
+	parent []int
+	size   []int
+}
+
+func NewDSU(n int) *DSU {
+	d := &DSU{parent: make([]int, n+1), size: make([]int, n+1)}
+	for i := 1; i <= n; i++ {
+		d.parent[i] = i
+		d.size[i] = 1
+	}
+	return d
+}
+
+func (d *DSU) Find(x int) int {
+	for x != d.parent[x] {
+		d.parent[x] = d.parent[d.parent[x]]
+		x = d.parent[x]
+	}
+	return x
+}
+
+func (d *DSU) Union(a, b int, odd *int) {
+	ra := d.Find(a)
+	rb := d.Find(b)
+	if ra == rb {
+		return
+	}
+	if d.size[ra] < d.size[rb] {
+		ra, rb = rb, ra
+	}
+	*odd -= d.size[ra] % 2
+	*odd -= d.size[rb] % 2
+	d.parent[rb] = ra
+	d.size[ra] += d.size[rb]
+	*odd += d.size[ra] % 2
+}
+
+func solveCase(n, m int, edges []Edge) []int64 {
+	if n%2 == 1 {
+		res := make([]int64, m)
+		for i := range res {
+			res[i] = -1
+		}
+		return res
+	}
+	res := make([]int64, m)
+	for i := 1; i <= m; i++ {
+		subset := make([]Edge, i)
+		copy(subset, edges[:i])
+		sort.Slice(subset, func(a, b int) bool { return subset[a].w < subset[b].w })
+		d := NewDSU(n)
+		odd := n
+		ans := int64(-1)
+		for _, e := range subset {
+			d.Union(e.u, e.v, &odd)
+			if odd == 0 {
+				ans = e.w
+				break
+			}
+		}
+		res[i-1] = ans
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	m := rng.Intn(8) + 1
+	edges := make([]Edge, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n-1) + 1
+		if v >= u {
+			v++
+		}
+		w := int64(rng.Intn(10) + 1)
+		edges[i] = Edge{u: u, v: v, w: w}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", u, v, w))
+	}
+	out := solveCase(n, m, edges)
+	var exp strings.Builder
+	for i, v := range out {
+		if i > 0 {
+			exp.WriteByte('\n')
+		}
+		exp.WriteString(fmt.Sprint(v))
+	}
+	exp.WriteByte('\n')
+	return sb.String(), exp.String()
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E in contest 603
- each verifier generates 100 random tests and checks a candidate binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68834b1cead8832493282f72257e4adb