### PR TITLE
Add Go solution for 1926A

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1926/1926A.go
+++ b/1000-1999/1900-1999/1920-1929/1926/1926A.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(in, &s)
+		cntA := 0
+		for i := 0; i < len(s); i++ {
+			if s[i] == 'A' {
+				cntA++
+			}
+		}
+		if cntA > len(s)-cntA {
+			fmt.Fprintln(out, "A")
+		} else {
+			fmt.Fprintln(out, "B")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem A of contest 1926 in Go

## Testing
- `go build 1000-1999/1900-1999/1920-1929/1926/1926A.go`


------
https://chatgpt.com/codex/tasks/task_e_6883abb458308324aeef942ec1a31a34