### PR TITLE
Add Go verifiers for contest 702

### DIFF
--- a/0-999/700-799/700-709/702/verifierA.go
+++ b/0-999/700-799/700-709/702/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(nums []int) int {
+	if len(nums) == 0 {
+		return 0
+	}
+	maxLen := 1
+	cur := 1
+	for i := 1; i < len(nums); i++ {
+		if nums[i] > nums[i-1] {
+			cur++
+		} else {
+			if cur > maxLen {
+				maxLen = cur
+			}
+			cur = 1
+		}
+	}
+	if cur > maxLen {
+		maxLen = cur
+	}
+	return maxLen
+}
+
+func buildCase(nums []int) testCase {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(len(nums)))
+	sb.WriteByte('\n')
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	expect := strconv.Itoa(solve(nums))
+	return testCase{input: sb.String(), expected: expect}
+}
+
+func genRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	nums := make([]int, n)
+	for i := range nums {
+		nums[i] = rng.Intn(100)
+	}
+	return buildCase(nums)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, buildCase([]int{1}))
+	cases = append(cases, buildCase([]int{1, 2, 3}))
+	cases = append(cases, buildCase([]int{3, 2, 1}))
+	cases = append(cases, buildCase([]int{1, 3, 2, 4, 5}))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genRandomCase(rng))
+	}
+
+	for idx, tc := range cases {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/702/verifierB.go
+++ b/0-999/700-799/700-709/702/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(nums []int64) int64 {
+	counts := make(map[int64]int)
+	var result int64
+	for _, a := range nums {
+		for p := 0; p < 32; p++ {
+			need := (int64(1) << p) - a
+			if c, ok := counts[need]; ok {
+				result += int64(c)
+			}
+		}
+		counts[a]++
+	}
+	return result
+}
+
+func buildCase(nums []int64) testCase {
+	var sb strings.Builder
+	n := len(nums)
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	expect := strconv.FormatInt(solve(nums), 10)
+	return testCase{input: sb.String(), expected: expect}
+}
+
+func genRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	nums := make([]int64, n)
+	for i := range nums {
+		nums[i] = int64(rng.Intn(100))
+	}
+	return buildCase(nums)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, buildCase([]int64{1, 3, 5, 7}))
+	cases = append(cases, buildCase([]int64{1, 1, 1, 1}))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genRandomCase(rng))
+	}
+
+	for idx, tc := range cases {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/702/verifierC.go
+++ b/0-999/700-799/700-709/702/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(cities, towers []int) int {
+	sort.Ints(towers)
+	m := len(towers)
+	result := 0
+	for _, x := range cities {
+		idx := sort.SearchInts(towers, x)
+		dist := int(1<<31 - 1)
+		if idx < m {
+			d := towers[idx] - x
+			if d < dist {
+				dist = d
+			}
+		}
+		if idx > 0 {
+			d := x - towers[idx-1]
+			if d < dist {
+				dist = d
+			}
+		}
+		if dist > result {
+			result = dist
+		}
+	}
+	return result
+}
+
+func buildCase(cities, towers []int) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", len(cities), len(towers)))
+	for i, v := range cities {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range towers {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	expect := strconv.Itoa(solve(cities, towers))
+	return testCase{input: sb.String(), expected: expect}
+}
+
+func genRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	cities := make([]int, n)
+	towers := make([]int, m)
+	for i := range cities {
+		cities[i] = rng.Intn(100)
+	}
+	for i := range towers {
+		towers[i] = rng.Intn(100)
+	}
+	return buildCase(cities, towers)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, buildCase([]int{1}, []int{1}))
+	cases = append(cases, buildCase([]int{0, 10}, []int{5}))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genRandomCase(rng))
+	}
+
+	for idx, tc := range cases {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/702/verifierD.go
+++ b/0-999/700-799/700-709/702/verifierD.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func min(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solve(d, k, a, b, t int64) int64 {
+	if d <= k {
+		return d * a
+	}
+	ans := k * a
+	d -= k
+	full := d / k
+	costDrive := t + k*a
+	costWalk := k * b
+	if costDrive < costWalk {
+		ans += full * costDrive
+	} else {
+		ans += full * costWalk
+		return ans + (d%k)*b
+	}
+	rem := d % k
+	if rem > 0 {
+		ans += min(t+rem*a, rem*b)
+	}
+	return ans
+}
+
+func buildCase(d, k, a, b, t int64) testCase {
+	input := fmt.Sprintf("%d %d %d %d %d\n", d, k, a, b, t)
+	expect := strconv.FormatInt(solve(d, k, a, b, t), 10)
+	return testCase{input: input, expected: expect}
+}
+
+func genRandomCase(rng *rand.Rand) testCase {
+	d := int64(rng.Intn(1000) + 1)
+	k := int64(rng.Intn(20) + 1)
+	a := int64(rng.Intn(5) + 1)
+	b := a + int64(rng.Intn(5)+1)
+	t := int64(rng.Intn(10) + 1)
+	return buildCase(d, k, a, b, t)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, buildCase(5, 2, 1, 3, 5))
+	cases = append(cases, buildCase(10, 3, 1, 4, 2))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genRandomCase(rng))
+	}
+
+	for idx, tc := range cases {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/702/verifierE.go
+++ b/0-999/700-799/700-709/702/verifierE.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	oracle := "./oracleE"
+	cmd := exec.Command("go", "build", "-o", oracle, "702E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build oracle: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	k := rng.Int63n(100) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(n)))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(100)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		expected, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/702/verifierF.go
+++ b/0-999/700-799/700-709/702/verifierF.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Shirt struct {
+	c, q int64
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(shirts []Shirt, budgets []int64) []int {
+	sort.Slice(shirts, func(i, j int) bool {
+		if shirts[i].q != shirts[j].q {
+			return shirts[i].q > shirts[j].q
+		}
+		return shirts[i].c < shirts[j].c
+	})
+	prefix := make([]int64, len(shirts)+1)
+	for i := 0; i < len(shirts); i++ {
+		prefix[i+1] = prefix[i] + shirts[i].c
+	}
+	res := make([]int, len(budgets))
+	for i, b := range budgets {
+		lo, hi := 0, len(shirts)
+		for lo < hi {
+			mid := (lo + hi + 1) >> 1
+			if prefix[mid] <= b {
+				lo = mid
+			} else {
+				hi = mid - 1
+			}
+		}
+		res[i] = lo
+	}
+	return res
+}
+
+func genRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 1
+	shirts := make([]Shirt, n)
+	for i := range shirts {
+		shirts[i] = Shirt{c: int64(rng.Intn(10) + 1), q: int64(rng.Intn(10) + 1)}
+	}
+	k := rng.Intn(6) + 1
+	budgets := make([]int64, k)
+	for i := range budgets {
+		budgets[i] = int64(rng.Intn(50) + 1)
+	}
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for i, s := range shirts {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprintf("%d %d", s.c, s.q))
+		if i != n-1 {
+			input.WriteByte(' ')
+		}
+	}
+	input.WriteByte('\n')
+	input.WriteString(fmt.Sprintf("%d\n", k))
+	for i, b := range budgets {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(strconv.FormatInt(b, 10))
+	}
+	input.WriteByte('\n')
+	answers := solve(shirts, budgets)
+	var expected strings.Builder
+	for i, v := range answers {
+		if i > 0 {
+			expected.WriteByte(' ')
+		}
+		expected.WriteString(strconv.Itoa(v))
+	}
+	expected.WriteByte('\n')
+	return testCase{input: input.String(), expected: strings.TrimSpace(expected.String())}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, genRandomCase(rand.New(rand.NewSource(42))))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genRandomCase(rng))
+	}
+
+	for idx, tc := range cases {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, tc.input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for each problem of Codeforces contest 702
- each verifier generates 100+ tests and checks a provided binary
- problem E verifier builds a reference binary from `702E.go`

## Testing
- `gofmt -w verifierA.go`
- `gofmt -w verifierB.go`
- `gofmt -w verifierC.go`
- `gofmt -w verifierD.go`
- `gofmt -w verifierE.go`
- `gofmt -w verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6883814ae0e483249c28dbacc6be1aef