### PR TITLE
Add Go solution for 1910C

### DIFF
--- a/1000-1999/1900-1999/1910-1919/1910/1910C.go
+++ b/1000-1999/1900-1999/1910-1919/1910/1910C.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func countSegments(s string) int {
+	count := 0
+	prevStar := false
+	for i := 0; i < len(s); i++ {
+		if s[i] == '*' {
+			if !prevStar {
+				count++
+				prevStar = true
+			}
+		} else {
+			prevStar = false
+		}
+	}
+	return count
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var row1, row2 string
+		fmt.Fscan(reader, &row1)
+		fmt.Fscan(reader, &row2)
+
+		segs := countSegments(row1) + countSegments(row2)
+		ans := n - segs
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement algorithm for problem 1910C in Go
- solution counts star segments per row to compute survivors

## Testing
- `go build 1000-1999/1900-1999/1910-1919/1910/1910C.go`
- `go test ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_6883674c883483248ba4826842ca69b5