### PR TITLE
Add placeholder solution for 1952I

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1952/1952I.go
+++ b/1000-1999/1900-1999/1950-1959/1952/1952I.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+// solve provides a placeholder implementation for problem I.
+// The original problem statement is unavailable in the repository,
+// so this program simply outputs "Not implemented".
+func solve() {
+	fmt.Println("Not implemented")
+}
+
+func main() {
+	solve()
+}


### PR DESCRIPTION
## Summary
- add a small Go file `1952I.go` for contest 1952 problem I
- since the statement is missing, the program just prints `Not implemented`

## Testing
- `gofmt -w ./1000-1999/1900-1999/1950-1959/1952/1952I.go`


------
https://chatgpt.com/codex/tasks/task_e_68839cedd0dc8324b6b7b8505f885639