### PR TITLE
Add verifiers for contest 615

### DIFF
--- a/0-999/600-699/610-619/615/verifierA.go
+++ b/0-999/600-699/610-619/615/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, m int, sets [][]int) string {
+	bulbs := make([]bool, m+1)
+	for _, s := range sets {
+		for _, b := range s {
+			if b >= 1 && b <= m {
+				bulbs[b] = true
+			}
+		}
+	}
+	for i := 1; i <= m; i++ {
+		if !bulbs[i] {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	sets := make([][]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		x := rng.Intn(m + 1)
+		sb.WriteString(fmt.Sprintf("%d", x))
+		sets[i] = make([]int, x)
+		for j := 0; j < x; j++ {
+			y := rng.Intn(m) + 1
+			sets[i][j] = y
+			sb.WriteString(fmt.Sprintf(" %d", y))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), expected(n, m, sets)
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	cases := []string{
+		"3 4\n1 1\n1 2\n2 3 4\n",
+		"2 2\n1 1\n0\n",
+	}
+	exps := []string{"YES", "NO"}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(cases) < 100 {
+		in, exp := genCase(rng)
+		cases = append(cases, in)
+		exps = append(exps, exp)
+	}
+
+	for i := range cases {
+		if err := runCase(bin, cases[i], exps[i]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, cases[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/615/verifierB.go
+++ b/0-999/600-699/610-619/615/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int, edges [][2]int) int {
+	deg := make([]int, n+1)
+	prev := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		deg[u]++
+		deg[v]++
+		if u < v {
+			prev[v] = append(prev[v], u)
+		} else {
+			prev[u] = append(prev[u], v)
+		}
+	}
+	dp := make([]int, n+1)
+	ans := 0
+	for i := 1; i <= n; i++ {
+		dp[i] = 1
+		for _, p := range prev[i] {
+			if dp[p]+1 > dp[i] {
+				dp[i] = dp[p] + 1
+			}
+		}
+		beauty := dp[i] * deg[i]
+		if beauty > ans {
+			ans = beauty
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(8) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges) + 1
+	edges := make([][2]int, m)
+	used := make(map[[2]int]bool)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		for {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			a, b := u, v
+			if a > b {
+				a, b = b, a
+			}
+			if used[[2]int{a, b}] {
+				continue
+			}
+			used[[2]int{a, b}] = true
+			edges[i] = [2]int{u, v}
+			sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+			break
+		}
+	}
+	return sb.String(), expected(n, edges)
+}
+
+func runCase(bin, input string, exp int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	cases := []string{
+		"2 1\n1 2\n",
+	}
+	exps := []int{2}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(cases) < 100 {
+		in, exp := genCase(rng)
+		cases = append(cases, in)
+		exps = append(exps, exp)
+	}
+
+	for i := range cases {
+		if err := runCase(bin, cases[i], exps[i]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, cases[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/615/verifierC.go
+++ b/0-999/600-699/610-619/615/verifierC.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func computeMinSegments(s1, s2 string) int {
+	b1 := append([]byte{0}, []byte(s1)...)
+	b2 := append([]byte{0}, []byte(s2)...)
+	l1 := len(s1)
+	l2 := len(s2)
+	i := 1
+	count := 0
+	for i <= l2 {
+		best := 0
+		for j := 1; j <= l1; j++ {
+			if b1[j] != b2[i] {
+				continue
+			}
+			k := j
+			for k+1 <= l1 && (k+1-j+i) <= l2 && b1[k+1] == b2[k+1-j+i] {
+				k++
+			}
+			if k-j+1 > best {
+				best = k - j + 1
+			}
+			k2 := j - 1
+			for k2 >= 1 && (j-k2+i) <= l2 && b1[k2] == b2[j-k2+i] {
+				k2--
+			}
+			if j-k2 > best {
+				best = j - k2
+			}
+		}
+		if best == 0 {
+			return -1
+		}
+		count++
+		i += best
+	}
+	return count
+}
+
+func buildFromSegments(s1 string, pairs [][2]int) string {
+	var sb strings.Builder
+	for _, p := range pairs {
+		l, r := p[0], p[1]
+		if l >= 1 && r >= 1 && l <= len(s1) && r <= len(s1) {
+			if l <= r {
+				sb.WriteString(s1[l-1 : r])
+			} else {
+				for i := l - 1; i >= r-1; i-- {
+					sb.WriteByte(s1[i])
+				}
+			}
+		}
+	}
+	return sb.String()
+}
+
+func genReachableCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	letters := "abcde"
+	s1b := make([]byte, n)
+	for i := range s1b {
+		s1b[i] = letters[rng.Intn(len(letters))]
+	}
+	s1 := string(s1b)
+	var s2 strings.Builder
+	pieces := rng.Intn(4) + 1
+	for i := 0; i < pieces; i++ {
+		l := rng.Intn(n)
+		r := rng.Intn(n)
+		if l <= r {
+			s2.WriteString(s1[l : r+1])
+		} else {
+			for j := l; j >= r; j-- {
+				s2.WriteByte(s1[j])
+			}
+		}
+	}
+	return s1, s2.String()
+}
+
+func genUnreachableCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	letters := "abcde"
+	s1b := make([]byte, n)
+	for i := range s1b {
+		s1b[i] = letters[rng.Intn(len(letters))]
+	}
+	s1 := string(s1b)
+	s2 := s1 + "z"
+	return s1, s2
+}
+
+func runCase(bin string, s1, s2 string) error {
+	input := fmt.Sprintf("%s\n%s\n", s1, s2)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	if fields[0] == "-1" {
+		exp := computeMinSegments(s1, s2)
+		if exp != -1 {
+			return fmt.Errorf("expected %d segments but got -1", exp)
+		}
+		return nil
+	}
+	var k int
+	if _, err := fmt.Sscan(fields[0], &k); err != nil {
+		return fmt.Errorf("cannot parse k: %v", err)
+	}
+	if len(fields) != 1+2*k {
+		return fmt.Errorf("expected %d coordinates, got %d", 2*k, len(fields)-1)
+	}
+	pairs := make([][2]int, k)
+	idx := 1
+	for i := 0; i < k; i++ {
+		var l, r int
+		fmt.Sscan(fields[idx], &l)
+		fmt.Sscan(fields[idx+1], &r)
+		pairs[i] = [2]int{l, r}
+		idx += 2
+	}
+	built := buildFromSegments(s1, pairs)
+	if built != s2 {
+		return fmt.Errorf("segments do not form target")
+	}
+	exp := computeMinSegments(s1, s2)
+	if exp != k {
+		return fmt.Errorf("expected %d segments got %d", exp, k)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	s1 := "abac"
+	s2 := "aba"
+	cases := [][2]string{{s1, s2}}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(cases) < 80 {
+		a, b := genReachableCase(rng)
+		cases = append(cases, [2]string{a, b})
+	}
+	for len(cases) < 100 {
+		a, b := genUnreachableCase(rng)
+		cases = append(cases, [2]string{a, b})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc[0], tc[1]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n%s\n", i+1, err, tc[0], tc[1])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/615/verifierD.go
+++ b/0-999/600-699/610-619/615/verifierD.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func modPow(base, exp, m int64) int64 {
+	res := int64(1)
+	base %= m
+	for exp > 0 {
+		if exp&1 == 1 {
+			res = res * base % m
+		}
+		base = base * base % m
+		exp >>= 1
+	}
+	return res
+}
+
+func expected(primes []int) int64 {
+	counts := make(map[int]int)
+	for _, p := range primes {
+		counts[p]++
+	}
+	type pair struct{ p, c int }
+	arr := make([]pair, 0, len(counts))
+	for p, c := range counts {
+		arr = append(arr, pair{p, c})
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i].p < arr[j].p })
+
+	k := len(arr)
+	modMinus1 := mod - 1
+	pref := make([]int64, k+1)
+	suff := make([]int64, k+1)
+	pref[0] = 1
+	for i := 0; i < k; i++ {
+		pref[i+1] = pref[i] * int64(arr[i].c+1) % modMinus1
+	}
+	suff[k] = 1
+	for i := k - 1; i >= 0; i-- {
+		suff[i] = suff[i+1] * int64(arr[i].c+1) % modMinus1
+	}
+
+	ans := int64(1)
+	for i := 0; i < k; i++ {
+		a := int64(arr[i].c)
+		expPart := a * (a + 1) / 2 % modMinus1
+		other := pref[i] * suff[i+1] % modMinus1
+		exp := expPart * other % modMinus1
+		ans = ans * modPow(int64(arr[i].p), exp, mod) % mod
+	}
+	return ans
+}
+
+var primesList = []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29}
+
+func genCase(rng *rand.Rand) (string, int64) {
+	m := rng.Intn(6) + 1
+	arr := make([]int, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		p := primesList[rng.Intn(len(primesList))]
+		arr[i] = p
+		sb.WriteString(fmt.Sprintf("%d ", p))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(arr)
+}
+
+func runCase(bin, input string, exp int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	cases := []string{
+		"1\n2\n",
+	}
+	exps := []int64{2}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(cases) < 100 {
+		in, exp := genCase(rng)
+		cases = append(cases, in)
+		exps = append(exps, exp)
+	}
+
+	for i := range cases {
+		if err := runCase(bin, cases[i], exps[i]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, cases[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/610-619/615/verifierE.go
+++ b/0-999/600-699/610-619/615/verifierE.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func spiralPos(n int64) (int64, int64) {
+	if n == 0 {
+		return 0, 0
+	}
+	low, high := int64(0), int64(1000000000)
+	for low < high {
+		mid := (low + high) / 2
+		if 3*mid*(mid+1) >= n {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+	r := low
+	prev := 3 * (r - 1) * r
+	k := n - prev
+	x, y := r, int64(0)
+	dirs := [6][2]int64{{-1, 1}, {-1, 0}, {0, -1}, {1, -1}, {1, 0}, {0, 1}}
+	for i := 0; i < 6 && k > 0; i++ {
+		step := r
+		if k < step {
+			step = k
+		}
+		x += dirs[i][0] * step
+		y += dirs[i][1] * step
+		k -= step
+	}
+	return x, y
+}
+
+func genCase(rng *rand.Rand) (string, [2]int64) {
+	n := rng.Int63n(1_000_000_000)
+	x, y := spiralPos(n)
+	input := fmt.Sprintf("%d\n", n)
+	return input, [2]int64{x, y}
+}
+
+func runCase(bin, input string, exp [2]int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var x, y int64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &x, &y); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	if x != exp[0] || y != exp[1] {
+		return fmt.Errorf("expected %d %d got %d %d", exp[0], exp[1], x, y)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	cases := []string{
+		"0\n",
+	}
+	exps := [][2]int64{{0, 0}}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(cases) < 100 {
+		in, exp := genCase(rng)
+		cases = append(cases, in)
+		exps = append(exps, exp)
+	}
+
+	for i := range cases {
+		if err := runCase(bin, cases[i], exps[i]); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, cases[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 615
- each verifier runs a candidate binary against at least 100 generated tests

## Testing
- `go build 0-999/600-699/610-619/615/verifierA.go`
- `go build 0-999/600-699/610-619/615/verifierB.go`
- `go build 0-999/600-699/610-619/615/verifierC.go`
- `go build 0-999/600-699/610-619/615/verifierD.go`
- `go build 0-999/600-699/610-619/615/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_688351ae3b048324ae0ef03ed52216fa