### PR TITLE
Add verifiers for contest 793

### DIFF
--- a/0-999/700-799/790-799/793/verifierA.go
+++ b/0-999/700-799/790-799/793/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(n int, k int64, arr []int64) string {
+	rem := arr[0] % k
+	minA := arr[0]
+	for i := 1; i < n; i++ {
+		if arr[i]%k != rem {
+			return "-1"
+		}
+		if arr[i] < minA {
+			minA = arr[i]
+		}
+	}
+	var ans int64
+	for i := 0; i < n; i++ {
+		ans += (arr[i] - minA) / k
+	}
+	return fmt.Sprint(ans)
+}
+
+func genCase(rng *rand.Rand) (int, int64, []int64) {
+	n := rng.Intn(8) + 2
+	k := int64(rng.Intn(20) + 1)
+	arr := make([]int64, n)
+	base := int64(rng.Intn(50))
+	rem := rng.Int63n(k)
+	for i := 0; i < n; i++ {
+		delta := int64(rng.Intn(50))
+		arr[i] = base + delta*k + rem
+	}
+	return n, k, arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, arr := genCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		expect := solveA(n, k, arr)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/793/verifierB.go
+++ b/0-999/700-799/790-799/793/verifierB.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var dx = []int{-1, 0, 1, 0}
+var dy = []int{0, 1, 0, -1}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func inBounds(x, y, n, m int) bool { return x >= 0 && x < n && y >= 0 && y < m }
+
+func solveB(grid [][]byte, sx, sy, tx, ty int) string {
+	n, m := len(grid), len(grid[0])
+	dist := make([][][]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = make([][]int, m)
+		for j := 0; j < m; j++ {
+			dist[i][j] = []int{3, 3, 3, 3}
+		}
+	}
+	type node struct{ x, y, d, t int }
+	q := []node{}
+	for d := 0; d < 4; d++ {
+		dist[sx][sy][d] = 0
+		q = append(q, node{sx, sy, d, 0})
+	}
+	for head := 0; head < len(q); head++ {
+		cur := q[head]
+		if cur.t > dist[cur.x][cur.y][cur.d] || cur.t > 2 {
+			continue
+		}
+		if cur.x == tx && cur.y == ty {
+			return "YES"
+		}
+		for nd := 0; nd < 4; nd++ {
+			nx, ny := cur.x+dx[nd], cur.y+dy[nd]
+			nt := cur.t
+			if nd != cur.d {
+				nt++
+			}
+			if !inBounds(nx, ny, n, m) || grid[nx][ny] == '*' || nt >= dist[nx][ny][nd] {
+				continue
+			}
+			dist[nx][ny][nd] = nt
+			q = append(q, node{nx, ny, nd, nt})
+		}
+	}
+	return "NO"
+}
+
+func genCase(rng *rand.Rand) ([][]byte, int, int, int, int) {
+	n := rng.Intn(5) + 2
+	m := rng.Intn(5) + 2
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(4) == 0 {
+				row[j] = '*'
+			} else {
+				row[j] = '.'
+			}
+		}
+		grid[i] = row
+	}
+	sx, sy := rng.Intn(n), rng.Intn(m)
+	tx, ty := rng.Intn(n), rng.Intn(m)
+	if sx == tx && sy == ty {
+		tx = (tx + 1) % n
+	}
+	grid[sx][sy] = 'S'
+	grid[tx][ty] = 'T'
+	return grid, sx, sy, tx, ty
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		grid, sx, sy, tx, ty := genCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", len(grid), len(grid[0]))
+		for _, row := range grid {
+			sb.WriteString(string(row))
+			sb.WriteByte('\n')
+		}
+		expect := solveB(grid, sx, sy, tx, ty)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/793/verifierC.go
+++ b/0-999/700-799/790-799/793/verifierC.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(n int, x1, y1, x2, y2 float64, data [][4]float64) string {
+	l, r := 0.0, 1e18
+	for _, m := range data {
+		x, y, vx, vy := m[0], m[1], m[2], m[3]
+		u, v := 0.0, 1e18
+		if vx == 0 {
+			if x <= x1 || x >= x2 {
+				return "-1"
+			}
+		} else {
+			u = (x1 - x) / vx
+			v = (x2 - x) / vx
+			if u > v {
+				u, v = v, u
+			}
+		}
+		l = math.Max(l, u)
+		r = math.Min(r, v)
+		if vy == 0 {
+			if y <= y1 || y >= y2 {
+				return "-1"
+			}
+		} else {
+			u = (y1 - y) / vy
+			v = (y2 - y) / vy
+			if u > v {
+				u, v = v, u
+			}
+		}
+		l = math.Max(l, u)
+		r = math.Min(r, v)
+	}
+	if l >= r {
+		return "-1"
+	}
+	return fmt.Sprintf("%.6f", l)
+}
+
+func genCase(rng *rand.Rand) (int, float64, float64, float64, float64, [][4]float64) {
+	n := rng.Intn(5) + 1
+	x1 := float64(rng.Intn(10))
+	y1 := float64(rng.Intn(10))
+	x2 := x1 + float64(rng.Intn(10)+1)
+	y2 := y1 + float64(rng.Intn(10)+1)
+	data := make([][4]float64, n)
+	for i := 0; i < n; i++ {
+		data[i][0] = float64(rng.Intn(15))
+		data[i][1] = float64(rng.Intn(15))
+		data[i][2] = float64(rng.Intn(5) - 2)
+		data[i][3] = float64(rng.Intn(5) - 2)
+		if data[i][2] == 0 && (data[i][0] <= x1 || data[i][0] >= x2) {
+			data[i][0] = (x1 + x2) / 2
+		}
+		if data[i][3] == 0 && (data[i][1] <= y1 || data[i][1] >= y2) {
+			data[i][1] = (y1 + y2) / 2
+		}
+	}
+	return n, x1, y1, x2, y2, data
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, x1, y1, x2, y2, data := genCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		fmt.Fprintf(&sb, "%d %d %d %d\n", int(x1), int(y1), int(x2), int(y2))
+		for _, m := range data {
+			fmt.Fprintf(&sb, "%d %d %d %d\n", int(m[0]), int(m[1]), int(m[2]), int(m[3]))
+		}
+		expect := solveC(n, x1, y1, x2, y2, data)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		var gv float64
+		fmt.Sscan(got, &gv)
+		var ev float64
+		fmt.Sscan(expect, &ev)
+		if math.Abs(gv-ev) > 1e-4 {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/793/verifierD.go
+++ b/0-999/700-799/790-799/793/verifierD.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	to int
+	w  int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveD(n, k int, adj [][]edge) string {
+	Np := n + 2
+	encode := func(L, R, pos int) int { return ((L*Np+R)*n + (pos - 1)) }
+	decode := func(code int) (int, int, int) {
+		pos := code%n + 1
+		code /= n
+		R := code % Np
+		L := code / Np
+		return L, R, pos
+	}
+	const INF int64 = 1 << 60
+	dpPrev := map[int]int64{}
+	for i := 1; i <= n; i++ {
+		idx := encode(0, n+1, i)
+		dpPrev[idx] = 0
+	}
+	for step := 1; step < k; step++ {
+		dpNext := map[int]int64{}
+		for idx, cost := range dpPrev {
+			L, R, pos := decode(idx)
+			for _, e := range adj[pos] {
+				nxt := e.to
+				if nxt <= L || nxt >= R || nxt == pos {
+					continue
+				}
+				var newL, newR int
+				if nxt > pos {
+					newL = pos
+					newR = R
+				} else {
+					newL = L
+					newR = pos
+				}
+				nidx := encode(newL, newR, nxt)
+				nc := cost + int64(e.w)
+				if old, ok := dpNext[nidx]; !ok || nc < old {
+					dpNext[nidx] = nc
+				}
+			}
+		}
+		dpPrev = dpNext
+		if len(dpPrev) == 0 {
+			break
+		}
+	}
+	ans := INF
+	for _, c := range dpPrev {
+		if c < ans {
+			ans = c
+		}
+	}
+	if ans == INF {
+		return "-1"
+	}
+	return fmt.Sprint(ans)
+}
+
+func genCase(rng *rand.Rand) (int, int, [][]edge) {
+	n := rng.Intn(5) + 2
+	k := rng.Intn(n) + 1
+	m := rng.Intn(10)
+	adj := make([][]edge, n+1)
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		for v == u {
+			v = rng.Intn(n) + 1
+		}
+		c := rng.Intn(10) + 1
+		adj[u] = append(adj[u], edge{v, c})
+	}
+	return n, k, adj
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, adj := genCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		m := 0
+		for _, edges := range adj {
+			m += len(edges)
+		}
+		fmt.Fprintf(&sb, "%d\n", m)
+		for u := 1; u <= n; u++ {
+			for _, e := range adj[u] {
+				fmt.Fprintf(&sb, "%d %d %d\n", u, e.to, e.w)
+			}
+		}
+		expect := solveD(n, k, adj)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/793/verifierE.go
+++ b/0-999/700-799/790-799/793/verifierE.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func subset(weights []int, target int) bool {
+	if target < 0 {
+		return false
+	}
+	dp := make([]bool, target+1)
+	dp[0] = true
+	for _, w := range weights {
+		for j := target; j >= w; j-- {
+			if dp[j-w] {
+				dp[j] = true
+			}
+		}
+	}
+	return dp[target]
+}
+
+func solveE(n int, a, b, c, d int, parent []int) string {
+	g := make([][]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := parent[i-2]
+		g[i] = append(g[i], p)
+		g[p] = append(g[p], i)
+	}
+	belong := make([]int, n+1)
+	leafCnt := make([]int, n+1)
+	var dfs func(int, int, int) int
+	dfs = func(v, p, root int) int {
+		belong[v] = root
+		cnt := 0
+		isLeaf := true
+		for _, to := range g[v] {
+			if to == p {
+				continue
+			}
+			isLeaf = false
+			cnt += dfs(to, v, root)
+		}
+		if isLeaf {
+			cnt = 1
+		}
+		leafCnt[v] = cnt
+		return cnt
+	}
+	total := 0
+	for _, ch := range g[1] {
+		total += dfs(ch, 1, ch)
+	}
+	if total%2 == 1 {
+		return "NO"
+	}
+	half := total / 2
+	childA := belong[a]
+	childC := belong[c]
+	childD := belong[d]
+	subLeaves := map[int]int{}
+	for _, ch := range g[1] {
+		subLeaves[ch] = leafCnt[ch]
+	}
+	check := func(x, y int) bool {
+		fixed := subLeaves[x] + subLeaves[y]
+		target := half - fixed
+		others := []int{}
+		for _, ch := range g[1] {
+			if ch == x || ch == y {
+				continue
+			}
+			others = append(others, subLeaves[ch])
+		}
+		return subset(others, target)
+	}
+	if check(childA, childC) || check(childA, childD) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func genCase(rng *rand.Rand) (int, int, int, int, int, []int) {
+	n := rng.Intn(8) + 5
+	parent := make([]int, n-1)
+	for i := 2; i <= n; i++ {
+		parent[i-2] = rng.Intn(i-1) + 1
+	}
+	leaves := []int{}
+	deg := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		deg[i]++
+		deg[parent[i-2]]++
+	}
+	for i := 2; i <= n; i++ {
+		if deg[i] == 1 {
+			leaves = append(leaves, i)
+		}
+	}
+	if len(leaves) < 4 {
+		for len(leaves) < 4 {
+			leaves = append(leaves, 2)
+		}
+	}
+	shuffle := rng.Perm(len(leaves))
+	a := leaves[shuffle[0]]
+	b := leaves[shuffle[1]]
+	c := leaves[shuffle[2]]
+	d := leaves[shuffle[3]]
+	return n, a, b, c, d, parent
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, a, b, c, d, parent := genCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		fmt.Fprintf(&sb, "%d %d %d %d\n", a, b, c, d)
+		for i := 2; i <= n; i++ {
+			fmt.Fprintf(&sb, "%d ", parent[i-2])
+		}
+		sb.WriteByte('\n')
+		expect := solveE(n, a, b, c, d, parent)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/793/verifierF.go
+++ b/0-999/700-799/790-799/793/verifierF.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type rope struct{ l, r int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+type segTree struct {
+	n int
+	t []int
+}
+
+func newSegTree(n int) *segTree {
+	size := 1
+	for size < n+2 {
+		size <<= 1
+	}
+	return &segTree{n: size, t: make([]int, 2*size)}
+}
+
+func (st *segTree) update(pos, val int) {
+	pos += st.n
+	if st.t[pos] >= val {
+		return
+	}
+	st.t[pos] = val
+	for pos > 1 {
+		pos >>= 1
+		if st.t[pos] >= val {
+			break
+		}
+		st.t[pos] = val
+	}
+}
+
+func (st *segTree) query(l, r int) int {
+	if l > r {
+		return 0
+	}
+	l += st.n
+	r += st.n
+	res := 0
+	for l <= r {
+		if l&1 == 1 {
+			res = max(res, st.t[l])
+			l++
+		}
+		if r&1 == 0 {
+			res = max(res, st.t[r])
+			r--
+		}
+		l >>= 1
+		r >>= 1
+	}
+	return res
+}
+
+func solveF(n int, ropes []rope, queries [][2]int) []int {
+	sort.Slice(ropes, func(i, j int) bool { return ropes[i].r < ropes[j].r })
+	type qu struct{ x, y, idx int }
+	qs := make([]qu, len(queries))
+	for i, q := range queries {
+		qs[i] = qu{q[0], q[1], i}
+	}
+	sort.Slice(qs, func(i, j int) bool { return qs[i].y < qs[j].y })
+	st := newSegTree(n)
+	ans := make([]int, len(queries))
+	j := 0
+	for _, q := range qs {
+		for j < len(ropes) && ropes[j].r <= q.y {
+			if ropes[j].l <= ropes[j].r {
+				st.update(ropes[j].l, ropes[j].r)
+			}
+			j++
+		}
+		h := q.x
+		if h > q.y {
+			ans[q.idx] = q.x
+			continue
+		}
+		for {
+			mx := st.query(q.x, h)
+			if mx > h {
+				h = mx
+				if h >= q.y {
+					if h > q.y {
+						h = q.y
+					}
+					break
+				}
+			} else {
+				break
+			}
+		}
+		if h > q.y {
+			h = q.y
+		}
+		ans[q.idx] = h
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (int, []rope, [][2]int) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(5)
+	ropes := make([]rope, m)
+	usedR := map[int]bool{}
+	for i := 0; i < m; i++ {
+		r := rng.Intn(n) + 1
+		for usedR[r] {
+			r = rng.Intn(n) + 1
+		}
+		usedR[r] = true
+		l := rng.Intn(r) + 1
+		ropes[i] = rope{l, r}
+	}
+	q := rng.Intn(5) + 1
+	qs := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		x := rng.Intn(n) + 1
+		y := x + rng.Intn(n-x+1)
+		qs[i] = [2]int{x, y}
+	}
+	return n, ropes, qs
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, ropes, qs := genCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		fmt.Fprintf(&sb, "%d\n", len(ropes))
+		for _, rp := range ropes {
+			fmt.Fprintf(&sb, "%d %d\n", rp.l, rp.r)
+		}
+		fmt.Fprintf(&sb, "%d\n", len(qs))
+		for _, q := range qs {
+			fmt.Fprintf(&sb, "%d %d\n", q[0], q[1])
+		}
+		expAns := solveF(n, ropes, qs)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		lines := strings.Fields(got)
+		if len(lines) != len(expAns) {
+			fmt.Fprintf(os.Stderr, "case %d failed: wrong number of lines\n", i+1)
+			os.Exit(1)
+		}
+		for idx, ansStr := range lines {
+			if ansStr != fmt.Sprint(expAns[idx]) {
+				fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %d got %s\n", i+1, sb.String(), expAns[idx], ansStr)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/793/verifierG.go
+++ b/0-999/700-799/790-799/793/verifierG.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func maxMatching(board [][]bool) int {
+	n := len(board)
+	matchV := make([]int, n)
+	for i := range matchV {
+		matchV[i] = -1
+	}
+	var dfs func(int, []bool) bool
+	dfs = func(u int, vis []bool) bool {
+		for v := 0; v < n; v++ {
+			if board[u][v] && !vis[v] {
+				vis[v] = true
+				if matchV[v] == -1 || dfs(matchV[v], vis) {
+					matchV[v] = u
+					return true
+				}
+			}
+		}
+		return false
+	}
+	result := 0
+	for u := 0; u < n; u++ {
+		vis := make([]bool, n)
+		if dfs(u, vis) {
+			result++
+		}
+	}
+	return result
+}
+
+func solveG(n int, removed [][4]int) string {
+	board := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		row := make([]bool, n)
+		for j := 0; j < n; j++ {
+			row[j] = true
+		}
+		board[i] = row
+	}
+	for _, rec := range removed {
+		x1, y1, x2, y2 := rec[0]-1, rec[1]-1, rec[2]-1, rec[3]-1
+		for i := x1; i <= x2; i++ {
+			for j := y1; j <= y2; j++ {
+				board[i][j] = false
+			}
+		}
+	}
+	ans := maxMatching(board)
+	return fmt.Sprint(ans)
+}
+
+func genCase(rng *rand.Rand) (int, [][4]int) {
+	n := rng.Intn(6) + 1
+	q := rng.Intn(4)
+	recs := make([][4]int, q)
+	used := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		used[i] = make([]bool, n)
+	}
+	for idx := 0; idx < q; idx++ {
+		x1 := rng.Intn(n) + 1
+		y1 := rng.Intn(n) + 1
+		x2 := x1 + rng.Intn(n-x1+1)
+		y2 := y1 + rng.Intn(n-y1+1)
+		recs[idx] = [4]int{x1, y1, x2, y2}
+		for i := x1 - 1; i <= x2-1; i++ {
+			for j := y1 - 1; j <= y2-1; j++ {
+				used[i][j] = true
+			}
+		}
+	}
+	return n, recs
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, recs := genCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		fmt.Fprintf(&sb, "%d\n", len(recs))
+		for _, r := range recs {
+			fmt.Fprintf(&sb, "%d %d %d %d\n", r[0], r[1], r[2], r[3])
+		}
+		expect := solveG(n, recs)
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected %s got %s\n", i+1, sb.String(), expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–G of contest 793
- each verifier runs 100 randomized tests and supports running arbitrary binaries or Go files via `go run`

## Testing
- `go run verifierA.go ./793A_bin`
- `go run verifierB.go ./793B_bin`
- `go run verifierC.go ./793C_bin`
- `go run verifierD.go ./793D_bin`
- `go run verifierE.go ./793E_bin`
- *(interrupted)* `go run verifierF.go ./793F_bin`
- `go run verifierG.go ./793G_bin`


------
https://chatgpt.com/codex/tasks/task_e_6883b31772648324ab9a95c9a9011b71