### PR TITLE
Add verifier for contest 635 problem A

### DIFF
--- a/0-999/600-699/630-639/635/verifierA.go
+++ b/0-999/600-699/630-639/635/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "635A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1))
+	cases := make([]Case, 100)
+	for i := range cases {
+		r := rng.Intn(10) + 1
+		c := rng.Intn(10) + 1
+		maxN := r * c
+		if maxN > 10 {
+			maxN = 10
+		}
+		n := rng.Intn(maxN) + 1
+		k := rng.Intn(n) + 1
+		used := make(map[[2]int]bool)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d\n", r, c, n, k)
+		for j := 0; j < n; {
+			x := rng.Intn(r) + 1
+			y := rng.Intn(c) + 1
+			coord := [2]int{x, y}
+			if used[coord] {
+				continue
+			}
+			used[coord] = true
+			fmt.Fprintf(&sb, "%d %d\n", x, y)
+			j++
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expect, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier for contest 635 problem A
- compile reference solution `635A.go`
- generate 100 random test cases and compare outputs

## Testing
- `go build 0-999/600-699/630-639/635/verifierA.go`
- `./verifierA 0-999/600-699/630-639/635/635A.go`

------
https://chatgpt.com/codex/tasks/task_e_68835ca0a7648324afdffc66fbc1ae0f