### PR TITLE
Add Go verifiers for contest 676

### DIFF
--- a/0-999/600-699/670-679/676/verifierA.go
+++ b/0-999/600-699/670-679/676/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(a []int) int {
+	n := len(a)
+	pos1, posn := 0, 0
+	for i, v := range a {
+		if v == 1 {
+			pos1 = i
+		}
+		if v == n {
+			posn = i
+		}
+	}
+	dist := func(x, y int) int {
+		if x > y {
+			return x - y
+		}
+		return y - x
+	}
+	ans := dist(pos1, 0)
+	if v := dist(pos1, n-1); v > ans {
+		ans = v
+	}
+	if v := dist(posn, 0); v > ans {
+		ans = v
+	}
+	if v := dist(posn, n-1); v > ans {
+		ans = v
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(99) + 2 // [2,100]
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	expected := fmt.Sprintf("%d\n", solve(perm))
+	return sb.String(), expected
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, strings.TrimSpace(expect), strings.TrimSpace(out), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/670-679/676/verifierB.go
+++ b/0-999/600-699/670-679/676/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n, t int) int {
+	g := make([][]float64, n+2)
+	for i := range g {
+		g[i] = make([]float64, n+2)
+	}
+	g[1][1] = float64(t)
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= i; j++ {
+			if g[i][j] > 1.0 {
+				over := g[i][j] - 1.0
+				g[i][j] = 1.0
+				g[i+1][j] += over / 2
+				g[i+1][j+1] += over / 2
+			}
+		}
+	}
+	ans := 0
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= i; j++ {
+			if g[i][j] >= 1.0-1e-9 {
+				ans++
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1 // [1,10]
+	t := rng.Intn(10001)  // [0,10000]
+	input := fmt.Sprintf("%d %d\n", n, t)
+	expected := fmt.Sprintf("%d\n", solve(n, t))
+	return input, expected
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, strings.TrimSpace(expect), strings.TrimSpace(out), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/670-679/676/verifierC.go
+++ b/0-999/600-699/670-679/676/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func maxLen(s string, k int, ch byte) int {
+	left := 0
+	cnt := 0
+	best := 0
+	for right := 0; right < len(s); right++ {
+		if s[right] != ch {
+			cnt++
+		}
+		for cnt > k {
+			if s[left] != ch {
+				cnt--
+			}
+			left++
+		}
+		if cur := right - left + 1; cur > best {
+			best = cur
+		}
+	}
+	return best
+}
+
+func solve(n, k int, s string) int {
+	a := maxLen(s, k, 'a')
+	b := maxLen(s, k, 'b')
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	k := rng.Intn(n + 1)
+	b := make([]byte, n)
+	for i := range b {
+		if rng.Intn(2) == 0 {
+			b[i] = 'a'
+		} else {
+			b[i] = 'b'
+		}
+	}
+	s := string(b)
+	input := fmt.Sprintf("%d %d\n%s\n", n, k, s)
+	expected := fmt.Sprintf("%d\n", solve(n, k, s))
+	return input, expected
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, strings.TrimSpace(expect), strings.TrimSpace(out), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/670-679/676/verifierD.go
+++ b/0-999/600-699/670-679/676/verifierD.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var symbols = []byte{'+', '-', '|', '^', '>', '<', 'v', 'L', 'R', 'U', 'D', '*'}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "676D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func randomSymbol(rng *rand.Rand) byte {
+	return symbols[rng.Intn(len(symbols))]
+}
+
+func generateCase(rng *rand.Rand) (string, string, error) {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(6) + 1
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			row[j] = randomSymbol(rng)
+		}
+		grid[i] = row
+	}
+	sx := rng.Intn(n)
+	sy := rng.Intn(m)
+	tx := rng.Intn(n)
+	ty := rng.Intn(m)
+	if grid[sx][sy] == '*' {
+		grid[sx][sy] = '+'
+	}
+	if grid[tx][ty] == '*' {
+		grid[tx][ty] = '+'
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		sb.WriteByte('\n')
+	}
+	fmt.Fprintf(&sb, "%d %d\n%d %d\n", sx+1, sy+1, tx+1, ty+1)
+	input := sb.String()
+	return input, "", nil
+}
+
+func run(cmdPath, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(cmdPath, ".go") {
+		cmd = exec.Command("go", "run", cmdPath)
+	} else {
+		cmd = exec.Command(cmdPath)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, _, _ := generateCase(rng)
+		expected, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/670-679/676/verifierE.go
+++ b/0-999/600-699/670-679/676/verifierE.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "676E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(15)
+	k := rng.Intn(21) - 10
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i <= n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteString("?\n")
+		} else {
+			v := rng.Intn(21) - 10
+			sb.WriteString(fmt.Sprintf("%d\n", v))
+		}
+	}
+	return sb.String()
+}
+
+func run(cmdPath, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(cmdPath, ".go") {
+		cmd = exec.Command("go", "run", cmdPath)
+	} else {
+		cmd = exec.Command(cmdPath)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expected, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E

## Testing
- `go run verifierA.go ./676A`
- `go run verifierB.go ./676B`
- `go run verifierC.go ./676C`
- `go run verifierD.go ./676D`
- `go run verifierE.go ./676E`


------
https://chatgpt.com/codex/tasks/task_e_68837311076c83249043edbbcd8618f9