### PR TITLE
Add verifiers for Codeforces contest 773

### DIFF
--- a/0-999/700-799/770-779/773/verifierA.go
+++ b/0-999/700-799/770-779/773/verifierA.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./773A_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "773A.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for i := 0; i < 100; i++ {
+		x := rand.Int63n(1e9 + 1)
+		y := x + rand.Int63n(1e9-x+1)
+		if y == 0 {
+			y = 1
+		}
+		p := rand.Int63n(1e9 + 1)
+		q := p + rand.Int63n(1e9-p+1)
+		if q == 0 {
+			q = 1
+		}
+		input := fmt.Sprintf("1\n%d %d %d %d\n", x, y, p, q)
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference solution failed on test", i+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", i+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", i+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/700-799/770-779/773/verifierB.go
+++ b/0-999/700-799/770-779/773/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./773B_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "773B.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 2
+		lines := make([][]int, n)
+		for i := 0; i < n; i++ {
+			lines[i] = make([]int, 5)
+			solved := false
+			for j := 0; j < 5; j++ {
+				if rand.Float64() < 0.2 {
+					lines[i][j] = -1
+				} else {
+					lines[i][j] = rand.Intn(120)
+					solved = true
+				}
+			}
+			if !solved {
+				idx := rand.Intn(5)
+				lines[i][idx] = rand.Intn(120)
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			for j := 0; j < 5; j++ {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", lines[i][j]))
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/700-799/770-779/773/verifierC.go
+++ b/0-999/700-799/770-779/773/verifierC.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./773C_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "773C.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 1
+		arr := make([]int, n)
+		for i := range arr {
+			arr[i] = rand.Intn(1000) + 1
+		}
+		sort.Ints(arr)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/700-799/770-779/773/verifierD.go
+++ b/0-999/700-799/770-779/773/verifierD.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./773D_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "773D.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(4) + 2
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n-1; i++ {
+			for j := i + 1; j < n; j++ {
+				w := rand.Intn(10) + 1
+				sb.WriteString(fmt.Sprintf("%d ", w))
+			}
+			if i < n-2 {
+				sb.WriteByte('\n')
+			}
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/700-799/770-779/773/verifierE.go
+++ b/0-999/700-799/770-779/773/verifierE.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./773E_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "773E.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			val := rand.Intn(11) - 5
+			sb.WriteString(fmt.Sprintf("%d", val))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/700-799/770-779/773/verifierF.go
+++ b/0-999/700-799/770-779/773/verifierF.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	refBin := "./773F_ref"
+	if err := exec.Command("go", "build", "-o", refBin, "773F.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	rand.Seed(42)
+	for t := 0; t < 100; t++ {
+		maxn := rand.Intn(10) + 1
+		maxa := maxn + rand.Intn(100)
+		q := rand.Intn(1000) + 104
+		input := fmt.Sprintf("%d %d %d\n", maxn, maxa, q)
+		expect, err := run(refBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "program failed on test", t+1, ":", err)
+			os.Exit(1)
+		}
+		if expect != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "mismatch on test %d: expected %s got %s\n", t+1, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–F in contest 773
- each verifier compiles the reference solution, generates 100 random tests and compares outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883a825d3d8832494371ce14d65febb