### PR TITLE
Add verifiers for contest 730

### DIFF
--- a/0-999/700-799/730-739/730/verifierA.go
+++ b/0-999/700-799/730-739/730/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refA.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "730A.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 2 // 2..6
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(6))
+		}
+		sb.WriteByte('\n')
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	exp, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/730/verifierB.go
+++ b/0-999/700-799/730-739/730/verifierB.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem B is interactive and cannot be automatically verified.")
+}

--- a/0-999/700-799/730-739/730/verifierC.go
+++ b/0-999/700-799/730-739/730/verifierC.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refC.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "730C.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(4) + 1
+		m := rng.Intn(n*(n-1)/2 + 1)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		edges := make(map[[2]int]struct{})
+		for j := 0; j < m; j++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			for u == v || contains(edges, u, v) {
+				u = rng.Intn(n) + 1
+				v = rng.Intn(n) + 1
+			}
+			edges[[2]int{u, v}] = struct{}{}
+			edges[[2]int{v, u}] = struct{}{}
+			fmt.Fprintf(&sb, "%d %d\n", u, v)
+		}
+		w := rng.Intn(3) + 1
+		fmt.Fprintf(&sb, "%d\n", w)
+		for j := 0; j < w; j++ {
+			c := rng.Intn(n) + 1
+			ki := rng.Intn(5) + 1
+			p := rng.Intn(10) + 1
+			fmt.Fprintf(&sb, "%d %d %d\n", c, ki, p)
+		}
+		q := rng.Intn(3) + 1
+		fmt.Fprintf(&sb, "%d\n", q)
+		for j := 0; j < q; j++ {
+			g := rng.Intn(n) + 1
+			r := rng.Intn(5) + 1
+			a := rng.Intn(20) + 1
+			fmt.Fprintf(&sb, "%d %d %d\n", g, r, a)
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func contains(m map[[2]int]struct{}, u, v int) bool {
+	_, ok := m[[2]int{u, v}]
+	return ok
+}
+
+func runCase(bin, ref string, c Case) error {
+	exp, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/730/verifierD.go
+++ b/0-999/700-799/730-739/730/verifierD.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refD.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "730D.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(4) + 1
+		r := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, r)
+		for j := 0; j < n; j++ {
+			l := rng.Intn(5) + 1
+			fmt.Fprintf(&sb, "%d ", l)
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			t := rng.Intn(10) + 1
+			fmt.Fprintf(&sb, "%d ", t)
+		}
+		sb.WriteByte('\n')
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	exp, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/730/verifierE.go
+++ b/0-999/700-799/730-739/730/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refE.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "730E.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			a := rng.Intn(20)
+			d := rng.Intn(11) - 5
+			fmt.Fprintf(&sb, "%d %d\n", a, d)
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	exp, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/730/verifierF.go
+++ b/0-999/700-799/730-739/730/verifierF.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refF.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "730F.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 1
+		b := rng.Intn(20)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, b)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(20))
+		}
+		sb.WriteByte('\n')
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	exp, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/730/verifierG.go
+++ b/0-999/700-799/730-739/730/verifierG.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refG.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "730G.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			s := rng.Intn(20) + 1
+			d := rng.Intn(5) + 1
+			fmt.Fprintf(&sb, "%d %d\n", s, d)
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	exp, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/730/verifierH.go
+++ b/0-999/700-799/730-739/730/verifierH.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refH.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "730H.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func randName(rng *rand.Rand, l int) string {
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(4) + 2
+		m := rng.Intn(n) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		names := make([]string, n)
+		for j := 0; j < n; j++ {
+			names[j] = randName(rng, rng.Intn(3)+3)
+			fmt.Fprintln(&sb, names[j])
+		}
+		idxs := rng.Perm(n)[:m]
+		for j, id := range idxs {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", id+1)
+		}
+		sb.WriteByte('\n')
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	exp, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/730/verifierI.go
+++ b/0-999/700-799/730-739/730/verifierI.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refI.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "730I.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 2
+		p := rng.Intn(n-1) + 1
+		s := rng.Intn(n-p) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, p, s)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(20)+1)
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(20)+1)
+		}
+		sb.WriteByte('\n')
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	exp, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/730/verifierJ.go
+++ b/0-999/700-799/730-739/730/verifierJ.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refJ.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "730J.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(10)+1)
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(10)+1)
+		}
+		sb.WriteByte('\n')
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	exp, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierJ.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/730/verifierK.go
+++ b/0-999/700-799/730-739/730/verifierK.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refK.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "730K.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		T := rng.Intn(2) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", T)
+		for t := 0; t < T; t++ {
+			n := rng.Intn(4) + 2
+			m := rng.Intn(n*(n-1)/2-n+1) + n - 1
+			s := 1
+			if n > 1 {
+				s = rng.Intn(n) + 1
+			}
+			tdest := rng.Intn(n) + 1
+			for tdest == s {
+				tdest = rng.Intn(n) + 1
+			}
+			fmt.Fprintf(&sb, "%d %d %d %d\n", n, m, s, tdest)
+			edges := make(map[[2]int]struct{})
+			for j := 0; j < m; j++ {
+				u := rng.Intn(n) + 1
+				v := rng.Intn(n) + 1
+				for u == v || edges[[2]int{u, v}] != (struct{}{}) {
+					u = rng.Intn(n) + 1
+					v = rng.Intn(n) + 1
+				}
+				edges[[2]int{u, v}] = struct{}{}
+				edges[[2]int{v, u}] = struct{}{}
+				fmt.Fprintf(&sb, "%d %d\n", u, v)
+			}
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	exp, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierK.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/730/verifierL.go
+++ b/0-999/700-799/730-739/730/verifierL.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, self, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(self)
+	ref := filepath.Join(dir, "refL.bin")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "730L.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func randExpr(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('0' + rng.Intn(10))
+	}
+	return string(b)
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]Case, 100)
+	for i := range cases {
+		expr := randExpr(rng, rng.Intn(5)+1)
+		m := rng.Intn(len(expr)) + 1
+		var sb strings.Builder
+		fmt.Fprintln(&sb, expr)
+		fmt.Fprintf(&sb, "%d\n", m)
+		for j := 0; j < m; j++ {
+			l := rng.Intn(len(expr)) + 1
+			r := rng.Intn(len(expr)-l+1) + l
+			fmt.Fprintf(&sb, "%d %d\n", l, r)
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	exp, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierL.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A through L of contest 730
- interactive problem B reports that it cannot be automatically verified
- each verifier builds the official solution and runs 100 random tests comparing output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build verifierI.go`
- `go build verifierJ.go`
- `go build verifierK.go`
- `go build verifierL.go`


------
https://chatgpt.com/codex/tasks/task_e_6883909da6848324978ed31bf672692a