### PR TITLE
Add verifiers for Codeforces contest 630

### DIFF
--- a/0-999/600-699/630-639/630/verifierA.go
+++ b/0-999/600-699/630-639/630/verifierA.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1e12) + 2
+	input := fmt.Sprintf("%d\n", n)
+	return input, "25"
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierB.go
+++ b/0-999/600-699/630-639/630/verifierB.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(9001) + 1000)
+	t := int64(rng.Int63n(2000000001))
+	ans := float64(n) * math.Pow(1.000000011, float64(t))
+	input := fmt.Sprintf("%d %d\n", n, t)
+	expected := fmt.Sprintf("%.6f", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierC.go
+++ b/0-999/600-699/630-639/630/verifierC.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(55) + 1)
+	ans := (int64(1) << (n + 1)) - 2
+	input := fmt.Sprintf("%d\n", n)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierD.go
+++ b/0-999/600-699/630-639/630/verifierD.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000 + 1)
+	ans := 1 + 3*n*(n+1)
+	input := fmt.Sprintf("%d\n", n)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierE.go
+++ b/0-999/600-699/630-639/630/verifierE.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(x1, y1, x2, y2 int64) int64 {
+	width := x2 - x1 + 1
+	height := y2 - y1 + 1
+	total := width * height
+	ans := total / 2
+	if total%2 == 1 {
+		if ((x1 ^ y1) & 1) == 0 {
+			ans++
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	w := int64(rng.Intn(1000))*2 + 2
+	h := int64(rng.Intn(1000)) + 1
+	x1 := int64(rng.Intn(2000)) - 1000
+	y1 := int64(rng.Intn(2000)) - 1000
+	x2 := x1 + w - 1
+	y2 := y1 + h - 1
+	ans := solve(x1, y1, x2, y2)
+	input := fmt.Sprintf("%d %d %d %d\n", x1, y1, x2, y2)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierF.go
+++ b/0-999/600-699/630-639/630/verifierF.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func comb(n, k int64) int64 {
+	if k < 0 || k > n {
+		return 0
+	}
+	if k > n-k {
+		k = n - k
+	}
+	res := int64(1)
+	for i := int64(1); i <= k; i++ {
+		res = res * (n - k + i) / i
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(771) + 7)
+	ans := comb(n, 5) + comb(n, 6) + comb(n, 7)
+	input := fmt.Sprintf("%d\n", n)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierG.go
+++ b/0-999/600-699/630-639/630/verifierG.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func comb(n, k int64) int64 {
+	if k < 0 || k > n {
+		return 0
+	}
+	if k > n-k {
+		k = n - k
+	}
+	res := int64(1)
+	for i := int64(1); i <= k; i++ {
+		res = res * (n - k + i) / i
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(500) + 1)
+	a := comb(n+4, 5)
+	b := comb(n+2, 3)
+	ans := a * b
+	input := fmt.Sprintf("%d\n", n)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierH.go
+++ b/0-999/600-699/630-639/630/verifierH.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func comb5(n int64) int64 {
+	return n * (n - 1) * (n - 2) * (n - 3) * (n - 4) / 120
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(96) + 5)
+	c := comb5(n)
+	ans := c * c * 120
+	input := fmt.Sprintf("%d\n", n)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierI.go
+++ b/0-999/600-699/630-639/630/verifierI.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func pow4(n int64) int64 {
+	res := int64(1)
+	for i := int64(0); i < n; i++ {
+		res *= 4
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(28) + 3)
+	ans := (9*n - 3) * pow4(n-3)
+	input := fmt.Sprintf("%d\n", n)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierJ.go
+++ b/0-999/600-699/630-639/630/verifierJ.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000_000_000_000) + 1
+	ans := n / 2520
+	input := fmt.Sprintf("%d\n", n)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierJ.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierK.go
+++ b/0-999/600-699/630-639/630/verifierK.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 2520
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+var prefix [mod + 1]int
+
+func init() {
+	for i := 1; i <= mod; i++ {
+		prefix[i] = prefix[i-1]
+		if gcd(i, mod) == 1 {
+			prefix[i]++
+		}
+	}
+}
+
+func solve(n int64) int64 {
+	blocks := n / mod
+	rem := int(n % mod)
+	return int64(prefix[mod])*blocks + int64(prefix[rem])
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000_000_000_000) + 1
+	ans := solve(n)
+	input := fmt.Sprintf("%d\n", n)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierK.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierL.go
+++ b/0-999/600-699/630-639/630/verifierL.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n int) string {
+	s := fmt.Sprintf("%05d", n)
+	rearr := []byte{s[0], s[2], s[4], s[3], s[1]}
+	var k int
+	fmt.Sscanf(string(rearr), "%d", &k)
+	res := 1
+	for i := 0; i < 5; i++ {
+		res = res * k % 100000
+	}
+	return fmt.Sprintf("%05d", res)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(90000) + 10000
+	ans := solve(n)
+	input := fmt.Sprintf("%d\n", n)
+	return input, ans
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierL.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierM.go
+++ b/0-999/600-699/630-639/630/verifierM.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(x int64) int64 {
+	bestK := int64(0)
+	bestDiff := int64(1<<62 - 1)
+	for k := int64(0); k < 4; k++ {
+		angle := -x + 90*k
+		mod := ((angle % 360) + 360) % 360
+		if mod > 180 {
+			mod -= 360
+		}
+		diff := int64(math.Abs(float64(mod)))
+		if diff < bestDiff {
+			bestDiff = diff
+			bestK = k
+		}
+	}
+	return bestK
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	x := int64(rng.Int63n(2_000_000_000_000_000_000) - 1_000_000_000_000_000_000)
+	ans := solve(x)
+	input := fmt.Sprintf("%d\n", x)
+	expected := fmt.Sprintf("%d", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierM.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierN.go
+++ b/0-999/600-699/630-639/630/verifierN.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(a, b, c int) (float64, float64) {
+	da := float64(b*b - 4*a*c)
+	d := math.Sqrt(da)
+	af := float64(a)
+	bf := float64(b)
+	x1 := (-bf + d) / (2 * af)
+	x2 := (-bf - d) / (2 * af)
+	if x1 < x2 {
+		x1, x2 = x2, x1
+	}
+	return x1, x2
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	var a, b, c int
+	for {
+		a = rng.Intn(2001) - 1000
+		if a != 0 {
+			break
+		}
+	}
+	for {
+		b = rng.Intn(2001) - 1000
+		c = rng.Intn(2001) - 1000
+		if float64(b*b-4*a*c) > 0 {
+			break
+		}
+	}
+	x1, x2 := solve(a, b, c)
+	input := fmt.Sprintf("%d %d %d\n", a, b, c)
+	expected := fmt.Sprintf("%.6f\n%.6f", x1, x2)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierN.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierO.go
+++ b/0-999/600-699/630-639/630/verifierO.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(px, py, vx, vy float64, a, b, c, d int) string {
+	t := math.Sqrt(vx*vx + vy*vy)
+	vx /= t
+	vy /= t
+	vx1 := vy
+	vy1 := -vx
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%.10f %.10f\n", px+vx*float64(b), py+vy*float64(b)))
+	sb.WriteString(fmt.Sprintf("%.10f %.10f\n", px-vx1*float64(a)/2, py-vy1*float64(a)/2))
+	sb.WriteString(fmt.Sprintf("%.10f %.10f\n", px-vx1*float64(c)/2, py-vy1*float64(c)/2))
+	sb.WriteString(fmt.Sprintf("%.10f %.10f\n", px-vx1*float64(c)/2-vx*float64(d), py-vy1*float64(c)/2-vy*float64(d)))
+	sb.WriteString(fmt.Sprintf("%.10f %.10f\n", px+vx1*float64(c)/2-vx*float64(d), py+vy1*float64(c)/2-vy*float64(d)))
+	sb.WriteString(fmt.Sprintf("%.10f %.10f\n", px+vx1*float64(c)/2, py+vy1*float64(c)/2))
+	sb.WriteString(fmt.Sprintf("%.10f %.10f", px+vx1*float64(a)/2, py+vy1*float64(a)/2))
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	px := rng.Float64()*2000 - 1000
+	py := rng.Float64()*2000 - 1000
+	vx := rng.Float64()*2000 - 1000
+	vy := rng.Float64()*2000 - 1000
+	if vx == 0 && vy == 0 {
+		vx = 1
+	}
+	a := rng.Intn(1000) + 1
+	c := rng.Intn(a-1) + 1
+	b := rng.Intn(1000) + 1
+	d := rng.Intn(1000) + 1
+	input := fmt.Sprintf("%.0f %.0f %.0f %.0f %d %d %d %d\n", px, py, vx, vy, a, b, c, d)
+	output := solve(px, py, vx, vy, a, b, c, d)
+	return input, output
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expected)
+	if got != exp {
+		return fmt.Errorf("expected\n%s\ngot\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierO.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierP.go
+++ b/0-999/600-699/630-639/630/verifierP.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var primes = []int{5, 7, 11, 13, 17, 19, 23, 29, 31}
+
+func solve(n int, r int) float64 {
+	nn := float64(n)
+	rr := float64(r)
+	angle := math.Pi / nn
+	angle2 := angle / 2
+	zj := angle
+	h := math.Sin(zj) * rr
+	d := math.Cos(zj) * rr
+	p := math.Pi/2 - zj - angle2
+	db := math.Tan(p) * h
+	s := (h*d - h*db) * nn
+	return s
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := primes[rng.Intn(len(primes))]
+	r := rng.Intn(1000) + 1
+	ans := solve(n, r)
+	input := fmt.Sprintf("%d %d\n", n, r)
+	expected := fmt.Sprintf("%.10f", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierP.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierQ.go
+++ b/0-999/600-699/630-639/630/verifierQ.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func pyramidVolume(side float64, k int) float64 {
+	r := side / 2 / math.Sin(math.Pi/float64(k))
+	h := math.Sqrt(side*side - r*r)
+	area := r * r * math.Sin(2*math.Pi/float64(k)) / 2 * float64(k)
+	return area * h / 3
+}
+
+func solve(l3, l4, l5 float64) float64 {
+	ret := pyramidVolume(l3, 3)
+	ret += pyramidVolume(l4, 4)
+	ret += pyramidVolume(l5, 5)
+	return ret
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	l3 := rng.Float64()*999 + 1
+	l4 := rng.Float64()*999 + 1
+	l5 := rng.Float64()*999 + 1
+	ans := solve(l3, l4, l5)
+	input := fmt.Sprintf("%.0f %.0f %.0f\n", l3, l4, l5)
+	expected := fmt.Sprintf("%.10f", ans)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierQ.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/630-639/630/verifierR.go
+++ b/0-999/600-699/630-639/630/verifierR.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n uint64) string {
+	if n%2 == 1 {
+		return "1"
+	}
+	return "2"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Uint64()%1_000_000_000_000_000_000 + 1
+	ans := solve(n)
+	input := fmt.Sprintf("%d\n", n)
+	return input, ans
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierR.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for all problems in contest 630
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go build verifierA.go` (and all other verifiers)

------
https://chatgpt.com/codex/tasks/task_e_688359e42010832486c5b13397d640d4