### PR TITLE
Add Go solution for 1954C

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1954/1954C.go
+++ b/1000-1999/1900-1999/1950-1959/1954/1954C.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/big"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	bigTen := big.NewInt(10)
+	for ; t > 0; t-- {
+		var xStr, yStr string
+		fmt.Fscan(in, &xStr)
+		fmt.Fscan(in, &yStr)
+		n := len(xStr)
+		diff := big.NewInt(0)
+		xb := make([]byte, n)
+		yb := make([]byte, n)
+		for i := 0; i < n; i++ {
+			da := int64(xStr[i] - '0')
+			db := int64(yStr[i] - '0')
+
+			diff1 := new(big.Int).Set(diff)
+			diff1.Mul(diff1, bigTen)
+			diff1.Add(diff1, big.NewInt(da-db))
+
+			diff2 := new(big.Int).Set(diff)
+			diff2.Mul(diff2, bigTen)
+			diff2.Add(diff2, big.NewInt(db-da))
+
+			abs1 := new(big.Int).Abs(new(big.Int).Set(diff1))
+			abs2 := new(big.Int).Abs(new(big.Int).Set(diff2))
+
+			if abs2.Cmp(abs1) < 0 {
+				diff = diff2
+				xb[i] = byte('0' + db)
+				yb[i] = byte('0' + da)
+			} else {
+				diff = diff1
+				xb[i] = byte('0' + da)
+				yb[i] = byte('0' + db)
+			}
+		}
+		fmt.Fprintln(out, string(xb))
+		fmt.Fprintln(out, string(yb))
+	}
+}


### PR DESCRIPTION
## Summary
- implement greedy solution to minimize absolute difference and thus maximize product for problem C

## Testing
- `go run 1000-1999/1900-1999/1950-1959/1954/1954C.go <<EOF
1
73
31
EOF`
- `go run 1000-1999/1900-1999/1950-1959/1954/1954C.go <<EOF
2
1234
4321
1111
9999
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6883a63b94b08324a55829b17713962c