### PR TITLE
Add simple solution for 1953A

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1953/1953A.go
+++ b/1000-1999/1900-1999/1950-1959/1953/1953A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	for i := 0; i < n; i++ {
+		var dummy float64
+		fmt.Fscan(reader, &dummy)
+	}
+
+	b := strings.Builder{}
+	b.WriteString("{d:")
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			b.WriteByte(',')
+		}
+		b.WriteString(fmt.Sprintf("%d", i))
+	}
+	b.WriteByte('}')
+
+	fmt.Fprint(writer, b.String())
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem 1953A that outputs the simplest valid summation algorithm

## Testing
- `go vet 1000-1999/1900-1999/1950-1959/1953/1953A.go`
- `gofmt -w 1000-1999/1900-1999/1950-1959/1953/1953A.go`
- `go build 1000-1999/1900-1999/1950-1959/1953/1953A.go`


------
https://chatgpt.com/codex/tasks/task_e_6883a7dfb87883249696cd6422a21f4e