### PR TITLE
Add Go solution for 1950C

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1950/1950C.go
+++ b/1000-1999/1900-1999/1950-1959/1950/1950C.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(in, &s)
+		hour, _ := strconv.Atoi(s[:2])
+		minute := s[3:]
+		if hour < 12 {
+			if hour == 0 {
+				hour = 12
+			}
+			fmt.Fprintf(out, "%02d:%s AM\n", hour, minute)
+		} else {
+			if hour > 12 {
+				hour -= 12
+			}
+			fmt.Fprintf(out, "%02d:%s PM\n", hour, minute)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement a simple Go program to convert 24-hour time to 12-hour format

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1950/1950C.go`
- `go vet 1000-1999/1900-1999/1950-1959/1950/1950C.go`


------
https://chatgpt.com/codex/tasks/task_e_68839800f2c083249cb493fbb9fd8c9d