### PR TITLE
Add placeholder Go solution for 1952E

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1952/1952E.go
+++ b/1000-1999/1900-1999/1950-1959/1952/1952E.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// Since the actual problem statement is missing, we simply read the
+// input as described and output zero.
+const mod = 20240401
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	for i := 0; i < n; i++ {
+		var x int
+		if _, err := fmt.Fscan(reader, &x); err != nil {
+			return
+		}
+		_ = x
+	}
+	fmt.Println(0)
+}


### PR DESCRIPTION
## Summary
- add `1952E.go` with placeholder solution implementation

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1952/1952E.go`


------
https://chatgpt.com/codex/tasks/task_e_68839e05f7808324a62a456b9b158565