### PR TITLE
Add Go verifiers for contest 681

### DIFF
--- a/0-999/600-699/680-689/681/verifierA.go
+++ b/0-999/600-699/680-689/681/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type participant struct {
+	before int
+	after  int
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(parts []participant) string {
+	good := false
+	for _, p := range parts {
+		if p.before >= 2400 && p.after > p.before {
+			good = true
+			break
+		}
+	}
+	if good {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	parts := make([]participant, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		before := rng.Intn(5001) - 2500
+		after := rng.Intn(5001) - 2500
+		parts[i] = participant{before, after}
+		sb.WriteString(fmt.Sprintf("user%d %d %d\n", i, before, after))
+	}
+	return sb.String(), expected(parts)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/681/verifierB.go
+++ b/0-999/600-699/680-689/681/verifierB.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int64) string {
+	for a := int64(0); a*1234567 <= n; a++ {
+		remA := n - a*1234567
+		for b := int64(0); b*123456 <= remA; b++ {
+			rem := remA - b*123456
+			if rem%1234 == 0 {
+				return "YES"
+			}
+		}
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := int64(rng.Intn(100000000) + 1)
+	input := fmt.Sprintf("%d\n", n)
+	return input, expected(n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/681/verifierC.go
+++ b/0-999/600-699/680-689/681/verifierC.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type IntHeap []int
+
+func (h IntHeap) Len() int            { return len(h) }
+func (h IntHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h IntHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *IntHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *IntHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+const (
+	opInsert = iota + 1
+	opGet
+	opRemove
+)
+
+type command struct {
+	t int
+	x int
+}
+
+func solve(cmds []command) string {
+	h := &IntHeap{}
+	heap.Init(h)
+	var ops []string
+	for _, c := range cmds {
+		switch c.t {
+		case opInsert:
+			heap.Push(h, c.x)
+			ops = append(ops, fmt.Sprintf("insert %d", c.x))
+		case opGet:
+			if h.Len() == 0 || (*h)[0] > c.x {
+				heap.Push(h, c.x)
+				ops = append(ops, fmt.Sprintf("insert %d", c.x))
+			} else {
+				for h.Len() > 0 && (*h)[0] < c.x {
+					heap.Pop(h)
+					ops = append(ops, "removeMin")
+				}
+				if h.Len() == 0 || (*h)[0] > c.x {
+					heap.Push(h, c.x)
+					ops = append(ops, fmt.Sprintf("insert %d", c.x))
+				}
+			}
+			ops = append(ops, fmt.Sprintf("getMin %d", c.x))
+		case opRemove:
+			if h.Len() == 0 {
+				heap.Push(h, 1)
+				ops = append(ops, "insert 1")
+			}
+			heap.Pop(h)
+			ops = append(ops, "removeMin")
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d", len(ops)))
+	for _, op := range ops {
+		sb.WriteByte('\n')
+		sb.WriteString(op)
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	cmds := make([]command, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		typ := rng.Intn(3)
+		switch typ {
+		case 0:
+			x := rng.Intn(50)
+			cmds[i] = command{opInsert, x}
+			sb.WriteString(fmt.Sprintf("insert %d\n", x))
+		case 1:
+			x := rng.Intn(50)
+			cmds[i] = command{opGet, x}
+			sb.WriteString(fmt.Sprintf("getMin %d\n", x))
+		default:
+			cmds[i] = command{opRemove, 0}
+			sb.WriteString("removeMin\n")
+		}
+	}
+	return sb.String(), solve(cmds)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\n\ngot:\n%s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/681/verifierD.go
+++ b/0-999/600-699/680-689/681/verifierD.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type edge struct{ u, v int }
+
+func solve(n int, edges []edge, gifts []int) string {
+	children := make([][]int, n+1)
+	parent := make([]int, n+1)
+	for _, e := range edges {
+		children[e.u] = append(children[e.u], e.v)
+		parent[e.v] = e.u
+	}
+	listVal := make([]bool, n+1)
+	q := make([]int, n)
+	head, tail := 0, 0
+	for i := 1; i <= n; i++ {
+		if gifts[i] >= 1 && gifts[i] <= n {
+			listVal[gifts[i]] = true
+		}
+		if parent[i] == 0 {
+			q[tail] = i
+			tail++
+			for head < tail {
+				u := q[head]
+				head++
+				for _, v := range children[u] {
+					q[tail] = v
+					tail++
+				}
+			}
+		}
+	}
+	var ans []int
+	for i := tail - 1; i >= 0; i-- {
+		u := q[i]
+		if gifts[u] != u {
+			p := parent[u]
+			if p == 0 || gifts[p] != gifts[u] {
+				return "-1"
+			}
+		}
+		if listVal[u] {
+			ans = append(ans, u)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d", len(ans)))
+	for _, x := range ans {
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d", x))
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	edges := make([]edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, edge{p, i})
+	}
+	gifts := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		gifts[i] = rng.Intn(n + 2)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	for i := 1; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", gifts[i]))
+		if i < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solve(n, edges, gifts)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\n\ngot:\n%s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/681/verifierE.go
+++ b/0-999/600-699/680-689/681/verifierE.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type segment struct{ l, r float64 }
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(x0, y0, v, T int64, circs [][3]int) string {
+	R := float64(v) * float64(T)
+	if R > 6e9 {
+		R = 6e9
+	}
+	segs := make([]segment, 0, len(circs))
+	inside := false
+	for _, c := range circs {
+		dx := float64(int64(c[0]) - x0)
+		dy := float64(int64(c[1]) - y0)
+		dist2 := dx*dx + dy*dy
+		r := float64(c[2])
+		if dist2 <= r*r {
+			inside = true
+			break
+		}
+		dist := math.Sqrt(dist2)
+		if r == 0 || R+r <= dist {
+			continue
+		}
+		angl := math.Atan2(dx, dy)
+		al := math.Asin(r / dist)
+		if R*R+r*r < dist*dist {
+			cosv := (R*R + dist*dist - r*r) / (2 * R * dist)
+			if cosv > 1 {
+				cosv = 1
+			} else if cosv < -1 {
+				cosv = -1
+			}
+			al = math.Acos(cosv)
+		}
+		ang1 := angl - al
+		ang2 := angl + al
+		if ang1 < -math.Pi {
+			segs = append(segs, segment{-math.Pi, ang2})
+			segs = append(segs, segment{ang1 + 2*math.Pi, math.Pi})
+		} else if ang2 > math.Pi {
+			segs = append(segs, segment{ang1, math.Pi})
+			segs = append(segs, segment{-math.Pi, ang2 - 2*math.Pi})
+		} else {
+			segs = append(segs, segment{ang1, ang2})
+		}
+	}
+	if inside {
+		return fmt.Sprintf("%.9f", 1.0)
+	}
+	if len(segs) == 0 {
+		return fmt.Sprintf("%.9f", 0.0)
+	}
+	sort.Slice(segs, func(i, j int) bool {
+		if segs[i].l != segs[j].l {
+			return segs[i].l < segs[j].l
+		}
+		return segs[i].r < segs[j].r
+	})
+	var total, currLen, end float64
+	end = -math.Pi
+	for _, s := range segs {
+		if end >= s.l {
+			if end < s.r {
+				currLen += s.r - end
+				end = s.r
+			}
+		} else {
+			total += currLen
+			currLen = s.r - s.l
+			end = s.r
+		}
+	}
+	total += currLen
+	p := total / (2 * math.Pi)
+	return fmt.Sprintf("%.9f", p)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	x0 := int64(rng.Intn(21) - 10)
+	y0 := int64(rng.Intn(21) - 10)
+	v := int64(rng.Intn(5) + 1)
+	T := int64(rng.Intn(5) + 1)
+	n := rng.Intn(3) + 1
+	circs := make([][3]int, n)
+	for i := 0; i < n; i++ {
+		circs[i] = [3]int{rng.Intn(21) - 10, rng.Intn(21) - 10, rng.Intn(10) + 1}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", x0, y0, v, T))
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, c := range circs {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", c[0], c[1], c[2]))
+	}
+	return sb.String(), solve(x0, y0, v, T, circs)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces contest 681 problems A–E
- each verifier executes an arbitrary binary on at least 100 random cases

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_688375cd3a988324a35534295934f4bf