### PR TITLE
Add verifiers for contest 777

### DIFF
--- a/0-999/700-799/770-779/777/verifierA.go
+++ b/0-999/700-799/770-779/777/verifierA.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int64
+	x int
+}
+
+func simulate(start int, steps int64) int {
+	pos := start
+	for i := int64(0); i < steps; i++ {
+		if i%2 == 0 {
+			if pos == 0 {
+				pos = 1
+			} else if pos == 1 {
+				pos = 0
+			}
+		} else {
+			if pos == 1 {
+				pos = 2
+			} else if pos == 2 {
+				pos = 1
+			}
+		}
+	}
+	return pos
+}
+
+func expected(n int64, x int) int {
+	steps := n % 6
+	for start := 0; start < 3; start++ {
+		if simulate(start, steps) == x {
+			return start
+		}
+	}
+	return -1
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildInput(tc testCase) string {
+	return fmt.Sprintf("%d\n%d\n", tc.n, tc.x)
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 120)
+	for n := int64(0); n <= 6; n++ {
+		for x := 0; x < 3; x++ {
+			cases = append(cases, testCase{n: n, x: x})
+		}
+	}
+	for len(cases) < 120 {
+		n := rng.Int63n(2_000_000_000) + 1
+		x := rng.Intn(3)
+		cases = append(cases, testCase{n: n, x: x})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		input := buildInput(tc)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		exp := strconv.Itoa(expected(tc.n, tc.x))
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/770-779/777/verifierB.go
+++ b/0-999/700-799/770-779/777/verifierB.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n    int
+	sher string
+	mor  string
+}
+
+func solve(n int, sher, mor string) (int, int) {
+	freq1 := [10]int{}
+	freq2 := [10]int{}
+	for i := 0; i < n; i++ {
+		d := mor[i] - '0'
+		freq1[d]++
+		freq2[d]++
+	}
+	minFlicks := 0
+	for i := 0; i < n; i++ {
+		d := int(sher[i] - '0')
+		j := d
+		for j < 10 && freq1[j] == 0 {
+			j++
+		}
+		if j < 10 {
+			freq1[j]--
+		} else {
+			minFlicks++
+			for k := 0; k < 10; k++ {
+				if freq1[k] > 0 {
+					freq1[k]--
+					break
+				}
+			}
+		}
+	}
+	maxSher := 0
+	for i := 0; i < n; i++ {
+		d := int(sher[i] - '0')
+		j := d + 1
+		for j < 10 && freq2[j] == 0 {
+			j++
+		}
+		if j < 10 {
+			freq2[j]--
+			maxSher++
+		} else {
+			for k := 0; k < 10; k++ {
+				if freq2[k] > 0 {
+					freq2[k]--
+					break
+				}
+			}
+		}
+	}
+	return minFlicks, maxSher
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildInput(tc testCase) string {
+	return fmt.Sprintf("%d\n%s\n%s\n", tc.n, tc.sher, tc.mor)
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{1, "0", "0"},
+		{2, "01", "10"},
+		{3, "123", "321"},
+	}
+	for len(cases) < 120 {
+		n := rng.Intn(20) + 1
+		b1 := make([]byte, n)
+		b2 := make([]byte, n)
+		for i := 0; i < n; i++ {
+			b1[i] = byte('0' + rng.Intn(10))
+			b2[i] = byte('0' + rng.Intn(10))
+		}
+		cases = append(cases, testCase{n: n, sher: string(b1), mor: string(b2)})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		input := buildInput(tc)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		minF, maxS := solve(tc.n, tc.sher, tc.mor)
+		exp := fmt.Sprintf("%d\n%d", minF, maxS)
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/770-779/777/verifierC.go
+++ b/0-999/700-799/770-779/777/verifierC.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m    int
+	grid    [][]int
+	k       int
+	queries [][2]int
+}
+
+func solve(tc testCase) []string {
+	n, m := tc.n, tc.m
+	a := tc.grid
+	up := make([]int, m)
+	rowMin := make([]int, n)
+	for i := 0; i < n; i++ {
+		minVal := i
+		if i == 0 {
+			for j := 0; j < m; j++ {
+				up[j] = 0
+			}
+			minVal = 0
+		} else {
+			for j := 0; j < m; j++ {
+				if a[i][j] < a[i-1][j] {
+					up[j] = i
+				}
+				if up[j] < minVal {
+					minVal = up[j]
+				}
+			}
+		}
+		if i == 0 {
+			minVal = 0
+		}
+		rowMin[i] = minVal
+	}
+	res := make([]string, len(tc.queries))
+	for idx, q := range tc.queries {
+		l := q[0] - 1
+		r := q[1] - 1
+		if rowMin[r] <= l {
+			res[idx] = "Yes"
+		} else {
+			res[idx] = "No"
+		}
+	}
+	return res
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for i := 0; i < tc.n; i++ {
+		for j := 0; j < tc.m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(tc.grid[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", tc.k))
+	for _, q := range tc.queries {
+		sb.WriteString(fmt.Sprintf("%d %d\n", q[0], q[1]))
+	}
+	return sb.String()
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 110)
+	for i := 0; i < 110; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		grid := make([][]int, n)
+		for r := 0; r < n; r++ {
+			grid[r] = make([]int, m)
+			for c := 0; c < m; c++ {
+				grid[r][c] = rng.Intn(20)
+			}
+		}
+		k := rng.Intn(n) + 1
+		queries := make([][2]int, k)
+		for j := 0; j < k; j++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			queries[j] = [2]int{l, r}
+		}
+		cases = append(cases, testCase{n: n, m: m, grid: grid, k: k, queries: queries})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		input := buildInput(tc)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		expRes := solve(tc)
+		exp := strings.Join(expRes, "\n")
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/770-779/777/verifierD.go
+++ b/0-999/700-799/770-779/777/verifierD.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	hashtags []string
+}
+
+func solve(tc testCase) []string {
+	n := len(tc.hashtags)
+	hashtags := make([]string, n)
+	copy(hashtags, tc.hashtags)
+	for i := n - 2; i >= 0; i-- {
+		a := hashtags[i]
+		b := hashtags[i+1]
+		la, lb := len(a), len(b)
+		j := 1
+		for j < la && j < lb && a[j] == b[j] {
+			j++
+		}
+		if j == la {
+			continue
+		}
+		if j == lb {
+			hashtags[i] = a[:lb]
+			continue
+		}
+		if a[j] > b[j] {
+			hashtags[i] = a[:j]
+		}
+	}
+	return hashtags
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.hashtags)))
+	for _, s := range tc.hashtags {
+		sb.WriteString(s)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 110)
+	for i := 0; i < 110; i++ {
+		n := rng.Intn(8) + 1
+		h := make([]string, n)
+		for j := 0; j < n; j++ {
+			l := rng.Intn(6) + 1
+			b := make([]byte, l)
+			for k := 0; k < l; k++ {
+				b[k] = byte('a' + rng.Intn(26))
+			}
+			h[j] = "#" + string(b)
+		}
+		cases = append(cases, testCase{hashtags: h})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		input := buildInput(tc)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		expArr := solve(tc)
+		exp := strings.Join(expArr, "\n")
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/700-799/770-779/777/verifierE.go
+++ b/0-999/700-799/770-779/777/verifierE.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type ring struct {
+	a, b int
+	h    int
+}
+
+type testCase struct {
+	rings []ring
+}
+
+// Fenwick tree for prefix maximum
+type bit struct {
+	n    int
+	tree []int64
+}
+
+func newBIT(n int) *bit {
+	return &bit{n: n, tree: make([]int64, n+2)}
+}
+
+func (b *bit) update(i int, val int64) {
+	for i <= b.n {
+		if val > b.tree[i] {
+			b.tree[i] = val
+		}
+		i += i & -i
+	}
+}
+
+func (b *bit) query(i int) int64 {
+	var res int64
+	for i > 0 {
+		if b.tree[i] > res {
+			res = b.tree[i]
+		}
+		i -= i & -i
+	}
+	return res
+}
+
+func solve(tc testCase) int64 {
+	rings := make([]ring, len(tc.rings))
+	copy(rings, tc.rings)
+	sort.Slice(rings, func(i, j int) bool {
+		if rings[i].b == rings[j].b {
+			return rings[i].a > rings[j].a
+		}
+		return rings[i].b > rings[j].b
+	})
+	bVals := make([]int, len(rings))
+	for i := range rings {
+		bVals[i] = rings[i].b
+	}
+	sort.Ints(bVals)
+	uniq := make([]int, 0, len(bVals))
+	for i := len(bVals) - 1; i >= 0; i-- {
+		if i == len(bVals)-1 || bVals[i] != bVals[i+1] {
+			uniq = append(uniq, bVals[i])
+		}
+	}
+	idxMap := make(map[int]int)
+	for i, v := range uniq {
+		idxMap[v] = i
+	}
+	bt := newBIT(len(uniq))
+	var ans int64
+	for _, r := range rings {
+		pos := sort.Search(len(uniq), func(i int) bool { return uniq[i] <= r.a })
+		var best int64
+		if pos > 0 {
+			best = bt.query(pos)
+		}
+		cur := int64(r.h) + best
+		bt.update(idxMap[r.b]+1, cur)
+		if cur > ans {
+			ans = cur
+		}
+	}
+	return ans
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.rings)))
+	for _, r := range tc.rings {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", r.a, r.b, r.h))
+	}
+	return sb.String()
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 110)
+	for i := 0; i < 110; i++ {
+		n := rng.Intn(8) + 1
+		arr := make([]ring, n)
+		for j := 0; j < n; j++ {
+			a := rng.Intn(50) + 1
+			b := a + rng.Intn(50) + 1
+			h := rng.Intn(50) + 1
+			arr[j] = ring{a: a, b: b, h: h}
+		}
+		cases = append(cases, testCase{rings: arr})
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, tc := range cases {
+		input := buildInput(tc)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		exp := fmt.Sprint(solve(tc))
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for all problems of Codeforces contest 777
- each verifier runs at least 100 randomized tests against any executable or Go source

## Testing
- `go build 0-999/700-799/770-779/777/verifierA.go`
- `go build 0-999/700-799/770-779/777/verifierB.go`
- `go build 0-999/700-799/770-779/777/verifierC.go`
- `go build 0-999/700-799/770-779/777/verifierD.go`
- `go build 0-999/700-799/770-779/777/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883aa561b508324ae3f03b938ffda05