### PR TITLE
Add verifiers for Codeforces Round 725

### DIFF
--- a/0-999/700-799/720-729/725/verifierA.go
+++ b/0-999/700-799/720-729/725/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "725A.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('<')
+			} else {
+				sb.WriteByte('>')
+			}
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/725/verifierB.go
+++ b/0-999/700-799/720-729/725/verifierB.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "725B.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	seats := []byte{'a', 'b', 'c', 'd', 'e', 'f'}
+	for i := 0; i < 100; i++ {
+		n := rng.Int63n(1e6) + 1
+		seat := seats[rng.Intn(len(seats))]
+		tests[i] = fmt.Sprintf("%d%c\n", n, seat)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/725/verifierC.go
+++ b/0-999/700-799/720-729/725/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "725C.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	letters := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	for i := 0; i < 100; i++ {
+		perm := rng.Perm(26)
+		base := make([]byte, 26)
+		for j, idx := range perm {
+			base[j] = letters[idx]
+		}
+		dup := base[rng.Intn(26)]
+		pos := rng.Intn(27)
+		s := make([]byte, 27)
+		copy(s, base[:pos])
+		s[pos] = dup
+		copy(s[pos+1:], base[pos:])
+		tests[i] = fmt.Sprintf("%s\n", string(s))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		e := strings.TrimSpace(exp)
+		o := strings.TrimSpace(out)
+		if e != o {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/725/verifierD.go
+++ b/0-999/700-799/720-729/725/verifierD.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refD_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "725D.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 2
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			t := rng.Intn(50) + 1
+			w := t + rng.Intn(50)
+			sb.WriteString(fmt.Sprintf("%d %d\n", t, w))
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/725/verifierE.go
+++ b/0-999/700-799/720-729/725/verifierE.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "725E.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		c := rng.Intn(200) + 1
+		n := rng.Intn(10) + 1
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d\n%d\n", c, n))
+		for j := 0; j < n; j++ {
+			val := rng.Intn(c) + 1
+			sb.WriteString(fmt.Sprintf("%d\n", val))
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/725/verifierF.go
+++ b/0-999/700-799/720-729/725/verifierF.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refF_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "725F.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			a1 := rng.Intn(10)
+			b1 := rng.Intn(10)
+			a2 := rng.Intn(10)
+			b2 := rng.Intn(10)
+			sb.WriteString(fmt.Sprintf("%d %d %d %d\n", a1, b1, a2, b2))
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/725/verifierG.go
+++ b/0-999/700-799/720-729/725/verifierG.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refG_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "725G.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		parents := make([]int, n+1)
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j := 1; j <= n; j++ {
+			if j == 1 {
+				parents[j] = 0
+			} else {
+				parents[j] = rng.Intn(j)
+			}
+			if j > 1 {
+				sb.WriteString(fmt.Sprintf("%d ", parents[j]))
+			}
+		}
+		if n > 0 {
+			sb.WriteByte('\n')
+		}
+		currentTime := int64(0)
+		for j := 0; j < m; j++ {
+			currentTime += int64(rng.Intn(5) + 1)
+			x := rng.Intn(n) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", x, currentTime))
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 725 (problems A–G)
- each verifier builds the corresponding reference solution and runs 100 random tests

## Testing
- `gofmt -w verifierA.go`
- `gofmt -w verifierB.go`
- `gofmt -w verifierC.go`
- `gofmt -w verifierD.go`
- `gofmt -w verifierE.go`
- `gofmt -w verifierF.go`
- `gofmt -w verifierG.go`

------
https://chatgpt.com/codex/tasks/task_e_68838de11a14832493e8784d493c1bd5