### PR TITLE
Add Go verifiers for Codeforces contest 1726

### DIFF
--- a/1000-1999/1700-1799/1720-1729/1726/verifierA.go
+++ b/1000-1999/1700-1799/1720-1729/1726/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1726A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(0)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(8) + 1
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		sb.WriteString(strconv.Itoa(n) + "\n")
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rand.Intn(50) + 1
+			sb.WriteString(strconv.Itoa(val))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	// add edge case n=1
+	tests = append(tests, Test{"1\n1\n5\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1726/verifierB.go
+++ b/1000-1999/1700-1799/1720-1729/1726/verifierB.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	n, m int
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("1\n%d %d\n", t.n, t.m)
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []Test {
+	rand.Seed(1)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(8) + 1
+		m := rand.Intn(60) + 1
+		tests = append(tests, Test{n: n, m: m})
+	}
+	return tests
+}
+
+func possible(n, m int) bool {
+	if m <= n-1 {
+		return false
+	}
+	if n%2 == 0 && m%2 == 1 {
+		return false
+	}
+	return true
+}
+
+func check(tc Test, out string) error {
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return fmt.Errorf("empty output")
+	}
+	poss := possible(tc.n, tc.m)
+	if fields[0] == "No" {
+		if poss {
+			return fmt.Errorf("expected Yes but got No")
+		}
+		if len(fields) != 1 {
+			return fmt.Errorf("unexpected tokens after No")
+		}
+		return nil
+	}
+	if fields[0] != "Yes" {
+		return fmt.Errorf("output should start with Yes or No")
+	}
+	if !poss {
+		return fmt.Errorf("expected No but got Yes")
+	}
+	if len(fields)-1 != tc.n {
+		return fmt.Errorf("expected %d numbers, got %d", tc.n, len(fields)-1)
+	}
+	seq := make([]int, tc.n)
+	sum := 0
+	for i := 0; i < tc.n; i++ {
+		v, err := strconv.Atoi(fields[i+1])
+		if err != nil {
+			return fmt.Errorf("invalid number")
+		}
+		if v <= 0 {
+			return fmt.Errorf("values must be positive")
+		}
+		seq[i] = v
+		sum += v
+	}
+	if sum != tc.m {
+		return fmt.Errorf("sum mismatch")
+	}
+	for i := 0; i < tc.n; i++ {
+		p := 0
+		for j := 0; j < tc.n; j++ {
+			if seq[j] < seq[i] {
+				p ^= seq[j]
+			}
+		}
+		if p != 0 {
+			return fmt.Errorf("xor condition failed at index %d", i)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		out, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(tc, out); err != nil {
+			fmt.Printf("Test %d failed: %v\nInput:%sOutput:%s\n", i+1, err, tc.Input(), out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1726/verifierC.go
+++ b/1000-1999/1700-1799/1720-1729/1726/verifierC.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n int
+	s string
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("1\n%d\n%s\n", t.n, t.s)
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1726C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genBalanced(n int) string {
+	var sb strings.Builder
+	open := 0
+	for i := 0; i < 2*n; i++ {
+		remaining := 2*n - i
+		if open == 0 {
+			sb.WriteByte('(')
+			open++
+			continue
+		}
+		if open == remaining {
+			sb.WriteByte(')')
+			open--
+			continue
+		}
+		if rand.Intn(2) == 0 {
+			sb.WriteByte('(')
+			open++
+		} else {
+			sb.WriteByte(')')
+			open--
+		}
+	}
+	return sb.String()
+}
+
+func genTests() []Test {
+	rand.Seed(2)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(5) + 1
+		tests = append(tests, Test{n: n, s: genBalanced(n)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.Input())
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1726/verifierD.go
+++ b/1000-1999/1700-1799/1720-1729/1726/verifierD.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Edge struct{ u, v int }
+
+type Test struct {
+	n, m  int
+	edges []Edge
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.m))
+	for _, e := range t.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	return sb.String()
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1726D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genGraph(n, m int) []Edge {
+	edges := make([]Edge, 0, m)
+	// tree edges
+	for i := 2; i <= n; i++ {
+		edges = append(edges, Edge{i - 1, i})
+	}
+	set := map[[2]int]struct{}{}
+	for _, e := range edges {
+		set[[2]int{e.u, e.v}] = struct{}{}
+		set[[2]int{e.v, e.u}] = struct{}{}
+	}
+	for len(edges) < m {
+		u := rand.Intn(n) + 1
+		v := rand.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if _, ok := set[[2]int{u, v}]; ok {
+			continue
+		}
+		edges = append(edges, Edge{u, v})
+		set[[2]int{u, v}] = struct{}{}
+		set[[2]int{v, u}] = struct{}{}
+	}
+	return edges
+}
+
+func genTests() []Test {
+	rand.Seed(3)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(4) + 2
+		maxM := n * (n - 1) / 2
+		m := n - 1 + rand.Intn(min(3, maxM-(n-1))+1)
+		if m > maxM {
+			m = maxM
+		}
+		edges := genGraph(n, m)
+		tests = append(tests, Test{n: n, m: m, edges: edges})
+	}
+	return tests
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1726/verifierE.go
+++ b/1000-1999/1700-1799/1720-1729/1726/verifierE.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ n int }
+
+func (t Test) Input() string { return fmt.Sprintf("1\n%d\n", t.n) }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1726E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(4)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		tests = append(tests, Test{n: n})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1700-1799/1720-1729/1726/verifierF.go
+++ b/1000-1999/1700-1799/1720-1729/1726/verifierF.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n int
+	t int64
+	g []int64
+	c []int64
+	d []int64
+}
+
+func (tc Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.t))
+	for i, v := range tc.g {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.c {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.d {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	if len(tc.d) > 0 {
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1726F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(5)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(4) + 2
+		t := int64(rand.Intn(7) + 3)
+		g := make([]int64, n)
+		c := make([]int64, n)
+		for j := 0; j < n; j++ {
+			g[j] = int64(rand.Intn(int(t-1)) + 1)
+			c[j] = int64(rand.Intn(int(t)))
+		}
+		d := make([]int64, n-1)
+		for j := 0; j < n-1; j++ {
+			d[j] = int64(rand.Intn(5))
+		}
+		tests = append(tests, Test{n: n, t: t, g: g, c: c, d: d})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers in Go for contest 1726 problems A–F
- verifiers build reference solutions, generate 100 random tests, and compare outputs

## Testing
- `go build 1000-1999/1700-1799/1720-1729/1726/verifierA.go`
- `go build 1000-1999/1700-1799/1720-1729/1726/verifierB.go`
- `go build 1000-1999/1700-1799/1720-1729/1726/verifierC.go`
- `go build 1000-1999/1700-1799/1720-1729/1726/verifierD.go`
- `go build 1000-1999/1700-1799/1720-1729/1726/verifierE.go`
- `go build 1000-1999/1700-1799/1720-1729/1726/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68838e6d3b4483248c47359846f5cbeb