### PR TITLE
Add Go verifiers for contest 625

### DIFF
--- a/0-999/600-699/620-629/625/verifierA.go
+++ b/0-999/600-699/620-629/625/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testA struct {
+	n, a, b, c int64
+}
+
+func solveA(n, a, b, c int64) int64 {
+	var ans int64
+	if n >= b && b-c <= a {
+		k := (n-b)/(b-c) + 1
+		ans += k
+		n -= k * (b - c)
+	}
+	ans += n / a
+	return ans
+}
+
+func genTests() []testA {
+	rand.Seed(1)
+	tests := make([]testA, 100)
+	for i := range tests {
+		n := rand.Int63n(1e12) + 1
+		a := rand.Int63n(1e12) + 1
+		b := rand.Int63n(1e12) + 1
+		if b == 1 {
+			b = 2
+		}
+		c := rand.Int63n(b-1) + 1
+		tests[i] = testA{n: n, a: a, b: b, c: c}
+	}
+	// add some edge cases
+	tests = append(tests, testA{n: 1, a: 1, b: 2, c: 1})
+	tests = append(tests, testA{n: 100, a: 5, b: 10, c: 1})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n%d\n%d\n%d\n", t.n, t.a, t.b, t.c)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expected := fmt.Sprintf("%d", solveA(t.n, t.a, t.b, t.c))
+		got := strings.TrimSpace(out.String())
+		if got != expected {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected: %s\nGot: %s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+		if i%10 == 0 {
+			time.Sleep(10 * time.Millisecond) // small delay to avoid runaway
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/600-699/620-629/625/verifierB.go
+++ b/0-999/600-699/620-629/625/verifierB.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveB(s, t string) int {
+	m := len(t)
+	pi := make([]int, m)
+	for i := 1; i < m; i++ {
+		j := pi[i-1]
+		for j > 0 && t[i] != t[j] {
+			j = pi[j-1]
+		}
+		if t[i] == t[j] {
+			j++
+		}
+		pi[i] = j
+	}
+	goTo := make([][26]int, m+1)
+	for k := 0; k <= m; k++ {
+		for c := 0; c < 26; c++ {
+			if k < m && byte('a'+c) == t[k] {
+				goTo[k][c] = k + 1
+			} else if k == 0 {
+				goTo[k][c] = 0
+			} else {
+				goTo[k][c] = goTo[pi[k-1]][c]
+			}
+		}
+	}
+	const inf = int(1e9)
+	dp := make([]int, m)
+	for i := range dp {
+		dp[i] = inf
+	}
+	dp[0] = 0
+	for i := 0; i < len(s); i++ {
+		c := s[i] - 'a'
+		ndp := make([]int, m)
+		for j := range ndp {
+			ndp[j] = inf
+		}
+		for k := 0; k < m; k++ {
+			if dp[k] == inf {
+				continue
+			}
+			if dp[k]+1 < ndp[0] {
+				ndp[0] = dp[k] + 1
+			}
+			next := goTo[k][c]
+			if next < m && dp[k] < ndp[next] {
+				ndp[next] = dp[k]
+			}
+		}
+		dp = ndp
+	}
+	ans := inf
+	for _, v := range dp {
+		if v < ans {
+			ans = v
+		}
+	}
+	return ans
+}
+
+type testB struct {
+	s, t string
+}
+
+func genTests() []testB {
+	rand.Seed(2)
+	tests := make([]testB, 100)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		m := rand.Intn(6) + 1
+		sb := make([]rune, n)
+		for j := range sb {
+			sb[j] = letters[rand.Intn(len(letters))]
+		}
+		tb := make([]rune, m)
+		for j := range tb {
+			tb[j] = letters[rand.Intn(len(letters))]
+		}
+		tests[i] = testB{s: string(sb), t: string(tb)}
+	}
+	// add edge case
+	tests = append(tests, testB{s: "aaa", t: "a"})
+	tests = append(tests, testB{s: "abcdef", t: "gh"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%s\n%s\n", t.s, t.t)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expected := fmt.Sprintf("%d", solveB(t.s, t.t))
+		got := strings.TrimSpace(out.String())
+		if got != expected {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected: %s\nGot: %s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/600-699/620-629/625/verifierC.go
+++ b/0-999/600-699/620-629/625/verifierC.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testC struct {
+	n, k int
+}
+
+func solveC(n, k int) (int, [][]int) {
+	ans := make([][]int, n)
+	for i := range ans {
+		ans[i] = make([]int, n)
+	}
+	times := 0
+	sum := 0
+	for c := 0; c < k-1; c++ {
+		for r := 0; r < n; r++ {
+			times++
+			ans[r][c] = times
+		}
+	}
+	for r := 0; r < n; r++ {
+		for c := k - 1; c < n; c++ {
+			times++
+			ans[r][c] = times
+			if c == k-1 {
+				sum += times
+			}
+		}
+	}
+	return sum, ans
+}
+
+func genTests() []testC {
+	rand.Seed(3)
+	tests := make([]testC, 100)
+	for i := range tests {
+		n := rand.Intn(8) + 1
+		k := rand.Intn(n) + 1
+		tests[i] = testC{n: n, k: k}
+	}
+	tests = append(tests, testC{n: 1, k: 1})
+	tests = append(tests, testC{n: 4, k: 2})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.n, t.k)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		sumExp, matExp := solveC(t.n, t.k)
+		reader := bufio.NewReader(bytes.NewReader(out.Bytes()))
+		var sumOut int
+		if _, err := fmt.Fscan(reader, &sumOut); err != nil {
+			fmt.Printf("Test %d failed to read sum: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if sumOut != sumExp {
+			fmt.Printf("Test %d sum mismatch\nInput:%sExpected %d got %d\n", i+1, input, sumExp, sumOut)
+			os.Exit(1)
+		}
+		for r := 0; r < t.n; r++ {
+			for c := 0; c < t.n; c++ {
+				var v int
+				if _, err := fmt.Fscan(reader, &v); err != nil {
+					fmt.Printf("Test %d failed reading matrix\n", i+1)
+					os.Exit(1)
+				}
+				if v != matExp[r][c] {
+					fmt.Printf("Test %d matrix mismatch at (%d,%d)\n", i+1, r, c)
+					os.Exit(1)
+				}
+			}
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/600-699/620-629/625/verifierD.go
+++ b/0-999/600-699/620-629/625/verifierD.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testD struct {
+	s string
+}
+
+func check(sum []int) (bool, string) {
+	n := len(sum)
+	ans := make([]byte, n)
+	i := 0
+	for i < n/2 {
+		if sum[i] == sum[n-1-i] {
+			i++
+		} else if sum[i] == sum[n-1-i]+1 || sum[i] == sum[n-1-i]+11 {
+			sum[i]--
+			sum[i+1] += 10
+		} else if sum[i] == sum[n-1-i]+10 {
+			sum[n-2-i]--
+			sum[n-1-i] += 10
+		} else {
+			return false, ""
+		}
+	}
+	if n%2 == 1 {
+		mid := n / 2
+		if sum[mid]%2 != 0 || sum[mid] > 18 || sum[mid] < 0 {
+			return false, ""
+		}
+		ans[mid] = byte(sum[mid]/2) + '0'
+	}
+	for j := 0; j < n/2; j++ {
+		if sum[j] > 18 || sum[j] < 0 {
+			return false, ""
+		}
+		ans[j] = byte((sum[j]+1)/2) + '0'
+		ans[n-1-j] = byte(sum[j]/2) + '0'
+	}
+	if ans[0] <= '0' {
+		return false, ""
+	}
+	return true, string(ans)
+}
+
+func solveD(s string) string {
+	n := len(s)
+	sum := make([]int, n)
+	for i := 0; i < n; i++ {
+		sum[i] = int(s[i] - '0')
+	}
+	if ok, res := check(append([]int{}, sum...)); ok {
+		return res
+	}
+	if n > 1 && s[0] == '1' {
+		n1 := n - 1
+		sum1 := make([]int, n1)
+		for i := 0; i < n1; i++ {
+			sum1[i] = int(s[i+1] - '0')
+		}
+		sum1[0] += 10
+		if ok, res := check(sum1); ok {
+			return res
+		}
+	}
+	return "0"
+}
+
+func genTests() []testD {
+	rand.Seed(4)
+	tests := make([]testD, 100)
+	for i := range tests {
+		l := rand.Intn(20) + 1
+		b := make([]byte, l)
+		for j := range b {
+			if j == 0 {
+				b[j] = byte(rand.Intn(9)+1) + '0'
+			} else {
+				b[j] = byte(rand.Intn(10)) + '0'
+			}
+		}
+		tests[i] = testD{s: string(b)}
+	}
+	tests = append(tests, testD{s: "4"})
+	tests = append(tests, testD{s: "11"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%s\n", t.s)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expected := solveD(t.s)
+		got := strings.TrimSpace(out.String())
+		if got != expected {
+			fmt.Printf("Test %d failed\nInput:%sExpected %s Got %s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/600-699/620-629/625/verifierE.go
+++ b/0-999/600-699/620-629/625/verifierE.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// Node holds position and jump power
+type Node struct {
+	p, z, n int
+}
+
+type Item struct {
+	idx  int
+	z    int
+	orig int
+}
+
+type PriorityQueue []Item
+
+func (pq PriorityQueue) Len() int { return len(pq) }
+func (pq PriorityQueue) Less(i, j int) bool {
+	if pq[i].z != pq[j].z {
+		return pq[i].z < pq[j].z
+	}
+	return pq[i].orig < pq[j].orig
+}
+func (pq PriorityQueue) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PriorityQueue) Push(x interface{}) { *pq = append(*pq, x.(Item)) }
+func (pq *PriorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	*pq = old[0 : n-1]
+	return item
+}
+
+func Find(x, k int, a []Node, add []int64, m int64) int {
+	if x == k {
+		return 0
+	}
+	l := int64(a[k].p - a[x].p)
+	if l <= 0 {
+		l += m
+	}
+	l += add[k] - add[x]
+	t := int64(0)
+	if a[x].n < a[k].n {
+		l -= int64(a[x].z)
+		t = 1
+	}
+	if l <= 0 && add[x] == 0 && add[k] == 0 {
+		return 1
+	}
+	if a[k].z < a[x].z {
+		d := int64(a[x].z - a[k].z)
+		return int((l-1)/d + t + 1)
+	}
+	return 0
+}
+
+func solveE(n int, m int64, frogs []Node) []int {
+	a := make([]Node, n)
+	copy(a, frogs)
+	sort.Slice(a, func(i, j int) bool { return a[i].p < a[j].p })
+	pl := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		pl[a[i].n] = i
+	}
+	nex := make([]int, n)
+	pre := make([]int, n)
+	c := make([]bool, n)
+	add := make([]int64, n)
+	w := make([]int, n)
+	for i := 0; i < n; i++ {
+		c[i] = true
+	}
+	pq := &PriorityQueue{}
+	heap.Init(pq)
+	for j := 1; j <= n; j++ {
+		i := pl[j]
+		k := (i + 1) % n
+		nex[i] = k
+		pre[k] = i
+		z := Find(i, k, a, add, m)
+		if z > 0 {
+			w[i] = z
+			heap.Push(pq, Item{idx: i, z: z, orig: a[i].n})
+		}
+	}
+	for pq.Len() > 0 {
+		item := heap.Pop(pq).(Item)
+		x, z := item.idx, item.z
+		if !c[x] || w[x] != z {
+			continue
+		}
+		c[nex[x]] = false
+		nex[x] = nex[nex[x]]
+		num := 1
+		for {
+			vl := Find(x, nex[x], a, add, m)
+			if vl == z {
+				c[nex[x]] = false
+				nex[x] = nex[nex[x]]
+				num++
+			} else {
+				break
+			}
+		}
+		a[x].z -= num
+		if a[x].z < 0 {
+			a[x].z = 0
+		}
+		pre[nex[x]] = x
+		add[x] += int64(num) * int64(z)
+		z2 := Find(x, nex[x], a, add, m)
+		if z2 > 0 {
+			w[x] = z2
+			heap.Push(pq, Item{idx: x, z: z2, orig: a[x].n})
+		} else {
+			w[x] = 0
+		}
+		px := pre[x]
+		z3 := Find(px, x, a, add, m)
+		if z3 > 0 {
+			w[px] = z3
+			heap.Push(pq, Item{idx: px, z: z3, orig: a[px].n})
+		} else {
+			w[px] = 0
+		}
+	}
+	ans := []int{}
+	for i := 0; i < n; i++ {
+		if c[i] {
+			ans = append(ans, a[i].n)
+		}
+	}
+	sort.Ints(ans)
+	return ans
+}
+
+type testE struct {
+	n     int
+	m     int64
+	frogs []Node
+}
+
+func genTests() []testE {
+	rand.Seed(5)
+	tests := make([]testE, 100)
+	for i := range tests {
+		n := rand.Intn(5) + 1
+		m := int64(rand.Intn(50) + n)
+		perm := rand.Perm(int(m))
+		frogs := make([]Node, n)
+		for j := 0; j < n; j++ {
+			frogs[j].p = perm[j]%int(m) + 1
+			frogs[j].z = rand.Intn(5) + 1
+			frogs[j].n = j + 1
+		}
+		tests[i] = testE{n: n, m: m, frogs: frogs}
+	}
+	// simple small test
+	tests = append(tests, testE{n: 1, m: 5, frogs: []Node{{p: 3, z: 2, n: 1}}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		var b strings.Builder
+		b.WriteString(fmt.Sprintf("%d %d\n", t.n, t.m))
+		for j := 0; j < t.n; j++ {
+			b.WriteString(fmt.Sprintf("%d %d\n", t.frogs[j].p, t.frogs[j].z))
+		}
+		input := b.String()
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expected := solveE(t.n, t.m, t.frogs)
+		reader := strings.Fields(strings.TrimSpace(out.String()))
+		if len(reader) < 1 {
+			fmt.Printf("Test %d no output\n", i+1)
+			os.Exit(1)
+		}
+		var cntOut int
+		fmt.Sscanf(reader[0], "%d", &cntOut)
+		if cntOut != len(expected) {
+			fmt.Printf("Test %d count mismatch expected %d got %d\n", i+1, len(expected), cntOut)
+			os.Exit(1)
+		}
+		if len(reader)-1 < cntOut {
+			fmt.Printf("Test %d insufficient numbers\n", i+1)
+			os.Exit(1)
+		}
+		for j := 0; j < cntOut; j++ {
+			var val int
+			fmt.Sscanf(reader[1+j], "%d", &val)
+			if val != expected[j] {
+				fmt.Printf("Test %d wrong answer expected %v got %v\n", i+1, expected, reader[1:1+cntOut])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 625 problems A–E
- each verifier generates 100+ random tests and checks a supplied binary

## Testing
- `go run verifierA.go ./625A`
- `go run verifierB.go ./625B`
- `go run verifierC.go ./625C`
- `go run verifierD.go ./625D`
- `go run verifierE.go ./625E`

------
https://chatgpt.com/codex/tasks/task_e_688357277b988324a105cf3b2647d191