### PR TITLE
Add verifiers for contest 704

### DIFF
--- a/0-999/700-799/700-709/704/verifierA.go
+++ b/0-999/700-799/700-709/704/verifierA.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(n, q int, ops [][2]int) string {
+	notifications := make([]int, 0)
+	read := make([]bool, q+5)
+	appQueues := make([][]int, n+1)
+	appPtr := make([]int, n+1)
+	globalPtr := 0
+	unread := 0
+	var sb strings.Builder
+	for _, op := range ops {
+		t := op[0]
+		x := op[1]
+		switch t {
+		case 1:
+			id := len(notifications)
+			notifications = append(notifications, x)
+			if len(read) <= id {
+				read = append(read, false)
+			}
+			appQueues[x] = append(appQueues[x], id)
+			unread++
+		case 2:
+			qlist := appQueues[x]
+			ptr := appPtr[x]
+			for ptr < len(qlist) {
+				id := qlist[ptr]
+				if !read[id] {
+					read[id] = true
+					unread--
+				}
+				ptr++
+			}
+			appPtr[x] = ptr
+		case 3:
+			tVal := x
+			for globalPtr < tVal {
+				if !read[globalPtr] {
+					read[globalPtr] = true
+					unread--
+				}
+				globalPtr++
+			}
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", unread))
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	q := rng.Intn(20) + 1
+	ops := make([][2]int, q)
+	type1Count := 0
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 0; i < q; i++ {
+		typ := rng.Intn(3) + 1
+		var x int
+		switch typ {
+		case 1:
+			x = rng.Intn(n) + 1
+			type1Count++
+		case 2:
+			x = rng.Intn(n) + 1
+		case 3:
+			if type1Count == 0 {
+				typ = 1
+				x = rng.Intn(n) + 1
+				type1Count++
+			} else {
+				x = rng.Intn(type1Count) + 1
+			}
+		}
+		ops[i] = [2]int{typ, x}
+		sb.WriteString(fmt.Sprintf("%d %d\n", typ, x))
+	}
+	expected := solveA(n, q, ops)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.ReplaceAll(strings.TrimSpace(out.String()), "\r", "")
+	expStr := strings.ReplaceAll(strings.TrimSpace(expected), "\r", "")
+	if outStr != expStr {
+		return fmt.Errorf("expected %q got %q", expStr, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/704/verifierB.go
+++ b/0-999/700-799/700-709/704/verifierB.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(n, s, e int, x, a, bArr, c, d []int) string {
+	used := make([]bool, n+1)
+	perm := make([]int, n)
+	best := int64(1<<62 - 1)
+	perm[0] = s
+	perm[n-1] = e
+	used[s] = true
+	used[e] = true
+	var dfs func(pos int)
+	dfs = func(pos int) {
+		if pos == n-1 {
+			cost := int64(0)
+			last := s
+			for i := 1; i < n; i++ {
+				j := perm[i]
+				if x[j] < x[last] {
+					cost += int64(x[last]-x[j]) + int64(c[last]) + int64(bArr[j])
+				} else {
+					cost += int64(x[j]-x[last]) + int64(d[last]) + int64(a[j])
+				}
+				last = j
+			}
+			if cost < best {
+				best = cost
+			}
+			return
+		}
+		for i := 1; i <= n; i++ {
+			if used[i] || i == e {
+				continue
+			}
+			used[i] = true
+			perm[pos] = i
+			dfs(pos + 1)
+			used[i] = false
+		}
+	}
+	if n == 2 {
+		best = 0
+		if x[e] < x[s] {
+			best = int64(x[s]-x[e]) + int64(c[s]) + int64(bArr[e])
+		} else {
+			best = int64(x[e]-x[s]) + int64(d[s]) + int64(a[e])
+		}
+	} else {
+		dfs(1)
+	}
+	return fmt.Sprintf("%d", best)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 2
+	s := rng.Intn(n) + 1
+	e := rng.Intn(n) + 1
+	for e == s {
+		e = rng.Intn(n) + 1
+	}
+	x := make([]int, n+1)
+	cur := 0
+	for i := 1; i <= n; i++ {
+		cur += rng.Intn(3) + 1
+		x[i] = cur
+	}
+	a := make([]int, n+1)
+	bArr := make([]int, n+1)
+	c := make([]int, n+1)
+	d := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = rng.Intn(5) + 1
+		bArr[i] = rng.Intn(5) + 1
+		c[i] = rng.Intn(5) + 1
+		d[i] = rng.Intn(5) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, s, e))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", x[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", bArr[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", d[i]))
+	}
+	sb.WriteByte('\n')
+	expected := solveB(n, s, e, x, a, bArr, c, d)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/704/verifierC.go
+++ b/0-999/700-799/700-709/704/verifierC.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func solveC(n, m int, clauses [][]int) string {
+	count := 0
+	total := 1 << m
+	for mask := 0; mask < total; mask++ {
+		xorVal := 0
+		for _, cl := range clauses {
+			orVal := 0
+			for _, lit := range cl {
+				v := lit
+				val := 0
+				if v > 0 {
+					if mask&(1<<(v-1)) != 0 {
+						val = 1
+					}
+				} else {
+					if mask&(1<<(-v-1)) == 0 {
+						val = 1
+					}
+				}
+				if val == 1 {
+					orVal = 1
+					break
+				}
+			}
+			xorVal ^= orVal
+		}
+		if xorVal == 1 {
+			count++
+		}
+	}
+	return fmt.Sprintf("%d", count%mod)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(4) + 1
+	counts := make([]int, m+1)
+	clauses := make([][]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		k := rng.Intn(2) + 1
+		clause := make([]int, k)
+		for j := 0; j < k; j++ {
+			var v int
+			attempts := 0
+			for {
+				attempts++
+				v = rng.Intn(m) + 1
+				if counts[v] < 2 || attempts > 10 {
+					break
+				}
+			}
+			counts[v]++
+			if rng.Intn(2) == 0 {
+				clause[j] = v
+			} else {
+				clause[j] = -v
+			}
+		}
+		clauses[i] = clause
+		sb.WriteString(fmt.Sprintf("%d", k))
+		for _, lit := range clause {
+			sb.WriteString(fmt.Sprintf(" %d", lit))
+		}
+		sb.WriteByte('\n')
+	}
+	expected := solveC(n, m, clauses)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != expected {
+		return fmt.Errorf("expected %s got %s", expected, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/704/verifierD.go
+++ b/0-999/700-799/700-709/704/verifierD.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isValid(colors []byte, n, m int, rCost, bCost int, xs, ys []int, cons [][3]int) (bool, int) {
+	cost := 0
+	for i := 0; i < n; i++ {
+		if colors[i] == 'r' {
+			cost += rCost
+		} else {
+			cost += bCost
+		}
+	}
+	for _, c := range cons {
+		t, l, d := c[0], c[1], c[2]
+		red, blue := 0, 0
+		for i := 0; i < n; i++ {
+			if (t == 1 && xs[i] == l) || (t == 2 && ys[i] == l) {
+				if colors[i] == 'r' {
+					red++
+				} else {
+					blue++
+				}
+			}
+		}
+		if abs(red-blue) > d {
+			return false, 0
+		}
+	}
+	return true, cost
+}
+
+func solveD(n, m, rCost, bCost int, xs, ys []int, cons [][3]int) string {
+	best := -1
+	bestMask := 0
+	for mask := 0; mask < (1 << n); mask++ {
+		colors := make([]byte, n)
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) != 0 {
+				colors[i] = 'r'
+			} else {
+				colors[i] = 'b'
+			}
+		}
+		ok, cost := isValid(colors, n, m, rCost, bCost, xs, ys, cons)
+		if !ok {
+			continue
+		}
+		if best == -1 || cost < best {
+			best = cost
+			bestMask = mask
+		}
+	}
+	if best == -1 {
+		return "-1"
+	}
+	colors := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if bestMask&(1<<i) != 0 {
+			colors[i] = 'r'
+		} else {
+			colors[i] = 'b'
+		}
+	}
+	return fmt.Sprintf("%d\n%s", best, string(colors))
+}
+
+func generateCase(rng *rand.Rand) (string, string, int, int, int, int, []int, []int, [][3]int) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(3)
+	r := rng.Intn(5) + 1
+	b := rng.Intn(5) + 1
+	xs := make([]int, n)
+	ys := make([]int, n)
+	for i := 0; i < n; i++ {
+		xs[i] = rng.Intn(5) + 1
+		ys[i] = rng.Intn(5) + 1
+	}
+	cons := make([][3]int, m)
+	for i := 0; i < m; i++ {
+		t := rng.Intn(2) + 1
+		l := rng.Intn(5) + 1
+		d := rng.Intn(n + 1)
+		cons[i] = [3]int{t, l, d}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	sb.WriteString(fmt.Sprintf("%d %d\n", r, b))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", xs[i], ys[i]))
+	}
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", cons[i][0], cons[i][1], cons[i][2]))
+	}
+	expected := solveD(n, m, r, b, xs, ys, cons)
+	return sb.String(), expected, n, m, r, b, xs, ys, cons
+}
+
+func runCase(bin, input, expected string, n, m, rCost, bCost int, xs, ys []int, cons [][3]int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expLines := strings.Split(strings.TrimSpace(expected), "\n")
+	outLines := strings.Split(outStr, "\n")
+	if expLines[0] == "-1" {
+		if outLines[0] != "-1" {
+			return fmt.Errorf("expected -1 got %s", outLines[0])
+		}
+		return nil
+	}
+	if outLines[0] != expLines[0] {
+		return fmt.Errorf("expected cost %s got %s", expLines[0], outLines[0])
+	}
+	if len(outLines) < 2 {
+		return fmt.Errorf("missing color string")
+	}
+	colors := outLines[1]
+	if len(colors) != n {
+		return fmt.Errorf("invalid color length")
+	}
+	// verify assignment validity
+	xsCopy := make([]int, len(xs))
+	ysCopy := make([]int, len(ys))
+	copy(xsCopy, xs)
+	copy(ysCopy, ys)
+	ok, cost := isValid([]byte(colors), n, m, rCost, bCost, xsCopy, ysCopy, cons)
+	if !ok {
+		return fmt.Errorf("assignment violates constraints")
+	}
+	if fmt.Sprintf("%d", cost) != expLines[0] {
+		return fmt.Errorf("cost mismatch")
+	}
+	return nil
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp, n, m, r, b, xs, ys, cons := generateCase(rng)
+		if err := runCase(bin, in, exp, n, m, r, b, xs, ys, cons); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/704/verifierE.go
+++ b/0-999/700-799/700-709/704/verifierE.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Segment struct {
+	start, end float64
+	from, to   int
+	speed      float64
+}
+
+type NodeEvent struct {
+	time float64
+	node int
+}
+
+func path(n int, edges [][]int, start, end int) []int {
+	if start == end {
+		return []int{start}
+	}
+	parent := make([]int, n+1)
+	for i := range parent {
+		parent[i] = -1
+	}
+	q := list.New()
+	q.PushBack(start)
+	parent[start] = 0
+	for q.Len() > 0 {
+		v := q.Remove(q.Front()).(int)
+		if v == end {
+			break
+		}
+		for _, to := range edges[v] {
+			if parent[to] == -1 {
+				parent[to] = v
+				q.PushBack(to)
+			}
+		}
+	}
+	var res []int
+	cur := end
+	for cur != 0 {
+		res = append(res, cur)
+		if cur == start {
+			break
+		}
+		cur = parent[cur]
+	}
+	for i, j := 0, len(res)-1; i < j; i, j = i+1, j-1 {
+		res[i], res[j] = res[j], res[i]
+	}
+	return res
+}
+
+func solveE(n, m int, edges [][]int, suits [][4]int) string {
+	segments := make([][]Segment, m)
+	nodeEvents := make([][]NodeEvent, m)
+	for i, s := range suits {
+		t0 := float64(s[0])
+		c := float64(s[1])
+		v := s[2]
+		u := s[3]
+		p := path(n, edges, v, u)
+		nodeEvents[i] = append(nodeEvents[i], NodeEvent{t0, v})
+		for j := 0; j < len(p)-1; j++ {
+			seg := Segment{start: t0, end: t0 + 1.0/c, from: p[j], to: p[j+1], speed: c}
+			segments[i] = append(segments[i], seg)
+			t0 += 1.0 / c
+			nodeEvents[i] = append(nodeEvents[i], NodeEvent{t0, p[j+1]})
+		}
+	}
+	ans := math.Inf(1)
+	eps := 1e-9
+	for i := 0; i < m; i++ {
+		for j := i + 1; j < m; j++ {
+			ei := nodeEvents[i]
+			ej := nodeEvents[j]
+			for _, a := range ei {
+				for _, b := range ej {
+					if a.node == b.node && math.Abs(a.time-b.time) < eps && a.time < ans {
+						ans = a.time
+					}
+				}
+			}
+		}
+	}
+	for i := 0; i < m; i++ {
+		for j := i + 1; j < m; j++ {
+			for _, s1 := range segments[i] {
+				for _, s2 := range segments[j] {
+					t, ok := collideSeg(s1, s2)
+					if ok && t < ans {
+						ans = t
+					}
+				}
+			}
+		}
+	}
+	if math.IsInf(ans, 1) {
+		return "-1"
+	}
+	return fmt.Sprintf("%.6f", ans)
+}
+
+func collideSeg(a, b Segment) (float64, bool) {
+	eps := 1e-9
+	if a.from == b.from && a.to == b.to {
+		if math.Abs(a.speed-b.speed) < eps {
+			if math.Abs(a.start-b.start) < eps {
+				t := math.Max(a.start, b.start)
+				if t <= a.end+eps && t <= b.end+eps {
+					return t, true
+				}
+			}
+			return 0, false
+		}
+		t := (a.speed*a.start - b.speed*b.start) / (a.speed - b.speed)
+		if t+eps < math.Max(a.start, b.start) || t-eps > math.Min(a.end, b.end) {
+			return 0, false
+		}
+		return t, true
+	}
+	if a.from == b.to && a.to == b.from {
+		t := (1 + a.speed*a.start + b.speed*b.start) / (a.speed + b.speed)
+		if t+eps < math.Max(a.start, b.start) || t-eps > math.Min(a.end, b.end) {
+			return 0, false
+		}
+		return t, true
+	}
+	return 0, false
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 2
+	edges := make([][]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i] = append(edges[i], p)
+		edges[p] = append(edges[p], i)
+	}
+	m := rng.Intn(3) + 2
+	suits := make([][4]int, m)
+	for i := 0; i < m; i++ {
+		ti := rng.Intn(6)
+		ci := rng.Intn(5) + 1
+		vi := rng.Intn(n) + 1
+		ui := rng.Intn(n) + 1
+		suits[i] = [4]int{ti, ci, vi, ui}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 2; i <= n; i++ {
+		for _, v := range edges[i] {
+			if v < i {
+				sb.WriteString(fmt.Sprintf("%d %d\n", i, v))
+			}
+		}
+	}
+	for i := 0; i < m; i++ {
+		s := suits[i]
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", s[0], s[1], s[2], s[3]))
+	}
+	expected := solveE(n, m, edges, suits)
+	return sb.String(), expected
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if expected == "-1" {
+		if outStr != "-1" {
+			return fmt.Errorf("expected -1 got %s", outStr)
+		}
+		return nil
+	}
+	valOut, err1 := strconv.ParseFloat(outStr, 64)
+	valExp, err2 := strconv.ParseFloat(expected, 64)
+	if err1 != nil || err2 != nil {
+		return fmt.Errorf("invalid float output")
+	}
+	if math.Abs(valOut-valExp) > 1e-6 {
+		return fmt.Errorf("expected %.6f got %.6f", valExp, valOut)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifierA.go for problem 704A
- add Go verifierB.go for problem 704B
- add Go verifierC.go for problem 704C
- add Go verifierD.go for problem 704D
- add Go verifierE.go for problem 704E

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_688382631fb0832481b33c20a90a03ac