### PR TITLE
Add verifiers for contest 691

### DIFF
--- a/0-999/600-699/690-699/691/verifierA.go
+++ b/0-999/600-699/690-699/691/verifierA.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func solveCase(n int, arr []int) string {
+	zeros := 0
+	for _, v := range arr {
+		if v == 0 {
+			zeros++
+		}
+	}
+	if n == 1 {
+		if zeros == 0 {
+			return "YES\n"
+		}
+		return "NO\n"
+	}
+	if zeros == 1 {
+		return "YES\n"
+	}
+	return "NO\n"
+}
+
+func buildCase(arr []int) testCase {
+	n := len(arr)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return testCase{in: sb.String(), out: solveCase(n, arr)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(2)
+	}
+	return buildCase(arr)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	if strings.TrimSpace(got) != strings.TrimSpace(tc.out) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(tc.out), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	// deterministic cases
+	cases = append(cases, buildCase([]int{0}))
+	cases = append(cases, buildCase([]int{1}))
+	cases = append(cases, buildCase([]int{0, 0}))
+	cases = append(cases, buildCase([]int{0, 1}))
+	cases = append(cases, buildCase([]int{1, 1}))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/690-699/691/verifierB.go
+++ b/0-999/600-699/690-699/691/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+var mirror = map[byte]byte{
+	'A': 'A', 'H': 'H', 'I': 'I', 'M': 'M',
+	'O': 'O', 'T': 'T', 'U': 'U', 'V': 'V',
+	'W': 'W', 'X': 'X', 'Y': 'Y',
+	'b': 'd', 'd': 'b', 'p': 'q', 'q': 'p',
+	'o': 'o', 'v': 'v', 'w': 'w', 'x': 'x',
+}
+
+func solveCase(s string) string {
+	n := len(s)
+	for i := 0; i < n; i++ {
+		m, ok := mirror[s[i]]
+		if !ok || m != s[n-1-i] {
+			return "NIE\n"
+		}
+	}
+	return "TAK\n"
+}
+
+func buildCase(s string) testCase {
+	return testCase{in: s + "\n", out: solveCase(s)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	letters := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return buildCase(string(b))
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	if strings.TrimSpace(got) != strings.TrimSpace(tc.out) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(tc.out), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, buildCase("A"))
+	cases = append(cases, buildCase("AB"))
+	cases = append(cases, buildCase("oHo"))
+	cases = append(cases, buildCase("aa"))
+	cases = append(cases, buildCase("pqp"))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/690-699/691/verifierC.go
+++ b/0-999/600-699/690-699/691/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func solveCase(s string) string {
+	pos := strings.IndexByte(s, '.')
+	if pos == -1 {
+		pos = len(s)
+	}
+	digits := strings.ReplaceAll(s, ".", "")
+	first := 0
+	for first < len(digits) && digits[first] == '0' {
+		first++
+	}
+	last := len(digits) - 1
+	for last >= 0 && digits[last] == '0' {
+		last--
+	}
+	digits = digits[first : last+1]
+	exponent := pos - (first + 1)
+	var sb strings.Builder
+	sb.WriteByte(digits[0])
+	if len(digits) > 1 {
+		sb.WriteByte('.')
+		sb.WriteString(digits[1:])
+	}
+	if exponent != 0 {
+		sb.WriteByte('E')
+		sb.WriteString(strconv.Itoa(exponent))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildCase(s string) testCase {
+	return testCase{in: s + "\n", out: solveCase(s)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	length := rng.Intn(25) + 1
+	digits := make([]byte, length)
+	for i := range digits {
+		digits[i] = byte('0' + rng.Intn(10))
+	}
+	// ensure at least one non-zero
+	digits[rng.Intn(length)] = byte('1' + rng.Intn(9))
+	if rng.Intn(2) == 0 && length > 1 {
+		// insert decimal point
+		pos := rng.Intn(length-1) + 1
+		s := string(digits[:pos]) + "." + string(digits[pos:])
+		return buildCase(s)
+	}
+	return buildCase(string(digits))
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	if strings.TrimSpace(got) != strings.TrimSpace(tc.out) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(tc.out), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, buildCase("100"))
+	cases = append(cases, buildCase("1"))
+	cases = append(cases, buildCase("0.1"))
+	cases = append(cases, buildCase("0000123.45000"))
+	cases = append(cases, buildCase("9.87654321"))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/690-699/691/verifierD.go
+++ b/0-999/600-699/690-699/691/verifierD.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+type dsu struct {
+	parent []int
+	size   []int
+}
+
+func newDSU(n int) *dsu {
+	d := &dsu{parent: make([]int, n+1), size: make([]int, n+1)}
+	for i := 1; i <= n; i++ {
+		d.parent[i] = i
+		d.size[i] = 1
+	}
+	return d
+}
+
+func (d *dsu) find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *dsu) union(a, b int) {
+	a = d.find(a)
+	b = d.find(b)
+	if a == b {
+		return
+	}
+	if d.size[a] < d.size[b] {
+		a, b = b, a
+	}
+	d.parent[b] = a
+	d.size[a] += d.size[b]
+}
+
+func solveCase(n int, p []int, pairs [][2]int) string {
+	d := newDSU(n)
+	for _, pr := range pairs {
+		d.union(pr[0], pr[1])
+	}
+	compPos := make(map[int][]int)
+	compVal := make(map[int][]int)
+	for i := 1; i <= n; i++ {
+		r := d.find(i)
+		compPos[r] = append(compPos[r], i)
+		compVal[r] = append(compVal[r], p[i-1])
+	}
+	ans := make([]int, n+1)
+	for r := range compPos {
+		pos := compPos[r]
+		val := compVal[r]
+		sort.Ints(pos)
+		sort.Slice(val, func(i, j int) bool { return val[i] > val[j] })
+		for i := 0; i < len(pos); i++ {
+			ans[pos[i]] = val[i]
+		}
+	}
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", ans[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildCase(n int, p []int, pairs [][2]int) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(pairs)))
+	for i, v := range p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for _, pr := range pairs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", pr[0], pr[1]))
+	}
+	return testCase{in: sb.String(), out: solveCase(n, p, pairs)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 2
+	p := rng.Perm(n)
+	for i := range p {
+		p[i]++
+	}
+	maxPairs := n * (n - 1) / 2
+	m := rng.Intn(maxPairs + 1)
+	pairs := make([][2]int, 0, m)
+	used := make(map[[2]int]bool)
+	for len(pairs) < m {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a == b {
+			continue
+		}
+		if a > b {
+			a, b = b, a
+		}
+		key := [2]int{a, b}
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		pairs = append(pairs, key)
+	}
+	return buildCase(n, p, pairs)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(tc.out)
+	if got != want {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, buildCase(1, []int{1}, nil))
+	cases = append(cases, buildCase(2, []int{2, 1}, [][2]int{{1, 2}}))
+	cases = append(cases, buildCase(3, []int{1, 2, 3}, nil))
+	cases = append(cases, buildCase(3, []int{3, 2, 1}, [][2]int{{1, 2}, {2, 3}}))
+	cases = append(cases, buildCase(4, []int{4, 3, 2, 1}, [][2]int{{1, 4}, {2, 3}}))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/690-699/691/verifierE.go
+++ b/0-999/600-699/690-699/691/verifierE.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func matMul(a, b [][]int64) [][]int64 {
+	n := len(a)
+	res := make([][]int64, n)
+	for i := range res {
+		res[i] = make([]int64, n)
+	}
+	for i := 0; i < n; i++ {
+		ai := a[i]
+		ri := res[i]
+		for k := 0; k < n; k++ {
+			if ai[k] == 0 {
+				continue
+			}
+			aik := ai[k]
+			bk := b[k]
+			for j := 0; j < n; j++ {
+				if bk[j] == 0 {
+					continue
+				}
+				ri[j] = (ri[j] + aik*bk[j]) % mod
+			}
+		}
+	}
+	return res
+}
+
+func matVecMul(a [][]int64, v []int64) []int64 {
+	n := len(a)
+	res := make([]int64, n)
+	for i := 0; i < n; i++ {
+		row := a[i]
+		var sum int64
+		for j := 0; j < n; j++ {
+			if row[j] == 0 || v[j] == 0 {
+				continue
+			}
+			sum = (sum + row[j]*v[j]) % mod
+		}
+		res[i] = sum
+	}
+	return res
+}
+
+func powMatVec(m [][]int64, e int64, vec []int64) []int64 {
+	for e > 0 {
+		if e&1 == 1 {
+			vec = matVecMul(m, vec)
+		}
+		m = matMul(m, m)
+		e >>= 1
+	}
+	return vec
+}
+
+func solveCase(n int, k int64, arr []int64) string {
+	if k == 1 {
+		return fmt.Sprintf("%d\n", n%int(mod))
+	}
+	adj := make([][]int64, n)
+	for i := 0; i < n; i++ {
+		adj[i] = make([]int64, n)
+		for j := 0; j < n; j++ {
+			if bits.OnesCount64(uint64(arr[i]^arr[j]))%3 == 0 {
+				adj[i][j] = 1
+			}
+		}
+	}
+	vec := make([]int64, n)
+	for i := range vec {
+		vec[i] = 1
+	}
+	vec = powMatVec(adj, k-1, vec)
+	var ans int64
+	for _, v := range vec {
+		ans = (ans + v) % mod
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func buildCase(n int, k int64, arr []int64) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return testCase{in: sb.String(), out: solveCase(n, k, arr)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	k := int64(rng.Intn(10) + 1)
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = int64(rng.Intn(1000))
+	}
+	return buildCase(n, k, arr)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(tc.out)
+	if got != want {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, buildCase(1, 1, []int64{0}))
+	cases = append(cases, buildCase(2, 2, []int64{1, 2}))
+	cases = append(cases, buildCase(3, 3, []int64{1, 1, 1}))
+	cases = append(cases, buildCase(2, 5, []int64{5, 10}))
+	cases = append(cases, buildCase(4, 4, []int64{1, 2, 3, 4}))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/690-699/691/verifierF.go
+++ b/0-999/600-699/690-699/691/verifierF.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func solveCase(n int, arr []int, queries []int) string {
+	var sb strings.Builder
+	for qi, p := range queries {
+		count := 0
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				if i == j {
+					continue
+				}
+				if arr[i]*arr[j] >= p {
+					count++
+				}
+			}
+		}
+		if qi > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fmt.Sprintf("%d", count))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildCase(n int, arr []int, qs []int) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", len(qs)))
+	for i, v := range qs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return testCase{in: sb.String(), out: solveCase(n, arr, qs)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(100) + 1
+	}
+	m := rng.Intn(5) + 1
+	qs := make([]int, m)
+	for i := range qs {
+		qs[i] = rng.Intn(200) + 1
+	}
+	return buildCase(n, arr, qs)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(tc.out)
+	if got != want {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, buildCase(1, []int{1}, []int{1, 2, 3}))
+	cases = append(cases, buildCase(2, []int{1, 2}, []int{1}))
+	cases = append(cases, buildCase(3, []int{2, 2, 2}, []int{4}))
+	cases = append(cases, buildCase(4, []int{1, 2, 3, 4}, []int{4, 5, 6}))
+	cases = append(cases, buildCase(5, []int{5, 4, 3, 2, 1}, []int{10}))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems in contest 691 (A–F)
- each verifier runs the given binary on 100+ generated test cases

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`
- `go run verifierF.go ./solF`

------
https://chatgpt.com/codex/tasks/task_e_68837b46485883249a3909a214a9fd25