### PR TITLE
Add Go verifiers for contest 727

### DIFF
--- a/0-999/700-799/720-729/727/verifierA.go
+++ b/0-999/700-799/720-729/727/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "727A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	a := rng.Int63n(1_000_000_000-1) + 1
+	b := rng.Int63n(1_000_000_000-a) + a + 1
+	return fmt.Sprintf("%d %d\n", a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/727/verifierB.go
+++ b/0-999/700-799/720-729/727/verifierB.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "727B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randName(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(rng.Intn(26) + 'a')
+	}
+	return string(b)
+}
+
+func formatPrice(cents int64) string {
+	dollars := cents / 100
+	centsPart := cents % 100
+	ds := fmt.Sprintf("%d", dollars)
+	var sb strings.Builder
+	n := len(ds)
+	first := n % 3
+	if first == 0 {
+		first = 3
+	}
+	sb.WriteString(ds[:first])
+	for i := first; i < n; i += 3 {
+		sb.WriteByte('.')
+		sb.WriteString(ds[i : i+3])
+	}
+	if centsPart > 0 {
+		sb.WriteByte('.')
+		sb.WriteString(fmt.Sprintf("%02d", centsPart))
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) string {
+	var sb strings.Builder
+	length := 0
+	for {
+		nameLen := rng.Intn(5) + 1
+		priceCents := rng.Int63n(1_000_000_00) + 1
+		price := formatPrice(priceCents)
+		name := randName(rng, nameLen)
+		if length+len(name)+len(price) > 950 && length > 0 {
+			break
+		}
+		sb.WriteString(name)
+		sb.WriteString(price)
+		length += len(name) + len(price)
+		if length > 900 || rng.Intn(3) == 0 {
+			break
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/727/verifierC.go
+++ b/0-999/700-799/720-729/727/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "727C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(1_000_000))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/727/verifierD.go
+++ b/0-999/700-799/720-729/727/verifierD.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "727D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+var sizes = []string{"S", "M", "L", "XL", "XXL", "XXXL"}
+
+func genCase(rng *rand.Rand) string {
+	counts := make([]int, 6)
+	total := 0
+	for i := 0; i < 6; i++ {
+		counts[i] = rng.Intn(10)
+		total += counts[i]
+	}
+	if total == 0 {
+		counts[0] = 1
+		total = 1
+	}
+	n := rng.Intn(total) + 1
+	var sb strings.Builder
+	for i := 0; i < 6; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", counts[i])
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			idx := rng.Intn(6)
+			sb.WriteString(sizes[idx])
+		} else {
+			idx := rng.Intn(5)
+			sb.WriteString(sizes[idx])
+			sb.WriteByte(',')
+			sb.WriteString(sizes[idx+1])
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/727/verifierE.go
+++ b/0-999/700-799/720-729/727/verifierE.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "727E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(rng.Intn(26) + 'a')
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(3) + 1
+	g := rng.Intn(5) + n
+	names := make([]string, g)
+	used := make(map[string]bool)
+	for i := 0; i < g; i++ {
+		for {
+			s := randString(rng, k)
+			if !used[s] {
+				used[s] = true
+				names[i] = s
+				break
+			}
+		}
+	}
+	perm := rng.Perm(g)[:n]
+	cd := make([]string, n)
+	for i := 0; i < n; i++ {
+		cd[i] = names[perm[i]]
+	}
+	big := strings.Join(cd, "")
+	shift := rng.Intn(n * k)
+	big = big[shift:] + big[:shift]
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	sb.WriteString(big)
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", g)
+	for i := 0; i < g; i++ {
+		sb.WriteString(names[i])
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/720-729/727/verifierF.go
+++ b/0-999/700-799/720-729/727/verifierF.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "727F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(201)-100)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Int63n(1000))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 727
- each verifier builds the official solution and runs 100 random tests against a candidate binary

## Testing
- `go build 0-999/700-799/720-729/727/verifierA.go`
- `go build 0-999/700-799/720-729/727/verifierB.go`
- `go build 0-999/700-799/720-729/727/verifierC.go`
- `go build 0-999/700-799/720-729/727/verifierD.go`
- `go build 0-999/700-799/720-729/727/verifierE.go`
- `go build 0-999/700-799/720-729/727/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68838ef950d483248c8d4a6875bf590f