### PR TITLE
Add Go verifiers for contest 792

### DIFF
--- a/0-999/700-799/790-799/792/verifierA.go
+++ b/0-999/700-799/790-799/792/verifierA.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveCase(arr []int) (int, int) {
+	sort.Ints(arr)
+	minDiff := arr[1] - arr[0]
+	cnt := 1
+	for i := 1; i < len(arr)-1; i++ {
+		diff := arr[i+1] - arr[i]
+		if diff < minDiff {
+			minDiff = diff
+			cnt = 1
+		} else if diff == minDiff {
+			cnt++
+		}
+	}
+	return minDiff, cnt
+}
+
+func genCase(rng *rand.Rand) (string, int, int) {
+	n := rng.Intn(18) + 2 // n between 2 and 19
+	m := make(map[int]struct{})
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		x := rng.Intn(2001) - 1000
+		for {
+			if _, ok := m[x]; !ok {
+				break
+			}
+			x = rng.Intn(2001) - 1000
+		}
+		arr[i] = x
+		m[x] = struct{}{}
+	}
+	minDiff, cnt := solveCase(append([]int(nil), arr...))
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), minDiff, cnt
+}
+
+func runCandidate(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, in string, expMin, expCnt int) error {
+	out, err := runCandidate(bin, []byte(in))
+	if err != nil {
+		return err
+	}
+	tokens := strings.Fields(out)
+	if len(tokens) < 2 {
+		return fmt.Errorf("expected two integers, got %q", out)
+	}
+	gotMin, err1 := strconv.Atoi(tokens[0])
+	gotCnt, err2 := strconv.Atoi(tokens[1])
+	if err1 != nil || err2 != nil {
+		return fmt.Errorf("invalid integers in output: %q", out)
+	}
+	if gotMin != expMin || gotCnt != expCnt {
+		return fmt.Errorf("expected %d %d got %d %d", expMin, expCnt, gotMin, gotCnt)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, minDiff, cnt := genCase(rng)
+		if err := runCase(bin, in, minDiff, cnt); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/792/verifierB.go
+++ b/0-999/700-799/790-799/792/verifierB.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testB struct {
+	n, k int
+	a    []int
+}
+
+func solveCaseB(tc testB) []int {
+	children := make([]int, tc.n)
+	for i := 0; i < tc.n; i++ {
+		children[i] = i + 1
+	}
+	leader := 0
+	res := make([]int, tc.k)
+	for i := 0; i < tc.k; i++ {
+		idx := (leader + tc.a[i]) % len(children)
+		res[i] = children[idx]
+		children = append(children[:idx], children[idx+1:]...)
+		if len(children) > 0 {
+			leader = idx % len(children)
+		} else {
+			leader = 0
+		}
+	}
+	return res
+}
+
+func genCaseB(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(98) + 2 // 2..99
+	k := rng.Intn(n-1) + 1
+	a := make([]int, k)
+	for i := range a {
+		a[i] = rng.Intn(100) + 1
+	}
+	tc := testB{n, k, a}
+	res := solveCaseB(tc)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), res
+}
+
+func runCandidate(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCaseB(bin string, in string, expected []int) error {
+	out, err := runCandidate(bin, []byte(in))
+	if err != nil {
+		return err
+	}
+	tokens := strings.Fields(out)
+	if len(tokens) != len(expected) {
+		return fmt.Errorf("expected %d numbers, got %d", len(expected), len(tokens))
+	}
+	for i, tok := range tokens {
+		val, err := strconv.Atoi(tok)
+		if err != nil {
+			return fmt.Errorf("invalid integer %q", tok)
+		}
+		if val != expected[i] {
+			return fmt.Errorf("at position %d expected %d got %d", i+1, expected[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseB(rng)
+		if err := runCaseB(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/792/verifierC.go
+++ b/0-999/700-799/790-799/792/verifierC.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(s string) string {
+	n := len(s)
+	sum := 0
+	idxMod := make([][]int, 3)
+	for i := 0; i < n; i++ {
+		d := int(s[i] - '0')
+		sum += d
+		idxMod[d%3] = append(idxMod[d%3], i)
+	}
+	p := sum % 3
+	remove := make([]bool, n)
+	switch p {
+	case 1:
+		if len(idxMod[1]) >= 1 {
+			pos := idxMod[1][len(idxMod[1])-1]
+			remove[pos] = true
+		} else if len(idxMod[2]) >= 2 {
+			l := len(idxMod[2])
+			remove[idxMod[2][l-1]] = true
+			remove[idxMod[2][l-2]] = true
+		} else {
+			return "-1"
+		}
+	case 2:
+		if len(idxMod[2]) >= 1 {
+			pos := idxMod[2][len(idxMod[2])-1]
+			remove[pos] = true
+		} else if len(idxMod[1]) >= 2 {
+			l := len(idxMod[1])
+			remove[idxMod[1][l-1]] = true
+			remove[idxMod[1][l-2]] = true
+		} else {
+			return "-1"
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if !remove[i] {
+			sb.WriteByte(s[i])
+		}
+	}
+	t := sb.String()
+	if len(t) == 0 {
+		return "-1"
+	}
+	i := 0
+	for i < len(t) && t[i] == '0' {
+		i++
+	}
+	if i == len(t) {
+		return "0"
+	}
+	return t[i:]
+}
+
+func genCaseC(rng *rand.Rand) (string, string) {
+	l := rng.Intn(20) + 1
+	digits := make([]byte, l)
+	digits[0] = byte(rng.Intn(9) + 1 + '0')
+	for i := 1; i < l; i++ {
+		digits[i] = byte(rng.Intn(10) + '0')
+	}
+	s := string(digits)
+	exp := solveC(s)
+	return s + "\n", exp
+}
+
+func runCandidate(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCaseC(bin, in, exp string) error {
+	out, err := runCandidate(bin, []byte(in))
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s", exp, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseC(rng)
+		if err := runCaseC(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/792/verifierD.go
+++ b/0-999/700-799/790-799/792/verifierD.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type queryD struct {
+	u uint64
+	s string
+}
+
+func solveQuery(n uint64, q queryD) uint64 {
+	exp := bits.Len64(n+1) - 1
+	H := exp - 1
+	path := make([]uint8, 0, H)
+	l, r := uint64(1), n
+	h := H
+	u := q.u
+	for {
+		mid := (l + r) >> 1
+		if u == mid {
+			break
+		} else if u < mid {
+			path = append(path, 0)
+			r = mid - 1
+		} else {
+			path = append(path, 1)
+			l = mid + 1
+		}
+		h--
+	}
+	curH := h
+	for _, c := range q.s {
+		switch c {
+		case 'L':
+			if curH > 0 {
+				path = append(path, 0)
+				curH--
+			}
+		case 'R':
+			if curH > 0 {
+				path = append(path, 1)
+				curH--
+			}
+		case 'U':
+			if len(path) > 0 {
+				path = path[:len(path)-1]
+				curH++
+			}
+		}
+	}
+	l, r = 1, n
+	for _, b := range path {
+		mid := (l + r) >> 1
+		if b == 0 {
+			r = mid - 1
+		} else {
+			l = mid + 1
+		}
+	}
+	return (l + r) >> 1
+}
+
+func genCaseD(rng *rand.Rand) (string, []uint64) {
+	exp := rng.Intn(5) + 2 // exponent 2..6 => n up to 63
+	n := uint64(1<<exp) - 1
+	q := rng.Intn(5) + 1
+	queries := make([]queryD, q)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 0; i < q; i++ {
+		u := uint64(rng.Intn(int(n)) + 1)
+		l := rng.Intn(15) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			switch rng.Intn(3) {
+			case 0:
+				b[j] = 'L'
+			case 1:
+				b[j] = 'R'
+			default:
+				b[j] = 'U'
+			}
+		}
+		s := string(b)
+		queries[i] = queryD{u, s}
+		sb.WriteString(fmt.Sprintf("%d\n%s\n", u, s))
+	}
+	answers := make([]uint64, q)
+	for i, qu := range queries {
+		answers[i] = solveQuery(n, qu)
+	}
+	return sb.String(), answers
+}
+
+func runCandidate(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCaseD(bin string, in string, exp []uint64) error {
+	out, err := runCandidate(bin, []byte(in))
+	if err != nil {
+		return err
+	}
+	tokens := strings.Fields(out)
+	if len(tokens) != len(exp) {
+		return fmt.Errorf("expected %d numbers, got %d", len(exp), len(tokens))
+	}
+	for i, tok := range tokens {
+		val, err := strconv.ParseUint(tok, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid integer %q", tok)
+		}
+		if val != exp[i] {
+			return fmt.Errorf("at line %d expected %d got %d", i+1, exp[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseD(rng)
+		if err := runCaseD(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/792/verifierE.go
+++ b/0-999/700-799/790-799/792/verifierE.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveCaseE(a []int64) int64 {
+	candMap := make(map[int64]struct{})
+	for _, x := range a {
+		for j := int64(1); j*j <= x; j++ {
+			candMap[j] = struct{}{}
+			if j-1 > 0 {
+				candMap[j-1] = struct{}{}
+			}
+			q := x / j
+			candMap[q] = struct{}{}
+			if q-1 > 0 {
+				candMap[q-1] = struct{}{}
+			}
+		}
+	}
+	cand := make([]int64, 0, len(candMap))
+	for k := range candMap {
+		if k > 0 {
+			cand = append(cand, k)
+		}
+	}
+	sort.Slice(cand, func(i, j int) bool { return cand[i] < cand[j] })
+	best := int64(1<<63 - 1)
+	for _, k := range cand {
+		total := int64(0)
+		feasible := true
+		for _, x := range a {
+			t := (x + k) / (k + 1)
+			maxSet := x / k
+			if t > maxSet {
+				feasible = false
+				break
+			}
+			total += t
+			if total >= best {
+				break
+			}
+		}
+		if feasible && total < best {
+			best = total
+		}
+	}
+	return best
+}
+
+func genCaseE(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(5) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(20) + 1)
+	}
+	best := solveCaseE(arr)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), best
+}
+
+func runCandidate(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCaseE(bin string, in string, exp int64) error {
+	out, err := runCandidate(bin, []byte(in))
+	if err != nil {
+		return err
+	}
+	val, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid output %q", out)
+	}
+	if val != exp {
+		return fmt.Errorf("expected %d got %d", exp, val)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseE(rng)
+		if err := runCaseE(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/792/verifierF.go
+++ b/0-999/700-799/790-799/792/verifierF.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type node struct {
+	y, x        int64
+	pr          int
+	left, right *node
+}
+
+func split(root *node, y int64) (l, r *node) {
+	if root == nil {
+		return nil, nil
+	}
+	if y < root.y {
+		l, root.left = split(root.left, y)
+		return l, root
+	}
+	root.right, r = split(root.right, y)
+	return root, r
+}
+
+func merge(a, b *node) *node {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	if a.pr < b.pr {
+		a.right = merge(a.right, b)
+		return a
+	}
+	b.left = merge(a, b.left)
+	return b
+}
+
+func insert(root, n *node) *node {
+	if root == nil {
+		return n
+	}
+	if n.pr < root.pr {
+		l, r := split(root, n.y)
+		n.left = l
+		n.right = r
+		return n
+	}
+	if n.y < root.y {
+		root.left = insert(root.left, n)
+	} else {
+		root.right = insert(root.right, n)
+	}
+	return root
+}
+
+func erase(root *node, y int64) *node {
+	if root == nil {
+		return nil
+	}
+	if y < root.y {
+		root.left = erase(root.left, y)
+		return root
+	}
+	if y > root.y {
+		root.right = erase(root.right, y)
+		return root
+	}
+	return merge(root.left, root.right)
+}
+
+func find(root *node, y int64) *node {
+	for root != nil {
+		if y < root.y {
+			root = root.left
+		} else if y > root.y {
+			root = root.right
+		} else {
+			return root
+		}
+	}
+	return nil
+}
+
+func predecessor(root *node, y int64) *node {
+	var res *node
+	for root != nil {
+		if y <= root.y {
+			root = root.left
+		} else {
+			res = root
+			root = root.right
+		}
+	}
+	return res
+}
+
+func successor(root *node, y int64) *node {
+	var res *node
+	for root != nil {
+		if y >= root.y {
+			root = root.right
+		} else {
+			res = root
+			root = root.left
+		}
+	}
+	return res
+}
+
+func lowerBound(root *node, y int64) *node {
+	var res *node
+	for root != nil {
+		if y <= root.y {
+			res = root
+			root = root.left
+		} else {
+			root = root.right
+		}
+	}
+	return res
+}
+
+func maxNode(root *node) *node {
+	if root == nil {
+		return nil
+	}
+	for root.right != nil {
+		root = root.right
+	}
+	return root
+}
+
+func cross(a, b, c *node) int64 {
+	return (b.y-a.y)*(c.x-b.x) - (b.x-a.x)*(c.y-b.y)
+}
+
+var rootF *node
+
+func isBad(n *node) bool {
+	if n == nil || n.y == 0 {
+		return false
+	}
+	p := predecessor(rootF, n.y)
+	r := successor(rootF, n.y)
+	if p == nil || r == nil {
+		return false
+	}
+	if p.y == 0 && r == nil {
+		return false
+	}
+	return cross(p, n, r) >= 0
+}
+
+func addSpell(x, y int64) {
+	if existing := find(rootF, y); existing != nil {
+		if existing.x >= x {
+			return
+		}
+		rootF = erase(rootF, y)
+	}
+	n := &node{y: y, x: x, pr: rand.Int()}
+	rootF = insert(rootF, n)
+	if isBad(n) {
+		rootF = erase(rootF, n.y)
+		return
+	}
+	for {
+		p := predecessor(rootF, n.y)
+		if p == nil || p.y == 0 {
+			break
+		}
+		if isBad(p) {
+			rootF = erase(rootF, p.y)
+		} else {
+			break
+		}
+	}
+	for {
+		r := successor(rootF, n.y)
+		if r == nil {
+			break
+		}
+		if isBad(r) {
+			rootF = erase(rootF, r.y)
+		} else {
+			break
+		}
+	}
+}
+
+func hullValue(z float64) float64 {
+	if rootF == nil {
+		return 0
+	}
+	if z <= 0 {
+		return 0
+	}
+	mx := maxNode(rootF)
+	if z >= float64(mx.y) {
+		return float64(mx.x)
+	}
+	r := lowerBound(rootF, int64(math.Ceil(z)))
+	if r == nil {
+		r = mx
+	}
+	if float64(r.y) == z {
+		return float64(r.x)
+	}
+	l := predecessor(rootF, r.y)
+	if l == nil {
+		return (float64(r.x) / float64(r.y)) * z
+	}
+	return float64(l.x) + (float64(r.x-l.x))*(z-float64(l.y))/float64(r.y-l.y)
+}
+
+type queryF struct {
+	k    int
+	a, b int64
+}
+
+func solveCaseF(q int, m int64, qs []queryF) []string {
+	rootF = &node{y: 0, x: 0, pr: rand.Int()}
+	lastOK := 0
+	res := make([]string, 0, q)
+	for i := 1; i <= q; i++ {
+		k := qs[i-1].k
+		a := (qs[i-1].a+int64(lastOK))%1000000 + 1
+		b := (qs[i-1].b+int64(lastOK))%1000000 + 1
+		if k == 1 {
+			addSpell(a, b)
+		} else {
+			t := a
+			h := b
+			rate := hullValue(float64(m) / float64(t))
+			if rate*float64(t) >= float64(h) {
+				lastOK = i
+				res = append(res, "YES")
+			} else {
+				res = append(res, "NO")
+			}
+		}
+	}
+	return res
+}
+
+func genCaseF(rng *rand.Rand) (string, []string) {
+	q := rng.Intn(10) + 1
+	m := int64(rng.Intn(1000) + 1)
+	qs := make([]queryF, q)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", q, m))
+	for i := 0; i < q; i++ {
+		k := rng.Intn(2) + 1
+		a := int64(rng.Intn(100) + 1)
+		b := int64(rng.Intn(100) + 1)
+		qs[i] = queryF{k, a, b}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", k, a, b))
+	}
+	exp := solveCaseF(q, m, qs)
+	return sb.String(), exp
+}
+
+func runCandidate(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCaseF(bin string, in string, exp []string) error {
+	out, err := runCandidate(bin, []byte(in))
+	if err != nil {
+		return err
+	}
+	tokens := strings.Fields(out)
+	if len(tokens) != len(exp) {
+		return fmt.Errorf("expected %d tokens, got %d", len(exp), len(tokens))
+	}
+	for i := range tokens {
+		if tokens[i] != exp[i] {
+			return fmt.Errorf("at query %d expected %s got %s", i+1, exp[i], tokens[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseF(rng)
+		if err := runCaseF(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers `verifierA.go`..`verifierF.go` for Codeforces contest 792
- each verifier generates at least 100 random tests and checks candidate binaries using embedded reference solutions

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883b28bbe7c83248813010bc75e4c01