### PR TITLE
Add Go verifiers for Codeforces Round 707

### DIFF
--- a/0-999/700-799/700-709/707/verifierA.go
+++ b/0-999/700-799/700-709/707/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+    "bytes"
+    "bufio"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func generateTest() string {
+    n := rand.Intn(100) + 1
+    m := rand.Intn(100) + 1
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+    colors := []string{"C", "M", "Y", "W", "G", "B"}
+    for i := 0; i < n; i++ {
+        for j := 0; j < m; j++ {
+            if j > 0 {
+                sb.WriteByte(' ')
+            }
+            sb.WriteString(colors[rand.Intn(len(colors))])
+        }
+        sb.WriteByte('\n')
+    }
+    return sb.String()
+}
+
+func expectedOutput(input string) string {
+    in := bufio.NewScanner(strings.NewReader(input))
+    in.Split(bufio.ScanWords)
+    in.Scan()
+    n := atoi(in.Text())
+    in.Scan()
+    m := atoi(in.Text())
+    isColor := false
+    for i := 0; i < n*m; i++ {
+        if !in.Scan() {
+            break
+        }
+        c := in.Text()[0]
+        if c == 'C' || c == 'M' || c == 'Y' {
+            isColor = true
+        }
+    }
+    if isColor {
+        return "#Color"
+    }
+    return "#Black&White"
+}
+
+func atoi(s string) int {
+    v := 0
+    for i := 0; i < len(s); i++ {
+        v = v*10 + int(s[i]-'0')
+    }
+    return v
+}
+
+func run(bin string, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    rand.Seed(time.Now().UnixNano())
+    bin := os.Args[1]
+    for t := 0; t < 100; t++ {
+        input := generateTest()
+        want := expectedOutput(input)
+        got, err := run(bin, input)
+        if err != nil {
+            fmt.Fprintln(os.Stderr, "test", t+1, "error running binary:", err)
+            os.Exit(1)
+        }
+        if got != want {
+            fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected: %s\nactual: %s\n", t+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("ok")
+}
+

--- a/0-999/700-799/700-709/707/verifierB.go
+++ b/0-999/700-799/700-709/707/verifierB.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func compileRef() (string, error) {
+    ref := "refB"
+    cmd := exec.Command("go", "build", "-o", ref, "707B.go")
+    if err := cmd.Run(); err != nil {
+        return "", err
+    }
+    return ref, nil
+}
+
+func run(bin string, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func generateTest() string {
+    n := rand.Intn(10) + 2
+    m := rand.Intn(n*(n-1)/2) + 1
+    k := rand.Intn(n + 1) // can be 0
+    edges := make(map[[2]int]bool)
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+    for len(edges) < m {
+        u := rand.Intn(n) + 1
+        v := rand.Intn(n) + 1
+        if u == v { continue }
+        if u > v { u, v = v, u }
+        key := [2]int{u,v}
+        if edges[key] { continue }
+        edges[key] = true
+        l := rand.Intn(100) + 1
+        sb.WriteString(fmt.Sprintf("%d %d %d\n", u, v, l))
+    }
+    if k > 0 {
+        used := make(map[int]bool)
+        for i := 0; i < k; i++ {
+            var v int
+            for {
+                v = rand.Intn(n) + 1
+                if !used[v] { break }
+            }
+            used[v] = true
+            if i > 0 { sb.WriteByte(' ') }
+            sb.WriteString(fmt.Sprintf("%d", v))
+        }
+        sb.WriteByte('\n')
+    }
+    return sb.String()
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    rand.Seed(time.Now().UnixNano())
+    ref, err := compileRef()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "could not build reference solution:", err)
+        os.Exit(1)
+    }
+    defer os.Remove(ref)
+
+    bin := os.Args[1]
+    for t := 0; t < 100; t++ {
+        input := generateTest()
+        want, err := run(ref, input)
+        if err != nil {
+            fmt.Fprintln(os.Stderr, "reference failed:", err)
+            os.Exit(1)
+        }
+        got, err := run(bin, input)
+        if err != nil {
+            fmt.Fprintln(os.Stderr, "test", t+1, "error running binary:", err)
+            os.Exit(1)
+        }
+        if got != want {
+            fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected: %s\nactual: %s\n", t+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("ok")
+}
+

--- a/0-999/700-799/700-709/707/verifierC.go
+++ b/0-999/700-799/700-709/707/verifierC.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func expected(n int64) string {
+    if n == 1 || n == 2 {
+        return "-1"
+    }
+    rec := 0
+    for n%2 == 0 {
+        n /= 2
+        rec++
+    }
+    if n == 1 {
+        x, y := int64(3), int64(5)
+        for i := 0; i < rec-2; i++ {
+            x *= 2
+            y *= 2
+        }
+        return fmt.Sprintf("%d %d", x, y)
+    }
+    x := n / 2
+    y := x + 1
+    ans1 := 2 * x * y
+    ans2 := x*x + y*y
+    for i := 0; i < rec; i++ {
+        ans1 *= 2
+        ans2 *= 2
+    }
+    return fmt.Sprintf("%d %d", ans1, ans2)
+}
+
+func generateTest() string {
+    n := rand.Int63n(1_000_000_000) + 1
+    return fmt.Sprintf("%d\n", n)
+}
+
+func run(bin string, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    rand.Seed(time.Now().UnixNano())
+    bin := os.Args[1]
+    for t := 0; t < 100; t++ {
+        input := generateTest()
+        var n int64
+        fmt.Sscanf(strings.TrimSpace(input), "%d", &n)
+        want := expected(n)
+        got, err := run(bin, input)
+        if err != nil {
+            fmt.Fprintln(os.Stderr, "test", t+1, "error running binary:", err)
+            os.Exit(1)
+        }
+        if got != want {
+            fmt.Fprintf(os.Stderr, "test %d failed\ninput: %sexpected: %s\nactual: %s\n", t+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("ok")
+}
+

--- a/0-999/700-799/700-709/707/verifierD.go
+++ b/0-999/700-799/700-709/707/verifierD.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func compileRef() (string, error) {
+    ref := "refD"
+    cmd := exec.Command("go", "build", "-o", ref, "707D.go")
+    if err := cmd.Run(); err != nil {
+        return "", err
+    }
+    return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func generateTest() string {
+    n := rand.Intn(3) + 1
+    m := rand.Intn(3) + 1
+    q := rand.Intn(20) + 1
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+    for i := 1; i <= q; i++ {
+        t := rand.Intn(4) + 1
+        if i == 1 && t == 4 {
+            t = rand.Intn(3) + 1
+        }
+        switch t {
+        case 1:
+            sb.WriteString(fmt.Sprintf("1 %d %d\n", rand.Intn(n)+1, rand.Intn(m)+1))
+        case 2:
+            sb.WriteString(fmt.Sprintf("2 %d %d\n", rand.Intn(n)+1, rand.Intn(m)+1))
+        case 3:
+            sb.WriteString(fmt.Sprintf("3 %d\n", rand.Intn(n)+1))
+        case 4:
+            sb.WriteString(fmt.Sprintf("4 %d\n", rand.Intn(i)))
+        }
+    }
+    return sb.String()
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    rand.Seed(time.Now().UnixNano())
+    ref, err := compileRef()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "could not build reference solution:", err)
+        os.Exit(1)
+    }
+    defer os.Remove(ref)
+
+    bin := os.Args[1]
+    for t := 0; t < 100; t++ {
+        input := generateTest()
+        want, err := run(ref, input)
+        if err != nil {
+            fmt.Fprintln(os.Stderr, "reference failed:", err)
+            os.Exit(1)
+        }
+        got, err := run(bin, input)
+        if err != nil {
+            fmt.Fprintln(os.Stderr, "test", t+1, "error running binary:", err)
+            os.Exit(1)
+        }
+        if got != want {
+            fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected: %s\nactual: %s\n", t+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("ok")
+}
+

--- a/0-999/700-799/700-709/707/verifierE.go
+++ b/0-999/700-799/700-709/707/verifierE.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func compileRef() (string, error) {
+    ref := "refE"
+    cmd := exec.Command("go", "build", "-o", ref, "707E.go")
+    if err := cmd.Run(); err != nil {
+        return "", err
+    }
+    return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func generateTest() string {
+    n := rand.Intn(3) + 1
+    m := rand.Intn(3) + 1
+    k := rand.Intn(3) + 1
+    used := make(map[[2]int]bool)
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+    for gi := 0; gi < k; gi++ {
+        sb.WriteString("1\n")
+        var x, y int
+        for {
+            x = rand.Intn(n) + 1
+            y = rand.Intn(m) + 1
+            if !used[[2]int{x,y}] {
+                used[[2]int{x,y}] = true
+                break
+            }
+        }
+        w := rand.Intn(10) + 1
+        sb.WriteString(fmt.Sprintf("%d %d %d\n", x, y, w))
+    }
+    q := rand.Intn(20) + 1
+    sb.WriteString(fmt.Sprintf("%d\n", q))
+    for i := 0; i < q; i++ {
+        if rand.Intn(2) == 0 {
+            sb.WriteString(fmt.Sprintf("SWITCH %d\n", rand.Intn(k)+1))
+        } else {
+            x1 := rand.Intn(n) + 1
+            y1 := rand.Intn(m) + 1
+            x2 := rand.Intn(n-x1+1) + x1
+            y2 := rand.Intn(m-y1+1) + y1
+            sb.WriteString(fmt.Sprintf("ASK %d %d %d %d\n", x1, y1, x2, y2))
+        }
+    }
+    return sb.String()
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    rand.Seed(time.Now().UnixNano())
+    ref, err := compileRef()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "could not build reference solution:", err)
+        os.Exit(1)
+    }
+    defer os.Remove(ref)
+
+    bin := os.Args[1]
+    for t := 0; t < 100; t++ {
+        input := generateTest()
+        want, err := run(ref, input)
+        if err != nil {
+            fmt.Fprintln(os.Stderr, "reference failed:", err)
+            os.Exit(1)
+        }
+        got, err := run(bin, input)
+        if err != nil {
+            fmt.Fprintln(os.Stderr, "test", t+1, "error running binary:", err)
+            os.Exit(1)
+        }
+        if got != want {
+            fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%s\nexpected: %s\nactual: %s\n", t+1, input, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("ok")
+}
+


### PR DESCRIPTION
## Summary
- add verifierA.go to automatically check binaries for problem A
- add verifierB.go compiling reference 707B.go and generating random tests
- add verifierC.go to check outputs for Pythagorean triples
- add verifierD.go and verifierE.go using reference solutions
- each verifier generates 100 random testcases

## Testing
- `go build 0-999/700-799/700-709/707/verifierA.go`
- `go build 0-999/700-799/700-709/707/verifierB.go`
- `go build 0-999/700-799/700-709/707/verifierC.go`
- `go build 0-999/700-799/700-709/707/verifierD.go`
- `go build 0-999/700-799/700-709/707/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_688384076a0c8324893409d502e7ccff