### PR TITLE
Add solution verifiers for contest 685

### DIFF
--- a/0-999/600-699/680-689/685/verifierA.go
+++ b/0-999/600-699/680-689/685/verifierA.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func digitsNeeded(x int) int {
+	d := 1
+	for x >= 7 {
+		x /= 7
+		d++
+	}
+	return d
+}
+
+func toBase7(x, d int) []int {
+	res := make([]int, d)
+	for i := d - 1; i >= 0; i-- {
+		res[i] = x % 7
+		x /= 7
+	}
+	return res
+}
+
+func distinct(a, b []int) bool {
+	used := make([]bool, 7)
+	for _, v := range a {
+		if used[v] {
+			return false
+		}
+		used[v] = true
+	}
+	for _, v := range b {
+		if used[v] {
+			return false
+		}
+		used[v] = true
+	}
+	return true
+}
+
+func expected(n, m int) int {
+	d1 := digitsNeeded(n - 1)
+	d2 := digitsNeeded(m - 1)
+	if d1+d2 > 7 {
+		return 0
+	}
+	ans := 0
+	for h := 0; h < n; h++ {
+		hd := toBase7(h, d1)
+		for mm := 0; mm < m; mm++ {
+			md := toBase7(mm, d2)
+			if distinct(hd, md) {
+				ans++
+			}
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		m := rand.Intn(10) + 1
+		input := fmt.Sprintf("%d %d\n", n, m)
+		want := expected(n, m)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\noutput:%s", i+1, err, out)
+			return
+		}
+		out = strings.TrimSpace(out)
+		got, err := strconv.Atoi(out)
+		if err != nil {
+			fmt.Printf("invalid output on test %d: %q\n", i+1, out)
+			return
+		}
+		if got != want {
+			fmt.Printf("wrong answer on test %d\ninput:%sexpected:%d got:%d\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/685/verifierB.go
+++ b/0-999/600-699/680-689/685/verifierB.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type edge struct{ to int }
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildTree(n int, parents []int) [][]int {
+	g := make([][]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := parents[i]
+		g[p] = append(g[p], i)
+		g[i] = append(g[i], p)
+	}
+	return g
+}
+
+func subtreeNodes(g [][]int, root, parent int, mark []bool) []int {
+	mark[root] = true
+	nodes := []int{root}
+	for _, v := range g[root] {
+		if v != parent {
+			nodes = append(nodes, subtreeNodes(g, v, root, mark)...)
+		}
+	}
+	return nodes
+}
+
+func componentSize(g [][]int, banned int, nodesMap map[int]bool, start int, visited map[int]bool) int {
+	stack := []int{start}
+	visited[start] = true
+	size := 0
+	for len(stack) > 0 {
+		u := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		size++
+		for _, v := range g[u] {
+			if v == banned || !nodesMap[v] || visited[v] {
+				continue
+			}
+			visited[v] = true
+			stack = append(stack, v)
+		}
+	}
+	return size
+}
+
+func centroidOfSubtree(g [][]int, root int) int {
+	mark := make([]bool, len(g))
+	nodes := subtreeNodes(g, root, 0, mark)
+	nodesMap := make(map[int]bool)
+	for _, v := range nodes {
+		nodesMap[v] = true
+	}
+	total := len(nodes)
+	for _, c := range nodes {
+		visited := make(map[int]bool)
+		maxComp := 0
+		for _, v := range nodes {
+			if v == c || visited[v] {
+				continue
+			}
+			size := componentSize(g, c, nodesMap, v, visited)
+			if size > maxComp {
+				maxComp = size
+			}
+		}
+		if maxComp*2 <= total {
+			return c
+		}
+	}
+	return root
+}
+
+func expected(n int, parents []int, queries []int) []int {
+	g := buildTree(n, parents)
+	res := make([]int, len(queries))
+	for i, v := range queries {
+		res[i] = centroidOfSubtree(g, v)
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		q := rand.Intn(10) + 1
+		parents := make([]int, n+1)
+		for i := 2; i <= n; i++ {
+			parents[i] = rand.Intn(i-1) + 1
+		}
+		queries := make([]int, q)
+		for i := 0; i < q; i++ {
+			queries[i] = rand.Intn(n) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		for i := 2; i <= n; i++ {
+			if i > 2 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(parents[i]))
+		}
+		if n > 1 {
+			sb.WriteByte('\n')
+		} else {
+			sb.WriteString("\n")
+		}
+		for i := 0; i < q; i++ {
+			sb.WriteString(fmt.Sprintf("%d\n", queries[i]))
+		}
+		want := expected(n, parents, queries)
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\noutput:%s", t+1, err, out)
+			return
+		}
+		outLines := strings.Fields(out)
+		if len(outLines) != q {
+			fmt.Printf("invalid output on test %d\ninput:%soutput:%s", t+1, sb.String(), out)
+			return
+		}
+		for i := 0; i < q; i++ {
+			got, err := strconv.Atoi(outLines[i])
+			if err != nil || got != want[i] {
+				fmt.Printf("wrong answer on test %d\ninput:%sexpected:%v\noutput:%s", t+1, sb.String(), want, out)
+				return
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/685/verifierC.go
+++ b/0-999/600-699/680-689/685/verifierC.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func bestPoint(points [][3]int) (int, int, int) {
+	minX, maxX := points[0][0], points[0][0]
+	minY, maxY := points[0][1], points[0][1]
+	minZ, maxZ := points[0][2], points[0][2]
+	for _, p := range points {
+		if p[0] < minX {
+			minX = p[0]
+		}
+		if p[0] > maxX {
+			maxX = p[0]
+		}
+		if p[1] < minY {
+			minY = p[1]
+		}
+		if p[1] > maxY {
+			maxY = p[1]
+		}
+		if p[2] < minZ {
+			minZ = p[2]
+		}
+		if p[2] > maxZ {
+			maxZ = p[2]
+		}
+	}
+	bestD := math.MaxInt32
+	bx, by, bz := 0, 0, 0
+	for x := minX - 2; x <= maxX+2; x++ {
+		for y := minY - 2; y <= maxY+2; y++ {
+			for z := minZ - 2; z <= maxZ+2; z++ {
+				md := 0
+				for _, p := range points {
+					d := abs(x-p[0]) + abs(y-p[1]) + abs(z-p[2])
+					if d > md {
+						md = d
+					}
+				}
+				if md < bestD || (md == bestD && (x < bx || (x == bx && (y < by || (y == by && z < bz))))) {
+					bestD = md
+					bx, by, bz = x, y, z
+				}
+			}
+		}
+	}
+	return bx, by, bz
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rand.Intn(4) + 1
+		points := make([][3]int, n)
+		for i := 0; i < n; i++ {
+			points[i][0] = rand.Intn(7) - 3
+			points[i][1] = rand.Intn(7) - 3
+			points[i][2] = rand.Intn(7) - 3
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(n) + "\n")
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", points[i][0], points[i][1], points[i][2]))
+		}
+		bx, by, bz := bestPoint(points)
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\noutput:%s", tcase+1, err, out)
+			return
+		}
+		outFields := strings.Fields(out)
+		if len(outFields) != 3 {
+			fmt.Printf("invalid output on test %d\ninput:%soutput:%s", tcase+1, sb.String(), out)
+			return
+		}
+		gx, _ := strconv.Atoi(outFields[0])
+		gy, _ := strconv.Atoi(outFields[1])
+		gz, _ := strconv.Atoi(outFields[2])
+		if gx != bx || gy != by || gz != bz {
+			fmt.Printf("wrong answer on test %d\ninput:%sexpected:%d %d %d\noutput:%s", tcase+1, sb.String(), bx, by, bz, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/685/verifierD.go
+++ b/0-999/600-699/680-689/685/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func countSquares(n, k int, pts [][2]int) []int64 {
+	res := make([]int64, n+1)
+	if n == 0 {
+		return res
+	}
+	minX, maxX := pts[0][0]-k+1, pts[0][0]
+	minY, maxY := pts[0][1]-k+1, pts[0][1]
+	for _, p := range pts {
+		if p[0]-k+1 < minX {
+			minX = p[0] - k + 1
+		}
+		if p[0] > maxX {
+			maxX = p[0]
+		}
+		if p[1]-k+1 < minY {
+			minY = p[1] - k + 1
+		}
+		if p[1] > maxY {
+			maxY = p[1]
+		}
+	}
+	for x := minX; x <= maxX; x++ {
+		for y := minY; y <= maxY; y++ {
+			cnt := 0
+			for _, p := range pts {
+				if p[0] >= x && p[0] <= x+k-1 && p[1] >= y && p[1] <= y+k-1 {
+					cnt++
+				}
+			}
+			if cnt >= 1 {
+				res[cnt]++
+			}
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rand.Intn(5) + 1
+		k := rand.Intn(4) + 1
+		pts := make([][2]int, n)
+		for i := 0; i < n; i++ {
+			pts[i][0] = rand.Intn(11) - 5
+			pts[i][1] = rand.Intn(11) - 5
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", pts[i][0], pts[i][1]))
+		}
+		want := countSquares(n, k, pts)
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\noutput:%s", tcase+1, err, out)
+			return
+		}
+		fields := strings.Fields(out)
+		if len(fields) != n {
+			fmt.Printf("invalid output on test %d\ninput:%soutput:%s", tcase+1, sb.String(), out)
+			return
+		}
+		for i := 0; i < n; i++ {
+			got, err := strconv.ParseInt(fields[i], 10, 64)
+			if err != nil || got != want[i+1] {
+				fmt.Printf("wrong answer on test %d\ninput:%sexpected:%v\noutput:%s", tcase+1, sb.String(), want[1:], out)
+				return
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/685/verifierE.go
+++ b/0-999/600-699/680-689/685/verifierE.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Edge struct {
+	to  int
+	idx int
+}
+
+type Item struct {
+	node int
+	time int
+}
+
+type PQ []Item
+
+func (pq PQ) Len() int            { return len(pq) }
+func (pq PQ) Less(i, j int) bool  { return pq[i].time < pq[j].time }
+func (pq PQ) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PQ) Push(x interface{}) { *pq = append(*pq, x.(Item)) }
+func (pq *PQ) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	it := old[n-1]
+	*pq = old[:n-1]
+	return it
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func reachable(adj [][]Edge, l, r, s, t int) bool {
+	const INF = int(1<<31 - 1)
+	dist := make([]int, len(adj))
+	for i := range dist {
+		dist[i] = INF
+	}
+	pq := &PQ{}
+	heap.Init(pq)
+	dist[s] = l
+	heap.Push(pq, Item{s, l})
+	for pq.Len() > 0 {
+		it := heap.Pop(pq).(Item)
+		if it.time != dist[it.node] {
+			continue
+		}
+		if it.time > r {
+			continue
+		}
+		if it.node == t {
+			break
+		}
+		for _, e := range adj[it.node] {
+			if e.idx < l || e.idx > r || e.idx < it.time {
+				continue
+			}
+			if e.idx < dist[e.to] {
+				dist[e.to] = e.idx
+				heap.Push(pq, Item{e.to, e.idx})
+			}
+		}
+	}
+	return dist[t] <= r
+}
+
+func buildGraph(n, m int) ([][]Edge, [][2]int) {
+	g := make([][]Edge, n+1)
+	edges := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		v := rand.Intn(n) + 1
+		u := rand.Intn(n) + 1
+		for u == v {
+			u = rand.Intn(n) + 1
+		}
+		idx := i + 1
+		g[v] = append(g[v], Edge{u, idx})
+		g[u] = append(g[u], Edge{v, idx})
+		edges[i] = [2]int{v, u}
+	}
+	return g, edges
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(42)
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rand.Intn(4) + 2
+		m := rand.Intn(6) + 1
+		q := rand.Intn(4) + 1
+		adj, edges := buildGraph(n, m)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+		for i := 0; i < m; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", edges[i][0], edges[i][1]))
+		}
+		answers := make([]string, q)
+		for i := 0; i < q; i++ {
+			l := rand.Intn(m) + 1
+			r := rand.Intn(m-l+1) + l
+			s := rand.Intn(n) + 1
+			t := rand.Intn(n) + 1
+			for t == s {
+				t = rand.Intn(n) + 1
+			}
+			sb.WriteString(fmt.Sprintf("%d %d %d %d\n", l, r, s, t))
+			if reachable(adj, l, r, s, t) {
+				answers[i] = "Yes"
+			} else {
+				answers[i] = "No"
+			}
+		}
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\noutput:%s", tcase+1, err, out)
+			return
+		}
+		outLines := strings.Fields(out)
+		if len(outLines) != q {
+			fmt.Printf("invalid output on test %d\ninput:%soutput:%s", tcase+1, sb.String(), out)
+			return
+		}
+		for i := 0; i < q; i++ {
+			if outLines[i] != answers[i] {
+				fmt.Printf("wrong answer on test %d\ninput:%sexpected:%v\noutput:%s", tcase+1, sb.String(), answers, out)
+				return
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 685
- each verifier runs 100 randomized tests against a given binary and reports mismatches

## Testing
- `go build 0-999/600-699/680-689/685/verifierA.go`
- `go build 0-999/600-699/680-689/685/verifierB.go`
- `go build 0-999/600-699/680-689/685/verifierC.go`
- `go build 0-999/600-699/680-689/685/verifierD.go`
- `go build 0-999/600-699/680-689/685/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_688377fdc62083249c92c8f39d22e421