### PR TITLE
Add contest 780 solution verifiers

### DIFF
--- a/0-999/700-799/780-789/780/verifierA.go
+++ b/0-999/700-799/780-789/780/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	n := rand.Intn(10) + 1
+	arr := make([]int, 0, 2*n)
+	for i := 1; i <= n; i++ {
+		arr = append(arr, i, i)
+	}
+	// shuffle
+	rand.Shuffle(len(arr), func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	// build reference solution
+	ref := "refA_bin"
+	if err := exec.Command("go", "build", "-o", ref, "780A.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed to run reference solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/780-789/780/verifierB.go
+++ b/0-999/700-799/780-789/780/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	n := rand.Intn(5) + 1
+	xs := make([]int, n)
+	vs := make([]int, n)
+	for i := 0; i < n; i++ {
+		xs[i] = rand.Intn(100) + 1
+		vs[i] = rand.Intn(20) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range xs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range vs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refB_bin"
+	if err := exec.Command("go", "build", "-o", ref, "780B.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed to run reference solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/780-789/780/verifierC.go
+++ b/0-999/700-799/780-789/780/verifierC.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	n := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", p, i))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refC_bin"
+	if err := exec.Command("go", "build", "-o", ref, "780C.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed to run reference solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/780-789/780/verifierD.go
+++ b/0-999/700-799/780-789/780/verifierD.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randName() string {
+	l := rand.Intn(3) + 3 // length 3..5
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = byte('A' + rand.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCase() string {
+	n := rand.Intn(7) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(randName())
+		sb.WriteByte(' ')
+		sb.WriteString(randName())
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refD_bin"
+	if err := exec.Command("go", "build", "-o", ref, "780D.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed to run reference solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/780-789/780/verifierE.go
+++ b/0-999/700-799/780-789/780/verifierE.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(n) + n // ensure connected by extra edges
+	k := rand.Intn(n) + 1
+	edges := make([][2]int, 0, m)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	for len(edges) < m {
+		a := rand.Intn(n) + 1
+		b := rand.Intn(n) + 1
+		edges = append(edges, [2]int{a, b})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, len(edges), k))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refE_bin"
+	if err := exec.Command("go", "build", "-o", ref, "780E.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed to run reference solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/780-789/780/verifierF.go
+++ b/0-999/700-799/780-789/780/verifierF.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(n*n + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		v := rand.Intn(n) + 1
+		u := rand.Intn(n) + 1
+		t := rand.Intn(2)
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", v, u, t))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refF_bin"
+	if err := exec.Command("go", "build", "-o", ref, "780F.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed to run reference solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/780-789/780/verifierG.go
+++ b/0-999/700-799/780-789/780/verifierG.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	h := rand.Intn(10) + 1
+	w := rand.Intn(10) + 1
+	n := rand.Intn(5)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", h, w, n))
+	for i := 0; i < n; i++ {
+		u := rand.Intn(h) + 1
+		l := rand.Intn(w) + 1
+		r := rand.Intn(w-l+1) + l
+		s := rand.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", u, l, r, s))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refG_bin"
+	if err := exec.Command("go", "build", "-o", ref, "780G.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed to run reference solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/780-789/780/verifierH.go
+++ b/0-999/700-799/780-789/780/verifierH.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateCase() string {
+	n := 4
+	m := rand.Intn(9) + 1
+	w := rand.Intn(50) + 1
+	h := rand.Intn(50) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	sb.WriteString(fmt.Sprintf("0 0\n"))
+	sb.WriteString(fmt.Sprintf("0 %d\n", h))
+	sb.WriteString(fmt.Sprintf("%d %d\n", w, h))
+	sb.WriteString(fmt.Sprintf("%d 0\n", w))
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref := "refH_bin"
+	if err := exec.Command("go", "build", "-o", ref, "780H.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := generateCase()
+		want, err := runBinary("./"+ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed to run reference solution:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(target, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 780 problems A–H
- each verifier compiles the reference solution and checks 100 random test cases
- verifiers accept the path to a binary, e.g. `go run verifierA.go ./mySolution`

## Testing
- `go run verifierA.go ./780A_bin`
- `go run verifierB.go ./780B_bin`


------
https://chatgpt.com/codex/tasks/task_e_6883abfac0648324bf9385d24c032ac5