### PR TITLE
Add Go verifiers for CF 632

### DIFF
--- a/0-999/600-699/630-639/632/verifierA.go
+++ b/0-999/600-699/630-639/632/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expected(n int, p int64, ops []string) int64 {
+	var money, cur int64
+	for i := n - 1; i >= 0; i-- {
+		if ops[i] == "half" {
+			money += cur * p
+			cur *= 2
+		} else {
+			money += cur*p + p/2
+			cur = cur*2 + 1
+		}
+	}
+	return money
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(40) + 1
+		p := int64(2 * (rand.Intn(500) + 1))
+		ops := make([]string, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, p))
+		for i := 0; i < n; i++ {
+			if rand.Intn(2) == 0 {
+				ops[i] = "half"
+			} else {
+				ops[i] = "halfplus"
+			}
+			sb.WriteString(ops[i])
+			if i+1 < n {
+				sb.WriteByte('\n')
+			}
+		}
+		input := sb.String()
+		exp := expected(n, p, ops)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%s\nOutput:\n%s\n", t+1, err, input, out)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(strings.Fields(out)[0], 10, 64)
+		if err != nil || val != exp {
+			fmt.Printf("Test %d failed\nInput:\n%s\nExpected: %d\nGot: %s\n", t+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/600-699/630-639/632/verifierB.go
+++ b/0-999/600-699/630-639/632/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expected(n int, p []int64, s string) int64 {
+	prefixA := make([]int64, n+1)
+	prefixB := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		prefixA[i+1] = prefixA[i]
+		prefixB[i+1] = prefixB[i]
+		if s[i] == 'A' {
+			prefixA[i+1] += p[i]
+		} else {
+			prefixB[i+1] += p[i]
+		}
+	}
+	totalA := prefixA[n]
+	totalB := prefixB[n]
+	ans := totalB
+	for k := 0; k <= n; k++ {
+		val := totalB - prefixB[k] + prefixA[k]
+		if val > ans {
+			ans = val
+		}
+		val = prefixB[n-k] + (totalA - prefixA[n-k])
+		if val > ans {
+			ans = val
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 1
+		pArr := make([]int64, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			pArr[i] = int64(rand.Intn(1000) + 1)
+			sb.WriteString(fmt.Sprintf("%d ", pArr[i]))
+		}
+		sb.WriteByte('\n')
+		var s strings.Builder
+		for i := 0; i < n; i++ {
+			if rand.Intn(2) == 0 {
+				s.WriteByte('A')
+			} else {
+				s.WriteByte('B')
+			}
+		}
+		str := s.String()
+		sb.WriteString(str)
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(n, pArr, str)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:\n%s\nOutput:\n%s\n", t+1, err, input, out)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(strings.Fields(out)[0], 10, 64)
+		if err != nil || val != exp {
+			fmt.Printf("Test %d failed\nInput:\n%s\nExpected: %d\nGot: %s\n", t+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/600-699/630-639/632/verifierC.go
+++ b/0-999/600-699/630-639/632/verifierC.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expected(strs []string) string {
+	sort.Slice(strs, func(i, j int) bool { return strs[i]+strs[j] < strs[j]+strs[i] })
+	return strings.Join(strs, "")
+}
+
+func randString() string {
+	l := rand.Intn(5) + 1
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('a' + rand.Intn(26))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(8) + 1
+		strsArr := make([]string, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			strsArr[i] = randString()
+			sb.WriteString(strsArr[i])
+			if i+1 < n {
+				sb.WriteByte('\n')
+			}
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(append([]string{}, strsArr...))
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:\n%s\nOutput:\n%s\n", t+1, err, input, out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed\nInput:\n%s\nExpected: %s\nGot: %s\n", t+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/600-699/630-639/632/verifierD.go
+++ b/0-999/600-699/630-639/632/verifierD.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int) int {
+	return a / gcd(a, b) * b
+}
+
+func brute(n, m int, arr []int) (int, []int) {
+	bestLen := -1
+	bestL := 1
+	bestIdx := []int{}
+	for mask := 0; mask < (1 << uint(n)); mask++ {
+		l := 1
+		curIdx := []int{}
+		valid := true
+		for i := 0; i < n; i++ {
+			if mask&(1<<uint(i)) != 0 {
+				l = lcm(l, arr[i])
+				if l > m {
+					valid = false
+					break
+				}
+				curIdx = append(curIdx, i)
+			}
+		}
+		if valid {
+			if len(curIdx) > bestLen {
+				bestLen = len(curIdx)
+				bestL = l
+				bestIdx = append([]int(nil), curIdx...)
+			}
+		}
+	}
+	for i := range bestIdx {
+		bestIdx[i]++
+	}
+	return bestL, bestIdx
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(6) + 1
+		m := rand.Intn(20) + 1
+		arr := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			arr[i] = rand.Intn(m) + 1
+			sb.WriteString(fmt.Sprintf("%d ", arr[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expL, expIdx := brute(n, m, arr)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:\n%s\nOutput:\n%s\n", t+1, err, input, out)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) < 2 {
+			fmt.Printf("Test %d failed to parse output\nInput:\n%s\nOutput:\n%s\n", t+1, input, out)
+			os.Exit(1)
+		}
+		gotL, err1 := strconv.Atoi(fields[0])
+		gotK, err2 := strconv.Atoi(fields[1])
+		if err1 != nil || err2 != nil {
+			fmt.Printf("Test %d failed: invalid numbers\n", t+1)
+			os.Exit(1)
+		}
+		idxOut := []int{}
+		for _, f := range fields[2:] {
+			v, err := strconv.Atoi(f)
+			if err != nil {
+				fmt.Printf("Test %d failed: invalid index\n", t+1)
+				os.Exit(1)
+			}
+			idxOut = append(idxOut, v)
+		}
+		if gotL != expL || gotK != len(expIdx) {
+			fmt.Printf("Test %d failed\nInput:\n%s\nExpected: %d %d %v\nGot: %s\n", t+1, input, expL, len(expIdx), expIdx, out)
+			os.Exit(1)
+		}
+		// order may matter but we expect ascending
+		for i := 0; i < gotK && i < len(expIdx); i++ {
+			if idxOut[i] != expIdx[i] {
+				fmt.Printf("Test %d failed indexes\nExpected %v\nGot %v\n", t+1, expIdx, idxOut)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/600-699/630-639/632/verifierE.go
+++ b/0-999/600-699/630-639/632/verifierE.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func brute(n, k int, costs []int) []int {
+	maxA := 0
+	for _, v := range costs {
+		if v > maxA {
+			maxA = v
+		}
+	}
+	limit := maxA * k
+	dp := make([]bool, limit+1)
+	dp[0] = true
+	for step := 0; step < k; step++ {
+		next := make([]bool, limit+1)
+		for _, c := range costs {
+			for s := 0; s <= limit-c; s++ {
+				if dp[s] {
+					next[s+c] = true
+				}
+			}
+		}
+		dp = next
+	}
+	res := []int{}
+	for i := 0; i <= limit; i++ {
+		if dp[i] {
+			res = append(res, i)
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(4) + 1
+		k := rand.Intn(4) + 1
+		costs := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n; i++ {
+			costs[i] = rand.Intn(10) + 1
+			sb.WriteString(fmt.Sprintf("%d ", costs[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := brute(n, k, costs)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:\n%s\nOutput:\n%s\n", t+1, err, input, out)
+			os.Exit(1)
+		}
+		outFields := strings.Fields(out)
+		got := []int{}
+		for _, f := range outFields {
+			v, err := strconv.Atoi(f)
+			if err != nil {
+				fmt.Printf("Test %d failed: invalid number\n", t+1)
+				os.Exit(1)
+			}
+			got = append(got, v)
+		}
+		sort.Ints(got)
+		if len(got) != len(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%s\nExpected: %v\nGot: %v\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+		for i := range exp {
+			if got[i] != exp[i] {
+				fmt.Printf("Test %d failed\nInput:\n%s\nExpected: %v\nGot: %v\n", t+1, input, exp, got)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/600-699/630-639/632/verifierF.go
+++ b/0-999/600-699/630-639/632/verifierF.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func isMagic(n int, a [][]int) bool {
+	for i := 0; i < n; i++ {
+		if a[i][i] != 0 {
+			return false
+		}
+		for j := 0; j < n; j++ {
+			if a[i][j] != a[j][i] {
+				return false
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			for k := 0; k < n; k++ {
+				if a[i][j] > max(a[i][k], a[k][j]) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 1
+		a := make([][]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			a[i] = make([]int, n)
+			for j := 0; j < n; j++ {
+				if i == j {
+					a[i][j] = 0
+				} else {
+					a[i][j] = rand.Intn(10)
+				}
+				sb.WriteString(fmt.Sprintf("%d ", a[i][j]))
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		exp := "NOT MAGIC"
+		if isMagic(n, a) {
+			exp = "MAGIC"
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\nInput:\n%s\nOutput:\n%s\n", t+1, err, input, out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed\nInput:\n%s\nExpected: %s\nGot: %s\n", t+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go .. verifierF.go for contest 632
- each verifier generates at least 100 random tests and compares candidate output against expected results
- verifiers execute the provided binary or Go source automatically

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go run verifierA.go ./solutionA` (all tests passed)

------
https://chatgpt.com/codex/tasks/task_e_68835afc43888324a7d50ffc58c7dd89