### PR TITLE
Add solution verifiers for CF 744

### DIFF
--- a/0-999/700-799/740-749/744/verifierA.go
+++ b/0-999/700-799/740-749/744/verifierA.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	parent []int
+	size   []int
+}
+
+func NewDSU(n int) *DSU {
+	p := make([]int, n+1)
+	s := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		p[i] = i
+		s[i] = 1
+	}
+	return &DSU{p, s}
+}
+
+func (d *DSU) Find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.Find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) Union(x, y int) {
+	rx := d.Find(x)
+	ry := d.Find(y)
+	if rx == ry {
+		return
+	}
+	if d.size[rx] < d.size[ry] {
+		rx, ry = ry, rx
+	}
+	d.parent[ry] = rx
+	d.size[rx] += d.size[ry]
+}
+
+func solveA(n int, edges [][2]int, gov []int) int64 {
+	dsu := NewDSU(n)
+	for _, e := range edges {
+		dsu.Union(e[0], e[1])
+	}
+	govRoot := make(map[int]bool)
+	var sizes []int64
+	for _, g := range gov {
+		r := dsu.Find(g)
+		if !govRoot[r] {
+			govRoot[r] = true
+			sizes = append(sizes, int64(dsu.size[r]))
+		}
+	}
+	var extra int64
+	for i := 1; i <= n; i++ {
+		if dsu.Find(i) == i && !govRoot[i] {
+			extra += int64(dsu.size[i])
+		}
+	}
+	maxIdx := 0
+	for i := range sizes {
+		if sizes[i] > sizes[maxIdx] {
+			maxIdx = i
+		}
+	}
+	var total int64
+	for i, sz := range sizes {
+		if i == maxIdx {
+			s := sz + extra
+			total += s * (s - 1) / 2
+		} else {
+			total += sz * (sz - 1) / 2
+		}
+	}
+	return total - int64(len(edges))
+}
+
+func genCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(n) + 1
+	nodes := rng.Perm(n)[:k]
+	gov := make([]int, k)
+	for i := 0; i < k; i++ {
+		gov[i] = nodes[i] + 1
+	}
+	dsu := NewDSU(n)
+	govComp := make(map[int]bool)
+	for _, g := range gov {
+		govComp[g] = true
+	}
+	edges := make([][2]int, 0)
+	used := make(map[[2]int]bool)
+	attempts := n * n
+	for attempts > 0 && len(edges) < n*(n-1)/2 {
+		attempts--
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		a, b := u, v
+		if a > b {
+			a, b = b, a
+		}
+		if used[[2]int{a, b}] {
+			continue
+		}
+		ru := dsu.Find(u)
+		rv := dsu.Find(v)
+		if ru == rv {
+			continue
+		}
+		if govComp[ru] && govComp[rv] {
+			continue
+		}
+		used[[2]int{a, b}] = true
+		edges = append(edges, [2]int{u, v})
+		dsu.Union(u, v)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, len(edges), k))
+	for i, g := range gov {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(g))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	ans := solveA(n, edges, gov)
+	return sb.String(), ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		in, expect := genCase(rng)
+		outStr, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, in)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(outStr, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid output %q\n", t, outStr)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", t, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/740-749/744/verifierB.go
+++ b/0-999/700-799/740-749/744/verifierB.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Matrix [][]int
+
+func generateMatrix(rng *rand.Rand) Matrix {
+	n := rng.Intn(3) + 2 // 2..4
+	m := make(Matrix, n)
+	for i := 0; i < n; i++ {
+		m[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			if i == j {
+				m[i][j] = 0
+			} else {
+				m[i][j] = rng.Intn(10)
+			}
+		}
+	}
+	return m
+}
+
+func expectedRowMins(mat Matrix) []int {
+	n := len(mat)
+	res := make([]int, n)
+	for i := 0; i < n; i++ {
+		best := math.MaxInt32
+		for j := 0; j < n; j++ {
+			if i == j {
+				continue
+			}
+			if mat[i][j] < best {
+				best = mat[i][j]
+			}
+		}
+		res[i] = best
+	}
+	return res
+}
+
+func runCase(bin string, mat Matrix) error {
+	n := len(mat)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	w := bufio.NewWriter(stdin)
+	r := bufio.NewReader(stdout)
+	fmt.Fprintln(w, n)
+	w.Flush()
+	queries := 0
+	for {
+		var token string
+		if _, err := fmt.Fscan(r, &token); err != nil {
+			return fmt.Errorf("read error: %v stderr:%s", err, stderr.String())
+		}
+		if token == "?" {
+			queries++
+			if queries > 20 {
+				return fmt.Errorf("too many queries")
+			}
+			var k int
+			fmt.Fscan(r, &k)
+			idx := make([]int, k)
+			for i := 0; i < k; i++ {
+				fmt.Fscan(r, &idx[i])
+			}
+			res := make([]int, n)
+			for i := 0; i < n; i++ {
+				best := math.MaxInt32
+				for _, id := range idx {
+					id--
+					if mat[i][id] < best {
+						best = mat[i][id]
+					}
+				}
+				res[i] = best
+			}
+			for i := 0; i < n; i++ {
+				if i > 0 {
+					fmt.Fprint(w, " ")
+				}
+				fmt.Fprint(w, res[i])
+			}
+			fmt.Fprint(w, "\n")
+			w.Flush()
+		} else if token == "-1" {
+			ans := make([]int, n)
+			for i := 0; i < n; i++ {
+				fmt.Fscan(r, &ans[i])
+			}
+			expect := expectedRowMins(mat)
+			for i := 0; i < n; i++ {
+				if ans[i] != expect[i] {
+					return fmt.Errorf("row %d expected %d got %d", i+1, expect[i], ans[i])
+				}
+			}
+			stdin.Close()
+			if err := cmd.Wait(); err != nil {
+				return fmt.Errorf("runtime error: %v stderr:%s", err, stderr.String())
+			}
+			return nil
+		} else {
+			return fmt.Errorf("unexpected token %s", token)
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		mat := generateMatrix(rng)
+		if err := runCase(bin, mat); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/740-749/744/verifierC.go
+++ b/0-999/700-799/740-749/744/verifierC.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ r, b int }
+
+func bitsTrailing(v int) int {
+	for i := 0; i < 32; i++ {
+		if v>>i&1 == 1 {
+			return i
+		}
+	}
+	return 0
+}
+
+func prune(arr []pair) []pair {
+	for i := 1; i < len(arr); i++ {
+		j := i
+		for j > 0 && (arr[j].r > arr[j-1].r || (arr[j].r == arr[j-1].r && arr[j].b > arr[j-1].b)) {
+			arr[j], arr[j-1] = arr[j-1], arr[j]
+			j--
+		}
+	}
+	res := make([]pair, 0, len(arr))
+	maxB := -1
+	for _, p := range arr {
+		if p.b > maxB {
+			res = append(res, p)
+			maxB = p.b
+		}
+	}
+	return res
+}
+
+func can(t, n int, rreq, breq []int, isRed []bool, rcnt, bcnt []int, goal int) bool {
+	N := 1 << n
+	dp := make([][]pair, N)
+	dp[0] = []pair{{t, t}}
+	for mask := 0; mask < N; mask++ {
+		states := dp[mask]
+		if len(states) == 0 {
+			continue
+		}
+		dp[mask] = prune(states)
+		if mask == goal && len(dp[mask]) > 0 {
+			return true
+		}
+		A := rcnt[mask]
+		B := bcnt[mask]
+		for _, st := range dp[mask] {
+			rrem, brem := st.r, st.b
+			for i := 0; i < n; i++ {
+				bit := 1 << i
+				if mask&bit != 0 {
+					continue
+				}
+				needR := rreq[i] - A
+				if needR < 0 {
+					needR = 0
+				}
+				needB := breq[i] - B
+				if needB < 0 {
+					needB = 0
+				}
+				if rrem >= needR && brem >= needB {
+					nm := mask | bit
+					dp[nm] = append(dp[nm], pair{rrem - needR, brem - needB})
+				}
+			}
+		}
+	}
+	return len(dp[goal]) > 0
+}
+
+func solveC(n int, isRed []bool, rreq, breq []int) int {
+	N := 1 << n
+	rcnt := make([]int, N)
+	bcnt := make([]int, N)
+	for mask := 1; mask < N; mask++ {
+		lsb := mask & -mask
+		i := bitsTrailing(lsb)
+		prev := mask ^ lsb
+		if isRed[i] {
+			rcnt[mask] = rcnt[prev] + 1
+			bcnt[mask] = bcnt[prev]
+		} else {
+			bcnt[mask] = bcnt[prev] + 1
+			rcnt[mask] = rcnt[prev]
+		}
+	}
+	sumR, sumB := 0, 0
+	for i := 0; i < n; i++ {
+		sumR += rreq[i]
+		sumB += breq[i]
+	}
+	lo, hi := 0, sumR+sumB
+	goal := N - 1
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if can(mid, n, rreq, breq, isRed, rcnt, bcnt, goal) {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return lo + n
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(4) + 1
+	isRed := make([]bool, n)
+	rreq := make([]int, n)
+	breq := make([]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			isRed[i] = true
+			sb.WriteByte('R')
+		} else {
+			sb.WriteByte('B')
+		}
+		rreq[i] = rng.Intn(5)
+		breq[i] = rng.Intn(5)
+		fmt.Fprintf(&sb, " %d %d\n", rreq[i], breq[i])
+	}
+	ans := solveC(n, isRed, rreq, breq)
+	return sb.String(), ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		in, expect := genCase(rng)
+		outStr, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, in)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(outStr, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid output %q\n", t, outStr)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", t, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/740-749/744/verifierD.go
+++ b/0-999/700-799/740-749/744/verifierD.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Pt struct{ x, y float64 }
+
+func dist(a, b Pt) float64 { dx := a.x - b.x; dy := a.y - b.y; return math.Hypot(dx, dy) }
+
+func cross(a, b, c Pt) float64 { return (b.x-a.x)*(c.y-a.y) - (b.y-a.y)*(c.x-a.x) }
+
+func convexHull(pts []Pt) []Pt {
+	if len(pts) == 0 {
+		return nil
+	}
+	p := make([]Pt, len(pts))
+	copy(p, pts)
+	sort.Slice(p, func(i, j int) bool {
+		if p[i].x == p[j].x {
+			return p[i].y < p[j].y
+		}
+		return p[i].x < p[j].x
+	})
+	n := len(p)
+	hull := make([]Pt, 0, 2*n)
+	for i := 0; i < n; i++ {
+		for len(hull) >= 2 && cross(hull[len(hull)-2], hull[len(hull)-1], p[i]) <= 0 {
+			hull = hull[:len(hull)-1]
+		}
+		hull = append(hull, p[i])
+	}
+	l := len(hull)
+	for i := n - 2; i >= 0; i-- {
+		for len(hull) > l && cross(hull[len(hull)-2], hull[len(hull)-1], p[i]) <= 0 {
+			hull = hull[:len(hull)-1]
+		}
+		hull = append(hull, p[i])
+	}
+	if len(hull) > 1 {
+		hull = hull[:len(hull)-1]
+	}
+	return hull
+}
+
+func pointInPoly(poly []Pt, p Pt) bool {
+	n := len(poly)
+	if n == 0 {
+		return false
+	}
+	pos, neg := false, false
+	for i := 0; i < n; i++ {
+		a := poly[i]
+		b := poly[(i+1)%n]
+		val := cross(a, b, p)
+		if val > 0 {
+			pos = true
+		} else if val < 0 {
+			neg = true
+		}
+		if pos && neg {
+			return false
+		}
+	}
+	return true
+}
+
+func solveD(reds, blues []Pt) float64 {
+	if len(blues) < 3 {
+		return math.Inf(1)
+	}
+	hull := convexHull(blues)
+	for _, r := range reds {
+		if !pointInPoly(hull, r) {
+			return math.Inf(1)
+		}
+	}
+	best := 0.0
+	for _, r := range reds {
+		mind := math.Inf(1)
+		for _, b := range blues {
+			d := dist(r, b)
+			if d < mind {
+				mind = d
+			}
+		}
+		if mind > best {
+			best = mind
+		}
+	}
+	return best
+}
+
+func genCase(rng *rand.Rand) (string, float64) {
+	blues := []Pt{{0, 0}, {10, 0}, {0, 10}, {10, 10}}
+	n := rng.Intn(3) + 1
+	reds := make([]Pt, n)
+	for i := 0; i < n; i++ {
+		reds[i] = Pt{float64(rng.Intn(9) + 1), float64(rng.Intn(9) + 1)}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, len(blues))
+	for _, r := range reds {
+		fmt.Fprintf(&sb, "%.0f %.0f\n", r.x, r.y)
+	}
+	for _, b := range blues {
+		fmt.Fprintf(&sb, "%.0f %.0f\n", b.x, b.y)
+	}
+	ans := solveD(reds, blues)
+	if math.IsInf(ans, 1) {
+		return sb.String(), math.Inf(1)
+	}
+	return sb.String(), ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func equalFloat(a, b float64) bool { return math.Abs(a-b) <= 1e-4*math.Max(1, math.Abs(b)) }
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		in, expect := genCase(rng)
+		outStr, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, in)
+			os.Exit(1)
+		}
+		if math.IsInf(expect, 1) {
+			if strings.TrimSpace(outStr) != "-1" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected -1 got %s\ninput:\n%s", t, outStr, in)
+				os.Exit(1)
+			}
+		} else {
+			var got float64
+			if _, err := fmt.Sscan(outStr, &got); err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: bad output %q\n", t, outStr)
+				os.Exit(1)
+			}
+			if !equalFloat(got, expect) {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %.5f got %.5f\ninput:\n%s", t, expect, got, in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/740-749/744/verifierE.go
+++ b/0-999/700-799/740-749/744/verifierE.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveE(n int, arr []string) int {
+	maxLen := 0
+	for _, s := range arr {
+		if len(s) > maxLen {
+			maxLen = len(s)
+		}
+	}
+	maxH := maxLen * 2
+	pow := make([]uint64, maxH+1)
+	const B uint64 = 1315423911
+	pow[0] = 1
+	for i := 1; i <= maxH; i++ {
+		pow[i] = pow[i-1] * B
+	}
+	ans := 0
+	for l := 0; l < n; l++ {
+		wordSet := make(map[string]struct{})
+		lengths := make(map[int]struct{})
+		localMax := 0
+		for r := l; r < n; r++ {
+			w := arr[r]
+			wordSet[w] = struct{}{}
+			L := len(w)
+			lengths[L] = struct{}{}
+			if L > localMax {
+				localMax = L
+			}
+			Ls := make([]int, 0, len(lengths))
+			for x := range lengths {
+				Ls = append(Ls, x)
+			}
+			hashMap := make(map[int]map[uint64]struct{})
+			for s := range wordSet {
+				var h uint64
+				for i := 0; i < len(s); i++ {
+					h = h*B + uint64(s[i])
+				}
+				l0 := len(s)
+				m0, ok := hashMap[l0]
+				if !ok {
+					m0 = make(map[uint64]struct{})
+					hashMap[l0] = m0
+				}
+				m0[h] = struct{}{}
+			}
+			stable := true
+			for x := range wordSet {
+				if !stable {
+					break
+				}
+				for y := range wordSet {
+					if !stable {
+						break
+					}
+					S := x + y
+					tot := len(S)
+					hpre := make([]uint64, tot+1)
+					for i := 0; i < tot; i++ {
+						hpre[i+1] = hpre[i]*B + uint64(S[i])
+					}
+					dpP := make([]bool, tot+1)
+					dpE := make([]bool, tot+1)
+					dpP[0] = true
+					for i := 0; i < tot; i++ {
+						if !dpP[i] {
+							continue
+						}
+						for _, L := range Ls {
+							j := i + L
+							if j <= tot {
+								h := hpre[j] - hpre[i]*pow[L]
+								if m0, ok := hashMap[L]; ok {
+									if _, ok2 := m0[h]; ok2 {
+										dpP[j] = true
+									}
+								}
+							}
+						}
+					}
+					dpE[tot] = true
+					for i := tot - 1; i >= 0; i-- {
+						for _, L := range Ls {
+							j := i + L
+							if j <= tot && dpE[j] {
+								h := hpre[j] - hpre[i]*pow[L]
+								if m0, ok := hashMap[L]; ok {
+									if _, ok2 := m0[h]; ok2 {
+										dpE[i] = true
+										break
+									}
+								}
+							}
+						}
+					}
+					lx := len(x)
+					for sft := 1; sft < tot; sft++ {
+						if sft == lx {
+							continue
+						}
+						if dpP[sft] && dpE[sft] {
+							stable = false
+							break
+						}
+					}
+				}
+			}
+			if stable {
+				ans++
+			}
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(3) + 1
+	arr := make([]string, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(3) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('a' + rng.Intn(3))
+		}
+		arr[i] = string(b)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		sb.WriteString(arr[i])
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	ans := solveE(n, arr)
+	return sb.String(), ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		in, expect := genCase(rng)
+		outStr, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, in)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(outStr, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output %q\n", t, outStr)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", t, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new Go verifiers for contest 744 problems A-E
- each verifier generates random cases and checks program output

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68839846fbb08324bc8db48b60637ab7