### PR TITLE
Add solution verifiers for contest 690

### DIFF
--- a/0-999/600-699/690-699/690/690A.go
+++ b/0-999/600-699/690-699/690/690A.go
@@ -1,0 +1,3 @@
+package main
+
+func main() { panic("boom") }

--- a/0-999/600-699/690-699/690/verifierA.go
+++ b/0-999/600-699/690-699/690/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "690A3.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	r := rng.Intn(20)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, r))
+	for i := 0; i < n-1; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(50)))
+	}
+	if n > 1 {
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/690-699/690/verifierB.go
+++ b/0-999/600-699/690-699/690/verifierB.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "690B3.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	N := rng.Intn(5) + 1
+	M := rng.Intn(5)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", N, M))
+	for i := 0; i < M; i++ {
+		x := rng.Intn(N) + 1
+		y := rng.Intn(N) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	sb.WriteString("0 0\n")
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/690-699/690/verifierC.go
+++ b/0-999/600-699/690-699/690/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "690C3.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		if i > 2 {
+			sb.WriteByte(' ')
+		}
+		parent := rng.Intn(i-1) + 1
+		sb.WriteString(fmt.Sprintf("%d", parent))
+	}
+	if n > 1 {
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/690-699/690/verifierD.go
+++ b/0-999/600-699/690-699/690/verifierD.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "690D3.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	C := rng.Int63n(10)
+	W := rng.Intn(5) + 1
+	H := rng.Intn(5) + 1
+	return fmt.Sprintf("%d %d %d\n", C, W, H)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/690-699/690/verifierE.go
+++ b/0-999/600-699/690-699/690/verifierE.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "690E2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	k := rng.Intn(3) + 1
+	pieceH := rng.Intn(3) + 1
+	h := pieceH * k
+	w := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", h, w, k))
+	for i := 0; i < k; i++ {
+		for r := 0; r < pieceH; r++ {
+			for c := 0; c < w; c++ {
+				val := rng.Intn(5)
+				sb.WriteString(fmt.Sprintf("%d", val))
+				if c+1 < w {
+					sb.WriteByte(' ')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/690-699/690/verifierF.go
+++ b/0-999/600-699/690-699/690/verifierF.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "690F3.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	k := 2
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < k; i++ {
+		m := rng.Intn(n)
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+		for j := 0; j < m; j++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add runtime-error example `690A.go`
- add `verifierA.go`..`verifierF.go` that compile oracle solutions and run 100 randomized tests each

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68837aba0b9c8324adbee7e16ea3c700