### PR TITLE
Add solution for 1919D (01 Tree)

### DIFF
--- a/1000-1999/1900-1999/1910-1919/1919/1919D.go
+++ b/1000-1999/1900-1999/1910-1919/1919/1919D.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func possible(a []int) bool {
+	st := []int{a[0]}
+	for i := 1; i < len(a); i++ {
+		v := a[i]
+		for len(st) >= 2 && st[len(st)-1] > v && st[len(st)-1]-1 == st[len(st)-2] {
+			st = st[:len(st)-1]
+		}
+		top := st[len(st)-1]
+		if top < v {
+			st = append(st, v)
+		} else if top-1 == v {
+			st[len(st)-1] = v
+		} else if top == v {
+			if v == 0 {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	for len(st) >= 2 && st[len(st)-1]-1 == st[len(st)-2] {
+		st = st[:len(st)-1]
+	}
+	return len(st) == 1 && st[0] == 0
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		if possible(arr) {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1919D.go` for the "01 Tree" problem
- uses stack-based reduction to verify if leaf distances form a valid binary tree

## Testing
- `go build 1000-1999/1900-1999/1910-1919/1919/1919D.go`
- `go run 1000-1999/1900-1999/1910-1919/1919/1919D.go < /tmp/input.txt`

------
https://chatgpt.com/codex/tasks/task_e_68835e8ba2d483249dcb54ddb56afaa1