### PR TITLE
Add Go verifiers for contest 682

### DIFF
--- a/0-999/600-699/680-689/682/verifierA.go
+++ b/0-999/600-699/680-689/682/verifierA.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m int64
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return out.String(), nil
+}
+
+func solve(n, m int64) int64 {
+	cntN := [5]int64{}
+	cntM := [5]int64{}
+	cntN[0] = n / 5
+	cntM[0] = m / 5
+	for i := int64(1); i < 5; i++ {
+		cntN[i] = n / 5
+		if n%5 >= i {
+			cntN[i]++
+		}
+		cntM[i] = m / 5
+		if m%5 >= i {
+			cntM[i]++
+		}
+	}
+	var ans int64
+	for r := 0; r < 5; r++ {
+		comp := (5 - r) % 5
+		ans += cntN[r] * cntM[comp]
+	}
+	return ans
+}
+
+func runCase(bin string, tc testCase) error {
+	input := fmt.Sprintf("%d %d\n", tc.n, tc.m)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	out = strings.TrimSpace(out)
+	var got int64
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expected := solve(tc.n, tc.m)
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, testCase{1, 1})
+	cases = append(cases, testCase{5, 5})
+	for i := 0; i < 100; i++ {
+		n := rng.Int63n(1_000_000) + 1
+		m := rng.Int63n(1_000_000) + 1
+		cases = append(cases, testCase{n, m})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %d %d\n", i+1, err, tc.n, tc.m)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/682/verifierB.go
+++ b/0-999/600-699/680-689/682/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	arr []int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return out.String(), nil
+}
+
+func solve(arr []int) int {
+	sort.Ints(arr)
+	mex := 1
+	for _, v := range arr {
+		if v >= mex {
+			mex++
+		}
+	}
+	return mex
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.arr)))
+	for i, v := range tc.arr {
+		sb.WriteString(fmt.Sprintf("%d", v))
+		if i+1 < len(tc.arr) {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	out = strings.TrimSpace(out)
+	var got int
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expected := solve(append([]int(nil), tc.arr...))
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(200) + 1
+	}
+	return testCase{arr: arr}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, testCase{arr: []int{1}})
+	cases = append(cases, testCase{arr: []int{1, 2, 3, 3, 4}})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %v\n", i+1, err, tc.arr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/682/verifierC.go
+++ b/0-999/600-699/680-689/682/verifierC.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	to int
+	w  int64
+}
+
+type testCase struct {
+	n int
+	a []int64
+	p []int
+	c []int64
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return out.String(), nil
+}
+
+func solve(tc testCase) int {
+	g := make([][]edge, tc.n+1)
+	for i := 2; i <= tc.n; i++ {
+		g[tc.p[i-2]] = append(g[tc.p[i-2]], edge{to: i, w: tc.c[i-2]})
+	}
+	type node struct {
+		v       int
+		dist    int64
+		minPref int64
+		rem     bool
+	}
+	stack := []node{{v: 1, dist: 0, minPref: 0, rem: false}}
+	removed := 0
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if cur.rem {
+			removed++
+			for _, e := range g[cur.v] {
+				nd := cur.dist + e.w
+				mp := cur.minPref
+				if nd < mp {
+					mp = nd
+				}
+				stack = append(stack, node{v: e.to, dist: nd, minPref: mp, rem: true})
+			}
+			continue
+		}
+		if cur.dist-cur.minPref > tc.a[cur.v-1] {
+			removed++
+			for _, e := range g[cur.v] {
+				nd := cur.dist + e.w
+				mp := cur.minPref
+				if nd < mp {
+					mp = nd
+				}
+				stack = append(stack, node{v: e.to, dist: nd, minPref: mp, rem: true})
+			}
+			continue
+		}
+		for _, e := range g[cur.v] {
+			nd := cur.dist + e.w
+			mp := cur.minPref
+			if nd < mp {
+				mp = nd
+			}
+			stack = append(stack, node{v: e.to, dist: nd, minPref: mp, rem: false})
+		}
+	}
+	return removed
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i := 0; i < tc.n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", tc.a[i]))
+		if i+1 < tc.n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 2; i <= tc.n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.p[i-2], tc.c[i-2]))
+	}
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	input := buildInput(tc)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	out = strings.TrimSpace(out)
+	var got int
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expected := solve(tc)
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = rng.Int63n(1000) + 1
+	}
+	p := make([]int, n-1)
+	c := make([]int64, n-1)
+	for i := 2; i <= n; i++ {
+		p[i-2] = rng.Intn(i-1) + 1
+		c[i-2] = rng.Int63n(2001) - 1000
+	}
+	return testCase{n: n, a: a, p: p, c: c}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, testCase{n: 1, a: []int64{1}})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/682/verifierD.go
+++ b/0-999/600-699/680-689/682/verifierD.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	m int
+	k int
+	s string
+	t string
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return out.String(), nil
+}
+
+func solve(tc testCase) int {
+	n := tc.n
+	m := tc.m
+	K := tc.k
+	s := tc.s
+	t := tc.t
+	f := make([][][]int, K+1)
+	for k := range f {
+		f[k] = make([][]int, n+1)
+		for i := range f[k] {
+			f[k][i] = make([]int, m+1)
+		}
+	}
+	g := make([][]int, n+1)
+	for i := range g {
+		g[i] = make([]int, m+1)
+	}
+	for k := 1; k <= K; k++ {
+		for i := 1; i <= n; i++ {
+			for j := 1; j <= m; j++ {
+				if s[i-1] == t[j-1] {
+					v1 := g[i-1][j-1] + 1
+					v2 := f[k-1][i-1][j-1] + 1
+					if v2 > v1 {
+						v1 = v2
+					}
+					g[i][j] = v1
+				} else {
+					g[i][j] = 0
+				}
+				v := f[k][i-1][j]
+				if f[k][i][j-1] > v {
+					v = f[k][i][j-1]
+				}
+				if g[i][j] > v {
+					v = g[i][j]
+				}
+				f[k][i][j] = v
+			}
+		}
+	}
+	return f[K][n][m]
+}
+
+func buildInput(tc testCase) string {
+	return fmt.Sprintf("%d %d %d\n%s\n%s\n", tc.n, tc.m, tc.k, tc.s, tc.t)
+}
+
+func runCase(bin string, tc testCase) error {
+	input := buildInput(tc)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	out = strings.TrimSpace(out)
+	var got int
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expected := solve(tc)
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(20) + 1
+	k := rng.Intn(10) + 1
+	s := randString(rng, n)
+	t := randString(rng, m)
+	return testCase{n: n, m: m, k: k, s: s, t: t}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, testCase{n: 1, m: 1, k: 1, s: "a", t: "a"})
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/682/verifierE.go
+++ b/0-999/600-699/680-689/682/verifierE.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int64 }
+
+type testCase struct {
+	n   int
+	S   int64
+	pts []point
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return out.String(), nil
+}
+
+func area2(a, b, c point) int64 {
+	v := (b.x-a.x)*(c.y-a.y) - (b.y-a.y)*(c.x-a.x)
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func pointInTriangle(p, a, b, c point) bool {
+	s1 := (b.x-a.x)*(p.y-a.y) - (b.y-a.y)*(p.x-a.x)
+	s2 := (c.x-b.x)*(p.y-b.y) - (c.y-b.y)*(p.x-b.x)
+	s3 := (a.x-c.x)*(p.y-c.y) - (a.y-c.y)*(p.x-c.x)
+	hasNeg := (s1 < 0) || (s2 < 0) || (s3 < 0)
+	hasPos := (s1 > 0) || (s2 > 0) || (s3 > 0)
+	return !(hasNeg && hasPos)
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.S))
+	for i, p := range tc.pts {
+		sb.WriteString(fmt.Sprintf("%d %d", p.x, p.y))
+		if i+1 < len(tc.pts) {
+			sb.WriteByte('\n')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	input := buildInput(tc)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	lines := strings.Fields(out)
+	if len(lines) < 6 {
+		return fmt.Errorf("output should contain six integers")
+	}
+	var tri [3]point
+	for i := 0; i < 3; i++ {
+		if _, err := fmt.Sscan(lines[2*i], &tri[i].x); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if _, err := fmt.Sscan(lines[2*i+1], &tri[i].y); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+	}
+	a, b, c := tri[0], tri[1], tri[2]
+	area := area2(a, b, c)
+	if area == 0 || area > 8*tc.S {
+		return fmt.Errorf("triangle area invalid")
+	}
+	for _, p := range tc.pts {
+		if !pointInTriangle(p, a, b, c) {
+			return fmt.Errorf("point (%d,%d) not inside triangle", p.x, p.y)
+		}
+	}
+	return nil
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 3
+	pts := make([]point, n)
+	for i := range pts {
+		pts[i] = point{int64(rng.Intn(200) - 100), int64(rng.Intn(200) - 100)}
+	}
+	S := int64(1000000000)
+	return testCase{n: n, S: S, pts: pts}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, generateRandomCase(rng))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces contest 682 problems A–E
- each verifier generates 100+ random tests and checks candidate binaries

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go verifierC.go verifierD.go verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_688376593b648324b5c17fbdf85e75a2