### PR TITLE
Add Go solution for 1913C

### DIFF
--- a/1000-1999/1900-1999/1910-1919/1913/1913C.go
+++ b/1000-1999/1900-1999/1910-1919/1913/1913C.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var m int
+	fmt.Fscan(reader, &m)
+
+	counts := make([]int64, 30)
+	for i := 0; i < m; i++ {
+		var t, v int
+		fmt.Fscan(reader, &t, &v)
+		if t == 1 {
+			if v >= 0 && v < 30 {
+				counts[v]++
+			}
+		} else {
+			w := int64(v)
+			carry := int64(0)
+			possible := true
+			for b := 0; b < 30; b++ {
+				carry += counts[b]
+				if (w>>b)&1 == 1 {
+					if carry == 0 {
+						possible = false
+						break
+					}
+					carry--
+				}
+				carry /= 2
+			}
+			if possible {
+				fmt.Fprintln(writer, "YES")
+			} else {
+				fmt.Fprintln(writer, "NO")
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement 1913C in Go

## Testing
- `gofmt -w 1000-1999/1900-1999/1910-1919/1913/1913C.go`
- `go build 1000-1999/1900-1999/1910-1919/1913/1913C.go`


------
https://chatgpt.com/codex/tasks/task_e_688371b272cc8324b524f289ce8da4b7