### PR TITLE
Add Go verifiers for Codeforces contest 627

### DIFF
--- a/0-999/600-699/620-629/627/verifierA.go
+++ b/0-999/600-699/620-629/627/verifierA.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expectedA(s, x int64) int64 {
+	if s < x || (s-x)%2 != 0 {
+		return 0
+	}
+	t := (s - x) / 2
+	if t&x != 0 {
+		return 0
+	}
+	cnt := 0
+	for tmp := x; tmp > 0; tmp >>= 1 {
+		if tmp&1 == 1 {
+			cnt++
+		}
+	}
+	res := int64(1) << cnt
+	if t == 0 {
+		res -= 2
+	}
+	return res
+}
+
+func runCase(exe string, s, x int64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(fmt.Sprintf("%d %d\n", s, x))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := fmt.Sprint(expectedA(s, x))
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		s := rng.Int63n(1_000_000_000) + 2
+		x := rng.Int63n(1_000_000_000)
+		if err := runCase(exe, s, x); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/627/verifierB.go
+++ b/0-999/600-699/620-629/627/verifierB.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type queryB struct {
+	t   int
+	d   int
+	val int
+}
+
+func solveB(n, k, a, b int, queries []queryB) []int64 {
+	cnt := make([]int, n+1)
+	var res []int64
+	for _, q := range queries {
+		if q.t == 1 {
+			d := q.d
+			add := q.val
+			cnt[d] += add
+		} else {
+			p := q.d
+			var before, after int64
+			for i := 1; i < p; i++ {
+				if cnt[i] < b {
+					before += int64(cnt[i])
+				} else {
+					before += int64(b)
+				}
+			}
+			for i := p + k; i <= n; i++ {
+				if cnt[i] < a {
+					after += int64(cnt[i])
+				} else {
+					after += int64(a)
+				}
+			}
+			res = append(res, before+after)
+		}
+	}
+	return res
+}
+
+func generateB(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	a := rng.Intn(5) + 2
+	b := rng.Intn(a-1) + 1
+	q := rng.Intn(20) + 1
+	queries := make([]queryB, q)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d %d\n", n, k, a, b, q)
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			d := rng.Intn(n) + 1
+			add := rng.Intn(5) + 1
+			queries[i] = queryB{1, d, add}
+			fmt.Fprintf(&sb, "1 %d %d\n", d, add)
+		} else {
+			p := rng.Intn(n) + 1
+			queries[i] = queryB{2, p, 0}
+			fmt.Fprintf(&sb, "2 %d\n", p)
+		}
+	}
+	expected := solveB(n, k, a, b, queries)
+	return sb.String(), expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(43))
+	for caseNum := 0; caseNum < 100; caseNum++ {
+		input, expected := generateB(rng)
+		cmd := exec.Command(exe)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("case %d runtime error: %v\n%s", caseNum+1, err, out.String())
+			return
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+		scanner.Split(bufio.ScanWords)
+		for i, exp := range expected {
+			if !scanner.Scan() {
+				fmt.Printf("case %d output ended early\ninput:\n%s", caseNum+1, input)
+				return
+			}
+			got := scanner.Text()
+			if got != fmt.Sprint(exp) {
+				fmt.Printf("case %d query %d expected %d got %s\ninput:\n%s", caseNum+1, i+1, exp, got, input)
+				return
+			}
+		}
+		if scanner.Scan() {
+			fmt.Printf("case %d extra output\n", caseNum+1)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/627/verifierC.go
+++ b/0-999/600-699/620-629/627/verifierC.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type station struct {
+	x int
+	p int
+}
+
+func expectedC(d, n int, stations []station) int64 {
+	st := make([]station, 0, len(stations)+2)
+	st = append(st, station{0, 0})
+	st = append(st, stations...)
+	st = append(st, station{d, 0})
+	sort.Slice(st, func(i, j int) bool { return st[i].x < st[j].x })
+	for i := 0; i < len(st)-1; i++ {
+		if st[i+1].x-st[i].x > n {
+			return -1
+		}
+	}
+	next := make([]int, len(st))
+	stack := []int{}
+	for i := len(st) - 1; i >= 0; i-- {
+		for len(stack) > 0 && st[stack[len(stack)-1]].p >= st[i].p {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == 0 {
+			next[i] = -1
+		} else {
+			next[i] = stack[len(stack)-1]
+		}
+		stack = append(stack, i)
+	}
+	fuel := n
+	var cost int64
+	for i := 0; i < len(st)-1; i++ {
+		dist := st[i+1].x - st[i].x
+		target := n
+		if j := next[i]; j != -1 {
+			if st[j].x-st[i].x <= n {
+				target = st[j].x - st[i].x
+			}
+		}
+		if target < dist {
+			target = dist
+		}
+		if fuel < target {
+			add := target - fuel
+			cost += int64(add * st[i].p)
+			fuel += add
+		}
+		fuel -= dist
+	}
+	return cost
+}
+
+func generateC(rng *rand.Rand) (string, int64) {
+	d := rng.Intn(100) + 1
+	n := rng.Intn(d) + 1
+	m := rng.Intn(5) + 1
+	st := make([]station, m)
+	posSet := map[int]bool{}
+	for i := 0; i < m; i++ {
+		for {
+			x := rng.Intn(d-1) + 1
+			if !posSet[x] {
+				posSet[x] = true
+				st[i] = station{x, rng.Intn(10) + 1}
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", d, n, m)
+	for _, s := range st {
+		fmt.Fprintf(&sb, "%d %d\n", s.x, s.p)
+	}
+	cost := expectedC(d, n, st)
+	return sb.String(), cost
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(44))
+	for i := 0; i < 100; i++ {
+		input, exp := generateC(rng)
+		cmd := exec.Command(exe)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("case %d runtime error: %v\n%s", i+1, err, out.String())
+			return
+		}
+		got := strings.TrimSpace(out.String())
+		if got != fmt.Sprint(exp) {
+			fmt.Printf("case %d failed: expected %d got %s\ninput:\n%s", i+1, exp, got, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/627/verifierD.go
+++ b/0-999/600-699/620-629/627/verifierD.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func checkD(n int, k int, a []int, edges [][2]int, th int) bool {
+	g := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	vis := make([]bool, n)
+	stack := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		if !vis[i] && a[i] >= th {
+			size := 0
+			stack = append(stack[:0], i)
+			vis[i] = true
+			for len(stack) > 0 {
+				v := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				size++
+				for _, to := range g[v] {
+					if !vis[to] && a[to] >= th {
+						vis[to] = true
+						stack = append(stack, to)
+					}
+				}
+			}
+			if size >= k {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func expectedD(n, k int, a []int, edges [][2]int) int {
+	maxA := 0
+	for _, v := range a {
+		if v > maxA {
+			maxA = v
+		}
+	}
+	low, high := 1, maxA
+	for low < high {
+		mid := (low + high + 1) / 2
+		if checkD(n, k, a, edges, mid) {
+			low = mid
+		} else {
+			high = mid - 1
+		}
+	}
+	return low
+}
+
+func generateD(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(20) + 1
+	}
+	edges := make([][2]int, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges[i-1] = [2]int{i, p}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0]+1, e[1]+1)
+	}
+	exp := expectedD(n, k, a, edges)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(45))
+	for i := 0; i < 100; i++ {
+		input, exp := generateD(rng)
+		cmd := exec.Command(exe)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("case %d runtime error: %v\n%s", i+1, err, out.String())
+			return
+		}
+		got := strings.TrimSpace(out.String())
+		if got != fmt.Sprint(exp) {
+			fmt.Printf("case %d failed: expected %d got %s\ninput:\n%s", i+1, exp, got, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/627/verifierE.go
+++ b/0-999/600-699/620-629/627/verifierE.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func countAtLeastK(arr []int, k int) int64 {
+	left := 0
+	sum := 0
+	var res int64
+	for right := 0; right < len(arr); right++ {
+		sum += arr[right]
+		for sum >= k {
+			sum -= arr[left]
+			left++
+		}
+		res += int64(left)
+	}
+	return res
+}
+
+func expectedE(r, c, k int, points [][2]int) int64 {
+	grid := make([][]byte, r)
+	for i := range grid {
+		grid[i] = make([]byte, c)
+	}
+	for _, p := range points {
+		grid[p[0]][p[1]] = 1
+	}
+	if r > c {
+		ng := make([][]byte, c)
+		for i := 0; i < c; i++ {
+			ng[i] = make([]byte, r)
+			for j := 0; j < r; j++ {
+				ng[i][j] = grid[j][i]
+			}
+		}
+		grid = ng
+		r, c = c, r
+	}
+	col := make([]int, c)
+	var ans int64
+	for top := 0; top < r; top++ {
+		for j := 0; j < c; j++ {
+			col[j] = 0
+		}
+		for bottom := top; bottom < r; bottom++ {
+			for j := 0; j < c; j++ {
+				if grid[bottom][j] == 1 {
+					col[j]++
+				}
+			}
+			ans += countAtLeastK(col, k)
+		}
+	}
+	return ans
+}
+
+func generateE(rng *rand.Rand) (string, int64) {
+	r := rng.Intn(5) + 1
+	c := rng.Intn(5) + 1
+	n := rng.Intn(r*c) + 1
+	k := rng.Intn(n) + 1
+	used := map[[2]int]bool{}
+	points := make([][2]int, 0, n)
+	for len(points) < n {
+		x := rng.Intn(r)
+		y := rng.Intn(c)
+		p := [2]int{x, y}
+		if !used[p] {
+			used[p] = true
+			points = append(points, p)
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", r, c, n, k)
+	for _, p := range points {
+		fmt.Fprintf(&sb, "%d %d\n", p[0]+1, p[1]+1)
+	}
+	exp := expectedE(r, c, k, points)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(46))
+	for i := 0; i < 100; i++ {
+		input, exp := generateE(rng)
+		cmd := exec.Command(exe)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("case %d runtime error: %v\n%s", i+1, err, out.String())
+			return
+		}
+		got := strings.TrimSpace(out.String())
+		if got != fmt.Sprint(exp) {
+			fmt.Printf("case %d failed: expected %d got %s\ninput:\n%s", i+1, exp, got, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/627/verifierF.go
+++ b/0-999/600-699/620-629/627/verifierF.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type edge struct{ u, v int }
+
+func bfs(adj [][]int, start, goal []int) int {
+	n := len(start)
+	encode := func(arr []int) string {
+		b := make([]byte, n)
+		for i, v := range arr {
+			b[i] = byte(v)
+		}
+		return string(b)
+	}
+	startKey := encode(start)
+	goalKey := encode(goal)
+	if startKey == goalKey {
+		return 0
+	}
+	q := []string{startKey}
+	dist := map[string]int{startKey: 0}
+	states := map[string][]int{startKey: append([]int(nil), start...)}
+	for len(q) > 0 {
+		curKey := q[0]
+		q = q[1:]
+		arr := states[curKey]
+		var zero int
+		for i, v := range arr {
+			if v == 0 {
+				zero = i
+				break
+			}
+		}
+		for _, nb := range adj[zero] {
+			next := make([]int, n)
+			copy(next, arr)
+			next[zero], next[nb] = next[nb], next[zero]
+			key := encode(next)
+			if _, ok := dist[key]; !ok {
+				dist[key] = dist[curKey] + 1
+				if key == goalKey {
+					return dist[key]
+				}
+				states[key] = next
+				q = append(q, key)
+			}
+		}
+	}
+	return -1
+}
+
+func solveF(n int, a, b []int, edges []edge) (int, int, int) {
+	adj := make([][]int, n)
+	exist := make(map[[2]int]bool)
+	for _, e := range edges {
+		u, v := e.u-1, e.v-1
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+		if u < v {
+			exist[[2]int{u, v}] = true
+		} else {
+			exist[[2]int{v, u}] = true
+		}
+	}
+	st := make([]int, n)
+	copy(st, a)
+	goal := make([]int, n)
+	copy(goal, b)
+	t0 := bfs(adj, st, goal)
+	if t0 != -1 {
+		return 0, 0, t0
+	}
+	bestT := -1
+	bestU, bestV := 0, 0
+	for u := 0; u < n; u++ {
+		for v := u + 1; v < n; v++ {
+			key := [2]int{u, v}
+			if exist[key] {
+				continue
+			}
+			adj[u] = append(adj[u], v)
+			adj[v] = append(adj[v], u)
+			t := bfs(adj, st, goal)
+			if t != -1 && (bestT == -1 || t < bestT) {
+				bestT = t
+				bestU = u + 1
+				bestV = v + 1
+			}
+			adj[u] = adj[u][:len(adj[u])-1]
+			adj[v] = adj[v][:len(adj[v])-1]
+		}
+	}
+	if bestT == -1 {
+		return -1, 0, 0
+	}
+	return bestU, bestV, bestT
+}
+
+func generateF(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 3
+	a := rand.Perm(n)
+	b := rand.Perm(n)
+	edges := make([]edge, n-1)
+	for i := 1; i < n; i++ {
+		v := rng.Intn(i)
+		edges[i-1] = edge{i + 1, v + 1}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range a {
+		if v == n-1 {
+			v = 0
+		} else {
+			v = v + 1
+		}
+		a[i] = v
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if v == n-1 {
+			v = 0
+		} else {
+			v = v + 1
+		}
+		b[i] = v
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+	}
+	u, v, t := solveF(n, a, b, edges)
+	if u == -1 {
+		return sb.String(), "-1"
+	}
+	if u == 0 {
+		return sb.String(), fmt.Sprintf("0 %d", t)
+	}
+	if u > v {
+		u, v = v, u
+	}
+	return sb.String(), fmt.Sprintf("%d %d %d", u, v, t)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(47))
+	for i := 0; i < 100; i++ {
+		input, exp := generateF(rng)
+		cmd := exec.Command(exe)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("case %d runtime error: %v\n%s", i+1, err, out.String())
+			return
+		}
+		got := strings.TrimSpace(out.String())
+		if got != exp {
+			fmt.Printf("case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add automated solution verifiers for problems A–F of contest 627
- each verifier generates 100 random tests and checks any executable

## Testing
- `go run 0-999/600-699/620-629/627/verifierA.go ./627A_bin`
- `go run 0-999/600-699/620-629/627/verifierB.go ./627B_bin`
- `go run 0-999/600-699/620-629/627/verifierF.go ./627F_bin` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_6883583fa7c88324ba9b66688f77b878