### PR TITLE
Add verifiers for contest 754

### DIFF
--- a/0-999/700-799/750-759/754/verifierA.go
+++ b/0-999/700-799/750-759/754/verifierA.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	a []int
+}
+
+func validSegments(a []int, segs [][2]int) bool {
+	if len(segs) == 0 {
+		return false
+	}
+	n := len(a)
+	if segs[0][0] != 1 {
+		return false
+	}
+	if segs[len(segs)-1][1] != n {
+		return false
+	}
+	for i := 0; i < len(segs); i++ {
+		l := segs[i][0]
+		r := segs[i][1]
+		if l > r || l < 1 || r > n {
+			return false
+		}
+		if i > 0 && segs[i-1][1]+1 != l {
+			return false
+		}
+		sum := 0
+		for j := l - 1; j < r; j++ {
+			sum += a[j]
+		}
+		if sum == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func hasSolution(a []int) bool {
+	allZero := true
+	total := 0
+	for _, v := range a {
+		if v != 0 {
+			allZero = false
+		}
+		total += v
+	}
+	if allZero {
+		return false
+	}
+	if total != 0 {
+		return true
+	}
+	prefix := 0
+	for i := 0; i < len(a)-1; i++ {
+		prefix += a[i]
+		if prefix != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintln(&sb, tc.n)
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	token := scanner.Text()
+	if token == "NO" {
+		if hasSolution(tc.a) {
+			return fmt.Errorf("reported NO but solution exists")
+		}
+		if scanner.Scan() {
+			return fmt.Errorf("extra output")
+		}
+		return nil
+	}
+	if token != "YES" {
+		return fmt.Errorf("first token should be YES or NO")
+	}
+	if !scanner.Scan() {
+		return fmt.Errorf("missing k")
+	}
+	k, err := strconv.Atoi(scanner.Text())
+	if err != nil || k <= 0 {
+		return fmt.Errorf("invalid k")
+	}
+	segs := make([][2]int, k)
+	for i := 0; i < k; i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("missing l for segment %d", i+1)
+		}
+		l, err1 := strconv.Atoi(scanner.Text())
+		if !scanner.Scan() {
+			return fmt.Errorf("missing r for segment %d", i+1)
+		}
+		r, err2 := strconv.Atoi(scanner.Text())
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("invalid segment %d", i+1)
+		}
+		segs[i] = [2]int{l, r}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	if !hasSolution(tc.a) {
+		return fmt.Errorf("reported YES but no valid solution exists")
+	}
+	if !validSegments(tc.a, segs) {
+		return fmt.Errorf("invalid segments")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{1, []int{0}},
+		{1, []int{5}},
+		{3, []int{1, -1, 0}},
+		{3, []int{1, 2, 3}},
+		{4, []int{0, 0, 5, -5}},
+		{2, []int{-1, 1}},
+		{2, []int{1, -1}},
+		{5, []int{0, 0, 1, 0, 0}},
+		{3, []int{-5, 5, 0}},
+		{3, []int{0, 0, 1}},
+	}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rng.Intn(21) - 10
+		}
+		cases = append(cases, testCase{n, a})
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %v\n", i+1, err, tc.a)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/754/verifierB.go
+++ b/0-999/700-799/750-759/754/verifierB.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(board [4]string) string {
+	check := func(a, b, c byte) bool {
+		x, dot := 0, 0
+		if a == 'x' {
+			x++
+		} else if a == '.' {
+			dot++
+		}
+		if b == 'x' {
+			x++
+		} else if b == '.' {
+			dot++
+		}
+		if c == 'x' {
+			x++
+		} else if c == '.' {
+			dot++
+		}
+		return x == 2 && dot == 1
+	}
+	yes := false
+	for i := 0; i < 4 && !yes; i++ {
+		for j := 0; j <= 1; j++ {
+			if check(board[i][j], board[i][j+1], board[i][j+2]) {
+				yes = true
+				break
+			}
+		}
+	}
+	for j := 0; j < 4 && !yes; j++ {
+		for i := 0; i <= 1; i++ {
+			if check(board[i][j], board[i+1][j], board[i+2][j]) {
+				yes = true
+				break
+			}
+		}
+	}
+	for i := 0; i <= 1 && !yes; i++ {
+		for j := 0; j <= 1; j++ {
+			if check(board[i][j], board[i+1][j+1], board[i+2][j+2]) {
+				yes = true
+				break
+			}
+		}
+	}
+	for i := 0; i <= 1 && !yes; i++ {
+		for j := 2; j < 4; j++ {
+			if check(board[i][j], board[i+1][j-1], board[i+2][j-2]) {
+				yes = true
+				break
+			}
+		}
+	}
+	if yes {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runCase(bin string, board [4]string) error {
+	var input strings.Builder
+	for i := 0; i < 4; i++ {
+		input.WriteString(board[i])
+		if i+1 < 4 {
+			input.WriteByte('\n')
+		}
+	}
+	input.WriteByte('\n')
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := expected(board)
+	if got != want {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func randBoard(rng *rand.Rand) [4]string {
+	var b [4]string
+	for i := 0; i < 4; i++ {
+		row := make([]byte, 4)
+		for j := 0; j < 4; j++ {
+			switch rng.Intn(3) {
+			case 0:
+				row[j] = '.'
+			case 1:
+				row[j] = 'x'
+			default:
+				row[j] = 'o'
+			}
+		}
+		b[i] = string(row)
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := [][4]string{
+		{"....", "....", "....", "...."},
+		{"xxx.", "....", "....", "...."},
+		{"xx..", "x...", "....", "...."},
+		{"..x.", "..x.", "..x.", "...."},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randBoard(rng))
+	}
+	for i, c := range cases {
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\nboard: %v\n", i+1, err, c)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/754/verifierC.go
+++ b/0-999/700-799/750-759/754/verifierC.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+	"unicode"
+)
+
+func isWordChar(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+func mentions(text, user string) bool {
+	for i := 0; ; {
+		idx := strings.Index(text[i:], user)
+		if idx == -1 {
+			return false
+		}
+		idx += i
+		beforeOK := idx == 0 || !isWordChar(rune(text[idx-1]))
+		afterIdx := idx + len(user)
+		afterOK := afterIdx == len(text) || !isWordChar(rune(text[afterIdx]))
+		if beforeOK && afterOK {
+			return true
+		}
+		i = idx + 1
+	}
+}
+
+type chatCase struct {
+	names  []string
+	prefix []string
+	texts  []string
+}
+
+func randomWord(rng *rand.Rand) string {
+	l := rng.Intn(5) + 1
+	b := make([]byte, l)
+	for i := 0; i < l; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func randomChat(rng *rand.Rand) chatCase {
+	n := rng.Intn(3) + 2
+	names := make([]string, n)
+	for i := 0; i < n; i++ {
+		names[i] = randomWord(rng)
+	}
+	m := rng.Intn(5) + 1
+	prefix := make([]string, m)
+	texts := make([]string, m)
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			prefix[i] = "?"
+		} else {
+			prefix[i] = names[rng.Intn(n)]
+		}
+		words := rng.Intn(4) + 1
+		var sb strings.Builder
+		for j := 0; j < words; j++ {
+			w := randomWord(rng)
+			if rng.Intn(4) == 0 {
+				w = names[rng.Intn(n)]
+			}
+			sb.WriteString(w)
+			if j+1 < words {
+				sb.WriteByte(' ')
+			}
+		}
+		texts[i] = sb.String()
+		if prefix[i] != "?" && mentions(texts[i], prefix[i]) {
+			texts[i] = randomWord(rng)
+		}
+	}
+	return chatCase{names, prefix, texts}
+}
+
+func solveChat(cc chatCase) ([]string, bool) {
+	n := len(cc.names)
+	m := len(cc.prefix)
+	nameIndex := make(map[string]int)
+	for i, nm := range cc.names {
+		nameIndex[nm] = i
+	}
+	allowed := make([][]int, m)
+	for i := 0; i < m; i++ {
+		if cc.prefix[i] != "?" {
+			if id, ok := nameIndex[cc.prefix[i]]; ok {
+				allowed[i] = []int{id}
+			} else {
+				return nil, false
+			}
+		} else {
+			cand := []int{}
+			for j, nm := range cc.names {
+				if !mentions(cc.texts[i], nm) {
+					cand = append(cand, j)
+				}
+			}
+			if len(cand) == 0 {
+				return nil, false
+			}
+			allowed[i] = cand
+		}
+	}
+	dp := make([][]int, m)
+	for i := range dp {
+		dp[i] = make([]int, n)
+		for j := range dp[i] {
+			dp[i][j] = -1
+		}
+	}
+	for _, u := range allowed[0] {
+		dp[0][u] = -2
+	}
+	for i := 1; i < m; i++ {
+		for _, u := range allowed[i] {
+			for v := 0; v < n; v++ {
+				if dp[i-1][v] != -1 && v != u {
+					dp[i][u] = v
+					break
+				}
+			}
+		}
+	}
+	endUser := -1
+	for u := 0; u < n; u++ {
+		if dp[m-1][u] != -1 {
+			endUser = u
+			break
+		}
+	}
+	if endUser == -1 {
+		return nil, false
+	}
+	resIdx := make([]int, m)
+	cur := endUser
+	for i := m - 1; i >= 0; i-- {
+		resIdx[i] = cur
+		cur = dp[i][cur]
+	}
+	res := make([]string, m)
+	for i := 0; i < m; i++ {
+		res[i] = cc.names[resIdx[i]] + ":" + cc.texts[i]
+	}
+	return res, true
+}
+
+func verifyOutput(cc chatCase, outLines []string) error {
+	if len(outLines) == 1 && strings.TrimSpace(outLines[0]) == "Impossible" {
+		if _, ok := solveChat(cc); ok {
+			return fmt.Errorf("should be possible")
+		}
+		return nil
+	}
+	if len(outLines) != len(cc.prefix) {
+		return fmt.Errorf("wrong number of lines")
+	}
+	prev := ""
+	for i, line := range outLines {
+		idx := strings.IndexByte(line, ':')
+		if idx == -1 {
+			return fmt.Errorf("line %d missing colon", i+1)
+		}
+		user := line[:idx]
+		text := line[idx+1:]
+		found := false
+		for _, nm := range cc.names {
+			if nm == user {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("unknown user %s", user)
+		}
+		if cc.prefix[i] != "?" && cc.prefix[i] != user {
+			return fmt.Errorf("line %d wrong user", i+1)
+		}
+		if user == prev {
+			return fmt.Errorf("line %d same as previous", i+1)
+		}
+		if mentions(text, user) {
+			return fmt.Errorf("user %s mentions himself", user)
+		}
+		prev = user
+	}
+	return nil
+}
+
+func runCase(bin string, cc chatCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(cc.names))
+	for i, nm := range cc.names {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(nm)
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", len(cc.prefix))
+	for i := 0; i < len(cc.prefix); i++ {
+		sb.WriteString(cc.prefix[i])
+		sb.WriteByte(':')
+		sb.WriteString(cc.texts[i])
+		sb.WriteByte('\n')
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	return verifyOutput(cc, lines)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []chatCase{}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomChat(rng))
+	}
+	for i, cc := range cases {
+		if err := runCase(bin, cc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/754/verifierD.go
+++ b/0-999/700-799/750-759/754/verifierD.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type interval struct{ l, r int }
+
+type testCase struct {
+	n, k int
+	segs []interval
+}
+
+func expected(tc testCase) (int, []int) {
+	type node struct{ l, r, id int }
+	arr := make([]node, tc.n)
+	for i := 0; i < tc.n; i++ {
+		arr[i] = node{tc.segs[i].l, tc.segs[i].r, i + 1}
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i].l < arr[j].l })
+	h := make([]int, 0)
+	rmin := make([]int, tc.n)
+	const INF = int(1e9)
+	heapPush := func(x int) {
+		h = append(h, x)
+		for i := len(h)/2 - 1; i >= 0; i-- {
+			for child := 2*i + 1; child < len(h); child = 2*child + 1 {
+				if child+1 < len(h) && h[child+1] < h[child] {
+					child++
+				}
+				if h[i] <= h[child] {
+					break
+				}
+				h[i], h[child] = h[child], h[i]
+			}
+		}
+	}
+	heapPop := func() int {
+		v := h[0]
+		h[0] = h[len(h)-1]
+		h = h[:len(h)-1]
+		for i := 0; ; {
+			l := 2*i + 1
+			if l >= len(h) {
+				break
+			}
+			r := l + 1
+			if r < len(h) && h[r] < h[l] {
+				l = r
+			}
+			if h[i] <= h[l] {
+				break
+			}
+			h[i], h[l] = h[l], h[i]
+			i = l
+		}
+		return v
+	}
+	heapTop := func() int { return h[0] }
+	tot := 0
+	for i := 0; i < tc.n; i++ {
+		if tot == tc.k {
+			t := heapTop()
+			if t <= arr[i].r {
+				heapPop()
+				heapPush(arr[i].r)
+			}
+			rmin[i] = heapTop()
+		} else {
+			heapPush(arr[i].r)
+			tot++
+			if tot != tc.k {
+				rmin[i] = -INF
+			} else {
+				rmin[i] = heapTop()
+			}
+		}
+	}
+	ans := 0
+	ansi := 0
+	for i := 0; i < tc.n; i++ {
+		cur := rmin[i] - arr[i].l + 1
+		if cur < 0 {
+			cur = 0
+		}
+		if cur > ans {
+			ans = cur
+			ansi = i
+		}
+	}
+	selected := make([]node, ansi+1)
+	copy(selected, arr[:ansi+1])
+	sort.Slice(selected, func(i, j int) bool { return selected[i].r > selected[j].r })
+	ids := make([]int, 0, tc.k)
+	for i := 0; i < tc.k && i < len(selected); i++ {
+		ids = append(ids, selected[i].id)
+	}
+	sort.Ints(ids)
+	return ans, ids
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.k)
+	for i := 0; i < tc.n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", tc.segs[i].l, tc.segs[i].r)
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	ansStr := scanner.Text()
+	ansVal, err := strconv.Atoi(ansStr)
+	if err != nil {
+		return fmt.Errorf("bad ans")
+	}
+	ids := []int{}
+	for scanner.Scan() {
+		v, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("bad id")
+		}
+		ids = append(ids, v)
+	}
+	if len(ids) != tc.k {
+		return fmt.Errorf("need %d ids", tc.k)
+	}
+	sort.Ints(ids)
+	expAns, _ := expected(tc)
+	if ansVal != expAns {
+		return fmt.Errorf("expected ans %d got %d", expAns, ansVal)
+	}
+	interL := -1 << 30
+	interR := 1 << 30
+	for _, id := range ids {
+		if id <= 0 || id > tc.n {
+			return fmt.Errorf("invalid id")
+		}
+		seg := tc.segs[id-1]
+		if seg.l > interL {
+			interL = seg.l
+		}
+		if seg.r < interR {
+			interR = seg.r
+		}
+	}
+	length := interR - interL + 1
+	if length < 0 {
+		length = 0
+	}
+	if length != ansVal {
+		return fmt.Errorf("ids intersection length %d mismatch", length)
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(n) + 1
+	segs := make([]interval, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(20)
+		r := l + rng.Intn(20)
+		segs[i] = interval{l, r}
+	}
+	return testCase{n, k, segs}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{2, 1, []interval{{0, 5}, {3, 8}}},
+		{3, 2, []interval{{0, 2}, {2, 4}, {1, 3}}},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/750-759/754/verifierE.go
+++ b/0-999/700-799/750-759/754/verifierE.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+const base1 int64 = 911382323
+const base2 int64 = 972663749
+
+type testCase struct {
+	n, m    int
+	board   []string
+	r, c    int
+	pattern []string
+}
+
+func solve(tc testCase) []string {
+	n, m, r, c := tc.n, tc.m, tc.r, tc.c
+	board := tc.board
+	pattern := tc.pattern
+	N := n + r - 1
+	M := m + c - 1
+	pow1 := make([]int64, N+1)
+	pow2 := make([]int64, M+1)
+	pow1[0] = 1
+	for i := 1; i <= N; i++ {
+		pow1[i] = pow1[i-1] * base1 % mod
+	}
+	pow2[0] = 1
+	for i := 1; i <= M; i++ {
+		pow2[i] = pow2[i-1] * base2 % mod
+	}
+	ans := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		ans[i] = make([]bool, m)
+		for j := range ans[i] {
+			ans[i][j] = true
+		}
+	}
+	prefix := make([][]int64, N+1)
+	for i := range prefix {
+		prefix[i] = make([]int64, M+1)
+	}
+	for ch := byte('a'); ch <= 'z'; ch++ {
+		var patHash int64
+		for i := 0; i < r; i++ {
+			row := pattern[i]
+			for j := 0; j < c; j++ {
+				if row[j] == ch {
+					patHash = (patHash + pow1[i]*pow2[j]) % mod
+				}
+			}
+		}
+		if patHash == 0 {
+			continue
+		}
+		for i := 0; i <= N; i++ {
+			for j := range prefix[i] {
+				prefix[i][j] = 0
+			}
+		}
+		for i := 0; i < N; i++ {
+			rowIdx := i % n
+			prev := prefix[i]
+			cur := prefix[i+1]
+			bRow := board[rowIdx]
+			for j := 0; j < M; j++ {
+				colIdx := j % m
+				var val int64
+				if bRow[colIdx] == ch {
+					val = pow1[i] * pow2[j] % mod
+				}
+				cur[j+1] = (cur[j] + prev[j+1] - prev[j] + val) % mod
+				if cur[j+1] < 0 {
+					cur[j+1] += mod
+				}
+			}
+		}
+		for i := 0; i < n; i++ {
+			base1Shift := pow1[i]
+			for j := 0; j < m; j++ {
+				if !ans[i][j] {
+					continue
+				}
+				sub := prefix[i+r][j+c]
+				sub -= prefix[i][j+c]
+				if sub < 0 {
+					sub += mod
+				}
+				sub -= prefix[i+r][j]
+				if sub < 0 {
+					sub += mod
+				}
+				sub += prefix[i][j]
+				sub %= mod
+				if sub < 0 {
+					sub += mod
+				}
+				expected := patHash * base1Shift % mod * pow2[j] % mod
+				if sub != expected {
+					ans[i][j] = false
+				}
+			}
+		}
+	}
+	res := make([]string, n)
+	for i := 0; i < n; i++ {
+		buf := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if ans[i][j] {
+				buf[j] = '1'
+			} else {
+				buf[j] = '0'
+			}
+		}
+		res[i] = string(buf)
+	}
+	return res
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+	for i := 0; i < tc.n; i++ {
+		sb.WriteString(tc.board[i])
+		sb.WriteByte('\n')
+	}
+	fmt.Fprintf(&sb, "%d %d\n", tc.r, tc.c)
+	for i := 0; i < tc.r; i++ {
+		sb.WriteString(tc.pattern[i])
+		sb.WriteByte('\n')
+	}
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	expect := solve(tc)
+	if len(lines) != len(expect) {
+		return fmt.Errorf("wrong number of lines")
+	}
+	for i := range lines {
+		if strings.TrimSpace(lines[i]) != expect[i] {
+			return fmt.Errorf("line %d expected %s got %s", i+1, expect[i], lines[i])
+		}
+	}
+	return nil
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	r := rng.Intn(n) + 1
+	c := rng.Intn(m) + 1
+	board := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			b[j] = byte('a' + rng.Intn(3))
+		}
+		board[i] = string(b)
+	}
+	pattern := make([]string, r)
+	for i := 0; i < r; i++ {
+		b := make([]byte, c)
+		for j := 0; j < c; j++ {
+			if rng.Intn(4) == 0 {
+				b[j] = '?'
+			} else {
+				b[j] = byte('a' + rng.Intn(3))
+			}
+		}
+		pattern[i] = string(b)
+	}
+	return testCase{n, m, board, r, c, pattern}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{1, 1, []string{"a"}, 1, 1, []string{"a"}},
+		{2, 2, []string{"ab", "ba"}, 1, 1, []string{"?"}},
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for Codeforces contest 754 problems A–E
- each verifier generates 100+ random test cases and checks a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68839dc0f7c08324998f9aeb6c5f2d38