### PR TITLE
Add configurable HTTP timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Several helper tools live in the repository root:
 - `auto_so.go` – generate Go solutions from problem statements with Codex.
 - `webserver.go` – simple HTTP server for browsing problems and submitting solutions locally.
 - Extra programs like `brute.go` or `probe.go` are helper utilities.
+- `eval.go` – evaluate AI-generated solutions. Supports flags like `-model`,
+  `-provider`, `-db` and `-timeout` to control the HTTP request timeout.
 
 All Go utilities build with the standard tooling. Example:
 

--- a/eval.go
+++ b/eval.go
@@ -47,12 +47,16 @@ type Problem struct {
 	Statement string
 }
 
+var requestTimeout time.Duration
+
 func main() {
 	model := flag.String("model", "", "The AI model to use (e.g., anthropic/claude-3.5-sonnet)")
 	provider := flag.String("provider", "openrouter", "Model provider: Gemini, OpenAI, xai, Claude, openrouter")
 	dbDSN := flag.String("db", "user:pass@tcp(127.0.0.1:3306)/dbname", "Database DSN")
 	maxAttempts := flag.Int("max-attempts", 1, "Maximum attempts to fix syntax errors (1-5)")
+	httpTimeout := flag.Duration("timeout", 30*time.Second, "HTTP request timeout")
 	flag.Parse()
+	requestTimeout = *httpTimeout
 
 	if *maxAttempts < 1 || *maxAttempts > 5 {
 		fmt.Println("max-attempts must be between 1 and 5")
@@ -465,7 +469,7 @@ func sendPrompt(provider, model, apiKey, prompt string) string {
 		return ""
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{Timeout: requestTimeout}
 	url := ""
 	headers := map[string]string{"Content-Type": "application/json"}
 


### PR DESCRIPTION
## Summary
- add `-timeout` flag to `eval.go` to control request timeout
- document `eval.go` utility and new flag in README

## Testing
- `go build eval.go` *(fails: go.mod file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839c78cc9c83248dfa3c0a971e6733