### PR TITLE
Add contest 689 Go verifiers

### DIFF
--- a/0-999/600-699/680-689/689/verifierA.go
+++ b/0-999/600-699/680-689/689/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// solve computes the expected output for the given phone number.
+func solve(n int, s string) string {
+	pos := map[byte][2]int{
+		'1': {0, 0}, '2': {1, 0}, '3': {2, 0},
+		'4': {0, 1}, '5': {1, 1}, '6': {2, 1},
+		'7': {0, 2}, '8': {1, 2}, '9': {2, 2},
+		'0': {1, 3},
+	}
+
+	board := [4][3]bool{}
+	for d, p := range pos {
+		board[p[1]][p[0]] = true
+		_ = d
+	}
+
+	if n == 1 {
+		return "YES"
+	}
+
+	moves := make([][2]int, n-1)
+	for i := 1; i < n; i++ {
+		a := pos[s[i-1]]
+		b := pos[s[i]]
+		moves[i-1] = [2]int{b[0] - a[0], b[1] - a[1]}
+	}
+
+	for d := byte('0'); d <= '9'; d++ {
+		start, ok := pos[d]
+		if !ok {
+			continue
+		}
+		x, y := start[0], start[1]
+		valid := true
+		for _, mv := range moves {
+			x += mv[0]
+			y += mv[1]
+			if y < 0 || y >= 4 || x < 0 || x >= 3 || !board[y][x] {
+				valid = false
+				break
+			}
+		}
+		if valid && d != s[0] {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func runCase(bin string, n int, s string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(fmt.Sprintf("%d\n%s\n", n, s))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solve(n, s)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) (int, string) {
+	n := rng.Intn(9) + 1 // 1..9
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('0' + rng.Intn(10))
+	}
+	return n, string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, s := randomCase(rng)
+		if err := runCase(bin, n, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %s\n", i+1, err, n, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/689/verifierB.go
+++ b/0-999/600-699/680-689/689/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int, a []int) []int {
+	dist := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		dist[i] = -1
+	}
+	q := make([]int, 0, n)
+	q = append(q, 1)
+	head := 0
+	for head < len(q) {
+		v := q[head]
+		head++
+		d := dist[v]
+		if v > 1 && dist[v-1] == -1 {
+			dist[v-1] = d + 1
+			q = append(q, v-1)
+		}
+		if v < n && dist[v+1] == -1 {
+			dist[v+1] = d + 1
+			q = append(q, v+1)
+		}
+		if dist[a[v]] == -1 {
+			dist[a[v]] = d + 1
+			q = append(q, a[v])
+		}
+	}
+	return dist[1:]
+}
+
+func runCase(bin string, n int, a []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a[1:] {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotFields := strings.Fields(out.String())
+	if len(gotFields) != n {
+		return fmt.Errorf("expected %d numbers, got %d", n, len(gotFields))
+	}
+	exp := expected(n, a)
+	for i := 0; i < n; i++ {
+		var val int
+		fmt.Sscan(gotFields[i], &val)
+		if val != exp[i] {
+			return fmt.Errorf("index %d expected %d got %d", i+1, exp[i], val)
+		}
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) (int, []int) {
+	n := rng.Intn(20) + 1
+	a := make([]int, n+1)
+	cur := 1
+	for i := 1; i <= n; i++ {
+		minVal := cur
+		if minVal < i {
+			minVal = i
+		}
+		val := rng.Intn(n-minVal+1) + minVal
+		a[i] = val
+		cur = val
+	}
+	return n, a
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, a := randomCase(rng)
+		if err := runCase(bin, n, a); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/689/verifierC.go
+++ b/0-999/600-699/680-689/689/verifierC.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func countWays(n int64) int64 {
+	var res int64
+	for k := int64(2); k*k*k <= n; k++ {
+		res += n / (k * k * k)
+	}
+	return res
+}
+
+func solve(m int64) int64 {
+	low, high := int64(1), int64(1e18)
+	for low < high {
+		mid := (low + high) / 2
+		if countWays(mid) >= m {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+	if countWays(low) == m {
+		return low
+	}
+	return -1
+}
+
+func runCase(bin string, m int64) error {
+	input := fmt.Sprintf("%d\n", m)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(bytes.NewReader(out.Bytes()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	exp := solve(m)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) int64 {
+	return rng.Int63n(1_000_000_000_000) + 1 // up to 1e12
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		m := randomCase(rng)
+		if err := runCase(bin, m); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/689/verifierD.go
+++ b/0-999/600-699/680-689/689/verifierD.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(a, b []int) int64 {
+	n := len(a)
+	var ans int64
+	for l := 0; l < n; l++ {
+		maxA := a[l]
+		minB := b[l]
+		if maxA == minB {
+			ans++
+		}
+		for r := l + 1; r < n; r++ {
+			if a[r] > maxA {
+				maxA = a[r]
+			}
+			if b[r] < minB {
+				minB = b[r]
+			}
+			if maxA == minB {
+				ans++
+			}
+		}
+	}
+	return ans
+}
+
+func runCase(bin string, a, b []int) error {
+	n := len(a)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(bytes.NewReader(out.Bytes()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	exp := expected(a, b)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) ([]int, []int) {
+	n := rng.Intn(8) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(21) - 10
+		b[i] = rng.Intn(21) - 10
+	}
+	return a, b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		a, b := randomCase(rng)
+		if err := runCase(bin, a, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/680-689/689/verifierE.go
+++ b/0-999/600-699/680-689/689/verifierE.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	a %= mod
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func prepare(n int) ([]int64, []int64) {
+	fact := make([]int64, n+1)
+	inv := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	inv[n] = modPow(fact[n], mod-2)
+	for i := n; i > 0; i-- {
+		inv[i-1] = inv[i] * int64(i) % mod
+	}
+	return fact, inv
+}
+
+func C(n, r int64, fact, inv []int64) int64 {
+	if r < 0 || r > n {
+		return 0
+	}
+	return fact[n] * inv[r] % mod * inv[n-r] % mod
+}
+
+func solve(n, k int, segs [][2]int64) int64 {
+	events := make(map[int64]int)
+	coords := make([]int64, 0, 2*n)
+	for i := 0; i < n; i++ {
+		l, r := segs[i][0], segs[i][1]
+		events[l]++
+		events[r+1]--
+	}
+	for x := range events {
+		coords = append(coords, x)
+	}
+	sort.Slice(coords, func(i, j int) bool { return coords[i] < coords[j] })
+	fact, inv := prepare(n)
+	var ans int64
+	active := 0
+	var prev int64
+	for i, x := range coords {
+		if i > 0 {
+			length := x - prev
+			if length > 0 {
+				ans = (ans + C(int64(active), int64(k), fact, inv)*length) % mod
+			}
+		}
+		active += events[x]
+		prev = x
+	}
+	return ans % mod
+}
+
+func runCase(bin string, n, k int, segs [][2]int64) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", segs[i][0], segs[i][1]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(bytes.NewReader(out.Bytes()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	exp := solve(n, k, segs)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) (int, int, [][2]int64) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n) + 1
+	segs := make([][2]int64, n)
+	for i := 0; i < n; i++ {
+		l := rng.Int63n(100) - 50
+		r := l + rng.Int63n(50)
+		segs[i] = [2]int64{l, r}
+	}
+	return n, k, segs
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, segs := randomCase(rng)
+		if err := runCase(bin, n, k, segs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces contest 689
- each verifier runs 100 randomized test cases
- supports running `go run verifierX.go /path/to/binary` for problems A–E

## Testing
- `go build 0-999/600-699/680-689/689/verifierA.go`
- `go build 0-999/600-699/680-689/689/verifierB.go`
- `go build 0-999/600-699/680-689/689/verifierC.go`
- `go build 0-999/600-699/680-689/689/verifierD.go`
- `go build 0-999/600-699/680-689/689/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68837a2e092c8324af2f0f0ad28ac6c2