### PR TITLE
Add Go verifiers for contest 701

### DIFF
--- a/0-999/700-799/700-709/701/verifierA.go
+++ b/0-999/700-799/700-709/701/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCaseA(rng *rand.Rand) (int, []int) {
+	n := rng.Intn(50)*2 + 2 // even between 2 and 100
+	d := rng.Intn(100) + 2
+	arr := make([]int, n)
+	for i := 0; i < n/2; i++ {
+		a := rng.Intn(d-1) + 1
+		b := d - a
+		arr[2*i] = a
+		arr[2*i+1] = b
+	}
+	rng.Shuffle(n, func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+	return n, arr
+}
+
+func runCaseA(bin string, n int, arr []int) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprint(arr[i]))
+	}
+	input.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != n {
+		return fmt.Errorf("expected %d numbers got %d", n, len(fields))
+	}
+	used := make([]bool, n+1)
+	idx := func(s string) int {
+		v, err := strconv.Atoi(s)
+		if err != nil {
+			return -1
+		}
+		return v
+	}
+	d := arr[idx(fields[0])-1] + arr[idx(fields[1])-1]
+	for i := 0; i < n; i += 2 {
+		a := idx(fields[i])
+		b := idx(fields[i+1])
+		if a < 1 || a > n || b < 1 || b > n {
+			return fmt.Errorf("index out of range")
+		}
+		if used[a] || used[b] {
+			return fmt.Errorf("index reused")
+		}
+		used[a], used[b] = true, true
+		if arr[a-1]+arr[b-1] != d {
+			return fmt.Errorf("pair sum mismatch")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, arr := generateCaseA(rng)
+		if err := runCaseA(bin, n, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d\n%v\n", i+1, err, n, arr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/701/verifierB.go
+++ b/0-999/700-799/700-709/701/verifierB.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedB(n int, moves [][2]int) string {
+	rows := make([]bool, n+1)
+	cols := make([]bool, n+1)
+	remRows, remCols := n, n
+	res := make([]string, len(moves))
+	for i, mv := range moves {
+		x, y := mv[0], mv[1]
+		if !rows[x] {
+			rows[x] = true
+			remRows--
+		}
+		if !cols[y] {
+			cols[y] = true
+			remCols--
+		}
+		res[i] = fmt.Sprint(remRows * remCols)
+	}
+	return strings.Join(res, " ")
+}
+
+func generateCaseB(rng *rand.Rand) (int, [][2]int) {
+	n := rng.Intn(10) + 1
+	maxM := n * n
+	m := rng.Intn(maxM) + 1
+	used := make(map[[2]int]bool)
+	moves := make([][2]int, 0, m)
+	for len(moves) < m {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(n) + 1
+		key := [2]int{x, y}
+		if !used[key] {
+			used[key] = true
+			moves = append(moves, key)
+		}
+	}
+	return n, moves
+}
+
+func runCaseB(bin string, n int, moves [][2]int) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d %d\n", n, len(moves)))
+	for _, mv := range moves {
+		input.WriteString(fmt.Sprintf("%d %d\n", mv[0], mv[1]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedB(n, moves)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, moves := generateCaseB(rng)
+		if err := runCaseB(bin, n, moves); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/700-709/701/verifierC.go
+++ b/0-999/700-799/700-709/701/verifierC.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedC(s string) int {
+	n := len(s)
+	freqTotal := make(map[byte]bool)
+	for i := 0; i < n; i++ {
+		freqTotal[s[i]] = true
+	}
+	totalTypes := len(freqTotal)
+	freq := make(map[byte]int)
+	have := 0
+	left := 0
+	best := n
+	for right := 0; right < n; right++ {
+		c := s[right]
+		freq[c]++
+		if freq[c] == 1 {
+			have++
+		}
+		for have == totalTypes {
+			if right-left+1 < best {
+				best = right - left + 1
+			}
+			lch := s[left]
+			freq[lch]--
+			if freq[lch] == 0 {
+				have--
+			}
+			left++
+		}
+	}
+	return best
+}
+
+func generateCaseC(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func runCaseC(bin string, s string) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n%s\n", len(s), s))
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out.String()))
+	if err != nil {
+		return fmt.Errorf("invalid output: %s", out.String())
+	}
+	expect := expectedC(s)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := generateCaseC(rng)
+		if err := runCaseC(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %s\n", i+1, err, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifiers for problems A, B, C in contest 701
- verifiers generate 100 random cases each and validate outputs of any binary

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go`

------
https://chatgpt.com/codex/tasks/task_e_688380bec530832481ab71b5eb81615b