### PR TITLE
Add Go solution for 1951D Buying Jewels

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1951/1951D.go
+++ b/1000-1999/1900-1999/1950-1959/1951/1951D.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var n, k int64
+		fmt.Fscan(in, &n, &k)
+
+		if k > n {
+			fmt.Fprintln(out, "NO")
+			continue
+		}
+		if k == n {
+			fmt.Fprintln(out, "YES")
+			fmt.Fprintln(out, 1)
+			fmt.Fprintln(out, 1)
+			continue
+		}
+		if k <= (n+1)/2 {
+			fmt.Fprintln(out, "YES")
+			fmt.Fprintln(out, 2)
+			fmt.Fprintln(out, n-k+1, 1)
+			continue
+		}
+		fmt.Fprintln(out, "NO")
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem D in contest 1951

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1951/1951D.go`

------
https://chatgpt.com/codex/tasks/task_e_688393140f7883248a3267fec9e439fe