### PR TITLE
Add Go verifiers for contest 735

### DIFF
--- a/0-999/700-799/730-739/735/verifierA.go
+++ b/0-999/700-799/730-739/735/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// solveA implements the reference solution for problem A.
+func solveA(n, k int, s string) string {
+	posG, posT := -1, -1
+	for i, ch := range s {
+		switch ch {
+		case 'G':
+			posG = i
+		case 'T':
+			posT = i
+		}
+	}
+	if (posT-posG)%k != 0 {
+		return "NO"
+	}
+	step := k
+	if posT < posG {
+		step = -k
+	}
+	for cur := posG; ; cur += step {
+		if s[cur] == '#' {
+			return "NO"
+		}
+		if cur == posT {
+			return "YES"
+		}
+	}
+}
+
+// genTestA generates a random test case.
+func genTestA() (int, int, string) {
+	n := rand.Intn(99) + 2  // 2..100
+	k := rand.Intn(n-1) + 1 // 1..n-1
+	arr := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rand.Intn(3) == 0 {
+			arr[i] = '#'
+		} else {
+			arr[i] = '.'
+		}
+	}
+	g := rand.Intn(n)
+	t := rand.Intn(n)
+	for t == g {
+		t = rand.Intn(n)
+	}
+	arr[g] = 'G'
+	arr[t] = 'T'
+	return n, k, string(arr)
+}
+
+func runBinary(path string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(time.Now().UnixNano())
+	path := os.Args[1]
+	for i := 0; i < 100; i++ {
+		n, k, s := genTestA()
+		input := fmt.Sprintf("%d %d\n%s\n", n, k, s)
+		expected := solveA(n, k, s)
+		got, err := runBinary(path, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\ninput:\n%s\n", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/735/verifierB.go
+++ b/0-999/700-799/730-739/735/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveB(n, n1, n2 int, a []int) float64 {
+	tmp := append([]int(nil), a...)
+	sort.Ints(tmp)
+	t := n1
+	if n2 < t {
+		t = n2
+	}
+	sum1 := 0
+	for i := n - t; i < n; i++ {
+		sum1 += tmp[i]
+	}
+	avg1 := float64(sum1) / float64(t)
+	t1 := n1
+	if n2 > t1 {
+		t1 = n2
+	}
+	sum2 := 0
+	for i := n - t - t1; i < n-t; i++ {
+		sum2 += tmp[i]
+	}
+	avg2 := float64(sum2) / float64(t1)
+	return avg1 + avg2
+}
+
+func genTestB() (int, int, int, []int) {
+	n := rand.Intn(40) + 2 // 2..41
+	n1 := rand.Intn(n-1) + 1
+	n2 := rand.Intn(n-n1) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(100000) + 1
+	}
+	return n, n1, n2, a
+}
+
+func runBinary(path string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(time.Now().UnixNano())
+	path := os.Args[1]
+	for i := 0; i < 100; i++ {
+		n, n1, n2, a := genTestB()
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d %d %d\n", n, n1, n2)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", a[j])
+		}
+		b.WriteByte('\n')
+		input := b.String()
+		expected := solveB(n, n1, n2, a)
+		gotStr, err := runBinary(path, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\ninput:\n%s\n", i+1, err, input)
+			os.Exit(1)
+		}
+		var got float64
+		_, err = fmt.Sscanf(gotStr, "%f", &got)
+		if err != nil {
+			fmt.Printf("test %d: parse output error: %v\ninput:\n%s\noutput:%s\n", i+1, err, input, gotStr)
+			os.Exit(1)
+		}
+		if diff := got - expected; diff < -1e-6 || diff > 1e-6 {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected: %.6f\ngot: %s\n", i+1, input, expected, gotStr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/735/verifierC.go
+++ b/0-999/700-799/730-739/735/verifierC.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(n uint64) uint64 {
+	l0, l1 := uint64(1), uint64(2)
+	h := uint64(1)
+	for l1 <= n {
+		h++
+		l0, l1 = l1, l0+l1
+	}
+	return h - 1
+}
+
+func genTestC() uint64 {
+	return uint64(rand.Int63n(1e18-1)) + 2
+}
+
+func runBinary(path string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(time.Now().UnixNano())
+	path := os.Args[1]
+	for i := 0; i < 100; i++ {
+		n := genTestC()
+		input := fmt.Sprintf("%d\n", n)
+		expected := solveC(n)
+		gotStr, err := runBinary(path, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got uint64
+		_, err = fmt.Sscanf(gotStr, "%d", &got)
+		if err != nil {
+			fmt.Printf("test %d: parse output error: %v\ninput:%soutput:%s\n", i+1, err, input, gotStr)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:%sexpected:%d\ngot:%d\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/735/verifierD.go
+++ b/0-999/700-799/730-739/735/verifierD.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isPrime(n uint64) bool {
+	if n < 2 {
+		return false
+	}
+	small := []uint64{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37}
+	for _, p := range small {
+		if n%p == 0 {
+			return n == p
+		}
+	}
+	d := n - 1
+	s := 0
+	for d&1 == 0 {
+		d >>= 1
+		s++
+	}
+	bases := []uint64{2, 7, 61}
+	for _, a := range bases {
+		if a >= n {
+			continue
+		}
+		if !millerTest(a, d, s, n) {
+			return false
+		}
+	}
+	return true
+}
+
+func millerTest(a, d uint64, s int, n uint64) bool {
+	x := modPow(a, d, n)
+	if x == 1 || x == n-1 {
+		return true
+	}
+	for i := 1; i < s; i++ {
+		x = mulMod(x, x, n)
+		if x == n-1 {
+			return true
+		}
+	}
+	return false
+}
+
+func modPow(a, e, m uint64) uint64 {
+	res := uint64(1)
+	a %= m
+	for e > 0 {
+		if e&1 == 1 {
+			res = mulMod(res, a, m)
+		}
+		a = mulMod(a, a, m)
+		e >>= 1
+	}
+	return res
+}
+
+func mulMod(a, b, mod uint64) uint64 {
+	return (a * b) % mod
+}
+
+func solveD(n uint64) int {
+	if isPrime(n) {
+		return 1
+	}
+	if n%2 == 0 {
+		return 2
+	}
+	if isPrime(n - 2) {
+		return 2
+	}
+	return 3
+}
+
+func genTestD() uint64 {
+	return uint64(rand.Int63n(2_000_000_000-1)) + 2
+}
+
+func runBinary(path string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(time.Now().UnixNano())
+	path := os.Args[1]
+	for i := 0; i < 100; i++ {
+		n := genTestD()
+		input := fmt.Sprintf("%d\n", n)
+		expected := solveD(n)
+		gotStr, err := runBinary(path, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got int
+		_, err = fmt.Sscanf(gotStr, "%d", &got)
+		if err != nil {
+			fmt.Printf("test %d: parse output error: %v\ninput:%soutput:%s\n", i+1, err, input, gotStr)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:%sexpected:%d\ngot:%d\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/735/verifierE.go
+++ b/0-999/700-799/730-739/735/verifierE.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+type edge struct{ u, v int }
+
+func add(a, b int) int {
+	a += b
+	if a >= MOD {
+		a -= MOD
+	}
+	return a
+}
+func mul(a, b int) int { return int((int64(a) * int64(b)) % MOD) }
+
+func solveE(n, k int, edges []edge) int {
+	g := make([][]int, n)
+	for _, e := range edges {
+		g[e.u] = append(g[e.u], e.v)
+		g[e.v] = append(g[e.v], e.u)
+	}
+	dp := make([][]int, n)
+	var dfs func(int, int)
+	dfs = func(v, p int) {
+		dp[v] = make([]int, k+2)
+		dp0 := make([]int, k+2)
+		dp0[k+1] = 1
+		prodAll := 1
+		for _, u := range g[v] {
+			if u == p {
+				continue
+			}
+			dfs(u, v)
+			new0 := make([]int, k+2)
+			for d0 := 0; d0 <= k+1; d0++ {
+				if dp0[d0] == 0 {
+					continue
+				}
+				for du := 0; du <= k+1; du++ {
+					if dp[u][du] == 0 {
+						continue
+					}
+					nd := du + 1
+					if nd > k+1 {
+						nd = k + 1
+					}
+					d := d0
+					if nd < d {
+						d = nd
+					}
+					new0[d] = (new0[d] + dp0[d0]*dp[u][du]) % MOD
+				}
+			}
+			dp0 = new0
+			s := 0
+			for du := 0; du <= k+1; du++ {
+				s = (s + dp[u][du]) % MOD
+			}
+			prodAll = prodAll * s % MOD
+		}
+		dp[v][0] = prodAll
+		for d := 0; d <= k+1; d++ {
+			dp[v][d] = add(dp[v][d], dp0[d])
+		}
+	}
+	dfs(0, -1)
+	res := 0
+	for d := 0; d <= k; d++ {
+		res = add(res, dp[0][d])
+	}
+	return res
+}
+
+func genTestE() (int, int, []edge) {
+	n := rand.Intn(10) + 1
+	k := rand.Intn(min(20, n-1) + 1)
+	edges := make([]edge, 0, n-1)
+	for i := 1; i < n; i++ {
+		p := rand.Intn(i)
+		edges = append(edges, edge{p, i})
+	}
+	return n, k, edges
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func runBinary(path string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	rand.Seed(time.Now().UnixNano())
+	path := os.Args[1]
+	for i := 0; i < 100; i++ {
+		n, k, edges := genTestE()
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d %d\n", n, k)
+		for _, e := range edges {
+			fmt.Fprintf(&b, "%d %d\n", e.u+1, e.v+1)
+		}
+		input := b.String()
+		expected := solveE(n, k, edges)
+		gotStr, err := runBinary(path, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got int
+		_, err = fmt.Sscanf(gotStr, "%d", &got)
+		if err != nil {
+			fmt.Printf("test %d: parse output error: %v\ninput:\n%soutput:%s\n", i+1, err, input, gotStr)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%d\ngot:%d\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E

Each verifier runs 100 random tests against a provided binary and checks the output using an embedded reference solution.

## Testing
- `go build 0-999/700-799/730-739/735/verifierA.go`
- `go build 0-999/700-799/730-739/735/verifierB.go`
- `go build 0-999/700-799/730-739/735/verifierC.go`
- `go build 0-999/700-799/730-739/735/verifierD.go`
- `go build 0-999/700-799/730-739/735/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_6883935a3a908324aed0a4107e91fddf