### PR TITLE
Add Go verifiers for contest 620

### DIFF
--- a/0-999/600-699/620-629/620/verifierA.go
+++ b/0-999/600-699/620-629/620/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func expected(x1, y1, x2, y2 int64) string {
+	dx := abs64(x1 - x2)
+	dy := abs64(y1 - y2)
+	if dx > dy {
+		return fmt.Sprintf("%d", dx)
+	}
+	return fmt.Sprintf("%d", dy)
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want = strings.TrimSpace(want)
+	if got != want {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tests := []struct{ x1, y1, x2, y2 int64 }{
+		{0, 0, 0, 0},
+		{0, 0, 1, 1},
+	}
+	for i := 0; i < 100; i++ {
+		x1 := rng.Int63n(2_000_000_001) - 1_000_000_000
+		y1 := rng.Int63n(2_000_000_001) - 1_000_000_000
+		x2 := rng.Int63n(2_000_000_001) - 1_000_000_000
+		y2 := rng.Int63n(2_000_000_001) - 1_000_000_000
+		tests = append(tests, struct{ x1, y1, x2, y2 int64 }{x1, y1, x2, y2})
+	}
+
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d\n%d %d\n", tc.x1, tc.y1, tc.x2, tc.y2)
+		want := expected(tc.x1, tc.y1, tc.x2, tc.y2)
+		if err := runCase(bin, input, want); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/620/verifierB.go
+++ b/0-999/600-699/620-629/620/verifierB.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var seg = []int{6, 2, 5, 5, 4, 5, 6, 3, 7, 6}
+
+func countSegments(x int) int {
+	if x == 0 {
+		return seg[0]
+	}
+	total := 0
+	for x > 0 {
+		total += seg[x%10]
+		x /= 10
+	}
+	return total
+}
+
+func expected(a, b int) string {
+	total := 0
+	for i := a; i <= b; i++ {
+		total += countSegments(i)
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(want) {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tests := []struct{ a, b int }{
+		{1, 3},
+		{10, 10},
+	}
+	for i := 0; i < 100; i++ {
+		a := rng.Intn(1_000_000) + 1
+		b := a + rng.Intn(20)
+		if b > 1_000_000 {
+			b = 1_000_000
+		}
+		tests = append(tests, struct{ a, b int }{a, b})
+	}
+
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d\n", tc.a, tc.b)
+		want := expected(tc.a, tc.b)
+		if err := runCase(bin, input, want); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/620/verifierC.go
+++ b/0-999/600-699/620-629/620/verifierC.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func maxSegments(arr []int) int {
+	n := len(arr)
+	coords := append([]int(nil), arr...)
+	sort.Ints(coords)
+	uniq := coords[:0]
+	for i := 0; i < n; {
+		v := coords[i]
+		uniq = append(uniq, v)
+		j := i + 1
+		for j < n && coords[j] == v {
+			j++
+		}
+		i = j
+	}
+	posMap := make(map[int]int, len(uniq))
+	for idx, v := range uniq {
+		posMap[v] = idx
+	}
+	dp := make([]int, n+1)
+	last := make([]int, len(uniq))
+	for i := 1; i <= n; i++ {
+		dp[i] = dp[i-1]
+		pos := posMap[arr[i-1]]
+		if last[pos] != 0 {
+			ptr := last[pos]
+			if dp[ptr-1]+1 > dp[i] {
+				dp[i] = dp[ptr-1] + 1
+			}
+		}
+		last[pos] = i
+	}
+	return dp[n]
+}
+
+func isGoodSegment(arr []int, l, r int) bool {
+	seen := make(map[int]bool)
+	for i := l; i <= r; i++ {
+		v := arr[i]
+		if seen[v] {
+			return true
+		}
+		seen[v] = true
+	}
+	return false
+}
+
+func verify(arr []int, out string) error {
+	expected := maxSegments(arr)
+	out = strings.TrimSpace(out)
+	if expected == 0 {
+		if out != "-1" {
+			return fmt.Errorf("expected -1 got %q", out)
+		}
+		return nil
+	}
+	reader := bufio.NewReader(strings.NewReader(out))
+	var k int
+	if _, err := fmt.Fscan(reader, &k); err != nil {
+		return fmt.Errorf("failed to read k: %v", err)
+	}
+	if k != expected {
+		return fmt.Errorf("expected %d segments got %d", expected, k)
+	}
+	segs := make([][2]int, k)
+	for i := 0; i < k; i++ {
+		if _, err := fmt.Fscan(reader, &segs[i][0], &segs[i][1]); err != nil {
+			return fmt.Errorf("failed to read segment %d: %v", i+1, err)
+		}
+	}
+	if _, err := fmt.Fscan(reader); err == nil {
+		return fmt.Errorf("extra output")
+	}
+	n := len(arr)
+	if segs[0][0] != 1 || segs[k-1][1] != n {
+		return fmt.Errorf("segments must cover the array")
+	}
+	for i := 0; i < k; i++ {
+		l, r := segs[i][0], segs[i][1]
+		if l > r || l < 1 || r > n {
+			return fmt.Errorf("segment %d out of range", i+1)
+		}
+		if i > 0 && l != segs[i-1][1]+1 {
+			return fmt.Errorf("segments not contiguous")
+		}
+		if !isGoodSegment(arr, l-1, r-1) {
+			return fmt.Errorf("segment %d is not good", i+1)
+		}
+	}
+	return nil
+}
+
+func runCase(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tests := [][]int{
+		{1, 2, 1, 2},
+		{1, 1, 1, 1},
+	}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(5) + 1
+		}
+		tests = append(tests, arr)
+	}
+
+	for i, arr := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		out, err := runCase(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+		if err := verify(arr, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, sb.String(), out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/620/verifierD.go
+++ b/0-999/600-699/620-629/620/verifierD.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func minDiff(a, b []int64) int64 {
+	sa, sb := int64(0), int64(0)
+	for _, v := range a {
+		sa += v
+	}
+	for _, v := range b {
+		sb += v
+	}
+	best := abs64(sa - sb)
+	base := sa - sb
+	for _, x := range a {
+		for _, y := range b {
+			diff := abs64(base - 2*x + 2*y)
+			if diff < best {
+				best = diff
+			}
+		}
+	}
+	if len(a) >= 2 && len(b) >= 2 {
+		asum := make([]int64, 0, len(a)*(len(a)-1)/2)
+		for i := 0; i < len(a); i++ {
+			for j := i + 1; j < len(a); j++ {
+				asum = append(asum, a[i]+a[j])
+			}
+		}
+		bsum := make([]int64, 0, len(b)*(len(b)-1)/2)
+		for i := 0; i < len(b); i++ {
+			for j := i + 1; j < len(b); j++ {
+				bsum = append(bsum, b[i]+b[j])
+			}
+		}
+		sort.Slice(asum, func(i, j int) bool { return asum[i] < asum[j] })
+		sort.Slice(bsum, func(i, j int) bool { return bsum[i] < bsum[j] })
+		ptr := 0
+		for _, x := range asum {
+			for ptr < len(bsum)-1 && abs64(base-2*x+2*bsum[ptr]) >= abs64(base-2*x+2*bsum[ptr+1]) {
+				ptr++
+			}
+			diff := abs64(base - 2*x + 2*bsum[ptr])
+			if diff < best {
+				best = diff
+			}
+		}
+	}
+	return best
+}
+
+func runCase(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return out.String(), nil
+}
+
+func verify(a []int64, b []int64, out string) error {
+	reader := bufio.NewReader(strings.NewReader(out))
+	var d int64
+	if _, err := fmt.Fscan(reader, &d); err != nil {
+		return fmt.Errorf("failed to read diff: %v", err)
+	}
+	var k int
+	if _, err := fmt.Fscan(reader, &k); err != nil {
+		return fmt.Errorf("failed to read k: %v", err)
+	}
+	if k < 0 || k > 2 {
+		return fmt.Errorf("invalid k")
+	}
+	aa := append([]int64(nil), a...)
+	bb := append([]int64(nil), b...)
+	for i := 0; i < k; i++ {
+		var x, y int
+		if _, err := fmt.Fscan(reader, &x, &y); err != nil {
+			return fmt.Errorf("failed to read swap %d: %v", i+1, err)
+		}
+		if x < 1 || x > len(aa) || y < 1 || y > len(bb) {
+			return fmt.Errorf("swap %d indices out of range", i+1)
+		}
+		aa[x-1], bb[y-1] = bb[y-1], aa[x-1]
+	}
+	if _, err := fmt.Fscan(reader); err == nil {
+		return fmt.Errorf("extra output")
+	}
+	sa, sb := int64(0), int64(0)
+	for _, v := range aa {
+		sa += v
+	}
+	for _, v := range bb {
+		sb += v
+	}
+	diff := abs64(sa - sb)
+	if diff != d {
+		return fmt.Errorf("reported diff %d but got %d", d, diff)
+	}
+	expect := minDiff(a, b)
+	if d != expect {
+		return fmt.Errorf("expected diff %d got %d", expect, d)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct{ a, b []int64 }
+	tests := []test{
+		{[]int64{1, 2}, []int64{3}},
+		{[]int64{1}, []int64{1}},
+	}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(6) + 1
+		aa := make([]int64, n)
+		bb := make([]int64, m)
+		for j := 0; j < n; j++ {
+			aa[j] = rng.Int63n(20) - 10
+		}
+		for j := 0; j < m; j++ {
+			bb[j] = rng.Int63n(20) - 10
+		}
+		tests = append(tests, test{aa, bb})
+	}
+
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(tc.a)))
+		for j, v := range tc.a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d\n", len(tc.b)))
+		for j, v := range tc.b {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		out, err := runCase(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+		if err := verify(tc.a, tc.b, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, sb.String(), out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/620/verifierE.go
+++ b/0-999/600-699/620-629/620/verifierE.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var tests []string
+	for t := 0; t < 102; t++ {
+		n := rng.Intn(15) + 1
+		m := rng.Intn(15) + 1
+		colors := make([]int, n)
+		for i := 0; i < n; i++ {
+			colors[i] = rng.Intn(60) + 1
+		}
+		edges := make([][2]int, n-1)
+		for i := 2; i <= n; i++ {
+			p := rng.Intn(i-1) + 1
+			edges[i-2] = [2]int{p, i}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i, v := range colors {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		for i := 0; i < m; i++ {
+			if rng.Intn(2) == 0 {
+				v := rng.Intn(n) + 1
+				c := rng.Intn(60) + 1
+				sb.WriteString(fmt.Sprintf("1 %d %d\n", v, c))
+			} else {
+				v := rng.Intn(n) + 1
+				sb.WriteString(fmt.Sprintf("2 %d\n", v))
+			}
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candE")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "620E.go")
+	refPath, err := prepareBinary(refSrc, "refE")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	tests := genTests()
+	for i, input := range tests {
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/600-699/620-629/620/verifierF.go
+++ b/0-999/600-699/620-629/620/verifierF.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func baseDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func prepareBinary(path, tag string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		bin := filepath.Join(os.TempDir(), tag)
+		cmd := exec.Command("go", "build", "-o", bin, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", fmt.Errorf("build %s: %v\n%s", path, err, out)
+		}
+		return bin, nil
+	}
+	return path, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var tests []string
+	for t := 0; t < 102; t++ {
+		n := rng.Intn(20) + 1
+		m := rng.Intn(20) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(1_000_000) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < m; i++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candPath, err := prepareBinary(os.Args[1], "candF")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	refSrc := filepath.Join(baseDir(), "620F.go")
+	refPath, err := prepareBinary(refSrc, "refF")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	tests := genTests()
+	for i, input := range tests {
+		exp, err := runBinary(refPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candPath, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- provide Go verifiers for Codeforces contest 620 problems A–F
- each verifier runs 100+ randomized tests
- verifiers for E and F cross-check against reference solutions
- others compute expected answers or validate candidate output

## Testing
- `go build 0-999/600-699/620-629/620/verifierA.go`
- `go build 0-999/600-699/620-629/620/verifierB.go`
- `go build 0-999/600-699/620-629/620/verifierC.go`
- `go build 0-999/600-699/620-629/620/verifierD.go`
- `go build 0-999/600-699/620-629/620/verifierE.go`
- `go build 0-999/600-699/620-629/620/verifierF.go`
- `/tmp/verA ./620A.go | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_6883546b51648324863e4cd5d764ff13