### PR TITLE
Add verifiers for Codeforces 706

### DIFF
--- a/0-999/700-799/700-709/706/verifierA.go
+++ b/0-999/700-799/700-709/706/verifierA.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, float64) {
+	a := rng.Intn(201) - 100
+	b := rng.Intn(201) - 100
+	n := rng.Intn(100) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n%d\n", a, b, n)
+	minT := math.Inf(1)
+	for i := 0; i < n; i++ {
+		x := rng.Intn(201) - 100
+		y := rng.Intn(201) - 100
+		v := rng.Intn(100) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", x, y, v)
+		dist := math.Hypot(float64(x-a), float64(y-b))
+		t := dist / float64(v)
+		if t < minT {
+			minT = t
+		}
+	}
+	return sb.String(), minT
+}
+
+func runCase(bin, input string, expected float64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if math.Abs(got-expected) > 1e-6*math.Max(1, math.Abs(expected)) {
+		return fmt.Errorf("expected %.6f got %.6f", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/706/verifierB.go
+++ b/0-999/700-799/700-709/706/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(100) + 1
+	prices := make([]int, n)
+	for i := range prices {
+		prices[i] = rng.Intn(1000) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, p := range prices {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", p)
+	}
+	sb.WriteByte('\n')
+	sort.Ints(prices)
+	q := rng.Intn(100) + 1
+	fmt.Fprintf(&sb, "%d\n", q)
+	ans := make([]int, q)
+	for i := 0; i < q; i++ {
+		m := rng.Intn(1000) + 1
+		fmt.Fprintf(&sb, "%d\n", m)
+		cnt := 0
+		for _, p := range prices {
+			if p <= m {
+				cnt++
+			} else {
+				break
+			}
+		}
+		ans[i] = cnt
+	}
+	return sb.String(), ans
+}
+
+func runCase(bin, input string, expected []int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outScan := bufio.NewScanner(strings.NewReader(out.String()))
+	outScan.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !outScan.Scan() {
+			return fmt.Errorf("missing output for query %d", i+1)
+		}
+		var got int
+		fmt.Sscan(outScan.Text(), &got)
+		if got != exp {
+			return fmt.Errorf("query %d: expected %d got %d", i+1, exp, got)
+		}
+	}
+	if outScan.Scan() {
+		return fmt.Errorf("extra output detected")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/706/verifierC.go
+++ b/0-999/700-799/700-709/706/verifierC.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func reverse(s string) string {
+	b := []byte(s)
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}
+
+func solveCase(costs []int64, words []string) int64 {
+	n := len(costs)
+	sr := make([]string, n)
+	for i := range words {
+		sr[i] = reverse(words[i])
+	}
+	const INF int64 = 1 << 60
+	prev0, prev1 := int64(0), costs[0]
+	for i := 1; i < n; i++ {
+		cur0, cur1 := INF, INF
+		if prev0 < INF && words[i-1] <= words[i] {
+			if prev0 < cur0 {
+				cur0 = prev0
+			}
+		}
+		if prev1 < INF && sr[i-1] <= words[i] {
+			if prev1 < cur0 {
+				cur0 = prev1
+			}
+		}
+		if prev0 < INF && words[i-1] <= sr[i] {
+			if prev0+costs[i] < cur1 {
+				cur1 = prev0 + costs[i]
+			}
+		}
+		if prev1 < INF && sr[i-1] <= sr[i] {
+			if prev1+costs[i] < cur1 {
+				cur1 = prev1 + costs[i]
+			}
+		}
+		prev0, prev1 = cur0, cur1
+	}
+	res := prev0
+	if prev1 < res {
+		res = prev1
+	}
+	if res >= INF {
+		return -1
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(6) + 1
+	costs := make([]int64, n)
+	words := make([]string, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := range costs {
+		costs[i] = int64(rng.Intn(10) + 1)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", costs[i])
+	}
+	sb.WriteByte('\n')
+	for i := range words {
+		l := rng.Intn(5) + 1
+		b := make([]byte, l)
+		for j := range b {
+			b[j] = byte('a' + rng.Intn(3))
+		}
+		words[i] = string(b)
+		sb.WriteString(words[i])
+		if i < n-1 {
+			sb.WriteByte('\n')
+		}
+	}
+	sb.WriteByte('\n')
+	res := solveCase(costs, words)
+	return sb.String(), res
+}
+
+func runCase(bin, input string, expected int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/706/verifierD.go
+++ b/0-999/700-799/700-709/706/verifierD.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type multiset map[int]int
+
+func (m multiset) add(x int) {
+	m[x]++
+}
+
+func (m multiset) remove(x int) {
+	m[x]--
+	if m[x] == 0 {
+		delete(m, x)
+	}
+}
+
+func (m multiset) maxXor(x int) int {
+	best := 0
+	for v := range m {
+		if cur := x ^ v; cur > best {
+			best = cur
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, []int) {
+	q := rng.Intn(50) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", q)
+	ms := make(multiset)
+	ms.add(0)
+	expected := []int{}
+	exists := []int{0}
+	for i := 0; i < q; i++ {
+		opType := rng.Intn(3)
+		if len(exists) == 1 {
+			opType = rng.Intn(2) // avoid remove when only 0 present
+		}
+		switch opType {
+		case 0: // add
+			x := rng.Intn(1000)
+			fmt.Fprintf(&sb, "+ %d\n", x)
+			ms.add(x)
+			exists = append(exists, x)
+		case 1: // remove
+			idx := rng.Intn(len(exists))
+			x := exists[idx]
+			fmt.Fprintf(&sb, "- %d\n", x)
+			ms.remove(x)
+			exists = append(exists[:idx], exists[idx+1:]...)
+		case 2: // query
+			x := rng.Intn(1000)
+			fmt.Fprintf(&sb, "? %d\n", x)
+			expected = append(expected, ms.maxXor(x))
+		}
+	}
+	return sb.String(), expected
+}
+
+func runCase(bin, input string, expected []int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scan := bufio.NewScanner(strings.NewReader(out.String()))
+	scan.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scan.Scan() {
+			return fmt.Errorf("missing output for query %d", i+1)
+		}
+		var got int
+		fmt.Sscan(scan.Text(), &got)
+		if got != exp {
+			return fmt.Errorf("query %d: expected %d got %d", i+1, exp, got)
+		}
+	}
+	if scan.Scan() {
+		return fmt.Errorf("extra output detected")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/706/verifierE.go
+++ b/0-999/700-799/700-709/706/verifierE.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateMatrix(rng *rand.Rand, n, m int) [][]int {
+	mat := make([][]int, n)
+	for i := 0; i < n; i++ {
+		mat[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			mat[i][j] = rng.Intn(10)
+		}
+	}
+	return mat
+}
+
+func swapSub(m [][]int, a, b, c, d, h, w int) {
+	for i := 0; i < h; i++ {
+		for j := 0; j < w; j++ {
+			m[a+i][b+j], m[c+i][d+j] = m[c+i][d+j], m[a+i][b+j]
+		}
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, [][]int) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	q := rng.Intn(4) + 1
+	mat := generateMatrix(rng, n, m)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, q)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", mat[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	for k := 0; k < q; k++ {
+		h := rng.Intn(n) + 1
+		w := rng.Intn(m) + 1
+		a := rng.Intn(n - h + 1)
+		b := rng.Intn(m - w + 1)
+		c := rng.Intn(n - h + 1)
+		d := rng.Intn(m - w + 1)
+		// ensure rectangles don't overlap or touch
+		for !(c+h <= a || a+h <= c || d+w <= b || b+w <= d) {
+			c = rng.Intn(n - h + 1)
+			d = rng.Intn(m - w + 1)
+		}
+		fmt.Fprintf(&sb, "%d %d %d %d %d %d\n", a+1, b+1, c+1, d+1, h, w)
+		swapSub(mat, a, b, c, d, h, w)
+	}
+	return sb.String(), mat
+}
+
+func matrixToString(m [][]int) string {
+	var sb strings.Builder
+	n := len(m)
+	if n == 0 {
+		return ""
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < len(m[i]); j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", m[i][j])
+		}
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func runCase(bin, input string, expected [][]int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outLines := strings.TrimSpace(out.String())
+	expectedStr := matrixToString(expected)
+	if outLines != expectedStr {
+		return fmt.Errorf("expected:\n%s\n\nGot:\n%s", expectedStr, outLines)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 706
- each verifier runs 100 randomized tests on a provided binary
- verifiers replicate official solutions to check correctness

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883837b54848324af0cfff95d10c172