### PR TITLE
Add Go solution for 1918A

### DIFF
--- a/1000-1999/1900-1999/1910-1919/1918/1918A.go
+++ b/1000-1999/1900-1999/1910-1919/1918/1918A.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(reader, &n, &m)
+		fmt.Fprintln(writer, n*(m/2))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 1918 problem A

## Testing
- `go build 1000-1999/1900-1999/1910-1919/1918/1918A.go`


------
https://chatgpt.com/codex/tasks/task_e_68836f830384832491c3de57996486f8