### PR TITLE
Add solution verifiers for Codeforces 799

### DIFF
--- a/0-999/700-799/790-799/799/verifierA.go
+++ b/0-999/700-799/790-799/799/verifierA.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(n, t, k, d int) string {
+	batches := (n + k - 1) / k
+	oneTime := batches * t
+	for current := 1; current < oneTime; current++ {
+		cakes := (current / t) * k
+		if current > d {
+			cakes += ((current - d) / t) * k
+		}
+		if cakes >= n {
+			return "YES\n"
+		}
+	}
+	return "NO\n"
+}
+
+func genA() (string, string) {
+	n := rand.Intn(50) + 1
+	t := rand.Intn(10) + 1
+	k := rand.Intn(10) + 1
+	d := rand.Intn(20) + 1
+	input := fmt.Sprintf("%d %d %d %d\n", n, t, k, d)
+	out := solveA(n, t, k, d)
+	return input, out
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genA()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%sOutput:\n%s", i+1, err, in, got)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/799/verifierB.go
+++ b/0-999/700-799/790-799/799/verifierB.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type tshirt struct{ price, idx int }
+
+type testB struct {
+	n       int
+	prices  []int
+	a       []int
+	b       []int
+	m       int
+	queries []int
+}
+
+func solveB(tc testB) []int {
+	lists := make([][]tshirt, 4)
+	for i := 0; i < tc.n; i++ {
+		if tc.a[i] == tc.b[i] {
+			lists[tc.a[i]] = append(lists[tc.a[i]], tshirt{tc.prices[i], i})
+		} else {
+			lists[tc.a[i]] = append(lists[tc.a[i]], tshirt{tc.prices[i], i})
+			lists[tc.b[i]] = append(lists[tc.b[i]], tshirt{tc.prices[i], i})
+		}
+	}
+	for c := 1; c <= 3; c++ {
+		sort.Slice(lists[c], func(i, j int) bool { return lists[c][i].price < lists[c][j].price })
+	}
+	ptr := make([]int, 4)
+	sold := make([]bool, tc.n)
+	res := make([]int, tc.m)
+	for i := 0; i < tc.m; i++ {
+		c := tc.queries[i]
+		for ptr[c] < len(lists[c]) && sold[lists[c][ptr[c]].idx] {
+			ptr[c]++
+		}
+		if ptr[c] == len(lists[c]) {
+			res[i] = -1
+		} else {
+			res[i] = lists[c][ptr[c]].price
+			sold[lists[c][ptr[c]].idx] = true
+			ptr[c]++
+		}
+	}
+	return res
+}
+
+func genB() (string, []int) {
+	n := rand.Intn(8) + 1
+	prices := rand.Perm(100)[:n]
+	for i := range prices {
+		prices[i]++
+	}
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(3) + 1
+		b[i] = rand.Intn(3) + 1
+	}
+	m := rand.Intn(n) + 1
+	queries := make([]int, m)
+	for i := 0; i < m; i++ {
+		queries[i] = rand.Intn(3) + 1
+	}
+	tc := testB{n, prices, a, b, m, queries}
+	outNums := solveB(tc)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range prices {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i, v := range queries {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	return input, outNums
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, expSlice := genB()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%sOutput:\n%s", i+1, err, in, got)
+			return
+		}
+		gotFields := strings.Fields(got)
+		if len(gotFields) != len(expSlice) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected %d numbers, got %d\n%s", i+1, in, len(expSlice), len(gotFields), got)
+			return
+		}
+		for j, g := range gotFields {
+			var val int
+			fmt.Sscan(g, &val)
+			if val != expSlice[j] {
+				fmt.Printf("Test %d failed at position %d\nInput:\n%sExpected:\n%v\nGot:\n%s", i+1, j+1, in, expSlice, got)
+				return
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/799/verifierC.go
+++ b/0-999/700-799/790-799/799/verifierC.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testC struct {
+	n      int
+	c      int
+	d      int
+	beauty []int
+	cost   []int
+	typ    []byte
+}
+
+func solveC(tc testC) int {
+	best := 0
+	for i := 0; i < tc.n; i++ {
+		for j := i + 1; j < tc.n; j++ {
+			b := tc.beauty[i] + tc.beauty[j]
+			t1 := tc.typ[i]
+			t2 := tc.typ[j]
+			if t1 == 'C' && t2 == 'C' {
+				if tc.cost[i]+tc.cost[j] <= tc.c && b > best {
+					best = b
+				}
+			} else if t1 == 'D' && t2 == 'D' {
+				if tc.cost[i]+tc.cost[j] <= tc.d && b > best {
+					best = b
+				}
+			} else if t1 == 'C' && t2 == 'D' {
+				if tc.cost[i] <= tc.c && tc.cost[j] <= tc.d && b > best {
+					best = b
+				}
+			} else if t1 == 'D' && t2 == 'C' {
+				if tc.cost[i] <= tc.d && tc.cost[j] <= tc.c && b > best {
+					best = b
+				}
+			}
+		}
+	}
+	return best
+}
+
+func genC() (string, int) {
+	n := rand.Intn(7) + 2
+	c := rand.Intn(20)
+	d := rand.Intn(20)
+	beauty := make([]int, n)
+	cost := make([]int, n)
+	typ := make([]byte, n)
+	for i := 0; i < n; i++ {
+		beauty[i] = rand.Intn(30) + 1
+		cost[i] = rand.Intn(20) + 1
+		if rand.Intn(2) == 0 {
+			typ[i] = 'C'
+		} else {
+			typ[i] = 'D'
+		}
+	}
+	tc := testC{n, c, d, beauty, cost, typ}
+	ans := solveC(tc)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, c, d))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %c\n", beauty[i], cost[i], typ[i]))
+	}
+	input := sb.String()
+	return input, ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genC()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%sOutput:\n%s", i+1, err, in, got)
+			return
+		}
+		got = strings.TrimSpace(got)
+		var val int
+		if _, err := fmt.Sscan(got, &val); err != nil || val != exp {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%d\nGot:\n%s", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/799/verifierD.go
+++ b/0-999/700-799/790-799/799/verifierD.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type pair struct{ w, h int64 }
+
+func solve(targetA, targetB, h, w int64, factors []int64) int {
+	if h >= targetA && w >= targetB {
+		return 0
+	}
+	sort.Slice(factors, func(i, j int) bool { return factors[i] > factors[j] })
+	limit := 10
+	if len(factors) < limit {
+		limit = len(factors)
+	}
+	factors = factors[:limit]
+	state := map[int64]int64{h: w}
+	for i, f := range factors {
+		next := make(map[int64]int64, len(state)*2)
+		for width, height := range state {
+			if height > next[width] {
+				next[width] = height
+			}
+			nw := width * f
+			if nw > targetA {
+				nw = targetA
+			}
+			if height > next[nw] {
+				next[nw] = height
+			}
+			nh := height * f
+			if nh > targetB {
+				nh = targetB
+			}
+			if nh > next[width] {
+				next[width] = nh
+			}
+		}
+		arr := make([]pair, 0, len(next))
+		for wv, hv := range next {
+			arr = append(arr, pair{wv, hv})
+		}
+		sort.Slice(arr, func(i, j int) bool { return arr[i].w < arr[j].w })
+		state = make(map[int64]int64)
+		maxH := int64(0)
+		for _, p := range arr {
+			if p.h > maxH {
+				maxH = p.h
+				state[p.w] = p.h
+			}
+		}
+		for wv, hv := range state {
+			if wv >= targetA && hv >= targetB {
+				return i + 1
+			}
+		}
+	}
+	return -1
+}
+
+func solveD(a, b, h, w int64, factors []int64) int {
+	r1 := solve(a, b, h, w, factors)
+	r2 := solve(b, a, h, w, factors)
+	if r1 == -1 {
+		return r2
+	}
+	if r2 == -1 {
+		return r1
+	}
+	if r1 < r2 {
+		return r1
+	}
+	return r2
+}
+
+func genD() (string, int) {
+	a := int64(rand.Intn(10) + 1)
+	b := int64(rand.Intn(10) + 1)
+	h := int64(rand.Intn(10) + 1)
+	w := int64(rand.Intn(10) + 1)
+	n := rand.Intn(5) + 1
+	factors := make([]int64, n)
+	for i := 0; i < n; i++ {
+		factors[i] = int64(rand.Intn(5) + 2)
+	}
+	ans := solveD(a, b, h, w, factors)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d %d\n", a, b, h, w, n))
+	for i, f := range factors {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", f))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genD()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%sOutput:\n%s", i+1, err, in, got)
+			return
+		}
+		got = strings.TrimSpace(got)
+		var val int
+		if _, err := fmt.Sscan(got, &val); err != nil || val != exp {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%d\nGot:\n%s", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/799/verifierE.go
+++ b/0-999/700-799/790-799/799/verifierE.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testE struct {
+	n     int
+	m     int
+	k     int
+	cost  []int
+	likeM []bool
+	likeA []bool
+}
+
+func solveE(tc testE) int {
+	best := math.MaxInt32
+	n := tc.n
+	for mask := 0; mask < (1 << n); mask++ {
+		if bits.OnesCount(uint(mask)) != tc.m {
+			continue
+		}
+		cntM, cntA, cost := 0, 0, 0
+		for i := 0; i < n; i++ {
+			if mask>>i&1 == 1 {
+				cost += tc.cost[i]
+				if tc.likeM[i] {
+					cntM++
+				}
+				if tc.likeA[i] {
+					cntA++
+				}
+			}
+		}
+		if cntM >= tc.k && cntA >= tc.k {
+			if cost < best {
+				best = cost
+			}
+		}
+	}
+	if best == math.MaxInt32 {
+		return -1
+	}
+	return best
+}
+
+func genE() (string, int) {
+	n := rand.Intn(7) + 1
+	m := rand.Intn(n) + 1
+	k := rand.Intn(m + 1)
+	cost := make([]int, n)
+	likeM := make([]bool, n)
+	likeA := make([]bool, n)
+	for i := 0; i < n; i++ {
+		cost[i] = rand.Intn(20) + 1
+		likeM[i] = rand.Intn(2) == 0
+		likeA[i] = rand.Intn(2) == 0
+	}
+	tc := testE{n, m, k, cost, likeM, likeA}
+	ans := solveE(tc)
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i, v := range cost {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	var idx []int
+	for i, v := range likeM {
+		if v {
+			idx = append(idx, i+1)
+		}
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", len(idx)))
+	for i, v := range idx {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	idx = idx[:0]
+	for i, v := range likeA {
+		if v {
+			idx = append(idx, i+1)
+		}
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", len(idx)))
+	for i, v := range idx {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genE()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%sOutput:\n%s", i+1, err, in, got)
+			return
+		}
+		got = strings.TrimSpace(got)
+		var val int
+		if _, err := fmt.Sscan(got, &val); err != nil || val != exp {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%d\nGot:\n%s", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/799/verifierF.go
+++ b/0-999/700-799/790-799/799/verifierF.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testF struct {
+	n int
+	m int
+	l []int
+	r []int
+}
+
+func solveF(tc testF) int {
+	total := 0
+	for a := 1; a <= tc.m; a++ {
+		for b := a; b <= tc.m; b++ {
+			valid := false
+			ok := true
+			for i := 0; i < tc.n; i++ {
+				start := a
+				if tc.l[i] > start {
+					start = tc.l[i]
+				}
+				end := b
+				if tc.r[i] < end {
+					end = tc.r[i]
+				}
+				length := end - start + 1
+				if start > end {
+					length = 0
+				}
+				if length > 0 {
+					valid = true
+				}
+				if length%2 == 0 {
+					if length != 0 {
+						ok = false
+						break
+					}
+				}
+			}
+			if ok && valid {
+				total += b - a + 1
+			}
+		}
+	}
+	return total
+}
+
+func genF() (string, int) {
+	n := rand.Intn(3) + 1
+	m := rand.Intn(6) + 1
+	l := make([]int, n)
+	r := make([]int, n)
+	for i := 0; i < n; i++ {
+		a := rand.Intn(m) + 1
+		b := rand.Intn(m) + 1
+		if a > b {
+			a, b = b, a
+		}
+		l[i], r[i] = a, b
+	}
+	tc := testF{n, m, l, r}
+	ans := solveF(tc)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", l[i], r[i]))
+	}
+	input := sb.String()
+	return input, ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genF()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%sOutput:\n%s", i+1, err, in, got)
+			return
+		}
+		got = strings.TrimSpace(got)
+		var val int
+		if _, err := fmt.Sscan(got, &val); err != nil || val != exp {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%d\nGot:\n%s", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/799/verifierG.go
+++ b/0-999/700-799/790-799/799/verifierG.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Point struct{ x, y float64 }
+
+func cross(a, b Point) float64 { return a.x*b.y - a.y*b.x }
+func sub(a, b Point) Point     { return Point{a.x - b.x, a.y - b.y} }
+
+func polygonArea(poly []Point) float64 {
+	area := 0.0
+	n := len(poly)
+	for i := 0; i < n; i++ {
+		j := (i + 1) % n
+		area += cross(poly[i], poly[j])
+	}
+	if area < 0 {
+		area = -area
+	}
+	return area / 2
+}
+
+func cutPolygon(poly []Point, p, dir Point) []Point {
+	res := make([]Point, 0, len(poly)+2)
+	n := len(poly)
+	for i := 0; i < n; i++ {
+		a := poly[i]
+		b := poly[(i+1)%n]
+		da := cross(dir, sub(a, p))
+		db := cross(dir, sub(b, p))
+		if da >= 0 {
+			res = append(res, a)
+		}
+		if da*db < 0 {
+			t := da / (da - db)
+			inter := Point{a.x + t*(b.x-a.x), a.y + t*(b.y-a.y)}
+			res = append(res, inter)
+		}
+	}
+	return res
+}
+
+func findAngle(poly []Point, p Point, total float64) float64 {
+	lo, hi := 0.0, math.Pi
+	for iter := 0; iter < 60; iter++ {
+		mid := (lo + hi) / 2
+		dir := Point{math.Cos(mid), math.Sin(mid)}
+		half := cutPolygon(poly, p, dir)
+		area := polygonArea(half)
+		if area > total/2 {
+			hi = mid
+		} else {
+			lo = mid
+		}
+	}
+	return (lo + hi) / 2
+}
+
+func genConvex(n int) []Point {
+	angles := make([]float64, n)
+	for i := 0; i < n; i++ {
+		angles[i] = rand.Float64() * 2 * math.Pi
+	}
+	sort.Float64s(angles)
+	poly := make([]Point, n)
+	for i := 0; i < n; i++ {
+		r := rand.Float64()*5 + 1
+		poly[i] = Point{r * math.Cos(angles[i]), r * math.Sin(angles[i])}
+	}
+	return poly
+}
+
+func genG() (string, []float64) {
+	n := rand.Intn(3) + 3
+	q := rand.Intn(3) + 1
+	poly := genConvex(n)
+	cx, cy := 0.0, 0.0
+	for _, p := range poly {
+		cx += p.x
+		cy += p.y
+	}
+	cx /= float64(n)
+	cy /= float64(n)
+	queries := make([]Point, q)
+	for i := 0; i < q; i++ {
+		queries[i] = Point{cx + (rand.Float64()-0.5)*0.1, cy + (rand.Float64()-0.5)*0.1}
+	}
+	total := polygonArea(poly)
+	answers := make([]float64, q)
+	for i := 0; i < q; i++ {
+		answers[i] = findAngle(poly, queries[i], total)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%.6f %.6f\n", poly[i].x, poly[i].y))
+	}
+	for i := 0; i < q; i++ {
+		sb.WriteString(fmt.Sprintf("%.6f %.6f\n", queries[i].x, queries[i].y))
+	}
+	return sb.String(), answers
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go <binary>")
+		return
+	}
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := genG()
+		got, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nInput:\n%sOutput:\n%s", i+1, err, in, got)
+			return
+		}
+		lines := strings.Fields(got)
+		if len(lines) != len(exp) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected %d numbers, got %d\n%s", i+1, in, len(exp), len(lines), got)
+			return
+		}
+		for j, field := range lines {
+			var val float64
+			fmt.Sscan(field, &val)
+			if math.Abs(val-exp[j]) > 1e-4 {
+				fmt.Printf("Test %d failed at line %d\nInput:\n%sExpected: %.6f Got: %s", i+1, j+1, in, exp[j], field)
+				return
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` through `verifierG.go` for contest 799
- each verifier generates at least 100 random testcases, runs an arbitrary binary and checks its output

## Testing
- `for f in verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go; do echo "building $f"; go build 0-999/700-799/790-799/799/$f || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_6883b65fe7fc8324a52b773d43b758d8