### PR TITLE
Add Go solution for problem 1965A

### DIFF
--- a/1000-1999/1900-1999/1960-1969/1965/1965A.go
+++ b/1000-1999/1900-1999/1960-1969/1965/1965A.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		seen := make(map[int]struct{})
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(in, &x)
+			seen[x] = struct{}{}
+		}
+		if len(seen)%2 == 1 {
+			fmt.Fprintln(out, "Alice")
+		} else {
+			fmt.Fprintln(out, "Bob")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `problemA.txt`
- the winner depends on the parity of distinct pile sizes

## Testing
- `go build 1000-1999/1900-1999/1960-1969/1965/1965A.go`

------
https://chatgpt.com/codex/tasks/task_e_688388ae6894832486aa00becec68171