### PR TITLE
Add Go verifiers for contest 767

### DIFF
--- a/0-999/700-799/760-769/767/verifierA.go
+++ b/0-999/700-799/760-769/767/verifierA.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n   int
+	seq []int
+}
+
+func solve(n int, seq []int) string {
+	arrived := make([]bool, n+1)
+	expected := n
+	var sb strings.Builder
+	for _, x := range seq {
+		arrived[x] = true
+		first := true
+		for expected > 0 && arrived[expected] {
+			if !first {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(expected))
+			expected--
+			first = false
+		}
+		sb.WriteByte('\n')
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func (tc testCase) input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i, v := range tc.seq {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	return testCase{n: n, seq: perm}
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, tc testCase) error {
+	in := tc.input()
+	expected := solve(tc.n, append([]int(nil), tc.seq...))
+	got, err := runProgram(bin, in)
+	if err != nil {
+		return err
+	}
+	exp := strings.ReplaceAll(expected, "\r", "")
+	got = strings.ReplaceAll(got, "\r", "")
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{n: 3, seq: []int{3, 1, 2}}}
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/767/verifierB.go
+++ b/0-999/700-799/760-769/767/verifierB.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	ts, tf, t int64
+	arrivals  []int64
+}
+
+func solve(ts, tf, t int64, arr []int64) string {
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	arr = append(arr, int64(1)<<62)
+	cur := make([]int64, len(arr))
+	cur[0] = ts
+	for i := 0; i < len(arr)-1; i++ {
+		start := cur[i]
+		if arr[i] > start {
+			start = arr[i]
+		}
+		cur[i+1] = start + t
+	}
+	for i := 0; i < len(arr)-1; i++ {
+		if cur[i]+t <= tf && cur[i] < arr[i] {
+			return fmt.Sprintf("%d", cur[i])
+		}
+	}
+	bestTime := ts
+	bestWait := int64(1<<63 - 1)
+	j := sort.Search(len(arr), func(i int) bool { return arr[i] > ts })
+	start := cur[j]
+	if start < ts {
+		start = ts
+	}
+	if start+t <= tf {
+		bestWait = start - ts
+		bestTime = ts
+	}
+	for i := 0; i < len(arr)-1; i++ {
+		x := arr[i] - 1
+		if x < 0 {
+			continue
+		}
+		j = sort.Search(len(arr), func(k int) bool { return arr[k] > x })
+		start = cur[j]
+		if start < x {
+			start = x
+		}
+		if start+t <= tf {
+			wait := start - x
+			if wait < bestWait {
+				bestWait = wait
+				bestTime = x
+			}
+		}
+	}
+	if cur[len(arr)-1]+t <= tf && 0 < bestWait {
+		bestTime = cur[len(arr)-1]
+	}
+	return fmt.Sprintf("%d", bestTime)
+}
+
+func (tc testCase) input() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", tc.ts, tc.tf, tc.t)
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.arrivals)))
+	for i, v := range tc.arrivals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	ts := int64(rng.Intn(10))
+	tf := ts + int64(rng.Intn(20)+10)
+	t := int64(rng.Intn(5) + 1)
+	n := rng.Intn(8) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = int64(rng.Intn(int(tf)))
+	}
+	return testCase{ts: ts, tf: tf, t: t, arrivals: arr}
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, tc testCase) error {
+	in := tc.input()
+	expected := solve(tc.ts, tc.tf, tc.t, append([]int64(nil), tc.arrivals...))
+	got, err := runProgram(bin, in)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{randomCase(rng)}
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/767/verifierC.go
+++ b/0-999/700-799/760-769/767/verifierC.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n      int
+	parent []int
+	val    []int64
+}
+
+func solve(n int, parent []int, val []int64) string {
+	children := make([][]int, n+1)
+	var root int
+	var total int64
+	for i := 1; i <= n; i++ {
+		if parent[i] == 0 {
+			root = i
+		} else {
+			children[parent[i]] = append(children[parent[i]], i)
+		}
+		total += val[i]
+	}
+	if total%3 != 0 {
+		return "-1"
+	}
+	target := total / 3
+	sum := make([]int64, n+1)
+	ans1, ans2 := 0, 0
+	type frame struct {
+		node int
+		done bool
+	}
+	stack := []frame{{node: root, done: false}}
+	for len(stack) > 0 && (ans1 == 0 || ans2 == 0) {
+		f := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if f.done {
+			sum[f.node] = val[f.node]
+			for _, c := range children[f.node] {
+				if sum[c] == target {
+					if ans1 == 0 {
+						ans1 = c
+					} else if ans2 == 0 {
+						ans2 = c
+					}
+				} else {
+					sum[f.node] += sum[c]
+				}
+			}
+		} else {
+			stack = append(stack, frame{node: f.node, done: true})
+			for _, c := range children[f.node] {
+				stack = append(stack, frame{node: c, done: false})
+			}
+		}
+	}
+	if ans1 == 0 || ans2 == 0 {
+		return "-1"
+	}
+	return fmt.Sprintf("%d %d", ans1, ans2)
+}
+
+func (tc testCase) input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i := 1; i <= tc.n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.parent[i], tc.val[i]))
+	}
+	return sb.String()
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 2
+	parent := make([]int, n+1)
+	val := make([]int64, n+1)
+	for i := 2; i <= n; i++ {
+		parent[i] = rng.Intn(i-1) + 1
+	}
+	for i := 1; i <= n; i++ {
+		val[i] = int64(rng.Intn(11) - 5)
+	}
+	return testCase{n: n, parent: parent, val: val}
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, tc testCase) error {
+	in := tc.input()
+	expected := solve(tc.n, append([]int(nil), tc.parent...), append([]int64(nil), tc.val...))
+	got, err := runProgram(bin, in)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{randomCase(rng)}
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/767/verifierD.go
+++ b/0-999/700-799/760-769/767/verifierD.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const INF = 1070000000
+
+type testCase struct {
+	n, m, k int
+	a       []int
+	tasks   []int
+}
+
+func solve(n, m, k int, a []int, tasks []int) string {
+	aa := append([]int(nil), a...)
+	sort.Ints(aa)
+	type task struct{ d, id int }
+	ts := make([]task, m)
+	for i := 0; i < m; i++ {
+		ts[i] = task{tasks[i], i + 1}
+	}
+	sort.Slice(ts, func(i, j int) bool { return ts[i].d < ts[j].d })
+	headA, headT := 0, 0
+	ans := []int{}
+	for d := 0; ; d++ {
+		for headT < m && ts[headT].d < d {
+			headT++
+		}
+		if headA < n && aa[headA] < d {
+			return "-1"
+		}
+		cnt := 0
+		for cnt < k && (headT < m || headA < n) {
+			td := INF
+			if headT < m {
+				td = ts[headT].d
+			}
+			if headA >= n || td < aa[headA] {
+				ans = append(ans, ts[headT].id)
+				headT++
+			} else {
+				headA++
+			}
+			cnt++
+		}
+		if headT >= m && headA >= n {
+			break
+		}
+	}
+	sort.Ints(ans)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(ans)))
+	for i, v := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	if len(ans) > 0 {
+		sb.WriteByte('\n')
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func (tc testCase) input() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", tc.n, tc.m, tc.k)
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.tasks {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	k := rng.Intn(3) + 1
+	a := make([]int, n)
+	tasks := make([]int, m)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(10)
+	}
+	for i := 0; i < m; i++ {
+		tasks[i] = rng.Intn(10)
+	}
+	return testCase{n: n, m: m, k: k, a: a, tasks: tasks}
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, tc testCase) error {
+	in := tc.input()
+	expected := solve(tc.n, tc.m, tc.k, append([]int(nil), tc.a...), append([]int(nil), tc.tasks...))
+	got, err := runProgram(bin, in)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{randomCase(rng)}
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/767/verifierE.go
+++ b/0-999/700-799/760-769/767/verifierE.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Opt struct {
+	v   int64
+	num int
+}
+
+type OptHeap []Opt
+
+func (h OptHeap) Len() int            { return len(h) }
+func (h OptHeap) Less(i, j int) bool  { return h[i].v < h[j].v }
+func (h OptHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *OptHeap) Push(x interface{}) { *h = append(*h, x.(Opt)) }
+func (h *OptHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+type testCase struct {
+	n  int
+	m  int64
+	ai []int64
+	w  []int64
+}
+
+func solve(n int, m int64, ai []int64, w []int64) string {
+	ans1 := make([]int64, n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		ans1[i] = ai[i] / 100
+		a[i] = int(ai[i] % 100)
+	}
+	ans2 := make([]bool, n)
+	now := int64(0)
+	h := &OptHeap{}
+	heap.Init(h)
+	for i := 0; i < n; i++ {
+		if a[i] != 0 {
+			cost := int64(a[i])
+			benefit := w[i] * int64(100-a[i])
+			if m >= cost {
+				m -= cost
+				heap.Push(h, Opt{benefit, i})
+			} else {
+				if h.Len() == 0 {
+					now += benefit
+					m += int64(100 - a[i])
+					ans2[i] = true
+				} else {
+					top := (*h)[0]
+					if top.v < benefit {
+						heap.Pop(h)
+						heap.Push(h, Opt{benefit, i})
+						now += top.v
+						ans2[top.num] = true
+						m += int64(100 - a[i])
+					} else {
+						now += benefit
+						m += int64(100 - a[i])
+						ans2[i] = true
+					}
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", now))
+	for i := 0; i < n; i++ {
+		if ans2[i] {
+			sb.WriteString(fmt.Sprintf("%d 0\n", ans1[i]+1))
+		} else {
+			sb.WriteString(fmt.Sprintf("%d %d\n", ans1[i], a[i]))
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func (tc testCase) input() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+	for i, v := range tc.ai {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.w {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	m := int64(rng.Intn(500))
+	ai := make([]int64, n)
+	w := make([]int64, n)
+	for i := 0; i < n; i++ {
+		ai[i] = int64(rng.Intn(400))
+		w[i] = int64(rng.Intn(10) + 1)
+	}
+	return testCase{n: n, m: m, ai: ai, w: w}
+}
+
+func runProgram(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, tc testCase) error {
+	in := tc.input()
+	expected := solve(tc.n, tc.m, append([]int64(nil), tc.ai...), append([]int64(nil), tc.w...))
+	got, err := runProgram(bin, in)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{randomCase(rng)}
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for all problems of contest 767
- each verifier runs 100+ randomized tests against a candidate binary

## Testing
- `go run 0-999/700-799/760-769/767/verifierA.go /tmp/solverA`
- `go run 0-999/700-799/760-769/767/verifierB.go /tmp/solverB`
- `go run 0-999/700-799/760-769/767/verifierC.go /tmp/solverC`
- `go run 0-999/700-799/760-769/767/verifierD.go /tmp/solverD`
- `go run 0-999/700-799/760-769/767/verifierE.go /tmp/solverE`

------
https://chatgpt.com/codex/tasks/task_e_6883a4dd94488324917eab158c019313