### PR TITLE
Add solution for 1956B

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1956/1956B.go
+++ b/1000-1999/1900-1999/1950-1959/1956/1956B.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		freq := make([]int, n+1)
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(in, &x)
+			freq[x]++
+		}
+		ans := 0
+		for _, c := range freq {
+			if c == 2 {
+				ans++
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1956B

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1956/1956B.go`


------
https://chatgpt.com/codex/tasks/task_e_68838f3f67188324b3e113dc89cbf8f7