### PR TITLE
Add Go solution for 1930D1

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1930/1930D1.go
+++ b/1000-1999/1900-1999/1930-1939/1930/1930D1.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func minOnes(p string) int {
+	n := len(p)
+	covered := make([]bool, n)
+	ans := 0
+	for i := 0; i < n; i++ {
+		if p[i] == '1' && !covered[i] {
+			pos := i + 1
+			if pos >= n {
+				pos = i
+			}
+			ans++
+			for j := pos - 1; j <= pos+1; j++ {
+				if j >= 0 && j < n {
+					covered[j] = true
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(reader, &n)
+		fmt.Fscan(reader, &s)
+		total := 0
+		for i := 0; i < n; i++ {
+			for j := i + 1; j <= n; j++ {
+				total += minOnes(s[i:j])
+			}
+		}
+		fmt.Println(total)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem D1 (easy version)
- brute force over substrings and compute minimal ones with greedy covering

## Testing
- `go build 1000-1999/1900-1999/1930-1939/1930/1930D1.go`
- `go vet 1000-1999/1900-1999/1930-1939/1930/1930D1.go`


------
https://chatgpt.com/codex/tasks/task_e_68835424a9fc8324b83421149f2851fb