### PR TITLE
Add Go solution verifiers for contest 762

### DIFF
--- a/0-999/700-799/760-769/762/verifierA.go
+++ b/0-999/700-799/760-769/762/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func divisors(n int64) []int64 {
+	small := make([]int64, 0)
+	big := make([]int64, 0)
+	for i := int64(1); i*i <= n; i++ {
+		if n%i == 0 {
+			small = append(small, i)
+			if i != n/i {
+				big = append(big, n/i)
+			}
+		}
+	}
+	for i := len(big)/2 - 1; i >= 0; i-- {
+		opposite := len(big) - 1 - i
+		big[i], big[opposite] = big[opposite], big[i]
+	}
+	return append(small, big...)
+}
+
+func expected(n, k int64) int64 {
+	divs := divisors(n)
+	if k <= 0 || k > int64(len(divs)) {
+		return -1
+	}
+	return divs[k-1]
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+
+	for t := 0; t < 100; t++ {
+		n := rng.Int63n(1_000_000_000_000) + 1
+		divs := divisors(n)
+		var k int64
+		if rng.Intn(2) == 0 {
+			k = int64(rng.Intn(len(divs))) + 1
+		} else {
+			k = int64(len(divs)) + int64(rng.Intn(5)+1)
+		}
+		input := fmt.Sprintf("%d %d\n", n, k)
+		exp := fmt.Sprintf("%d", expected(n, k))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", t+1, err)
+			fmt.Printf("input:\n%s\noutput:\n%s\n", input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/760-769/762/verifierB.go
+++ b/0-999/700-799/760-769/762/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type Mouse struct {
+	cost int64
+	typ  string
+}
+
+func expected(a, b, c int, items []Mouse) (int, int64) {
+	usb := []int64{}
+	ps := []int64{}
+	for _, m := range items {
+		if m.typ == "USB" {
+			usb = append(usb, m.cost)
+		} else {
+			ps = append(ps, m.cost)
+		}
+	}
+	sort.Slice(usb, func(i, j int) bool { return usb[i] < usb[j] })
+	sort.Slice(ps, func(i, j int) bool { return ps[i] < ps[j] })
+	count := 0
+	total := int64(0)
+	u := 0
+	for u < len(usb) && a > 0 {
+		total += usb[u]
+		count++
+		u++
+		a--
+	}
+	p := 0
+	for p < len(ps) && b > 0 {
+		total += ps[p]
+		count++
+		p++
+		b--
+	}
+	rest := append(append([]int64{}, usb[u:]...), ps[p:]...)
+	sort.Slice(rest, func(i, j int) bool { return rest[i] < rest[j] })
+	r := 0
+	for r < len(rest) && c > 0 {
+		total += rest[r]
+		count++
+		r++
+		c--
+	}
+	return count, total
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+
+	for t := 0; t < 100; t++ {
+		a := rng.Intn(6)
+		b := rng.Intn(6)
+		c := rng.Intn(6)
+		m := rng.Intn(15)
+		items := make([]Mouse, m)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", a, b, c))
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+		for i := 0; i < m; i++ {
+			cost := rng.Int63n(1000) + 1
+			typ := "USB"
+			if rng.Intn(2) == 0 {
+				typ = "PS/2"
+			}
+			items[i] = Mouse{cost: cost, typ: typ}
+			sb.WriteString(fmt.Sprintf("%d %s\n", cost, typ))
+		}
+		input := sb.String()
+		cnt, tot := expected(a, b, c, items)
+		exp := fmt.Sprintf("%d %d", cnt, tot)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\noutput:\n%s\n", t+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/760-769/762/verifierC.go
+++ b/0-999/700-799/760-769/762/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expected(a, b string) string {
+	n := len(a)
+	m := len(b)
+	pref := make([]int, m)
+	pos := 0
+	for i := 0; i < m; i++ {
+		for pos < n && a[pos] != b[i] {
+			pos++
+		}
+		if pos == n {
+			pref[i] = n
+		} else {
+			pref[i] = pos
+			pos++
+		}
+	}
+	suff := make([]int, m+1)
+	suff[m] = n
+	pos = n - 1
+	for i := m - 1; i >= 0; i-- {
+		for pos >= 0 && a[pos] != b[i] {
+			pos--
+		}
+		if pos < 0 {
+			suff[i] = -1
+		} else {
+			suff[i] = pos
+			pos--
+		}
+	}
+	bestL, bestR, bestLen := 0, m, m
+	r := 0
+	for l := 0; l <= m; l++ {
+		prefixPos := -1
+		if l > 0 {
+			if pref[l-1] == n {
+				break
+			}
+			prefixPos = pref[l-1]
+		}
+		if r < l {
+			r = l
+		}
+		for r <= m {
+			if r == m {
+				break
+			}
+			if suff[r] == -1 || suff[r] <= prefixPos {
+				r++
+				continue
+			}
+			break
+		}
+		if r > m {
+			break
+		}
+		delLen := r - l
+		if delLen < bestLen {
+			bestLen = delLen
+			bestL = l
+			bestR = r
+		}
+	}
+	res := b[:bestL] + b[bestR:]
+	if len(res) == 0 {
+		return "-"
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func randString(rng *rand.Rand, n int) string {
+	letters := []rune("abcde")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+
+	for t := 0; t < 100; t++ {
+		a := randString(rng, rng.Intn(10)+1)
+		b := randString(rng, rng.Intn(10)+1)
+		input := fmt.Sprintf("%s\n%s\n", a, b)
+		exp := expected(a, b)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\noutput:\n%s\n", t+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/760-769/762/verifierD.go
+++ b/0-999/700-799/760-769/762/verifierD.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expected(a [][]int) int {
+	n := len(a[0])
+	dp0 := a[0][0]
+	dp1 := a[0][0] + a[1][0]
+	dp2 := a[0][0] + a[1][0] + a[2][0]
+	for i := 1; i < n; i++ {
+		ndp0 := max(dp0+a[0][i], max(dp1+a[0][i]+a[1][i], dp2+a[0][i]+a[1][i]+a[2][i]))
+		ndp1 := max(dp1+a[1][i], max(dp0+a[0][i]+a[1][i], dp2+a[1][i]+a[2][i]))
+		ndp2 := max(dp2+a[2][i], max(dp1+a[1][i]+a[2][i], dp0+a[0][i]+a[1][i]+a[2][i]))
+		dp0, dp1, dp2 = ndp0, ndp1, ndp2
+	}
+	return dp2
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(10) + 1
+		a := make([][]int, 3)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < 3; i++ {
+			a[i] = make([]int, n)
+			for j := 0; j < n; j++ {
+				val := rng.Intn(21) - 10
+				a[i][j] = val
+				sb.WriteString(fmt.Sprintf("%d ", val))
+			}
+			sb.WriteString("\n")
+		}
+		input := sb.String()
+		exp := fmt.Sprintf("%d", expected(a))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\noutput:\n%s\n", t+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/760-769/762/verifierE.go
+++ b/0-999/700-799/760-769/762/verifierE.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type BIT struct {
+	n    int
+	tree []int
+}
+
+func NewBIT(n int) *BIT {
+	return &BIT{n: n, tree: make([]int, n+2)}
+}
+
+func (b *BIT) Add(i, delta int) {
+	for i <= b.n {
+		b.tree[i] += delta
+		i += i & -i
+	}
+}
+
+func (b *BIT) Sum(i int) int {
+	if i > b.n {
+		i = b.n
+	}
+	s := 0
+	for i > 0 {
+		s += b.tree[i]
+		i &= i - 1
+	}
+	return s
+}
+
+type Station struct {
+	x   int
+	r   int
+	f   int
+	idx int
+}
+
+func uniqueInts(a []int) []int {
+	if len(a) == 0 {
+		return a
+	}
+	j := 1
+	for i := 1; i < len(a); i++ {
+		if a[i] != a[i-1] {
+			a[j] = a[i]
+			j++
+		}
+	}
+	return a[:j]
+}
+
+func expected(n, k int, stations []Station) int64 {
+	freqCoords := make(map[int][]int)
+	for i := 0; i < n; i++ {
+		freqCoords[stations[i].f] = append(freqCoords[stations[i].f], stations[i].x)
+	}
+	bits := make(map[int]*BIT, len(freqCoords))
+	coords := make(map[int][]int, len(freqCoords))
+	for f, arr := range freqCoords {
+		sort.Ints(arr)
+		arr = uniqueInts(arr)
+		coords[f] = arr
+		bits[f] = NewBIT(len(arr))
+	}
+	for i := range stations {
+		arr := coords[stations[i].f]
+		stations[i].idx = sort.SearchInts(arr, stations[i].x) + 1
+	}
+	sort.Slice(stations, func(i, j int) bool { return stations[i].x < stations[j].x })
+	ans := int64(0)
+	left := 0
+	for i, st := range stations {
+		for left < i && stations[left].x+stations[left].r < st.x {
+			rm := stations[left]
+			bits[rm.f].Add(rm.idx, -1)
+			left++
+		}
+		for freq := st.f - k; freq <= st.f+k; freq++ {
+			if freq < 1 || freq > 10000 {
+				continue
+			}
+			bit := bits[freq]
+			if bit == nil {
+				continue
+			}
+			arr := coords[freq]
+			pos := sort.SearchInts(arr, st.x-st.r)
+			cnt := bit.Sum(len(arr)) - bit.Sum(pos)
+			ans += int64(cnt)
+		}
+		bits[st.f].Add(st.idx, 1)
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(5)
+		stations := make([]Station, n)
+		usedX := map[int]bool{}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n; i++ {
+			x := rng.Intn(1000) + 1
+			for usedX[x] {
+				x = rng.Intn(1000) + 1
+			}
+			usedX[x] = true
+			r := rng.Intn(10) + 1
+			f := rng.Intn(10) + 1
+			stations[i] = Station{x: x, r: r, f: f}
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", x, r, f))
+		}
+		input := sb.String()
+		exp := fmt.Sprintf("%d", expected(n, k, stations))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\noutput:\n%s\n", t+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/760-769/762/verifierF.go
+++ b/0-999/700-799/760-769/762/verifierF.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const mod int = 1000000007
+
+var sTree [][]int
+var tTree [][]int
+var fact [13]int
+
+type state struct {
+	u int
+	p int
+	t int
+}
+
+var memo map[state]int
+
+func modMul(a, b int) int {
+	return int((int64(a) * int64(b)) % int64(mod))
+}
+
+func solve(u, p, t, pt int) int {
+	key := state{u, p, t}
+	if val, ok := memo[key]; ok {
+		return val
+	}
+	children := []int{}
+	for _, v := range tTree[t] {
+		if v != pt {
+			children = append(children, v)
+		}
+	}
+	neighbors := []int{}
+	for _, v := range sTree[u] {
+		if v != p {
+			neighbors = append(neighbors, v)
+		}
+	}
+	if len(neighbors) < len(children) {
+		memo[key] = 0
+		return 0
+	}
+	k := len(children)
+	m := len(neighbors)
+	val := make([][]int, m)
+	for j := 0; j < m; j++ {
+		val[j] = make([]int, k)
+		for i := 0; i < k; i++ {
+			val[j][i] = solve(neighbors[j], u, children[i], t)
+		}
+	}
+	dp := make([]int, 1<<k)
+	dp[0] = 1
+	for j := 0; j < m; j++ {
+		ndp := make([]int, 1<<k)
+		copy(ndp, dp)
+		for mask := 0; mask < (1 << k); mask++ {
+			if dp[mask] == 0 {
+				continue
+			}
+			for i := 0; i < k; i++ {
+				if (mask>>i)&1 == 0 {
+					if val[j][i] == 0 {
+						continue
+					}
+					nm := mask | (1 << i)
+					ndp[nm] = (ndp[nm] + modMul(dp[mask], val[j][i])) % mod
+				}
+			}
+		}
+		dp = ndp
+	}
+	res := dp[(1<<k)-1]
+	memo[key] = res
+	return res
+}
+
+func dfsCanon(u, p int) (string, int) {
+	forms := []string{}
+	aut := 1
+	for _, v := range tTree[u] {
+		if v == p {
+			continue
+		}
+		s, a := dfsCanon(v, u)
+		forms = append(forms, s)
+		aut *= a
+	}
+	sort.Strings(forms)
+	i := 0
+	for i < len(forms) {
+		j := i
+		for j < len(forms) && forms[j] == forms[i] {
+			j++
+		}
+		aut *= fact[j-i]
+		i = j
+	}
+	return "(" + strings.Join(forms, "") + ")", aut
+}
+
+func modPow(a, e int) int {
+	res := 1
+	base := a % mod
+	for e > 0 {
+		if e&1 == 1 {
+			res = modMul(res, base)
+		}
+		base = modMul(base, base)
+		e >>= 1
+	}
+	return res
+}
+
+func expected(nS int, edgesS [][2]int, nT int, edgesT [][2]int) int {
+	sTree = make([][]int, nS)
+	for _, e := range edgesS {
+		u, v := e[0], e[1]
+		sTree[u] = append(sTree[u], v)
+		sTree[v] = append(sTree[v], u)
+	}
+	tTree = make([][]int, nT)
+	for _, e := range edgesT {
+		x, y := e[0], e[1]
+		tTree[x] = append(tTree[x], y)
+		tTree[y] = append(tTree[y], x)
+	}
+	for i := 0; i < len(fact); i++ {
+		if i == 0 {
+			fact[i] = 1
+		} else {
+			fact[i] = fact[i-1] * i
+		}
+	}
+	forms := make([]string, nT)
+	autos := make([]int, nT)
+	counts := make(map[string]int)
+	for v := 0; v < nT; v++ {
+		s, a := dfsCanon(v, -1)
+		forms[v] = s
+		autos[v] = a
+		counts[s]++
+	}
+	rootForm := forms[0]
+	autRoot := autos[0]
+	orbit := counts[rootForm]
+	autTotal := autRoot * orbit
+	memo = make(map[state]int)
+	total := 0
+	for s := 0; s < nS; s++ {
+		val := solve(s, -1, 0, -1)
+		total += val
+		if total >= mod {
+			total -= mod
+		}
+	}
+	invAut := modPow(autTotal%mod, mod-2)
+	ans := modMul(total, invAut)
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// generate random tree with n nodes
+func genTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+
+	for t := 0; t < 100; t++ {
+		nS := rng.Intn(8) + 1
+		edgesS := genTree(rng, nS)
+		nT := rng.Intn(4) + 1
+		edgesT := genTree(rng, nT)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", nS))
+		for _, e := range edgesS {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", nT))
+		for _, e := range edgesT {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+		}
+		input := sb.String()
+		exp := fmt.Sprintf("%d", expected(nS, edgesS, nT, edgesT))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\ninput:\n%s\noutput:\n%s\n", t+1, err, input, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for Codeforces contest 762 problems A–F
- each verifier runs 100 randomized tests and checks a provided binary

## Testing
- `go build 0-999/700-799/760-769/762/verifierA.go`
- `go build 0-999/700-799/760-769/762/verifierB.go`
- `go build 0-999/700-799/760-769/762/verifierC.go`
- `go build 0-999/700-799/760-769/762/verifierD.go`
- `go build 0-999/700-799/760-769/762/verifierE.go`
- `go build 0-999/700-799/760-769/762/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883a22148308324b8ad2d18b8cade26