### PR TITLE
Add Go verifiers for Codeforces contest 639

### DIFF
--- a/0-999/600-699/630-639/639/verifierA.go
+++ b/0-999/600-699/630-639/639/verifierA.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type query struct{ typ, id int }
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(n, k int, t []int, qs []query) []string {
+	displayed := make([]query, 0, k)
+	inDisp := make([]bool, n+1)
+	res := make([]string, 0, len(qs))
+	for _, q := range qs {
+		if q.typ == 1 {
+			if k == 0 {
+				continue
+			}
+			if len(displayed) < k {
+				displayed = append(displayed, query{q.id, t[q.id]})
+				for i := len(displayed) - 1; i > 0 && displayed[i].id != 0 && displayed[i].typ > displayed[i-1].typ; i-- {
+					displayed[i], displayed[i-1] = displayed[i-1], displayed[i]
+				}
+				inDisp[q.id] = true
+			} else if t[q.id] > displayed[len(displayed)-1].typ {
+				rem := displayed[len(displayed)-1].id
+				inDisp[rem] = false
+				displayed[len(displayed)-1] = query{q.id, t[q.id]}
+				for i := len(displayed) - 1; i > 0 && displayed[i].typ > displayed[i-1].typ; i-- {
+					displayed[i], displayed[i-1] = displayed[i-1], displayed[i]
+				}
+				inDisp[q.id] = true
+			}
+		} else {
+			if inDisp[q.id] {
+				res = append(res, "YES")
+			} else {
+				res = append(res, "NO")
+			}
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(6) + 1
+	k := rng.Intn(n + 1)
+	q := rng.Intn(10) + 1
+	t := make([]int, n+1)
+	usedT := make(map[int]bool)
+	for i := 1; i <= n; i++ {
+		v := rng.Intn(100) + 1
+		for usedT[v] {
+			v = rng.Intn(100) + 1
+		}
+		usedT[v] = true
+		t[i] = v
+	}
+	qs := make([]query, 0, q)
+	used := make([]bool, n+1)
+	haveType2 := false
+	for len(qs) < q {
+		if !haveType2 || rng.Intn(2) == 0 && len(qs) < q-1 && len(qs) < n {
+			// type1
+			id := rng.Intn(n) + 1
+			if used[id] {
+				continue
+			}
+			used[id] = true
+			qs = append(qs, query{1, id})
+		} else {
+			id := rng.Intn(n) + 1
+			qs = append(qs, query{2, id})
+			haveType2 = true
+		}
+	}
+	if !haveType2 {
+		qs[len(qs)-1].typ = 2
+	}
+	input := fmt.Sprintf("%d %d %d\n", n, k, q)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", t[i])
+	}
+	input += "\n"
+	for _, qu := range qs {
+		input += fmt.Sprintf("%d %d\n", qu.typ, qu.id)
+	}
+	out := solveA(n, k, t, qs)
+	return input, out
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, outLines := generateCase(rng)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		gotLines := strings.Split(strings.TrimSpace(got), "\n")
+		expLines := outLines
+		if len(gotLines) != len(expLines) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", i+1, len(expLines), len(gotLines), input)
+			os.Exit(1)
+		}
+		for j := range expLines {
+			if strings.TrimSpace(gotLines[j]) != expLines[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expLines[j], gotLines[j], input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/639/verifierB.go
+++ b/0-999/600-699/630-639/639/verifierB.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func isPossible(n, d, h int) bool {
+	if d < h {
+		return false
+	}
+	if d > 2*h {
+		return false
+	}
+	if d == 1 && n > 2 {
+		return false
+	}
+	return true
+}
+
+func parseEdges(out string) ([]edge, error) {
+	scan := bufio.NewScanner(strings.NewReader(out))
+	edges := make([]edge, 0)
+	for scan.Scan() {
+		line := strings.TrimSpace(scan.Text())
+		if line == "" {
+			continue
+		}
+		var a, b int
+		if _, err := fmt.Sscanf(line, "%d %d", &a, &b); err != nil {
+			return nil, fmt.Errorf("bad line: %s", line)
+		}
+		edges = append(edges, edge{a, b})
+	}
+	return edges, nil
+}
+
+func checkTree(n, d, h int, edges []edge) bool {
+	if len(edges) != n-1 {
+		return false
+	}
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		if e.u < 1 || e.u > n || e.v < 1 || e.v > n {
+			return false
+		}
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	vis := make([]bool, n+1)
+	order := make([]int, 0, n)
+	queue := []int{1}
+	vis[1] = true
+	for len(queue) > 0 {
+		v := queue[0]
+		queue = queue[1:]
+		order = append(order, v)
+		for _, to := range adj[v] {
+			if !vis[to] {
+				vis[to] = true
+				queue = append(queue, to)
+			}
+		}
+	}
+	if len(order) != n {
+		return false
+	}
+	// compute height from 1
+	dist := make([]int, n+1)
+	for i := range dist {
+		dist[i] = -1
+	}
+	queue = []int{1}
+	dist[1] = 0
+	for len(queue) > 0 {
+		v := queue[0]
+		queue = queue[1:]
+		for _, to := range adj[v] {
+			if dist[to] == -1 {
+				dist[to] = dist[v] + 1
+				queue = append(queue, to)
+			}
+		}
+	}
+	maxh := 0
+	far := 1
+	for i := 1; i <= n; i++ {
+		if dist[i] > maxh {
+			maxh = dist[i]
+			far = i
+		}
+	}
+	if maxh != h {
+		return false
+	}
+	// diameter
+	dist2 := make([]int, n+1)
+	for i := range dist2 {
+		dist2[i] = -1
+	}
+	queue = []int{far}
+	dist2[far] = 0
+	for len(queue) > 0 {
+		v := queue[0]
+		queue = queue[1:]
+		for _, to := range adj[v] {
+			if dist2[to] == -1 {
+				dist2[to] = dist2[v] + 1
+				queue = append(queue, to)
+			}
+		}
+	}
+	maxd := 0
+	for i := 1; i <= n; i++ {
+		if dist2[i] > maxd {
+			maxd = dist2[i]
+		}
+	}
+	return maxd == d
+}
+
+func generateCase(rng *rand.Rand) (string, bool) {
+	n := rng.Intn(8) + 2
+	d := rng.Intn(n-1) + 1
+	h := rng.Intn(d) + 1
+	input := fmt.Sprintf("%d %d %d\n", n, d, h)
+	return input, isPossible(n, d, h)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, possible := generateCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if !possible {
+			if strings.TrimSpace(out) != "-1" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected -1 got %s\ninput:%s", i+1, out, input)
+				os.Exit(1)
+			}
+			continue
+		}
+		var n, d, h int
+		fmt.Sscanf(strings.TrimSpace(input), "%d %d %d", &n, &d, &h)
+		edges, err2 := parseEdges(out)
+		if err2 != nil || !checkTree(n, d, h, edges) {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid tree\ninput:%s output:%s", i+1, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/639/verifierC.go
+++ b/0-999/600-699/630-639/639/verifierC.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n int, k int64, a []int64) int {
+	p := big.NewInt(0)
+	for i := n; i >= 0; i-- {
+		p.Lsh(p, 1)
+		p.Add(p, big.NewInt(a[i]))
+	}
+	y := new(big.Int).Set(p)
+	divisible := true
+	ans := 0
+	for j := 0; j <= n; j++ {
+		if divisible && y.BitLen() <= 62 {
+			val := y.Int64()
+			diff := a[j] - val
+			if diff >= -k && diff <= k {
+				if j != n || diff != 0 {
+					ans++
+				}
+			}
+		}
+		divisible = divisible && y.Bit(0) == 0
+		y.Rsh(y, 1)
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	k := int64(rng.Intn(5) + 1)
+	a := make([]int64, n+1)
+	for i := 0; i <= n; i++ {
+		a[i] = int64(rng.Intn(11) - 5)
+	}
+	input := fmt.Sprintf("%d %d\n", n, k)
+	for i := 0; i <= n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", a[i])
+	}
+	input += "\n"
+	exp := fmt.Sprintf("%d", solve(n, k, a))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/639/verifierD.go
+++ b/0-999/600-699/630-639/639/verifierD.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type pair struct{ tp, base int64 }
+
+func solve(n, k int, b, c int64, t []int64) int64 {
+	per5 := b
+	if per5 > 5*c {
+		per5 = 5 * c
+	}
+	const inf int64 = 1<<63 - 1
+	ans := inf
+	for r := int64(0); r < 5; r++ {
+		arr := make([]pair, n)
+		for i := 0; i < n; i++ {
+			rem := ((t[i] % 5) + 5) % 5
+			diff := (r - rem + 5) % 5
+			tp := t[i] + diff
+			w := tp / 5
+			base := diff*c - w*per5
+			arr[i] = pair{tp, base}
+		}
+		sort.Slice(arr, func(i, j int) bool { return arr[i].tp < arr[j].tp })
+		heap := make([]int64, 0, k)
+		var sum int64
+		push := func(x int64) {
+			heap = append(heap, x)
+			i := len(heap) - 1
+			for i > 0 {
+				p := (i - 1) / 2
+				if heap[p] >= heap[i] {
+					break
+				}
+				heap[p], heap[i] = heap[i], heap[p]
+				i = p
+			}
+			sum += x
+			if len(heap) > k {
+				sum -= heap[0]
+				heap[0] = heap[len(heap)-1]
+				heap = heap[:len(heap)-1]
+				i = 0
+				for {
+					l := 2*i + 1
+					if l >= len(heap) {
+						break
+					}
+					r := l + 1
+					if r < len(heap) && heap[r] > heap[l] {
+						l = r
+					}
+					if heap[i] >= heap[l] {
+						break
+					}
+					heap[i], heap[l] = heap[l], heap[i]
+					i = l
+				}
+			}
+		}
+		i := 0
+		for i < n {
+			curW := arr[i].tp / 5
+			for i < n && arr[i].tp/5 == curW {
+				push(arr[i].base)
+				i++
+			}
+			if len(heap) == k {
+				cost := sum + int64(k)*curW*per5
+				if cost < ans {
+					ans = cost
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	k := rng.Intn(n) + 1
+	b := int64(rng.Intn(5) + 1)
+	c := int64(rng.Intn(5) + 1)
+	t := make([]int64, n)
+	for i := 0; i < n; i++ {
+		t[i] = int64(rng.Intn(10))
+	}
+	input := fmt.Sprintf("%d %d %d %d\n", n, k, b, c)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", t[i])
+	}
+	input += "\n"
+	exp := fmt.Sprintf("%d", solve(n, k, b, c, t))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/639/verifierE.go
+++ b/0-999/600-699/630-639/639/verifierE.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Item struct{ p, t, l, r int64 }
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func check(A []Item, x float64, T int64) bool {
+	var max1, max2 float64
+	n := len(A)
+	i := 0
+	for i < n {
+		t1 := float64(A[i].p) * (1.0 - x*float64(A[i].r)/float64(T))
+		if max1 > t1+1e-12 {
+			return false
+		}
+		t2 := float64(A[i].p) * (1.0 - x*float64(A[i].l)/float64(T))
+		if t2 > max2 {
+			max2 = t2
+		}
+		j := i
+		for j+1 < n && A[j+1].p == A[i].p {
+			j++
+			t1 = float64(A[j].p) * (1.0 - x*float64(A[j].r)/float64(T))
+			if max1 > t1+1e-12 {
+				return false
+			}
+			t2 = float64(A[j].p) * (1.0 - x*float64(A[j].l)/float64(T))
+			if t2 > max2 {
+				max2 = t2
+			}
+		}
+		max1 = max2
+		i = j + 1
+	}
+	return true
+}
+
+func solve(n int, P, Tarr []int64) float64 {
+	A := make([]Item, n)
+	for i := 0; i < n; i++ {
+		A[i].p = P[i]
+		A[i].t = Tarr[i]
+	}
+	var T int64
+	for i := 0; i < n; i++ {
+		T += A[i].t
+	}
+	sort.Slice(A, func(i, j int) bool { return A[i].t*A[j].p < A[j].t*A[i].p })
+	var suml, sumr int64
+	for i := 0; i < n; i++ {
+		sumr += A[i].t
+		j := i
+		for j+1 < n && A[j].t*A[j+1].p == A[j+1].t*A[j].p {
+			j++
+			sumr += A[j].t
+		}
+		for k := i; k <= j; k++ {
+			A[k].l = suml + A[k].t
+			A[k].r = sumr
+		}
+		suml = sumr
+		i = j
+	}
+	sort.Slice(A, func(i, j int) bool { return A[i].p < A[j].p })
+	lo, hi := 0.0, 1.0
+	for it := 0; it < 50; it++ {
+		mid := (lo + hi) * 0.5
+		if check(A, mid, T) {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	return lo
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	P := make([]int64, n)
+	T := make([]int64, n)
+	for i := 0; i < n; i++ {
+		P[i] = int64(rng.Intn(10) + 1)
+	}
+	for i := 0; i < n; i++ {
+		T[i] = int64(rng.Intn(10) + 1)
+	}
+	input := fmt.Sprintf("%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", P[i])
+	}
+	input += "\n"
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", T[i])
+	}
+	input += "\n"
+	exp := fmt.Sprintf("%.12f", solve(n, P, T))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/639/verifierF.go
+++ b/0-999/600-699/630-639/639/verifierF.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildBCC(n int, edges []edge) []int {
+	adj := make([][]struct{ to, id int }, n)
+	for i, e := range edges {
+		u, v := e.u, e.v
+		adj[u] = append(adj[u], struct{ to, id int }{v, i})
+		adj[v] = append(adj[v], struct{ to, id int }{u, i})
+	}
+	timer := 0
+	tin := make([]int, n)
+	low := make([]int, n)
+	bridge := make([]bool, len(edges))
+	var dfs func(int, int)
+	dfs = func(v, pe int) {
+		timer++
+		tin[v] = timer
+		low[v] = timer
+		for _, e := range adj[v] {
+			if e.id == pe {
+				continue
+			}
+			if tin[e.to] == 0 {
+				dfs(e.to, e.id)
+				if low[e.to] > tin[v] {
+					bridge[e.id] = true
+				}
+				if low[e.to] < low[v] {
+					low[v] = low[e.to]
+				}
+			} else if tin[e.to] < low[v] {
+				low[v] = tin[e.to]
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		if tin[i] == 0 {
+			dfs(i, -1)
+		}
+	}
+	comp := make([]int, n)
+	cid := 0
+	var dfs2 func(int)
+	dfs2 = func(v int) {
+		comp[v] = cid
+		for _, e := range adj[v] {
+			if comp[e.to] == 0 && !bridge[e.id] {
+				dfs2(e.to)
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		if comp[i] == 0 {
+			cid++
+			dfs2(i)
+		}
+	}
+	return comp
+}
+
+func checkQuery(n int, base []edge, fav []int, qEdges []edge) bool {
+	allEdges := append([]edge(nil), base...)
+	allEdges = append(allEdges, qEdges...)
+	comp := buildBCC(n, allEdges)
+	c0 := comp[fav[0]]
+	for _, v := range fav[1:] {
+		if comp[v] != c0 {
+			return false
+		}
+	}
+	return true
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(6)
+	base := make([]edge, m)
+	for i := 0; i < m; i++ {
+		base[i] = edge{rng.Intn(n), rng.Intn(n)}
+	}
+	q := rng.Intn(3) + 1
+	input := fmt.Sprintf("%d %d %d\n", n, m, q)
+	for _, e := range base {
+		input += fmt.Sprintf("%d %d\n", e.u+1, e.v+1)
+	}
+	answers := make([]string, q)
+	for qi := 0; qi < q; qi++ {
+		ni := rng.Intn(n) + 1
+		mi := rng.Intn(3)
+		favSet := rand.Perm(n)[:ni]
+		input += fmt.Sprintf("%d %d\n", ni, mi)
+		for i, idx := range favSet {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", idx+1)
+		}
+		input += "\n"
+		qEdges := make([]edge, mi)
+		for i := 0; i < mi; i++ {
+			qEdges[i] = edge{rng.Intn(n), rng.Intn(n)}
+			input += fmt.Sprintf("%d %d\n", qEdges[i].u+1, qEdges[i].v+1)
+		}
+		if checkQuery(n, base, favSet, qEdges) {
+			answers[qi] = "YES"
+		} else {
+			answers[qi] = "NO"
+		}
+	}
+	expected := strings.Join(answers, "\n")
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` through `verifierF.go` for contest 639
- each verifier generates 100 randomized tests and runs a candidate binary
- validates output and reports success when all tests pass

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68835ed10ee88324810590dfb17f58ad