### PR TITLE
Add Go verifiers for Codeforces contest 666

### DIFF
--- a/0-999/600-699/660-669/666/verifierA.go
+++ b/0-999/600-699/660-669/666/verifierA.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+    "time"
+)
+
+type testCase struct{ s string }
+
+func genCase(rng *rand.Rand) testCase {
+    n := rng.Intn(16)+5 // length 5..20
+    b := make([]byte,n)
+    for i:=0;i<n;i++{ b[i]=byte('a'+rng.Intn(26)) }
+    return testCase{ s:string(b) }
+}
+
+func solve(s string) string {
+    n := len(s)
+    dp2 := make([]bool,n+1)
+    dp3 := make([]bool,n+1)
+    for i:=n-2;i>=5;i--{
+        if i+2<=n {
+            if i+2==n {
+                dp2[i]=true
+            } else if (dp2[i+2] && s[i:i+2]!=s[i+2:i+4]) || (dp3[i+2] && s[i:i+2]!=s[i+2:i+5]) {
+                dp2[i]=true
+            }
+        }
+        if i+3<=n {
+            if i+3==n {
+                dp3[i]=true
+            } else if (dp2[i+3] && s[i:i+3]!=s[i+3:i+5]) || (dp3[i+3] && s[i:i+3]!=s[i+3:i+6]) {
+                dp3[i]=true
+            }
+        }
+    }
+    set := make(map[string]struct{})
+    for i:=5;i<n;i++{
+        if dp2[i]{ set[s[i:i+2]]=struct{}{} }
+        if dp3[i]{ set[s[i:i+3]]=struct{}{} }
+    }
+    arr := make([]string,0,len(set))
+    for k := range set { arr = append(arr,k) }
+    sort.Strings(arr)
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d\n",len(arr)))
+    for _,v := range arr{ sb.WriteString(v); sb.WriteByte('\n') }
+    return strings.TrimSpace(sb.String())
+}
+
+func run(bin,input string)(string,error){
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin,".go"){
+        cmd=exec.Command("go","run",bin)
+    }else{
+        cmd=exec.Command(bin)
+    }
+    cmd.Stdin=strings.NewReader(input)
+    var out bytes.Buffer
+    var stderr bytes.Buffer
+    cmd.Stdout=&out
+    cmd.Stderr=&stderr
+    if err:=cmd.Run();err!=nil{
+        return "",fmt.Errorf("runtime error: %v\n%s",err,stderr.String())
+    }
+    return strings.TrimSpace(out.String()),nil
+}
+
+func main(){
+    if len(os.Args)==3 && os.Args[1]=="--" {
+        os.Args = append([]string{os.Args[0]}, os.Args[2])
+    }
+    if len(os.Args)!=2{
+        fmt.Println("usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin:=os.Args[1]
+    rng:=rand.New(rand.NewSource(time.Now().UnixNano()))
+    for i:=0;i<100;i++{
+        tc:=genCase(rng)
+        exp:=solve(tc.s)
+        got,err:=run(bin,tc.s+"\n")
+        if err!=nil{
+            fmt.Fprintf(os.Stderr,"case %d failed: %v\n",i+1,err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got)!=exp{
+            fmt.Fprintf(os.Stderr,"case %d failed: input %s expected:\n%s\ngot:\n%s\n",i+1,tc.s,exp,got)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/600-699/660-669/666/verifierB.go
+++ b/0-999/600-699/660-669/666/verifierB.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ a, b int }
+
+type testCase struct {
+	n     int
+	edges []edge
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(3) + 4 // 4..6
+	m := n
+	edges := make([]edge, 0, m*2)
+	for i := 0; i < n; i++ { // cycle
+		edges = append(edges, edge{i + 1, (i+1)%n + 1})
+	}
+	for len(edges) < n*3 {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a == b {
+			continue
+		}
+		edges = append(edges, edge{a, b})
+	}
+	return testCase{n: n, edges: edges}
+}
+
+func bfs(n int, adj [][]int, start int) []int {
+	dist := make([]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = -1
+	}
+	q := []int{start}
+	dist[start] = 0
+	for h := 0; h < len(q); h++ {
+		v := q[h]
+		for _, to := range adj[v] {
+			if dist[to] == -1 {
+				dist[to] = dist[v] + 1
+				q = append(q, to)
+			}
+		}
+	}
+	return dist
+}
+
+func allDist(tc testCase) [][]int {
+	adj := make([][]int, tc.n)
+	for _, e := range tc.edges {
+		adj[e.a-1] = append(adj[e.a-1], e.b-1)
+	}
+	d := make([][]int, tc.n)
+	for i := 0; i < tc.n; i++ {
+		d[i] = bfs(tc.n, adj, i)
+	}
+	return d
+}
+
+func solve(tc testCase) (int, [4]int) {
+	n := tc.n
+	adj := make([][]int, n)
+	for _, e := range tc.edges {
+		adj[e.a-1] = append(adj[e.a-1], e.b-1)
+	}
+	dist := make([][]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = bfs(n, adj, i)
+	}
+	bestVal := -1
+	res := [4]int{}
+	for a := 0; a < n; a++ {
+		for b := 0; b < n; b++ {
+			if a == b || dist[a][b] == -1 {
+				continue
+			}
+			for c := 0; c < n; c++ {
+				if c == a || c == b || dist[b][c] == -1 {
+					continue
+				}
+				for d := 0; d < n; d++ {
+					if d == a || d == b || d == c || dist[c][d] == -1 {
+						continue
+					}
+					val := dist[a][b] + dist[b][c] + dist[c][d]
+					if val > bestVal {
+						bestVal = val
+						res = [4]int{a + 1, b + 1, c + 1, d + 1}
+					}
+				}
+			}
+		}
+	}
+	return bestVal, res
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, len(tc.edges)))
+		for _, e := range tc.edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e.a, e.b))
+		}
+		best, _ := solve(tc)
+		gotStr, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var a, b, c, d int
+		if _, err := fmt.Sscan(gotStr, &a, &b, &c, &d); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d invalid output: %s\n", i+1, gotStr)
+			os.Exit(1)
+		}
+		dist := allDist(tc)
+		if a < 1 || a > tc.n || b < 1 || b > tc.n || c < 1 || c > tc.n || d < 1 || d > tc.n {
+			fmt.Fprintf(os.Stderr, "case %d invalid city index\n", i+1)
+			os.Exit(1)
+		}
+		if dist[a-1][b-1] == -1 || dist[b-1][c-1] == -1 || dist[c-1][d-1] == -1 {
+			fmt.Fprintf(os.Stderr, "case %d impossible path\n", i+1)
+			os.Exit(1)
+		}
+		val := dist[a-1][b-1] + dist[b-1][c-1] + dist[c-1][d-1]
+		if val != best {
+			fmt.Fprintf(os.Stderr, "case %d failed expected %d got %d\n", i+1, best, val)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/660-669/666/verifierC.go
+++ b/0-999/600-699/660-669/666/verifierC.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+const MAXN = 200
+
+var fact [MAXN + 1]int64
+var invfact [MAXN + 1]int64
+var pow25 [MAXN + 1]int64
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	a %= MOD
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func initPrecalc() {
+	fact[0] = 1
+	for i := 1; i <= MAXN; i++ {
+		fact[i] = fact[i-1] * int64(i) % MOD
+	}
+	invfact[MAXN] = modPow(fact[MAXN], MOD-2)
+	for i := MAXN; i >= 1; i-- {
+		invfact[i-1] = invfact[i] * int64(i) % MOD
+	}
+	pow25[0] = 1
+	for i := 1; i <= MAXN; i++ {
+		pow25[i] = pow25[i-1] * 25 % MOD
+	}
+}
+
+func C(n, k int) int64 {
+	if k < 0 || k > n {
+		return 0
+	}
+	return fact[n] * invfact[k] % MOD * invfact[n-k] % MOD
+}
+
+type event struct {
+	t   int
+	str string
+	n   int
+}
+
+type testCase struct {
+	start  string
+	events []event
+}
+
+func genCase(rng *rand.Rand) testCase {
+	m := rng.Intn(5) + 5
+	startLen := rng.Intn(3) + 1
+	b := make([]byte, startLen)
+	for i := 0; i < startLen; i++ {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	s := string(b)
+	evs := make([]event, 0, m)
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			l := rng.Intn(3) + 1
+			bb := make([]byte, l)
+			for j := 0; j < l; j++ {
+				bb[j] = byte('a' + rng.Intn(3))
+			}
+			evs = append(evs, event{t: 1, str: string(bb)})
+			s = string(bb)
+		} else {
+			n := len(s) + rng.Intn(4)
+			evs = append(evs, event{t: 2, n: n})
+		}
+	}
+	return testCase{start: s, events: evs}
+}
+
+func solve(tc testCase) string {
+	cur := tc.start
+	curLen := len(cur)
+	dp := map[int][]int64{}
+	arrInit := make([]int64, curLen+1)
+	arrInit[curLen] = 1
+	dp[curLen] = arrInit
+	var out strings.Builder
+	for _, ev := range tc.events {
+		if ev.t == 1 {
+			cur = ev.str
+			curLen = len(cur)
+			if _, ok := dp[curLen]; !ok {
+				arr := make([]int64, curLen+1)
+				arr[curLen] = 1
+				dp[curLen] = arr
+			}
+		} else {
+			n := ev.n
+			if n < curLen {
+				out.WriteString("0\n")
+				continue
+			}
+			arr := dp[curLen]
+			for len(arr) <= n {
+				i := len(arr)
+				val := (arr[i-1]*26 + C(i-1, curLen-1)*pow25[i-curLen]) % MOD
+				arr = append(arr, val)
+			}
+			dp[curLen] = arr
+			out.WriteString(fmt.Sprintf("%d\n", arr[n]%MOD))
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.events)))
+	sb.WriteString(tc.start + "\n")
+	for _, ev := range tc.events {
+		if ev.t == 1 {
+			sb.WriteString(fmt.Sprintf("1 %s\n", ev.str))
+		} else {
+			sb.WriteString(fmt.Sprintf("2 %d\n", ev.n))
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	initPrecalc()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		input := buildInput(tc)
+		exp := solve(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexp:\n%s\n---\ngot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/660-669/666/verifierD.go
+++ b/0-999/600-699/660-669/666/verifierD.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	bots [4][2]int
+}
+
+func genCase(rng *rand.Rand) testCase {
+	side := rng.Intn(5) + 1
+	x0 := rng.Intn(5)
+	y0 := rng.Intn(5)
+	// square corners
+	corners := [4][2]int{{x0, y0}, {x0 + side, y0}, {x0, y0 + side}, {x0 + side, y0 + side}}
+	// shuffle order and add small noise
+	perm := rng.Perm(4)
+	var bots [4][2]int
+	for i := 0; i < 4; i++ {
+		bots[i][0] = corners[perm[i]][0] + rng.Intn(3) - 1
+		bots[i][1] = corners[perm[i]][1] + rng.Intn(3) - 1
+	}
+	return testCase{bots: bots}
+}
+
+var perms [][4]int
+var cornerPositions = [4][2]int{{0, 0}, {1, 0}, {0, 1}, {1, 1}}
+
+func init() {
+	used := make([]bool, 4)
+	var cur [4]int
+	var dfs func(int)
+	dfs = func(pos int) {
+		if pos == 4 {
+			tmp := cur
+			perms = append(perms, tmp)
+			return
+		}
+		for i := 0; i < 4; i++ {
+			if !used[i] {
+				used[i] = true
+				cur[pos] = i
+				dfs(pos + 1)
+				used[i] = false
+			}
+		}
+	}
+	dfs(0)
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func solve(tc testCase) string {
+	A := tc.bots
+	INF := int(1e9)
+	Dset := make(map[int]struct{})
+	for i := 0; i < 4; i++ {
+		for j := i + 1; j < 4; j++ {
+			Dset[abs(A[i][0]-A[j][0])] = struct{}{}
+			Dset[abs(A[i][1]-A[j][1])] = struct{}{}
+		}
+	}
+	Ds := make([]int, 0, len(Dset))
+	for k := range Dset {
+		Ds = append(Ds, k)
+	}
+	Ds = uniqueInts(Ds)
+	ans := INF
+	var final [4][2]int
+	for _, d := range Ds {
+		X := make([]int, 0, 40)
+		Y := make([]int, 0, 40)
+		for j := 0; j < 4; j++ {
+			X = append(X, A[j][0], A[j][0]-d, A[j][0]+d)
+			Y = append(Y, A[j][1], A[j][1]-d, A[j][1]+d)
+		}
+		for _, p := range perms {
+			lx, rx := INF, -INF
+			ly, ry := INF, -INF
+			for k := 0; k < 4; k++ {
+				xx := A[k][0] - cornerPositions[p[k]][0]*d
+				yy := A[k][1] - cornerPositions[p[k]][1]*d
+				if xx < lx {
+					lx = xx
+				}
+				if xx > rx {
+					rx = xx
+				}
+				if yy < ly {
+					ly = yy
+				}
+				if yy > ry {
+					ry = yy
+				}
+			}
+			X = append(X, (lx+rx)/2)
+			Y = append(Y, (ly+ry)/2)
+		}
+		X = uniqueInts(X)
+		Y = uniqueInts(Y)
+		for _, x := range X {
+			for _, y := range Y {
+				for _, p := range perms {
+					tmax := 0
+					ok := true
+					var pos [4][2]int
+					for j := 0; j < 4; j++ {
+						xx := x + cornerPositions[p[j]][0]*d
+						yy := y + cornerPositions[p[j]][1]*d
+						if xx != A[j][0] && yy != A[j][1] {
+							ok = false
+							break
+						}
+						move := abs(xx-A[j][0]) + abs(yy-A[j][1])
+						if move > tmax {
+							tmax = move
+						}
+						pos[j][0] = xx
+						pos[j][1] = yy
+					}
+					if ok && tmax < ans {
+						ans = tmax
+						final = pos
+					}
+				}
+			}
+		}
+	}
+	if ans == INF {
+		return "-1"
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", ans))
+	for i := 0; i < 4; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", final[i][0], final[i][1]))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func uniqueInts(a []int) []int {
+	sort.Ints(a)
+	j := 0
+	for i := 0; i < len(a); i++ {
+		if i == 0 || a[i] != a[i-1] {
+			a[j] = a[i]
+			j++
+		}
+	}
+	return a[:j]
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	for i := 0; i < 4; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.bots[i][0], tc.bots[i][1]))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		input := buildInput(tc)
+		exp := solve(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexp:\n%s\n---\ngot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/600-699/660-669/666/verifierE.go
+++ b/0-999/600-699/660-669/666/verifierE.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	s       string
+	texts   []string
+	queries [][4]int
+}
+
+func genCase(rng *rand.Rand) testCase {
+	slen := rng.Intn(5) + 1
+	sb := make([]byte, slen)
+	for i := 0; i < slen; i++ {
+		sb[i] = byte('a' + rng.Intn(3))
+	}
+	s := string(sb)
+	m := rng.Intn(3) + 1
+	texts := make([]string, m)
+	for i := 0; i < m; i++ {
+		l := rng.Intn(5) + 1
+		tb := make([]byte, l)
+		for j := 0; j < l; j++ {
+			tb[j] = byte('a' + rng.Intn(3))
+		}
+		texts[i] = string(tb)
+	}
+	q := rng.Intn(3) + 1
+	queries := make([][4]int, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(m) + 1
+		r := l + rng.Intn(m-l+1)
+		pl := rng.Intn(slen) + 1
+		pr := pl + rng.Intn(slen-pl+1)
+		queries[i] = [4]int{l, r, pl, pr}
+	}
+	return testCase{s: s, texts: texts, queries: queries}
+}
+
+func solve(tc testCase) string {
+	input := buildInput(tc)
+	out, err := run("666E.go", input)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(tc.s + "\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.texts)))
+	for _, t := range tc.texts {
+		sb.WriteString(t + "\n")
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.queries)))
+	for _, q := range tc.queries {
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", q[0], q[1], q[2], q[3]))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		input := buildInput(tc)
+		exp := solve(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexp:\n%s\n---\ngot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement verifiers for problems A–E in contest 666
- each verifier generates 100 random tests and checks a solution binary
- verifiers run arbitrary binaries or `go run` sources

## Testing
- `go run verifierA.go -- 666A.go`
- `go run verifierB.go -- 666B.go`
- `go run verifierC.go -- 666C.go`
- `go run verifierD.go -- 666D.go`
- `go run verifierE.go -- 666E.go`


------
https://chatgpt.com/codex/tasks/task_e_68836d9819188324ab85934b8ea83034