### PR TITLE
Add verifiers for Codeforces Round 644

### DIFF
--- a/0-999/600-699/640-649/644/verifierA.go
+++ b/0-999/600-699/640-649/644/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Case struct {
+	n, a, b int
+	expect  string
+}
+
+func solveA(n, a, b int) string {
+	if n > a*b {
+		return "-1\n"
+	}
+	M := make([][]int, a)
+	for i := 0; i < a; i++ {
+		M[i] = make([]int, b)
+	}
+	cnt := 1
+	for i := 0; i < a; i++ {
+		for j := 0; j < b; j++ {
+			M[i][j] = cnt
+			if b%2 == 0 && i%2 == 1 {
+				if j%2 == 0 {
+					M[i][j]++
+				} else {
+					M[i][j]--
+				}
+			}
+			if M[i][j] > n {
+				M[i][j] = 0
+			}
+			cnt++
+			if cnt > n+1 {
+				break
+			}
+		}
+		if cnt > n+1 {
+			break
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < a; i++ {
+		for j := 0; j < b; j++ {
+			if j == b-1 {
+				fmt.Fprintf(&sb, "%d\n", M[i][j])
+			} else {
+				fmt.Fprintf(&sb, "%d ", M[i][j])
+			}
+		}
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	a := rng.Intn(20) + 1
+	b := rng.Intn(20) + 1
+	n := rng.Intn(2*a*b) + 1
+	if n > 10000 {
+		n = 10000
+	}
+	input := fmt.Sprintf("%d %d %d\n", n, a, b)
+	expected := solveA(n, a, b)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/640-649/644/verifierB.go
+++ b/0-999/600-699/640-649/644/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Query struct {
+	t, d int64
+}
+
+func solveB(n, b int, qs []Query) string {
+	q := make([]int64, 0)
+	ans := make([]int64, n)
+	for i := 0; i < n; i++ {
+		t := qs[i].t
+		d := qs[i].d
+		for len(q) > 0 && q[0] <= t {
+			q = q[1:]
+		}
+		if len(q) > b {
+			ans[i] = -1
+			continue
+		}
+		var start int64
+		if len(q) == 0 {
+			start = t
+		} else {
+			start = q[len(q)-1]
+		}
+		finish := start + d
+		q = append(q, finish)
+		ans[i] = finish
+	}
+	var sb strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	b := rng.Intn(5) + 1
+	qs := make([]Query, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, b)
+	cur := int64(rng.Intn(5))
+	for i := 0; i < n; i++ {
+		cur += int64(rng.Intn(10) + 1)
+		d := int64(rng.Intn(10) + 1)
+		qs[i] = Query{cur, d}
+		fmt.Fprintf(&sb, "%d %d\n", cur, d)
+	}
+	input := sb.String()
+	expected := solveB(n, b, qs)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/640-649/644/verifierC.go
+++ b/0-999/600-699/640-649/644/verifierC.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	seed uint64 = 357
+	base uint64 = 10317
+)
+
+func hsv(s string) uint64 {
+	var h uint64
+	for i := 0; i < len(s); i++ {
+		h = h*seed + uint64(s[i])
+	}
+	return h
+}
+
+func solveC(urls []string) string {
+	hostPaths := make(map[string]map[string]struct{}, len(urls))
+	for _, url := range urls {
+		s := strings.TrimPrefix(url, "http://")
+		j := 0
+		for j < len(s) {
+			c := s[j]
+			if (c >= 'a' && c <= 'z') || c == '.' {
+				j++
+			} else {
+				break
+			}
+		}
+		host := s[:j]
+		k := j
+		for k < len(s) {
+			c := s[k]
+			if (c >= 'a' && c <= 'z') || c == '.' || c == '/' {
+				k++
+			} else {
+				break
+			}
+		}
+		path := s[j:k]
+		if len(path) == 0 {
+			path = "$"
+		}
+		m, ok := hostPaths[host]
+		if !ok {
+			m = make(map[string]struct{})
+			hostPaths[host] = m
+		}
+		m[path] = struct{}{}
+	}
+	groups := make(map[uint64][]string)
+	for host, pathsMap := range hostPaths {
+		paths := make([]string, 0, len(pathsMap))
+		for p := range pathsMap {
+			paths = append(paths, p)
+		}
+		sort.Strings(paths)
+		var hv uint64
+		for _, p := range paths {
+			hv = hv*base + hsv(p)
+		}
+		groups[hv] = append(groups[hv], host)
+	}
+	keys := make([]uint64, 0)
+	for hv, hs := range groups {
+		if len(hs) > 1 {
+			keys = append(keys, hv)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintln(len(keys)))
+	for _, hv := range keys {
+		hs := groups[hv]
+		sort.Strings(hs)
+		for i, host := range hs {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString("http://")
+			sb.WriteString(host)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func randHost(rng *rand.Rand) string {
+	letters := []byte{'a', 'b', 'c', 'd', 'e'}
+	l := rng.Intn(3) + 1
+	var sb strings.Builder
+	for i := 0; i < l; i++ {
+		sb.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	if rng.Intn(2) == 0 {
+		sb.WriteByte('.')
+		l2 := rng.Intn(3) + 1
+		for i := 0; i < l2; i++ {
+			sb.WriteByte(letters[rng.Intn(len(letters))])
+		}
+	}
+	return sb.String()
+}
+
+func randPath(rng *rand.Rand) string {
+	letters := []byte{'a', 'b', 'c'}
+	if rng.Intn(2) == 0 {
+		return ""
+	}
+	segs := rng.Intn(2) + 1
+	var sb strings.Builder
+	for s := 0; s < segs; s++ {
+		sb.WriteByte('/')
+		l := rng.Intn(3) + 1
+		for i := 0; i < l; i++ {
+			sb.WriteByte(letters[rng.Intn(len(letters))])
+		}
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	urls := make([]string, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		h := randHost(rng)
+		p := randPath(rng)
+		url := "http://" + h + p
+		urls[i] = url
+		sb.WriteString(url)
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	expected := solveC(urls)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for contest 644 problems A–C
- each verifier generates 100 random test cases
- check binary outputs against the official algorithms

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`


------
https://chatgpt.com/codex/tasks/task_e_6883618d92a08324ba42940d9f84c91c