### PR TITLE
Add Go verifiers for CF round 653

### DIFF
--- a/0-999/600-699/650-659/653/verifierA.go
+++ b/0-999/600-699/650-659/653/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "653A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []Case{
+		{"3\n1 2 3\n"},
+		{"4\n1 1 1 1\n"},
+	}
+	for len(cases) < 102 {
+		n := rng.Intn(48) + 3
+		arr := make([]int, n)
+		for i := range arr {
+			arr[i] = rng.Intn(1000) + 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/650-659/653/verifierB.go
+++ b/0-999/600-699/650-659/653/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "653B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []Case{}
+	for len(cases) < 102 {
+		n := rng.Intn(5) + 2
+		q := rng.Intn(36) + 1
+		used := make(map[string]struct{})
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, q)
+		for i := 0; i < q; i++ {
+			var a string
+			for {
+				a = string([]byte{'a' + byte(rng.Intn(6)), 'a' + byte(rng.Intn(6))})
+				if _, ok := used[a]; !ok {
+					used[a] = struct{}{}
+					break
+				}
+			}
+			b := 'a' + byte(rng.Intn(6))
+			fmt.Fprintf(&sb, "%s %c\n", a, b)
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/650-659/653/verifierC.go
+++ b/0-999/600-699/650-659/653/verifierC.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "653C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []Case{{"2\n1 2\n"}}
+	for len(cases) < 102 {
+		n := rng.Intn(50) + 2
+		arr := make([]int, n)
+		for i := range arr {
+			arr[i] = rng.Intn(150000) + 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/650-659/653/verifierD.go
+++ b/0-999/600-699/650-659/653/verifierD.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "653D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []Case{{"2 1 1\n1 2 1\n"}}
+	for len(cases) < 102 {
+		n := rng.Intn(7) + 2
+		m := rng.Intn(10) + n - 1
+		x := rng.Intn(20) + 1
+		edges := make(map[[2]int]struct{})
+		var extra []struct{ u, v, c int }
+		// ensure path
+		for i := 1; i < n; i++ {
+			c := rng.Intn(1000) + 1
+			edges[[2]int{i, i + 1}] = struct{}{}
+			extra = append(extra, struct{ u, v, c int }{i, i + 1, c})
+		}
+		for len(edges) < m {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			key := [2]int{u, v}
+			if _, ok := edges[key]; ok {
+				continue
+			}
+			edges[key] = struct{}{}
+			c := rng.Intn(1000) + 1
+			extra = append(extra, struct{ u, v, c int }{u, v, c})
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, m, x)
+		for _, e := range extra {
+			fmt.Fprintf(&sb, "%d %d %d\n", e.u, e.v, e.c)
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/650-659/653/verifierE.go
+++ b/0-999/600-699/650-659/653/verifierE.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "653E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []Case{}
+	for len(cases) < 102 {
+		n := rng.Intn(10) + 2
+		maxPairs := n * (n - 1) / 2
+		m := rng.Intn(min(maxPairs, 20) + 1)
+		k := rng.Intn(n-1) + 1
+		pairs := make(map[[2]int]struct{})
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+		for len(pairs) < m {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			if a == b {
+				continue
+			}
+			if a > b {
+				a, b = b, a
+			}
+			key := [2]int{a, b}
+			if _, ok := pairs[key]; ok {
+				continue
+			}
+			pairs[key] = struct{}{}
+			fmt.Fprintf(&sb, "%d %d\n", a, b)
+		}
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/650-659/653/verifierF.go
+++ b/0-999/600-699/650-659/653/verifierF.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "653F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []Case{}
+	for len(cases) < 102 {
+		n := rng.Intn(100) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('(')
+			} else {
+				sb.WriteByte(')')
+			}
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/650-659/653/verifierG.go
+++ b/0-999/600-699/650-659/653/verifierG.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Case struct{ input string }
+
+func buildRef() (string, error) {
+	ref := "./refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "653G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []Case{}
+	for len(cases) < 102 {
+		n := rng.Intn(50) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(300000)+1)
+		}
+		sb.WriteByte('\n')
+		cases = append(cases, Case{sb.String()})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verification tools for Codeforces round 653 problems A–G
- each verifier builds the official Go solution as reference
- run the candidate binary (or `.go` file) against 100+ random tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build -o candA 653A.go && go run verifierA.go ./candA`
- `go build -o candB 653B.go && go run verifierB.go ./candB`

------
https://chatgpt.com/codex/tasks/task_e_6883667a53f083249d3e9a62fd0099bd