### PR TITLE
Add Go verifiers for Codeforces contest 617

### DIFF
--- a/0-999/600-699/610-619/617/verifierA.go
+++ b/0-999/600-699/610-619/617/verifierA.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(x int) int {
+	return (x + 4) / 5
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]test, 100)
+	for i := 0; i < 100; i++ {
+		x := rng.Intn(1_000_000) + 1
+		exp := solve(x)
+		tests[i] = test{
+			input:    fmt.Sprintf("%d\n", x),
+			expected: fmt.Sprintf("%d", exp),
+		}
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := run(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/600-699/610-619/617/verifierB.go
+++ b/0-999/600-699/610-619/617/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(arr []int) int64 {
+	positions := []int{}
+	for i, v := range arr {
+		if v == 1 {
+			positions = append(positions, i)
+		}
+	}
+	if len(positions) == 0 {
+		return 0
+	}
+	ans := int64(1)
+	for i := 1; i < len(positions); i++ {
+		diff := positions[i] - positions[i-1]
+		ans *= int64(diff)
+	}
+	return ans
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(43))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(20) + 1
+		arr := make([]int, n)
+		hasOne := false
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 1 {
+				arr[i] = 1
+				hasOne = true
+			}
+		}
+		if !hasOne {
+			arr[rng.Intn(n)] = 1
+		}
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		expected := fmt.Sprintf("%d", solve(arr))
+		tests = append(tests, test{sb.String(), expected})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := run(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/600-699/610-619/617/verifierC.go
+++ b/0-999/600-699/610-619/617/verifierC.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(n int, x1, y1, x2, y2 int, points [][2]int) int64 {
+	d1 := make([]int64, n)
+	d2 := make([]int64, n)
+	for i := 0; i < n; i++ {
+		dx1 := int64(points[i][0] - x1)
+		dy1 := int64(points[i][1] - y1)
+		d1[i] = dx1*dx1 + dy1*dy1
+		dx2 := int64(points[i][0] - x2)
+		dy2 := int64(points[i][1] - y2)
+		d2[i] = dx2*dx2 + dy2*dy2
+	}
+	const inf int64 = 1 << 62
+	ans := inf
+	for i := 0; i < n; i++ {
+		r1 := d1[i]
+		var r2 int64
+		for j := 0; j < n; j++ {
+			if d1[j] > r1 {
+				if d2[j] > r2 {
+					r2 = d2[j]
+				}
+			}
+		}
+		if r1+r2 < ans {
+			ans = r1 + r2
+		}
+	}
+	var r2 int64
+	for i := 0; i < n; i++ {
+		if d2[i] > r2 {
+			r2 = d2[i]
+		}
+	}
+	if r2 < ans {
+		ans = r2
+	}
+	return ans
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(44))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		x1 := rng.Intn(21) - 10
+		y1 := rng.Intn(21) - 10
+		x2 := rng.Intn(21) - 10
+		y2 := rng.Intn(21) - 10
+		points := make([][2]int, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d %d\n", n, x1, y1, x2, y2)
+		for i := 0; i < n; i++ {
+			px := rng.Intn(21) - 10
+			py := rng.Intn(21) - 10
+			points[i] = [2]int{px, py}
+			fmt.Fprintf(&sb, "%d %d\n", px, py)
+		}
+		ans := solve(n, x1, y1, x2, y2, points)
+		tests = append(tests, test{sb.String(), fmt.Sprintf("%d", ans)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := run(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/600-699/610-619/617/verifierD.go
+++ b/0-999/600-699/610-619/617/verifierD.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(points [][2]int64) int {
+	x := [3]int64{points[0][0], points[1][0], points[2][0]}
+	y := [3]int64{points[0][1], points[1][1], points[2][1]}
+	if (x[0] == x[1] && x[1] == x[2]) || (y[0] == y[1] && y[1] == y[2]) {
+		return 1
+	}
+	for k := 0; k < 3; k++ {
+		i := (k + 1) % 3
+		j := (k + 2) % 3
+		if x[i] == x[k] && y[j] == y[k] {
+			return 2
+		}
+		if y[i] == y[k] && x[j] == x[k] {
+			return 2
+		}
+	}
+	if x[0] == x[1] || x[0] == x[2] || x[1] == x[2] || y[0] == y[1] || y[0] == y[2] || y[1] == y[2] {
+		return 3
+	}
+	return 4
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(45))
+	tests := make([]test, 100)
+	for i := 0; i < 100; i++ {
+		pts := make([][2]int64, 3)
+		var sb strings.Builder
+		for j := 0; j < 3; j++ {
+			x := int64(rng.Intn(21) - 10)
+			y := int64(rng.Intn(21) - 10)
+			pts[j] = [2]int64{x, y}
+			fmt.Fprintf(&sb, "%d %d\n", x, y)
+		}
+		ans := solve(pts)
+		tests[i] = test{sb.String(), fmt.Sprintf("%d", ans)}
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := run(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/600-699/610-619/617/verifierE.go
+++ b/0-999/600-699/610-619/617/verifierE.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func brute(n, m, k int, arr []int, queries [][2]int) []int64 {
+	pref := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		pref[i] = pref[i-1] ^ arr[i-1]
+	}
+	res := make([]int64, m)
+	for idx, q := range queries {
+		l := q[0]
+		r := q[1]
+		var count int64
+		for i := l; i <= r; i++ {
+			for j := i; j <= r; j++ {
+				if pref[j]^pref[i-1] == k {
+					count++
+				}
+			}
+		}
+		res[idx] = count
+	}
+	return res
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(46))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(5) + 1
+		k := rng.Intn(8)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(8)
+		}
+		queries := make([][2]int, m)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(arr[i]))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < m; i++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			queries[i] = [2]int{l, r}
+			fmt.Fprintf(&sb, "%d %d\n", l, r)
+		}
+		ansSlice := brute(n, m, k, arr, queries)
+		var out strings.Builder
+		for i, v := range ansSlice {
+			if i > 0 {
+				out.WriteByte('\n')
+			}
+			out.WriteString(fmt.Sprintf("%d", v))
+		}
+		tests = append(tests, test{sb.String(), out.String()})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := run(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem 617A with 100 randomized tests
- add verifierB.go for problem 617B with 100 randomized tests
- add verifierC.go for problem 617C with 100 randomized tests
- add verifierD.go for problem 617D with 100 randomized tests
- add verifierE.go for problem 617E with 100 randomized tests

## Testing
- `go build 0-999/600-699/610-619/617/verifierA.go`
- `go build 0-999/600-699/610-619/617/verifierB.go`
- `go build 0-999/600-699/610-619/617/verifierC.go`
- `go build 0-999/600-699/610-619/617/verifierD.go`
- `go build 0-999/600-699/610-619/617/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_688352c675948324b1cbcecb785adfda