### PR TITLE
Add Go verifiers for CF contest 674 A and B

### DIFF
--- a/0-999/600-699/670-679/674/674A.go
+++ b/0-999/600-699/670-679/674/674A.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(in, &n)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &arr[i])
+	}
+	ans := make([]int, n+1)
+	for l := 0; l < n; l++ {
+		cnt := make([]int, n+1)
+		best := 0
+		for r := l; r < n; r++ {
+			c := arr[r]
+			cnt[c]++
+			if cnt[c] > cnt[best] || (cnt[c] == cnt[best] && c < best) {
+				best = c
+			}
+			ans[best]++
+		}
+	}
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			fmt.Fprint(out, " ")
+		}
+		fmt.Fprint(out, ans[i])
+	}
+	fmt.Fprintln(out)
+}

--- a/0-999/600-699/670-679/674/verifierA.go
+++ b/0-999/600-699/670-679/674/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(arr []int) []int {
+	n := len(arr)
+	ans := make([]int, n+1)
+	for l := 0; l < n; l++ {
+		cnt := make([]int, n+1)
+		best := 0
+		for r := l; r < n; r++ {
+			c := arr[r]
+			cnt[c]++
+			if cnt[c] > cnt[best] || (cnt[c] == cnt[best] && c < best) {
+				best = c
+			}
+			ans[best]++
+		}
+	}
+	return ans[1:]
+}
+
+func runCase(exe string, input string, exp []int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != len(exp) {
+		return fmt.Errorf("expected %d numbers, got %d", len(exp), len(fields))
+	}
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("bad integer %q", f)
+		}
+		if v != exp[i] {
+			return fmt.Errorf("mismatch at %d: expected %d got %d", i, exp[i], v)
+		}
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(9) + 1 // up to 10
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	exp := expected(arr)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/670-679/674/verifierB.go
+++ b/0-999/600-699/670-679/674/verifierB.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func checkPaths(n, k, a, b, c, d int, v, u []int) error {
+	if len(v) != n || len(u) != n {
+		return fmt.Errorf("expected %d numbers per line", n)
+	}
+	if v[0] != a || v[n-1] != b || u[0] != c || u[n-1] != d {
+		return fmt.Errorf("endpoints mismatch")
+	}
+	used1 := make([]bool, n+1)
+	used2 := make([]bool, n+1)
+	for i := 0; i < n; i++ {
+		if v[i] < 1 || v[i] > n || used1[v[i]] {
+			return fmt.Errorf("line1 not a permutation")
+		}
+		used1[v[i]] = true
+		if u[i] < 1 || u[i] > n || used2[u[i]] {
+			return fmt.Errorf("line2 not a permutation")
+		}
+		used2[u[i]] = true
+	}
+	edges := make(map[[2]int]struct{})
+	addEdge := func(x, y int) {
+		if x > y {
+			x, y = y, x
+		}
+		edges[[2]int{x, y}] = struct{}{}
+	}
+	for i := 0; i < n-1; i++ {
+		addEdge(v[i], v[i+1])
+		addEdge(u[i], u[i+1])
+	}
+	if _, ok := edges[[2]int{a, b}]; ok {
+		return fmt.Errorf("edge between a and b present")
+	}
+	if _, ok := edges[[2]int{c, d}]; ok {
+		return fmt.Errorf("edge between c and d present")
+	}
+	if len(edges) > k {
+		return fmt.Errorf("too many edges: %d > %d", len(edges), k)
+	}
+	return nil
+}
+
+func runCase(exe string, input string, n, k, a, b, c, d int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	output := strings.TrimSpace(out.String())
+	if output == "-1" {
+		if n <= 4 || k < n+1 {
+			return nil
+		}
+		return fmt.Errorf("reported no solution, but one exists")
+	}
+	lines := strings.Split(output, "\n")
+	if len(lines) < 2 {
+		return fmt.Errorf("expected two lines of output")
+	}
+	parse := func(s string) ([]int, error) {
+		f := strings.Fields(s)
+		if len(f) != n {
+			return nil, fmt.Errorf("expected %d numbers", n)
+		}
+		res := make([]int, n)
+		for i, x := range f {
+			v, err := strconv.Atoi(x)
+			if err != nil {
+				return nil, fmt.Errorf("bad integer %q", x)
+			}
+			res[i] = v
+		}
+		return res, nil
+	}
+	v, err := parse(lines[0])
+	if err != nil {
+		return err
+	}
+	u, err := parse(lines[1])
+	if err != nil {
+		return err
+	}
+	return checkPaths(n, k, a, b, c, d, v, u)
+}
+
+func generateCase(rng *rand.Rand) (string, int, int, int, int, int, int) {
+	n := rng.Intn(6) + 5     // 5..10
+	k := rng.Intn(n) + n + 1 // >= n+1
+	perm := rng.Perm(n)
+	a := perm[0] + 1
+	b := perm[1] + 1
+	c := perm[2] + 1
+	d := perm[3] + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", a, b, c, d))
+	return sb.String(), n, k, a, b, c, d
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n, k, a, b, c, d := generateCase(rng)
+		if err := runCase(exe, in, n, k, a, b, c, d); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- create contest directory `674`
- add sample solution `674A.go`
- implement randomised verifiers `verifierA.go` and `verifierB.go`

## Testing
- `gofmt -w 0-999/600-699/670-679/674/*.go`


------
https://chatgpt.com/codex/tasks/task_e_688371f88c2c83249eceeacf972a053a