### PR TITLE
Add Go verifiers for Codeforces contest 622

### DIFF
--- a/0-999/600-699/620-629/622/verifierA.go
+++ b/0-999/600-699/620-629/622/verifierA.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveA(n int64) int64 {
+	k := int64(1)
+	for n > k {
+		n -= k
+		k++
+	}
+	return n
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	tests := []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+		100, 500, 1000, 99999999999999, 100000000000000}
+	for len(tests) < 100 {
+		tests = append(tests, rand.Int63n(100000000000000)+1)
+	}
+	for idx, n := range tests {
+		inp := fmt.Sprintf("%d\n", n)
+		expected := fmt.Sprintf("%d", solveA(n))
+		got, err := runBinary(bin, inp)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed: n=%d expected %s got %s\n", idx+1, n, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/622/verifierB.go
+++ b/0-999/600-699/620-629/622/verifierB.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveB(timeStr string, a int) string {
+	var h, m int
+	fmt.Sscanf(timeStr, "%d:%d", &h, &m)
+	total := h*60 + m + a
+	total %= 24 * 60
+	h = total / 60
+	m = total % 60
+	return fmt.Sprintf("%02d:%02d", h, m)
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(2)
+	// predefined tests
+	times := []string{"00:00", "23:59", "12:34", "01:02"}
+	adds := []int{0, 1, 30, 1439}
+	tests := make([]struct {
+		t string
+		a int
+	}, 0, 100)
+	for i := range times {
+		tests = append(tests, struct {
+			t string
+			a int
+		}{times[i], adds[i]})
+	}
+	for len(tests) < 100 {
+		h := rand.Intn(24)
+		m := rand.Intn(60)
+		a := rand.Intn(10001)
+		tests = append(tests, struct {
+			t string
+			a int
+		}{fmt.Sprintf("%02d:%02d", h, m), a})
+	}
+	for i, tc := range tests {
+		inp := fmt.Sprintf("%s\n%d\n", tc.t, tc.a)
+		expected := solveB(tc.t, tc.a)
+		got, err := runBinary(bin, inp)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed: input=%s %d expected %s got %s\n", i+1, tc.t, tc.a, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/622/verifierC.go
+++ b/0-999/600-699/620-629/622/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Query struct{ l, r, x int }
+
+func solveC(n int, m int, a []int, qs []Query) []int {
+	res := make([]int, m)
+	for i, q := range qs {
+		pos := -1
+		for j := q.l - 1; j <= q.r-1; j++ {
+			if a[j] != q.x {
+				pos = j + 1
+				break
+			}
+		}
+		res[i] = pos
+	}
+	return res
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	type Test struct {
+		n, m int
+		a    []int
+		qs   []Query
+	}
+	var tests []Test
+	// small deterministic tests
+	tests = append(tests, Test{n: 1, m: 1, a: []int{1}, qs: []Query{{1, 1, 1}}})
+	tests = append(tests, Test{n: 2, m: 2, a: []int{1, 2}, qs: []Query{{1, 2, 1}, {1, 2, 2}}})
+	for len(tests) < 100 {
+		n := rand.Intn(20) + 1
+		m := rand.Intn(20) + 1
+		a := make([]int, n)
+		for i := range a {
+			a[i] = rand.Intn(100) + 1
+		}
+		qs := make([]Query, m)
+		for i := range qs {
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			x := rand.Intn(100) + 1
+			qs[i] = Query{l, r, x}
+		}
+		tests = append(tests, Test{n: n, m: m, a: a, qs: qs})
+	}
+
+	for idx, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.m))
+		for i, val := range t.a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", val))
+		}
+		sb.WriteByte('\n')
+		for _, q := range t.qs {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", q.l, q.r, q.x))
+		}
+		input := sb.String()
+		expRes := solveC(t.n, t.m, t.a, t.qs)
+		expected := strings.TrimSpace(strings.Join(func() []string {
+			out := make([]string, len(expRes))
+			for i, v := range expRes {
+				out[i] = fmt.Sprintf("%d", v)
+			}
+			return out
+		}(), "\n"))
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", idx+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/622/verifierD.go
+++ b/0-999/600-699/620-629/622/verifierD.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveD(n int) []int {
+	res := make([]int, 0, 2*n)
+	x := (n - 1) % 2
+	if x == 0 {
+		x = 2
+	}
+	for x != n+1 {
+		res = append(res, x)
+		x += 2
+	}
+	x -= 2
+	for x > 0 {
+		res = append(res, x)
+		x -= 2
+	}
+	res = append(res, n)
+	x = n % 2
+	if x == 0 {
+		x = 2
+	}
+	for x != n+2 {
+		res = append(res, x)
+		x += 2
+	}
+	x -= 4
+	for x > 0 {
+		res = append(res, x)
+		x -= 2
+	}
+	return res
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(4)
+	var tests []int
+	tests = append(tests, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+	for len(tests) < 100 {
+		tests = append(tests, rand.Intn(50)+1)
+	}
+	for i, n := range tests {
+		input := fmt.Sprintf("%d\n", n)
+		res := solveD(n)
+		var sb strings.Builder
+		for j, v := range res {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		expected := sb.String()
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Printf("test %d failed: n=%d expected\n%s\ngot\n%s\n", i+1, n, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/622/verifierE.go
+++ b/0-999/600-699/620-629/622/verifierE.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveE(n int, edges [][2]int) int {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		x, y := e[0], e[1]
+		adj[x] = append(adj[x], y)
+		adj[y] = append(adj[y], x)
+	}
+	parent := make([]int, n+1)
+	depth := make([]int, n+1)
+	queue := make([]int, n)
+	head, tail := 0, 0
+	queue[tail] = 1
+	tail++
+	parent[1] = 0
+	order := []int{1}
+	for head < tail {
+		u := queue[head]
+		head++
+		for _, v := range adj[u] {
+			if v == parent[u] {
+				continue
+			}
+			parent[v] = u
+			depth[v] = depth[u] + 1
+			queue[tail] = v
+			tail++
+			order = append(order, v)
+		}
+	}
+	leafCount := make([]int, n+1)
+	maxDepthLeaf := 0
+	ans := 0
+	for i := len(order) - 1; i >= 0; i-- {
+		u := order[i]
+		if u != 1 && len(adj[u]) == 1 {
+			leafCount[u] = 1
+			if depth[u] > maxDepthLeaf {
+				maxDepthLeaf = depth[u]
+			}
+		} else {
+			sum := 0
+			for _, v := range adj[u] {
+				if v == parent[u] {
+					continue
+				}
+				sum += leafCount[v]
+			}
+			leafCount[u] = sum
+		}
+		if u != 1 && leafCount[u] > 1 {
+			t := depth[u] + leafCount[u]
+			if t > ans {
+				ans = t
+			}
+		}
+	}
+	if maxDepthLeaf > ans {
+		ans = maxDepthLeaf
+	}
+	return ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randTree(n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	type Test struct {
+		n     int
+		edges [][2]int
+	}
+	var tests []Test
+	tests = append(tests, Test{2, [][2]int{{1, 2}}})
+	tests = append(tests, Test{3, [][2]int{{1, 2}, {1, 3}}})
+	for len(tests) < 100 {
+		n := rand.Intn(20) + 2
+		tests = append(tests, Test{n, randTree(n)})
+	}
+	for idx, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", t.n))
+		for _, e := range t.edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		input := sb.String()
+		expected := fmt.Sprintf("%d", solveE(t.n, t.edges))
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed:\ninput:\n%sexpected %s got %s\n", idx+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/622/verifierF.go
+++ b/0-999/600-699/620-629/622/verifierF.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod int64 = 1000000007
+
+func modPow(a, b int64) int64 {
+	a %= mod
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func solveF(n, k int64) int64 {
+	var sum int64
+	for i := int64(1); i <= n; i++ {
+		sum = (sum + modPow(i, k)) % mod
+	}
+	return sum
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(6)
+	type Test struct{ n, k int64 }
+	tests := []Test{{1, 0}, {10, 1}, {5, 2}, {100, 3}}
+	for len(tests) < 100 {
+		n := int64(rand.Intn(1000) + 1)
+		k := int64(rand.Intn(6))
+		tests = append(tests, Test{n, k})
+	}
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.n, t.k)
+		expected := fmt.Sprintf("%d", solveF(t.n, t.k))
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed: n=%d k=%d expected %s got %s\n", i+1, t.n, t.k, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–F of contest 622
- each verifier runs 100 randomised tests against a supplied binary

## Testing
- `go run verifierA.go ./622A`
- `go run verifierB.go ./622B`
- `go run verifierC.go ./622C`
- `go run verifierD.go ./622D`
- `go run verifierE.go ./622E`
- `go run verifierF.go ./622F`


------
https://chatgpt.com/codex/tasks/task_e_68835582ec0883249894a31cd070f8a5