### PR TITLE
Add solution verifiers for Codeforces contest 766

### DIFF
--- a/0-999/700-799/760-769/766/verifierA.go
+++ b/0-999/700-799/760-769/766/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "766A.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randomString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		l1 := rng.Intn(20) + 1
+		l2 := rng.Intn(20) + 1
+		s1 := randomString(rng, l1)
+		var s2 string
+		if rng.Intn(5) == 0 {
+			s2 = s1
+		} else {
+			s2 = randomString(rng, l2)
+		}
+		tests[i] = fmt.Sprintf("%s\n%s\n", s1, s2)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/766/verifierB.go
+++ b/0-999/700-799/760-769/766/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "766B.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(9) + 3
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(30)+1))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/766/verifierC.go
+++ b/0-999/700-799/760-769/766/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "766C.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randomString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		s := randomString(rng, n)
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		sb.WriteString(fmt.Sprintf("%s\n", s))
+		for j := 0; j < 26; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(n)+1))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/766/verifierD.go
+++ b/0-999/700-799/760-769/766/verifierD.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refD_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "766D.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randomWord(rng *rand.Rand, l int) string {
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 2
+		m := rng.Intn(5) + 1
+		q := rng.Intn(5) + 1
+		words := make([]string, n)
+		used := map[string]bool{}
+		for j := 0; j < n; j++ {
+			for {
+				w := randomWord(rng, rng.Intn(5)+1)
+				if !used[w] {
+					used[w] = true
+					words[j] = w
+					break
+				}
+			}
+		}
+		sb := strings.Builder{}
+		fmt.Fprintf(&sb, "%d %d %d\n", n, m, q)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(words[j])
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < m; j++ {
+			t := rng.Intn(2) + 1
+			x := words[rng.Intn(n)]
+			y := words[rng.Intn(n)]
+			for x == y {
+				y = words[rng.Intn(n)]
+			}
+			fmt.Fprintf(&sb, "%d %s %s\n", t, x, y)
+		}
+		for j := 0; j < q; j++ {
+			x := words[rng.Intn(n)]
+			y := words[rng.Intn(n)]
+			for x == y {
+				y = words[rng.Intn(n)]
+			}
+			fmt.Fprintf(&sb, "%s %s\n", x, y)
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/760-769/766/verifierE.go
+++ b/0-999/700-799/760-769/766/verifierE.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "766E.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		sb := strings.Builder{}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 1; j <= n; j++ {
+			if j > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(1000)))
+		}
+		sb.WriteByte('\n')
+		for j := 2; j <= n; j++ {
+			p := rng.Intn(j-1) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", p, j))
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- provide Go verifiers for problems A–E of contest 766
- each verifier builds the corresponding reference solution and runs 100 random tests
- verifiers report runtime errors or wrong answers when running any submitted binary

## Testing
- `go build 0-999/700-799/760-769/766/verifierA.go`
- `go build 0-999/700-799/760-769/766/verifierB.go`
- `go build 0-999/700-799/760-769/766/verifierC.go`
- `go build 0-999/700-799/760-769/766/verifierD.go`
- `go build 0-999/700-799/760-769/766/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883a4512300832480598efb3c62483e