### PR TITLE
Add Go solution for 1926E

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1926/1926E.go
+++ b/1000-1999/1900-1999/1920-1929/1926/1926E.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+
+	for ; t > 0; t-- {
+		var n, k int64
+		fmt.Fscan(in, &n, &k)
+		pow := int64(1)
+		for {
+			count := n/pow - n/(pow*2)
+			if k > count {
+				k -= count
+				pow <<= 1
+			} else {
+				ans := pow * (2*k - 1)
+				fmt.Fprintln(out, ans)
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem E of contest 1926

## Testing
- `go build 1000-1999/1900-1999/1920-1929/1926/1926E.go`


------
https://chatgpt.com/codex/tasks/task_e_6883a86bc410832482c07be270386a47