### PR TITLE
Add verifiers for contest 715

### DIFF
--- a/0-999/700-799/710-719/715/verifierA.go
+++ b/0-999/700-799/710-719/715/verifierA.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) []string {
+	xprev := big.NewInt(2)
+	one := big.NewInt(1)
+	res := make([]string, n)
+	for k := 1; k <= n; k++ {
+		sqrtFloor := new(big.Int).Sqrt(xprev)
+		sqrtCeil := new(big.Int).Set(sqrtFloor)
+		tmp := new(big.Int).Mul(sqrtFloor, sqrtFloor)
+		if tmp.Cmp(xprev) < 0 {
+			sqrtCeil.Add(sqrtCeil, one)
+		}
+		kp1 := big.NewInt(int64(k + 1))
+		m0 := new(big.Int).Add(sqrtCeil, new(big.Int).Sub(kp1, one))
+		m0.Div(m0, kp1)
+		bk := big.NewInt(int64(k))
+		m := new(big.Int).Add(m0, new(big.Int).Sub(bk, one))
+		m.Div(m, bk)
+		m.Mul(m, bk)
+		t := new(big.Int).Mul(m, kp1)
+		t2 := new(big.Int).Mul(t, t)
+		diff := new(big.Int).Sub(t2, xprev)
+		a := new(big.Int).Div(diff, bk)
+		res[k-1] = a.String()
+		xprev.Set(t)
+	}
+	return res
+}
+
+func runCase(bin string, n int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(fmt.Sprintf("%d\n", n))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.Fields(strings.TrimSpace(out.String()))
+	exp := expected(n)
+	if len(got) != len(exp) {
+		return fmt.Errorf("expected %d numbers, got %d", len(exp), len(got))
+	}
+	for i := range exp {
+		if got[i] != exp[i] {
+			return fmt.Errorf("mismatch at line %d: expected %s got %s", i+1, exp[i], got[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/715/verifierB.go
+++ b/0-999/700-799/710-719/715/verifierB.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Edge struct{ u, v, w int }
+
+type Case struct {
+	n, m, L int
+	s, t    int
+	edges   []Edge
+}
+
+func shortestPath(n int, edges []Edge, s, t int) int {
+	const INF = int(1e9)
+	g := make([][]Edge, n)
+	for _, e := range edges {
+		g[e.u] = append(g[e.u], Edge{e.v, 0, e.w})
+		g[e.v] = append(g[e.v], Edge{e.u, 0, e.w})
+	}
+	dist := make([]int, n)
+	vis := make([]bool, n)
+	for i := range dist {
+		dist[i] = INF
+	}
+	dist[s] = 0
+	for {
+		u := -1
+		for i := 0; i < n; i++ {
+			if !vis[i] && (u == -1 || dist[i] < dist[u]) {
+				u = i
+			}
+		}
+		if u == -1 || dist[u] == INF {
+			break
+		}
+		vis[u] = true
+		for _, e := range g[u] {
+			if dist[e.u] > dist[u]+e.w {
+				dist[e.u] = dist[u] + e.w
+			}
+		}
+	}
+	return dist[t]
+}
+
+func existsAssignment(c Case) bool {
+	var zeros []int
+	for i, e := range c.edges {
+		if e.w == 0 {
+			zeros = append(zeros, i)
+		}
+	}
+	maxW := c.L
+	if maxW < 1 {
+		maxW = 1
+	}
+	var dfs func(int) bool
+	dfs = func(idx int) bool {
+		if idx == len(zeros) {
+			return shortestPath(c.n, c.edges, c.s, c.t) == c.L
+		}
+		for w := 1; w <= maxW; w++ {
+			c.edges[zeros[idx]].w = w
+			if dfs(idx + 1) {
+				return true
+			}
+		}
+		return false
+	}
+	return dfs(0)
+}
+
+func generateCase(rng *rand.Rand) Case {
+	n := rng.Intn(3) + 2 //2..4
+	edges := make([]Edge, 0)
+	for i := 0; i < n-1; i++ {
+		w := rng.Intn(3) + 1
+		edges = append(edges, Edge{i, i + 1, w})
+	}
+	// maybe add extra edge
+	if rng.Intn(2) == 0 {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		for v == u {
+			v = rng.Intn(n)
+		}
+		w := rng.Intn(3) + 1
+		edges = append(edges, Edge{u, v, w})
+	}
+	// at most 2 zero edges
+	zeroCount := 0
+	for i := range edges {
+		if rng.Intn(2) == 0 && zeroCount < 2 {
+			edges[i].w = 0
+			zeroCount++
+		}
+	}
+	m := len(edges)
+	L := rng.Intn(8) + 2
+	s := 0
+	t := n - 1
+	return Case{n, m, L, s, t, edges}
+}
+
+func runCase(bin string, c Case, expectPossible bool) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d %d\n", c.n, c.m, c.L, c.s, c.t)
+	for _, e := range c.edges {
+		fmt.Fprintf(&sb, "%d %d %d\n", e.u, e.v, e.w)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	tokens := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	tokens.Split(bufio.ScanWords)
+	if !tokens.Scan() {
+		return fmt.Errorf("no output")
+	}
+	ans := strings.ToUpper(tokens.Text())
+	if ans == "NO" {
+		if expectPossible {
+			return fmt.Errorf("expected YES, got NO")
+		}
+		if tokens.Scan() {
+			return fmt.Errorf("extra output after NO")
+		}
+		return nil
+	}
+	if ans != "YES" {
+		return fmt.Errorf("first token should be YES or NO")
+	}
+	edgesOut := make([]Edge, c.m)
+	for i := 0; i < c.m; i++ {
+		if !tokens.Scan() {
+			return fmt.Errorf("missing edge data")
+		}
+		u, _ := strconv.Atoi(tokens.Text())
+		if !tokens.Scan() {
+			return fmt.Errorf("missing edge data")
+		}
+		v, _ := strconv.Atoi(tokens.Text())
+		if !tokens.Scan() {
+			return fmt.Errorf("missing edge data")
+		}
+		w, err := strconv.Atoi(tokens.Text())
+		if err != nil {
+			return fmt.Errorf("bad weight")
+		}
+		if u != c.edges[i].u || v != c.edges[i].v {
+			return fmt.Errorf("edge %d endpoints mismatch", i+1)
+		}
+		if c.edges[i].w > 0 && w != c.edges[i].w {
+			return fmt.Errorf("edge %d weight changed", i+1)
+		}
+		if c.edges[i].w == 0 && w <= 0 {
+			return fmt.Errorf("edge %d weight not positive", i+1)
+		}
+		edgesOut[i] = Edge{u, v, w}
+	}
+	if tokens.Scan() {
+		return fmt.Errorf("extra output detected")
+	}
+	sp := shortestPath(c.n, edgesOut, c.s, c.t)
+	if sp != c.L {
+		return fmt.Errorf("path length %d != %d", sp, c.L)
+	}
+	if !expectPossible {
+		// enumeration said impossible but candidate found one
+		// accept it as valid
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := generateCase(rng)
+		possible := existsAssignment(c)
+		if err := runCase(bin, c, possible); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/715/verifierC.go
+++ b/0-999/700-799/710-719/715/verifierC.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Edge struct{ to, d int }
+
+type Case struct {
+	n   int
+	M   int
+	adj [][]Edge
+}
+
+func generateCase(rng *rand.Rand) Case {
+	n := rng.Intn(5) + 2 //2..6
+	Ms := []int{3, 7, 9, 11, 13, 17, 19}
+	M := Ms[rng.Intn(len(Ms))]
+	adj := make([][]Edge, n)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		d := rng.Intn(9) + 1
+		adj[i] = append(adj[i], Edge{p, d})
+		adj[p] = append(adj[p], Edge{i, d})
+	}
+	return Case{n, M, adj}
+}
+
+func pathDigits(c Case, start, goal int) []int {
+	n := c.n
+	parent := make([]int, n)
+	digit := make([]int, n)
+	for i := range parent {
+		parent[i] = -1
+	}
+	queue := []int{start}
+	parent[start] = start
+	for len(queue) > 0 {
+		u := queue[0]
+		queue = queue[1:]
+		if u == goal {
+			break
+		}
+		for _, e := range c.adj[u] {
+			if parent[e.to] == -1 {
+				parent[e.to] = u
+				digit[e.to] = e.d
+				queue = append(queue, e.to)
+			}
+		}
+	}
+	if parent[goal] == -1 {
+		return nil
+	}
+	var digits []int
+	for v := goal; v != start; v = parent[v] {
+		digits = append([]int{digit[v]}, digits...)
+	}
+	return digits
+}
+
+func countPairs(c Case) int {
+	cnt := 0
+	for u := 0; u < c.n; u++ {
+		for v := 0; v < c.n; v++ {
+			if u == v {
+				continue
+			}
+			digits := pathDigits(c, u, v)
+			val := 0
+			for _, d := range digits {
+				val = (val*10 + d) % c.M
+			}
+			if val == 0 {
+				cnt++
+			}
+		}
+	}
+	return cnt
+}
+
+func runCase(bin string, c Case) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", c.n, c.M)
+	for u := 0; u < c.n; u++ {
+		for _, e := range c.adj[u] {
+			if e.to > u { // avoid duplicates
+				fmt.Fprintf(&sb, "%d %d %d\n", u, e.to, e.d)
+			}
+		}
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expect := countPairs(c)
+	gotStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(gotStr)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := generateCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/715/verifierD.go
+++ b/0-999/700-799/710-719/715/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Block struct{ a, b, c, d int }
+
+func countPaths(n, m int, blocks map[[4]int]bool) *big.Int {
+	dp := make([][]*big.Int, n+1)
+	for i := 0; i <= n; i++ {
+		dp[i] = make([]*big.Int, m+1)
+		for j := 0; j <= m; j++ {
+			dp[i][j] = new(big.Int)
+		}
+	}
+	dp[1][1].SetInt64(1)
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			if i == 1 && j == 1 {
+				continue
+			}
+			if i > 1 {
+				if !blocks[[4]int{i - 1, j, i, j}] {
+					dp[i][j].Add(dp[i][j], dp[i-1][j])
+				}
+			}
+			if j > 1 {
+				if !blocks[[4]int{i, j - 1, i, j}] {
+					dp[i][j].Add(dp[i][j], dp[i][j-1])
+				}
+			}
+		}
+	}
+	return dp[n][m]
+}
+
+func generateCase(rng *rand.Rand) *big.Int {
+	// random T up to about 1e6
+	val := rng.Int63n(1_000_000) + 1
+	return big.NewInt(val)
+}
+
+func runCase(bin string, T *big.Int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(fmt.Sprintf("%s\n", T.String()))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	vals := []int{}
+	for scanner.Scan() {
+		v, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("non-integer output")
+		}
+		vals = append(vals, v)
+	}
+	if len(vals) < 3 || (len(vals)-2)%4 != 0 {
+		return fmt.Errorf("invalid output format")
+	}
+	n := vals[0]
+	m := vals[1]
+	if n <= 0 || m <= 0 || n > 50 || m > 50 {
+		return fmt.Errorf("invalid grid size")
+	}
+	k := vals[2]
+	if k < 0 || k*4 != len(vals)-3 {
+		return fmt.Errorf("k mismatch")
+	}
+	blocks := make(map[[4]int]bool)
+	idx := 3
+	for i := 0; i < k; i++ {
+		a, b, c, d := vals[idx], vals[idx+1], vals[idx+2], vals[idx+3]
+		idx += 4
+		if a < 1 || a > n || c < 1 || c > n || b < 1 || b > m || d < 1 || d > m {
+			return fmt.Errorf("invalid coordinates")
+		}
+		if !((a == c && abs(b-d) == 1) || (b == d && abs(a-c) == 1)) {
+			return fmt.Errorf("non-adjacent rooms")
+		}
+		blocks[[4]int{a, b, c, d}] = true
+		blocks[[4]int{c, d, a, b}] = true
+	}
+	paths := countPaths(n, m, blocks)
+	if paths.Cmp(T) != 0 {
+		return fmt.Errorf("expected %s paths got %s", T.String(), paths.String())
+	}
+	return nil
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		T := generateCase(rng)
+		if err := runCase(bin, T); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/715/verifierE.go
+++ b/0-999/700-799/710-719/715/verifierE.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Case struct {
+	n int
+	p []int
+	q []int
+}
+
+func generatePermutation(n int, rng *rand.Rand) []int {
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	return perm
+}
+
+func generateCase(rng *rand.Rand) Case {
+	n := rng.Intn(5) + 2 //2..6
+	p := generatePermutation(n, rng)
+	q := generatePermutation(n, rng)
+	// randomly replace with zeros
+	for i := 0; i < n; i++ {
+		if rng.Intn(3) == 0 {
+			p[i] = 0
+		}
+		if rng.Intn(3) == 0 {
+			q[i] = 0
+		}
+	}
+	return Case{n, p, q}
+}
+
+func completions(base []int) [][]int {
+	n := len(base)
+	used := make([]bool, n+1)
+	for _, v := range base {
+		if v != 0 {
+			used[v] = true
+		}
+	}
+	res := [][]int{}
+	var cur []int = make([]int, n)
+	var dfs func(int)
+	dfs = func(i int) {
+		if i == n {
+			tmp := make([]int, n)
+			copy(tmp, cur)
+			res = append(res, tmp)
+			return
+		}
+		if base[i] != 0 {
+			cur[i] = base[i]
+			dfs(i + 1)
+			return
+		}
+		for v := 1; v <= n; v++ {
+			if !used[v] {
+				used[v] = true
+				cur[i] = v
+				dfs(i + 1)
+				used[v] = false
+			}
+		}
+	}
+	dfs(0)
+	return res
+}
+
+func distance(p, q []int) int {
+	n := len(p)
+	mp := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		mp[p[i]] = q[i]
+	}
+	vis := make([]bool, n+1)
+	cycles := 0
+	for i := 1; i <= n; i++ {
+		if !vis[i] {
+			cycles++
+			j := i
+			for !vis[j] {
+				vis[j] = true
+				j = mp[j]
+			}
+		}
+	}
+	return n - cycles
+}
+
+func expectedCounts(c Case) []int {
+	cp := completions(c.p)
+	cq := completions(c.q)
+	counts := make([]int, c.n)
+	for _, p := range cp {
+		for _, q := range cq {
+			d := distance(p, q)
+			counts[d]++
+		}
+	}
+	return counts
+}
+
+func runCase(bin string, c Case) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", c.n)
+	for i, v := range c.p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range c.q {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outFields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(outFields) != c.n {
+		return fmt.Errorf("expected %d numbers", c.n)
+	}
+	expect := expectedCounts(c)
+	for i := 0; i < c.n; i++ {
+		val, err := strconv.Atoi(outFields[i])
+		if err != nil {
+			return fmt.Errorf("bad int")
+		}
+		if val != expect[i] {
+			return fmt.Errorf("pos %d expected %d got %d", i, expect[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := generateCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifierA with 100 randomized tests for problem A
- add Go verifierB with randomized graph checks
- add Go verifierC generating trees and counting interesting pairs
- add Go verifierD to validate maze output for a given `T`
- add Go verifierE computing counts over all completions

## Testing
- `go build 0-999/700-799/710-719/715/verifierA.go`
- `go build 0-999/700-799/710-719/715/verifierB.go`
- `go build 0-999/700-799/710-719/715/verifierC.go`
- `go build 0-999/700-799/710-719/715/verifierD.go`
- `go build 0-999/700-799/710-719/715/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883886815408324afa1697dba178419