### PR TITLE
Add verifiers for contest 611

### DIFF
--- a/0-999/600-699/610-619/611/verifierA.go
+++ b/0-999/600-699/610-619/611/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(x int, typ string) int {
+	if typ == "week" {
+		if x == 5 || x == 6 {
+			return 53
+		}
+		return 52
+	}
+	days := []int{31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
+	cnt := 0
+	for _, d := range days {
+		if x <= d {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		week := rng.Intn(2) == 0
+		var sb strings.Builder
+		var x int
+		if week {
+			x = rng.Intn(7) + 1
+			fmt.Fprintf(&sb, "%d of week\n", x)
+			want := expected(x, "week")
+			out, err := runCandidate(bin, sb.String())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+				os.Exit(1)
+			}
+			got, err := strconv.Atoi(strings.TrimSpace(out))
+			if err != nil || got != want {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, want, out)
+				os.Exit(1)
+			}
+		} else {
+			x = rng.Intn(31) + 1
+			fmt.Fprintf(&sb, "%d of month\n", x)
+			want := expected(x, "month")
+			out, err := runCandidate(bin, sb.String())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+				os.Exit(1)
+			}
+			got, err := strconv.Atoi(strings.TrimSpace(out))
+			if err != nil || got != want {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, want, out)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/611/verifierB.go
+++ b/0-999/600-699/610-619/611/verifierB.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(a, b int64) int64 {
+	count := int64(0)
+	for l := 2; l <= 60; l++ {
+		allOnes := (int64(1) << uint(l)) - 1
+		for i := 0; i < l-1; i++ {
+			num := allOnes - (int64(1) << uint(i))
+			if num >= a && num <= b {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < 100; i++ {
+		var a, b int64
+		a = rng.Int63n(1<<60) + 1
+		b = a + rng.Int63n(1<<20)
+		if rng.Intn(4) == 0 {
+			a = 1
+			b = (1 << 60) - 1
+		}
+		if a > b {
+			a, b = b, a
+		}
+		input := fmt.Sprintf("%d %d\n", a, b)
+		want := expected(a, b)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil || got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/611/verifierC.go
+++ b/0-999/600-699/610-619/611/verifierC.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(h, w int, grid []string, queries [][4]int) []int {
+	hPref := make([][]int, h+1)
+	vPref := make([][]int, h+1)
+	for i := 0; i <= h; i++ {
+		hPref[i] = make([]int, w+1)
+		vPref[i] = make([]int, w+1)
+	}
+	for i := 1; i <= h; i++ {
+		for j := 1; j <= w; j++ {
+			if j < w && grid[i-1][j-1] == '.' && grid[i-1][j] == '.' {
+				hPref[i][j] = 1
+			}
+			if i < h && grid[i-1][j-1] == '.' && grid[i][j-1] == '.' {
+				vPref[i][j] = 1
+			}
+			hPref[i][j] += hPref[i-1][j] + hPref[i][j-1] - hPref[i-1][j-1]
+			vPref[i][j] += vPref[i-1][j] + vPref[i][j-1] - vPref[i-1][j-1]
+		}
+	}
+	res := make([]int, len(queries))
+	for idx, q := range queries {
+		r1, c1, r2, c2 := q[0], q[1], q[2], q[3]
+		horizontal := hPref[r2][c2-1] - hPref[r1-1][c2-1] - hPref[r2][c1-1] + hPref[r1-1][c1-1]
+		vertical := vPref[r2-1][c2] - vPref[r1-1][c2] - vPref[r2-1][c1-1] + vPref[r1-1][c1-1]
+		res[idx] = horizontal + vertical
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(3))
+	for t := 0; t < 100; t++ {
+		h := rng.Intn(4) + 2
+		w := rng.Intn(4) + 2
+		grid := make([]string, h)
+		for i := 0; i < h; i++ {
+			var sb strings.Builder
+			for j := 0; j < w; j++ {
+				if rng.Intn(4) == 0 {
+					sb.WriteByte('#')
+				} else {
+					sb.WriteByte('.')
+				}
+			}
+			grid[i] = sb.String()
+		}
+		q := rng.Intn(5) + 1
+		queries := make([][4]int, q)
+		for i := 0; i < q; i++ {
+			r1 := rng.Intn(h) + 1
+			r2 := rng.Intn(h-r1+1) + r1
+			c1 := rng.Intn(w) + 1
+			c2 := rng.Intn(w-c1+1) + c1
+			queries[i] = [4]int{r1, c1, r2, c2}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", h, w)
+		for _, row := range grid {
+			sb.WriteString(row)
+			sb.WriteByte('\n')
+		}
+		fmt.Fprintf(&sb, "%d\n", q)
+		for _, qu := range queries {
+			fmt.Fprintf(&sb, "%d %d %d %d\n", qu[0], qu[1], qu[2], qu[3])
+		}
+		input := sb.String()
+		want := expected(h, w, grid, queries)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(strings.TrimSpace(out))
+		if len(fields) != len(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\n", t+1, len(want), len(fields))
+			os.Exit(1)
+		}
+		for i, f := range fields {
+			val, err := strconv.Atoi(f)
+			if err != nil || val != want[i] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %v got %v\n", t+1, want, fields)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/611/verifierD.go
+++ b/0-999/600-699/610-619/611/verifierD.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const MOD int32 = 1000000007
+
+func expected(s string) int32 {
+	n := len(s)
+	bs := []byte(" " + s)
+	lcp := make([][]uint16, n+2)
+	for i := range lcp {
+		lcp[i] = make([]uint16, n+2)
+	}
+	for i := n; i >= 1; i-- {
+		for j := n; j >= 1; j-- {
+			if bs[i] == bs[j] {
+				lcp[i][j] = lcp[i+1][j+1] + 1
+			}
+		}
+	}
+	dp := make([][]int32, n+2)
+	pref := make([][]int32, n+2)
+	for i := range dp {
+		dp[i] = make([]int32, n+2)
+		pref[i] = make([]int32, n+2)
+	}
+	dp[0][0] = 1
+	pref[0][0] = 1
+	for j := 1; j <= n; j++ {
+		for i := 1; i <= j; i++ {
+			if bs[i] == '0' {
+				dp[i][j] = 0
+				pref[i][j] = (pref[i-1][j] + dp[i][j]) % MOD
+				continue
+			}
+			ans := pref[i-1][i-1]
+			length := j - i + 1
+			if k := i - length - 1; k >= 0 {
+				val := pref[k][i-1]
+				ans = (ans - val) % MOD
+			}
+			if k := i - length; k >= 1 {
+				common := int(lcp[k][i])
+				if common >= length || bs[k+common] > bs[i+common] {
+					ans = (ans - dp[k][i-1]) % MOD
+				}
+			}
+			if ans < 0 {
+				ans += MOD
+			}
+			dp[i][j] = ans
+			pref[i][j] = (pref[i-1][j] + dp[i][j]) % MOD
+		}
+	}
+	return pref[n][n]
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(4))
+	digits := []byte("123456789")
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(12) + 1
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteByte(digits[rng.Intn(len(digits))])
+		}
+		s := sb.String()
+		input := fmt.Sprintf("%d\n%s\n", n, s)
+		want := expected(s)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got64, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil || int32(got64) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/611/verifierE.go
+++ b/0-999/600-699/610-619/611/verifierE.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, strengths [3]int, criminals []int) int {
+	s := []int{strengths[0], strengths[1], strengths[2]}
+	sort.Ints(s)
+	a, b, c := s[0], s[1], s[2]
+	sort.Ints(criminals)
+	used := make([]bool, n)
+	remain := n
+	pa := n - 1
+	for pa >= 0 && criminals[pa] > a {
+		pa--
+	}
+	pb := n - 1
+	for pb >= 0 && criminals[pb] > b {
+		pb--
+	}
+	r := n - 1
+	hours := 0
+	remove := func(limit int, p *int) bool {
+		for *p >= 0 && (used[*p] || criminals[*p] > limit) {
+			(*p)--
+		}
+		if *p >= 0 {
+			used[*p] = true
+			remain--
+			(*p)--
+			return true
+		}
+		return false
+	}
+	for remain > 0 {
+		for r >= 0 && used[r] {
+			r--
+		}
+		if r < 0 {
+			break
+		}
+		idx := r
+		x := criminals[idx]
+		used[idx] = true
+		remain--
+		r--
+		hours++
+		if x > a+b+c {
+			return -1
+		}
+		if x > b+c {
+			continue
+		}
+		if x > c {
+			if x > a+c {
+				remove(a, &pa)
+			} else {
+				remove(b, &pb)
+			}
+			continue
+		}
+		remove(b, &pb)
+		remove(a, &pa)
+	}
+	return hours
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(5))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(20) + 1
+		strengths := [3]int{rng.Intn(50) + 1, rng.Intn(50) + 1, rng.Intn(50) + 1}
+		criminals := make([]int, n)
+		for i := 0; i < n; i++ {
+			criminals[i] = rng.Intn(50) + 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		fmt.Fprintf(&sb, "%d %d %d\n", strengths[0], strengths[1], strengths[2])
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", criminals[i])
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want := expected(n, strengths, append([]int(nil), criminals...))
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil || got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/611/verifierF.go
+++ b/0-999/600-699/610-619/611/verifierF.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const MOD int64 = 1000000007
+
+func expected(n, h, w int, s string) int64 {
+	remW := int64(w)
+	remH := int64(h)
+	dx, dy := 0, 0
+	minX, maxX := 0, 0
+	minY, maxY := 0, 0
+	ans := int64(0)
+	step := 0
+	idx := 0
+	for remW > 0 && remH > 0 {
+		ch := s[idx]
+		idx++
+		if idx == n {
+			idx = 0
+		}
+		step++
+		switch ch {
+		case 'L':
+			dx--
+		case 'R':
+			dx++
+		case 'U':
+			dy--
+		case 'D':
+			dy++
+		}
+		changed := false
+		if dx < minX {
+			minX = dx
+			remW--
+			ans = (ans + remH*int64(step)) % MOD
+			changed = true
+		}
+		if dx > maxX && remW > 0 {
+			maxX = dx
+			remW--
+			ans = (ans + remH*int64(step)) % MOD
+			changed = true
+		}
+		if dy < minY && remH > 0 {
+			minY = dy
+			remH--
+			ans = (ans + remW*int64(step)) % MOD
+			changed = true
+		}
+		if dy > maxY && remH > 0 {
+			maxY = dy
+			remH--
+			ans = (ans + remW*int64(step)) % MOD
+			changed = true
+		}
+		if !changed && idx == 0 && dx == 0 && dy == 0 {
+			return -1
+		}
+	}
+	return ans % MOD
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(6))
+	letters := []byte("LRUD")
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(20) + 1
+		h := rng.Intn(10) + 1
+		w := rng.Intn(10) + 1
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteByte(letters[rng.Intn(4)])
+		}
+		s := sb.String()
+		input := fmt.Sprintf("%d %d %d\n%s\n", n, h, w, s)
+		want := expected(n, h, w, s)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil || got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/611/verifierG.go
+++ b/0-999/600-699/610-619/611/verifierG.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProgram(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generatePolygon(rng *rand.Rand, n int) [][2]int64 {
+	pts := make([][2]int64, n)
+	radius := float64(1000)
+	for i := 0; i < n; i++ {
+		angle := 2 * math.Pi * float64(i) / float64(n)
+		x := int64(math.Round(radius * math.Cos(angle)))
+		y := int64(math.Round(radius * math.Sin(angle)))
+		pts[i] = [2]int64{x, y}
+	}
+	return pts
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref611G.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "611G.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(7))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(6) + 4
+		pts := generatePolygon(rng, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", pts[i][0]+int64(rng.Intn(3)), pts[i][1]+int64(rng.Intn(3)))
+		}
+		input := sb.String()
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/611/verifierH.go
+++ b/0-999/600-699/610-619/611/verifierH.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProgram(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func digits(x int) int {
+	d := 0
+	for x > 0 {
+		d++
+		x /= 10
+	}
+	if d == 0 {
+		d = 1
+	}
+	return d
+}
+
+func randomEdges(rng *rand.Rand, n int) [][2]string {
+	D := digits(n)
+	edges := make([][2]string, n-1)
+	for i := 0; i < n-1; i++ {
+		a := rng.Intn(D) + 1
+		b := rng.Intn(D) + 1
+		edges[i] = [2]string{strings.Repeat("?", a), strings.Repeat("?", b)}
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	refBin := "ref611H.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "611H.go").Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(8))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(8) + 2
+		edges := randomEdges(rng, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for _, e := range edges {
+			fmt.Fprintf(&sb, "%s %s\n", e[0], e[1])
+		}
+		input := sb.String()
+		want, err := runProgram(refBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		out, err := runProgram(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\n=== got ===\n%s\n", t+1, want, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for Codeforces contest 611 (problems A–H)
- each verifier runs 100 randomized test cases
- complex problems G and H use the official solutions as reference binaries

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_68834f7dd20883249d6660f912f882bb