### PR TITLE
Add Go solution for 1967B1

### DIFF
--- a/1000-1999/1900-1999/1960-1969/1967/1967B1.go
+++ b/1000-1999/1900-1999/1960-1969/1967/1967B1.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m int64
+		fmt.Fscan(reader, &n, &m)
+		ans := int64(0)
+		for g := int64(1); g <= m; g++ {
+			kmax := (n + g) / (g * g)
+			kmin := int64(1)
+			if g == 1 {
+				kmin = 2
+			}
+			if kmax >= kmin {
+				ans += kmax - kmin + 1
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem 1967B1

## Testing
- `go run 1000-1999/1900-1999/1960-1969/1967/1967B1.go << EOF
1
10 3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68837d3038c88324850363387d78c436