### PR TITLE
Add Go verifiers for Codeforces round 734

### DIFF
--- a/0-999/700-799/730-739/734/verifierA.go
+++ b/0-999/700-799/730-739/734/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedResult(s string) string {
+	a := 0
+	d := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == 'A' {
+			a++
+		} else if s[i] == 'D' {
+			d++
+		}
+	}
+	switch {
+	case a > d:
+		return "Anton"
+	case d > a:
+		return "Danik"
+	default:
+		return "Friendship"
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b.WriteByte('A')
+		} else {
+			b.WriteByte('D')
+		}
+	}
+	s := b.String()
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	exp := expectedResult(s)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/734/verifierB.go
+++ b/0-999/700-799/730-739/734/verifierB.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedResult(k2, k3, k5, k6 int64) string {
+	min := func(a, b int64) int64 {
+		if a < b {
+			return a
+		}
+		return b
+	}
+	x := min(k2, min(k5, k6))
+	k2 -= x
+	y := min(k2, k3)
+	res := x*256 + y*32
+	return fmt.Sprint(res)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	k2 := rng.Int63n(50)
+	k3 := rng.Int63n(50)
+	k5 := rng.Int63n(50)
+	k6 := rng.Int63n(50)
+	input := fmt.Sprintf("%d %d %d %d\n", k2, k3, k5, k6)
+	exp := expectedResult(k2, k3, k5, k6)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/734/verifierC.go
+++ b/0-999/700-799/730-739/734/verifierC.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, m, k int, x, s int64, a, b, c, d []int64) string {
+	ans := int64(n) * x
+	for i := 0; i <= m; i++ {
+		cost1 := b[i]
+		if cost1 > s {
+			continue
+		}
+		rem := s - cost1
+		idx := sort.Search(len(d), func(j int) bool { return d[j] > rem })
+		j := idx - 1
+		if j < 0 {
+			j = 0
+		}
+		need := int64(n) - c[j]
+		if need < 0 {
+			need = 0
+		}
+		t := need * a[i]
+		if t < ans {
+			ans = t
+		}
+	}
+	return fmt.Sprint(ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(5) + 1
+	k := rng.Intn(5) + 1
+	x := int64(rng.Intn(20) + 2)
+	s := int64(rng.Intn(100) + 1)
+
+	a := make([]int64, m+1)
+	b := make([]int64, m+1)
+	a[0] = x
+	b[0] = 0
+	for i := 1; i <= m; i++ {
+		a[i] = int64(rng.Intn(int(x-1)) + 1)
+	}
+	for i := 1; i <= m; i++ {
+		b[i] = int64(rng.Intn(100) + 1)
+	}
+
+	c := make([]int64, k+1)
+	d := make([]int64, k+1)
+	c[0] = 0
+	d[0] = 0
+	curC := int64(0)
+	curD := int64(0)
+	for i := 1; i <= k; i++ {
+		curC += int64(rng.Intn(n) + 1)
+		if curC > int64(n) {
+			curC = int64(n)
+		}
+		c[i] = curC
+	}
+	for i := 1; i <= k; i++ {
+		curD += int64(rng.Intn(100) + 1)
+		d[i] = curD
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	sb.WriteString(fmt.Sprintf("%d %d\n", x, s))
+	for i := 1; i <= m; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= m; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(b[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= k; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(c[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= k; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(d[i]))
+	}
+	sb.WriteByte('\n')
+
+	input := sb.String()
+	exp := expected(n, m, k, x, s, a, b, c, d)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/734/verifierD.go
+++ b/0-999/700-799/730-739/734/verifierD.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const INF = int64(1 << 62)
+
+func expected(n int, x0, y0 int64, types []byte, xs, ys []int64) string {
+	dist := [8]int64{INF, INF, INF, INF, INF, INF, INF, INF}
+	piece := [8]byte{}
+	abs := func(v int64) int64 {
+		if v < 0 {
+			return -v
+		}
+		return v
+	}
+	for i := 0; i < n; i++ {
+		dx := xs[i] - x0
+		dy := ys[i] - y0
+		dir := -1
+		var d int64
+		if dx == 0 {
+			if dy > 0 {
+				dir, d = 0, dy
+			} else if dy < 0 {
+				dir, d = 4, -dy
+			}
+		} else if dy == 0 {
+			if dx > 0 {
+				dir, d = 2, dx
+			} else if dx < 0 {
+				dir, d = 6, -dx
+			}
+		} else if abs(dx) == abs(dy) {
+			switch {
+			case dx > 0 && dy > 0:
+				dir, d = 1, dx
+			case dx > 0 && dy < 0:
+				dir, d = 3, dx
+			case dx < 0 && dy < 0:
+				dir, d = 5, -dx
+			case dx < 0 && dy > 0:
+				dir, d = 7, -dx
+			}
+		}
+		if dir >= 0 && d < dist[dir] {
+			dist[dir] = d
+			piece[dir] = types[i]
+		}
+	}
+	for dir, t := range piece {
+		if t == 0 {
+			continue
+		}
+		if dir%2 == 0 {
+			if t == 'R' || t == 'Q' {
+				return "YES"
+			}
+		} else {
+			if t == 'B' || t == 'Q' {
+				return "YES"
+			}
+		}
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	x0 := int64(rng.Intn(11) - 5)
+	y0 := int64(rng.Intn(11) - 5)
+	types := make([]byte, n)
+	xs := make([]int64, n)
+	ys := make([]int64, n)
+	for i := 0; i < n; i++ {
+		types[i] = []byte{'B', 'R', 'Q'}[rng.Intn(3)]
+		for {
+			x := int64(rng.Intn(11) - 5)
+			y := int64(rng.Intn(11) - 5)
+			if x != x0 || y != y0 {
+				xs[i] = x
+				ys[i] = y
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	sb.WriteString(fmt.Sprintf("%d %d\n", x0, y0))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%c %d %d\n", types[i], xs[i], ys[i]))
+	}
+	input := sb.String()
+	exp := expected(n, x0, y0, types, xs, ys)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/734/verifierE.go
+++ b/0-999/700-799/730-739/734/verifierE.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int, colors []int, edges [][2]int) string {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	visited := make([]bool, n)
+	comp := [2]int{}
+	stack := make([]int, 0, n)
+	for target := 0; target <= 1; target++ {
+		for i := 0; i < n; i++ {
+			visited[i] = false
+		}
+		for i := 0; i < n; i++ {
+			if !visited[i] && colors[i] == target {
+				comp[target]++
+				stack = stack[:0]
+				stack = append(stack, i)
+				visited[i] = true
+				for len(stack) > 0 {
+					u := stack[len(stack)-1]
+					stack = stack[:len(stack)-1]
+					for _, v := range adj[u] {
+						if !visited[v] && colors[v] == target {
+							visited[v] = true
+							stack = append(stack, v)
+						}
+					}
+				}
+			}
+		}
+	}
+	ans := comp[0]
+	if comp[1] < ans {
+		ans = comp[1]
+	}
+	return fmt.Sprint(ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	colors := make([]int, n)
+	for i := range colors {
+		colors[i] = rng.Intn(2)
+	}
+	edges := make([][2]int, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges[i-1] = [2]int{i, p}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, c := range colors {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(c))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+	}
+	input := sb.String()
+	exp := expected(n, colors, edges)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/730-739/734/verifierF.go
+++ b/0-999/700-799/730-739/734/verifierF.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(b, c []int64) string {
+	n := len(b)
+	var sum int64
+	for i := 0; i < n; i++ {
+		sum += b[i] + c[i]
+	}
+	denom := int64(2 * n)
+	if sum%denom != 0 {
+		return "-1"
+	}
+	S := sum / denom
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		tmp := b[i] + c[i] - S
+		if tmp%int64(n) != 0 {
+			return "-1"
+		}
+		ai := tmp / int64(n)
+		if ai < 0 {
+			return "-1"
+		}
+		a[i] = ai
+	}
+	const maxbit = 31
+	cnt := make([]int64, maxbit+1)
+	for _, ai := range a {
+		for k := 0; k <= maxbit; k++ {
+			if (ai>>k)&1 == 1 {
+				cnt[k]++
+			}
+		}
+	}
+	for i, ai := range a {
+		var b2, c2 int64
+		for k := 0; k <= maxbit; k++ {
+			bit := int64(1) << k
+			if (ai>>k)&1 == 1 {
+				b2 += cnt[k] * bit
+				c2 += int64(n) * bit
+			} else {
+				c2 += cnt[k] * bit
+			}
+		}
+		if b2 != b[i] || c2 != c[i] {
+			return "-1"
+		}
+	}
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func generateValidCase(rng *rand.Rand) (int, []int64, []int64, string) {
+	n := rng.Intn(5) + 1
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = int64(rng.Intn(10))
+	}
+	const maxbit = 31
+	cnt := make([]int64, maxbit+1)
+	for _, ai := range a {
+		for k := 0; k <= maxbit; k++ {
+			if (ai>>k)&1 == 1 {
+				cnt[k]++
+			}
+		}
+	}
+	b := make([]int64, n)
+	c := make([]int64, n)
+	for i, ai := range a {
+		var bi, ci int64
+		for k := 0; k <= maxbit; k++ {
+			bit := int64(1) << k
+			if (ai>>k)&1 == 1 {
+				bi += cnt[k] * bit
+				ci += int64(n) * bit
+			} else {
+				ci += cnt[k] * bit
+			}
+		}
+		b[i] = bi
+		c[i] = ci
+	}
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	expect := sb.String()
+	return n, b, c, expect
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	if rng.Float64() < 0.6 {
+		n, b, c, expect := generateValidCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range b {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		for i, v := range c {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		return input, expect
+	}
+	n := rng.Intn(5) + 1
+	b := make([]int64, n)
+	c := make([]int64, n)
+	for i := 0; i < n; i++ {
+		b[i] = int64(rng.Intn(50))
+		c[i] = int64(rng.Intn(50))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range c {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	exp := expected(b, c)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- provide verifierA-F for contest 734
- each verifier generates 100 random tests and checks any binary

## Testing
- `go build verifierA.go` etc
- `go run verifierA.go ./candidateA`

------
https://chatgpt.com/codex/tasks/task_e_688392cf0a3483248b47755b7e755da4