### PR TITLE
Add Go verifiers for contest 624

### DIFF
--- a/0-999/600-699/620-629/624/verifierA.go
+++ b/0-999/600-699/620-629/624/verifierA.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(d, L, v1, v2 int) float64 {
+	return float64(L-d) / float64(v1+v2)
+}
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	d := rng.Intn(9999) + 1
+	L := d + rng.Intn(10000-d) + 1
+	v1 := rng.Intn(10000) + 1
+	v2 := rng.Intn(10000) + 1
+	input := fmt.Sprintf("%d %d %d %d\n", d, L, v1, v2)
+	return input, expected(d, L, v1, v2)
+}
+
+func runCase(bin, input string, exp float64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Sscan(out.String(), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	diff := math.Abs(got - exp)
+	if diff > 1e-6*math.Max(1, math.Abs(exp)) {
+		return fmt.Errorf("expected %.10f got %.10f", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/620-629/624/verifierB.go
+++ b/0-999/600-699/620-629/624/verifierB.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(a []int64) int64 {
+	sort.Slice(a, func(i, j int) bool { return a[i] > a[j] })
+	last := int64(1 << 60)
+	var res int64
+	for _, v := range a {
+		if last == 0 {
+			break
+		}
+		if v >= last {
+			v = last - 1
+		}
+		if v < 0 {
+			v = 0
+		}
+		res += v
+		last = v
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(25) + 2
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Int63n(1_000_000_000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(a)
+}
+
+func runCase(bin, input string, exp int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verification utilities for contest 624 problems A and B
- support running both compiled binaries and `.go` sources
- each verifier runs 100 random test cases

## Testing
- `go run 0-999/600-699/620-629/624/verifierA.go /tmp/624A_bin`
- `go run 0-999/600-699/620-629/624/verifierB.go /tmp/624B_bin`

------
https://chatgpt.com/codex/tasks/task_e_6883569b65288324b72567bd1f116199