### PR TITLE
Add Go verifiers for contest 768

### DIFF
--- a/0-999/700-799/760-769/768/verifierA.go
+++ b/0-999/700-799/760-769/768/verifierA.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n      int
+	arr    []int
+	expect int
+}
+
+func expectedCount(arr []int) int {
+	if len(arr) == 0 {
+		return 0
+	}
+	minVal, maxVal := arr[0], arr[0]
+	for _, v := range arr {
+		if v < minVal {
+			minVal = v
+		}
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	cnt := 0
+	for _, v := range arr {
+		if v > minVal && v < maxVal {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 0, 100)
+	// deterministic edge cases
+	edges := [][]int{
+		{0},
+		{1},
+		{1, 1},
+		{0, 1},
+		{5, 1, 5},
+		{1, 2, 3, 4, 5},
+		{5, 4, 3, 2, 1},
+	}
+	for _, arr := range edges {
+		tests = append(tests, testCase{n: len(arr), arr: append([]int(nil), arr...), expect: expectedCount(arr)})
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(100)
+		}
+		tests = append(tests, testCase{n: n, arr: arr, expect: expectedCount(arr)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for j, v := range tc.arr {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(strconv.Itoa(v))
+		}
+		input.WriteByte('\n')
+		expected := strconv.Itoa(tc.expect)
+		got, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input.String())
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/768/verifierB.go
+++ b/0-999/700-799/760-769/768/verifierB.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n      int64
+	l      int64
+	r      int64
+	expect int64
+}
+
+var lenMemo map[int64]int64
+var onesMemo map[int64]int64
+
+func seqLen(n int64) int64 {
+	if n <= 1 {
+		return 1
+	}
+	if v, ok := lenMemo[n]; ok {
+		return v
+	}
+	v := 2*seqLen(n/2) + 1
+	lenMemo[n] = v
+	return v
+}
+
+func onesCount(n int64) int64 {
+	if n <= 1 {
+		return n
+	}
+	if v, ok := onesMemo[n]; ok {
+		return v
+	}
+	v := 2*onesCount(n/2) + n%2
+	onesMemo[n] = v
+	return v
+}
+
+func prefix(n, pos int64) int64 {
+	if pos <= 0 || n == 0 {
+		return 0
+	}
+	if n == 1 {
+		if pos >= 1 {
+			return 1
+		}
+		return 0
+	}
+	leftLen := seqLen(n / 2)
+	if pos <= leftLen {
+		return prefix(n/2, pos)
+	}
+	leftOnes := onesCount(n / 2)
+	if pos == leftLen+1 {
+		return leftOnes + n%2
+	}
+	return leftOnes + n%2 + prefix(n/2, pos-leftLen-1)
+}
+
+func expectedOnes(n, l, r int64) int64 {
+	lenMemo = make(map[int64]int64)
+	onesMemo = make(map[int64]int64)
+	return prefix(n, r) - prefix(n, l-1)
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 0, 100)
+	deterministic := []testCase{
+		{n: 0, l: 1, r: 1},
+		{n: 1, l: 1, r: 1},
+		{n: 7, l: 2, r: 5},
+		{n: 10, l: 3, r: 10},
+	}
+	for _, tc := range deterministic {
+		tc.expect = expectedOnes(tc.n, tc.l, tc.r)
+		tests = append(tests, tc)
+	}
+	for len(tests) < 100 {
+		n := rng.Int63n(1 << 50) // keep reasonably small
+		length := expectedSeqLen(n)
+		l := rng.Int63n(length) + 1
+		r := l + rng.Int63n(length-l+1)
+		tc := testCase{n: n, l: l, r: r}
+		tc.expect = expectedOnes(n, l, r)
+		tests = append(tests, tc)
+	}
+	return tests
+}
+
+func expectedSeqLen(n int64) int64 {
+	lenMemo = make(map[int64]int64)
+	return seqLen(n)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d %d\n", tc.n, tc.l, tc.r)
+		expected := strconv.FormatInt(tc.expect, 10)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/768/verifierC.go
+++ b/0-999/700-799/760-769/768/verifierC.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n         int
+	k         int
+	x         int
+	arr       []int
+	expectMax int
+	expectMin int
+}
+
+func expectedVals(n, k, x int, arr []int) (int, int) {
+	const maxVal = 1024
+	cnt := make([]int, maxVal)
+	for _, v := range arr {
+		cnt[v]++
+	}
+	for iter := 0; iter < k; iter++ {
+		next := make([]int, maxVal)
+		odd := 0
+		for v := 0; v < maxVal; v++ {
+			c := cnt[v]
+			if c == 0 {
+				continue
+			}
+			var toXor int
+			if odd == 0 {
+				toXor = (c + 1) / 2
+			} else {
+				toXor = c / 2
+			}
+			next[v^x] += toXor
+			next[v] += c - toXor
+			if c%2 == 1 {
+				odd ^= 1
+			}
+		}
+		cnt = next
+	}
+	minVal, maxValIdx := -1, -1
+	for i := 0; i < maxVal; i++ {
+		if cnt[i] > 0 {
+			if minVal == -1 {
+				minVal = i
+			}
+			maxValIdx = i
+		}
+	}
+	return maxValIdx, minVal
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 0, 100)
+	deterministic := []testCase{
+		{n: 5, k: 1, x: 2, arr: []int{5, 7, 9, 11, 15}},
+		{n: 3, k: 0, x: 5, arr: []int{1, 2, 3}},
+		{n: 1, k: 10, x: 0, arr: []int{42}},
+	}
+	for _, tc := range deterministic {
+		tc.expectMax, tc.expectMin = expectedVals(tc.n, tc.k, tc.x, append([]int(nil), tc.arr...))
+		tests = append(tests, tc)
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		k := rng.Intn(10)
+		x := rng.Intn(1024)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(1024)
+		}
+		maxV, minV := expectedVals(n, k, x, append([]int(nil), arr...))
+		tests = append(tests, testCase{n: n, k: k, x: x, arr: arr, expectMax: maxV, expectMin: minV})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.k, tc.x))
+		for j, v := range tc.arr {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(strconv.Itoa(v))
+		}
+		input.WriteByte('\n')
+		expect := fmt.Sprintf("%d %d", tc.expectMax, tc.expectMin)
+		got, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input.String())
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/768/verifierD.go
+++ b/0-999/700-799/760-769/768/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	k       int
+	q       int
+	queries []int
+	expect  []int
+}
+
+func expectedAnswers(k int, queries []int) []int {
+	const maxP = 1000
+	ans := make([]int, maxP+1)
+	prev := make([]float64, k+1)
+	curr := make([]float64, k+1)
+	prev[0] = 1.0
+	idx := 1
+	n := 0
+	kf := float64(k)
+	for idx <= maxP {
+		n++
+		curr[0] = 0
+		for j := 1; j <= k; j++ {
+			curr[j] = prev[j]*float64(j)/kf + prev[j-1]*float64(k-j+1)/kf
+		}
+		prev, curr = curr, prev
+		p := prev[k]
+		for idx <= maxP && p >= float64(idx)/2000.0-1e-12 {
+			ans[idx] = n
+			idx++
+		}
+	}
+	res := make([]int, len(queries))
+	for i, pi := range queries {
+		if pi < 1 {
+			pi = 1
+		} else if pi > 1000 {
+			pi = 1000
+		}
+		res[i] = ans[pi]
+	}
+	return res
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 0, 100)
+	deterministic := []testCase{
+		{k: 1, q: 3, queries: []int{1, 500, 1000}},
+		{k: 3, q: 2, queries: []int{1000, 1}},
+		{k: 5, q: 1, queries: []int{600}},
+	}
+	for _, tc := range deterministic {
+		tc.expect = expectedAnswers(tc.k, tc.queries)
+		tests = append(tests, tc)
+	}
+	for len(tests) < 100 {
+		k := rng.Intn(10) + 1
+		q := rng.Intn(5) + 1
+		qs := make([]int, q)
+		for i := 0; i < q; i++ {
+			qs[i] = rng.Intn(1000) + 1
+		}
+		expect := expectedAnswers(k, qs)
+		tests = append(tests, testCase{k: k, q: q, queries: qs, expect: expect})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d %d\n", tc.k, tc.q))
+		for _, v := range tc.queries {
+			input.WriteString(fmt.Sprintf("%d\n", v))
+		}
+		expectParts := make([]string, len(tc.expect))
+		for i2, v := range tc.expect {
+			expectParts[i2] = strconv.Itoa(v)
+		}
+		expected := strings.Join(expectParts, "\n")
+		got, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input.String())
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\n--- got:\n%s\ninput:\n%s", i+1, expected, got, input.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/768/verifierE.go
+++ b/0-999/700-799/760-769/768/verifierE.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n      int
+	piles  []int
+	expect string
+}
+
+func expectedResult(piles []int) string {
+	grundy := make([]int, 61)
+	for s := 1; s <= 60; s++ {
+		g := 1
+		for (g+1)*(g+2)/2 <= s {
+			g++
+		}
+		grundy[s] = g
+	}
+	xor := 0
+	for _, x := range piles {
+		xor ^= grundy[x]
+	}
+	if xor == 0 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 0, 100)
+	deterministic := []testCase{
+		{n: 1, piles: []int{1}},
+		{n: 2, piles: []int{1, 2}},
+		{n: 3, piles: []int{3, 3, 3}},
+	}
+	for _, tc := range deterministic {
+		tc.expect = expectedResult(tc.piles)
+		tests = append(tests, tc)
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		piles := make([]int, n)
+		for i := 0; i < n; i++ {
+			piles[i] = rng.Intn(60) + 1
+		}
+		tests = append(tests, testCase{n: n, piles: piles, expect: expectedResult(piles)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for _, v := range tc.piles {
+			input.WriteString(fmt.Sprintf("%d ", v))
+		}
+		input.WriteByte('\n')
+		got, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input.String())
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expect, got, input.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/768/verifierF.go
+++ b/0-999/700-799/760-769/768/verifierF.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	a %= MOD
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func modInv(a int64) int64 { return modPow(a, MOD-2) }
+
+var fac, ifac []int64
+
+func comb(n, k int) int64 {
+	if n < 0 || k < 0 || k > n {
+		return 0
+	}
+	return fac[n] * ifac[k] % MOD * ifac[n-k] % MOD
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func expectedProbability(f, w, h int) int64 {
+	if w == 0 {
+		return 1
+	}
+	if f == 0 {
+		if w > h {
+			return 1
+		}
+		return 0
+	}
+	limit := f + w + 5
+	fac = make([]int64, limit)
+	ifac = make([]int64, limit)
+	fac[0] = 1
+	for i := 1; i < limit; i++ {
+		fac[i] = fac[i-1] * int64(i) % MOD
+	}
+	ifac[limit-1] = modInv(fac[limit-1])
+	for i := limit - 1; i > 0; i-- {
+		ifac[i-1] = ifac[i] * int64(i) % MOD
+	}
+	var total, liked int64
+	for x := 1; x <= f; x++ {
+		for _, dy := range []int{-1, 0, 1} {
+			y := x + dy
+			if y < 1 || y > w {
+				continue
+			}
+			if abs(x-y) > 1 {
+				continue
+			}
+			patterns := int64(1)
+			if x == y {
+				patterns = 2
+			}
+			waysF := comb(f-1, x-1)
+			waysW := comb(w-1, y-1)
+			total = (total + patterns*waysF%MOD*waysW) % MOD
+			if w >= (h+1)*y {
+				waysWL := comb(w-(h+1)*y+y-1, y-1)
+				liked = (liked + patterns*waysF%MOD*waysWL) % MOD
+			}
+		}
+	}
+	invTotal := modInv(total)
+	ans := liked % MOD * invTotal % MOD
+	return ans
+}
+
+type testCase struct {
+	f      int
+	w      int
+	h      int
+	expect int64
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 0, 100)
+	deterministic := []testCase{
+		{f: 1, w: 1, h: 1},
+		{f: 1, w: 2, h: 1},
+		{f: 2, w: 0, h: 5},
+	}
+	for _, tc := range deterministic {
+		tc.expect = expectedProbability(tc.f, tc.w, tc.h)
+		tests = append(tests, tc)
+	}
+	for len(tests) < 100 {
+		f := rng.Intn(5)
+		w := rng.Intn(5)
+		if f == 0 && w == 0 {
+			f = 1
+		}
+		h := rng.Intn(5)
+		tc := testCase{f: f, w: w, h: h}
+		tc.expect = expectedProbability(f, w, h)
+		tests = append(tests, tc)
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d %d\n", tc.f, tc.w, tc.h)
+		expected := strconv.FormatInt(tc.expect, 10)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/768/verifierG.go
+++ b/0-999/700-799/760-769/768/verifierG.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n      int
+	edges  [][2]int // each pair {parent, child}, parent=0 indicates root
+	expect []int
+}
+
+func copyAdj(adj [][]int) [][]int {
+	res := make([][]int, len(adj))
+	for i := range adj {
+		res[i] = append([]int(nil), adj[i]...)
+	}
+	return res
+}
+
+func removeEdge(adj [][]int, a, b int) {
+	for i, v := range adj[a] {
+		if v == b {
+			adj[a] = append(adj[a][:i], adj[a][i+1:]...)
+			break
+		}
+	}
+	for i, v := range adj[b] {
+		if v == a {
+			adj[b] = append(adj[b][:i], adj[b][i+1:]...)
+			break
+		}
+	}
+}
+
+func addEdge(adj [][]int, a, b int) {
+	adj[a] = append(adj[a], b)
+	adj[b] = append(adj[b], a)
+}
+
+func largestComponent(adj [][]int, remove int) int {
+	n := len(adj) - 1
+	visited := make([]bool, n+1)
+	maxSize := 0
+	for i := 1; i <= n; i++ {
+		if i == remove || visited[i] {
+			continue
+		}
+		size := 0
+		stack := []int{i}
+		visited[i] = true
+		for len(stack) > 0 {
+			v := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			size++
+			for _, w := range adj[v] {
+				if w == remove || visited[w] {
+					continue
+				}
+				visited[w] = true
+				stack = append(stack, w)
+			}
+		}
+		if size > maxSize {
+			maxSize = size
+		}
+	}
+	return maxSize
+}
+
+func compute(n int, parent []int, remove int) int {
+	adj := make([][]int, n+1)
+	for v := 1; v <= n; v++ {
+		if v == remove {
+			continue
+		}
+		p := parent[v]
+		if p == remove || p == 0 {
+			continue
+		}
+		adj[v] = append(adj[v], p)
+		adj[p] = append(adj[p], v)
+	}
+	best := largestComponent(adj, remove)
+	for u := 1; u <= n; u++ {
+		if u == remove {
+			continue
+		}
+		p := parent[u]
+		if p == 0 || p == remove {
+			continue
+		}
+		adj2 := copyAdj(adj)
+		removeEdge(adj2, u, p)
+		for w := 1; w <= n; w++ {
+			if w == remove || w == u {
+				continue
+			}
+			adj3 := copyAdj(adj2)
+			addEdge(adj3, u, w)
+			size := largestComponent(adj3, remove)
+			if size < best {
+				best = size
+			}
+		}
+	}
+	return best
+}
+
+func bruteAnswer(n int, edges [][2]int) []int {
+	parent := make([]int, n+1)
+	for _, e := range edges {
+		parent[e[1]] = e[0]
+	}
+	res := make([]int, n)
+	for rm := 1; rm <= n; rm++ {
+		res[rm-1] = compute(n, parent, rm)
+	}
+	return res
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 0, 100)
+	// small deterministic tree
+	edges := [][2]int{{0, 1}, {1, 2}, {1, 3}}
+	tests = append(tests, testCase{n: 3, edges: edges, expect: bruteAnswer(3, edges)})
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 2 // 2..6
+		edges := make([][2]int, n)
+		edges[0] = [2]int{0, 1}
+		for i := 2; i <= n; i++ {
+			p := rng.Intn(i-1) + 1
+			edges[i-1] = [2]int{p, i}
+		}
+		rng.Shuffle(n, func(i, j int) { edges[i], edges[j] = edges[j], edges[i] })
+		tests = append(tests, testCase{n: n, edges: edges, expect: bruteAnswer(n, edges)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for _, e := range tc.edges {
+			input.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		expectParts := make([]string, len(tc.expect))
+		for j, v := range tc.expect {
+			expectParts[j] = strconv.Itoa(v)
+		}
+		expected := strings.Join(expectParts, "\n")
+		got, err := run(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input.String())
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\n--- got:\n%s\ninput:\n%s", i+1, expected, got, input.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for problems A–G of contest 768
- each verifier generates at least 100 random tests
- verifiers run any binary or `.go` file via `exec.Command`

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`
- `go run verifierF.go ./solF`
- `go run verifierG.go ./solG` *(fails as expected because `768G.go` is a stub)*

------
https://chatgpt.com/codex/tasks/task_e_6883a569595883249ccb19968b12c890