### PR TITLE
Add Go solution for 1950F

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1950/1950F.go
+++ b/1000-1999/1900-1999/1950-1959/1950/1950F.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func calc(a, b, c, cap int) int {
+	height := 0
+	for a+b+c > 0 {
+		if cap <= 0 {
+			return math.MaxInt32
+		}
+		height++
+		useA := a
+		if useA > cap {
+			useA = cap
+		}
+		cap -= useA
+		a -= useA
+		newCap := useA * 2
+		useB := b
+		if useB > cap {
+			useB = cap
+		}
+		cap -= useB
+		b -= useB
+		newCap += useB
+		useC := c
+		if useC > cap {
+			useC = cap
+		}
+		cap -= useC
+		c -= useC
+		cap = newCap
+	}
+	return height
+}
+
+func minHeight(a, b, c int) int {
+	if c != a+1 {
+		return -1
+	}
+	best := math.MaxInt32
+	if a > 0 {
+		if h := calc(a-1, b, c, 2); h < best {
+			best = h
+		}
+	}
+	if b > 0 {
+		if h := calc(a, b-1, c, 1); h < best {
+			best = h
+		}
+	}
+	if c > 0 {
+		if h := calc(a, b, c-1, 0); h < best {
+			best = h
+		}
+	}
+	if best == math.MaxInt32 {
+		return -1
+	}
+	return best
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var a, b, c int
+		fmt.Fscan(reader, &a, &b, &c)
+		fmt.Fprintln(writer, minHeight(a, b, c))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problemF in contest 1950
- uses greedy level construction to minimize tree height

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1950/1950F.go`


------
https://chatgpt.com/codex/tasks/task_e_688396e8cd0c83248d4b1a3e80488f00