### PR TITLE
Add Go solution for 1918B

### DIFF
--- a/1000-1999/1900-1999/1910-1919/1918/1918B.go
+++ b/1000-1999/1900-1999/1910-1919/1918/1918B.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		b := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &b[i])
+		}
+		idx := make([]int, n)
+		for i := 0; i < n; i++ {
+			idx[i] = i
+		}
+		sort.Slice(idx, func(i, j int) bool {
+			return a[idx[i]] < a[idx[j]]
+		})
+		// output a' and b'
+		for i, id := range idx {
+			if i > 0 {
+				out.WriteByte(' ')
+			}
+			fmt.Fprint(out, a[id])
+		}
+		out.WriteByte('\n')
+		for i, id := range idx {
+			if i > 0 {
+				out.WriteByte(' ')
+			}
+			fmt.Fprint(out, b[id])
+		}
+		out.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem B in contest 1918

## Testing
- `go build 1000-1999/1900-1999/1910-1919/1918/1918B.go`
- `go vet 1000-1999/1900-1999/1910-1919/1918/1918B.go`


------
https://chatgpt.com/codex/tasks/task_e_68836ef6161c83248be95c351517f232