### PR TITLE
Add Go solution for 1935A

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1935/1935A.go
+++ b/1000-1999/1900-1999/1930-1939/1935/1935A.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func reverseString(s string) string {
+	b := []byte(s)
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		var s string
+		fmt.Fscan(in, &s)
+
+		rev := reverseString(s)
+		ans := s
+		if tmp := s + rev; tmp < ans {
+			ans = tmp
+		}
+		if tmp := rev + s; tmp < ans {
+			ans = tmp
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem A in CF round 1935
- compute lexicographically minimal string using reverse and concatenation

## Testing
- `go build 1000-1999/1900-1999/1930-1939/1935/1935A.go`

------
https://chatgpt.com/codex/tasks/task_e_68834eab9e4083249e53ae6f6a91a71b