### PR TITLE
Add Go verifiers for Codeforces Round 629

### DIFF
--- a/0-999/600-699/620-629/629/verifierA.go
+++ b/0-999/600-699/620-629/629/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"time"
+)
+
+func solveA(n int, grid []string) int {
+	ans := 0
+	for i := 0; i < n; i++ {
+		cnt := 0
+		for j := 0; j < n; j++ {
+			if grid[i][j] == 'C' {
+				cnt++
+			}
+		}
+		ans += cnt * (cnt - 1) / 2
+	}
+	for j := 0; j < n; j++ {
+		cnt := 0
+		for i := 0; i < n; i++ {
+			if grid[i][j] == 'C' {
+				cnt++
+			}
+		}
+		ans += cnt * (cnt - 1) / 2
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(100) + 1
+		grid := make([]string, n)
+		for i := 0; i < n; i++ {
+			row := make([]byte, n)
+			for j := 0; j < n; j++ {
+				if rand.Intn(2) == 0 {
+					row[j] = '.'
+				} else {
+					row[j] = 'C'
+				}
+			}
+			grid[i] = string(row)
+		}
+		var input bytes.Buffer
+		fmt.Fprintln(&input, n)
+		for i := 0; i < n; i++ {
+			fmt.Fprintln(&input, grid[i])
+		}
+		expected := solveA(n, grid)
+		cmd := exec.Command(binary)
+		cmd.Stdin = &input
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: binary error: %v\n", t, err)
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(&out)
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "test %d: no output\n", t)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(scanner.Text(), &got); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: invalid output\n", t)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d got %d\n", t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/600-699/620-629/629/verifierB.go
+++ b/0-999/600-699/620-629/629/verifierB.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"time"
+)
+
+type Friend struct {
+	g    byte
+	a, b int
+}
+
+func solveB(n int, friends []Friend) int {
+	const days = 366
+	male := make([]int, days+1)
+	female := make([]int, days+1)
+	for _, f := range friends {
+		for d := f.a; d <= f.b; d++ {
+			if f.g == 'M' {
+				male[d]++
+			} else {
+				female[d]++
+			}
+		}
+	}
+	ans := 0
+	for d := 1; d <= days; d++ {
+		m := male[d]
+		f := female[d]
+		if m < f {
+			if ans < m*2 {
+				ans = m * 2
+			}
+		} else {
+			if ans < f*2 {
+				ans = f * 2
+			}
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(50) + 1
+		friends := make([]Friend, n)
+		var input bytes.Buffer
+		fmt.Fprintln(&input, n)
+		for i := 0; i < n; i++ {
+			g := byte('M')
+			if rand.Intn(2) == 0 {
+				g = 'F'
+			}
+			a := rand.Intn(366) + 1
+			b := rand.Intn(366-a+1) + a
+			friends[i] = Friend{g: g, a: a, b: b}
+			fmt.Fprintf(&input, "%c %d %d\n", g, a, b)
+		}
+		expected := solveB(n, friends)
+		cmd := exec.Command(binary)
+		cmd.Stdin = &input
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: binary error: %v\n", t, err)
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(&out)
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "test %d: no output\n", t)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(scanner.Text(), &got); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: invalid output\n", t)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d got %d\n", t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/600-699/620-629/629/verifierC.go
+++ b/0-999/600-699/620-629/629/verifierC.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"time"
+)
+
+const mod = 1000000007
+
+func solveC(n, m int, s string) int {
+	delta := 0
+	minPref := 0
+	bal := 0
+	for _, ch := range s {
+		if ch == '(' {
+			bal++
+		} else {
+			bal--
+		}
+		if bal < minPref {
+			minPref = bal
+		}
+	}
+	delta = bal
+	maxLen := n - m
+	dp := make([][]int64, maxLen+1)
+	for i := range dp {
+		dp[i] = make([]int64, maxLen+1)
+	}
+	dp[0][0] = 1
+	for i := 0; i < maxLen; i++ {
+		for j := 0; j <= maxLen; j++ {
+			v := dp[i][j]
+			if v == 0 {
+				continue
+			}
+			if j+1 <= maxLen {
+				dp[i+1][j+1] = (dp[i+1][j+1] + v) % mod
+			}
+			if j > 0 {
+				dp[i+1][j-1] = (dp[i+1][j-1] + v) % mod
+			}
+		}
+	}
+	ans := int64(0)
+	for l := 0; l <= maxLen; l++ {
+		qlen := maxLen - l
+		for j := 0; j <= maxLen; j++ {
+			v := dp[l][j]
+			if v == 0 {
+				continue
+			}
+			if j+minPref < 0 {
+				continue
+			}
+			y := j + delta
+			if y < 0 || y > maxLen {
+				continue
+			}
+			add := dp[qlen][y]
+			if add == 0 {
+				continue
+			}
+			ans = (ans + v*add) % mod
+		}
+	}
+	return int(ans)
+}
+
+func randomString(length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		if rand.Intn(2) == 0 {
+			b[i] = '('
+		} else {
+			b[i] = ')'
+		}
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(30) + 1
+		m := rand.Intn(n) + 1
+		s := randomString(m)
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", n, m)
+		fmt.Fprintln(&input, s)
+		expected := solveC(n, m, s)
+		cmd := exec.Command(binary)
+		cmd.Stdin = &input
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: binary error: %v\n", t, err)
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(&out)
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "test %d: no output\n", t)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(scanner.Text(), &got); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: invalid output\n", t)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d got %d\n", t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/600-699/620-629/629/verifierD.go
+++ b/0-999/600-699/620-629/629/verifierD.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"time"
+)
+
+type Cake struct {
+	idx int
+	r2h float64
+}
+
+type BIT struct {
+	n    int
+	tree []float64
+}
+
+func NewBIT(n int) *BIT {
+	return &BIT{n: n, tree: make([]float64, n+1)}
+}
+
+func (b *BIT) Update(i int, val float64) {
+	for ; i <= b.n; i += i & -i {
+		if b.tree[i] < val {
+			b.tree[i] = val
+		}
+	}
+}
+
+func (b *BIT) Query(i int) float64 {
+	var ret float64
+	for ; i > 0; i -= i & -i {
+		if ret < b.tree[i] {
+			ret = b.tree[i]
+		}
+	}
+	return ret
+}
+
+func solveD(n int, pairs [][2]int) float64 {
+	cakes := make([]Cake, n)
+	for i := 0; i < n; i++ {
+		r := pairs[i][0]
+		h := pairs[i][1]
+		cakes[i].idx = n - i
+		cakes[i].r2h = float64(r) * float64(r) * float64(h)
+	}
+	sort.Slice(cakes, func(i, j int) bool {
+		return cakes[i].r2h > cakes[j].r2h
+	})
+	bit := NewBIT(n)
+	v := make([]float64, n)
+	var ans float64
+	last := 0
+	for i := 0; i < n; i++ {
+		v[i] = cakes[i].r2h + bit.Query(cakes[i].idx-1)
+		if i < n-1 && cakes[i].r2h == cakes[i+1].r2h {
+		} else {
+			for j := last; j <= i; j++ {
+				bit.Update(cakes[j].idx, v[j])
+			}
+			last = i + 1
+		}
+		if v[i] > ans {
+			ans = v[i]
+		}
+	}
+	return ans * math.Pi
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(30) + 1
+		pairs := make([][2]int, n)
+		var input bytes.Buffer
+		fmt.Fprintln(&input, n)
+		for i := 0; i < n; i++ {
+			r := rand.Intn(100) + 1
+			h := rand.Intn(100) + 1
+			pairs[i] = [2]int{r, h}
+			fmt.Fprintf(&input, "%d %d\n", r, h)
+		}
+		expected := solveD(n, pairs)
+		cmd := exec.Command(binary)
+		cmd.Stdin = &input
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: binary error: %v\n", t, err)
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(&out)
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "test %d: no output\n", t)
+			os.Exit(1)
+		}
+		var got float64
+		if _, err := fmt.Sscan(scanner.Text(), &got); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: invalid output\n", t)
+			os.Exit(1)
+		}
+		if math.Abs(got-expected) > 1e-6*math.Max(1, math.Abs(expected)) {
+			fmt.Fprintf(os.Stderr, "test %d: expected %.6f got %.6f\n", t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/600-699/620-629/629/verifierE.go
+++ b/0-999/600-699/620-629/629/verifierE.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"time"
+)
+
+var (
+	n, m               int
+	g                  [][]int
+	fa, deep, son, top []int
+	siz                []int
+	sum, src           []float64
+)
+
+func dfs1(x int) {
+	siz[x] = 1
+	deep[x] = deep[fa[x]] + 1
+	for _, to := range g[x] {
+		if to != fa[x] {
+			fa[to] = x
+			dfs1(to)
+			siz[x] += siz[to]
+			sum[x] += sum[to] + float64(siz[to])
+			if siz[son[x]] < siz[to] {
+				son[x] = to
+			}
+		}
+	}
+}
+
+func dfs2(x int) {
+	if x == son[fa[x]] {
+		top[x] = top[fa[x]]
+	} else {
+		top[x] = x
+	}
+	for _, to := range g[x] {
+		if fa[to] == x {
+			dfs2(to)
+		}
+	}
+}
+
+func dfs3(x int) {
+	src[x] += sum[x]
+	for _, to := range g[x] {
+		if fa[to] == x {
+			src[to] += src[x] - sum[to] - float64(siz[to]) + float64(n-siz[to])
+			dfs3(to)
+		}
+	}
+}
+
+func lca(u, v int) int {
+	for top[u] != top[v] {
+		if deep[top[u]] > deep[top[v]] {
+			u = fa[top[u]]
+		} else {
+			v = fa[top[v]]
+		}
+	}
+	if deep[u] < deep[v] {
+		return u
+	}
+	return v
+}
+
+func solveNode(u, f int) int {
+	for {
+		if deep[fa[top[u]]] > deep[f] {
+			u = fa[top[u]]
+		} else if fa[u] == f {
+			return u
+		} else if deep[top[u]] > deep[f] {
+			u = top[u]
+		} else {
+			return son[f]
+		}
+	}
+}
+
+func ask(u, v int) float64 {
+	l := lca(u, v)
+	if u != l && v != l {
+		return sum[u]/float64(siz[u]) + sum[v]/float64(siz[v]) + float64(deep[u]+deep[v]+1-2*deep[l])
+	}
+	if u == l {
+		u, v = v, u
+	}
+	nw := solveNode(u, v)
+	x := sum[u] / float64(siz[u])
+	y := (src[v] - sum[nw] - float64(siz[nw])) / float64(n-siz[nw])
+	return x + y + float64(deep[u]-deep[v]+1)
+}
+
+func solveE(nv int, edges [][2]int, queries [][2]int) []float64 {
+	n = nv
+	g = make([][]int, n+1)
+	for _, e := range edges {
+		u := e[0]
+		v := e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	fa = make([]int, n+1)
+	deep = make([]int, n+1)
+	son = make([]int, n+1)
+	top = make([]int, n+1)
+	siz = make([]int, n+1)
+	sum = make([]float64, n+1)
+	src = make([]float64, n+1)
+	fa[1] = 0
+	deep[0] = 0
+	dfs1(1)
+	dfs2(1)
+	dfs3(1)
+	res := make([]float64, len(queries))
+	for i, q := range queries {
+		res[i] = ask(q[0], q[1])
+	}
+	return res
+}
+
+func genTree(n int) [][2]int {
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 2
+		m := rand.Intn(10) + 1
+		edges := genTree(n)
+		queries := make([][2]int, m)
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", n, m)
+		for _, e := range edges {
+			fmt.Fprintf(&input, "%d %d\n", e[0], e[1])
+		}
+		for i := 0; i < m; i++ {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			for v == u {
+				v = rand.Intn(n) + 1
+			}
+			queries[i] = [2]int{u, v}
+			fmt.Fprintf(&input, "%d %d\n", u, v)
+		}
+		expected := solveE(n, edges, queries)
+		cmd := exec.Command(binary)
+		cmd.Stdin = &input
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: binary error: %v\n", t, err)
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(&out)
+		for i := 0; i < m; i++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "test %d: no output line %d\n", t, i)
+				os.Exit(1)
+			}
+			var got float64
+			if _, err := fmt.Sscan(scanner.Text(), &got); err != nil {
+				fmt.Fprintf(os.Stderr, "test %d: invalid output\n", t)
+				os.Exit(1)
+			}
+			exp := expected[i]
+			if math.Abs(got-exp) > 1e-6*math.Max(1, math.Abs(exp)) {
+				fmt.Fprintf(os.Stderr, "test %d line %d: expected %.7f got %.7f\n", t, i, exp, got)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 629
- each verifier generates 100 random tests and checks the given binary's output against an internal reference implementation

## Testing
- `go run verifierA.go ./629A.bin`
- `go run verifierB.go ./629B.bin`
- `go run verifierC.go ./629C.bin`
- `go run verifierD.go ./629D.bin`
- `go run verifierE.go ./629E.bin`


------
https://chatgpt.com/codex/tasks/task_e_68835957ebdc8324a0670fb663d3231f