### PR TITLE
Add verifiers for contest 680

### DIFF
--- a/0-999/600-699/680-689/680/verifierA.go
+++ b/0-999/600-699/680-689/680/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(nums [5]int) int {
+	freq := make(map[int]int)
+	sum := 0
+	for _, v := range nums {
+		sum += v
+		freq[v]++
+	}
+	best := 0
+	for v, c := range freq {
+		if c >= 2 {
+			cand := v * 2
+			if c >= 3 {
+				cand = v * 3
+			}
+			if cand > best {
+				best = cand
+			}
+		}
+	}
+	return sum - best
+}
+
+func generateCase(rng *rand.Rand) string {
+	nums := [5]int{}
+	for i := 0; i < 5; i++ {
+		nums[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	for i := 0; i < 5; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", nums[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func parseInput(input string) ([5]int, error) {
+	var nums [5]int
+	parts := strings.Fields(input)
+	if len(parts) != 5 {
+		return nums, fmt.Errorf("invalid input")
+	}
+	for i := 0; i < 5; i++ {
+		fmt.Sscan(parts[i], &nums[i])
+	}
+	return nums, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 200; i++ {
+		input := generateCase(rng)
+		expectedNums, err := parseInput(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to parse generated input: %v", err)
+			os.Exit(1)
+		}
+		expected := fmt.Sprint(solve(expectedNums))
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/680/verifierB.go
+++ b/0-999/600-699/680-689/680/verifierB.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n, a int, arr []int) int {
+	ans := 0
+	maxDist := a - 1
+	if n-a > maxDist {
+		maxDist = n - a
+	}
+	for d := 0; d <= maxDist; d++ {
+		l := a - d
+		r := a + d
+		if l >= 1 && r <= n {
+			if l == r {
+				ans += arr[l-1]
+			} else if arr[l-1] == 1 && arr[r-1] == 1 {
+				ans += 2
+			}
+		} else if l >= 1 && l <= n && (r < 1 || r > n) {
+			ans += arr[l-1]
+		} else if r >= 1 && r <= n && (l < 1 || l > n) {
+			ans += arr[r-1]
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	a := rng.Intn(n) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, a)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(2))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func parseInput(input string) (int, int, []int, error) {
+	lines := strings.Split(strings.TrimSpace(input), "\n")
+	if len(lines) < 2 {
+		return 0, 0, nil, fmt.Errorf("invalid input")
+	}
+	var n, a int
+	fmt.Sscanf(lines[0], "%d %d", &n, &a)
+	arr := make([]int, n)
+	fields := strings.Fields(lines[1])
+	if len(fields) != n {
+		return 0, 0, nil, fmt.Errorf("invalid input")
+	}
+	for i := 0; i < n; i++ {
+		fmt.Sscan(fields[i], &arr[i])
+	}
+	return n, a, arr, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 200; i++ {
+		input := generateCase(rng)
+		n, a, arr, err := parseInput(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "parse error: %v", err)
+			os.Exit(1)
+		}
+		expected := fmt.Sprint(solve(n, a, arr))
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\n got:%s\ninput:%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go and verifierB.go in contest 680
- each verifier generates 200 random tests and checks outputs against internal solver

## Testing
- `go run verifierA.go ./680A`
- `go run verifierB.go ./680B`


------
https://chatgpt.com/codex/tasks/task_e_6883754107748324971e3575d132d17c