### PR TITLE
Add contest 618 solution verifiers

### DIFF
--- a/0-999/600-699/610-619/618/verifierA.go
+++ b/0-999/600-699/610-619/618/verifierA.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for t := 0; t < 120; t++ {
+		n := rng.Intn(100000) + 1
+		input := fmt.Sprintf("%d\n", n)
+		expected, err := run("618A.go", input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/618/verifierB.go
+++ b/0-999/600-699/610-619/618/verifierB.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand, n int) string {
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	mat := make([][]int, n)
+	for i := 0; i < n; i++ {
+		mat[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			if perm[i] < perm[j] {
+				mat[i][j] = perm[i]
+			} else {
+				mat[i][j] = perm[j]
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(mat[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 120; t++ {
+		n := rng.Intn(50) + 1
+		input := genCase(rng, n)
+		expected, err := run("618B.go", input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/618/verifierC.go
+++ b/0-999/600-699/610-619/618/verifierC.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand, n int) string {
+	points := make([][2]int, n)
+	// ensure first three points are non-collinear
+	points[0] = [2]int{0, 0}
+	points[1] = [2]int{1, 0}
+	points[2] = [2]int{0, 1}
+	used := map[[2]int]bool{{0, 0}: true, {1, 0}: true, {0, 1}: true}
+	for i := 3; i < n; i++ {
+		for {
+			x := rng.Intn(2001) - 1000
+			y := rng.Intn(2001) - 1000
+			pt := [2]int{x, y}
+			if !used[pt] {
+				points[i] = pt
+				used[pt] = true
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", points[i][0], points[i][1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 120; t++ {
+		n := rng.Intn(20) + 3
+		input := genCase(rng, n)
+		expected, err := run("618C.go", input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/618/verifierD.go
+++ b/0-999/600-699/610-619/618/verifierD.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func buildInput(n int, x, y int64, edges [][2]int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x, y))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 120; t++ {
+		n := rng.Intn(20) + 2
+		x := int64(rng.Intn(100) + 1)
+		y := int64(rng.Intn(100) + 1)
+		edges := genTree(rng, n)
+		input := buildInput(n, x, y, edges)
+		expected, err := run("618D.go", input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/618/verifierE.go
+++ b/0-999/600-699/610-619/618/verifierE.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand, n, m int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		typ := rng.Intn(2) + 1
+		seg := rng.Intn(n) + 1
+		val := rng.Intn(359) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", typ, seg, val))
+	}
+	return sb.String()
+}
+
+func parseFloat(s string) (float64, float64, error) {
+	parts := strings.Fields(s)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("expected two floats")
+	}
+	a, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	b, err := strconv.ParseFloat(parts[1], 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	return a, b, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 120; t++ {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		input := genCase(rng, n, m)
+		expectedStr, err := run("618E.go", input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		gotStr, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		exX, exY, err := parseFloat(expectedStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal parse error: %v\n", err)
+			os.Exit(1)
+		}
+		gX, gY, err := parseFloat(gotStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected two numbers got %s\n", t+1, gotStr)
+			os.Exit(1)
+		}
+		if math.Abs(gX-exX) > 1e-4*math.Max(1, math.Abs(exX)) || math.Abs(gY-exY) > 1e-4*math.Max(1, math.Abs(exY)) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.5f %.5f got %.5f %.5f\ninput:\n%s", t+1, exX, exY, gX, gY, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/618/verifierF.go
+++ b/0-999/600-699/610-619/618/verifierF.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand, n int) string {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(n) + 1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(n) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 120; t++ {
+		n := rng.Intn(50) + 1
+		input := genCase(rng, n)
+		expected, err := run("618F.go", input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/618/verifierG.go
+++ b/0-999/600-699/610-619/618/verifierG.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 120; t++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		p := rng.Int63n(1_000_000_000-1) + 1
+		input := fmt.Sprintf("%d %d\n", n, p)
+		expectedStr, err := run("618G.go", input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		gotStr, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		exVal, err := strconv.ParseFloat(strings.TrimSpace(expectedStr), 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal parse error: %v\n", err)
+			os.Exit(1)
+		}
+		gotVal, err := strconv.ParseFloat(strings.TrimSpace(gotStr), 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: non float output %s\n", t+1, gotStr)
+			os.Exit(1)
+		}
+		if math.Abs(gotVal-exVal) > 1e-4*math.Max(1, math.Abs(exVal)) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.6f got %.6f\ninput:\n%s", t+1, exVal, gotVal, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest 618 problems A–G
- each verifier generates 120 random tests and compares against reference solution

## Testing
- `go build 0-999/600-699/610-619/618/verifierA.go`
- `go build 0-999/600-699/610-619/618/verifierB.go`
- `go build 0-999/600-699/610-619/618/verifierC.go`
- `go build 0-999/600-699/610-619/618/verifierD.go`
- `go build 0-999/600-699/610-619/618/verifierE.go`
- `go build 0-999/600-699/610-619/618/verifierF.go`
- `go build 0-999/600-699/610-619/618/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68835352881c8324b85b839867d2af5f