### PR TITLE
Add Go solution for 1955A

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1955/1955A.go
+++ b/1000-1999/1900-1999/1950-1959/1955/1955A.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, a, b int
+		fmt.Fscan(in, &n, &a, &b)
+		// Cost if we buy two with promotion vs individually
+		pairCost := b
+		if 2*a < b {
+			pairCost = 2 * a
+		}
+		cost := (n/2)*pairCost + (n%2)*a
+		fmt.Fprintln(out, cost)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for 1955A

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1955/1955A.go`
- `echo '1
3 5 11
' | go run 1000-1999/1900-1999/1950-1959/1955/1955A.go`

------
https://chatgpt.com/codex/tasks/task_e_6883a40b3bf48324985f48d56006b28f