### PR TITLE
Add Go verifiers for Codeforces 778

### DIFF
--- a/0-999/700-799/770-779/778/verifierA.go
+++ b/0-999/700-799/770-779/778/verifierA.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleA")
+	src := filepath.Join(dir, "778A.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 2
+	t := randString(rng, n)
+	k := rng.Intn(n-1) + 1
+	idxs := rng.Perm(n)[:k]
+	sort.Ints(idxs)
+	var p strings.Builder
+	for _, idx := range idxs {
+		p.WriteByte(t[idx])
+	}
+	perm := rng.Perm(n)
+	var sb strings.Builder
+	sb.WriteString(t)
+	sb.WriteByte('\n')
+	sb.WriteString(p.String())
+	sb.WriteByte('\n')
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/778/verifierB.go
+++ b/0-999/700-799/770-779/778/verifierB.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleB")
+	src := filepath.Join(dir, "778B.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func randName(rng *rand.Rand) string {
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	l := rng.Intn(3) + 1
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func randBits(rng *rand.Rand, m int) string {
+	b := make([]byte, m)
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(5) + 1
+	names := make([]string, n)
+	for i := range names {
+		names[i] = randName(rng)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	ops := []string{"AND", "OR", "XOR"}
+	for i := 0; i < n; i++ {
+		if i == 0 || rng.Intn(2) == 0 {
+			sb.WriteString(fmt.Sprintf("%s := %s\n", names[i], randBits(rng, m)))
+		} else {
+			op1 := "?"
+			if rng.Intn(2) == 0 {
+				op1 = names[rng.Intn(i)]
+			}
+			op2 := "?"
+			if rng.Intn(2) == 0 {
+				op2 = names[rng.Intn(i)]
+			}
+			op := ops[rng.Intn(3)]
+			sb.WriteString(fmt.Sprintf("%s := %s %s %s\n", names[i], op1, op, op2))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/778/verifierC.go
+++ b/0-999/700-799/770-779/778/verifierC.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleC")
+	src := filepath.Join(dir, "778C.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(15) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for v := 2; v <= n; v++ {
+		u := rng.Intn(v-1) + 1
+		ch := 'a' + rng.Intn(3)
+		sb.WriteString(fmt.Sprintf("%d %d %c\n", u, v, ch))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/778/verifierD.go
+++ b/0-999/700-799/770-779/778/verifierD.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleD")
+	src := filepath.Join(dir, "778D.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func genGrid(rng *rand.Rand, n, m int) []string {
+	g := make([][]byte, n)
+	for i := range g {
+		g[i] = make([]byte, m)
+	}
+	for i := 0; i < n; i += 2 {
+		for j := 0; j < m; j += 2 {
+			if rng.Intn(2) == 0 {
+				g[i][j], g[i+1][j] = 'U', 'D'
+				g[i][j+1], g[i+1][j+1] = 'U', 'D'
+			} else {
+				g[i][j], g[i][j+1] = 'L', 'R'
+				g[i+1][j], g[i+1][j+1] = 'L', 'R'
+			}
+		}
+	}
+	res := make([]string, n)
+	for i := range g {
+		res[i] = string(g[i])
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(3)*2 + 2
+	m := rng.Intn(3)*2 + 2
+	g1 := genGrid(rng, n, m)
+	g2 := genGrid(rng, n, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(g1[i])
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < n; i++ {
+		sb.WriteString(g2[i])
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/778/verifierE.go
+++ b/0-999/700-799/770-779/778/verifierE.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	exe := filepath.Join(dir, "oracleE")
+	src := filepath.Join(dir, "778E.go")
+	cmd := exec.Command("go", "build", "-o", exe, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func randDigit(rng *rand.Rand) byte { return byte('0' + rng.Intn(10)) }
+
+func genCase(rng *rand.Rand) string {
+	l := rng.Intn(5) + 1
+	var A strings.Builder
+	first := byte('1' + rng.Intn(9))
+	A.WriteByte(first)
+	for i := 1; i < l; i++ {
+		if rng.Intn(2) == 0 {
+			A.WriteByte('?')
+		} else {
+			A.WriteByte(randDigit(rng))
+		}
+	}
+	n := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(A.String())
+	sb.WriteByte('\n')
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		length := rng.Intn(5) + 1
+		var b strings.Builder
+		b.WriteByte(byte('1' + rng.Intn(9)))
+		for j := 1; j < length; j++ {
+			b.WriteByte(randDigit(rng))
+		}
+		sb.WriteString(b.String())
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < 10; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(10)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(oracle, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: oracle error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement new Go verifiers for contest 778 problems A–E
- each verifier compiles the official solution and compares its output to a candidate program on 100 randomly generated tests

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_6883aae233648324bb964e6091551c02