### PR TITLE
Add verifiers for CF 729

### DIFF
--- a/0-999/700-799/720-729/729/verifierA.go
+++ b/0-999/700-799/720-729/729/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, s string) string {
+	var result []rune
+	for i := 0; i < len(s); {
+		if i+3 <= len(s) && s[i:i+3] == "ogo" {
+			j := i + 3
+			for j+1 < len(s) && s[j:j+2] == "go" {
+				j += 2
+			}
+			result = append(result, '*', '*', '*')
+			i = j
+		} else {
+			result = append(result, rune(s[i]))
+			i++
+		}
+	}
+	return string(result)
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		n := r.Intn(100) + 1
+		letters := "abgoxyz"
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteByte(letters[r.Intn(len(letters))])
+		}
+		s := sb.String()
+		input := fmt.Sprintf("%d\n%s\n", n, s)
+		expect := expected(n, s)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, input, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/0-999/700-799/720-729/729/verifierB.go
+++ b/0-999/700-799/720-729/729/verifierB.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m int, grid [][]int) string {
+	prefRow := make([][]int, n)
+	for i := 0; i < n; i++ {
+		prefRow[i] = make([]int, m)
+		sum := 0
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 1 {
+				sum++
+			}
+			prefRow[i][j] = sum
+		}
+	}
+	prefCol := make([][]int, n)
+	for i := 0; i < n; i++ {
+		prefCol[i] = make([]int, m)
+	}
+	for j := 0; j < m; j++ {
+		sum := 0
+		for i := 0; i < n; i++ {
+			if grid[i][j] == 1 {
+				sum++
+			}
+			prefCol[i][j] = sum
+		}
+	}
+	ans := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 1 {
+				continue
+			}
+			if j > 0 && prefRow[i][j-1] > 0 {
+				ans++
+			}
+			if j+1 < m && prefRow[i][m-1]-prefRow[i][j] > 0 {
+				ans++
+			}
+			if i > 0 && prefCol[i-1][j] > 0 {
+				ans++
+			}
+			if i+1 < n && prefCol[n-1][j]-prefCol[i][j] > 0 {
+				ans++
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	r := rand.New(rand.NewSource(2))
+	for tc := 1; tc <= 100; tc++ {
+		n := r.Intn(8) + 1
+		m := r.Intn(8) + 1
+		grid := make([][]int, n)
+		ones := 0
+		for i := 0; i < n; i++ {
+			grid[i] = make([]int, m)
+			for j := 0; j < m; j++ {
+				v := r.Intn(2)
+				grid[i][j] = v
+				if v == 1 {
+					ones++
+				}
+			}
+		}
+		if ones == 0 {
+			grid[0][0] = 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				fmt.Fprintf(&sb, "%d", grid[i][j])
+				if j+1 < m {
+					sb.WriteByte(' ')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expect := expected(n, m, grid)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", tc, input, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/0-999/700-799/720-729/729/verifierC.go
+++ b/0-999/700-799/720-729/729/verifierC.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func can(v int64, d []int64, t int64, maxD int64) bool {
+	if v < maxD {
+		return false
+	}
+	var total int64
+	for _, dist := range d {
+		if v >= 2*dist {
+			total += dist
+		} else {
+			total += 3*dist - v
+		}
+		if total > t {
+			return false
+		}
+	}
+	return total <= t
+}
+
+func expected(n, k int, s, t int64, cars [][2]int64, stations []int64) string {
+	all := make([]int64, 0, k+2)
+	all = append(all, 0)
+	all = append(all, stations...)
+	all = append(all, s)
+	sort.Slice(all, func(i, j int) bool { return all[i] < all[j] })
+	m := len(all) - 1
+	d := make([]int64, m)
+	var maxD int64
+	for i := 0; i < m; i++ {
+		dist := all[i+1] - all[i]
+		d[i] = dist
+		if dist > maxD {
+			maxD = dist
+		}
+	}
+	var maxV int64
+	for _, cv := range cars {
+		if cv[1] > maxV {
+			maxV = cv[1]
+		}
+	}
+	l, r := int64(0), maxV+1
+	for l < r {
+		mid := (l + r) / 2
+		if can(mid, d, t, maxD) {
+			r = mid
+		} else {
+			l = mid + 1
+		}
+	}
+	if l > maxV || !can(l, d, t, maxD) {
+		return "-1"
+	}
+	vReq := l
+	ans := int64(1<<62 - 1)
+	for _, cv := range cars {
+		if cv[1] >= vReq && cv[0] < ans {
+			ans = cv[0]
+		}
+	}
+	if ans == int64(1<<62-1) {
+		return "-1"
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	r := rand.New(rand.NewSource(3))
+	for tc := 1; tc <= 100; tc++ {
+		n := r.Intn(4) + 1
+		k := r.Intn(3) + 1
+		sVal := int64(r.Intn(15) + 5)
+		tVal := int64(r.Intn(40) + int(sVal) + 1)
+		cars := make([][2]int64, n)
+		for i := 0; i < n; i++ {
+			cars[i][0] = int64(r.Intn(50) + 1)
+			cars[i][1] = int64(r.Intn(30) + 1)
+		}
+		posSet := make(map[int64]bool)
+		stations := make([]int64, 0, k)
+		for len(stations) < k {
+			p := int64(r.Intn(int(sVal-1)) + 1)
+			if !posSet[p] {
+				posSet[p] = true
+				stations = append(stations, p)
+			}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d\n", n, k, sVal, tVal)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d %d\n", cars[i][0], cars[i][1])
+		}
+		for i := 0; i < k; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", stations[i])
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := expected(n, k, sVal, tVal, cars, stations)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", tc, input, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/0-999/700-799/720-729/729/verifierD.go
+++ b/0-999/700-799/720-729/729/verifierD.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, a, b, k int, s string) (string, []int) {
+	var candidates []int
+	for i := 0; i < n; {
+		if s[i] == '1' {
+			i++
+			continue
+		}
+		j := i
+		for j < n && s[j] == '0' {
+			j++
+		}
+		L := j - i
+		cnt := L / b
+		for t := 1; t <= cnt; t++ {
+			pos := i + t*b
+			candidates = append(candidates, pos)
+		}
+		i = j
+	}
+	R := len(candidates) - a + 1
+	if R < 0 {
+		R = 0
+	}
+	if R > len(candidates) {
+		R = len(candidates)
+	}
+	return fmt.Sprintf("%d", R), candidates[:R]
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	r := rand.New(rand.NewSource(4))
+	for tc := 1; tc <= 100; tc++ {
+		n := r.Intn(20) + 1
+		a := r.Intn(n) + 1
+		b := r.Intn(n) + 1
+		if b == 0 {
+			b = 1
+		}
+		k := r.Intn(n)
+		onesPos := make([]int, 0, k)
+		used := make(map[int]bool)
+		for len(onesPos) < k {
+			p := r.Intn(n)
+			if !used[p] {
+				used[p] = true
+				onesPos = append(onesPos, p)
+			}
+		}
+		str := make([]byte, n)
+		for i := 0; i < n; i++ {
+			if used[i] {
+				str[i] = '1'
+			} else {
+				str[i] = '0'
+			}
+		}
+		s := string(str)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d\n", n, a, b, k)
+		sb.WriteString(s)
+		sb.WriteByte('\n')
+		input := sb.String()
+		expectCount, expectPositions := expected(n, a, b, k, s)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		fields := strings.Fields(out)
+		if len(fields) < 1 {
+			fmt.Printf("test %d: output too short\n", tc)
+			os.Exit(1)
+		}
+		if fields[0] != expectCount {
+			fmt.Printf("test %d failed\ninput:\n%sexpected count: %s got: %s\n", tc, input, expectCount, fields[0])
+			os.Exit(1)
+		}
+		if len(fields)-1 != len(expectPositions) {
+			fmt.Printf("test %d failed\nexpected %d positions got %d\n", tc, len(expectPositions), len(fields)-1)
+			os.Exit(1)
+		}
+		for i, pos := range expectPositions {
+			if fields[i+1] != fmt.Sprintf("%d", pos) {
+				fmt.Printf("test %d failed\nposition %d expected %d got %s\n", tc, i+1, pos, fields[i+1])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/0-999/700-799/720-729/729/verifierE.go
+++ b/0-999/700-799/720-729/729/verifierE.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, s int, a []int) string {
+	costChief := 0
+	if a[s-1] != 0 {
+		costChief = 1
+	}
+	r := make([]int, n+2)
+	for i := 1; i <= n; i++ {
+		if i == s {
+			continue
+		}
+		ai := a[i-1]
+		if ai < 0 {
+			ai = 0
+		}
+		if ai > n {
+			ai = n
+		}
+		r[ai]++
+	}
+	r0 := r[0]
+	total := n - 1
+	big := total - r0
+	bestP := total + 5
+	z := 0
+	for D := 1; D <= n; D++ {
+		if D <= n {
+			big -= r[D]
+		}
+		if D < len(r) {
+			if r[D] == 0 {
+				z++
+			}
+		} else {
+			z++
+		}
+		A := r0 + big
+		P := z
+		if A > P {
+			P = A
+		}
+		if P < bestP {
+			bestP = P
+		}
+	}
+	ans := costChief + bestP
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	r := rand.New(rand.NewSource(5))
+	for tc := 1; tc <= 100; tc++ {
+		n := r.Intn(10) + 1
+		sID := r.Intn(n) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = r.Intn(n)
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, sID)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", arr[i])
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := expected(n, sID, arr)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", tc, input, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/0-999/700-799/720-729/729/verifierF.go
+++ b/0-999/700-799/720-729/729/verifierF.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type state struct {
+	l, r, k int
+	turn    int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func getSum(l, r int, pref []int64) int64 {
+	if l > r {
+		return 0
+	}
+	return pref[r+1] - pref[l]
+}
+
+func solve(l, r, k, turn int, pref []int64, memo map[state]int64) int64 {
+	if l > r {
+		return 0
+	}
+	st := state{l, r, k, turn}
+	if v, ok := memo[st]; ok {
+		return v
+	}
+	var res int64
+	rem := r - l + 1
+	moves := []int{}
+	if k == 0 {
+		moves = []int{1, 2}
+	} else {
+		moves = []int{k, k + 1}
+	}
+	if turn == 0 {
+		res = -1 << 60
+		for _, x := range moves {
+			if x <= rem {
+				sum := getSum(l, l+x-1, pref)
+				val := sum + solve(l+x, r, x, 1, pref, memo)
+				if val > res {
+					res = val
+				}
+			}
+		}
+	} else {
+		res = 1 << 60
+		for _, x := range moves {
+			if x <= rem {
+				sum := getSum(r-x+1, r, pref)
+				val := solve(l, r-x, x, 0, pref, memo) - sum
+				if val < res {
+					res = val
+				}
+			}
+		}
+	}
+	if res > 1<<59 || res < -(1<<59) {
+		res = 0
+	}
+	memo[st] = res
+	return res
+}
+
+func expected(a []int64) string {
+	n := len(a)
+	pref := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		pref[i+1] = pref[i] + a[i]
+	}
+	memo := make(map[state]int64)
+	ans := solve(0, n-1, 0, 0, pref, memo)
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	r := rand.New(rand.NewSource(6))
+	for tc := 1; tc <= 100; tc++ {
+		n := r.Intn(8) + 1
+		arr := make([]int64, n)
+		for i := 0; i < n; i++ {
+			arr[i] = int64(r.Intn(21) - 10)
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", arr[i])
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := expected(arr)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", tc, input, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 729 problems A–F
- each verifier runs 100 random tests and supports running Go source directly via `--`

## Testing
- `go run verifierA.go -- 729A.go`
- `go run verifierB.go -- 729B.go`
- `go run verifierF.go -- 729F.go`

------
https://chatgpt.com/codex/tasks/task_e_6883901177508324b2e3a9ad7bd28705