### PR TITLE
Add Go solution for 1955F

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1955/1955F.go
+++ b/1000-1999/1900-1999/1950-1959/1955/1955F.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var c1, c2, c3, c4 int
+		if _, err := fmt.Fscan(reader, &c1, &c2, &c3, &c4); err != nil {
+			return
+		}
+		pairs := c1/2 + c2/2 + c3/2 + c4/2
+		if c1%2 == 1 && c2%2 == 1 && c3%2 == 1 {
+			pairs++
+		}
+		fmt.Fprintln(writer, pairs)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem F of 1955 using simple arithmetic

## Testing
- `go vet 1000-1999/1900-1999/1950-1959/1955/1955F.go`
- `gofmt -w 1000-1999/1900-1999/1950-1959/1955/1955F.go`
- `echo -e "1\n1 2 3 4" | go run 1000-1999/1900-1999/1950-1959/1955/1955F.go`

------
https://chatgpt.com/codex/tasks/task_e_6883a1dad14883248b77ebaf847711b7