### PR TITLE
Add Go solution for problem 1958B

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1958/1958B.go
+++ b/1000-1999/1900-1999/1950-1959/1958/1958B.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var k, m int64
+		fmt.Fscan(reader, &k, &m)
+		mod := m % (3 * k)
+		if mod >= 2*k {
+			fmt.Fprintln(writer, 0)
+		} else {
+			fmt.Fprintln(writer, 2*k-mod)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement problem 1958B solution in Go

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1958/1958B.go`

------
https://chatgpt.com/codex/tasks/task_e_68838d9b1af083248a38eca45dada5f0