### PR TITLE
Add Go verifiers for Codeforces contest 612

### DIFF
--- a/0-999/600-699/610-619/612/verifierA.go
+++ b/0-999/600-699/610-619/612/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCmd(exe, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, exe)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	refBin := "./refA_bin"
+	cmd := exec.Command("go", "build", "-o", refBin, "612A.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refBin, nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(42))
+	letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(20) + 1
+		p := r.Intn(n) + 1
+		q := r.Intn(n) + 1
+		sb := strings.Builder{}
+		for j := 0; j < n; j++ {
+			sb.WriteByte(letters[r.Intn(len(letters))])
+		}
+		s := sb.String()
+		tests[i] = fmt.Sprintf("%d %d %d\n%s\n", n, p, q, s)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	tests := generateTests()
+	for idx, input := range tests {
+		expect, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", idx+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/600-699/610-619/612/verifierB.go
+++ b/0-999/600-699/610-619/612/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCmd(exe, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, exe)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	refBin := "./refB_bin"
+	cmd := exec.Command("go", "build", "-o", refBin, "612B.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refBin, nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(42))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(20) + 1
+		perm := rand.Perm(n)
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range perm {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v+1))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	tests := generateTests()
+	for idx, input := range tests {
+		expect, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", idx+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/600-699/610-619/612/verifierC.go
+++ b/0-999/600-699/610-619/612/verifierC.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCmd(exe, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, exe)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	refBin := "./refC_bin"
+	cmd := exec.Command("go", "build", "-o", refBin, "612C.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refBin, nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(42))
+	br := []byte{'(', ')', '[', ']', '{', '}', '<', '>'}
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		l := r.Intn(20) + 1
+		sb := strings.Builder{}
+		for j := 0; j < l; j++ {
+			sb.WriteByte(br[r.Intn(len(br))])
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	tests := generateTests()
+	for idx, input := range tests {
+		expect, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", idx+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/600-699/610-619/612/verifierD.go
+++ b/0-999/600-699/610-619/612/verifierD.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCmd(exe, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, exe)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	refBin := "./refD_bin"
+	cmd := exec.Command("go", "build", "-o", refBin, "612D.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refBin, nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(42))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(8) + 1
+		k := r.Intn(n) + 1
+		sb := strings.Builder{}
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			l := r.Intn(21) - 10
+			r2 := l + r.Intn(11)
+			fmt.Fprintf(&sb, "%d %d\n", l, r2)
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	tests := generateTests()
+	for idx, input := range tests {
+		expect, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", idx+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/600-699/610-619/612/verifierE.go
+++ b/0-999/600-699/610-619/612/verifierE.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCmd(exe, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, exe)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	refBin := "./refE_bin"
+	cmd := exec.Command("go", "build", "-o", refBin, "612E.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refBin, nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(42))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(6) + 1
+		perm := rand.Perm(n)
+		sb := strings.Builder{}
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j, v := range perm {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v+1)
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	tests := generateTests()
+	for idx, input := range tests {
+		expect, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", idx+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/600-699/610-619/612/verifierF.go
+++ b/0-999/600-699/610-619/612/verifierF.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCmd(exe, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, exe)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	refBin := "./refF_bin"
+	cmd := exec.Command("go", "build", "-o", refBin, "612F.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refBin, nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(42))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(6) + 1
+		s := r.Intn(n) + 1
+		sb := strings.Builder{}
+		fmt.Fprintf(&sb, "%d %d\n", n, s)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", r.Intn(21)-10)
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	tests := generateTests()
+	for idx, input := range tests {
+		expect, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", idx+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to automatically test solutions for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E
- add verifierF.go for problem F

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go vet verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68835009ec6883248ce42873dfdaebe6