### PR TITLE
Add Go solution for 1958C

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1958/1958C.go
+++ b/1000-1999/1900-1999/1950-1959/1958/1958C.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// This program solves the wood log splitting problem described in problemC.txt.
+// Starting with a log of weight 2^n, we may split any log into two halves.
+// We want the minimum number of splits so that a subset of logs weighs exactly k.
+// The optimal strategy recursively chooses a half that is closer to k and
+// continues on that half. This leads to the recurrence:
+//   f(n, k) = 0 if k == 0 or k == 2^n
+//   f(n, k) = 1 + f(n-1, |k - 2^{n-1}|) otherwise.
+// We iterate this relation until k becomes 0 or 2^n.
+
+func minSplits(n int64, k int64) int64 {
+	var steps int64
+	for k > 0 && k < (int64(1)<<n) {
+		half := int64(1) << (n - 1)
+		if k > half {
+			k -= half
+		} else {
+			k = half - k
+		}
+		steps++
+		n--
+	}
+	return steps
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, k int64
+		fmt.Fscan(in, &n, &k)
+		fmt.Fprintln(out, minSplits(n, k))
+	}
+}


### PR DESCRIPTION
## Summary
- implement solver for the log splitting problem in `1958C.go`

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1958/1958C.go`
- `echo -e "1\n2 1\n" | go run 1000-1999/1900-1999/1950-1959/1958/1958C.go`

------
https://chatgpt.com/codex/tasks/task_e_68838d0f95c4832499aa66020f6fd796