### PR TITLE
Add Go verifiers for Codeforces contest 713

### DIFF
--- a/0-999/700-799/710-719/713/verifierA.go
+++ b/0-999/700-799/710-719/713/verifierA.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// numKey computes the parity pattern key for a decimal number string.
+func numKey(s string) int {
+	key := 0
+	for i, j := 0, len(s)-1; j >= 0; i, j = i+1, j-1 {
+		if (s[j]-'0')&1 == 1 {
+			key |= 1 << i
+		}
+	}
+	return key
+}
+
+// patKey computes the key from the pattern string of '0' and '1'.
+func patKey(s string) int {
+	key := 0
+	for i, j := 0, len(s)-1; j >= 0; i, j = i+1, j-1 {
+		if s[j] == '1' {
+			key |= 1 << i
+		}
+	}
+	return key
+}
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	t := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	counts := make(map[int]int)
+	nums := make([]string, 0)
+	var out strings.Builder
+	for i := 0; i < t; i++ {
+		op := rng.Intn(3)
+		if op == 2 && len(nums) == 0 {
+			op = 0
+		}
+		switch op {
+		case 0: // add
+			val := fmt.Sprintf("%d", rng.Int63n(1000000))
+			fmt.Fprintf(&sb, "+ %s\n", val)
+			counts[numKey(val)]++
+			nums = append(nums, val)
+		case 1: // query
+			l := rng.Intn(18) + 1
+			pat := make([]byte, l)
+			for j := 0; j < l; j++ {
+				if rng.Intn(2) == 1 {
+					pat[j] = '1'
+				} else {
+					pat[j] = '0'
+				}
+			}
+			ps := string(pat)
+			fmt.Fprintf(&sb, "? %s\n", ps)
+			out.WriteString(fmt.Sprintf("%d\n", counts[patKey(ps)]))
+		case 2: // remove
+			idx := rng.Intn(len(nums))
+			val := nums[idx]
+			nums = append(nums[:idx], nums[idx+1:]...)
+			fmt.Fprintf(&sb, "- %s\n", val)
+			counts[numKey(val)]--
+		}
+	}
+	return testCase{in: sb.String(), out: strings.TrimSpace(out.String())}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.out {
+		return fmt.Errorf("expected %q got %q", tc.out, got)
+	}
+	return nil
+}
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/713/verifierB.go
+++ b/0-999/700-799/710-719/713/verifierB.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type rect [4]int
+
+type testCase struct {
+	n     int
+	rects [2]rect
+}
+
+func overlap(a, b rect) bool {
+	return !(a[2] < b[0] || b[2] < a[0] || a[3] < b[1] || b[3] < a[1])
+}
+
+func randomRect(rng *rand.Rand, n int) rect {
+	x1 := rng.Intn(n) + 1
+	x2 := rng.Intn(n) + 1
+	if x1 > x2 {
+		x1, x2 = x2, x1
+	}
+	y1 := rng.Intn(n) + 1
+	y2 := rng.Intn(n) + 1
+	if y1 > y2 {
+		y1, y2 = y2, y1
+	}
+	return rect{x1, y1, x2, y2}
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 2
+	r1 := randomRect(rng, n)
+	var r2 rect
+	for {
+		r2 = randomRect(rng, n)
+		if !overlap(r1, r2) {
+			break
+		}
+	}
+	return testCase{n: n, rects: [2]rect{r1, r2}}
+}
+
+func runCase(bin string, tc testCase) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdin, "%d\n", tc.n)
+	reader := bufio.NewReader(stdout)
+	queryCnt := 0
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				return fmt.Errorf("time limit")
+			}
+			return fmt.Errorf("read error: %v stderr:%s", err, stderr.String())
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "?") {
+			var x1, y1, x2, y2 int
+			if _, err := fmt.Sscanf(line, "? %d %d %d %d", &x1, &y1, &x2, &y2); err != nil {
+				return fmt.Errorf("bad query: %q", line)
+			}
+			cnt := 0
+			for _, r := range tc.rects {
+				if x1 <= r[0] && y1 <= r[1] && x2 >= r[2] && y2 >= r[3] {
+					cnt++
+				}
+			}
+			fmt.Fprintf(stdin, "%d\n", cnt)
+			queryCnt++
+			if queryCnt > 200 {
+				return fmt.Errorf("too many queries")
+			}
+		} else if strings.HasPrefix(line, "!") {
+			var a rect
+			var b rect
+			if _, err := fmt.Sscanf(line, "! %d %d %d %d %d %d %d %d", &a[0], &a[1], &a[2], &a[3], &b[0], &b[1], &b[2], &b[3]); err != nil {
+				return fmt.Errorf("bad answer: %q", line)
+			}
+			ok := (a == tc.rects[0] && b == tc.rects[1]) || (a == tc.rects[1] && b == tc.rects[0])
+			if !ok {
+				return fmt.Errorf("wrong answer: expected %v %v got %v %v", tc.rects[0], tc.rects[1], a, b)
+			}
+			stdin.Close()
+			return cmd.Wait()
+		}
+	}
+}
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\nrect1:%v rect2:%v n:%d\n", i+1, err, tc.rects[0], tc.rects[1], tc.n)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/713/verifierC.go
+++ b/0-999/700-799/710-719/713/verifierC.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "713C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	arr := make([]int64, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Int63n(1000)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	return testCase{in: sb.String(), out: ""}
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	if tc.out == "" {
+		cmdO := exec.Command(oracle)
+		cmdO.Stdin = strings.NewReader(tc.in)
+		outO, err := cmdO.Output()
+		if err != nil {
+			return fmt.Errorf("oracle error: %v", err)
+		}
+		tc.out = strings.TrimSpace(string(outO))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.out {
+		return fmt.Errorf("expected %s got %s", tc.out, got)
+	}
+	return nil
+}
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/713/verifierD.go
+++ b/0-999/700-799/710-719/713/verifierD.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "713D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	grid := make([][]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			v := rng.Intn(2)
+			grid[i][j] = v
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	q := rng.Intn(5) + 1
+	fmt.Fprintf(&sb, "%d\n", q)
+	for i := 0; i < q; i++ {
+		x1 := rng.Intn(n) + 1
+		x2 := rng.Intn(n) + 1
+		if x1 > x2 {
+			x1, x2 = x2, x1
+		}
+		y1 := rng.Intn(m) + 1
+		y2 := rng.Intn(m) + 1
+		if y1 > y2 {
+			y1, y2 = y2, y1
+		}
+		fmt.Fprintf(&sb, "%d %d %d %d\n", x1, y1, x2, y2)
+	}
+	return testCase{in: sb.String(), out: ""}
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	if tc.out == "" {
+		cmdO := exec.Command(oracle)
+		cmdO.Stdin = strings.NewReader(tc.in)
+		outO, err := cmdO.Output()
+		if err != nil {
+			return fmt.Errorf("oracle error: %v", err)
+		}
+		tc.out = strings.TrimSpace(string(outO))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.out {
+		return fmt.Errorf("expected %s got %s", tc.out, got)
+	}
+	return nil
+}
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/713/verifierE.go
+++ b/0-999/700-799/710-719/713/verifierE.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "713E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	m := int64(rng.Intn(1000) + 1)
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n%d\n", m, n)
+	pos := make([]int64, n)
+	used := make(map[int64]struct{})
+	for i := 0; i < n; i++ {
+		for {
+			v := int64(rng.Intn(int(m)) + 1)
+			if _, ok := used[v]; !ok {
+				used[v] = struct{}{}
+				pos[i] = v
+				break
+			}
+		}
+	}
+	sort.Slice(pos, func(i, j int) bool { return pos[i] < pos[j] })
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", pos[i])
+	}
+	sb.WriteByte('\n')
+	return testCase{in: sb.String(), out: ""}
+}
+
+func runCase(bin, oracle string, tc testCase) error {
+	if tc.out == "" {
+		cmdO := exec.Command(oracle)
+		cmdO.Stdin = strings.NewReader(tc.in)
+		outO, err := cmdO.Output()
+		if err != nil {
+			return fmt.Errorf("oracle error: %v", err)
+		}
+		tc.out = strings.TrimSpace(string(outO))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != tc.out {
+		return fmt.Errorf("expected %s got %s", tc.out, got)
+	}
+	return nil
+}
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, out)
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, oracle, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A with random test generation
- add verifierB.go for interactive problem B
- add verifierC.go/D.go/E.go using compiled oracle solutions

## Testing
- `go fmt` on all verifier files
- `git commit`

------
https://chatgpt.com/codex/tasks/task_e_6883875000688324bb0cda1b1baf95e3