### PR TITLE
Add Go solution for 1952H palindrome check

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1952/1952H.go
+++ b/1000-1999/1900-1999/1950-1959/1952/1952H.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// isPalindrome checks if the given string is a palindrome.
+func isPalindrome(s string) bool {
+	n := len(s)
+	for i := 0; i < n/2; i++ {
+		if s[i] != s[n-1-i] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		if _, err := fmt.Fscan(reader, &s); err != nil {
+			return
+		}
+		if isPalindrome(s) {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem H in contest 1952

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1952/1952H.go`
- `echo -e "3\naba\ncoder\nmadam" | go run 1000-1999/1900-1999/1950-1959/1952/1952H.go`

------
https://chatgpt.com/codex/tasks/task_e_68839d79f4248324a08d26464379a33a