### PR TITLE
Add Go verifiers for Codeforces contest 683

### DIFF
--- a/0-999/600-699/680-689/683/verifierA.go
+++ b/0-999/600-699/680-689/683/verifierA.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "683A.go")
+	return runProg(ref, input)
+}
+
+func genCase() string {
+	a := rand.Intn(1000) + 1
+	x := rand.Intn(2001) - 1000
+	y := rand.Intn(2001) - 1000
+	return fmt.Sprintf("%d %d %d\n", a, x, y)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		in := genCase()
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/680-689/683/verifierB.go
+++ b/0-999/600-699/680-689/683/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "683B.go")
+	return runProg(ref, input)
+}
+
+func randName() string {
+	l := rand.Intn(5) + 1
+	b := make([]byte, l)
+	for i := range b {
+		v := rand.Intn(52)
+		if v < 26 {
+			b[i] = byte('a' + v)
+		} else {
+			b[i] = byte('A' + v - 26)
+		}
+	}
+	return string(b)
+}
+
+func genCase() string {
+	n := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%s %d\n", randName(), rand.Intn(86)+130))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		in := genCase()
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expect = strings.TrimSpace(expect)
+		got = strings.TrimSpace(got)
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/680-689/683/verifierC.go
+++ b/0-999/600-699/680-689/683/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "683C.go")
+	return runProg(ref, input)
+}
+
+func genSet(n int) []int {
+	m := make(map[int]struct{})
+	res := make([]int, 0, n)
+	for len(res) < n {
+		v := rand.Intn(2001) - 1000
+		if _, ok := m[v]; !ok {
+			m[v] = struct{}{}
+			res = append(res, v)
+		}
+	}
+	return res
+}
+
+func genCase() string {
+	n1 := rand.Intn(10) + 1
+	n2 := rand.Intn(10) + 1
+	s1 := genSet(n1)
+	s2 := genSet(n2)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d", n1))
+	for _, v := range s1 {
+		sb.WriteString(fmt.Sprintf(" %d", v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d", n2))
+	for _, v := range s2 {
+		sb.WriteString(fmt.Sprintf(" %d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		in := genCase()
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/680-689/683/verifierD.go
+++ b/0-999/600-699/680-689/683/verifierD.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "683D.go")
+	return runProg(ref, input)
+}
+
+func genCase() string {
+	q := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		n := rand.Intn(20) + 1
+		m := rand.Intn(20) + 1
+		p := rand.Intn(400) + 1
+		if rand.Intn(5) == 0 {
+			p = n*m + rand.Intn(20)
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, p))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		in := genCase()
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		expect = strings.TrimSpace(expect)
+		got = strings.TrimSpace(got)
+		if expect != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/680-689/683/verifierE.go
+++ b/0-999/600-699/680-689/683/verifierE.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "683E.go")
+	return runProg(ref, input)
+}
+
+func genCase() string {
+	n := rand.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(n)))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		in := genCase()
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/680-689/683/verifierF.go
+++ b/0-999/600-699/680-689/683/verifierF.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "683F.go")
+	return runProg(ref, input)
+}
+
+func randWord() string {
+	l := rand.Intn(5) + 1
+	b := make([]byte, l)
+	for i := range b {
+		v := rand.Intn(52)
+		if v < 26 {
+			b[i] = byte('a' + v)
+		} else {
+			b[i] = byte('A' + v - 26)
+		}
+	}
+	return string(b)
+}
+
+func genCase() string {
+	tokenCount := rand.Intn(15) + 1
+	var tokens []string
+	for i := 0; i < tokenCount; i++ {
+		if rand.Intn(5) == 0 {
+			if rand.Intn(2) == 0 {
+				tokens = append(tokens, ".")
+			} else {
+				tokens = append(tokens, ",")
+			}
+		} else {
+			tokens = append(tokens, randWord())
+		}
+	}
+	var sb strings.Builder
+	if rand.Intn(2) == 0 {
+		sb.WriteByte(' ')
+	}
+	for i, t := range tokens {
+		sb.WriteString(t)
+		if i+1 < len(tokens) {
+			sb.WriteString(strings.Repeat(" ", rand.Intn(3)))
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		in := genCase()
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/680-689/683/verifierG.go
+++ b/0-999/600-699/680-689/683/verifierG.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "683G.go")
+	return runProg(ref, input)
+}
+
+func genDigits(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('0' + rand.Intn(10))
+	}
+	return string(b)
+}
+
+func genCase() string {
+	k := rand.Intn(3)     // non-periodic length
+	m := rand.Intn(3) + 1 // period length
+	b := genDigits(k)
+	c := genDigits(m)
+	return fmt.Sprintf("0.%s(%s)\n", b, c)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		in := genCase()
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/680-689/683/verifierH.go
+++ b/0-999/600-699/680-689/683/verifierH.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "683H.go")
+	return runProg(ref, input)
+}
+
+func randPermutation(n int) []int {
+	p := rand.Perm(n)
+	// ensure no fixed points
+	for i := 0; i < n; i++ {
+		if p[i] == i {
+			j := (i + 1) % n
+			p[i], p[j] = p[j], p[i]
+		}
+	}
+	return p
+}
+
+func genCase() string {
+	n := rand.Intn(9) + 2
+	k := rand.Int63n(50) + 1
+	perm := randPermutation(n)
+	a := make([]int, n)
+	for j, v := range perm {
+		a[v] = j + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		in := genCase()
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/680-689/683/verifierI.go
+++ b/0-999/600-699/680-689/683/verifierI.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "683I.go")
+	return runProg(ref, input)
+}
+
+func genGrid(n, m int) []string {
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rand.Intn(5) == 0 {
+				row[j] = 'X'
+			} else {
+				row[j] = '.'
+			}
+		}
+		grid[i] = string(row)
+	}
+	// place Y, B, T distinct
+	sx, sy := rand.Intn(n), rand.Intn(m)
+	grid[sx] = grid[sx][:sy] + "Y" + grid[sx][sy+1:]
+	bx, by := rand.Intn(n), rand.Intn(m)
+	for bx == sx && by == sy {
+		bx, by = rand.Intn(n), rand.Intn(m)
+	}
+	grid[bx] = grid[bx][:by] + "B" + grid[bx][by+1:]
+	tx, ty := rand.Intn(n), rand.Intn(m)
+	for (tx == sx && ty == sy) || (tx == bx && ty == by) {
+		tx, ty = rand.Intn(n), rand.Intn(m)
+	}
+	grid[tx] = grid[tx][:ty] + "T" + grid[tx][ty+1:]
+	return grid
+}
+
+func genCase() string {
+	n := rand.Intn(4) + 3
+	m := rand.Intn(4) + 3
+	grid := genGrid(n, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(grid[i])
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierI.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		in := genCase()
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/600-699/680-689/683/verifierJ.go
+++ b/0-999/600-699/680-689/683/verifierJ.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func runRef(input string) (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "683J.go")
+	return runProg(ref, input)
+}
+
+func genGrid(n, m int) []string {
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rand.Intn(5) == 0 {
+				row[j] = 'X'
+			} else {
+				row[j] = '.'
+			}
+		}
+		grid[i] = string(row)
+	}
+	ex, ey := rand.Intn(n), rand.Intn(m)
+	grid[ex] = grid[ex][:ey] + "E" + grid[ex][ey+1:]
+	tx, ty := rand.Intn(n), rand.Intn(m)
+	for tx == ex && ty == ey {
+		tx, ty = rand.Intn(n), rand.Intn(m)
+	}
+	grid[tx] = grid[tx][:ty] + "T" + grid[tx][ty+1:]
+	return grid
+}
+
+func genCase() string {
+	n := rand.Intn(4) + 3
+	m := rand.Intn(4) + 3
+	g := genGrid(n, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(g[i])
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierJ.go <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		in := genCase()
+		expect, err := runRef(in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", i+1, in, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifier programs for problems A-J in contest 683
- each verifier runs the target binary on 100 random tests
- reference outputs are produced by the official Go solutions

## Testing
- `go fmt` on all new verifiers


------
https://chatgpt.com/codex/tasks/task_e_688376e569188324870a75759e67fac1