### PR TITLE
Add Go solution verifiers for contest 671

### DIFF
--- a/0-999/600-699/670-679/671/verifierA.go
+++ b/0-999/600-699/670-679/671/verifierA.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type testCaseA struct {
+	ax, ay float64
+	bx, by float64
+	tx, ty float64
+	n      int
+	pts    [][2]float64
+}
+
+func genTestsA() []testCaseA {
+	rand.Seed(1)
+	tests := make([]testCaseA, 100)
+	for i := range tests {
+		tc := testCaseA{}
+		tc.ax = float64(rand.Intn(6))
+		tc.ay = float64(rand.Intn(6))
+		tc.bx = float64(rand.Intn(6))
+		tc.by = float64(rand.Intn(6))
+		tc.tx = float64(rand.Intn(6))
+		tc.ty = float64(rand.Intn(6))
+		tc.n = rand.Intn(4) + 1 // 1..4
+		tc.pts = make([][2]float64, tc.n)
+		for j := 0; j < tc.n; j++ {
+			tc.pts[j][0] = float64(rand.Intn(6))
+			tc.pts[j][1] = float64(rand.Intn(6))
+		}
+		tests[i] = tc
+	}
+	return tests
+}
+
+func solveA(tc testCaseA) float64 {
+	ax, ay := tc.ax, tc.ay
+	bx, by := tc.bx, tc.by
+	tx, ty := tc.tx, tc.ty
+	n := tc.n
+	x := make([]float64, n)
+	y := make([]float64, n)
+	for i := 0; i < n; i++ {
+		x[i] = tc.pts[i][0]
+		y[i] = tc.pts[i][1]
+	}
+	sum := 0.0
+	distT := make([]float64, n)
+	for i := 0; i < n; i++ {
+		d := math.Hypot(x[i]-tx, y[i]-ty)
+		distT[i] = d
+		sum += 2 * d
+	}
+	ans := math.Inf(1)
+	for i := 0; i < n; i++ {
+		costA := math.Hypot(x[i]-ax, y[i]-ay)
+		cand := costA + sum - distT[i]
+		if cand < ans {
+			ans = cand
+		}
+		costB := math.Hypot(x[i]-bx, y[i]-by)
+		cand = costB + sum - distT[i]
+		if cand < ans {
+			ans = cand
+		}
+	}
+	if n == 1 {
+		return ans
+	}
+	deltaA := make([]float64, n)
+	deltaB := make([]float64, n)
+	for i := 0; i < n; i++ {
+		deltaA[i] = math.Hypot(x[i]-ax, y[i]-ay) - distT[i]
+		deltaB[i] = math.Hypot(x[i]-bx, y[i]-by) - distT[i]
+	}
+	idx := make([]int, n)
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(i, j int) bool { return deltaB[idx[i]] < deltaB[idx[j]] })
+	first := idx[0]
+	second := idx[1%len(idx)]
+	for i := 0; i < n; i++ {
+		total := sum + deltaA[i]
+		if i == first {
+			total += deltaB[second]
+		} else {
+			total += deltaB[first]
+		}
+		if total < ans {
+			ans = total
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+	for i, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%.0f %.0f %.0f %.0f %.0f %.0f %d\n", tc.ax, tc.ay, tc.bx, tc.by, tc.tx, tc.ty, tc.n)
+		for j := 0; j < tc.n; j++ {
+			fmt.Fprintf(&input, "%.0f %.0f\n", tc.pts[j][0], tc.pts[j][1])
+		}
+		expect := solveA(tc)
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseFloat(strings.TrimSpace(out), 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: invalid output %q\n", i+1, out)
+			os.Exit(1)
+		}
+		if math.Abs(val-expect) > 1e-6 {
+			fmt.Fprintf(os.Stderr, "test %d: expected %.6f got %.6f\n", i+1, expect, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/600-699/670-679/671/verifierB.go
+++ b/0-999/600-699/670-679/671/verifierB.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type testCaseB struct {
+	n   int
+	k   int64
+	arr []int64
+}
+
+func genTestsB() []testCaseB {
+	rand.Seed(2)
+	tests := make([]testCaseB, 100)
+	for i := range tests {
+		n := rand.Intn(6) + 1 //1..6
+		k := int64(rand.Intn(20))
+		arr := make([]int64, n)
+		for j := range arr {
+			arr[j] = int64(rand.Intn(20)) + 1
+		}
+		tests[i] = testCaseB{n, k, arr}
+	}
+	return tests
+}
+
+func solveB(tc testCaseB) int64 {
+	n, k := tc.n, tc.k
+	arr := append([]int64(nil), tc.arr...)
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	l, r := 0, n-1
+	for l < r && k > 0 {
+		if l+1 <= n-1-r {
+			diff := arr[l+1] - arr[l]
+			cost := diff * int64(l+1)
+			if cost <= k {
+				k -= cost
+				l++
+			} else {
+				arr[l] += k / int64(l+1)
+				k = 0
+			}
+		} else {
+			diff := arr[r] - arr[r-1]
+			cost := diff * int64(n-r)
+			if cost <= k {
+				k -= cost
+				r--
+			} else {
+				arr[r] -= k / int64(n-r)
+				k = 0
+			}
+		}
+	}
+	if arr[r] < arr[l] {
+		return 0
+	}
+	return arr[r] - arr[l]
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+	for i, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		for j, v := range tc.arr {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		expect := solveB(tc)
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: invalid output %q\n", i+1, out)
+			os.Exit(1)
+		}
+		if val != expect {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d got %d\n", i+1, expect, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/600-699/670-679/671/verifierC.go
+++ b/0-999/600-699/670-679/671/verifierC.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCaseC struct {
+	n   int
+	arr []int
+}
+
+func genTestsC() []testCaseC {
+	rand.Seed(3)
+	tests := make([]testCaseC, 100)
+	for i := range tests {
+		n := rand.Intn(6) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(10) + 1
+		}
+		tests[i] = testCaseC{n, arr}
+	}
+	return tests
+}
+
+// solver copied from 671C.go
+func solveC(tc testCaseC) int64 {
+	n := tc.n
+	arr := tc.arr
+	maxV := 0
+	for _, v := range arr {
+		if v > maxV {
+			maxV = v
+		}
+	}
+	first1 := make([]int, maxV+1)
+	first2 := make([]int, maxV+1)
+	last1 := make([]int, maxV+1)
+	last2 := make([]int, maxV+1)
+	cnt := make([]int, maxV+1)
+	for i := 0; i <= maxV; i++ {
+		first1[i] = n + 1
+		first2[i] = n + 1
+	}
+	for idx, v := range arr {
+		pos := idx + 1
+		for d := 1; d*d <= v; d++ {
+			if v%d == 0 {
+				update := func(div int) {
+					cnt[div]++
+					if pos < first1[div] {
+						first2[div] = first1[div]
+						first1[div] = pos
+					} else if pos < first2[div] {
+						first2[div] = pos
+					}
+					if pos > last1[div] {
+						last2[div] = last1[div]
+						last1[div] = pos
+					} else if pos > last2[div] {
+						last2[div] = pos
+					}
+				}
+				update(d)
+				if d*d != v {
+					update(v / d)
+				}
+			}
+		}
+	}
+	total := int64(n) * int64(n+1) / 2
+	S := make([]int64, maxV+1)
+	for g := 1; g <= maxV; g++ {
+		if cnt[g] >= 2 {
+			c := int64(first2[g])*(int64(n)-int64(last1[g])+1) + int64(first1[g])*(int64(last1[g])-int64(last2[g]))
+			S[g] = total - c
+		}
+	}
+	F := make([]int64, maxV+1)
+	var ans int64
+	for g := maxV; g >= 1; g-- {
+		val := S[g]
+		for m := g * 2; m <= maxV; m += g {
+			val -= F[m]
+		}
+		if val < 0 {
+			val = 0
+		}
+		F[g] = val
+		ans += val * int64(g)
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+	for i, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d\n", tc.n)
+		for j, v := range tc.arr {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		expect := solveC(tc)
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: invalid output %q\n", i+1, out)
+			os.Exit(1)
+		}
+		if val != expect {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d got %d\n", i+1, expect, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/600-699/670-679/671/verifierD.go
+++ b/0-999/600-699/670-679/671/verifierD.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type worker struct {
+	u, v int
+	c    int64
+}
+
+type testCaseD struct {
+	n       int
+	m       int
+	edges   [][2]int
+	workers []worker
+}
+
+func genTree(n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func genTestsD() []testCaseD {
+	rand.Seed(4)
+	tests := make([]testCaseD, 100)
+	for i := range tests {
+		n := rand.Intn(5) + 2 //2..6
+		m := rand.Intn(5) + 1
+		edges := genTree(n)
+		// build parent map
+		parent := make([]int, n+1)
+		for _, e := range edges {
+			x, y := e[0], e[1]
+			parent[y] = x
+		}
+		workers := make([]worker, m)
+		for j := 0; j < m; j++ {
+			u := rand.Intn(n-1) + 2 // 2..n
+			// choose ancestor from path u->1
+			v := u
+			for v != 1 && rand.Intn(2) == 0 {
+				v = parent[v]
+			}
+			if v == 0 {
+				v = 1
+			}
+			c := int64(rand.Intn(5) + 1)
+			workers[j] = worker{u, v, c}
+		}
+		tests[i] = testCaseD{n, m, edges, workers}
+	}
+	return tests
+}
+
+// solver copied from 671D.go
+
+type Node struct {
+	val         int64
+	to          int
+	add         int64
+	left, right *Node
+}
+
+func apply(n *Node, d int64) {
+	if n != nil {
+		n.val += d
+		n.add += d
+	}
+}
+
+func push(n *Node) {
+	if n != nil && n.add != 0 {
+		apply(n.left, n.add)
+		apply(n.right, n.add)
+		n.add = 0
+	}
+}
+
+func merge(a, b *Node) *Node {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	if a.val > b.val {
+		a, b = b, a
+	}
+	push(a)
+	a.right = merge(a.right, b)
+	a.left, a.right = a.right, a.left
+	return a
+}
+
+var (
+	g       [][]int
+	roots   []*Node
+	visited []bool
+)
+
+func dfs(u, p int, top []int, weight []int64, ans *int64) bool {
+	for _, v := range g[u] {
+		if v != p {
+			if !dfs(v, u, top, weight, ans) {
+				return false
+			}
+			roots[u] = merge(roots[u], roots[v])
+		}
+	}
+	visited[u] = true
+	if u == 1 {
+		return true
+	}
+	for roots[u] != nil {
+		push(roots[u])
+		if visited[roots[u].to] {
+			roots[u] = merge(roots[u].left, roots[u].right)
+		} else {
+			break
+		}
+	}
+	if roots[u] == nil {
+		return false
+	}
+	*ans += roots[u].val
+	apply(roots[u], -roots[u].val)
+	return true
+}
+
+func solveD(tc testCaseD) int64 {
+	n, m := tc.n, tc.m
+	g = make([][]int, n+1)
+	for _, e := range tc.edges {
+		x, y := e[0], e[1]
+		g[x] = append(g[x], y)
+		g[y] = append(g[y], x)
+	}
+	roots = make([]*Node, n+1)
+	top := make([]int, m+1)
+	weight := make([]int64, m+1)
+	for i, w := range tc.workers {
+		idx := i + 1
+		top[idx] = w.v
+		weight[idx] = w.c
+		node := &Node{val: w.c, to: w.v}
+		roots[w.u] = merge(roots[w.u], node)
+	}
+	visited = make([]bool, n+1)
+	var ans int64
+	if !dfs(1, 0, top, weight, &ans) {
+		return -1
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+	for i, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.m)
+		for _, e := range tc.edges {
+			fmt.Fprintf(&input, "%d %d\n", e[0], e[1])
+		}
+		for _, w := range tc.workers {
+			fmt.Fprintf(&input, "%d %d %d\n", w.u, w.v, w.c)
+		}
+		expect := solveD(tc)
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: invalid output %q\n", i+1, out)
+			os.Exit(1)
+		}
+		if val != expect {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d got %d\n", i+1, expect, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/600-699/670-679/671/verifierE.go
+++ b/0-999/600-699/670-679/671/verifierE.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCaseE struct {
+	n int
+	k int64
+	w []int64
+	g []int64
+}
+
+func genTestsE() []testCaseE {
+	rand.Seed(5)
+	tests := make([]testCaseE, 100)
+	for i := range tests {
+		n := rand.Intn(5) + 2 // 2..6
+		k := int64(rand.Intn(10))
+		w := make([]int64, n)
+		for j := 1; j < n; j++ {
+			w[j] = int64(rand.Intn(5) + 1)
+		}
+		g := make([]int64, n+1)
+		for j := 1; j <= n; j++ {
+			g[j] = int64(rand.Intn(5))
+		}
+		tests[i] = testCaseE{n, k, w, g}
+	}
+	return tests
+}
+
+// solver copied from 671E.go
+func solveE(tc testCaseE) int {
+	n := tc.n
+	k := tc.k
+	w := tc.w
+	g := tc.g
+	W := make([]int64, n+2)
+	G := make([]int64, n+2)
+	for i := 1; i <= n; i++ {
+		W[i] = W[i-1]
+		if i >= 2 {
+			W[i] += w[i-1]
+		}
+		G[i] = G[i-1] + g[i]
+	}
+	A := make([]int64, n)
+	B := make([]int64, n)
+	for j := 1; j < n; j++ {
+		A[j] = W[j+1] - G[j]
+		B[j] = W[j] - G[j]
+	}
+	check := func(L int) bool {
+		if L <= 1 {
+			return true
+		}
+		d := L - 1
+		qa := make([]int, 0, n)
+		qb := make([]int, 0, n)
+		for j := 1; j < n; j++ {
+			start := j - d + 1
+			if len(qa) > 0 && qa[0] < start {
+				qa = qa[1:]
+			}
+			if len(qb) > 0 && qb[0] < start {
+				qb = qb[1:]
+			}
+			for len(qa) > 0 && A[qa[len(qa)-1]] <= A[j] {
+				qa = qa[:len(qa)-1]
+			}
+			qa = append(qa, j)
+			for len(qb) > 0 && B[qb[len(qb)-1]] >= B[j] {
+				qb = qb[:len(qb)-1]
+			}
+			qb = append(qb, j)
+			if j >= d {
+				l := j - d + 1
+				r := l + L - 1
+				ma := A[qa[0]]
+				mb := B[qb[0]]
+				C := W[l] - G[l-1]
+				E := W[r] - G[r]
+				fdef := ma - C
+				if fdef < 0 {
+					fdef = 0
+				}
+				bdef := E - mb
+				if bdef < 0 {
+					bdef = 0
+				}
+				need := fdef
+				if bdef > need {
+					need = bdef
+				}
+				if need <= k {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	low, high := 1, n
+	ans := 1
+	for low <= high {
+		mid := (low + high) / 2
+		if check(mid) {
+			ans = mid
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+	for i, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		for j := 1; j < tc.n; j++ {
+			if j > 1 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, tc.w[j])
+		}
+		input.WriteByte('\n')
+		for j := 1; j <= tc.n; j++ {
+			if j > 1 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, tc.g[j])
+		}
+		input.WriteByte('\n')
+		expect := solveE(tc)
+		out, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: invalid output %q\n", i+1, out)
+			os.Exit(1)
+		}
+		if val != expect {
+			fmt.Fprintf(os.Stderr, "test %d: expected %d got %d\n", i+1, expect, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`–`verifierE.go` for contest 671
- each verifier generates 100 random tests and runs a user binary
- verifiers include reference implementations derived from the official solutions

## Testing
- `go run verifierA.go ./671A.go`
- `go run verifierB.go ./671B.go`
- `go run verifierC.go ./671C.go`
- `go run verifierD.go ./671D.go`
- `go run verifierE.go ./671E.go`


------
https://chatgpt.com/codex/tasks/task_e_688370549ca08324a00e35f44563d545