### PR TITLE
Add Go verifiers for Codeforces Round 774

### DIFF
--- a/0-999/700-799/770-779/774/verifierA.go
+++ b/0-999/700-799/770-779/774/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(n, c1, c2 int64, s string) int64 {
+	adults := int64(strings.Count(s, "1"))
+	if adults == 0 {
+		return 0
+	}
+	if adults > n {
+		adults = n
+	}
+	best := int64(1<<63 - 1)
+	for k := int64(1); k <= adults; k++ {
+		q := n / k
+		r := n % k
+		cost := r*(c1+c2*q*q) + (k-r)*(c1+c2*(q-1)*(q-1))
+		if cost < best {
+			best = cost
+		}
+	}
+	return best
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, int64) {
+	n := int64(rng.Intn(20) + 1)
+	if rng.Float64() < 0.1 {
+		n = int64(rng.Intn(200) + 1)
+	}
+	c1 := int64(rng.Intn(10) + 1)
+	c2 := int64(rng.Intn(10) + 1)
+	sb := make([]byte, n)
+	hasAdult := false
+	for i := int64(0); i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb[i] = '0'
+		} else {
+			sb[i] = '1'
+			hasAdult = true
+		}
+	}
+	if !hasAdult {
+		sb[rng.Intn(int(n))] = '1'
+	}
+	s := string(sb)
+	input := fmt.Sprintf("%d %d %d\n%s\n", n, c1, c2, s)
+	return input, expected(n, c1, c2, s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: cannot parse output: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/774/verifierB.go
+++ b/0-999/700-799/770-779/774/verifierB.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Cup struct {
+	c int64
+	w int64
+}
+
+func expected(n, m int, d int64, phys, info []Cup) int64 {
+	sort.Slice(phys, func(i, j int) bool { return phys[i].c > phys[j].c })
+	sort.Slice(info, func(i, j int) bool { return info[i].c > info[j].c })
+	wp := make([]int64, n+1)
+	sp := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		wp[i] = wp[i-1] + phys[i-1].w
+		sp[i] = sp[i-1] + phys[i-1].c
+	}
+	wi := make([]int64, m+1)
+	si := make([]int64, m+1)
+	for i := 1; i <= m; i++ {
+		wi[i] = wi[i-1] + info[i-1].w
+		si[i] = si[i-1] + info[i-1].c
+	}
+	ans := int64(0)
+	for i := 1; i <= n; i++ {
+		remain := d - wp[i]
+		if remain < 0 {
+			continue
+		}
+		j := sort.Search(len(wi), func(k int) bool { return wi[k] > remain }) - 1
+		if j >= 1 {
+			val := sp[i] + si[j]
+			if val > ans {
+				ans = val
+			}
+		}
+	}
+	for j := 1; j <= m; j++ {
+		remain := d - wi[j]
+		if remain < 0 {
+			continue
+		}
+		i := sort.Search(len(wp), func(k int) bool { return wp[k] > remain }) - 1
+		if i >= 1 {
+			val := si[j] + sp[i]
+			if val > ans {
+				ans = val
+			}
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	if rng.Float64() < 0.1 {
+		n = rng.Intn(10) + 1
+		m = rng.Intn(10) + 1
+	}
+	d := int64(rng.Intn(20) + 1)
+	phys := make([]Cup, n)
+	for i := 0; i < n; i++ {
+		phys[i] = Cup{int64(rng.Intn(10) + 1), int64(rng.Intn(5) + 1)}
+	}
+	info := make([]Cup, m)
+	for i := 0; i < m; i++ {
+		info[i] = Cup{int64(rng.Intn(10) + 1), int64(rng.Intn(5) + 1)}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %d %d\n", n, m, d)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "%d %d\n", phys[i].c, phys[i].w)
+	}
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&b, "%d %d\n", info[i].c, info[i].w)
+	}
+	return b.String(), expected(n, m, d, phys, info)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: cannot parse output: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/774/verifierC.go
+++ b/0-999/700-799/770-779/774/verifierC.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) string {
+	if n%2 == 1 {
+		return "7" + strings.Repeat("1", (n-3)/2)
+	}
+	return strings.Repeat("1", n/2)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 2
+	if rng.Float64() < 0.1 {
+		n = rng.Intn(100) + 2
+	}
+	input := fmt.Sprintf("%d\n", n)
+	return input, expected(n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, strings.TrimSpace(out), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/774/verifierD.go
+++ b/0-999/700-799/770-779/774/verifierD.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, l, r int, a, b []int) string {
+	for i := 0; i < l-1; i++ {
+		if a[i] != b[i] {
+			return "LIE"
+		}
+	}
+	for i := r; i < n; i++ {
+		if a[i] != b[i] {
+			return "LIE"
+		}
+	}
+	freq := make([]int, n+1)
+	for i := l - 1; i <= r-1; i++ {
+		freq[a[i]]++
+		freq[b[i]]--
+	}
+	for i := 1; i <= n; i++ {
+		if freq[i] != 0 {
+			return "LIE"
+		}
+	}
+	return "TRUTH"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	if rng.Float64() < 0.1 {
+		n = rng.Intn(20) + 1
+	}
+	l := rng.Intn(n) + 1
+	r := rng.Intn(n-l+1) + l
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(n) + 1
+		b[i] = rng.Intn(n) + 1
+	}
+	var bld strings.Builder
+	fmt.Fprintf(&bld, "%d %d %d\n", n, l, r)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			bld.WriteByte(' ')
+		}
+		fmt.Fprintf(&bld, "%d", a[i])
+	}
+	bld.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			bld.WriteByte(' ')
+		}
+		fmt.Fprintf(&bld, "%d", b[i])
+	}
+	bld.WriteByte('\n')
+	exp := expected(n, l, r, a, b)
+	return bld.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, strings.TrimSpace(out), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/774/verifierE.go
+++ b/0-999/700-799/770-779/774/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(s string, m int64) int64 {
+	n := len(s)
+	t := s + s
+	pref := make([]int64, 2*n+1)
+	for i := 0; i < 2*n; i++ {
+		d := int64(t[i] - '0')
+		pref[i+1] = (pref[i]*10 + d) % m
+	}
+	pow10n := int64(1)
+	for i := 0; i < n; i++ {
+		pow10n = (pow10n * 10) % m
+	}
+	minRem := int64(-1)
+	for i := 0; i < n; i++ {
+		if s[i] == '0' {
+			continue
+		}
+		val := (pref[i+n] - (pref[i]*pow10n)%m + m) % m
+		if minRem == -1 || val < minRem {
+			minRem = val
+		}
+	}
+	return minRem
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(6) + 1
+	if rng.Float64() < 0.1 {
+		n = rng.Intn(12) + 1
+	}
+	sb := make([]byte, n)
+	for i := 0; i < n; i++ {
+		sb[i] = byte('0' + rng.Intn(10))
+	}
+	s := string(sb)
+	m := int64(rng.Intn(1000) + 1)
+	input := fmt.Sprintf("%s\n%d\n", s, m)
+	return input, expected(s, m)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: cannot parse output: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/774/verifierF.go
+++ b/0-999/700-799/770-779/774/verifierF.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func expected(n int, ink []int64) int {
+	L := int64(n) * 7 / gcd(int64(n), 7)
+	pos := make([][]int64, n)
+	for d := int64(1); d <= L; d++ {
+		pen := int((d - 1) % int64(n))
+		dow := (d - 1) % 7
+		if dow != 6 {
+			pos[pen] = append(pos[pen], d)
+		}
+	}
+	bestPen := -1
+	bestDay := int64(1<<63 - 1)
+	for i := 0; i < n; i++ {
+		arr := pos[i]
+		cnt := int64(len(arr))
+		if cnt == 0 {
+			continue
+		}
+		k := ink[i]
+		q := (k - 1) / cnt
+		p := arr[(k-1)%cnt]
+		day := q*L + p
+		if day < bestDay {
+			bestDay = day
+			bestPen = i + 1
+		}
+	}
+	return bestPen
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(5) + 1
+	if rng.Float64() < 0.1 {
+		n = rng.Intn(10) + 1
+	}
+	inks := make([]int64, n)
+	for i := 0; i < n; i++ {
+		inks[i] = int64(rng.Intn(10) + 1)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", inks[i])
+	}
+	b.WriteByte('\n')
+	return b.String(), expected(n, inks)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: cannot parse output: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/774/verifierG.go
+++ b/0-999/700-799/770-779/774/verifierG.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func extendedGCD(a, b int64) (int64, int64, int64) {
+	if b == 0 {
+		return a, 1, 0
+	}
+	g, x1, y1 := extendedGCD(b, a%b)
+	return g, y1, x1 - (a/b)*y1
+}
+
+func ceilDiv(a, b int64) int64 {
+	if b < 0 {
+		a, b = -a, -b
+	}
+	if a >= 0 {
+		return (a + b - 1) / b
+	}
+	return a / b
+}
+
+func floorDiv(a, b int64) int64 {
+	if b < 0 {
+		a, b = -a, -b
+	}
+	if a >= 0 {
+		return a / b
+	}
+	return -((-a + b - 1) / b)
+}
+
+func expected(a, h, w int64) (float64, bool) {
+	if h < a || w < a {
+		return 0, false
+	}
+	A := h + a
+	B := w + a
+	C := w - h
+	g, x0, y0 := extendedGCD(A, B)
+	if C%g != 0 {
+		return 0, false
+	}
+	factor := C / g
+	m0 := x0 * factor
+	n0 := -y0 * factor
+	Bdiv := B / g
+	Adiv := A / g
+	lowN := ceilDiv(1-n0, Adiv)
+	highN := floorDiv(h/a-n0, Adiv)
+	lowM := ceilDiv(1-m0, Bdiv)
+	highM := floorDiv(w/a-m0, Bdiv)
+	low := lowN
+	if lowM > low {
+		low = lowM
+	}
+	high := highN
+	if highM < high {
+		high = highM
+	}
+	if low > high {
+		return 0, false
+	}
+	t := high
+	n := n0 + Adiv*t
+	x := float64(h-n*a) / float64(n+1)
+	return x, true
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, float64, bool) {
+	a := int64(rng.Intn(10) + 1)
+	h := int64(rng.Intn(20) + int(a))
+	w := int64(rng.Intn(20) + int(a))
+	if rng.Float64() < 0.1 {
+		h = int64(rng.Intn(50) + int(a))
+		w = int64(rng.Intn(50) + int(a))
+	}
+	input := fmt.Sprintf("%d %d %d\n", a, h, w)
+	val, ok := expected(a, h, w)
+	if !ok {
+		return input, 0, false
+	}
+	return input, val, true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp, ok := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if !ok {
+			if strings.TrimSpace(out) != "-1" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected -1 got %s\ninput:\n%s", i+1, strings.TrimSpace(out), input)
+				os.Exit(1)
+			}
+			continue
+		}
+		got, err := strconv.ParseFloat(strings.TrimSpace(out), 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: cannot parse output: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if diff := got - exp; diff < -1e-6 || diff > 1e-6 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.6f got %.6f\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/774/verifierH.go
+++ b/0-999/700-799/770-779/774/verifierH.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type counts []int
+
+func computeCounts(s string) counts {
+	n := len(s)
+	c := make(counts, n)
+	for i := 0; i < n; i++ {
+		run := 1
+		for j := i + 1; j < n && s[j] == s[i]; j++ {
+			run++
+		}
+		for l := 1; l <= run; l++ {
+			c[l-1]++
+		}
+	}
+	return c
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, counts) {
+	n := rng.Intn(8) + 1
+	if rng.Float64() < 0.1 {
+		n = rng.Intn(12) + 1
+	}
+	letters := []byte{'a', 'b', 'c'}
+	sb := make([]byte, n)
+	for i := 0; i < n; i++ {
+		sb[i] = letters[rng.Intn(len(letters))]
+	}
+	s := string(sb)
+	c := computeCounts(s)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", c[i])
+	}
+	b.WriteByte('\n')
+	return b.String(), c
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out)
+		if len(got) != len(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: length mismatch expected %d got %d\ninput:\n%s", i+1, len(exp), len(got), input)
+			os.Exit(1)
+		}
+		cGot := computeCounts(got)
+		for j := range exp {
+			if j >= len(cGot) || cGot[j] != exp[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed: counts mismatch\ninput:\n%s", i+1, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/774/verifierI.go
+++ b/0-999/700-799/770-779/774/verifierI.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func match(s string, pos int, t string) int {
+	j := pos
+	for i := 0; i < len(t) && j < len(s); i++ {
+		if t[i] == s[j] {
+			j++
+		}
+	}
+	return j
+}
+
+func expected(arr []string, s string) int {
+	m := len(s)
+	dist := make([]int, m+1)
+	for i := range dist {
+		dist[i] = -1
+	}
+	queue := make([]int, 0, m+1)
+	dist[0] = 0
+	queue = append(queue, 0)
+	for len(queue) > 0 {
+		pos := queue[0]
+		queue = queue[1:]
+		if pos == m {
+			return dist[pos]
+		}
+		for _, t := range arr {
+			np := match(s, pos, t)
+			if np > pos && dist[np] == -1 {
+				dist[np] = dist[pos] + 1
+				queue = append(queue, np)
+			}
+		}
+	}
+	return -1
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(5) + 1
+	if rng.Float64() < 0.1 {
+		n = rng.Intn(10) + 1
+	}
+	arr := make([]string, n)
+	for i := range arr {
+		l := rng.Intn(4) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('a' + rng.Intn(3))
+		}
+		arr[i] = string(b)
+	}
+	slen := rng.Intn(10) + 1
+	if rng.Float64() < 0.2 {
+		slen = rng.Intn(25) + 1
+	}
+	sb := make([]byte, slen)
+	for i := 0; i < slen; i++ {
+		sb[i] = byte('a' + rng.Intn(3))
+	}
+	s := string(sb)
+	var bld strings.Builder
+	fmt.Fprintf(&bld, "%d\n", n)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&bld, "%s\n", arr[i])
+	}
+	fmt.Fprintf(&bld, "%s\n", s)
+	return bld.String(), expected(arr, s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: cannot parse output: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/774/verifierJ.go
+++ b/0-999/700-799/770-779/774/verifierJ.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, k int, s string) string {
+	dp := make([][]bool, n+1)
+	for i := range dp {
+		dp[i] = make([]bool, n+1)
+	}
+	dp[0][0] = true
+	for idx := 0; idx < n; idx++ {
+		ndp := make([][]bool, n+1)
+		for i := range ndp {
+			ndp[i] = make([]bool, n+1)
+		}
+		for j := 0; j <= n; j++ {
+			for m := 0; m <= n; m++ {
+				if !dp[j][m] {
+					continue
+				}
+				c := s[idx]
+				if c != 'N' {
+					newJ := 0
+					newM := m
+					if j > newM {
+						newM = j
+					}
+					ndp[newJ][newM] = true
+				}
+				if c != 'Y' {
+					newJ := j + 1
+					newM := m
+					if newJ > newM {
+						newM = newJ
+					}
+					if newJ <= n && newM <= n {
+						ndp[newJ][newM] = true
+					}
+				}
+			}
+		}
+		dp = ndp
+	}
+	for j := 0; j <= n; j++ {
+		if dp[j][k] {
+			return "YES"
+		}
+	}
+	return "NO"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	if rng.Float64() < 0.1 {
+		n = rng.Intn(20) + 1
+	}
+	k := rng.Intn(n + 1)
+	letters := []byte{'Y', 'N', '?'}
+	sb := make([]byte, n)
+	for i := 0; i < n; i++ {
+		sb[i] = letters[rng.Intn(len(letters))]
+	}
+	s := string(sb)
+	input := fmt.Sprintf("%d %d\n%s\n", n, k, s)
+	return input, expected(n, k, s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierJ.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, strings.TrimSpace(out), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/774/verifierK.go
+++ b/0-999/700-799/770-779/774/verifierK.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isVowel(c byte) bool {
+	switch c {
+	case 'a', 'e', 'i', 'o', 'u', 'y':
+		return true
+	}
+	return false
+}
+
+func expected(n int, s string) string {
+	var res []byte
+	i := 0
+	for i < n {
+		ch := s[i]
+		j := i + 1
+		for j < n && s[j] == ch {
+			j++
+		}
+		runLen := j - i
+		if isVowel(ch) {
+			if (ch == 'e' || ch == 'o') && runLen == 2 {
+				res = append(res, ch, ch)
+			} else {
+				res = append(res, ch)
+			}
+		} else {
+			for k := 0; k < runLen; k++ {
+				res = append(res, ch)
+			}
+		}
+		i = j
+	}
+	return string(res)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	if rng.Float64() < 0.1 {
+		n = rng.Intn(50) + 1
+	}
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	sb := make([]byte, n)
+	for i := 0; i < n; i++ {
+		sb[i] = letters[rng.Intn(len(letters))]
+	}
+	s := string(sb)
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	return input, expected(n, s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierK.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, strings.TrimSpace(out), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/774/verifierL.go
+++ b/0-999/700-799/770-779/774/verifierL.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func feasible(b int, pos []int, k int) bool {
+	maxDiff := b + 1
+	prev := pos[0]
+	used := 1
+	i := 1
+	last := pos[len(pos)-1]
+	for {
+		if last-prev <= maxDiff {
+			used++
+			return used <= k
+		}
+		j := i
+		for j < len(pos) && pos[j]-prev <= maxDiff {
+			j++
+		}
+		if j == i {
+			return false
+		}
+		prev = pos[j-1]
+		used++
+		if used > k {
+			return false
+		}
+		i = j
+	}
+}
+
+func expected(n, k int, s string) int {
+	pos := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		if s[i] == '0' {
+			pos = append(pos, i+1)
+		}
+	}
+	left, right := 0, n
+	for left < right {
+		mid := (left + right) / 2
+		if feasible(mid, pos, k) {
+			right = mid
+		} else {
+			left = mid + 1
+		}
+	}
+	return left
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10) + 2
+	if rng.Float64() < 0.1 {
+		n = rng.Intn(50) + 2
+	}
+	k := rng.Intn(n-1) + 2
+	sb := make([]byte, n)
+	sb[0] = '0'
+	sb[n-1] = '0'
+	for i := 1; i < n-1; i++ {
+		if rng.Intn(2) == 0 {
+			sb[i] = '0'
+		} else {
+			sb[i] = '1'
+		}
+	}
+	s := string(sb)
+	input := fmt.Sprintf("%d %d\n%s\n", n, k, s)
+	return input, expected(n, k, s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierL.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: cannot parse output: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- added Go solution verifiers for all problems of contest 774
- each verifier generates 100 random test cases and checks a provided binary
- verifiers support running Go sources directly via `go run` or any executable

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build verifierI.go`
- `go build verifierJ.go`
- `go build verifierK.go`
- `go build verifierL.go`


------
https://chatgpt.com/codex/tasks/task_e_6883a8b20a2c832484f6f00d49689951