### PR TITLE
Add Go verifiers for Codeforces contest 779

### DIFF
--- a/0-999/700-799/770-779/779/verifierA.go
+++ b/0-999/700-799/770-779/779/verifierA.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCaseA(n int, a, b []int) string {
+	freqA := make([]int, 6)
+	freqB := make([]int, 6)
+	for _, v := range a {
+		freqA[v]++
+	}
+	for _, v := range b {
+		freqB[v]++
+	}
+	sumDiff := 0
+	for i := 1; i <= 5; i++ {
+		if (freqA[i]+freqB[i])%2 != 0 {
+			return "-1"
+		}
+		d := freqA[i] - freqB[i]
+		if d < 0 {
+			d = -d
+		}
+		sumDiff += d
+	}
+	return fmt.Sprintf("%d", sumDiff/4)
+}
+
+func generateCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(5) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		b[i] = rng.Intn(5) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(b[i]))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expect := solveCaseA(n, a, b)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseA(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/779/verifierB.go
+++ b/0-999/700-799/770-779/779/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCaseB(nStr string, k int) string {
+	zeroCount := 0
+	removed := 0
+	for i := len(nStr) - 1; i >= 0 && zeroCount < k; i-- {
+		if nStr[i] == '0' {
+			zeroCount++
+		} else {
+			removed++
+		}
+	}
+	if zeroCount < k {
+		return fmt.Sprintf("%d", len(nStr)-1)
+	}
+	return fmt.Sprintf("%d", removed)
+}
+
+func generateCaseB(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(2000000001)
+	k := rng.Intn(9) + 1
+	nStr := strconv.FormatInt(n, 10)
+	input := fmt.Sprintf("%s %d\n", nStr, k)
+	expect := solveCaseB(nStr, k)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseB(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/770-779/779/verifierC.go
+++ b/0-999/700-799/770-779/779/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCaseC(n, k int, a, b []int) string {
+	idx := make([]int, n)
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(i, j int) bool {
+		di := a[idx[i]] - b[idx[i]]
+		dj := a[idx[j]] - b[idx[j]]
+		return di < dj
+	})
+	var total int64
+	for i, id := range idx {
+		if i < k || a[id] <= b[id] {
+			total += int64(a[id])
+		} else {
+			total += int64(b[id])
+		}
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+func generateCaseC(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	k := rng.Intn(n + 1)
+	a := make([]int, n)
+	b := make([]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(10000) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		b[i] = rng.Intn(10000) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(b[i]))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expect := solveCaseC(n, k, a, b)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseC(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 779 problems A, B, and C
- each verifier generates 100 random tests and checks candidate outputs

## Testing
- `go run verifierA.go -- 779A.go`
- `go run verifierB.go -- 779B.go`
- `go run verifierC.go -- 779C.go`


------
https://chatgpt.com/codex/tasks/task_e_6883ab6e37448324aa124dad15a3ed07