### PR TITLE
Add Go solution for 1957D

### DIFF
--- a/1000-1999/1900-1999/1950-1959/1957/1957D.go
+++ b/1000-1999/1900-1999/1950-1959/1957/1957D.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		// prefix xor
+		p := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			p[i] = p[i-1] ^ a[i-1]
+		}
+		const maxB = 30
+		count := make([][]int, maxB)
+		for b := 0; b < maxB; b++ {
+			count[b] = make([]int, n+1)
+		}
+		for i := 1; i <= n; i++ {
+			x := p[i]
+			for b := 0; b < maxB; b++ {
+				count[b][i] = count[b][i-1]
+				if (x>>b)&1 == 1 {
+					count[b][i]++
+				}
+			}
+		}
+		var ans int64
+		for y := 1; y <= n; y++ {
+			ay := a[y-1]
+			k := 0
+			for b := maxB - 1; b >= 0; b-- {
+				if (ay>>b)&1 == 1 {
+					k = b
+					break
+				}
+			}
+			leftOne := count[k][y-1]
+			leftZero := y - leftOne
+			rightOne := count[k][n] - count[k][y-1]
+			rightZero := (n - y + 1) - rightOne
+			ans += int64(leftZero*rightZero + leftOne*rightOne)
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solver for problem D in Go
- use prefix XOR counts per bit to count valid triples efficiently

## Testing
- `go build 1000-1999/1900-1999/1950-1959/1957/1957D.go`
- `echo -e '1\n3\n6 2 4\n' | go run 1000-1999/1900-1999/1950-1959/1957/1957D.go`
- `python3 - <<'PY'
import random, subprocess, os, textwrap, sys

def brute(a):
    n=len(a)
    p=[0]
    for v in a: p.append(p[-1]^v)
    res=0
    for x in range(1,n+1):
        for y in range(x,n+1):
            for z in range(y,n+1):
                f=lambda l,r: p[r]^p[l-1]
                if (f(x,y)^f(y,z))>f(x,z): res+=1
    return res

for n in range(1,8):
    for _ in range(10):
        a=[random.randint(1,20) for __ in range(n)]
        expected=brute(a)
        input_str='1\n'+str(n)+'\n'+' '.join(map(str,a))+'\n'
        result=subprocess.check_output(['go', 'run', '1000-1999/1900-1999/1950-1959/1957/1957D.go'], input=input_str.encode())
        got=int(result.decode().strip())
        if expected!=got:
            print('Mismatch',a,expected,got)
            sys.exit()
print('All correct')
PY

------
https://chatgpt.com/codex/tasks/task_e_68839b497814832499890ed25d7cacac