### PR TITLE
Add verifiers for Codeforces contest 717

### DIFF
--- a/0-999/700-799/710-719/717/717A.go
+++ b/0-999/700-799/710-719/717/717A.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
 const MOD = 1000000007
@@ -14,184 +14,186 @@ type ext struct{ a, b int64 }
 func (x ext) add(y ext) ext { return ext{(x.a + y.a) % MOD, (x.b + y.b) % MOD} }
 func (x ext) sub(y ext) ext { return ext{(x.a - y.a + MOD) % MOD, (x.b - y.b + MOD) % MOD} }
 func (x ext) mul(y ext) ext {
-   // (a+b√5)*(c+d√5) = (ac + 5bd) + (ad+bc)√5
-   return ext{
-       (x.a*y.a + 5*x.b%MOD*y.b) % MOD,
-       (x.a*y.b + x.b*y.a) % MOD,
-   }
+	// (a+b√5)*(c+d√5) = (ac + 5bd) + (ad+bc)√5
+	return ext{
+		(x.a*y.a + 5*x.b%MOD*y.b) % MOD,
+		(x.a*y.b + x.b*y.a) % MOD,
+	}
 }
 func (x ext) neg() ext { return ext{(MOD - x.a) % MOD, (MOD - x.b) % MOD} }
