### PR TITLE
Add Go verifiers for Codeforces contest 788

### DIFF
--- a/0-999/700-799/780-789/788/verifierA.go
+++ b/0-999/700-799/780-789/788/verifierA.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func solveA(nums []int64) int64 {
+	n := len(nums)
+	if n < 2 {
+		return 0
+	}
+	diff := make([]int64, n-1)
+	for i := 0; i < n-1; i++ {
+		diff[i] = abs64(nums[i+1] - nums[i])
+	}
+	dpPlus := make([]int64, n-1)
+	dpMinus := make([]int64, n-1)
+	dpPlus[0] = diff[0]
+	dpMinus[0] = -diff[0]
+	ans := dpPlus[0]
+	if dpMinus[0] > ans {
+		ans = dpMinus[0]
+	}
+	for i := 1; i < n-1; i++ {
+		if dpMinus[i-1]+diff[i] > diff[i] {
+			dpPlus[i] = dpMinus[i-1] + diff[i]
+		} else {
+			dpPlus[i] = diff[i]
+		}
+		if dpPlus[i-1]-diff[i] > -diff[i] {
+			dpMinus[i] = dpPlus[i-1] - diff[i]
+		} else {
+			dpMinus[i] = -diff[i]
+		}
+		if dpPlus[i] > ans {
+			ans = dpPlus[i]
+		}
+		if dpMinus[i] > ans {
+			ans = dpMinus[i]
+		}
+	}
+	return ans
+}
+
+type testCase struct {
+	nums []int64
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 2
+	nums := make([]int64, n)
+	for i := range nums {
+		nums[i] = rng.Int63n(2000) - 1000
+	}
+	return testCase{nums}
+}
+
+func formatInput(tc testCase) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(tc.nums))
+	for i, v := range tc.nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func expected(tc testCase) string {
+	return fmt.Sprintf("%d", solveA(tc.nums))
+}
+
+func runCase(bin string, tc testCase) error {
+	input := formatInput(tc)
+	exp := expected(tc)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	if out != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s\ninput:\n%s", exp, out, input)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		{nums: []int64{1, 2}},
+		{nums: []int64{-5, 0, 5}},
+		{nums: []int64{5, 4, 3, 2, 1}},
+		{nums: []int64{0, 0, 0}},
+	}
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/780-789/788/verifierB.go
+++ b/0-999/700-799/780-789/788/verifierB.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type dsu struct {
+	parent []int
+	size   []int
+}
+
+func newDSU(n int) *dsu {
+	d := &dsu{parent: make([]int, n+1), size: make([]int, n+1)}
+	for i := 1; i <= n; i++ {
+		d.parent[i] = i
+		d.size[i] = 1
+	}
+	return d
+}
+
+func (d *dsu) find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *dsu) union(a, b int) {
+	a = d.find(a)
+	b = d.find(b)
+	if a == b {
+		return
+	}
+	if d.size[a] < d.size[b] {
+		a, b = b, a
+	}
+	d.parent[b] = a
+	d.size[a] += d.size[b]
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type edge struct{ u, v int }
+
+type testCase struct {
+	n     int
+	edges []edge
+}
+
+func solveB(tc testCase) int64 {
+	n := tc.n
+	m := len(tc.edges)
+	d := newDSU(n)
+	deg := make([]int64, n+1)
+	has := make([]bool, n+1)
+	var loops int64
+	for _, e := range tc.edges {
+		u, v := e.u, e.v
+		if u == v {
+			loops++
+			has[u] = true
+		} else {
+			deg[u]++
+			deg[v]++
+			d.union(u, v)
+			has[u] = true
+			has[v] = true
+		}
+	}
+	root := -1
+	for i := 1; i <= n; i++ {
+		if has[i] {
+			if root == -1 {
+				root = d.find(i)
+			} else if d.find(i) != root {
+				return 0
+			}
+		}
+	}
+	if m < 2 {
+		return 0
+	}
+	ans := loops*(loops-1)/2 + loops*(int64(m)-loops)
+	for i := 1; i <= n; i++ {
+		if deg[i] >= 2 {
+			ans += deg[i] * (deg[i] - 1) / 2
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(6) + 1
+	maxEdges := n * n
+	m := rng.Intn(maxEdges + 1)
+	edges := make([]edge, 0, m)
+	used := make(map[string]bool)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		key := fmt.Sprintf("%d-%d", u, v)
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		edges = append(edges, edge{u, v})
+	}
+	return testCase{n: n, edges: edges}
+}
+
+func formatInput(tc testCase) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, len(tc.edges))
+	for _, e := range tc.edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+	}
+	return sb.String()
+}
+
+func expected(tc testCase) string {
+	return fmt.Sprintf("%d", solveB(tc))
+}
+
+func runCase(bin string, tc testCase) error {
+	input := formatInput(tc)
+	exp := expected(tc)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	if out != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s\ninput:\n%s", exp, out, input)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	// some fixed edge cases
+	cases = append(cases, testCase{n: 2, edges: []edge{{1, 1}, {2, 2}}})
+	cases = append(cases, testCase{n: 3, edges: []edge{{1, 2}, {2, 3}}})
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/780-789/788/verifierC.go
+++ b/0-999/700-799/780-789/788/verifierC.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+type testCase struct {
+	n     int
+	types []int
+}
+
+func solveC(tc testCase) int {
+	n := tc.n
+	a := tc.types
+	seen := make([]bool, 1001)
+	less := []int{}
+	greater := []int{}
+	minA, maxA := 1001, -1
+	for _, v := range a {
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		if v == n {
+			return 1
+		}
+		if v < n {
+			less = append(less, v)
+		} else {
+			greater = append(greater, v)
+		}
+		if v < minA {
+			minA = v
+		}
+		if v > maxA {
+			maxA = v
+		}
+	}
+	if n < minA || n > maxA || len(less) == 0 || len(greater) == 0 {
+		return -1
+	}
+	ans := int(^uint(0) >> 1)
+	for _, ai := range less {
+		for _, aj := range greater {
+			g := gcd(n-ai, aj-n)
+			L := (aj - ai) / g
+			if L < ans {
+				ans = L
+			}
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(1001)
+	k := rng.Intn(10) + 1
+	types := make([]int, k)
+	for i := range types {
+		types[i] = rng.Intn(1001)
+	}
+	return testCase{n: n, types: types}
+}
+
+func formatInput(tc testCase) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, len(tc.types))
+	for i, v := range tc.types {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func expected(tc testCase) string {
+	return fmt.Sprintf("%d", solveC(tc))
+}
+
+func runCase(bin string, tc testCase) error {
+	input := formatInput(tc)
+	exp := expected(tc)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	if out != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s\ninput:\n%s", exp, out, input)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, testCase{n: 0, types: []int{0}})
+	cases = append(cases, testCase{n: 500, types: []int{300, 700}})
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/780-789/788/verifierD.go
+++ b/0-999/700-799/780-789/788/verifierD.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem D is interactive and cannot be automatically verified.")
+}

--- a/0-999/700-799/780-789/788/verifierE.go
+++ b/0-999/700-799/780-789/788/verifierE.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "788E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	return "./" + ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCase struct {
+	input string
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	skills := make([]int, n)
+	for i := range skills {
+		skills[i] = rng.Intn(20) + 1
+	}
+	q := rng.Intn(8) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range skills {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", q)
+	for i := 0; i < q; i++ {
+		typ := rng.Intn(2) + 1
+		x := rng.Intn(n) + 1
+		fmt.Fprintf(&sb, "%d %d\n", typ, x)
+	}
+	return testCase{input: sb.String()}
+}
+
+func runCase(candidate, reference string, tc testCase) error {
+	exp, err := run(reference, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	out, err := run(candidate, tc.input)
+	if err != nil {
+		return err
+	}
+	if out != exp {
+		return fmt.Errorf("expected %s got %s\ninput:\n%s", exp, out, tc.input)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []testCase
+	cases = append(cases, genCase(rng))
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go with 100+ random tests for problem A
- add verifierB.go to check graph solution for problem B
- add verifierC.go to verify mixing problem C
- add verifierD.go placeholder for interactive problem D
- add verifierE.go which uses compiled reference solution for problem E

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierE.go ./solE`


------
https://chatgpt.com/codex/tasks/task_e_6883b05b98f483248d331cec7ede762a