### PR TITLE
Add verifiers for contest 604

### DIFF
--- a/0-999/600-699/600-609/604/verifierA.go
+++ b/0-999/600-699/600-609/604/verifierA.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func score(m, w [5]int, hs, hu int) int {
+	x := [5]int{500, 1000, 1500, 2000, 2500}
+	total := 0
+	for i := 0; i < 5; i++ {
+		score1 := 3 * x[i] / 10
+		score2 := (250-m[i])*x[i]/250 - 50*w[i]
+		if score1 > score2 {
+			total += score1
+		} else {
+			total += score2
+		}
+	}
+	total += hs * 100
+	total -= hu * 50
+	return total
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	var m, w [5]int
+	for i := 0; i < 5; i++ {
+		m[i] = rng.Intn(120)
+	}
+	for i := 0; i < 5; i++ {
+		w[i] = rng.Intn(11)
+	}
+	hs := rng.Intn(21)
+	hu := rng.Intn(21)
+	input := fmt.Sprintf("%d %d %d %d %d\n%d %d %d %d %d\n%d %d\n", m[0], m[1], m[2], m[3], m[4], w[0], w[1], w[2], w[3], w[4], hs, hu)
+	exp := fmt.Sprintf("%d", score(m, w, hs, hu))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	fixed := []struct {
+		m, w   [5]int
+		hs, hu int
+	}{
+		{[5]int{0, 0, 0, 0, 0}, [5]int{0, 0, 0, 0, 0}, 0, 0},
+		{[5]int{119, 119, 119, 119, 119}, [5]int{10, 10, 10, 10, 10}, 20, 20},
+		{[5]int{30, 50, 70, 90, 110}, [5]int{1, 2, 3, 4, 5}, 5, 3},
+	}
+
+	caseNum := 1
+	for _, tc := range fixed {
+		input := fmt.Sprintf("%d %d %d %d %d\n%d %d %d %d %d\n%d %d\n", tc.m[0], tc.m[1], tc.m[2], tc.m[3], tc.m[4], tc.w[0], tc.w[1], tc.w[2], tc.w[3], tc.w[4], tc.hs, tc.hu)
+		exp := fmt.Sprintf("%d", score(tc.m, tc.w, tc.hs, tc.hu))
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", caseNum, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", caseNum, exp, out, input)
+			os.Exit(1)
+		}
+		caseNum++
+	}
+
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", caseNum, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", caseNum, exp, out, in)
+			os.Exit(1)
+		}
+		caseNum++
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/600-609/604/verifierB.go
+++ b/0-999/600-699/600-609/604/verifierB.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("time limit")
+		}
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, k int, sizes []int) int {
+	if n <= k {
+		return sizes[n-1]
+	}
+	single := 2*k - n
+	maxVal := 0
+	for i := 0; i < single; i++ {
+		if sizes[i] > maxVal {
+			maxVal = sizes[i]
+		}
+	}
+	left, right := single, n-1
+	for left < right {
+		sum := sizes[left] + sizes[right]
+		if sum > maxVal {
+			maxVal = sum
+		}
+		left++
+		right--
+	}
+	return maxVal
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	kMin := (n + 1) / 2
+	k := rng.Intn(100-kMin+1) + kMin
+	sizes := make([]int, n)
+	for i := 0; i < n; i++ {
+		sizes[i] = rng.Intn(1000000) + 1
+	}
+	sort.Ints(sizes)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", sizes[i])
+	}
+	sb.WriteByte('\n')
+	exp := fmt.Sprintf("%d", expected(n, k, sizes))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	fixed := []struct {
+		n, k  int
+		sizes []int
+	}{
+		{2, 1, []int{1, 2}},
+		{3, 2, []int{2, 3, 5}},
+		{4, 2, []int{3, 5, 7, 9}},
+	}
+
+	caseNum := 1
+	for _, tc := range fixed {
+		sizes := append([]int(nil), tc.sizes...)
+		sort.Ints(sizes)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.k)
+		for i := 0; i < tc.n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", sizes[i])
+		}
+		sb.WriteByte('\n')
+		exp := fmt.Sprintf("%d", expected(tc.n, tc.k, sizes))
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", caseNum, err, sb.String())
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", caseNum, exp, out, sb.String())
+			os.Exit(1)
+		}
+		caseNum++
+	}
+
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", caseNum, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", caseNum, exp, out, in)
+			os.Exit(1)
+		}
+		caseNum++
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for contest 604
- each verifier runs 100+ test cases against a submitted binary
- deterministic edge cases included before random generation

## Testing
- `go run 0-999/600-699/600-609/604/verifierA.go 0-999/600-699/600-609/604/604A_bin`
- `go run 0-999/600-699/600-609/604/verifierB.go 0-999/600-699/600-609/604/604B_bin`

------
https://chatgpt.com/codex/tasks/task_e_68834ba906a48324a01f806793588537