+
 // inv computes multiplicative inverse in ext
 func (x ext) inv() ext {
-   // 1/(a+b√5) = (a - b√5)/(a^2 - 5b^2)
-   d := (x.a*x.a - 5*(x.b*x.b)%MOD + MOD) % MOD
-   invd := modinv(d)
-   return ext{(x.a * invd) % MOD, ((MOD - x.b) * invd) % MOD}
+	// 1/(a+b√5) = (a - b√5)/(a^2 - 5b^2)
+	d := (x.a*x.a - 5*(x.b*x.b)%MOD + MOD) % MOD
+	invd := modinv(d)
+	return ext{(x.a * invd) % MOD, ((MOD - x.b) * invd) % MOD}
 }
 func (x ext) pow(e int64) ext {
-   var res ext = ext{1, 0}
-   base := x
-   for e > 0 {
-       if e&1 == 1 {
-           res = res.mul(base)
-       }
-       base = base.mul(base)
-       e >>= 1
-   }
-   return res
+	var res ext = ext{1, 0}
+	base := x
+	for e > 0 {
+		if e&1 == 1 {
+			res = res.mul(base)
+		}
+		base = base.mul(base)
+		e >>= 1
+	}
+	return res
 }
 
 func modinv(x int64) int64 {
-   return powmod(x, MOD-2)
+	return powmod(x, MOD-2)
 }
 func powmod(a, e int64) int64 {
-   var r int64 = 1
-   a %= MOD
-   for e > 0 {
-       if e&1 == 1 {
-           r = (r * a) % MOD
-       }
-       a = (a * a) % MOD
-       e >>= 1
-   }
-   return r
+	var r int64 = 1
+	a %= MOD
+	for e > 0 {
+		if e&1 == 1 {
+			r = (r * a) % MOD
+		}
+		a = (a * a) % MOD
+		e >>= 1
+	}
+	return r
 }
 
 func main() {
-   in := bufio.NewReader(os.Stdin)
-   var k int
-   var l, r int64
-   fmt.Fscan(in, &k, &l, &r)
-   // precompute f(n) for small n and find threshold n0 where f(n)>=k
-   smallF := []int64{0, 2, 3} // f(1)=2,f(2)=3
-   n0 := int64(1)
-   for {
-       if n0 < 2 {
-           if smallF[n0] >= int64(k) {
-               break
-           }
-       } else {
-           x := smallF[n0] + smallF[n0-1]
-           smallF = append(smallF, x)
-           if x >= int64(k) {
-               break
-           }
-       }
-       n0++
-   }
-   // sum small n naive
-   var ans int64
-   up := r
-   if up >= n0 {
-       up = n0 - 1
-   }
-   for n := l; n <= up; n++ {
-       // compute f(n)
-       fn := smallF[n]
-       if fn >= int64(k) {
-           ans = (ans + C(fn, int64(k))) % MOD
-       }
-   }
-   if r < n0 {
-       fmt.Println(ans)
-       return
-   }
-   L := max64(l, n0)
-   // prepare polynomial p(x) = prod_{j=0..k-1}(x - j) = sum_{d=0..k} p[d]*x^d
-   p := make([]int64, k+1)
-   p[0] = 1
-   for j := 0; j < k; j++ {
-       for d := j + 1; d >= 1; d-- {
-           p[d] = (p[d-1] - int64(j)*p[d] % MOD + MOD) % MOD
-       }
-   }
-   invfk := modinv(fact(int64(k)))
-   // P coefficients
-   P := make([]int64, k+1)
-   for d := 0; d <= k; d++ {
-       P[d] = p[d] * invfk % MOD
-   }
-   // precompute binomials C[n][i]
-   Cb := make([][]int64, k+1)
-   for n := 0; n <= k; n++ {
-       Cb[n] = make([]int64, n+1)
-       Cb[n][0], Cb[n][n] = 1, 1
-       for i := 1; i < n; i++ {
-           Cb[n][i] = (Cb[n-1][i-1] + Cb[n-1][i]) % MOD
-       }
-   }
-   // compute alpha, beta, A, C
-   inv2 := modinv(2)
-   inv5 := modinv(5)
-   sqrt5 := ext{0, 1}
-   inv_sqrt5 := ext{0, inv5}
-   alpha := ext{inv2, inv2}
-   beta := ext{inv2, (MOD - inv2) % MOD}
-   a2 := alpha.mul(alpha)
-   b2 := beta.mul(beta)
-   A := a2.mul(inv_sqrt5)
-   Cc := b2.mul(inv_sqrt5).neg()
-   // precompute powers
-   powA := make([]ext, k+1)
-   powC := make([]ext, k+1)
-   powA[0], powC[0] = ext{1, 0}, ext{1, 0}
-   for i := 1; i <= k; i++ {
-       powA[i] = powA[i-1].mul(A)
-       powC[i] = powC[i-1].mul(Cc)
-   }
-   // powers of alpha and beta
-   powAl := make([]ext, k+1)
-   powBe := make([]ext, k+1)
-   powAl[0], powBe[0] = ext{1, 0}, ext{1, 0}
-   for i := 1; i <= k; i++ {
-       powAl[i] = powAl[i-1].mul(alpha)
-       powBe[i] = powBe[i-1].mul(beta)
-   }
-   // sum over i,j
-   var sum ext
-   total := r - L + 1
-   for i := 0; i <= k; i++ {
-       for j := 0; j+i <= k; j++ {
-           coeff := P[i+j] * Cb[i+j][i] % MOD
-           termBase := powA[i].mul(powC[j])
-           coeffE := ext{coeff, 0}.mul(termBase)
-           d := powAl[i].mul(powBe[j])
-           // geometric sum of d^n for n=L..r = d^L * (1 - d^total) / (1 - d)
-           dL := d.pow(L)
-           num := ext{1, 0}.sub(d.pow(total))
-           denom := ext{1, 0}.sub(d)
-           geom := num.mul(denom.inv()).mul(dL)
-           sum = sum.add(coeffE.mul(geom))
-       }
-   }
-   // sum.a is result for n>=L
-   ans = (ans + sum.a) % MOD
-   fmt.Println(ans)
+	in := bufio.NewReader(os.Stdin)
+	var k int
+	var l, r int64
+	fmt.Fscan(in, &k, &l, &r)
+	// precompute f(n) for small n and find threshold n0 where f(n)>=k
+	smallF := []int64{0, 2, 3} // f(1)=2,f(2)=3
+	n0 := int64(1)
+	for {
+		if n0 < 2 {
+			if smallF[n0] >= int64(k) {
+				break
+			}
+		} else {
+			x := smallF[n0] + smallF[n0-1]
+			smallF = append(smallF, x)
+			if x >= int64(k) {
+				break
+			}
+		}
+		n0++
+	}
+	// sum small n naive
+	var ans int64
+	up := r
+	if up >= n0 {
+		up = n0 - 1
+	}
+	for n := l; n <= up; n++ {
+		// compute f(n)
+		fn := smallF[n]
+		if fn >= int64(k) {
+			ans = (ans + C(fn, int64(k))) % MOD
+		}
+	}
+	if r < n0 {
+		fmt.Println(ans)
+		return
+	}
+	L := max64(l, n0)
+	// prepare polynomial p(x) = prod_{j=0..k-1}(x - j) = sum_{d=0..k} p[d]*x^d
+	p := make([]int64, k+1)
+	p[0] = 1
+	for j := 0; j < k; j++ {
+		for d := j + 1; d >= 1; d-- {
+			p[d] = (p[d-1] - int64(j)*p[d]%MOD + MOD) % MOD
+		}
+	}
+	invfk := modinv(fact(int64(k)))
+	// P coefficients
+	P := make([]int64, k+1)
+	for d := 0; d <= k; d++ {
+		P[d] = p[d] * invfk % MOD
+	}
+	// precompute binomials C[n][i]
+	Cb := make([][]int64, k+1)
+	for n := 0; n <= k; n++ {
+		Cb[n] = make([]int64, n+1)
+		Cb[n][0], Cb[n][n] = 1, 1
+		for i := 1; i < n; i++ {
+			Cb[n][i] = (Cb[n-1][i-1] + Cb[n-1][i]) % MOD
+		}
+	}
+	// compute alpha, beta, A, C
+	inv2 := modinv(2)
+	inv5 := modinv(5)
+	sqrt5 := ext{0, 1}
+	_ = sqrt5
+	inv_sqrt5 := ext{0, inv5}
+	alpha := ext{inv2, inv2}
+	beta := ext{inv2, (MOD - inv2) % MOD}
+	a2 := alpha.mul(alpha)
+	b2 := beta.mul(beta)
+	A := a2.mul(inv_sqrt5)
+	Cc := b2.mul(inv_sqrt5).neg()
+	// precompute powers
+	powA := make([]ext, k+1)
+	powC := make([]ext, k+1)
+	powA[0], powC[0] = ext{1, 0}, ext{1, 0}
+	for i := 1; i <= k; i++ {
+		powA[i] = powA[i-1].mul(A)
+		powC[i] = powC[i-1].mul(Cc)
+	}
+	// powers of alpha and beta
+	powAl := make([]ext, k+1)
+	powBe := make([]ext, k+1)
+	powAl[0], powBe[0] = ext{1, 0}, ext{1, 0}
+	for i := 1; i <= k; i++ {
+		powAl[i] = powAl[i-1].mul(alpha)
+		powBe[i] = powBe[i-1].mul(beta)
+	}
+	// sum over i,j
+	var sum ext
+	total := r - L + 1
+	for i := 0; i <= k; i++ {
+		for j := 0; j+i <= k; j++ {
+			coeff := P[i+j] * Cb[i+j][i] % MOD
+			termBase := powA[i].mul(powC[j])
+			coeffE := ext{coeff, 0}.mul(termBase)
+			d := powAl[i].mul(powBe[j])
+			// geometric sum of d^n for n=L..r = d^L * (1 - d^total) / (1 - d)
+			dL := d.pow(L)
+			num := ext{1, 0}.sub(d.pow(total))
+			denom := ext{1, 0}.sub(d)
+			geom := num.mul(denom.inv()).mul(dL)
+			sum = sum.add(coeffE.mul(geom))
+		}
+	}
+	// sum.a is result for n>=L
+	ans = (ans + sum.a) % MOD
+	fmt.Println(ans)
 }
 
 func fact(n int64) int64 {
-   var r int64 = 1
-   for i := int64(1); i <= n; i++ {
-       r = r * i % MOD
-   }
-   return r
+	var r int64 = 1
+	for i := int64(1); i <= n; i++ {
+		r = r * i % MOD
+	}
+	return r
 }
 
 func C(n, k int64) int64 {
-   if n < k || k < 0 {
-       return 0
-   }
-   var r int64 = 1
-   for i := int64(0); i < k; i++ {
-       r = r * ((n - i) % MOD) % MOD
-   }
-   r = r * modinv(fact(k)) % MOD
-   return r
+	if n < k || k < 0 {
+		return 0
+	}
+	var r int64 = 1
+	for i := int64(0); i < k; i++ {
+		r = r * ((n - i) % MOD) % MOD
+	}
+	r = r * modinv(fact(k)) % MOD
+	return r
 }
 
 func max64(a, b int64) int64 {
-   if a > b {
-       return a
-   }
-   return b
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/0-999/700-799/710-719/717/717G.go
+++ b/0-999/700-799/710-719/717/717G.go
@@ -1,44 +1,44 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
 // Edge represents an edge in the flow network
 type Edge struct {
-   to, rev, cap, cost int
+	to, rev, cap, cost int
 }
 
 // Graph holds the flow network
 type Graph struct {
-   n   int
-   adj [][]*Edge
+	n   int
+	adj [][]*Edge
 }
 
 // NewGraph creates a new graph with n nodes
 func NewGraph(n int) *Graph {
-   g := &Graph{n: n, adj: make([][]*Edge, n)}
-   return g
+	g := &Graph{n: n, adj: make([][]*Edge, n)}
+	return g
 }
 
 // AddEdge adds an edge u->v with capacity cap and cost, and reverse edge
 func (g *Graph) AddEdge(u, v, cap, cost int) {
-   a := &Edge{to: v, rev: len(g.adj[v]), cap: cap, cost: cost}
-   b := &Edge{to: u, rev: len(g.adj[u]), cap: 0, cost: -cost}
-   g.adj[u] = append(g.adj[u], a)
-   g.adj[v] = append(g.adj[v], b)
+	a := &Edge{to: v, rev: len(g.adj[v]), cap: cap, cost: cost}
+	b := &Edge{to: u, rev: len(g.adj[u]), cap: 0, cost: -cost}
+	g.adj[u] = append(g.adj[u], a)
+	g.adj[v] = append(g.adj[v], b)
 }
 
 // Item for priority queue
 type Item struct {
-   v, dist int
+	v, dist int
 }
 
 // PQ is a min-heap of Items
 type PQ struct {
-   items []Item
+	items []Item
 }
 
 // Len returns the number of items
@@ -46,143 +46,143 @@ func (pq *PQ) Len() int { return len(pq.items) }
 
 // Push adds an item to the heap
 func (pq *PQ) Push(it Item) {
-   pq.items = append(pq.items, it)
-   i := len(pq.items) - 1
-   for i > 0 {
-       p := (i - 1) / 2
-       if pq.items[p].dist <= pq.items[i].dist {
-           break
-       }
-       pq.items[p], pq.items[i] = pq.items[i], pq.items[p]
-       i = p
-   }
+	pq.items = append(pq.items, it)
+	i := len(pq.items) - 1
+	for i > 0 {
+		p := (i - 1) / 2
+		if pq.items[p].dist <= pq.items[i].dist {
+			break
+		}
+		pq.items[p], pq.items[i] = pq.items[i], pq.items[p]
+		i = p
+	}
 }
 
 // Pop removes and returns the smallest item
 func (pq *PQ) Pop() Item {
-   min := pq.items[0]
-   n := len(pq.items)
-   pq.items[0] = pq.items[n-1]
-   pq.items = pq.items[:n-1]
-   i := 0
-   for {
-       left, right := 2*i+1, 2*i+2
-       smallest := i
-       if left < len(pq.items) && pq.items[left].dist < pq.items[smallest].dist {
-           smallest = left
-       }
-       if right < len(pq.items) && pq.items[right].dist < pq.items[smallest].dist {
-           smallest = right
-       }
-       if smallest == i {
-           break
-       }
-       pq.items[i], pq.items[smallest] = pq.items[smallest], pq.items[i]
-       i = smallest
-   }
-   return min
+	min := pq.items[0]
+	n := len(pq.items)
+	pq.items[0] = pq.items[n-1]
+	pq.items = pq.items[:n-1]
+	i := 0
+	for {
+		left, right := 2*i+1, 2*i+2
+		smallest := i
+		if left < len(pq.items) && pq.items[left].dist < pq.items[smallest].dist {
+			smallest = left
+		}
+		if right < len(pq.items) && pq.items[right].dist < pq.items[smallest].dist {
+			smallest = right
+		}
+		if smallest == i {
+			break
+		}
+		pq.items[i], pq.items[smallest] = pq.items[smallest], pq.items[i]
+		i = smallest
+	}
+	return min
 }
 
 // MinCostFlow computes min cost flow from s to t, stopping when no negative cost path exists
 // Returns total flow and total cost
 func (g *Graph) MinCostFlow(s, t int) (int, int) {
-   n := g.n
-   const INF = 1e9
-   flow, cost := 0, 0
-   h := make([]int, n)    // potentials
-   prevv := make([]int, n)
-   preve := make([]int, n)
-   for {
-       dist := make([]int, n)
-       for i := range dist {
-           dist[i] = INF
-       }
-       dist[s] = 0
-       pq := &PQ{}
-       pq.Push(Item{v: s, dist: 0})
-       for pq.Len() > 0 {
-           it := pq.Pop()
-           v := it.v
-           if dist[v] < it.dist {
-               continue
-           }
-           for i, e := range g.adj[v] {
-               if e.cap > 0 && dist[e.to] > dist[v]+e.cost+h[v]-h[e.to] {
-                   dist[e.to] = dist[v] + e.cost + h[v] - h[e.to]
-                   prevv[e.to] = v
-                   preve[e.to] = i
-                   pq.Push(Item{v: e.to, dist: dist[e.to]})
-               }
-           }
-       }
-       if dist[t] == INF {
-           break
-       }
-       // real distance
-       if dist[t]+h[t] >= 0 {
-           break
-       }
-       for v := 0; v < n; v++ {
-           if dist[v] < INF {
-               h[v] += dist[v]
-           }
-       }
-       // add as much as possible (here 1)
-       d := INF
-       for v := t; v != s; v = prevv[v] {
-           e := g.adj[prevv[v]][preve[v]]
-           if e.cap < d {
-               d = e.cap
-           }
-       }
-       if d == INF {
-           break
-       }
-       flow += d
-       cost += d * h[t]
-       for v := t; v != s; v = prevv[v] {
-           e := g.adj[prevv[v]][preve[v]]
-           e.cap -= d
-           g.adj[v][e.rev].cap += d
-       }
-   }
-   return flow, cost
+	n := g.n
+	const INF = int(1e9)
+	flow, cost := 0, 0
+	h := make([]int, n) // potentials
+	prevv := make([]int, n)
+	preve := make([]int, n)
+	for {
+		dist := make([]int, n)
+		for i := range dist {
+			dist[i] = INF
+		}
+		dist[s] = 0
+		pq := &PQ{}
+		pq.Push(Item{v: s, dist: 0})
+		for pq.Len() > 0 {
+			it := pq.Pop()
+			v := it.v
+			if dist[v] < it.dist {
+				continue
+			}
+			for i, e := range g.adj[v] {
+				if e.cap > 0 && dist[e.to] > dist[v]+e.cost+h[v]-h[e.to] {
+					dist[e.to] = dist[v] + e.cost + h[v] - h[e.to]
+					prevv[e.to] = v
+					preve[e.to] = i
+					pq.Push(Item{v: e.to, dist: dist[e.to]})
+				}
+			}
+		}
+		if dist[t] == INF {
+			break
+		}
+		// real distance
+		if dist[t]+h[t] >= 0 {
+			break
+		}
+		for v := 0; v < n; v++ {
+			if dist[v] < INF {
+				h[v] += dist[v]
+			}
+		}
+		// add as much as possible (here 1)
+		d := INF
+		for v := t; v != s; v = prevv[v] {
+			e := g.adj[prevv[v]][preve[v]]
+			if e.cap < d {
+				d = e.cap
+			}
+		}
+		if d == INF {
+			break
+		}
+		flow += d
+		cost += d * h[t]
+		for v := t; v != s; v = prevv[v] {
+			e := g.adj[prevv[v]][preve[v]]
+			e.cap -= d
+			g.adj[v][e.rev].cap += d
+		}
+	}
+	return flow, cost
 }
 
 func main() {
-   in := bufio.NewReader(os.Stdin)
-   var n int
-   fmt.Fscan(in, &n)
-   sBuf := make([]byte, n)
-   fmt.Fscan(in, &sBuf)
-   s := string(sBuf)
-   var m int
-   fmt.Fscan(in, &m)
-   words := make([]string, m)
-   pts := make([]int, m)
-   for i := 0; i < m; i++ {
-       fmt.Fscan(in, &words[i], &pts[i])
-   }
-   var x int
-   fmt.Fscan(in, &x)
-   // build graph nodes 0..n
-   g := NewGraph(n + 1)
-   // edges i->i+1 cap x cost 0
-   for i := 0; i < n; i++ {
-       g.AddEdge(i, i+1, x, 0)
-   }
-   // for each word, find occurrences
-   for i := 0; i < m; i++ {
-       w := words[i]
-       L := len(w)
-       for j := 0; j+L <= n; j++ {
-           if s[j:j+L] == w {
-               g.AddEdge(j, j+L, 1, -pts[i])
-           }
-       }
-   }
-   // compute min cost flow from 0 to n
-   _, cost := g.MinCostFlow(0, n)
-   // answer is -cost
-   fmt.Println(-cost)
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(in, &n)
+	sBuf := make([]byte, n)
+	fmt.Fscan(in, &sBuf)
+	s := string(sBuf)
+	var m int
+	fmt.Fscan(in, &m)
+	words := make([]string, m)
+	pts := make([]int, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(in, &words[i], &pts[i])
+	}
+	var x int
+	fmt.Fscan(in, &x)
+	// build graph nodes 0..n
+	g := NewGraph(n + 1)
+	// edges i->i+1 cap x cost 0
+	for i := 0; i < n; i++ {
+		g.AddEdge(i, i+1, x, 0)
+	}
+	// for each word, find occurrences
+	for i := 0; i < m; i++ {
+		w := words[i]
+		L := len(w)
+		for j := 0; j+L <= n; j++ {
+			if s[j:j+L] == w {
+				g.AddEdge(j, j+L, 1, -pts[i])
+			}
+		}
+	}
+	// compute min cost flow from 0 to n
+	_, cost := g.MinCostFlow(0, n)
+	// answer is -cost
+	fmt.Println(-cost)
 }

--- a/0-999/700-799/710-719/717/verifierA.go
+++ b/0-999/700-799/710-719/717/verifierA.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "717A.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		k := rng.Intn(5) + 1
+		l := rng.Int63n(10) + 1
+		r := l + rng.Int63n(10)
+		input := fmt.Sprintf("%d %d %d\n", k, l, r)
+		expect, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/717/verifierB.go
+++ b/0-999/700-799/710-719/717/verifierB.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "717B.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		c0 := rng.Intn(3)
+		c1 := rng.Intn(3)
+		input := fmt.Sprintf("%d %d %d\n", n, c0, c1)
+		expect, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/717/verifierC.go
+++ b/0-999/700-799/710-719/717/verifierC.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "717C.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		vals := make([]int, n)
+		for j := range vals {
+			vals[j] = rng.Intn(100)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range vals {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/717/verifierD.go
+++ b/0-999/700-799/710-719/717/verifierD.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "717D.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 1
+		m := rng.Intn(4)
+		probs := make([]float64, m+1)
+		for j := range probs {
+			probs[j] = rng.Float64()
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j, v := range probs {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%.3f", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/717/verifierE.go
+++ b/0-999/700-799/710-719/717/verifierE.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "717E.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 1
+		colors := make([]int, n+1)
+		for j := 1; j <= n; j++ {
+			colors[j] = rng.Intn(3) - 1
+		}
+		edges := genTree(rng, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 1; j <= n; j++ {
+			if j > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", colors[j]))
+		}
+		sb.WriteByte('\n')
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		input := sb.String()
+		expect, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/717/verifierF.go
+++ b/0-999/700-799/710-719/717/verifierF.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "717F.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(3)
+		}
+		q := rng.Intn(3) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d\n", q))
+		for t := 0; t < q; t++ {
+			typ := rng.Intn(2) + 1
+			if typ == 1 {
+				l := 0
+				r := n - 1
+				if l > r {
+					l, r = r, l
+				}
+				k := rng.Intn(2)
+				sb.WriteString(fmt.Sprintf("1 %d %d %d\n", l, r, k))
+			} else {
+				l := 0
+				r := n - 1
+				if l > r {
+					l, r = r, l
+				}
+				sb.WriteString(fmt.Sprintf("2 %d %d\n", l, r))
+			}
+		}
+		input := sb.String()
+		expect, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/717/verifierG.go
+++ b/0-999/700-799/710-719/717/verifierG.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "717G.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		s := randString(rng, n)
+		m := rng.Intn(3) + 1
+		words := make([]string, m)
+		pts := make([]int, m)
+		for j := 0; j < m; j++ {
+			L := rng.Intn(n) + 1
+			if L > n {
+				L = n
+			}
+			words[j] = randString(rng, L)
+			pts[j] = rng.Intn(5)
+		}
+		x := rng.Intn(3) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n%s\n%d\n", n, s, m))
+		for j := 0; j < m; j++ {
+			sb.WriteString(fmt.Sprintf("%s %d\n", words[j], pts[j]))
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", x))
+		input := sb.String()
+		expect, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/717/verifierH.go
+++ b/0-999/700-799/710-719/717/verifierH.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "717H.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(3) + 1
+		m := rng.Intn(n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j := 0; j < m; j++ {
+			u := rng.Intn(n)
+			v := rng.Intn(n)
+			sb.WriteString(fmt.Sprintf("%d %d\n", u+1, v+1))
+		}
+		for j := 0; j < n; j++ {
+			l := rng.Intn(3) + 1
+			sb.WriteString(fmt.Sprintf("%d", l))
+			for k := 0; k < l; k++ {
+				sb.WriteString(fmt.Sprintf(" %d", rng.Intn(3)+1))
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expect, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/710-719/717/verifierI.go
+++ b/0-999/700-799/710-719/717/verifierI.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "717I.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		var sb strings.Builder
+		sb.WriteString("3\n")
+		sb.WriteString("0 0 0\n1 0 0\n0 1 0\n")
+		sb.WriteString("3\n")
+		z := rng.Float64()*2 - 1
+		sb.WriteString(fmt.Sprintf("0 0 %.2f\n1 0 %.2f\n0 1 %.2f\n", z, z, z))
+		input := sb.String()
+		expect, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- fix unused variable in `717A.go`
- fix constant type in `717G.go`
- add Go verifiers `verifierA.go`–`verifierI.go`

## Testing
- `go build 0-999/700-799/710-719/717/verifierA.go`
- `go build 0-999/700-799/710-719/717/verifierB.go 0-999/700-799/710-719/717/verifierC.go 0-999/700-799/710-719/717/verifierD.go 0-999/700-799/710-719/717/verifierE.go 0-999/700-799/710-719/717/verifierF.go 0-999/700-799/710-719/717/verifierG.go 0-999/700-799/710-719/717/verifierH.go 0-999/700-799/710-719/717/verifierI.go`

------
https://chatgpt.com/codex/tasks/task_e_68838980c3488324ac709d1b2f3708f4