### PR TITLE
Add verification tools for contest 660

### DIFF
--- a/0-999/600-699/660-669/660/verifierA.go
+++ b/0-999/600-699/660-669/660/verifierA.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solveA(n int, arr []int) (int, []int) {
+	const maxP = 1000
+	isPrime := make([]bool, maxP+1)
+	for i := 2; i <= maxP; i++ {
+		isPrime[i] = true
+	}
+	for i := 2; i*i <= maxP; i++ {
+		if isPrime[i] {
+			for j := i * i; j <= maxP; j += i {
+				isPrime[j] = false
+			}
+		}
+	}
+	primes := make([]int, 0)
+	for i := 2; i <= maxP; i++ {
+		if isPrime[i] {
+			primes = append(primes, i)
+		}
+	}
+
+	b := make([]int, n)
+	ans := 0
+	for i := 0; i+1 < n; i++ {
+		if gcd(arr[i], arr[i+1]) != 1 {
+			for _, p := range primes {
+				if gcd(arr[i], p) == 1 && gcd(p, arr[i+1]) == 1 {
+					b[i] = p
+					break
+				}
+			}
+			ans++
+		}
+	}
+	res := make([]int, 0, n+ans)
+	for i := 0; i < n; i++ {
+		res = append(res, arr[i])
+		if i < n-1 && b[i] != 0 {
+			res = append(res, b[i])
+		}
+	}
+	return ans, res
+}
+
+func runBinary(binPath string, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(8) + 2
+		arr := make([]int, n)
+		for i := range arr {
+			arr[i] = rand.Intn(30) + 1
+		}
+		var sb strings.Builder
+		fmt.Fprintln(&sb, n)
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprint(&sb, v)
+		}
+		sb.WriteByte('\n')
+		ans, res := solveA(n, append([]int(nil), arr...))
+		var exp strings.Builder
+		fmt.Fprintln(&exp, ans)
+		for i, v := range res {
+			if i > 0 {
+				exp.WriteByte(' ')
+			}
+			fmt.Fprint(&exp, v)
+		}
+		exp.WriteByte('\n')
+		output, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(output)
+		want := strings.TrimSpace(exp.String())
+		if got != want {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", t+1, sb.String(), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/660-669/660/verifierB.go
+++ b/0-999/600-699/660-669/660/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveB(n, m int) []int {
+	res := make([]int, 0, m)
+	for i := 1; i <= n; i++ {
+		lNonWindow := 2*n + 2*(i-1) + 1
+		lWindow := 2*(i-1) + 1
+		rNonWindow := 2*n + 2*(i-1) + 2
+		rWindow := 2*(i-1) + 2
+		if lNonWindow <= m {
+			res = append(res, lNonWindow)
+		}
+		if lWindow <= m {
+			res = append(res, lWindow)
+		}
+		if rNonWindow <= m {
+			res = append(res, rNonWindow)
+		}
+		if rWindow <= m {
+			res = append(res, rWindow)
+		}
+	}
+	return res
+}
+
+func runBinary(binPath string, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(2)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(20) + 1
+		m := rand.Intn(4*n) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		expected := solveB(n, m)
+		var exp strings.Builder
+		for i, v := range expected {
+			if i > 0 {
+				exp.WriteByte(' ')
+			}
+			fmt.Fprint(&exp, v)
+		}
+		exp.WriteByte('\n')
+		output, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(output)
+		want := strings.TrimSpace(exp.String())
+		if got != want {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", t+1, sb.String(), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/660-669/660/verifierC.go
+++ b/0-999/600-699/660-669/660/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveC(n, k int, arr []int) (int, []int) {
+	l, zeroes := 0, 0
+	bestLen, bestL := 0, 0
+	for r := 0; r < n; r++ {
+		if arr[r] == 0 {
+			zeroes++
+		}
+		for zeroes > k {
+			if arr[l] == 0 {
+				zeroes--
+			}
+			l++
+		}
+		if r-l+1 > bestLen {
+			bestLen = r - l + 1
+			bestL = l
+		}
+	}
+	res := append([]int(nil), arr...)
+	for i := bestL; i < bestL+bestLen; i++ {
+		res[i] = 1
+	}
+	return bestLen, res
+}
+
+func runBinary(binPath string, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(n + 1)
+		arr := make([]int, n)
+		for i := range arr {
+			if rand.Intn(2) == 0 {
+				arr[i] = 0
+			} else {
+				arr[i] = 1
+			}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprint(&sb, v)
+		}
+		sb.WriteByte('\n')
+		best, res := solveC(n, k, arr)
+		var exp strings.Builder
+		fmt.Fprintln(&exp, best)
+		for i, v := range res {
+			if i > 0 {
+				exp.WriteByte(' ')
+			}
+			fmt.Fprint(&exp, v)
+		}
+		exp.WriteByte('\n')
+		output, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(output)
+		want := strings.TrimSpace(exp.String())
+		if got != want {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", t+1, sb.String(), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/660-669/660/verifierD.go
+++ b/0-999/600-699/660-669/660/verifierD.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type pair struct {
+	x int64
+	y int64
+}
+
+func solveD(n int, xs, ys []int64) int64 {
+	cnt := make(map[pair]int64)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			p := pair{xs[i] + xs[j], ys[i] + ys[j]}
+			cnt[p]++
+		}
+	}
+	var res int64
+	for _, v := range cnt {
+		res += v * (v - 1) / 2
+	}
+	return res
+}
+
+func runBinary(binPath string, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(4)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(10) + 2
+		xs := make([]int64, n)
+		ys := make([]int64, n)
+		for i := 0; i < n; i++ {
+			xs[i] = int64(rand.Intn(20))
+			ys[i] = int64(rand.Intn(20))
+		}
+		var sb strings.Builder
+		fmt.Fprintln(&sb, n)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", xs[i], ys[i])
+		}
+		expected := solveD(n, xs, ys)
+		var exp strings.Builder
+		fmt.Fprintln(&exp, expected)
+		output, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(output)
+		want := strings.TrimSpace(exp.String())
+		if got != want {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", t+1, sb.String(), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/660-669/660/verifierE.go
+++ b/0-999/600-699/660-669/660/verifierE.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod int64 = 1000000007
+
+func solveE(n, m int) int64 {
+	aPrev := int64(1)
+	dPrev := int64(1)
+	dPrevPrev := int64(0)
+	for i := 1; i <= n; i++ {
+		ai := (2*aPrev - dPrevPrev) % mod
+		if ai < 0 {
+			ai += mod
+		}
+		ai = ai * int64(m) % mod
+		di := (ai + int64(m-1)*dPrev%mod) % mod
+		dPrevPrev, dPrev, aPrev = dPrev, di, ai
+	}
+	return aPrev % mod
+}
+
+func runBinary(binPath string, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(20) + 1
+		m := rand.Intn(20) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		expected := solveE(n, m)
+		var exp strings.Builder
+		fmt.Fprintln(&exp, expected)
+		output, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(output)
+		want := strings.TrimSpace(exp.String())
+		if got != want {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", t+1, sb.String(), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/660-669/660/verifierF.go
+++ b/0-999/600-699/660-669/660/verifierF.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Line struct {
+	m int64
+	b int64
+}
+
+type Node struct {
+	ln    Line
+	left  *Node
+	right *Node
+}
+
+func eval(ln Line, x int64) int64 {
+	return ln.m*x + ln.b
+}
+
+func insert(node *Node, l, r int64, ln Line) *Node {
+	if node == nil {
+		return &Node{ln: ln}
+	}
+	mid := (l + r) >> 1
+	if eval(ln, mid) > eval(node.ln, mid) {
+		node.ln, ln = ln, node.ln
+	}
+	if l == r {
+		return node
+	}
+	if eval(ln, l) > eval(node.ln, l) {
+		node.left = insert(node.left, l, mid, ln)
+	} else if eval(ln, r) > eval(node.ln, r) {
+		node.right = insert(node.right, mid+1, r, ln)
+	}
+	return node
+}
+
+func query(node *Node, l, r, x int64) int64 {
+	if node == nil {
+		return math.MinInt64
+	}
+	res := eval(node.ln, x)
+	if l == r {
+		return res
+	}
+	mid := (l + r) >> 1
+	if x <= mid {
+		if v := query(node.left, l, mid, x); v > res {
+			res = v
+		}
+	} else {
+		if v := query(node.right, mid+1, r, x); v > res {
+			res = v
+		}
+	}
+	return res
+}
+
+type LiChao struct {
+	root *Node
+	l    int64
+	r    int64
+}
+
+func NewLiChao(l, r int64) *LiChao {
+	return &LiChao{l: l, r: r}
+}
+
+func (lc *LiChao) Insert(ln Line) {
+	lc.root = insert(lc.root, lc.l, lc.r, ln)
+}
+
+func (lc *LiChao) Query(x int64) int64 {
+	return query(lc.root, lc.l, lc.r, x)
+}
+
+func solveF(n int, a []int64) int64 {
+	S := make([]int64, n+1)
+	T := make([]int64, n+1)
+	minS, maxS := int64(0), int64(0)
+	for i := 1; i <= n; i++ {
+		S[i] = S[i-1] + a[i]
+		if S[i] < minS {
+			minS = S[i]
+		}
+		if S[i] > maxS {
+			maxS = S[i]
+		}
+		T[i] = T[i-1] + int64(i)*a[i]
+	}
+	lc := NewLiChao(minS, maxS)
+	lc.Insert(Line{m: 0, b: 0})
+	ans := int64(0)
+	for r := 1; r <= n; r++ {
+		val := lc.Query(S[r])
+		cand := T[r] + val
+		if cand > ans {
+			ans = cand
+		}
+		line := Line{m: -int64(r), b: int64(r)*S[r] - T[r]}
+		lc.Insert(line)
+	}
+	return ans
+}
+
+func runBinary(binPath string, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(6)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(15) + 1
+		a := make([]int64, n+1)
+		for i := 1; i <= n; i++ {
+			a[i] = int64(rand.Intn(10) - 5)
+		}
+		var sb strings.Builder
+		fmt.Fprintln(&sb, n)
+		for i := 1; i <= n; i++ {
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprint(&sb, a[i])
+		}
+		sb.WriteByte('\n')
+		expected := solveF(n, a)
+		var exp strings.Builder
+		fmt.Fprintln(&exp, expected)
+		output, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(output)
+		want := strings.TrimSpace(exp.String())
+		if got != want {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", t+1, sb.String(), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers `verifierA.go` through `verifierF.go` for contest 660
- each verifier generates 100 deterministic tests and checks a provided binary

## Testing
- `go run verifierA.go ../../../../660A_bin`
- `go run verifierB.go ../../../../660A_bin` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_68836a4f01c083249c924e0113bf2009