### PR TITLE
Add Go verifiers for contest 649

### DIFF
--- a/0-999/600-699/640-649/649/verifierA.go
+++ b/0-999/600-699/640-649/649/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	nums := make([]int, n)
+	for i := range nums {
+		nums[i] = rng.Intn(1000000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+
+	maxPow := 0
+	for _, v := range nums {
+		pow := v & -v
+		if pow > maxPow {
+			maxPow = pow
+		}
+	}
+	cnt := 0
+	for _, v := range nums {
+		if v%maxPow == 0 {
+			cnt++
+		}
+	}
+	exp := fmt.Sprintf("%d %d\n", maxPow, cnt)
+	return sb.String(), exp
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/640-649/649/verifierB.go
+++ b/0-999/600-699/640-649/649/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	k := rng.Intn(4) + 1
+	per := n * m * k
+	a := rng.Intn(per) + 1
+	b := rng.Intn(per-1) + 1
+	if b >= a {
+		b++
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+
+	perEntrance := m * k
+	entranceA := (a-1)/perEntrance + 1
+	entranceB := (b-1)/perEntrance + 1
+	floorA := ((a-1)%perEntrance)/k + 1
+	floorB := ((b-1)%perEntrance)/k + 1
+	downA := min((floorA-1)*5, 10+(floorA-1))
+	upB := min((floorB-1)*5, 10+(floorB-1))
+	diff := abs(entranceA - entranceB)
+	walk := min(diff, n-diff) * 15
+	exp := fmt.Sprintf("%d\n", downA+walk+upB)
+	return sb.String(), exp
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/640-649/649/verifierC.go
+++ b/0-999/600-699/640-649/649/verifierC.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	x := rng.Intn(20)
+	y := rng.Intn(20)
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(10) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x, y))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+
+	b := append([]int(nil), arr...)
+	sort.Ints(b)
+	prefixDouble := make([]int64, n+1)
+	prefixOdd := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		prefixDouble[i+1] = prefixDouble[i] + int64((b[i]+1)/2)
+		if b[i]%2 == 1 {
+			prefixOdd[i+1] = prefixOdd[i] + 1
+		} else {
+			prefixOdd[i+1] = prefixOdd[i]
+		}
+	}
+	feasible := func(k int) bool {
+		totalDouble := prefixDouble[k]
+		need := totalDouble - int64(x)
+		if need <= 0 {
+			return true
+		}
+		odd := prefixOdd[k]
+		use1 := odd
+		if use1 > int64(y) {
+			use1 = int64(y)
+		}
+		if use1 > need {
+			use1 = need
+		}
+		need -= use1
+		yLeft := int64(y) - use1
+		if yLeft >= need*2 {
+			return true
+		}
+		return false
+	}
+	l, r := 0, n
+	for l < r {
+		mid := (l + r + 1) / 2
+		if feasible(mid) {
+			l = mid
+		} else {
+			r = mid - 1
+		}
+	}
+	exp := fmt.Sprintf("%d\n", l)
+	return sb.String(), exp
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/640-649/649/verifierD.go
+++ b/0-999/600-699/640-649/649/verifierD.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Process struct{ start, end int }
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	cells := make([]int, n)
+	allZero := true
+	for i := range cells {
+		if rng.Intn(2) == 0 { // empty
+			cells[i] = 0
+		} else {
+			cells[i] = rng.Intn(4) + 1
+			allZero = false
+		}
+	}
+	if allZero {
+		cells[0] = 1
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i, v := range cells {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+
+	processes := make([]Process, 0)
+	for i := 0; i < n; {
+		if cells[i] == 0 {
+			i++
+			continue
+		}
+		id := cells[i]
+		j := i
+		for j+1 < n && cells[j+1] == id {
+			j++
+		}
+		processes = append(processes, Process{start: i + 1, end: j + 1})
+		i = j + 1
+	}
+	totalMoves := 0
+	prefix := 0
+	for _, p := range processes {
+		length := p.end - p.start + 1
+		finalStart := prefix + 1
+		finalEnd := finalStart + length - 1
+		overlapStart := p.start
+		if finalStart > overlapStart {
+			overlapStart = finalStart
+		}
+		overlapEnd := p.end
+		if finalEnd < overlapEnd {
+			overlapEnd = finalEnd
+		}
+		overlap := 0
+		if overlapStart <= overlapEnd {
+			overlap = overlapEnd - overlapStart + 1
+		}
+		totalMoves += length - overlap
+		prefix += length
+	}
+	exp := fmt.Sprintf("%d\n", totalMoves)
+	return sb.String(), exp
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/640-649/649/verifierE.go
+++ b/0-999/600-699/640-649/649/verifierE.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type traveler struct{ x, d int }
+
+type event struct {
+	pos int
+	typ int
+}
+
+func maxOverlap(trs []traveler, mask int) int {
+	events := make([]event, 0, 2*len(trs))
+	for i := 0; i < len(trs); i++ {
+		if mask&(1<<i) == 0 {
+			continue
+		}
+		s := trs[i].x
+		e := trs[i].x + trs[i].d
+		events = append(events, event{pos: e, typ: -1})
+		events = append(events, event{pos: s, typ: 1})
+	}
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].pos != events[j].pos {
+			return events[i].pos < events[j].pos
+		}
+		return events[i].typ < events[j].typ // leaves before enters
+	})
+	cur, maxV := 0, 0
+	for _, ev := range events {
+		cur += ev.typ
+		if cur > maxV {
+			maxV = cur
+		}
+	}
+	return maxV
+}
+
+func brute(trs []traveler, a int) (int, [][]int) {
+	n := len(trs)
+	best := -1
+	var bestSubs [][]int
+	for mask := 0; mask < (1 << n); mask++ {
+		if bits.OnesCount(uint(mask)) != a {
+			continue
+		}
+		overlap := maxOverlap(trs, mask)
+		if best == -1 || overlap < best {
+			best = overlap
+			bestSubs = bestSubs[:0]
+			idx := make([]int, 0, a)
+			for i := 0; i < n; i++ {
+				if mask&(1<<i) != 0 {
+					idx = append(idx, i+1)
+				}
+			}
+			bestSubs = append(bestSubs, idx)
+		} else if overlap == best {
+			idx := make([]int, 0, a)
+			for i := 0; i < n; i++ {
+				if mask&(1<<i) != 0 {
+					idx = append(idx, i+1)
+				}
+			}
+			bestSubs = append(bestSubs, idx)
+		}
+	}
+	return best, bestSubs
+}
+
+func generateCase(rng *rand.Rand) (string, string, []traveler) {
+	n := rng.Intn(7) + 1
+	a := rng.Intn(n) + 1
+	trs := make([]traveler, n)
+	for i := range trs {
+		trs[i].x = rng.Intn(20) + 1
+		trs[i].d = rng.Intn(10) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, a))
+	for i, v := range trs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", v.x, v.d))
+		_ = i
+	}
+	best, _ := brute(trs, a)
+	exp := fmt.Sprintf("%d\n", best)
+	return sb.String(), exp, trs
+}
+
+func runCase(exe string, input string, exp string, trs []traveler, a int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) < 1 {
+		return fmt.Errorf("no output")
+	}
+	seat, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("bad seat: %v", err)
+	}
+	if seat != int(seat) {
+		// not necessary but for style
+	}
+	if len(fields)-1 != a {
+		return fmt.Errorf("expected %d indices, got %d", a, len(fields)-1)
+	}
+	idxs := make([]int, 0, a)
+	seen := make(map[int]bool)
+	for i := 1; i < len(fields); i++ {
+		v, err := strconv.Atoi(fields[i])
+		if err != nil {
+			return fmt.Errorf("bad index: %v", err)
+		}
+		if v < 1 || v > len(trs) {
+			return fmt.Errorf("index out of range")
+		}
+		if seen[v] {
+			return fmt.Errorf("duplicate index")
+		}
+		seen[v] = true
+		idxs = append(idxs, v)
+	}
+	// compute seat requirement for provided subset
+	mask := 0
+	for _, v := range idxs {
+		mask |= 1 << (v - 1)
+	}
+	need := maxOverlap(trs, mask)
+
+	best, _ := brute(trs, a)
+	if seat != need || seat != best {
+		return fmt.Errorf("expected seat %d but got %d (need %d)", best, seat, need)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp, trs := generateCase(rng)
+		a, _ := strconv.Atoi(strings.Fields(in)[1])
+		if err := runCase(exe, in, exp, trs, a); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement standalone Go verifiers for all problems in contest 649
- each verifier generates 100 random tests and checks a given binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_6883644a0834832491857804bcd7a9fc