### PR TITLE
Add Go solution for 1968B

### DIFF
--- a/1000-1999/1900-1999/1960-1969/1968/1968B.go
+++ b/1000-1999/1900-1999/1960-1969/1968/1968B.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(reader, &n, &m)
+		var a, b string
+		fmt.Fscan(reader, &a)
+		fmt.Fscan(reader, &b)
+		i, j := 0, 0
+		for i < n && j < m {
+			if a[i] == b[j] {
+				i++
+			}
+			j++
+		}
+		fmt.Fprintln(writer, i)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1968B

## Testing
- `go vet 1000-1999/1900-1999/1960-1969/1968/1968B.go`
- `go build 1000-1999/1900-1999/1960-1969/1968/1968B.go`

------
https://chatgpt.com/codex/tasks/task_e_68838565a8f883249ba2ea974004e9c5