### PR TITLE
Add verifiers for Codeforces Round 732

### DIFF
--- a/0-999/700-799/730-739/732/verifierA.go
+++ b/0-999/700-799/730-739/732/verifierA.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(k, r int) int {
+	for i := 1; i <= 10; i++ {
+		total := i * k
+		if total%10 == 0 || total%10 == r {
+			return i
+		}
+	}
+	return -1
+}
+
+func runCase(bin string, k, r int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	input := fmt.Sprintf("%d %d\n", k, r)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var ans int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &ans); err != nil {
+		return fmt.Errorf("bad output: %s", out.String())
+	}
+	if ans != expected(k, r) {
+		return fmt.Errorf("expected %d got %d", expected(k, r), ans)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []struct{ k, r int }{
+		{1, 1},
+		{117, 3},
+		{10, 1},
+		{999, 9},
+		{1000, 5},
+	}
+	for len(cases) < 105 {
+		cases = append(cases, struct{ k, r int }{
+			rng.Intn(1000) + 1,
+			rng.Intn(9) + 1,
+		})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc.k, tc.r); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %d %d\n", i+1, err, tc.k, tc.r)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/730-739/732/verifierB.go
+++ b/0-999/700-799/730-739/732/verifierB.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedExtra(n, k int, a []int) int {
+	if n == 0 {
+		return 0
+	}
+	b := make([]int, n)
+	b[0] = a[0]
+	extra := 0
+	for i := 1; i < n; i++ {
+		need := k - b[i-1]
+		if need < a[i] {
+			need = a[i]
+		}
+		if need < 0 {
+			need = 0
+		}
+		b[i] = need
+		extra += b[i] - a[i]
+	}
+	return extra
+}
+
+func buildInput(n, k int, a []int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func parseOutput(out string, n int) (int, []int, error) {
+	fields := strings.Fields(out)
+	if len(fields) < 1+n {
+		return 0, nil, fmt.Errorf("not enough numbers")
+	}
+	var extra int
+	if _, err := fmt.Sscan(fields[0], &extra); err != nil {
+		return 0, nil, fmt.Errorf("bad extra: %v", err)
+	}
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		if _, err := fmt.Sscan(fields[1+i], &b[i]); err != nil {
+			return 0, nil, fmt.Errorf("bad schedule: %v", err)
+		}
+	}
+	return extra, b, nil
+}
+
+func runCase(bin string, n, k int, a []int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	input := buildInput(n, k, a)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	extra, b, err := parseOutput(out.String(), n)
+	if err != nil {
+		return err
+	}
+	// verify constraints
+	if extra != expectedExtra(n, k, a) {
+		return fmt.Errorf("expected %d got %d", expectedExtra(n, k, a), extra)
+	}
+	sum := 0
+	for i := 0; i < n; i++ {
+		if b[i] < a[i] {
+			return fmt.Errorf("day %d less than input", i)
+		}
+		if i > 0 && b[i]+b[i-1] < k {
+			return fmt.Errorf("constraint failed day %d", i)
+		}
+		sum += b[i] - a[i]
+	}
+	if sum != extra {
+		return fmt.Errorf("extra mismatch")
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) (int, int, []int) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(10) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(10)
+	}
+	return n, k, a
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	type tc struct {
+		n, k int
+		a    []int
+	}
+	cases := []tc{
+		{3, 5, []int{1, 2, 3}},
+		{1, 1, []int{0}},
+		{2, 3, []int{1, 1}},
+	}
+	for len(cases) < 105 {
+		n, k, a := randomCase(rng)
+		cases = append(cases, tc{n, k, a})
+	}
+	for i, c := range cases {
+		if err := runCase(bin, c.n, c.k, c.a); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, buildInput(c.n, c.k, c.a))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/730-739/732/verifierC.go
+++ b/0-999/700-799/730-739/732/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(b, d, s int64) int64 {
+	mx := b
+	if d > mx {
+		mx = d
+	}
+	if s > mx {
+		mx = s
+	}
+	res := int64(0)
+	if mx-1 > b {
+		res += mx - 1 - b
+	}
+	if mx-1 > d {
+		res += mx - 1 - d
+	}
+	if mx-1 > s {
+		res += mx - 1 - s
+	}
+	return res
+}
+
+func runCase(bin string, b, d, s int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	input := fmt.Sprintf("%d %d %d\n", b, d, s)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var ans int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &ans); err != nil {
+		return fmt.Errorf("bad output: %s", out.String())
+	}
+	if ans != expected(b, d, s) {
+		return fmt.Errorf("expected %d got %d", expected(b, d, s), ans)
+	}
+	return nil
+}
+
+func randCase(rng *rand.Rand) (int64, int64, int64) {
+	b := rng.Int63n(20)
+	d := rng.Int63n(20)
+	s := rng.Int63n(20)
+	if b+d+s == 0 {
+		b = 1
+	}
+	return b, d, s
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []struct{ b, d, s int64 }{
+		{1, 1, 1},
+		{0, 0, 1},
+		{10, 10, 10},
+	}
+	for len(cases) < 105 {
+		b, d, s := randCase(rng)
+		cases = append(cases, struct{ b, d, s int64 }{b, d, s})
+	}
+	for i, c := range cases {
+		if err := runCase(bin, c.b, c.d, c.s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %d %d %d\n", i+1, err, c.b, c.d, c.s)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/730-739/732/verifierD.go
+++ b/0-999/700-799/730-739/732/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, _ := os.Getwd()
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "732D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		val := rng.Intn(m + 1)
+		sb.WriteString(fmt.Sprint(val))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprint(rng.Intn(5) + 1))
+		if i+1 < m {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []string
+	for i := 0; i < 105; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/730-739/732/verifierE.go
+++ b/0-999/700-799/730-739/732/verifierE.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, _ := os.Getwd()
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "732E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(20) + 1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(20) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []string
+	for i := 0; i < 105; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/730-739/732/verifierF.go
+++ b/0-999/700-799/730-739/732/verifierF.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, _ := os.Getwd()
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "732F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges-n+2) + n - 1 // ensure at least n-1 edges
+	edges := make([][2]int, 0, m)
+	used := make(map[[2]int]bool)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		key := [2]int{u, v}
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		edges = append(edges, key)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []string
+	for i := 0; i < 105; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 732
- each verifier generates at least 100 random test cases
- oracles built from provided solutions for harder tasks

## Testing
- `go build` on all new verifier files

------
https://chatgpt.com/codex/tasks/task_e_688391b5c99c8324a068f71ac821eb53