### PR TITLE
Add Go verifiers for contest 722

### DIFF
--- a/0-999/700-799/720-729/722/verifierA.go
+++ b/0-999/700-799/720-729/722/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseA struct {
+	format int
+	time   string
+}
+
+func genTestsA() []testCaseA {
+	rand.Seed(42)
+	tests := make([]testCaseA, 100)
+	for i := range tests {
+		f := 12
+		if rand.Intn(2) == 0 {
+			f = 24
+		}
+		hh1 := rand.Intn(10)
+		hh2 := rand.Intn(10)
+		mm1 := rand.Intn(10)
+		mm2 := rand.Intn(10)
+		t := fmt.Sprintf("%d%d:%d%d", hh1, hh2, mm1, mm2)
+		tests[i] = testCaseA{f, t}
+	}
+	return tests
+}
+
+func solveA(tc testCaseA) string {
+	b := []byte(tc.time)
+	if b[3] > '5' {
+		b[3] = '0'
+	}
+	if tc.format == 12 {
+		if b[0] != '1' && b[1] == '0' {
+			b[0] = '1'
+		} else if b[0] > '1' || (b[0] == '1' && b[1] > '2') {
+			b[0] = '0'
+		}
+	} else {
+		if b[0] > '2' || (b[0] == '2' && b[1] > '3') {
+			b[0] = '0'
+		}
+	}
+	return string(b)
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d\n%s\n", tc.format, tc.time)
+		exp := solveA(tc)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != exp {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/722/verifierB.go
+++ b/0-999/700-799/720-729/722/verifierB.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseB struct {
+	n       int
+	pattern []int
+	lines   []string
+}
+
+func genTestsB() []testCaseB {
+	rand.Seed(43)
+	tests := make([]testCaseB, 100)
+	for i := range tests {
+		n := rand.Intn(5) + 1
+		pat := make([]int, n)
+		lines := make([]string, n)
+		for j := 0; j < n; j++ {
+			pat[j] = rand.Intn(6)
+			words := rand.Intn(3) + 1
+			var sb strings.Builder
+			for w := 0; w < words; w++ {
+				if w > 0 {
+					sb.WriteByte(' ')
+				}
+				l := rand.Intn(5) + 1
+				for k := 0; k < l; k++ {
+					ch := byte('a' + rand.Intn(26))
+					sb.WriteByte(ch)
+				}
+			}
+			lines[j] = sb.String()
+		}
+		tests[i] = testCaseB{n, pat, lines}
+	}
+	return tests
+}
+
+func countVowels(s string) int {
+	cnt := 0
+	for _, r := range s {
+		switch r {
+		case 'a', 'e', 'i', 'o', 'u', 'y':
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func solveB(tc testCaseB) string {
+	for i, line := range tc.lines {
+		c := countVowels(line)
+		if c != tc.pattern[i] {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", tc.n)
+		for j, v := range tc.pattern {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		for _, line := range tc.lines {
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		exp := solveB(tc)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != exp {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/722/verifierC.go
+++ b/0-999/700-799/720-729/722/verifierC.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type testCaseC struct {
+	n    int
+	arr  []int64
+	perm []int
+}
+
+func genTestsC() []testCaseC {
+	rand.Seed(44)
+	tests := make([]testCaseC, 100)
+	for i := range tests {
+		n := rand.Intn(8) + 2
+		arr := make([]int64, n)
+		for j := range arr {
+			arr[j] = int64(rand.Intn(20))
+		}
+		p := rand.Perm(n)
+		for j := range p {
+			p[j]++
+		}
+		tests[i] = testCaseC{n, arr, p}
+	}
+	return tests
+}
+
+var parent []int
+var segSum []int64
+var used []bool
+
+func find(x int) int {
+	if parent[x] != x {
+		parent[x] = find(parent[x])
+	}
+	return parent[x]
+}
+
+func union(x, y int) {
+	rx := find(x)
+	ry := find(y)
+	if rx == ry {
+		return
+	}
+	parent[ry] = rx
+	segSum[rx] += segSum[ry]
+}
+
+func solveC(tc testCaseC) []int64 {
+	n := tc.n
+	parent = make([]int, n)
+	segSum = make([]int64, n)
+	used = make([]bool, n)
+	ans := make([]int64, n)
+	curMax := int64(0)
+	for i := n - 1; i >= 0; i-- {
+		ans[i] = curMax
+		pos := tc.perm[i] - 1
+		used[pos] = true
+		parent[pos] = pos
+		segSum[pos] = tc.arr[pos]
+		if pos > 0 && used[pos-1] {
+			union(pos, pos-1)
+		}
+		if pos+1 < n && used[pos+1] {
+			union(pos, pos+1)
+		}
+		root := find(pos)
+		if segSum[root] > curMax {
+			curMax = segSum[root]
+		}
+	}
+	return ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func parseOutputC(out string, n int) ([]int64, error) {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	scanner.Split(bufio.ScanWords)
+	res := make([]int64, n)
+	for i := 0; i < n; i++ {
+		if !scanner.Scan() {
+			return nil, fmt.Errorf("not enough output")
+		}
+		v, err := strconv.ParseInt(scanner.Text(), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	if scanner.Scan() {
+		return nil, fmt.Errorf("extra output")
+	}
+	return res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", tc.n)
+		for j, v := range tc.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		for j, v := range tc.perm {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expArr := solveC(tc)
+		gotStr, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, gotStr)
+			os.Exit(1)
+		}
+		gotArr, err := parseOutputC(gotStr, tc.n)
+		if err != nil {
+			fmt.Printf("test %d: bad output: %v\ninput:\n%soutput:\n%s", i+1, err, input, gotStr)
+			os.Exit(1)
+		}
+		for j := 0; j < tc.n; j++ {
+			if gotArr[j] != expArr[j] {
+				fmt.Printf("test %d failed on line %d: expected %d got %d\ninput:\n%s", i+1, j+1, expArr[j], gotArr[j], input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/722/verifierD.go
+++ b/0-999/700-799/720-729/722/verifierD.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type testCaseD struct {
+	n   int
+	arr []int
+}
+
+func genTestsD() []testCaseD {
+	rand.Seed(45)
+	tests := make([]testCaseD, 100)
+	for i := range tests {
+		n := rand.Intn(6) + 1
+		arr := make([]int, n)
+		used := make(map[int]bool)
+		for j := 0; j < n; j++ {
+			v := rand.Intn(100) + 1
+			for used[v] {
+				v = rand.Intn(100) + 1
+			}
+			used[v] = true
+			arr[j] = v
+		}
+		tests[i] = testCaseD{n, arr}
+	}
+	return tests
+}
+
+func compileRef() (string, error) {
+	exe := filepath.Join(os.TempDir(), "722D_ref")
+	cmd := exec.Command("go", "build", "-o", exe, "722D.go")
+	cmd.Dir = "."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("compile reference failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTestsD()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", tc.n)
+		for j, v := range tc.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(got), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/722/verifierE.go
+++ b/0-999/700-799/720-729/722/verifierE.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type testCaseE struct {
+	n, m  int
+	k     int
+	s     int
+	cells [][2]int
+}
+
+func genTestsE() []testCaseE {
+	rand.Seed(46)
+	tests := make([]testCaseE, 100)
+	for i := range tests {
+		n := rand.Intn(4) + 1
+		m := rand.Intn(4) + 1
+		maxCells := n * m
+		k := rand.Intn(maxCells + 1)
+		s := rand.Intn(100) + 1
+		used := make(map[[2]int]bool)
+		cells := make([][2]int, 0, k)
+		for j := 0; j < k; j++ {
+			var r, c int
+			for {
+				r = rand.Intn(n) + 1
+				c = rand.Intn(m) + 1
+				if !used[[2]int{r, c}] {
+					used[[2]int{r, c}] = true
+					break
+				}
+			}
+			cells = append(cells, [2]int{r, c})
+		}
+		tests[i] = testCaseE{n, m, k, s, cells}
+	}
+	return tests
+}
+
+func compileRef() (string, error) {
+	exe := filepath.Join(os.TempDir(), "722E_ref")
+	cmd := exec.Command("go", "build", "-o", exe, "722E.go")
+	cmd.Dir = "."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("compile reference failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTestsE()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d\n", tc.n, tc.m, tc.k, tc.s)
+		for _, p := range tc.cells {
+			fmt.Fprintf(&sb, "%d %d\n", p[0], p[1])
+		}
+		input := sb.String()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(got), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/722/verifierF.go
+++ b/0-999/700-799/720-729/722/verifierF.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type testCaseF struct {
+	n, m int
+	seqs [][]int
+}
+
+func genTestsF() []testCaseF {
+	rand.Seed(47)
+	tests := make([]testCaseF, 100)
+	for i := range tests {
+		n := rand.Intn(3) + 1
+		m := rand.Intn(10) + 1
+		seqs := make([][]int, n)
+		for j := 0; j < n; j++ {
+			k := rand.Intn(3) + 1
+			seq := make([]int, k)
+			used := make(map[int]bool)
+			for x := 0; x < k; x++ {
+				v := rand.Intn(m) + 1
+				for used[v] {
+					v = rand.Intn(m) + 1
+				}
+				used[v] = true
+				seq[x] = v
+			}
+			seqs[j] = seq
+		}
+		tests[i] = testCaseF{n, m, seqs}
+	}
+	return tests
+}
+
+func compileRef() (string, error) {
+	exe := filepath.Join(os.TempDir(), "722F_ref")
+	cmd := exec.Command("go", "build", "-o", exe, "722F.go")
+	cmd.Dir = "."
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("compile reference failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTestsF()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+		for _, seq := range tc.seqs {
+			fmt.Fprintf(&sb, "%d", len(seq))
+			for _, v := range seq {
+				fmt.Fprintf(&sb, " %d", v)
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\noutput:\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed: expected %q got %q\ninput:\n%s", i+1, strings.TrimSpace(exp), strings.TrimSpace(got), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add autogenerated verifiers for contest 722 problems A–F
- each verifier runs 100 randomly generated test cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_68838c3cd4408324aa90964bdfae70b4