### PR TITLE
Add Go verifiers for contest 740

### DIFF
--- a/0-999/700-799/740-749/740/verifierA.go
+++ b/0-999/700-799/740-749/740/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(reader *bufio.Reader) string {
+	var n, a, b, c int64
+	if _, err := fmt.Fscan(reader, &n, &a, &b, &c); err != nil {
+		return ""
+	}
+	const INF int64 = math.MaxInt64 / 4
+	dp := [4]int64{0, INF, INF, INF}
+	for it := 0; it < 4; it++ {
+		old := dp
+		for r := 0; r < 4; r++ {
+			curr := old[r]
+			if curr >= INF {
+				continue
+			}
+			nr := (r + 1) & 3
+			if val := curr + a; val < dp[nr] {
+				dp[nr] = val
+			}
+			nr2 := (r + 2) & 3
+			if val := curr + b; val < dp[nr2] {
+				dp[nr2] = val
+			}
+			nr3 := (r + 3) & 3
+			if val := curr + c; val < dp[nr3] {
+				dp[nr3] = val
+			}
+		}
+	}
+	rem := int((4 - n%4) % 4)
+	return fmt.Sprint(dp[rem])
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Int63n(1_000_000_000) + 1
+	a := rng.Int63n(1_000_000_000) + 1
+	b := rng.Int63n(1_000_000_000) + 1
+	c := rng.Int63n(1_000_000_000) + 1
+	return fmt.Sprintf("%d %d %d %d\n", n, a, b, c)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/740-749/740/verifierB.go
+++ b/0-999/700-799/740-749/740/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(reader *bufio.Reader) string {
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return ""
+	}
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	var ans int64
+	for j := 0; j < m; j++ {
+		var l, r int
+		fmt.Fscan(reader, &l, &r)
+		var sum int64
+		for i := l - 1; i < r; i++ {
+			sum += a[i]
+		}
+		if sum > 0 {
+			ans += sum
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	m := rng.Intn(100) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		val := rng.Intn(201) - 100
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", val)
+	}
+	sb.WriteByte('\n')
+	for j := 0; j < m; j++ {
+		l := rng.Intn(n) + 1
+		r := l + rng.Intn(n-l+1)
+		fmt.Fprintf(&sb, "%d %d\n", l, r)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		expect := solve(bufio.NewReader(strings.NewReader(tc)))
+		got, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expect, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for contest 740
- each verifier generates 100 random test cases and checks a given solution

## Testing
- `go run 0-999/700-799/740-749/740/verifierA.go /tmp/solA`
- `go run 0-999/700-799/740-749/740/verifierB.go /tmp/solB`
- `go build 0-999/700-799/740-749/740/verifierA.go`
- `go build 0-999/700-799/740-749/740/verifierB.go`

------
https://chatgpt.com/codex/tasks/task_e_68839616a1b08324ba5c6eaedd6f0023