### PR TITLE
Add solution verifiers for contest 643

### DIFF
--- a/0-999/600-699/640-649/643/verifierA.go
+++ b/0-999/600-699/640-649/643/verifierA.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	expect []int
+}
+
+func brute(n int, arr []int) []int {
+	ans := make([]int, n+1)
+	for l := 0; l < n; l++ {
+		freq := make([]int, n+1)
+		maxColor, maxCount := 0, 0
+		for r := l; r < n; r++ {
+			c := arr[r]
+			freq[c]++
+			if freq[c] > maxCount || (freq[c] == maxCount && c < maxColor) {
+				maxCount = freq[c]
+				maxColor = c
+			}
+			ans[maxColor]++
+		}
+	}
+	return ans[1:]
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(7) + 1 // 1..7
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	expect := brute(n, arr)
+	return testCase{sb.String(), expect}
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseOutput(out string, n int) ([]int, error) {
+	fields := strings.Fields(out)
+	if len(fields) != n {
+		return nil, fmt.Errorf("expected %d numbers, got %d", n, len(fields))
+	}
+	res := make([]int, n)
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, fmt.Errorf("invalid integer: %v", err)
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		c := genCase(rng)
+		out, err := run(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+		got, err := parseOutput(out, len(c.expect))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%soutput:\n%s", i+1, err, c.input, out)
+			os.Exit(1)
+		}
+		for j, v := range got {
+			if v != c.expect[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed at position %d: expected %d got %d\ninput:\n%s", i+1, j+1, c.expect[j], v, c.input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/600-699/640-649/643/verifierB.go
+++ b/0-999/600-699/640-649/643/verifierB.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, k       int
+	a, b, c, d int
+	input      string
+	possible   bool
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 2                   // 2..9 (some invalid when <=4)
+	k := rng.Intn(2*n-2-(n-1)+1) + (n - 1) // range [n-1, 2n-2]
+	a := rng.Intn(n) + 1
+	b := rng.Intn(n-1) + 1
+	if b >= a {
+		b++
+	}
+	c := rng.Intn(n-2) + 1
+	if c >= a {
+		c++
+	}
+	if c >= b {
+		c++
+	}
+	d := rng.Intn(n-3) + 1
+	if d >= a {
+		d++
+	}
+	if d >= b {
+		d++
+	}
+	if d >= c {
+		d++
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	fmt.Fprintf(&sb, "%d %d %d %d\n", a, b, c, d)
+
+	possible := !(k <= n || n <= 4)
+
+	return testCase{n, k, a, b, c, d, sb.String(), possible}
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseLine(line string, n int) ([]int, error) {
+	fields := strings.Fields(strings.TrimSpace(line))
+	if len(fields) != n {
+		return nil, fmt.Errorf("expected %d numbers, got %d", n, len(fields))
+	}
+	res := make([]int, n)
+	used := make([]bool, n+1)
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, err
+		}
+		if v < 1 || v > n {
+			return nil, fmt.Errorf("value out of range")
+		}
+		if used[v] {
+			return nil, fmt.Errorf("number %d repeated", v)
+		}
+		used[v] = true
+		res[i] = v
+	}
+	return res, nil
+}
+
+func validate(tc testCase, out string) error {
+	out = strings.TrimSpace(out)
+	if !tc.possible {
+		if out != "-1" {
+			return fmt.Errorf("expected -1 for impossible case")
+		}
+		return nil
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) < 2 {
+		return fmt.Errorf("expected two lines in output")
+	}
+	path1, err := parseLine(lines[0], tc.n)
+	if err != nil {
+		return fmt.Errorf("first line: %v", err)
+	}
+	path2, err := parseLine(lines[1], tc.n)
+	if err != nil {
+		return fmt.Errorf("second line: %v", err)
+	}
+	if path1[0] != tc.a || path1[tc.n-1] != tc.b {
+		return fmt.Errorf("first line should start with %d and end with %d", tc.a, tc.b)
+	}
+	if path2[0] != tc.c || path2[tc.n-1] != tc.d {
+		return fmt.Errorf("second line should start with %d and end with %d", tc.c, tc.d)
+	}
+	// edges
+	edges := make(map[[2]int]struct{})
+	addEdge := func(x, y int) {
+		if x > y {
+			x, y = y, x
+		}
+		edges[[2]int{x, y}] = struct{}{}
+	}
+	for i := 0; i < tc.n-1; i++ {
+		addEdge(path1[i], path1[i+1])
+	}
+	for i := 0; i < tc.n-1; i++ {
+		addEdge(path2[i], path2[i+1])
+	}
+	if _, ok := edges[[2]int{min(tc.a, tc.b), max(tc.a, tc.b)}]; ok {
+		return fmt.Errorf("edge a-b should not exist")
+	}
+	if _, ok := edges[[2]int{min(tc.c, tc.d), max(tc.c, tc.d)}]; ok {
+		return fmt.Errorf("edge c-d should not exist")
+	}
+	if len(edges) > tc.k {
+		return fmt.Errorf("too many edges: got %d expect <= %d", len(edges), tc.k)
+	}
+	return nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		c := genCase(rng)
+		out, err := run(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+		if err := validate(c, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, c.input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/600-699/640-649/643/verifierC.go
+++ b/0-999/600-699/640-649/643/verifierC.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	n, k   int
+	t      []int
+	expect float64
+}
+
+func cost(S, P1, P2 []float64, l, r int) float64 {
+	return P1[r] - P1[l-1] - S[l-1]*(P2[r]-P2[l-1])
+}
+
+func solve(n, k int, t []int) float64 {
+	S := make([]float64, n+1)
+	P1 := make([]float64, n+1)
+	P2 := make([]float64, n+1)
+	for i := 1; i <= n; i++ {
+		S[i] = S[i-1] + float64(t[i-1])
+		P1[i] = P1[i-1] + S[i]/float64(t[i-1])
+		P2[i] = P2[i-1] + 1.0/float64(t[i-1])
+	}
+	inf := math.Inf(1)
+	dp := make([][]float64, k+1)
+	for i := 0; i <= k; i++ {
+		dp[i] = make([]float64, n+1)
+		for j := 0; j <= n; j++ {
+			dp[i][j] = inf
+		}
+	}
+	dp[0][0] = 0
+	for c := 1; c <= k; c++ {
+		for i := 1; i <= n; i++ {
+			for j := 0; j < i; j++ {
+				v := dp[c-1][j] + cost(S, P1, P2, j+1, i)
+				if v < dp[c][i] {
+					dp[c][i] = v
+				}
+			}
+		}
+	}
+	return dp[k][n]
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 1
+	k := rng.Intn(n) + 1
+	t := make([]int, n)
+	for i := 0; i < n; i++ {
+		t[i] = rng.Intn(5) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", t[i])
+	}
+	sb.WriteByte('\n')
+	expect := solve(n, k, t)
+	return testCase{sb.String(), n, k, t, expect}
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseFloat(out string) (float64, error) {
+	return strconv.ParseFloat(strings.TrimSpace(out), 64)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		c := genCase(rng)
+		out, err := run(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+		val, err := parseFloat(out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse float: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		expect := c.expect
+		if math.Abs(val-expect) > 1e-4*math.Max(1, math.Abs(expect)) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.6f got %.6f\ninput:\n%s", i+1, expect, val, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/600-699/640-649/643/verifierD.go
+++ b/0-999/600-699/640-649/643/verifierD.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type query struct {
+	typ int
+	a   int
+	b   int
+}
+
+type testCase struct {
+	n, q  int
+	t     []int64
+	fol   []int
+	qs    []query
+	input string
+}
+
+func computeIncome(t []int64, fol []int) []int64 {
+	n := len(t)
+	deg := make([]int, n)
+	for _, f := range fol {
+		deg[f]++
+	}
+	x := make([]int64, n)
+	for i := 0; i < n; i++ {
+		x[i] = t[i] / int64(deg[i]+2)
+	}
+	followerPart := make([]int64, n)
+	for i := 0; i < n; i++ {
+		followerPart[fol[i]] += x[i]
+	}
+	ownerPart := make([]int64, n)
+	for i := 0; i < n; i++ {
+		ownerPart[i] = t[i] - int64(deg[i]+1)*x[i]
+	}
+	inc := make([]int64, n)
+	for i := 0; i < n; i++ {
+		inc[i] = ownerPart[i] + followerPart[i] + x[fol[i]]
+	}
+	return inc
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 2 // 2..5
+	q := rng.Intn(4) + 2 // 2..5
+	t := make([]int64, n)
+	for i := range t {
+		t[i] = int64(rng.Intn(10) + 1)
+	}
+	fol := make([]int, n)
+	for i := range fol {
+		fol[i] = rng.Intn(n)
+	}
+	var qs []query
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i, v := range t {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range fol {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		typ := rng.Intn(3) + 1
+		if typ == 1 {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			qs = append(qs, query{1, a, b})
+			fmt.Fprintf(&sb, "1 %d %d\n", a, b)
+			fol[a-1] = b - 1
+		} else if typ == 2 {
+			a := rng.Intn(n) + 1
+			qs = append(qs, query{2, a, 0})
+			fmt.Fprintf(&sb, "2 %d\n", a)
+		} else {
+			qs = append(qs, query{3, 0, 0})
+			fmt.Fprintln(&sb, "3")
+		}
+	}
+	return testCase{n, q, t, fol, qs, sb.String()}
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseInts(line string) ([]int64, error) {
+	fields := strings.Fields(strings.TrimSpace(line))
+	res := make([]int64, len(fields))
+	for i, f := range fields {
+		v, err := strconv.ParseInt(f, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func validate(tc testCase, out string) error {
+	outputs := strings.Split(strings.TrimSpace(out), "\n")
+	idx := 0
+	fol := make([]int, len(tc.fol))
+	copy(fol, tc.fol)
+	for _, q := range tc.qs {
+		if q.typ == 1 {
+			fol[q.a-1] = q.b - 1
+		} else {
+			if idx >= len(outputs) {
+				return fmt.Errorf("missing output line for query")
+			}
+			incomes := computeIncome(tc.t, fol)
+			if q.typ == 2 {
+				want := incomes[q.a-1]
+				val, err := strconv.ParseInt(strings.TrimSpace(outputs[idx]), 10, 64)
+				if err != nil {
+					return err
+				}
+				if val != want {
+					return fmt.Errorf("expected %d got %d", want, val)
+				}
+			} else {
+				vals, err := parseInts(outputs[idx])
+				if err != nil {
+					return err
+				}
+				if len(vals) != 2 {
+					return fmt.Errorf("expected two integers")
+				}
+				minv, maxv := incomes[0], incomes[0]
+				for _, v := range incomes[1:] {
+					if v < minv {
+						minv = v
+					}
+					if v > maxv {
+						maxv = v
+					}
+				}
+				if vals[0] != minv || vals[1] != maxv {
+					return fmt.Errorf("expected %d %d got %d %d", minv, maxv, vals[0], vals[1])
+				}
+			}
+			idx++
+		}
+	}
+	if idx != len(outputs) {
+		return fmt.Errorf("extra output lines")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		c := genCase(rng)
+		out, err := run(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+		if err := validate(c, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, c.input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/600-699/640-649/643/verifierE.go
+++ b/0-999/600-699/640-649/643/verifierE.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const H = 40
+
+type query struct {
+	typ int
+	v   int
+}
+
+type testCase struct {
+	q     int
+	qs    []query
+	input string
+}
+
+func solve(qs []query) []float64 {
+	n := len(qs) + 2
+	dp := make([]float64, n*H)
+	mul := make([]float64, n*H)
+	p := make([]int, n)
+	var path [H]int
+	dp[0*H+0] = 1.0
+	p[0] = -1
+	for i := 0; i < n; i++ {
+		for j := 0; j < H; j++ {
+			mul[i*H+j] = 1.0
+		}
+	}
+	cur := 1
+	var outputs []float64
+	for _, qu := range qs {
+		if qu.typ == 1 {
+			v := qu.v
+			p[cur] = v
+			dp[cur*H+0] = 1.0
+			u := cur
+			pcur := 0
+			for h := 0; h < H && u != -1; h++ {
+				path[pcur] = u
+				pcur++
+				u = p[u]
+			}
+			for k := 2; k < pcur; k++ {
+				node := path[k]
+				prev := path[k-1]
+				mul[node*H+k] /= (1 - dp[prev*H+(k-1)]/2)
+			}
+			for k := 1; k < pcur; k++ {
+				node := path[k]
+				prev := path[k-1]
+				mul[node*H+k] *= (1 - dp[prev*H+(k-1)]/2)
+				dp[node*H+k] = 1 - mul[node*H+k]
+			}
+			cur++
+		} else {
+			v := qu.v
+			sum := 0.0
+			base := v * H
+			for j := 1; j < H; j++ {
+				sum += dp[base+j]
+			}
+			outputs = append(outputs, sum)
+		}
+	}
+	return outputs
+}
+
+func genCase(rng *rand.Rand) testCase {
+	q := rng.Intn(8) + 2 // 2..9
+	var qs []query
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", q)
+	cur := 1
+	for i := 0; i < q; i++ {
+		if i == q-1 { // ensure at least one type 2
+			v := rng.Intn(cur) + 1
+			qs = append(qs, query{2, v - 1})
+			fmt.Fprintf(&sb, "2 %d\n", v)
+			continue
+		}
+		typ := rng.Intn(2) + 1
+		if typ == 1 {
+			v := rng.Intn(cur) + 1
+			qs = append(qs, query{1, v - 1})
+			fmt.Fprintf(&sb, "1 %d\n", v)
+			cur++
+		} else {
+			v := rng.Intn(cur) + 1
+			qs = append(qs, query{2, v - 1})
+			fmt.Fprintf(&sb, "2 %d\n", v)
+		}
+	}
+	return testCase{q, qs, sb.String()}
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseFloats(lines []string) ([]float64, error) {
+	res := make([]float64, len(lines))
+	for i, l := range lines {
+		v, err := strconv.ParseFloat(strings.TrimSpace(l), 64)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func validate(tc testCase, out string) error {
+	outputs := strings.Split(strings.TrimSpace(out), "\n")
+	expect := solve(tc.qs)
+	if len(outputs) != len(expect) {
+		return fmt.Errorf("expected %d lines, got %d", len(expect), len(outputs))
+	}
+	vals, err := parseFloats(outputs)
+	if err != nil {
+		return err
+	}
+	for i := range vals {
+		if math.Abs(vals[i]-expect[i]) > 1e-6*math.Max(1, math.Abs(expect[i])) {
+			return fmt.Errorf("line %d expected %.7f got %.7f", i+1, expect[i], vals[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		c := genCase(rng)
+		out, err := run(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+		if err := validate(c, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, c.input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/600-699/640-649/643/verifierF.go
+++ b/0-999/600-699/640-649/643/verifierF.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n      uint64
+	p      int
+	q      int
+	input  string
+	expect uint32
+}
+
+func solve(n uint64, p, q int) uint32 {
+	var m int
+	if n == 0 {
+		m = 0
+	} else if p < int(n-1) {
+		m = p
+	} else {
+		m = int(n - 1)
+	}
+	S := big.NewInt(0)
+	cur := big.NewInt(1)
+	nn := new(big.Int).SetUint64(n)
+	for k := 1; k <= m; k++ {
+		term := new(big.Int).Sub(nn, big.NewInt(int64(k-1)))
+		cur.Mul(cur, term)
+		cur.Div(cur, big.NewInt(int64(k)))
+		S.Add(S, cur)
+	}
+	mask := new(big.Int).SetUint64(0xffffffff)
+	Smod := new(big.Int).And(S, mask)
+	mod := uint64(1) << 32
+	var ans uint32
+	for i := 1; i <= q; i++ {
+		x := uint64(i)
+		t := (x * x) & (mod - 1)
+		t = (t * Smod.Uint64()) & (mod - 1)
+		val := (x + t) & (mod - 1)
+		ans ^= uint32(val)
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := uint64(rng.Intn(100) + 1)
+	p := rng.Intn(20) + 1
+	q := rng.Intn(50) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, p, q)
+	expect := solve(n, p, q)
+	return testCase{n, p, q, sb.String(), expect}
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		c := genCase(rng)
+		out, err := run(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseUint(strings.TrimSpace(out), 10, 32)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: invalid integer output\n", i+1)
+			os.Exit(1)
+		}
+		if uint32(val) != c.expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, c.expect, val, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}

--- a/0-999/600-699/640-649/643/verifierG.go
+++ b/0-999/600-699/640-649/643/verifierG.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type query struct {
+	typ int
+	l   int
+	r   int
+	x   int
+}
+
+type testCase struct {
+	n, m, p int
+	arr     []int
+	qs      []query
+	input   string
+}
+
+func ceilMul(a, b int) int {
+	return (a*b + 99) / 100
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	p0 := 20 + rng.Intn(81) // 20..100
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(5) + 1
+	}
+	var qs []query
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, p0)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		typ := rng.Intn(2) + 1
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		if typ == 1 {
+			x := rng.Intn(5) + 1
+			qs = append(qs, query{1, l, r, x})
+			fmt.Fprintf(&sb, "1 %d %d %d\n", l, r, x)
+			for j := l - 1; j < r; j++ {
+				arr[j] = x
+			}
+		} else {
+			qs = append(qs, query{2, l, r, 0})
+			fmt.Fprintf(&sb, "2 %d %d\n", l, r)
+		}
+	}
+	return testCase{n, m, p0, arr, qs, sb.String()}
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func validate(tc testCase, out string) error {
+	outputs := strings.Split(strings.TrimSpace(out), "\n")
+	idx := 0
+	arr := append([]int(nil), tc.arr...)
+	limit := 100 / tc.p
+	for _, q := range tc.qs {
+		if q.typ == 1 {
+			for j := q.l - 1; j < q.r; j++ {
+				arr[j] = q.x
+			}
+		} else {
+			if idx >= len(outputs) {
+				return fmt.Errorf("missing output line")
+			}
+			line := strings.TrimSpace(outputs[idx])
+			idx++
+			fields := strings.Fields(line)
+			if len(fields) == 0 {
+				return fmt.Errorf("empty output line")
+			}
+			cnt, err := strconv.Atoi(fields[0])
+			if err != nil {
+				return err
+			}
+			if cnt != len(fields)-1 {
+				return fmt.Errorf("count mismatch")
+			}
+			if cnt > limit {
+				return fmt.Errorf("too many ids")
+			}
+			ids := make([]int, cnt)
+			for i := 0; i < cnt; i++ {
+				v, err := strconv.Atoi(fields[1+i])
+				if err != nil {
+					return err
+				}
+				ids[i] = v
+			}
+			// compute heavy advertisers
+			freq := make(map[int]int)
+			for j := q.l - 1; j < q.r; j++ {
+				freq[arr[j]]++
+			}
+			need := ceilMul(tc.p, q.r-q.l+1)
+			for id, f := range freq {
+				if f >= need {
+					found := false
+					for _, v := range ids {
+						if v == id {
+							found = true
+							break
+						}
+					}
+					if !found {
+						return fmt.Errorf("id %d missing", id)
+					}
+				}
+			}
+		}
+	}
+	if idx != len(outputs) {
+		return fmt.Errorf("extra output lines")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const cases = 100
+	for i := 0; i < cases; i++ {
+		c := genCase(rng)
+		out, err := run(bin, c.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+		if err := validate(c, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, c.input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", cases)
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–G of Codeforces contest 643
- each verifier generates around 100 random tests and checks a candidate binary's output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6883610174808324a0aebeecb117da56