### PR TITLE
Add factorial solution for 1952C

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1952/1952C.go
+++ b/1000-1999/1900-1999/1950-1959/1952/1952C.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+func factorial(n int) int {
+    res := 1
+    for i := 2; i <= n; i++ {
+        res *= i
+    }
+    return res
+}
+
+func main() {
+    in := bufio.NewReader(os.Stdin)
+    var n int
+    if _, err := fmt.Fscan(in, &n); err != nil {
+        return
+    }
+    fmt.Print(factorial(n))
+}
+


### PR DESCRIPTION
## Summary
- add Go solution `1952C.go` implementing factorial

## Testing
- `go build ./1000-1999/1900-1999/1950-1959/1952/1952C.go`


------
https://chatgpt.com/codex/tasks/task_e_68839f1e35908324b79203c0779050bb