### PR TITLE
Add verifiers for contest 670

### DIFF
--- a/0-999/600-699/670-679/670/verifierA.go
+++ b/0-999/600-699/670-679/670/verifierA.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) string {
+	minDays := (n / 7) * 2
+	maxDays := (n / 7) * 2
+	rem := n % 7
+	if rem > 2 {
+		maxDays += 2
+	} else {
+		maxDays += rem
+	}
+	if rem > 5 {
+		minDays += rem - 5
+	}
+	return fmt.Sprintf("%d %d", minDays, maxDays)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(1000000) + 1
+	inp := fmt.Sprintf("%d\n", n)
+	return inp, expected(n)
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected: %s\n got: %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/670-679/670/verifierB.go
+++ b/0-999/600-699/670-679/670/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(n int, k int64, ids []int) string {
+	kk := k
+	for i := 1; i <= n; i++ {
+		if kk <= int64(i) {
+			return fmt.Sprintf("%d", ids[kk-1])
+		}
+		kk -= int64(i)
+	}
+	return ""
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	ids := make([]int, n)
+	used := make(map[int]struct{})
+	for i := 0; i < n; i++ {
+		for {
+			v := rng.Intn(1000000000) + 1
+			if _, ok := used[v]; !ok {
+				ids[i] = v
+				used[v] = struct{}{}
+				break
+			}
+		}
+	}
+	total := int64(n * (n + 1) / 2)
+	var k int64
+	if total > 2000000000 {
+		total = 2000000000
+	}
+	k = rng.Int63n(total) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range ids {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	inp := sb.String()
+	exp := expected(n, k, ids)
+	return inp, exp
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected: %s\n got: %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/670-679/670/verifierC.go
+++ b/0-999/600-699/670-679/670/verifierC.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(n int, langs []int, m int, audio []int, sub []int) string {
+	freq := make(map[int]int)
+	for _, v := range langs {
+		freq[v]++
+	}
+	bestIdx := 0
+	bestAudio := -1
+	bestSub := -1
+	for i := 0; i < m; i++ {
+		a := freq[audio[i]]
+		s := freq[sub[i]]
+		if a > bestAudio || (a == bestAudio && s > bestSub) {
+			bestAudio = a
+			bestSub = s
+			bestIdx = i + 1
+		}
+	}
+	return fmt.Sprintf("%d", bestIdx)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	langs := make([]int, n)
+	for i := range langs {
+		langs[i] = rng.Intn(50) + 1
+	}
+	m := rng.Intn(20) + 1
+	audio := make([]int, m)
+	sub := make([]int, m)
+	for i := 0; i < m; i++ {
+		audio[i] = rng.Intn(50) + 1
+		for {
+			sub[i] = rng.Intn(50) + 1
+			if sub[i] != audio[i] {
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range langs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i, v := range audio {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range sub {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	inp := sb.String()
+	exp := expected(n, langs, m, audio, sub)
+	return inp, exp
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected: %s\n got: %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/670-679/670/verifierD1.go
+++ b/0-999/600-699/670-679/670/verifierD1.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func canMake(a, b []int64, k, x int64) bool {
+	var need int64
+	for i := range a {
+		req := a[i] * x
+		if req > b[i] {
+			need += req - b[i]
+			if need > k {
+				return false
+			}
+		}
+	}
+	return need <= k
+}
+
+func expected(a, b []int64, k int64) string {
+	var lo int64 = 0
+	var hi int64 = 2000000000
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if canMake(a, b, k, mid) {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return fmt.Sprintf("%d", lo)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	k := int64(rng.Intn(1000))
+	a := make([]int64, n)
+	b := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(10) + 1)
+		b[i] = int64(rng.Intn(20))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(a[i], 10))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(b[i], 10))
+	}
+	sb.WriteByte('\n')
+	inp := sb.String()
+	exp := expected(a, b, k)
+	return inp, exp
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected: %s\n got: %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/670-679/670/verifierD2.go
+++ b/0-999/600-699/670-679/670/verifierD2.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func canMake(a, b []int64, k, x int64) bool {
+	var need int64
+	for i := range a {
+		req := a[i] * x
+		if req > b[i] {
+			need += req - b[i]
+			if need > k {
+				return false
+			}
+		}
+	}
+	return need <= k
+}
+
+func expected(a, b []int64, k int64) string {
+	var lo int64 = 0
+	var hi int64 = 2000000000
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if canMake(a, b, k, mid) {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return fmt.Sprintf("%d", lo)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	k := int64(rng.Intn(1000000000))
+	a := make([]int64, n)
+	b := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(100000) + 1)
+		b[i] = int64(rng.Intn(100000))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(a[i], 10))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(b[i], 10))
+	}
+	sb.WriteByte('\n')
+	inp := sb.String()
+	exp := expected(a, b, k)
+	return inp, exp
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected: %s\n got: %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/670-679/670/verifierE.go
+++ b/0-999/600-699/670-679/670/verifierE.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func simulate(n int, s string, ops string, p int) string {
+	pair := make([]int, n+1)
+	stack := make([]int, 0, n/2)
+	for i := 1; i <= n; i++ {
+		if s[i-1] == '(' {
+			stack = append(stack, i)
+		} else {
+			j := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			pair[i] = j
+			pair[j] = i
+		}
+	}
+	next := make([]int, n+2)
+	prev := make([]int, n+2)
+	for i := 1; i <= n; i++ {
+		next[i] = i + 1
+		prev[i] = i - 1
+	}
+	next[n] = 0
+	prev[1] = 0
+	cur := p
+	for i := 0; i < len(ops); i++ {
+		switch ops[i] {
+		case 'L':
+			cur = prev[cur]
+		case 'R':
+			cur = next[cur]
+		case 'D':
+			l := cur
+			r := pair[cur]
+			if l > r {
+				l, r = r, l
+			}
+			lp := prev[l]
+			rn := next[r]
+			if lp != 0 {
+				next[lp] = rn
+			}
+			if rn != 0 {
+				prev[rn] = lp
+			}
+			if rn != 0 {
+				cur = rn
+			} else {
+				cur = lp
+			}
+		}
+	}
+	for prev[cur] != 0 {
+		cur = prev[cur]
+	}
+	var out strings.Builder
+	for i := cur; i != 0; i = next[i] {
+		out.WriteByte(s[i-1])
+	}
+	return out.String()
+}
+
+func randomBalanced(n int, rng *rand.Rand) string {
+	open := n / 2
+	close := n / 2
+	var sb strings.Builder
+	stack := 0
+	for open > 0 || close > 0 {
+		if open == 0 {
+			sb.WriteByte(')')
+			close--
+			stack--
+		} else if stack == 0 {
+			sb.WriteByte('(')
+			open--
+			stack++
+		} else {
+			if rng.Intn(open+close) < open {
+				sb.WriteByte('(')
+				open--
+				stack++
+			} else {
+				sb.WriteByte(')')
+				close--
+				stack--
+			}
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := (rng.Intn(10) + 1) * 2
+	s := randomBalanced(n, rng)
+	m := rng.Intn(10) + 1
+	p := rng.Intn(n) + 1
+	pair := make([]int, n+1)
+	stack := make([]int, 0, n/2)
+	for i := 1; i <= n; i++ {
+		if s[i-1] == '(' {
+			stack = append(stack, i)
+		} else {
+			j := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			pair[i] = j
+			pair[j] = i
+		}
+	}
+	next := make([]int, n+2)
+	prev := make([]int, n+2)
+	for i := 1; i <= n; i++ {
+		next[i] = i + 1
+		prev[i] = i - 1
+	}
+	next[n] = 0
+	prev[1] = 0
+	cur := p
+	var ops []byte
+	length := n
+	for len(ops) < m {
+		choices := []byte{'L', 'R', 'D'}
+		op := choices[rng.Intn(len(choices))]
+		valid := true
+		switch op {
+		case 'L':
+			if prev[cur] == 0 {
+				valid = false
+			}
+		case 'R':
+			if next[cur] == 0 {
+				valid = false
+			}
+		case 'D':
+			l := cur
+			r := pair[cur]
+			if l > r {
+				l, r = r, l
+			}
+			if length-(r-l+1) == 0 {
+				valid = false
+			}
+		}
+		if !valid {
+			continue
+		}
+		ops = append(ops, op)
+		switch op {
+		case 'L':
+			cur = prev[cur]
+		case 'R':
+			cur = next[cur]
+		case 'D':
+			l := cur
+			r := pair[cur]
+			if l > r {
+				l, r = r, l
+			}
+			lp := prev[l]
+			rn := next[r]
+			if lp != 0 {
+				next[lp] = rn
+			}
+			if rn != 0 {
+				prev[rn] = lp
+			}
+			length -= r - l + 1
+			if rn != 0 {
+				cur = rn
+			} else {
+				cur = lp
+			}
+		}
+	}
+	input := fmt.Sprintf("%d %d %d\n%s\n%s\n", n, m, p, s, string(ops))
+	expected := simulate(n, s, string(ops), p)
+	return input, expected
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected: %s\n got: %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/670-679/670/verifierF.go
+++ b/0-999/600-699/670-679/670/verifierF.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func numDigits(x int) int {
+	if x == 0 {
+		return 1
+	}
+	c := 0
+	for x > 0 {
+		c++
+		x /= 10
+	}
+	return c
+}
+
+func expected(s, t string) string {
+	n := len(s)
+	length := 1
+	for d := 1; d <= 7; d++ {
+		l := n - d
+		if l >= 1 && numDigits(l) == d {
+			length = l
+			break
+		}
+	}
+	cnt := make([]int, 10)
+	for i := 0; i < len(s); i++ {
+		cnt[s[i]-'0']++
+	}
+	strL := fmt.Sprintf("%d", length)
+	for i := 0; i < len(strL); i++ {
+		cnt[strL[i]-'0']--
+	}
+	cntT := make([]int, 10)
+	for i := 0; i < len(t); i++ {
+		cntT[t[i]-'0']++
+	}
+	rem := make([]int, 10)
+	for i := 0; i < 10; i++ {
+		rem[i] = cnt[i] - cntT[i]
+	}
+	build := func(arr []int) string {
+		first := int(t[0] - '0')
+		var less, equal, greater []byte
+		for d := 0; d < 10; d++ {
+			for i := 0; i < arr[d]; i++ {
+				if d < first {
+					less = append(less, byte('0'+d))
+				} else if d == first {
+					equal = append(equal, byte('0'+d))
+				} else {
+					greater = append(greater, byte('0'+d))
+				}
+			}
+		}
+		cand1 := string(append(append(append([]byte{}, less...), []byte(t)...), append(equal, greater...)...))
+		cand2 := string(append(append(append([]byte{}, less...), equal...), append([]byte(t), greater...)...))
+		if cand1 < cand2 {
+			return cand1
+		}
+		return cand2
+	}
+	ans := ""
+	have := false
+	if t[0] != '0' || length == 1 {
+		var rest []byte
+		for d := 0; d < 10; d++ {
+			for i := 0; i < rem[d]; i++ {
+				rest = append(rest, byte('0'+d))
+			}
+		}
+		cand := t + string(rest)
+		ans = cand
+		have = true
+	}
+	for d := 1; d <= 9; d++ {
+		if rem[d] > 0 {
+			rem[d]--
+			cand := string('0'+byte(d)) + build(rem)
+			rem[d]++
+			if !have || cand < ans {
+				ans = cand
+				have = true
+			}
+			break
+		}
+	}
+	if !have {
+		ans = t
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(1000000)
+	s0 := fmt.Sprintf("%d", n)
+	k := len(s0)
+	digits := append([]byte(s0), []byte(fmt.Sprintf("%d", k))...)
+	rng.Shuffle(len(digits), func(i, j int) { digits[i], digits[j] = digits[j], digits[i] })
+	s := string(digits)
+	start := rng.Intn(len(s0))
+	end := rng.Intn(len(s0)-start) + start
+	t := s0[start : end+1]
+	input := s + "\n" + t + "\n"
+	exp := expected(s, t)
+	return input, exp
+}
+
+func runProg(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected: %s\n got: %s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 670 problems A–F
- verifiers generate 100 random test cases and check a submitted binary
- fix unused import in `verifierF.go`

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD1.go`
- `go build verifierD2.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68836fc835fc83249ba6b5032162a80d