### PR TITLE
Add Go solution for 1969B

### DIFF
--- a/1000-1999/1900-1999/1960-1969/1969/1969B.go
+++ b/1000-1999/1900-1999/1960-1969/1969/1969B.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		var ones, cost int64
+		for _, ch := range s {
+			if ch == '1' {
+				ones++
+			} else if ones > 0 {
+				cost += ones + 1
+			}
+		}
+		fmt.Fprintln(writer, cost)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1969B

## Testing
- `go vet 1000-1999/1900-1999/1960-1969/1969/1969B.go`
- `go build 1000-1999/1900-1999/1960-1969/1969/1969B.go`
- `go run 1000-1999/1900-1999/1960-1969/1969/1969B.go < sample_input`

------
https://chatgpt.com/codex/tasks/task_e_6883821d090c832491a48b4569e6e3fc