### PR TITLE
Add Go solution for 1930B

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1930/1930B.go
+++ b/1000-1999/1900-1999/1930-1939/1930/1930B.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		res := make([]int, 0, n)
+		l, r := 1, n
+		for l < r {
+			res = append(res, l)
+			res = append(res, r)
+			l++
+			r--
+		}
+		if l == r {
+			res = append(res, l)
+		}
+		for i, v := range res {
+			if i > 0 {
+				out.WriteByte(' ')
+			}
+			fmt.Fprint(out, v)
+		}
+		out.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- add implementation for problem B in contest 1930
- algorithm outputs numbers in alternating low-high order

## Testing
- `go build 1000-1999/1900-1999/1930-1939/1930/1930B.go`
- `echo -e "3\n4\n3\n5" | ./1930B`

------
https://chatgpt.com/codex/tasks/task_e_6883528099008324baada755889f3b4c