### PR TITLE
Add Go solution for 1956A

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1956/1956A.go
+++ b/1000-1999/1900-1999/1950-1959/1956/1956A.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func winners(n int, a []int) int {
+	for n >= a[0] {
+		cnt := 0
+		for _, v := range a {
+			if v <= n {
+				cnt++
+			} else {
+				break
+			}
+		}
+		if cnt == 0 {
+			break
+		}
+		n -= cnt
+	}
+	return n
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var k, q int
+		fmt.Fscan(in, &k, &q)
+		a := make([]int, k)
+		for i := 0; i < k; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		res := make([]int, q)
+		for i := 0; i < q; i++ {
+			fmt.Fscan(in, &res[i])
+			res[i] = winners(res[i], a)
+		}
+		for i, v := range res {
+			if i > 0 {
+				out.WriteByte(' ')
+			}
+			fmt.Fprint(out, v)
+		}
+		out.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem A in contest 1956
- follow simple elimination algorithm per problem statement

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1956/1956A.go`
- ran a custom example input through the built binary

------
https://chatgpt.com/codex/tasks/task_e_68838fcb66388324b93903176583d528