### PR TITLE
Add Go verifiers for contest 616

### DIFF
--- a/0-999/600-699/610-619/616/verifierA.go
+++ b/0-999/600-699/610-619/616/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "616A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(6160))
+	cases := make([]Case, 100)
+	for i := range cases {
+		la := rng.Intn(50) + 1
+		lb := rng.Intn(50) + 1
+		var sa, sb strings.Builder
+		for j := 0; j < la; j++ {
+			sa.WriteByte(byte('0' + rng.Intn(10)))
+		}
+		for j := 0; j < lb; j++ {
+			sb.WriteByte(byte('0' + rng.Intn(10)))
+		}
+		input := fmt.Sprintf("%s\n%s\n", sa.String(), sb.String())
+		cases[i] = Case{input}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/616/verifierB.go
+++ b/0-999/600-699/610-619/616/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "616B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(6161))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for r := 0; r < n; r++ {
+			for c := 0; c < m; c++ {
+				val := rng.Intn(21) - 10
+				if c > 0 {
+					sb.WriteByte(' ')
+				}
+				fmt.Fprintf(&sb, "%d", val)
+			}
+			sb.WriteByte('\n')
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/616/verifierC.go
+++ b/0-999/600-699/610-619/616/verifierC.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "616C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(6162))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(6) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for r := 0; r < n; r++ {
+			for c := 0; c < m; c++ {
+				if rng.Intn(2) == 0 {
+					sb.WriteByte('.')
+				} else {
+					sb.WriteByte('*')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/616/verifierD.go
+++ b/0-999/600-699/610-619/616/verifierD.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "616D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(6163))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(n) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(10))
+		}
+		sb.WriteByte('\n')
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/616/verifierE.go
+++ b/0-999/600-699/610-619/616/verifierE.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "616E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(6164))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Int63n(1000000) + 1
+		m := rng.Int63n(1000000) + 1
+		input := fmt.Sprintf("%d %d\n", n, m)
+		cases[i] = Case{input}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/616/verifierF.go
+++ b/0-999/600-699/610-619/616/verifierF.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "616F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(6165))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(4) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		strs := make([]string, n)
+		for j := 0; j < n; j++ {
+			l := rng.Intn(6) + 1
+			var s strings.Builder
+			for k := 0; k < l; k++ {
+				s.WriteByte(byte('a' + rng.Intn(3)))
+			}
+			strs[j] = s.String()
+			fmt.Fprintln(&sb, strs[j])
+		}
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(21)-10)
+		}
+		sb.WriteByte('\n')
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces contest 616 problems A–F
- each verifier builds the reference solution and runs 100 random tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883523a551c8324a5d66b15832bf030