### PR TITLE
Add Go solution for 1951C

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1951/1951C.go
+++ b/1000-1999/1900-1999/1950-1959/1951/1951C.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var m, k int64
+		fmt.Fscan(reader, &n, &m, &k)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		// indices sorted by price
+		idx := make([]int, n)
+		for i := range idx {
+			idx[i] = i
+		}
+		sort.Slice(idx, func(i, j int) bool { return a[idx[i]] < a[idx[j]] })
+
+		x := make([]int64, n)
+		left := k
+		for _, id := range idx {
+			if left == 0 {
+				break
+			}
+			take := m
+			if left < take {
+				take = left
+			}
+			x[id] = take
+			left -= take
+		}
+		var prefix, ans int64
+		for i := 0; i < n; i++ {
+			ans += x[i] * (int64(a[i]) + prefix)
+			prefix += x[i]
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution `1951C.go` implementing greedy approach

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1951/1951C.go`
- `echo -e "1\n4 2 3\n6 4 2 3\n" | go run 1000-1999/1900-1999/1950-1959/1951/1951C.go`

------
https://chatgpt.com/codex/tasks/task_e_6883942c9d64832487d69df4954085f9