### PR TITLE
Add solution for 1928A

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1928/1928A.go
+++ b/1000-1999/1900-1999/1920-1929/1928/1928A.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func canTransform(a, b int64) bool {
+	// ensure a <= b for simplified logic
+	if a > b {
+		a, b = b, a
+	}
+
+	// both odd cannot form a different rectangle
+	if a%2 == 1 && b%2 == 1 {
+		return false
+	}
+
+	// if one side is 1
+	if a == 1 {
+		if b%2 == 0 && b > 2 {
+			return true
+		}
+		return false
+	}
+
+	// one side odd, other even
+	if a%2 == 1 || b%2 == 1 {
+		// let odd=a (since a<=b but if b odd, swap?). Actually we just check even == 2*odd.
+		var odd, even int64
+		if a%2 == 1 {
+			odd, even = a, b
+		} else {
+			odd, even = b, a
+		}
+		if even == 2*odd {
+			return false
+		}
+		return true
+	}
+
+	// both even
+	return true
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var a, b int64
+		fmt.Fscan(reader, &a, &b)
+		if canTransform(a, b) {
+			fmt.Fprintln(writer, "Yes")
+		} else {
+			fmt.Fprintln(writer, "No")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1928A

## Testing
- `go build 1000-1999/1900-1999/1920-1929/1928/1928A.go`
- `echo '8\n1 1\n1 2\n1 4\n2 3\n3 4\n3 6\n4 5\n5 10\n' | go run 1000-1999/1900-1999/1920-1929/1928/1928A.go`

------
https://chatgpt.com/codex/tasks/task_e_6883b24550608324966dfb91f2159d04