### PR TITLE
Add Go verifiers for contest 659

### DIFF
--- a/0-999/600-699/650-659/659/verifierA.go
+++ b/0-999/600-699/650-659/659/verifierA.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solve(input string) string {
+	var n, a, b int
+	fmt.Sscan(input, &n, &a, &b)
+	pos := (a - 1 + b) % n
+	if pos < 0 {
+		pos += n
+	}
+	return fmt.Sprintln(pos + 1)
+}
+
+func generateTests() []string {
+	rand.Seed(42)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(100) + 1
+		a := rand.Intn(n) + 1
+		b := rand.Intn(201) - 100
+		tests[i] = fmt.Sprintf("%d %d %d\n", n, a, b)
+	}
+	return tests
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for idx, t := range tests {
+		expect := strings.TrimSpace(solve(t))
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if expect != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", idx+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/600-699/650-659/659/verifierB.go
+++ b/0-999/600-699/650-659/659/verifierB.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type student struct {
+	name   string
+	region int
+	points int
+}
+
+func solve(input string) string {
+	var n, m int
+	fmt.Sscan(strings.SplitN(input, "\n", 2)[0], &n, &m)
+	lines := strings.Split(strings.TrimSpace(input), "\n")[1:]
+	top := make([][3]student, m+1)
+	for i := range top {
+		for j := range top[i] {
+			top[i][j].points = -1
+		}
+	}
+	for _, line := range lines {
+		var s student
+		fmt.Sscan(line, &s.name, &s.region, &s.points)
+		r := s.region
+		if s.points >= top[r][0].points {
+			top[r][2] = top[r][1]
+			top[r][1] = top[r][0]
+			top[r][0] = s
+		} else if s.points >= top[r][1].points {
+			top[r][2] = top[r][1]
+			top[r][1] = s
+		} else if s.points >= top[r][2].points {
+			top[r][2] = s
+		}
+	}
+	var b strings.Builder
+	for i := 1; i <= m; i++ {
+		if top[i][1].points == top[i][2].points {
+			b.WriteString("?\n")
+		} else {
+			fmt.Fprintf(&b, "%s %s\n", top[i][0].name, top[i][1].name)
+		}
+	}
+	return b.String()
+}
+
+func generateTests() []string {
+	rand.Seed(43)
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		m := rand.Intn(5) + 1
+		n := 2*m + rand.Intn(6)
+		students := make([]student, 0, n)
+		nameID := 1
+		for r := 1; r <= m; r++ {
+			for i := 0; i < 2; i++ {
+				s := student{
+					name:   fmt.Sprintf("name%d", nameID),
+					region: r,
+					points: rand.Intn(801),
+				}
+				nameID++
+				students = append(students, s)
+			}
+		}
+		for len(students) < n {
+			s := student{
+				name:   fmt.Sprintf("name%d", nameID),
+				region: rand.Intn(m) + 1,
+				points: rand.Intn(801),
+			}
+			nameID++
+			students = append(students, s)
+		}
+		sort.Slice(students, func(i, j int) bool { return students[i].name < students[j].name })
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d %d\n", n, m)
+		for _, s := range students {
+			fmt.Fprintf(&b, "%s %d %d\n", s.name, s.region, s.points)
+		}
+		tests[t] = b.String()
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		expect := strings.TrimSpace(solve(t))
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if expect != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/600-699/650-659/659/verifierC.go
+++ b/0-999/600-699/650-659/659/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solve(input string) string {
+	var n int
+	var m int64
+	fmt.Sscan(strings.SplitN(input, "\n", 2)[0], &n, &m)
+	parts := strings.Fields(strings.SplitN(input, "\n", 2)[1])
+	have := make(map[int64]bool, n)
+	for i := 0; i < n; i++ {
+		var x int64
+		fmt.Sscan(parts[i], &x)
+		have[x] = true
+	}
+	var res []int64
+	var cost int64
+	for t := int64(1); cost+t <= m; t++ {
+		if !have[t] {
+			res = append(res, t)
+			cost += t
+		}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", len(res))
+	for i, v := range res {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", v)
+	}
+	if len(res) > 0 {
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func generateTests() []string {
+	rand.Seed(44)
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 1
+		m := rand.Int63n(1000) + int64(rand.Intn(10))
+		have := make(map[int64]bool)
+		vals := make([]int64, 0, n)
+		for len(vals) < n {
+			x := rand.Int63n(1000) + 1
+			if !have[x] {
+				have[x] = true
+				vals = append(vals, x)
+			}
+		}
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d %d\n", n, m)
+		for i, v := range vals {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", v)
+		}
+		b.WriteByte('\n')
+		tests[t] = b.String()
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		expect := strings.TrimSpace(solve(t))
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if expect != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/600-699/650-659/659/verifierD.go
+++ b/0-999/600-699/650-659/659/verifierD.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Point struct{ x, y int64 }
+
+func solve(input string) string {
+	lines := strings.Fields(input)
+	idx := 0
+	n := 0
+	fmt.Sscan(lines[idx], &n)
+	idx++
+	pts := make([]Point, n+2)
+	for i := 0; i <= n; i++ {
+		fmt.Sscan(lines[idx], &pts[i].x)
+		idx++
+		fmt.Sscan(lines[idx], &pts[i].y)
+		idx++
+	}
+	pts[n+1] = pts[1]
+	var area int64
+	for i := 0; i < n; i++ {
+		area += pts[i].x*pts[i+1].y - pts[i+1].x*pts[i].y
+	}
+	orient := int64(1)
+	if area < 0 {
+		orient = -1
+	}
+	cnt := 0
+	for i := 0; i < n; i++ {
+		v1x := pts[i+1].x - pts[i].x
+		v1y := pts[i+1].y - pts[i].y
+		v2x := pts[i+2].x - pts[i+1].x
+		v2y := pts[i+2].y - pts[i+1].y
+		cross := v1x*v2y - v1y*v2x
+		if cross*orient < 0 {
+			cnt++
+		}
+	}
+	return fmt.Sprintln(cnt)
+}
+
+func rectTest(w, h int) string {
+	return fmt.Sprintf("4\n0 0\n0 %d\n%d %d\n%d 0\n0 0\n", h, w, h, w)
+}
+
+func lShapeTest(w1, w2, h, cut int) string {
+	return fmt.Sprintf("6\n0 0\n0 %d\n%d %d\n%d %d\n%d 0\n0 0\n", h, w1, h, w1, cut, w1+w2)
+}
+
+func generateTests() []string {
+	rand.Seed(45)
+	tests := make([]string, 100)
+	for i := 0; i < 50; i++ {
+		w := rand.Intn(9) + 2
+		h := rand.Intn(9) + 2
+		tests[i] = rectTest(w, h)
+	}
+	for i := 50; i < 100; i++ {
+		w1 := rand.Intn(5) + 2
+		w2 := rand.Intn(5) + 2
+		h := rand.Intn(5) + 3
+		cut := rand.Intn(h-1) + 1
+		tests[i] = lShapeTest(w1, w2, h, cut)
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		expect := strings.TrimSpace(solve(t))
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if expect != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/600-699/650-659/659/verifierE.go
+++ b/0-999/600-699/650-659/659/verifierE.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solve(input string) string {
+	fields := strings.Fields(input)
+	idx := 0
+	n := 0
+	m := 0
+	fmt.Sscan(fields[idx], &n)
+	idx++
+	fmt.Sscan(fields[idx], &m)
+	idx++
+	adj := make([][]int, n+1)
+	for i := 0; i < m; i++ {
+		var x, y int
+		fmt.Sscan(fields[idx], &x)
+		idx++
+		fmt.Sscan(fields[idx], &y)
+		idx++
+		adj[x] = append(adj[x], y)
+		adj[y] = append(adj[y], x)
+	}
+	vis := make([]bool, n+1)
+	ans := 0
+	stack := make([]int, 0)
+	for i := 1; i <= n; i++ {
+		if !vis[i] {
+			countV := 0
+			countE := 0
+			stack = append(stack[:0], i)
+			vis[i] = true
+			for len(stack) > 0 {
+				v := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				countV++
+				countE += len(adj[v])
+				for _, to := range adj[v] {
+					if !vis[to] {
+						vis[to] = true
+						stack = append(stack, to)
+					}
+				}
+			}
+			if countE/2 == countV-1 {
+				ans++
+			}
+		}
+	}
+	return fmt.Sprintln(ans)
+}
+
+func generateTests() []string {
+	rand.Seed(46)
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(8) + 2
+		maxEdges := n * (n - 1) / 2
+		m := rand.Intn(maxEdges + 1)
+		edges := make([][2]int, 0, m)
+		exist := make(map[[2]int]bool)
+		for len(edges) < m {
+			x := rand.Intn(n) + 1
+			y := rand.Intn(n) + 1
+			if x == y {
+				continue
+			}
+			if x > y {
+				x, y = y, x
+			}
+			p := [2]int{x, y}
+			if !exist[p] {
+				exist[p] = true
+				edges = append(edges, p)
+			}
+		}
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d %d\n", n, m)
+		for _, e := range edges {
+			fmt.Fprintf(&b, "%d %d\n", e[0], e[1])
+		}
+		tests[t] = b.String()
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		expect := strings.TrimSpace(solve(t))
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if expect != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/600-699/650-659/659/verifierF.go
+++ b/0-999/600-699/650-659/659/verifierF.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildModel() (string, error) {
+	modelPath := filepath.Join(filepath.Dir(os.Args[0]), "659F.go")
+	out := filepath.Join(os.TempDir(), "modelF.bin")
+	cmd := exec.Command("go", "build", "-o", out, modelPath)
+	err := cmd.Run()
+	return out, err
+}
+
+func solveWithModel(model string, input string) (string, error) {
+	cmd := exec.Command(model)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateTests() []string {
+	rand.Seed(47)
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(3) + 1
+		m := rand.Intn(3) + 1
+		k := rand.Intn(20) + 1
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d %d %d\n", n, m, k)
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				val := rand.Intn(9) + 1
+				if j > 0 {
+					b.WriteByte(' ')
+				}
+				fmt.Fprintf(&b, "%d", val)
+			}
+			b.WriteByte('\n')
+		}
+		tests[t] = b.String()
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	model, err := buildModel()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build model: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(model)
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := solveWithModel(model, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "model run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expect = strings.TrimSpace(expect)
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if expect != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/600-699/650-659/659/verifierG.go
+++ b/0-999/600-699/650-659/659/verifierG.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func buildModel() (string, error) {
+	modelPath := filepath.Join(filepath.Dir(os.Args[0]), "659G.go")
+	out := filepath.Join(os.TempDir(), "modelG.bin")
+	cmd := exec.Command("go", "build", "-o", out, modelPath)
+	err := cmd.Run()
+	return out, err
+}
+
+func solveWithModel(model, input string) (string, error) {
+	cmd := exec.Command(model)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func generateTests() []string {
+	rand.Seed(48)
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 1
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d\n", n)
+		for i := 0; i < n; i++ {
+			val := rand.Intn(10) + 1
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", val)
+		}
+		b.WriteByte('\n')
+		tests[t] = b.String()
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	model, err := buildModel()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build model: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(model)
+	tests := generateTests()
+	for i, t := range tests {
+		expect, err := solveWithModel(model, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "model run error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expect = strings.TrimSpace(expect)
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if expect != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, t, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` through `verifierG.go` for contest 659
- each verifier runs at least 100 deterministic random tests
- verifiers F and G compile the reference solutions to check outputs

## Testing
- `go build 0-999/600-699/650-659/659/verifierA.go`
- `go build 0-999/600-699/650-659/659/verifierB.go`
- `go build 0-999/600-699/650-659/659/verifierC.go`
- `go build 0-999/600-699/650-659/659/verifierD.go`
- `go build 0-999/600-699/650-659/659/verifierE.go`
- `go build 0-999/600-699/650-659/659/verifierF.go`
- `go build 0-999/600-699/650-659/659/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_688369c33d8083249e2366696927f490