### PR TITLE
Add Go verifiers for contest 757

### DIFF
--- a/0-999/700-799/750-759/757/verifierA.go
+++ b/0-999/700-799/750-759/757/verifierA.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteRune(letters[rng.Intn(len(letters))])
+	}
+	s := sb.String()
+	freq := make(map[rune]int)
+	for _, ch := range s {
+		freq[ch]++
+	}
+	need := map[rune]int{'B': 1, 'u': 2, 'l': 1, 'b': 1, 'a': 2, 's': 1, 'r': 1}
+	ans := int(^uint(0) >> 1)
+	for ch, cnt := range need {
+		val := freq[ch] / cnt
+		if val < ans {
+			ans = val
+		}
+	}
+	if ans == int(^uint(0)>>1) {
+		ans = 0
+	}
+	return s + "\n", fmt.Sprintf("%d", ans)
+}
+
+func runCase(exe, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := runCase(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/757/verifierB.go
+++ b/0-999/700-799/750-759/757/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func primeFactors(x int) map[int]struct{} {
+	res := make(map[int]struct{})
+	for p := 2; p*p <= x; p++ {
+		if x%p == 0 {
+			res[p] = struct{}{}
+			for x%p == 0 {
+				x /= p
+			}
+		}
+	}
+	if x > 1 {
+		res[x] = struct{}{}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(100) + 1
+	}
+	counts := make(map[int]int)
+	best := 0
+	for _, v := range arr {
+		fac := primeFactors(v)
+		for p := range fac {
+			counts[p]++
+			if counts[p] > best {
+				best = counts[p]
+			}
+		}
+	}
+	if best == 0 {
+		best = 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String(), fmt.Sprintf("%d", best)
+}
+
+func runCase(exe, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := runCase(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/757/verifierC.go
+++ b/0-999/700-799/750-759/757/verifierC.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func solveC(n, m int, gyms [][]int) int64 {
+	typeCount := make(map[int]map[int]int)
+	for i := 0; i < n; i++ {
+		for _, t := range gyms[i] {
+			mp := typeCount[t]
+			if mp == nil {
+				mp = make(map[int]int)
+				typeCount[t] = mp
+			}
+			mp[i]++
+		}
+	}
+
+	groups := make(map[string]int)
+	buf := &bytes.Buffer{}
+	idx := make([]int, 0)
+	for t := 1; t <= m; t++ {
+		mp := typeCount[t]
+		if mp == nil {
+			groups[""]++
+			continue
+		}
+		buf.Reset()
+		idx = idx[:0]
+		for gym := range mp {
+			idx = append(idx, gym)
+		}
+		sort.Ints(idx)
+		for _, gym := range idx {
+			fmt.Fprintf(buf, "%d:%d|", gym, mp[gym])
+		}
+		key := buf.String()
+		groups[key]++
+	}
+
+	fact := make([]int64, m+1)
+	fact[0] = 1
+	for i := 1; i <= m; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+
+	ans := int64(1)
+	for _, s := range groups {
+		ans = ans * fact[s] % mod
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(4) + 1
+	gyms := make([][]int, n)
+	for i := 0; i < n; i++ {
+		g := rng.Intn(3)
+		gyms[i] = make([]int, g)
+		for j := 0; j < g; j++ {
+			gyms[i][j] = rng.Intn(m) + 1
+		}
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d", len(gyms[i]))
+		for _, t := range gyms[i] {
+			fmt.Fprintf(&sb, " %d", t)
+		}
+		sb.WriteByte('\n')
+	}
+	expected := solveC(n, m, gyms)
+	return sb.String(), fmt.Sprintf("%d", expected)
+}
+
+func runCase(exe, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := runCase(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/757/verifierD.go
+++ b/0-999/700-799/750-759/757/verifierD.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1e9 + 7
+
+type edge struct {
+	to  int
+	val int
+}
+
+func solveD(s string) int64 {
+	n := len(s)
+	edges := make([][]edge, n)
+	for i := 0; i < n; i++ {
+		val := 0
+		for j := i; j < n; j++ {
+			val = val*2 + int(s[j]-'0')
+			if val > 20 {
+				break
+			}
+			if val > 0 {
+				edges[i] = append(edges[i], edge{j + 1, val})
+			}
+		}
+	}
+	dp := make([]map[int]int64, n+1)
+	for i := 0; i <= n; i++ {
+		dp[i] = make(map[int]int64)
+	}
+	for i := 0; i < n; i++ {
+		dp[i][0] = (dp[i][0] + 1) % MOD
+	}
+	for i := 0; i < n; i++ {
+		for mask, cnt := range dp[i] {
+			for _, e := range edges[i] {
+				nm := mask | (1 << (e.val - 1))
+				dp[e.to][nm] = (dp[e.to][nm] + cnt) % MOD
+			}
+		}
+	}
+	var ans int64
+	for i := 0; i <= n; i++ {
+		for mask, cnt := range dp[i] {
+			if mask != 0 && (mask&(mask+1)) == 0 {
+				ans = (ans + cnt) % MOD
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(12) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	s := sb.String()
+	expected := solveD(s)
+	return fmt.Sprintf("%d\n%s\n", n, s), fmt.Sprintf("%d", expected)
+}
+
+func runCase(exe, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := runCase(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/757/verifierE.go
+++ b/0-999/700-799/750-759/757/verifierE.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+
+var spf []int
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	a %= MOD
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func comb(n, k int, fact, invFact []int64) int64 {
+	if n < k || k < 0 {
+		return 0
+	}
+	return fact[n] * invFact[k] % MOD * invFact[n-k] % MOD
+}
+
+func precompute(limit int) ([]int64, []int64) {
+	fact := make([]int64, limit+1)
+	invFact := make([]int64, limit+1)
+	fact[0] = 1
+	for i := 1; i <= limit; i++ {
+		fact[i] = fact[i-1] * int64(i) % MOD
+	}
+	invFact[limit] = modPow(fact[limit], MOD-2)
+	for i := limit; i >= 1; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % MOD
+	}
+	return fact, invFact
+}
+
+func initSPF(max int) {
+	spf = make([]int, max+1)
+	for i := 2; i*i <= max; i++ {
+		if spf[i] == 0 {
+			for j := i * i; j <= max; j += i {
+				if spf[j] == 0 {
+					spf[j] = i
+				}
+			}
+		}
+	}
+	for i := 2; i <= max; i++ {
+		if spf[i] == 0 {
+			spf[i] = i
+		}
+	}
+}
+
+func solveQuery(r, n int, fact, invFact []int64) int64 {
+	ans := int64(1)
+	m := n
+	for m > 1 {
+		p := spf[m]
+		cnt := 0
+		for m%p == 0 {
+			m /= p
+			cnt++
+		}
+		val := comb(r+cnt+1, r+1, fact, invFact) - comb(r+cnt-1, r+1, fact, invFact)
+		if val < 0 {
+			val += MOD
+		}
+		ans = ans * val % MOD
+	}
+	return ans % MOD
+}
+
+func generateCase(rng *rand.Rand, fact, invFact []int64) (string, string) {
+	q := rng.Intn(5) + 1
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		r := rng.Intn(5)
+		n := rng.Intn(1000) + 1
+		queries[i] = [2]int{r, n}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", q)
+	for _, qq := range queries {
+		fmt.Fprintf(&sb, "%d %d\n", qq[0], qq[1])
+	}
+	var out strings.Builder
+	for _, qq := range queries {
+		ans := solveQuery(qq[0], qq[1], fact, invFact)
+		fmt.Fprintf(&out, "%d\n", ans)
+	}
+	return sb.String(), strings.TrimSpace(out.String())
+}
+
+func runCase(exe, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	initSPF(1000000)
+	fact, invFact := precompute(10000)
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng, fact, invFact)
+		got, err := runCase(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/757/verifierF.go
+++ b/0-999/700-799/750-759/757/verifierF.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, string, error) {
+	n := rng.Intn(5) + 2
+	m := n - 1 + rng.Intn(3)
+	s := rng.Intn(n) + 1
+	type edge struct{ u, v int }
+	edges := make([]edge, 0, m)
+	// build tree first
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, edge{p, i})
+	}
+	exist := make(map[[2]int]bool)
+	for _, e := range edges {
+		a, b := e.u, e.v
+		if a > b {
+			a, b = b, a
+		}
+		exist[[2]int{a, b}] = true
+	}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		a, b := u, v
+		if a > b {
+			a, b = b, a
+		}
+		if exist[[2]int{a, b}] {
+			continue
+		}
+		exist[[2]int{a, b}] = true
+		edges = append(edges, edge{u, v})
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, len(edges), s)
+	for _, e := range edges {
+		w := rng.Intn(10) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", e.u, e.v, w)
+	}
+	input := sb.String()
+	exp, err := runCase("757F.go", input)
+	if err != nil {
+		return "", "", err
+	}
+	return input, exp, nil
+}
+
+func runCase(exe, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp, err := generateCase(rng)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to generate case: %v", err)
+			os.Exit(1)
+		}
+		got, err := runCase(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/757/verifierG.go
+++ b/0-999/700-799/750-759/757/verifierG.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func generateTree(n int, rng *rand.Rand) [][3]int {
+	edges := make([][3]int, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i) + 1
+		w := rng.Intn(10) + 1
+		edges[i-1] = [3]int{p, i + 1, w}
+	}
+	return edges
+}
+
+func generateCase(rng *rand.Rand) (string, string, error) {
+	n := rng.Intn(5) + 2
+	q := rng.Intn(5) + 1
+	seq := rng.Perm(n)
+	for i := range seq {
+		seq[i]++
+	}
+	edges := generateTree(n, rng)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i, v := range seq {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d %d\n", e[0], e[1], e[2])
+	}
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			v := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "1 %d %d %d\n", l, r, v)
+		} else {
+			x := rng.Intn(n-1) + 1
+			fmt.Fprintf(&sb, "2 %d\n", x)
+		}
+	}
+	input := sb.String()
+	exp, err := runCase("757G.go", input)
+	if err != nil {
+		return "", "", err
+	}
+	return input, exp, nil
+}
+
+func runCase(exe, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp, err := generateCase(rng)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to generate case: %v", err)
+			os.Exit(1)
+		}
+		got, err := runCase(exe, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go through verifierG.go for Codeforces contest 757
- each verifier runs 100 randomized tests against the provided binary

## Testing
- `go fmt verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68839f643da8832495c1915c251342ba