### PR TITLE
Add verifiers for Codeforces Round 743

### DIFF
--- a/0-999/700-799/740-749/743/verifierA.go
+++ b/0-999/700-799/740-749/743/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCaseA(n, a, b int, s string) int {
+	if s[a-1] == s[b-1] {
+		return 0
+	}
+	pos := [2][]int{}
+	for i, ch := range s {
+		c := int(ch - '0')
+		if c == 0 || c == 1 {
+			pos[c] = append(pos[c], i+1)
+		}
+	}
+	src := pos[int(s[a-1]-'0')]
+	dst := pos[int(s[b-1]-'0')]
+	i, j := 0, 0
+	ans := n
+	for i < len(src) && j < len(dst) {
+		diff := src[i] - dst[j]
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff < ans {
+			ans = diff
+		}
+		if src[i] < dst[j] {
+			i++
+		} else {
+			j++
+		}
+	}
+	return ans
+}
+
+func generateCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	a := rng.Intn(n) + 1
+	b := rng.Intn(n) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	s := sb.String()
+	input := fmt.Sprintf("%d %d %d\n%s\n", n, a, b, s)
+	expect := fmt.Sprintf("%d", solveCaseA(n, a, b, s))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseA(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/740-749/743/verifierB.go
+++ b/0-999/700-799/740-749/743/verifierB.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCaseB(n, k int64) int64 {
+	for {
+		mid := int64(1) << (n - 1)
+		if k == mid {
+			return n
+		} else if k < mid {
+			n--
+		} else {
+			k -= mid
+			n--
+		}
+	}
+}
+
+func generateCaseB(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(50) + 1
+	var maxK int64
+	if n >= 62 {
+		maxK = int64(1)<<61 - 1
+	} else {
+		maxK = (int64(1) << n) - 1
+	}
+	k := rng.Int63n(maxK) + 1
+	input := fmt.Sprintf("%d %d\n", n, k)
+	expect := fmt.Sprintf("%d", solveCaseB(n, k))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseB(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/740-749/743/verifierC.go
+++ b/0-999/700-799/740-749/743/verifierC.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveCaseC(n int64) string {
+	if n == 1 {
+		return "-1"
+	}
+	if n%2 == 0 {
+		k := n / 2
+		x := k + 2
+		y := k * (k + 1)
+		z := (k + 1) * (k + 2)
+		return fmt.Sprintf("%d %d %d", x, y, z)
+	}
+	half := n/2 + 1
+	maxX := half + 2000
+	if maxX > 2*n {
+		maxX = 2 * n
+	}
+	for x := half; x <= maxX; x++ {
+		num := 2*x - n
+		den := n * x
+		g := gcd(num, den)
+		a := num / g
+		b := den / g
+		y0 := b/a + 1
+		if y0 <= x {
+			y0 = x + 1
+		}
+		for y := y0; y < y0+10; y++ {
+			d := a*y - b
+			if d <= 0 {
+				continue
+			}
+			by := b * y
+			if by%d != 0 {
+				continue
+			}
+			z := by / d
+			if z <= 0 || z > 1000000000 {
+				continue
+			}
+			if z == y || z == x {
+				continue
+			}
+			return fmt.Sprintf("%d %d %d", x, y, z)
+		}
+	}
+	return "-1"
+}
+
+func generateCaseC(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	expect := solveCaseC(n)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseC(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/740-749/743/verifierD.go
+++ b/0-999/700-799/740-749/743/verifierD.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCaseD(n int, vals []int64, edges [][2]int) string {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	parent := make([]int, n+1)
+	order := make([]int, 0, n)
+	stack := []int{1}
+	parent[1] = 0
+	for len(stack) > 0 {
+		u := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, u)
+		for _, v := range adj[u] {
+			if v == parent[u] {
+				continue
+			}
+			parent[v] = u
+			stack = append(stack, v)
+		}
+	}
+	sum := make([]int64, n+1)
+	f := make([]int64, n+1)
+	const inf int64 = 1 << 60
+	var ans int64
+	hasAns := false
+	for i := n - 1; i >= 0; i-- {
+		u := order[i]
+		sum[u] = vals[u-1]
+		best1, best2 := -inf, -inf
+		for _, v := range adj[u] {
+			if v == parent[u] {
+				continue
+			}
+			sum[u] += sum[v]
+			if f[v] > best1 {
+				best2 = best1
+				best1 = f[v]
+			} else if f[v] > best2 {
+				best2 = f[v]
+			}
+		}
+		if best2 > -inf {
+			cand := best1 + best2
+			if !hasAns || cand > ans {
+				ans = cand
+				hasAns = true
+			}
+		}
+		f[u] = sum[u]
+		if best1 > f[u] {
+			f[u] = best1
+		}
+	}
+	if !hasAns {
+		return "Impossible"
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCaseD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 2
+	vals := make([]int64, n)
+	for i := range vals {
+		vals[i] = int64(rng.Intn(21) - 10)
+	}
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	input := sb.String()
+	expect := solveCaseD(n, vals, edges)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseD(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/740-749/743/verifierE.go
+++ b/0-999/700-799/740-749/743/verifierE.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func bitsOnes(x int) int {
+	cnt := 0
+	for x > 0 {
+		cnt++
+		x &= x - 1
+	}
+	return cnt
+}
+
+func solveCaseE(n int, seq []int) int {
+	pos := make([][]int, 8)
+	for i, v := range seq {
+		v--
+		if v >= 0 && v < 8 {
+			pos[v] = append(pos[v], i+1)
+		}
+	}
+	ans1 := 0
+	for i := 0; i < 8; i++ {
+		if len(pos[i]) > 0 {
+			ans1++
+		}
+	}
+	ans := ans1
+	if ans1 == 8 {
+		INF := n + 1
+		dp := make([][9]int, 1<<8)
+		for m := range dp {
+			for d := range dp[m] {
+				dp[m][d] = INF
+			}
+		}
+		dp[0][0] = 0
+		for mask := 0; mask < (1 << 8); mask++ {
+			t := bitsOnes(mask)
+			for d := 0; d <= t; d++ {
+				cur := dp[mask][d]
+				if cur > n {
+					continue
+				}
+				for i := 0; i < 8; i++ {
+					if mask&(1<<i) != 0 {
+						continue
+					}
+					arr := pos[i]
+					j := sort.Search(len(arr), func(k int) bool { return arr[k] > cur })
+					if j < len(arr) {
+						m2 := mask | (1 << i)
+						if arr[j] < dp[m2][d] {
+							dp[m2][d] = arr[j]
+						}
+					}
+					if len(arr) >= 2 {
+						j1 := sort.Search(len(arr), func(k int) bool { return arr[k] > cur })
+						if j1 < len(arr) {
+							j2 := sort.Search(len(arr), func(k int) bool { return arr[k] > arr[j1] })
+							if j2 < len(arr) {
+								m2 := mask | (1 << i)
+								if arr[j2] < dp[m2][d+1] {
+									dp[m2][d+1] = arr[j2]
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		full := (1 << 8) - 1
+		for d := 0; d <= 8; d++ {
+			if dp[full][d] <= n {
+				tot := 8 + d
+				if tot > ans {
+					ans = tot
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func generateCaseE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	seq := make([]int, n)
+	for i := range seq {
+		seq[i] = rng.Intn(8) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range seq {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expect := fmt.Sprintf("%d", solveCaseE(n, seq))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseE(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier for problem A
- add Go verifier for problem B
- add Go verifier for problem C
- add Go verifier for problem D
- add Go verifier for problem E

## Testing
- `go build 0-999/700-799/740-749/743/verifierA.go`
- `go build 0-999/700-799/740-749/743/verifierB.go`
- `go build 0-999/700-799/740-749/743/verifierC.go`
- `go build 0-999/700-799/740-749/743/verifierD.go`
- `go build 0-999/700-799/740-749/743/verifierE.go`
- `go run 0-999/700-799/740-749/743/verifierA.go /tmp/743A_bin`
- `go run 0-999/700-799/740-749/743/verifierB.go /tmp/743B_bin`


------
https://chatgpt.com/codex/tasks/task_e_688397badf508324946af2374c4c8857