### PR TITLE
Add verifiers for contest 613

### DIFF
--- a/0-999/600-699/610-619/613/verifierA.go
+++ b/0-999/600-699/610-619/613/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "613A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(61))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(7) + 3 // 3..9
+		cx := rng.Intn(21) - 10
+		cy := rng.Intn(21) - 10
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, cx, cy)
+		for j := 0; j < n; j++ {
+			angle := 2 * math.Pi * float64(j) / float64(n)
+			r := rng.Float64()*9 + 1
+			x := int(r * math.Cos(angle))
+			y := int(r * math.Sin(angle))
+			fmt.Fprintf(&sb, "%d %d\n", x, y)
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/613/verifierB.go
+++ b/0-999/600-699/610-619/613/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "613B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(62))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(6) + 1
+		A := rng.Int63n(20) + 1
+		cf := rng.Int63n(10)
+		cm := rng.Int63n(10)
+		m := rng.Int63n(100)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d %d\n", n, A, cf, cm, m)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			v := rng.Int63n(A + 1)
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/613/verifierC.go
+++ b/0-999/600-699/610-619/613/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "613C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(63))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rng.Intn(10) + 1
+			fmt.Fprintf(&sb, "%d", val)
+		}
+		sb.WriteByte('\n')
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/613/verifierD.go
+++ b/0-999/600-699/610-619/613/verifierD.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "613D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTree(n int, rng *rand.Rand) [][2]int {
+	edges := make([][2]int, n-1)
+	for v := 2; v <= n; v++ {
+		p := rng.Intn(v-1) + 1
+		edges[v-2] = [2]int{p, v}
+	}
+	return edges
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(64))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(8) + 2 // 2..9
+		edges := genTree(n, rng)
+		q := rng.Intn(4) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for _, e := range edges {
+			fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+		}
+		fmt.Fprintf(&sb, "%d\n", q)
+		for j := 0; j < q; j++ {
+			k := rng.Intn(n) + 1
+			used := make(map[int]bool)
+			var nodes []int
+			for len(nodes) < k {
+				x := rng.Intn(n) + 1
+				if !used[x] {
+					used[x] = true
+					nodes = append(nodes, x)
+				}
+			}
+			fmt.Fprintf(&sb, "%d", k)
+			for _, x := range nodes {
+				fmt.Fprintf(&sb, " %d", x)
+			}
+			sb.WriteByte('\n')
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/613/verifierE.go
+++ b/0-999/600-699/610-619/613/verifierE.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "613E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(65))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(8) + 1
+		row1 := randString(rng, n)
+		row2 := randString(rng, n)
+		k := rng.Intn(8) + 1
+		word := randString(rng, k)
+		var sb strings.Builder
+		sb.WriteString(row1)
+		sb.WriteByte('\n')
+		sb.WriteString(row2)
+		sb.WriteString("\n\n")
+		sb.WriteString(word)
+		sb.WriteByte('\n')
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 613
- each verifier builds the reference solution and checks 100 random test cases

## Testing
- `go build 0-999/600-699/610-619/613/verifierA.go`
- `go build 0-999/600-699/610-619/613/verifierB.go`
- `go build 0-999/600-699/610-619/613/verifierC.go`
- `go build 0-999/600-699/610-619/613/verifierD.go`
- `go build 0-999/600-699/610-619/613/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883509611888324bcf85903631fa2e9