### PR TITLE
Add Go verifiers for Codeforces contest 610

### DIFF
--- a/0-999/600-699/610-619/610/verifierA.go
+++ b/0-999/600-699/610-619/610/verifierA.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveA(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int64
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return ""
+	}
+	if n%2 == 1 {
+		return "0"
+	}
+	half := n / 2
+	ans := (half - 1) / 2
+	return fmt.Sprint(ans)
+}
+
+func genTestA(rng *rand.Rand) string {
+	n := rng.Int63n(2000000000) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestA(rng)
+		expect := solveA(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/610-619/610/verifierB.go
+++ b/0-999/600-699/610-619/610/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveB(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return ""
+	}
+	a := make([]int64, n)
+	var minV int64 = 1<<63 - 1
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+		if a[i] < minV {
+			minV = a[i]
+		}
+	}
+	longest := 0
+	cur := 0
+	for i := 0; i < 2*n; i++ {
+		if a[i%n] > minV {
+			cur++
+			if cur > longest {
+				longest = cur
+			}
+		} else {
+			if cur > longest {
+				longest = cur
+			}
+			cur = 0
+		}
+	}
+	if cur > longest {
+		longest = cur
+	}
+	result := int64(n)*minV + int64(longest)
+	return fmt.Sprint(result)
+}
+
+func genTestB(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			buf.WriteByte(' ')
+		}
+		fmt.Fprintf(&buf, "%d", rng.Int63n(1000)+1)
+	}
+	buf.WriteByte('\n')
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestB(rng)
+		expect := solveB(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/610-619/610/verifierC.go
+++ b/0-999/600-699/610-619/610/verifierC.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveC(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var k int
+	if _, err := fmt.Fscan(in, &k); err != nil {
+		return ""
+	}
+	n := 1 << uint(k)
+	mat := [][]byte{[]byte{'+'}}
+	size := 1
+	for size < n {
+		newSize := size * 2
+		newMat := make([][]byte, newSize)
+		for i := range newMat {
+			newMat[i] = make([]byte, newSize)
+		}
+		for i := 0; i < size; i++ {
+			for j := 0; j < size; j++ {
+				ch := mat[i][j]
+				newMat[i][j] = ch
+				newMat[i][j+size] = ch
+				newMat[i+size][j] = ch
+				if ch == '+' {
+					newMat[i+size][j+size] = '*'
+				} else {
+					newMat[i+size][j+size] = '+'
+				}
+			}
+		}
+		mat = newMat
+		size = newSize
+	}
+	var buf bytes.Buffer
+	for i := 0; i < n; i++ {
+		buf.Write(mat[i])
+		buf.WriteByte('\n')
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+func genTestC(rng *rand.Rand) string {
+	k := rng.Intn(5) // 0..4
+	return fmt.Sprintf("%d\n", k)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestC(rng)
+		expect := solveC(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/610-619/610/verifierD.go
+++ b/0-999/600-699/610-619/610/verifierD.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type cell struct{ x, y int64 }
+
+func solveD(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return ""
+	}
+	cells := make(map[cell]struct{})
+	for i := 0; i < n; i++ {
+		var x1, y1, x2, y2 int64
+		fmt.Fscan(in, &x1, &y1, &x2, &y2)
+		if x1 == x2 {
+			if y1 > y2 {
+				y1, y2 = y2, y1
+			}
+			for y := y1; y <= y2; y++ {
+				cells[cell{x1, y}] = struct{}{}
+			}
+		} else {
+			if x1 > x2 {
+				x1, x2 = x2, x1
+			}
+			for x := x1; x <= x2; x++ {
+				cells[cell{x, y1}] = struct{}{}
+			}
+		}
+	}
+	return fmt.Sprint(len(cells))
+}
+
+func genTestD(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 { // vertical
+			x := rng.Intn(11) - 5
+			y1 := rng.Intn(11) - 5
+			y2 := rng.Intn(11) - 5
+			fmt.Fprintf(&buf, "%d %d %d %d\n", x, y1, x, y2)
+		} else { // horizontal
+			y := rng.Intn(11) - 5
+			x1 := rng.Intn(11) - 5
+			x2 := rng.Intn(11) - 5
+			fmt.Fprintf(&buf, "%d %d %d %d\n", x1, y, x2, y)
+		}
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestD(rng)
+		expect := solveD(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/610-619/610/verifierE.go
+++ b/0-999/600-699/610-619/610/verifierE.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func repeatsNeeded(s string, p string) int {
+	k := len(p)
+	pos := make([][]int, 26)
+	for i := 0; i < k; i++ {
+		c := p[i] - 'a'
+		pos[c] = append(pos[c], i)
+	}
+	idx := -1
+	for i := 0; i < len(s); i++ {
+		arr := pos[s[i]-'a']
+		mod := -1
+		if idx >= 0 {
+			mod = idx % k
+		}
+		found := false
+		for _, j := range arr {
+			if j > mod {
+				idx = (idx/k)*k + j
+				found = true
+				break
+			}
+		}
+		if !found {
+			idx = ((idx/k)+1)*k + arr[0]
+		}
+	}
+	return idx/k + 1
+}
+
+func solveE(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n, m, k int
+	if _, err := fmt.Fscan(in, &n, &m, &k); err != nil {
+		return ""
+	}
+	var str string
+	fmt.Fscan(in, &str)
+	s := []byte(str)
+	var out bytes.Buffer
+	for ; m > 0; m-- {
+		var tp int
+		fmt.Fscan(in, &tp)
+		if tp == 1 {
+			var l, r int
+			var c string
+			fmt.Fscan(in, &l, &r, &c)
+			for i := l - 1; i <= r-1; i++ {
+				s[i] = c[0]
+			}
+		} else {
+			var perm string
+			fmt.Fscan(in, &perm)
+			val := repeatsNeeded(string(s), perm)
+			if out.Len() > 0 {
+				out.WriteByte('\n')
+			}
+			fmt.Fprintf(&out, "%d", val)
+		}
+	}
+	return out.String()
+}
+
+func genTestE(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	k := rng.Intn(4) + 1
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d %d %d\n", n, m, k)
+	for i := 0; i < n; i++ {
+		buf.WriteByte(byte('a' + rng.Intn(k)))
+	}
+	buf.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			c := byte('a' + rng.Intn(k))
+			fmt.Fprintf(&buf, "1 %d %d %c\n", l, r, c)
+		} else {
+			perm := make([]byte, k)
+			used := make([]bool, k)
+			for j := 0; j < k; j++ {
+				for {
+					x := rng.Intn(k)
+					if !used[x] {
+						perm[j] = byte('a' + x)
+						used[x] = true
+						break
+					}
+				}
+			}
+			fmt.Fprintf(&buf, "2 %s\n", string(perm))
+		}
+	}
+	return buf.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(1))
+	for i := 1; i <= 100; i++ {
+		in := genTestE(rng)
+		expect := solveE(in)
+		got, err := run(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–E of contest 610
- each verifier supports running any binary or Go source
- generators create 100 random tests per problem

## Testing
- `gofmt -w 0-999/600-699/610-619/610/verifier*.go`


------
https://chatgpt.com/codex/tasks/task_e_68834ef1b2048324a2c8aea7577470e0