### PR TITLE
Add solution for 1914E2 in Go

### DIFF
--- a/1000-1999/1900-1999/1910-1919/1914/1914E2.go
+++ b/1000-1999/1900-1999/1910-1919/1914/1914E2.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+type pair struct {
+	a   int64
+	b   int64
+	sum int64
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int64, n)
+		b := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &b[i])
+		}
+
+		diff := int64(0)
+		cont := make([]pair, 0)
+		for i := 0; i < n; i++ {
+			if a[i] > 0 && b[i] > 0 {
+				cont = append(cont, pair{a[i], b[i], a[i] + b[i]})
+			} else if a[i] > 0 {
+				diff += a[i]
+			} else {
+				diff -= b[i]
+			}
+		}
+
+		sort.Slice(cont, func(i, j int) bool {
+			return cont[i].sum > cont[j].sum
+		})
+
+		for idx, p := range cont {
+			if idx%2 == 0 {
+				diff += p.a
+			} else {
+				diff -= p.b
+			}
+		}
+		if len(cont)%2 == 1 {
+			diff -= 1
+		}
+		fmt.Fprintln(writer, diff)
+	}
+}


### PR DESCRIPTION
## Summary
- add `1914E2.go` implementing a greedy strategy for problem E2
- sort contested colors by `a_i + b_i` and alternate picks

## Testing
- `go build 1000-1999/1900-1999/1910-1919/1914/1914E2.go`

------
https://chatgpt.com/codex/tasks/task_e_6883772ba0b083249603884ee98a9ce6