### PR TITLE
Add Go verifiers for contest 662

### DIFF
--- a/0-999/600-699/660-669/662/verifierA.go
+++ b/0-999/600-699/660-669/662/verifierA.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n int
+	a []uint64
+	b []uint64
+}
+
+func solveA(tc testCaseA) string {
+	base := uint64(0)
+	diffs := make([]uint64, tc.n)
+	for i := 0; i < tc.n; i++ {
+		base ^= tc.a[i]
+		diffs[i] = tc.a[i] ^ tc.b[i]
+	}
+	var basis [64]uint64
+	rank := 0
+	for _, d := range diffs {
+		x := d
+		for j := 63; j >= 0; j-- {
+			if (x>>uint(j))&1 == 0 {
+				continue
+			}
+			if basis[j] == 0 {
+				basis[j] = x
+				rank++
+				break
+			}
+			x ^= basis[j]
+		}
+	}
+	inSpan := func(v uint64) bool {
+		x := v
+		for j := 63; j >= 0; j-- {
+			if (x>>uint(j))&1 == 0 {
+				continue
+			}
+			if basis[j] == 0 {
+				return false
+			}
+			x ^= basis[j]
+		}
+		return true
+	}(base)
+	if !inSpan {
+		return "1/1"
+	}
+	denom := uint64(1) << uint(rank)
+	numer := denom - 1
+	return fmt.Sprintf("%d/%d", numer, denom)
+}
+
+func runCaseA(bin string, tc testCaseA) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i := 0; i < tc.n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.a[i], tc.b[i]))
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveA(tc)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func genCaseA(rng *rand.Rand) testCaseA {
+	n := rng.Intn(10) + 1
+	a := make([]uint64, n)
+	b := make([]uint64, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Uint64() % 1000
+		b[i] = rng.Uint64() % 1000
+	}
+	return testCaseA{n, a, b}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseA(rng)
+		if err := runCaseA(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/660-669/662/verifierB.go
+++ b/0-999/600-699/660-669/662/verifierB.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	u, v  int
+	color byte
+}
+
+type testCaseB struct {
+	n     int
+	edges []edge
+}
+
+func solveB(tc testCaseB) (int, []int) {
+	n := tc.n
+	G := make([][]edge, n+1)
+	for _, e := range tc.edges {
+		G[e.u] = append(G[e.u], edge{e.v, 0, e.color})
+		G[e.v] = append(G[e.v], edge{e.u, 0, e.color})
+	}
+	const INF = int(1e9)
+	resR, resB := 0, 0
+	wrongR, wrongB := false, false
+	Rcol := make([]int, n+1)
+	Bcol := make([]int, n+1)
+	visR := make([]bool, n+1)
+	visB := make([]bool, n+1)
+	var resultR, resultB []int
+	// R-coloring
+	for i := 1; i <= n; i++ {
+		if !visR[i] {
+			queue := []int{i}
+			visR[i] = true
+			Rcol[i] = 0
+			comp := []int{i}
+			for qi := 0; qi < len(queue); qi++ {
+				v := queue[qi]
+				for _, e := range G[v] {
+					if !visR[e.u] {
+						if e.color == 'R' {
+							Rcol[e.u] = Rcol[v]
+						} else {
+							Rcol[e.u] = Rcol[v] ^ 1
+						}
+						visR[e.u] = true
+						queue = append(queue, e.u)
+						comp = append(comp, e.u)
+					}
+				}
+			}
+			var part0, part1 []int
+			for _, v := range comp {
+				if Rcol[v] == 0 {
+					part0 = append(part0, v)
+				} else {
+					part1 = append(part1, v)
+				}
+			}
+			if len(part0) < len(part1) {
+				resultR = append(resultR, part0...)
+				resR += len(part0)
+			} else {
+				resultR = append(resultR, part1...)
+				resR += len(part1)
+			}
+		}
+	}
+	// B-coloring
+	for i := 1; i <= n; i++ {
+		if !visB[i] {
+			queue := []int{i}
+			visB[i] = true
+			Bcol[i] = 0
+			comp := []int{i}
+			for qi := 0; qi < len(queue); qi++ {
+				v := queue[qi]
+				for _, e := range G[v] {
+					if !visB[e.u] {
+						if e.color == 'B' {
+							Bcol[e.u] = Bcol[v]
+						} else {
+							Bcol[e.u] = Bcol[v] ^ 1
+						}
+						visB[e.u] = true
+						queue = append(queue, e.u)
+						comp = append(comp, e.u)
+					}
+				}
+			}
+			var part0, part1 []int
+			for _, v := range comp {
+				if Bcol[v] == 0 {
+					part0 = append(part0, v)
+				} else {
+					part1 = append(part1, v)
+				}
+			}
+			if len(part0) < len(part1) {
+				resultB = append(resultB, part0...)
+				resB += len(part0)
+			} else {
+				resultB = append(resultB, part1...)
+				resB += len(part1)
+			}
+		}
+	}
+	for u := 1; u <= n; u++ {
+		for _, e := range G[u] {
+			v := e.u
+			if e.color == 'R' && Rcol[u] != Rcol[v] {
+				wrongR = true
+			}
+			if e.color == 'B' && Rcol[u] == Rcol[v] {
+				wrongR = true
+			}
+			if e.color == 'B' && Bcol[u] != Bcol[v] {
+				wrongB = true
+			}
+			if e.color == 'R' && Bcol[u] == Bcol[v] {
+				wrongB = true
+			}
+		}
+	}
+	if wrongR && wrongB {
+		return -1, nil
+	}
+	if wrongB {
+		resB = INF
+	}
+	if wrongR {
+		resR = INF
+	}
+	if resR < resB {
+		return resR, resultR
+	}
+	return resB, resultB
+}
+
+func applyMoves(tc testCaseB, moves []int) []edge {
+	// copy edges
+	edges := make([]edge, len(tc.edges))
+	copy(edges, tc.edges)
+	for _, v := range moves {
+		for i := range edges {
+			if edges[i].u == v || edges[i].v == v {
+				if edges[i].color == 'R' {
+					edges[i].color = 'B'
+				} else {
+					edges[i].color = 'R'
+				}
+			}
+		}
+	}
+	return edges
+}
+
+func allSameColor(edges []edge) bool {
+	if len(edges) == 0 {
+		return true
+	}
+	c := edges[0].color
+	for _, e := range edges {
+		if e.color != c {
+			return false
+		}
+	}
+	return true
+}
+
+func runCaseB(bin string, tc testCaseB, minimal int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, len(tc.edges)))
+	for _, e := range tc.edges {
+		sb.WriteString(fmt.Sprintf("%d %d %c\n", e.u, e.v, e.color))
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	if fields[0] == "-1" {
+		if minimal != -1 {
+			return fmt.Errorf("expected solution of size %d", minimal)
+		}
+		return nil
+	}
+	var k int
+	fmt.Sscan(fields[0], &k)
+	if k != minimal {
+		return fmt.Errorf("expected size %d got %d", minimal, k)
+	}
+	if len(fields)-1 != k {
+		return fmt.Errorf("expected %d vertices got %d", k, len(fields)-1)
+	}
+	moves := make([]int, k)
+	for i := 0; i < k; i++ {
+		fmt.Sscan(fields[i+1], &moves[i])
+	}
+	edges := applyMoves(tc, moves)
+	if !allSameColor(edges) {
+		return fmt.Errorf("moves do not unify edge colors")
+	}
+	return nil
+}
+
+func genCaseB(rng *rand.Rand) testCaseB {
+	n := rng.Intn(5) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	seen := make(map[[2]int]bool)
+	edges := make([]edge, 0, m)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		key := [2]int{u, v}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		c := byte('R')
+		if rng.Intn(2) == 0 {
+			c = 'B'
+		}
+		edges = append(edges, edge{u, v, c})
+	}
+	return testCaseB{n, edges}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseB(rng)
+		minK, _ := solveB(tc)
+		if err := runCaseB(bin, tc, minK); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/660-669/662/verifierC.go
+++ b/0-999/600-699/660-669/662/verifierC.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	n, m int
+	rows []string
+}
+
+func fwt(a []int64, invert bool) {
+	n := len(a)
+	for step := 1; step < n; step <<= 1 {
+		for i := 0; i < n; i += step << 1 {
+			for j := 0; j < step; j++ {
+				x := a[i+j]
+				y := a[i+j+step]
+				a[i+j] = x + y
+				a[i+j+step] = x - y
+			}
+		}
+	}
+	if invert {
+		for i := 0; i < n; i++ {
+			a[i] /= int64(n)
+		}
+	}
+}
+
+func solveC(tc testCaseC) int64 {
+	size := 1 << tc.n
+	cnt := make([]int64, size)
+	for col := 0; col < tc.m; col++ {
+		mask := 0
+		for i := 0; i < tc.n; i++ {
+			if tc.rows[i][col] == '1' {
+				mask |= 1 << i
+			}
+		}
+		cnt[mask]++
+	}
+	weight := make([]int64, size)
+	for mask := 0; mask < size; mask++ {
+		k := bits.OnesCount(uint(mask))
+		if k > tc.n-k {
+			k = tc.n - k
+		}
+		weight[mask] = int64(k)
+	}
+	fwt(cnt, false)
+	fwt(weight, false)
+	for i := 0; i < size; i++ {
+		cnt[i] *= weight[i]
+	}
+	fwt(cnt, true)
+	minVal := cnt[0]
+	for _, v := range cnt {
+		if v < minVal {
+			minVal = v
+		}
+	}
+	return minVal
+}
+
+func runCaseC(bin string, tc testCaseC) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for _, row := range tc.rows {
+		sb.WriteString(row)
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solveC(tc)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func genCaseC(rng *rand.Rand) testCaseC {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(8) + 1
+	rows := make([]string, n)
+	for i := 0; i < n; i++ {
+		var sb strings.Builder
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		rows[i] = sb.String()
+	}
+	return testCaseC{n, m, rows}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseC(rng)
+		if err := runCaseC(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/660-669/662/verifierD.go
+++ b/0-999/600-699/660-669/662/verifierD.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseD struct {
+	abbr string
+}
+
+func solveD(abbr string) int64 {
+	digits := strings.TrimSpace(abbr[4:])
+	pow10 := make([]int64, 10)
+	pow10[0] = 1
+	for i := 1; i < 10; i++ {
+		pow10[i] = pow10[i-1] * 10
+	}
+	start := make([]int64, 10)
+	start[1] = 1989
+	for i := 2; i < 10; i++ {
+		start[i] = start[i-1] + pow10[i-1]
+	}
+	k := len(digits)
+	val, _ := strconv.ParseInt(digits, 10, 64)
+	year := val
+	mod := pow10[k]
+	for year < start[k] {
+		year += mod
+	}
+	return year
+}
+
+func runCaseD(bin string, tc testCaseD) error {
+	input := fmt.Sprintf("1\n%s\n", tc.abbr)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solveD(tc.abbr)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func genCaseD(rng *rand.Rand) testCaseD {
+	k := rng.Intn(9) + 1
+	maxVal := 1
+	for i := 0; i < k; i++ {
+		maxVal *= 10
+	}
+	val := rng.Intn(maxVal)
+	abbr := fmt.Sprintf("IAO'%0*d", k, val)
+	return testCaseD{abbr}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseD(rng)
+		if err := runCaseD(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/660-669/662/verifierE.go
+++ b/0-999/600-699/660-669/662/verifierE.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCaseE struct {
+	n     int
+	times [][3]int
+}
+
+func solveE(tc testCaseE) int {
+	n := tc.n
+	times := tc.times
+	k0 := [3]int{}
+	H := make([][]int, 3)
+	for i := 0; i < n; i++ {
+		for j := 0; j < 3; j++ {
+			t := times[i][j]
+			if t != 0 {
+				k0[j]++
+			}
+			if t < 0 {
+				H[j] = append(H[j], i)
+			}
+		}
+	}
+	for j := 0; j < 3; j++ {
+		sort.Slice(H[j], func(a, b int) bool {
+			ta := -times[H[j][a]][j]
+			tb := -times[H[j][b]][j]
+			return ta > tb
+		})
+	}
+	scores := []int{500, 1000, 1500, 2000, 2500, 3000}
+	bestRank := n + 1
+	for _, s0 := range scores {
+		for _, s1 := range scores {
+			for _, s2 := range scores {
+				s := [3]int{s0, s1, s2}
+				valid := true
+				minx := [3]int{}
+				maxx := [3]int{}
+				for j := 0; j < 3; j++ {
+					L, R := 0, n
+					switch s[j] {
+					case 500:
+						L = n/2 + 1
+						R = n
+					case 1000:
+						L = n/4 + 1
+						R = n / 2
+					case 1500:
+						L = n/8 + 1
+						R = n / 4
+					case 2000:
+						L = n/16 + 1
+						R = n / 8
+					case 2500:
+						L = n/32 + 1
+						R = n / 16
+					case 3000:
+						L = 0
+						R = n / 32
+					}
+					lo := k0[j] - R
+					hi := k0[j] - L
+					if lo < 0 {
+						lo = 0
+					}
+					if hi > len(H[j]) {
+						hi = len(H[j])
+					}
+					if lo > hi {
+						valid = false
+						break
+					}
+					minx[j] = lo
+					maxx[j] = hi
+				}
+				if !valid {
+					continue
+				}
+				for mask := 0; mask < 8; mask++ {
+					x := [3]int{}
+					for j := 0; j < 3; j++ {
+						if (mask>>j)&1 == 0 {
+							x[j] = minx[j]
+						} else {
+							x[j] = maxx[j]
+						}
+					}
+					hacked := make([][3]bool, n)
+					for j := 0; j < 3; j++ {
+						for t := 0; t < x[j]; t++ {
+							i := H[j][t]
+							hacked[i][j] = true
+						}
+					}
+					Sc := 0.0
+					for j := 0; j < 3; j++ {
+						t := times[0][j]
+						if t > 0 {
+							Sc += float64(s[j]) * float64(250-t) / 250.0
+						}
+					}
+					Sc += float64(100 * (x[0] + x[1] + x[2]))
+					rank := 1
+					for i := 1; i < n; i++ {
+						Pi := 0.0
+						for j := 0; j < 3; j++ {
+							t := times[i][j]
+							if t > 0 && !hacked[i][j] {
+								Pi += float64(s[j]) * float64(250-t) / 250.0
+							}
+						}
+						if Pi > Sc {
+							rank++
+							if rank >= bestRank {
+								break
+							}
+						}
+					}
+					if rank < bestRank {
+						bestRank = rank
+					}
+				}
+			}
+		}
+	}
+	return bestRank
+}
+
+func runCaseE(bin string, tc testCaseE) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i := 0; i < tc.n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.times[i][0], tc.times[i][1], tc.times[i][2]))
+	}
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solveE(tc)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func genCaseE(rng *rand.Rand) testCaseE {
+	n := rng.Intn(5) + 2
+	times := make([][3]int, n)
+	for i := 0; i < n; i++ {
+		for j := 0; j < 3; j++ {
+			if i == 0 {
+				// you (participant 1) non-negative
+				if rng.Intn(2) == 0 {
+					times[i][j] = 0
+				} else {
+					times[i][j] = rng.Intn(120) + 1
+				}
+			} else {
+				t := rng.Intn(241) - 120 // [-120,120]
+				if t == 0 {
+					times[i][j] = 0
+				} else {
+					times[i][j] = t
+				}
+			}
+		}
+	}
+	return testCaseE{n, times}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseE(rng)
+		if err := runCaseE(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 662
- each verifier generates at least 100 random test cases and checks a binary solution

## Testing
- `go build 0-999/600-699/660-669/662/verifierA.go`
- `go run 0-999/600-699/660-669/662/verifierA.go ./solA`
- `go build 0-999/600-699/660-669/662/verifierB.go`
- `go run 0-999/600-699/660-669/662/verifierB.go ./solB`
- `go build 0-999/600-699/660-669/662/verifierC.go`
- `go run 0-999/600-699/660-669/662/verifierC.go ./solC`
- `go build 0-999/600-699/660-669/662/verifierD.go`
- `go run 0-999/600-699/660-669/662/verifierD.go ./solD`
- `go build 0-999/600-699/660-669/662/verifierE.go`
- `go run 0-999/600-699/660-669/662/verifierE.go ./solE`


------
https://chatgpt.com/codex/tasks/task_e_68836b6720648324a1f58adb3935b163