### PR TITLE
Add Go verifiers for contest 721

### DIFF
--- a/0-999/700-799/720-729/721/verifierA.go
+++ b/0-999/700-799/720-729/721/verifierA.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	s string
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(tc testCase) string {
+	res := []int{}
+	cnt := 0
+	for i := 0; i < tc.n; i++ {
+		if tc.s[i] == 'B' {
+			cnt++
+		} else if cnt > 0 {
+			res = append(res, cnt)
+			cnt = 0
+		}
+	}
+	if cnt > 0 {
+		res = append(res, cnt)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprint(len(res)))
+	sb.WriteByte('\n')
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func buildInput(tc testCase) string {
+	return fmt.Sprintf("%d\n%s\n", tc.n, tc.s)
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = 'B'
+		} else {
+			b[i] = 'W'
+		}
+	}
+	return testCase{n: n, s: string(b)}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{1, "B"},
+		{1, "W"},
+		{3, "BBB"},
+		{4, "BWBW"},
+	}
+	for len(cases) < 105 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		input := buildInput(tc)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		exp := expected(tc)
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/720-729/721/verifierB.go
+++ b/0-999/700-799/720-729/721/verifierB.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n         int
+	k         int
+	passwords []string
+	target    string
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(tc testCase) string {
+	L := len(tc.target)
+	less, equal := 0, 0
+	for _, p := range tc.passwords {
+		if len(p) < L {
+			less++
+		} else if len(p) == L {
+			equal++
+		}
+	}
+	bestPos := less + 1
+	worstPos := less + equal
+	best := bestPos + (bestPos-1)/tc.k*5
+	worst := worstPos + (worstPos-1)/tc.k*5
+	return fmt.Sprintf("%d %d", best, worst)
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+	for _, p := range tc.passwords {
+		sb.WriteString(p)
+		sb.WriteByte('\n')
+	}
+	sb.WriteString(tc.target)
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+
+func randStr(rng *rand.Rand, n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 1
+	k := rng.Intn(100) + 1
+	passwords := make([]string, n)
+	for i := 0; i < n; i++ {
+		passwords[i] = randStr(rng, rng.Intn(10)+1)
+	}
+	target := passwords[rng.Intn(n)]
+	return testCase{n: n, k: k, passwords: passwords, target: target}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{1, 1, []string{"a"}, "a"},
+		{2, 1, []string{"ab", "c"}, "ab"},
+		{3, 2, []string{"a", "bb", "ccc"}, "bb"},
+	}
+	for len(cases) < 105 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		input := buildInput(tc)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		exp := expected(tc)
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/720-729/721/verifierC.go
+++ b/0-999/700-799/720-729/721/verifierC.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	u, v, w int
+}
+
+type testCase struct {
+	n, m, T int
+	edges   []edge
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.m, tc.T))
+	for _, e := range tc.edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.u, e.v, e.w))
+	}
+	return sb.String()
+}
+
+func expected(tc testCase) string {
+	adj := make([][]edge, tc.n+1)
+	for _, e := range tc.edges {
+		adj[e.u] = append(adj[e.u], e)
+	}
+	dp := make([]map[int]int, tc.n+1)
+	visited := make([]bool, tc.n+1)
+	var dfs func(int)
+	dfs = func(u int) {
+		if visited[u] {
+			return
+		}
+		visited[u] = true
+		dp[u] = make(map[int]int)
+		if u == tc.n {
+			dp[u][1] = 0
+			return
+		}
+		for _, ed := range adj[u] {
+			dfs(ed.v)
+			for k, val := range dp[ed.v] {
+				wsum := val + ed.w
+				if wsum > tc.T {
+					continue
+				}
+				nk := k + 1
+				if prev, ok := dp[u][nk]; !ok || wsum < prev {
+					dp[u][nk] = wsum
+				}
+			}
+		}
+	}
+	dfs(1)
+	best := 0
+	for k := range dp[1] {
+		if k > best {
+			best = k
+		}
+	}
+	path := make([]int, 0, best)
+	cur, k := 1, best
+	for {
+		path = append(path, cur)
+		if cur == tc.n {
+			break
+		}
+		for _, ed := range adj[cur] {
+			if next, ok := dp[ed.v][k-1]; ok && next+ed.w == dp[cur][k] {
+				cur = ed.v
+				k--
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintln(best))
+	for i, x := range path {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(x))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 2 // 2..7
+	edges := make([]edge, 0)
+	sum := 0
+	for i := 1; i < n; i++ {
+		w := rng.Intn(5) + 1
+		edges = append(edges, edge{i, i + 1, w})
+		sum += w
+	}
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges-(n-1)+1) + (n - 1)
+	for len(edges) < m {
+		u := rng.Intn(n-1) + 1
+		v := rng.Intn(n-u) + u + 1
+		w := rng.Intn(5) + 1
+		edges = append(edges, edge{u, v, w})
+	}
+	T := sum + rng.Intn(10)
+	return testCase{n: n, m: len(edges), T: T, edges: edges}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{}
+	for len(cases) < 105 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		input := buildInput(tc)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		exp := expected(tc)
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/720-729/721/verifierD.go
+++ b/0-999/700-799/720-729/721/verifierD.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m int
+	x    int64
+	arr  []int64
+}
+
+type item struct {
+	v   int64
+	pos int
+}
+
+type maxHeap []item
+
+func (h maxHeap) Len() int           { return len(h) }
+func (h maxHeap) Less(i, j int) bool { return h[i].v > h[j].v }
+func (h maxHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *maxHeap) Push(x interface{}) { *h = append(*h, x.(item)) }
+func (h *maxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	it := old[n-1]
+	*h = old[:n-1]
+	return it
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.m, tc.x))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func expected(tc testCase) string {
+	a := append([]int64(nil), tc.arr...)
+	h := &maxHeap{}
+	heap.Init(h)
+	num := 0
+	for i, v := range a {
+		if v < 0 {
+			num++
+		}
+		heap.Push(h, item{v: abs(v), pos: i})
+	}
+	for k := 0; k < tc.m; k++ {
+		it := heap.Pop(h).(item)
+		p := it.pos
+		if a[p] < 0 {
+			num--
+		}
+		if num&1 == 1 {
+			a[p] += tc.x
+		} else {
+			a[p] -= tc.x
+		}
+		if a[p] < 0 {
+			num++
+		}
+		heap.Push(h, item{v: abs(a[p]), pos: p})
+	}
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	x := int64(rng.Intn(5) + 1)
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(21) - 10)
+	}
+	return testCase{n: n, m: m, x: x, arr: arr}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{}
+	for len(cases) < 105 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		input := buildInput(tc)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		exp := expected(tc)
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/720-729/721/verifierE.go
+++ b/0-999/700-799/720-729/721/verifierE.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type segment struct {
+	l, r int64
+}
+
+type testCase struct {
+	L    int64
+	n    int
+	p, t int64
+	segs []segment
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", tc.L, tc.n, tc.p, tc.t))
+	for _, s := range tc.segs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", s.l, s.r))
+	}
+	return sb.String()
+}
+
+func expected(tc testCase) string {
+	nextAvail := int64(0)
+	ans := int64(0)
+	for _, s := range tc.segs {
+		y0 := s.l
+		if nextAvail > y0 {
+			y0 = nextAvail
+		}
+		if s.r-y0 >= tc.p {
+			avail := s.r - y0
+			k := avail / tc.p
+			ans += k
+			lastEnd := y0 + k*tc.p
+			nextAvail = lastEnd + tc.t
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	L := int64(rng.Intn(100) + 1)
+	n := rng.Intn(5)
+	p := int64(rng.Intn(10) + 1)
+	t := int64(rng.Intn(5) + 1)
+	segs := make([]segment, 0, n)
+	cur := int64(0)
+	for i := 0; i < n; i++ {
+		gap := int64(rng.Intn(3) + 1)
+		start := cur + gap
+		if start >= L {
+			break
+		}
+		length := int64(rng.Intn(10) + 1)
+		end := start + length
+		if end > L {
+			end = L
+		}
+		segs = append(segs, segment{start, end})
+		cur = end
+	}
+	return testCase{L: L, n: len(segs), p: p, t: t, segs: segs}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{}
+	for len(cases) < 105 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		input := buildInput(tc)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		exp := expected(tc)
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 721 problems A–E
- each verifier supports running either a compiled binary or a Go source file
- random test generation provides at least 100 cases per problem

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`


------
https://chatgpt.com/codex/tasks/task_e_68838bb0b8a883249ed8f5c6198e05c3