### PR TITLE
Add Go solution for problem 1957A

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1957/1957A.go
+++ b/1000-1999/1900-1999/1950-1959/1957/1957A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		freq := make([]int, 101)
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(in, &x)
+			if x >= 0 && x < len(freq) {
+				freq[x]++
+			}
+		}
+		ans := 0
+		for _, c := range freq {
+			ans += c / 3
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1957A

## Testing
- `go vet 1000-1999/1900-1999/1950-1959/1957/1957A.go`
- `go run 1000-1999/1900-1999/1950-1959/1957/1957A.go <<EOF
1
4
3 3 3 3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68839c61bc288324897d63d5a2dc37e7