### PR TITLE
Add verifiers for contest 712

### DIFF
--- a/0-999/700-799/710-719/712/verifierA.go
+++ b/0-999/700-799/710-719/712/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func solveA(arr []int64) []int64 {
+	n := len(arr)
+	b := make([]int64, n)
+	for i := 0; i < n-1; i++ {
+		b[i] = arr[i] + arr[i+1]
+	}
+	b[n-1] = arr[n-1]
+	return b
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(19) + 2 // at least 2
+		arr := make([]int64, n)
+		var inBuilder strings.Builder
+		inBuilder.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Int63n(2001) - 1000
+			if i > 0 {
+				inBuilder.WriteByte(' ')
+			}
+			inBuilder.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		inBuilder.WriteByte('\n')
+		res := solveA(arr)
+		var outBuilder strings.Builder
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				outBuilder.WriteByte(' ')
+			}
+			outBuilder.WriteString(fmt.Sprintf("%d", res[i]))
+		}
+		outBuilder.WriteByte('\n')
+		tests[t] = testCase{in: inBuilder.String(), out: outBuilder.String()}
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(tc.out)
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/710-719/712/verifierB.go
+++ b/0-999/700-799/710-719/712/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func solveB(s string) int {
+	n := len(s)
+	if n%2 == 1 {
+		return -1
+	}
+	l0, r0, u0, d0 := 0, 0, 0, 0
+	for i := 0; i < n; i++ {
+		switch s[i] {
+		case 'L':
+			l0++
+		case 'R':
+			r0++
+		case 'U':
+			u0++
+		case 'D':
+			d0++
+		}
+	}
+	half := n / 2
+	best := 2 * n
+	for k := 0; k <= half; k++ {
+		m := half - k
+		dev := abs(l0-k) + abs(r0-k) + abs(u0-m) + abs(d0-m)
+		if dev < best {
+			best = dev
+		}
+	}
+	return best / 2
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(2))
+	tests := make([]testCase, 100)
+	chars := []byte{'L', 'R', 'U', 'D'}
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(20) + 1
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			b[i] = chars[rng.Intn(4)]
+		}
+		s := string(b)
+		expect := solveB(s)
+		tests[t] = testCase{in: s + "\n", out: fmt.Sprintf("%d\n", expect)}
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(tc.out)
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/710-719/712/verifierC.go
+++ b/0-999/700-799/710-719/712/verifierC.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func solveC(x, y int64) int64 {
+	if x == y {
+		return 0
+	}
+	prev := y
+	curr := 2*y - 1
+	t := int64(1)
+	for curr < x {
+		next := curr + prev - 1
+		prev = curr
+		curr = next
+		t++
+	}
+	return t + 2
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(3))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		y := int64(rng.Intn(97) + 3)
+		x := int64(rng.Intn(int(100000-y)) + int(y) + 1)
+		expect := solveC(x, y)
+		in := fmt.Sprintf("%d %d\n", x, y)
+		out := fmt.Sprintf("%d\n", expect)
+		tests[i] = testCase{in: in, out: out}
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(tc.out)
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/710-719/712/verifierD.go
+++ b/0-999/700-799/710-719/712/verifierD.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func solveD(a, b, k, t int) int64 {
+	mod := int64(1e9 + 7)
+	d := b - a
+	N := 4*k*t + 1
+	base := 2 * k * t
+	dp := make([]int64, N)
+	newdp := make([]int64, N)
+	s0 := make([]int64, N)
+	s1 := make([]int64, N)
+	dp[base] = 1
+	twok1 := int64(2*k + 1)
+	for step := 1; step <= t; step++ {
+		currLow := base - 2*k*step
+		currHigh := base + 2*k*step
+		s0[0] = dp[0]
+		s1[0] = 0
+		for i := 1; i < N; i++ {
+			s0[i] = s0[i-1] + dp[i]
+			if s0[i] >= mod {
+				s0[i] -= mod
+			}
+			s1[i] = s1[i-1] + dp[i]*int64(i)%mod
+			if s1[i] >= mod {
+				s1[i] -= mod
+			}
+		}
+		for i := currLow; i <= currHigh; i++ {
+			newdp[i] = 0
+		}
+		for dIdx := currLow; dIdx <= currHigh; dIdx++ {
+			L := dIdx - 2*k
+			if L < 0 {
+				L = 0
+			}
+			R := dIdx + 2*k
+			if R >= N {
+				R = N - 1
+			}
+			var sumPrev int64
+			if L > 0 {
+				sumPrev = s0[R] - s0[L-1]
+			} else {
+				sumPrev = s0[R]
+			}
+			if sumPrev < 0 {
+				sumPrev += mod
+			}
+			Rleft := dIdx
+			if Rleft > R {
+				Rleft = R
+			}
+			Lleft := L
+			var sumLeft, sumS1Left int64
+			if Rleft >= Lleft {
+				if Lleft > 0 {
+					sumLeft = s0[Rleft] - s0[Lleft-1]
+					sumS1Left = s1[Rleft] - s1[Lleft-1]
+				} else {
+					sumLeft = s0[Rleft]
+					sumS1Left = s1[Rleft]
+				}
+				if sumLeft < 0 {
+					sumLeft += mod
+				}
+				if sumS1Left < 0 {
+					sumS1Left += mod
+				}
+			}
+			Lright := dIdx + 1
+			if Lright > R {
+				newdp[dIdx] = twok1 * sumPrev % mod
+			} else {
+				sumPrevRight := s0[R] - s0[dIdx]
+				sumS1Right := s1[R] - s1[dIdx]
+				if sumPrevRight < 0 {
+					sumPrevRight += mod
+				}
+				if sumS1Right < 0 {
+					sumS1Right += mod
+				}
+				part1 := (sumLeft*int64(dIdx)%mod - sumS1Left) % mod
+				if part1 < 0 {
+					part1 += mod
+				}
+				part2 := (sumS1Right - sumPrevRight*int64(dIdx)%mod) % mod
+				if part2 < 0 {
+					part2 += mod
+				}
+				W1 := part1 + part2
+				if W1 >= mod {
+					W1 -= mod
+				}
+				val := twok1*sumPrev%mod - W1
+				if val < 0 {
+					val += mod
+				}
+				newdp[dIdx] = val
+			}
+		}
+		dp, newdp = newdp, dp
+	}
+	s0[0] = dp[0]
+	for i := 1; i < N; i++ {
+		s0[i] = s0[i-1] + dp[i]
+		if s0[i] >= mod {
+			s0[i] -= mod
+		}
+	}
+	start := base + d + 1
+	if start < 0 {
+		start = 0
+	}
+	if start > N-1 {
+		return 0
+	}
+	res := s0[N-1]
+	if start > 0 {
+		res = (res - s0[start-1] + mod) % mod
+	}
+	return res
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(4))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		a := rng.Intn(20) + 1
+		b := rng.Intn(20) + 1
+		k := rng.Intn(5) + 1
+		t := rng.Intn(3) + 1
+		expect := solveD(a, b, k, t)
+		in := fmt.Sprintf("%d %d %d %d\n", a, b, k, t)
+		out := fmt.Sprintf("%d\n", expect)
+		tests[i] = testCase{in: in, out: out}
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(tc.out)
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/710-719/712/verifierE.go
+++ b/0-999/700-799/710-719/712/verifierE.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+type node struct {
+	r1, r2 float64
+}
+
+func merge(a, b node) node {
+	if a.r1 < 0 {
+		return b
+	}
+	if b.r1 < 0 {
+		return a
+	}
+	r1 := a.r1 * b.r1 / (1 - a.r2*(1-b.r1))
+	r2 := b.r2 + ((1 - b.r2) * a.r2 * b.r1 / (1 - (1-b.r1)*a.r2))
+	return node{r1, r2}
+}
+
+func solveE(n int, p []float64, ops []op) []float64 {
+	size := n
+	t := make([]node, 2*size)
+	for i := 0; i < n; i++ {
+		t[size+i] = node{p[i], p[i]}
+	}
+	for i := size - 1; i >= 1; i-- {
+		t[i] = merge(t[2*i], t[2*i+1])
+	}
+	var res []float64
+	for _, op := range ops {
+		if op.typ == 1 {
+			prob := float64(op.a) / float64(op.b)
+			pos := size + op.idx - 1
+			t[pos] = node{prob, prob}
+			for pos >>= 1; pos > 0; pos >>= 1 {
+				t[pos] = merge(t[2*pos], t[2*pos+1])
+			}
+		} else {
+			l := op.l + size - 1
+			r := op.r + size
+			left := node{-1, 0}
+			right := node{-1, 0}
+			for l < r {
+				if l&1 == 1 {
+					left = merge(left, t[l])
+					l++
+				}
+				if r&1 == 1 {
+					r--
+					right = merge(t[r], right)
+				}
+				l >>= 1
+				r >>= 1
+			}
+			val := merge(left, right)
+			res = append(res, val.r1)
+		}
+	}
+	return res
+}
+
+type op struct {
+	typ    int
+	idx, a int
+	b      int
+	l, r   int
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(5))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 1
+		q := rng.Intn(4) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		probs := make([]float64, n)
+		for j := 0; j < n; j++ {
+			a := rng.Intn(9) + 1
+			b := rng.Intn(9) + 1
+			probs[j] = float64(a) / float64(b)
+			sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+		}
+		var ops []op
+		var expOut strings.Builder
+		for j := 0; j < q; j++ {
+			typ := rng.Intn(2) + 1
+			if typ == 1 {
+				idx := rng.Intn(n) + 1
+				a := rng.Intn(9) + 1
+				b := rng.Intn(9) + 1
+				ops = append(ops, op{typ: 1, idx: idx, a: a, b: b})
+				sb.WriteString(fmt.Sprintf("1 %d %d %d\n", idx, a, b))
+			} else {
+				l := rng.Intn(n) + 1
+				r := rng.Intn(n-l+1) + l
+				ops = append(ops, op{typ: 2, l: l, r: r})
+				sb.WriteString(fmt.Sprintf("2 %d %d\n", l, r))
+			}
+		}
+		results := solveE(n, probs, ops)
+		for _, val := range results {
+			expOut.WriteString(fmt.Sprintf("%.9f\n", val))
+		}
+		tests[i] = testCase{in: sb.String(), out: expOut.String()}
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := strings.TrimSpace(tc.out)
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add new Go verifier programs for contest 712
- each verifier generates 100 random tests and checks a provided binary
- verifiers cover problems A through E

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_688386c3dd888324adff40147d32776c