### PR TITLE
Add Go verifiers for CF 756

### DIFF
--- a/0-999/700-799/750-759/756/verifierA.go
+++ b/0-999/700-799/750-759/756/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(42))
+	tests := make([]string, 0, 20)
+	for i := 0; i < 20; i++ {
+		n := r.Intn(6) + 1
+		perm := r.Perm(n)
+		for j := range perm {
+			perm[j]++
+		}
+		b := make([]int, n)
+		for j := range b {
+			b[j] = r.Intn(2)
+		}
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for j, v := range perm {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		for j, v := range b {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierA.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "756A.go")
+
+	tests := generateTests()
+	for i, t := range tests {
+		expected, err1 := runBinary(ref, t)
+		if err1 != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err1)
+			os.Exit(1)
+		}
+		got, err2 := runBinary(candidate, t)
+		if err2 != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err2)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/756/verifierB.go
+++ b/0-999/700-799/750-759/756/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(43))
+	tests := make([]string, 0, 20)
+	for i := 0; i < 20; i++ {
+		n := r.Intn(15) + 1
+		times := make([]int, n)
+		cur := 0
+		for j := 0; j < n; j++ {
+			cur += r.Intn(100) + 1
+			times[j] = cur
+		}
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for j, v := range times {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierB.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "756B.go")
+
+	tests := generateTests()
+	for i, t := range tests {
+		expected, err1 := runBinary(ref, t)
+		if err1 != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err1)
+			os.Exit(1)
+		}
+		got, err2 := runBinary(candidate, t)
+		if err2 != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err2)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/756/verifierC.go
+++ b/0-999/700-799/750-759/756/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(44))
+	tests := make([]string, 0, 20)
+	for i := 0; i < 20; i++ {
+		m := r.Intn(10) + 1
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(m))
+		sb.WriteByte('\n')
+		for j := 0; j < m; j++ {
+			p := r.Intn(m) + 1
+			t := r.Intn(2)
+			sb.WriteString(strconv.Itoa(p))
+			sb.WriteByte(' ')
+			sb.WriteString(strconv.Itoa(t))
+			if t == 1 {
+				sb.WriteByte(' ')
+				x := r.Intn(100) + 1
+				sb.WriteString(strconv.Itoa(x))
+			}
+			if j+1 < m {
+				sb.WriteByte('\n')
+			}
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierC.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "756C.go")
+
+	tests := generateTests()
+	for i, t := range tests {
+		expected, err1 := runBinary(ref, t)
+		if err1 != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err1)
+			os.Exit(1)
+		}
+		got, err2 := runBinary(candidate, t)
+		if err2 != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err2)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/756/verifierD.go
+++ b/0-999/700-799/750-759/756/verifierD.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(45))
+	tests := make([]string, 0, 20)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	for i := 0; i < 20; i++ {
+		n := r.Intn(10) + 1
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			sb.WriteRune(letters[r.Intn(len(letters))])
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierD.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "756D.go")
+
+	tests := generateTests()
+	for i, t := range tests {
+		expected, err1 := runBinary(ref, t)
+		if err1 != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err1)
+			os.Exit(1)
+		}
+		got, err2 := runBinary(candidate, t)
+		if err2 != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err2)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/756/verifierE.go
+++ b/0-999/700-799/750-759/756/verifierE.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(46))
+	tests := make([]string, 0, 20)
+	for i := 0; i < 20; i++ {
+		n := r.Intn(4) + 2 // at least 2
+		a := make([]int64, n-1)
+		for j := 0; j < n-1; j++ {
+			a[j] = int64(r.Intn(3) + 1)
+		}
+		b := make([]int, n)
+		for j := 0; j < n; j++ {
+			b[j] = r.Intn(3)
+		}
+		m := int64(r.Intn(1000))
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(n))
+		sb.WriteByte('\n')
+		for j, v := range a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(v, 10))
+		}
+		sb.WriteByte('\n')
+		for j, v := range b {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(strconv.FormatInt(m, 10))
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierE.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "756E.go")
+
+	tests := generateTests()
+	for i, t := range tests {
+		expected, err1 := runBinary(ref, t)
+		if err1 != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err1)
+			os.Exit(1)
+		}
+		got, err2 := runBinary(candidate, t)
+		if err2 != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err2)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/756/verifierF.go
+++ b/0-999/700-799/750-759/756/verifierF.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func runBinary(path string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randNum(r *rand.Rand) string {
+	return strconv.Itoa(r.Intn(99) + 1)
+}
+
+func randTerm(r *rand.Rand, depth int) string {
+	typ := r.Intn(3)
+	if depth <= 0 && typ > 0 {
+		typ = 0
+	}
+	switch typ {
+	case 0:
+		return randNum(r)
+	case 1:
+		l := r.Intn(50) + 1
+		r2 := l + r.Intn(50)
+		return fmt.Sprintf("%d-%d", l, r2)
+	default:
+		return randNum(r) + "(" + randExpr(r, depth-1) + ")"
+	}
+}
+
+func randExpr(r *rand.Rand, depth int) string {
+	terms := r.Intn(3) + 1
+	res := randTerm(r, depth)
+	for i := 1; i < terms; i++ {
+		res += "+" + randTerm(r, depth)
+	}
+	return res
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(47))
+	tests := make([]string, 0, 20)
+	for i := 0; i < 20; i++ {
+		expr := randExpr(r, 2)
+		tests = append(tests, expr+"\n")
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierF.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "756F.go")
+
+	tests := generateTests()
+	for i, t := range tests {
+		expected, err1 := runBinary(ref, t)
+		if err1 != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err1)
+			os.Exit(1)
+		}
+		got, err2 := runBinary(candidate, t)
+		if err2 != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err2)
+			os.Exit(1)
+		}
+		if expected != got {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for Codeforces contest 756 problems A–F
- each verifier generates 20 randomized test cases
- verifiers run the reference solution and compare its output with the target binary

## Testing
- `go build 0-999/700-799/750-759/756/verifierA.go`
- `go build 0-999/700-799/750-759/756/verifierB.go`
- `go build 0-999/700-799/750-759/756/verifierC.go`
- `go build 0-999/700-799/750-759/756/verifierD.go`
- `go build 0-999/700-799/750-759/756/verifierE.go`
- `go build 0-999/700-799/750-759/756/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68839ed830688324bd6137d49888afdb