### PR TITLE
Add Go solution for 1931F

### DIFF
--- a/1000-1999/1900-1999/1930-1939/1931/1931F.go
+++ b/1000-1999/1900-1999/1930-1939/1931/1931F.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(in, &n, &k)
+
+		base := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &base[i])
+		}
+		pos := make([]int, n+1)
+		for i, v := range base {
+			pos[v] = i
+		}
+
+		arr := make([]int, n)
+		ok := true
+		for s := 1; s < k; s++ {
+			for i := 0; i < n; i++ {
+				fmt.Fscan(in, &arr[i])
+			}
+			start := pos[arr[0]]
+			for i := 0; i < n && ok; i++ {
+				if arr[i] != base[(start+i)%n] {
+					ok = false
+				}
+			}
+		}
+		if ok {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem F from contest 1931

## Testing
- `go build 1000-1999/1900-1999/1930-1939/1931/1931F.go`


------
https://chatgpt.com/codex/tasks/task_e_6883599df7c08324ae92254383344603