### PR TITLE
Add Go solution for 1950A

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1950/1950A.go
+++ b/1000-1999/1900-1999/1950-1959/1950/1950A.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a, b, c int
+		fmt.Fscan(reader, &a, &b, &c)
+		if a < b && b < c {
+			fmt.Fprintln(writer, "STAIR")
+		} else if a < b && b > c {
+			fmt.Fprintln(writer, "PEAK")
+		} else {
+			fmt.Fprintln(writer, "NONE")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1950A.go` for problem A in contest 1950

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1950/1950A.go`

------
https://chatgpt.com/codex/tasks/task_e_688399191b3c8324a082793080143cb7