### PR TITLE
Add Go verifiers for contest 731

### DIFF
--- a/0-999/700-799/730-739/731/verifierA.go
+++ b/0-999/700-799/730-739/731/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(s string) string {
+	curr := 'a'
+	total := 0
+	for _, ch := range s {
+		diff := int(ch - curr)
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > 26-diff {
+			diff = 26 - diff
+		}
+		total += diff
+		curr = ch
+	}
+	return fmt.Sprintf("%d\n", total)
+}
+
+func genCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(rng.Intn(26) + 'a')
+	}
+	s := string(b)
+	return s + "\n", solveA(s)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseA(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/731/verifierB.go
+++ b/0-999/700-799/730-739/731/verifierB.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(a []int) string {
+	n := len(a)
+	coupons := 0
+	for i := 0; i < n-1; i++ {
+		if coupons > a[i] {
+			coupons = a[i]
+		}
+		rem := a[i] - coupons
+		maxC := a[i+1]
+		newC := rem
+		if newC > maxC {
+			newC = maxC
+		}
+		if (rem-newC)%2 != 0 {
+			if newC > 0 {
+				newC--
+			} else {
+				return "NO\n"
+			}
+		}
+		coupons = newC
+	}
+	last := a[n-1]
+	if coupons > last {
+		coupons = last
+	}
+	rem := last - coupons
+	if rem%2 != 0 {
+		return "NO\n"
+	}
+	return "YES\n"
+}
+
+func genCaseB(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(20)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveB(arr)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseB(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/731/verifierC.go
+++ b/0-999/700-799/730-739/731/verifierC.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	parent []int
+	rank   []int
+}
+
+func NewDSU(n int) *DSU {
+	d := &DSU{parent: make([]int, n), rank: make([]int, n)}
+	for i := 0; i < n; i++ {
+		d.parent[i] = i
+	}
+	return d
+}
+
+func (d *DSU) Find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.Find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) Union(x, y int) {
+	rx := d.Find(x)
+	ry := d.Find(y)
+	if rx == ry {
+		return
+	}
+	if d.rank[rx] < d.rank[ry] {
+		d.parent[rx] = ry
+	} else if d.rank[ry] < d.rank[rx] {
+		d.parent[ry] = rx
+	} else {
+		d.parent[ry] = rx
+		d.rank[rx]++
+	}
+}
+
+func solveC(n, m, k int, colors []int, pairs [][2]int) string {
+	dsu := NewDSU(n)
+	used := make([]bool, n)
+	for _, p := range pairs {
+		l := p[0]
+		r := p[1]
+		dsu.Union(l, r)
+		used[l] = true
+		used[r] = true
+	}
+	compCount := make(map[int]int)
+	maxFreq := make(map[int]int)
+	colorCount := make(map[int]map[int]int)
+	for i := 0; i < n; i++ {
+		if !used[i] {
+			continue
+		}
+		root := dsu.Find(i)
+		compCount[root]++
+		col := colors[i]
+		cmap := colorCount[root]
+		if cmap == nil {
+			cmap = make(map[int]int)
+			colorCount[root] = cmap
+		}
+		cmap[col]++
+		if cmap[col] > maxFreq[root] {
+			maxFreq[root] = cmap[col]
+		}
+	}
+	result := 0
+	for root, cnt := range compCount {
+		result += cnt - maxFreq[root]
+	}
+	return fmt.Sprintf("%d\n", result)
+}
+
+func genCaseC(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	k := rng.Intn(5) + 1
+	m := rng.Intn(n)
+	colors := make([]int, n)
+	for i := range colors {
+		colors[i] = rng.Intn(k) + 1
+	}
+	pairs := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n)
+		r := rng.Intn(n)
+		for r == l {
+			r = rng.Intn(n)
+		}
+		pairs[i] = [2]int{l, r}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i, c := range colors {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", c)
+	}
+	sb.WriteByte('\n')
+	for _, p := range pairs {
+		fmt.Fprintf(&sb, "%d %d\n", p[0]+1, p[1]+1)
+	}
+	return sb.String(), solveC(n, m, k, colors, pairs)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseC(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/731/verifierD.go
+++ b/0-999/700-799/730-739/731/verifierD.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(n, c int, words [][]int) string {
+	L, R := 0, c-1
+	prev := words[0]
+	ok := true
+	for i := 1; i < n; i++ {
+		curr := words[i]
+		minl := len(prev)
+		if len(curr) < minl {
+			minl = len(curr)
+		}
+		k := 0
+		for k < minl && prev[k] == curr[k] {
+			k++
+		}
+		if k == minl {
+			if len(prev) > len(curr) {
+				ok = false
+				break
+			}
+		} else {
+			a, b := prev[k], curr[k]
+			if a > b {
+				Li := c - a + 1
+				Ri := c - b
+				if Li > R || Ri < L {
+					ok = false
+					break
+				}
+				if Li > L {
+					L = Li
+				}
+				if Ri < R {
+					R = Ri
+				}
+			}
+		}
+		prev = curr
+	}
+	if !ok || L > R {
+		return "-1\n"
+	}
+	return fmt.Sprintf("%d\n", L)
+}
+
+func genCaseD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	c := rng.Intn(8) + 2
+	words := make([][]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, c)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(4) + 1
+		words[i] = make([]int, l)
+		fmt.Fprintf(&sb, "%d", l)
+		for j := 0; j < l; j++ {
+			words[i][j] = rng.Intn(c) + 1
+			fmt.Fprintf(&sb, " %d", words[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), solveD(n, c, words)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseD(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/731/verifierE.go
+++ b/0-999/700-799/730-739/731/verifierE.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(a []int64) string {
+	n := len(a) - 1
+	pref := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		pref[i] = pref[i-1] + a[i]
+	}
+	dp := make([]int64, n+2)
+	mx := make([]int64, n+3)
+	const inf = int64(1) << 60
+	dp[n] = 0
+	mx[n+1] = -inf
+	mx[n] = pref[n] - dp[n]
+	for j := n - 1; j >= 1; j-- {
+		dp[j] = mx[j+1]
+		v := pref[j] - dp[j]
+		if v > mx[j+1] {
+			mx[j] = v
+		} else {
+			mx[j] = mx[j+1]
+		}
+	}
+	return fmt.Sprintf("%d\n", dp[1])
+}
+
+func genCaseE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	arr := make([]int64, n+1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 1; i <= n; i++ {
+		arr[i] = int64(rng.Intn(21) - 10)
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveE(arr)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseE(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/731/verifierF.go
+++ b/0-999/700-799/730-739/731/verifierF.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveF(nums []int) string {
+	maxVal := 0
+	for _, x := range nums {
+		if x > maxVal {
+			maxVal = x
+		}
+	}
+	freq := make([]int, maxVal+1)
+	for _, x := range nums {
+		if x >= 0 {
+			freq[x]++
+		}
+	}
+	pref := make([]int, maxVal+1)
+	for i := 1; i <= maxVal; i++ {
+		pref[i] = pref[i-1] + freq[i]
+	}
+	var ans int64
+	for v := 1; v <= maxVal; v++ {
+		if freq[v] == 0 {
+			continue
+		}
+		var total int64
+		for j := v; j <= maxVal; j += v {
+			r := j + v - 1
+			if r > maxVal {
+				r = maxVal
+			}
+			cnt := pref[r] - pref[j-1]
+			total += int64(cnt) * int64(j)
+		}
+		if total > ans {
+			ans = total
+		}
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func genCaseF(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := range arr {
+		arr[i] = rng.Intn(50) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveF(arr)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseF(rand.New(rand.NewSource(time.Now().UnixNano() + int64(i))))
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\ninput:\n%soutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%sbut got:\n%s", i+1, in, expect, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces Round 731 problems A–F
- each verifier generates 100 random test cases and checks a given binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68839129bad88324ae9d15e753b7654a