### PR TITLE
Add Go solution for 1915C

### DIFF
--- a/1000-1999/1900-1999/1910-1919/1915/1915C.go
+++ b/1000-1999/1900-1999/1910-1919/1915/1915C.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		sum := int64(0)
+		for i := 0; i < n; i++ {
+			var x int64
+			fmt.Fscan(in, &x)
+			sum += x
+		}
+		root := int64(math.Sqrt(float64(sum)))
+		if root*root == sum {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1915C

## Testing
- `go build ./1000-1999/1900-1999/1910-1919/1915/1915C.go`
- `echo -e "3\n1\n9\n1\n16\n3\n1 1 2" | go run ./1000-1999/1900-1999/1910-1919/1915/1915C.go`

------
https://chatgpt.com/codex/tasks/task_e_688379e81ef483249d0bc40dc24e57c3