### PR TITLE
Add Go verifiers for CF 672

### DIFF
--- a/0-999/600-699/670-679/672/verifierA.go
+++ b/0-999/600-699/670-679/672/verifierA.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedDigit(n int) string {
+	s := make([]byte, 0, n+10)
+	for i := 1; len(s) < n; i++ {
+		s = append(s, fmt.Sprint(i)...)
+	}
+	return fmt.Sprintf("%c", s[n-1])
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(1000) + 1
+		input := fmt.Sprintf("%d\n", n)
+		expected := expectedDigit(n)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/670-679/672/verifierB.go
+++ b/0-999/600-699/670-679/672/verifierB.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedChanges(s string) int {
+	n := len(s)
+	if n > 26 {
+		return -1
+	}
+	seen := make(map[rune]struct{})
+	for _, ch := range s {
+		seen[ch] = struct{}{}
+	}
+	return n - len(seen)
+}
+
+func randString(rng *rand.Rand, n int) string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	sb := make([]rune, n)
+	for i := 0; i < n; i++ {
+		sb[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(sb)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(100) + 1
+		s := randString(rng, n)
+		input := fmt.Sprintf("%d\n%s\n", n, s)
+		expected := fmt.Sprintf("%d", expectedChanges(s))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go and verifierB.go for contest 672
- each verifier runs 100 random test cases
- allows running `go run verifier*.go /path/to/binary`

## Testing
- `go run 0-999/600-699/670-679/672/verifierA.go /tmp/672A`
- `go run 0-999/600-699/670-679/672/verifierB.go /tmp/672B`


------
https://chatgpt.com/codex/tasks/task_e_688370e04ffc83249452d10e205389fa