### PR TITLE
Add verifiers for Codeforces contest 796

### DIFF
--- a/0-999/700-799/790-799/796/verifierA.go
+++ b/0-999/700-799/790-799/796/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runBinary(binPath, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	// Build reference solution
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "796A.go")
+	refBin := filepath.Join(os.TempDir(), "796A_ref_bin")
+	build := exec.Command("go", "build", "-o", refBin, refSrc)
+	if out, err := build.CombinedOutput(); err != nil {
+		fmt.Println("Failed to build reference:", err)
+		fmt.Println(string(out))
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rng := rand.New(rand.NewSource(42))
+
+	for tc := 1; tc <= 100; tc++ {
+		n := rng.Intn(99) + 2 // 2..100
+		m := rng.Intn(n) + 1
+		k := rng.Intn(100) + 1
+		houses := make([]int, n)
+		for i := range houses {
+			if rng.Intn(2) == 0 {
+				houses[i] = 0
+			} else {
+				houses[i] = rng.Intn(100) + 1
+			}
+		}
+		houses[m-1] = 0
+		idx := rng.Intn(n)
+		if idx == m-1 {
+			idx = (idx + 1) % n
+		}
+		houses[idx] = rng.Intn(k) + 1
+
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+		for i, v := range houses {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+
+		exp, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Println("Reference solution error on test", tc)
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("Candidate runtime error on test %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", tc, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/790-799/796/verifierB.go
+++ b/0-999/700-799/790-799/796/verifierB.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runBinary(binPath, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "796B.go")
+	refBin := filepath.Join(os.TempDir(), "796B_ref_bin")
+	cmd := exec.Command("go", "build", "-o", refBin, refSrc)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Println("Failed to build reference:", err)
+		fmt.Println(string(out))
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rng := rand.New(rand.NewSource(43))
+
+	for tc := 1; tc <= 100; tc++ {
+		n := rng.Intn(20) + 2
+		m := rng.Intn(n-1) + 1
+		k := rng.Intn(20) + 1
+		holesSet := make(map[int]bool)
+		for len(holesSet) < m {
+			holesSet[rng.Intn(n)+1] = true
+		}
+		holes := make([]int, 0, m)
+		for h := range holesSet {
+			holes = append(holes, h)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+		for i, h := range holes {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", h))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < k; i++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				v = (v % n) + 1
+			}
+			sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+		}
+		input := sb.String()
+
+		exp, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Println("Reference solution error on test", tc)
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("Candidate runtime error on test %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", tc, input, exp, got)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/790-799/796/verifierC.go
+++ b/0-999/700-799/790-799/796/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runBinary(binPath, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTree(n int, rng *rand.Rand) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "796C.go")
+	refBin := filepath.Join(os.TempDir(), "796C_ref_bin")
+	cmd := exec.Command("go", "build", "-o", refBin, refSrc)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Println("Failed to build reference:", err)
+		fmt.Println(string(out))
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rng := rand.New(rand.NewSource(44))
+
+	for tc := 1; tc <= 100; tc++ {
+		n := rng.Intn(14) + 2
+		a := make([]int, n)
+		for i := range a {
+			a[i] = rng.Intn(21) - 10
+		}
+		edges := genTree(n, rng)
+
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		input := sb.String()
+
+		exp, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Println("Reference solution error on test", tc)
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("Candidate runtime error on test %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", tc, input, exp, got)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/790-799/796/verifierD.go
+++ b/0-999/700-799/790-799/796/verifierD.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runBinary(binPath, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTree(n int, rng *rand.Rand) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "796D.go")
+	refBin := filepath.Join(os.TempDir(), "796D_ref_bin")
+	cmd := exec.Command("go", "build", "-o", refBin, refSrc)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Println("Failed to build reference:", err)
+		fmt.Println(string(out))
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rng := rand.New(rand.NewSource(45))
+
+	for tc := 1; tc <= 100; tc++ {
+		n := rng.Intn(15) + 2
+		k := rng.Intn(n) + 1
+		d := rng.Intn(n)
+		police := make([]int, k)
+		for i := range police {
+			police[i] = rng.Intn(n) + 1
+		}
+		edges := genTree(n, rng)
+
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, k, d))
+		for i, v := range police {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		input := sb.String()
+
+		exp, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Println("Reference solution error on test", tc)
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("Candidate runtime error on test %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", tc, input, exp, got)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("All tests passed.")
+}

--- a/0-999/700-799/790-799/796/verifierE.go
+++ b/0-999/700-799/790-799/796/verifierE.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+func runBinary(binPath, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "796E.go")
+	refBin := filepath.Join(os.TempDir(), "796E_ref_bin")
+	cmd := exec.Command("go", "build", "-o", refBin, refSrc)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Println("Failed to build reference:", err)
+		fmt.Println(string(out))
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rng := rand.New(rand.NewSource(46))
+
+	for tc := 1; tc <= 100; tc++ {
+		n := rng.Intn(20) + 1
+		p := rng.Intn(20) + 1
+		k := rng.Intn(min(n, 5)) + 1
+		r := rng.Intn(n + 1)
+		a := randIndices(n, r, rng)
+		s := rng.Intn(n + 1)
+		b := randIndices(n, s, rng)
+
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, p, k))
+		sb.WriteString(fmt.Sprintf("%d", r))
+		for _, v := range a {
+			sb.WriteString(fmt.Sprintf(" %d", v))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d", s))
+		for _, v := range b {
+			sb.WriteString(fmt.Sprintf(" %d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+
+		exp, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Println("Reference solution error on test", tc)
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("Candidate runtime error on test %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", tc, input, exp, got)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("All tests passed.")
+}
+
+func randIndices(n, cnt int, rng *rand.Rand) []int {
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = i + 1
+	}
+	rng.Shuffle(n, func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+	res := arr[:cnt]
+	sort.Ints(res)
+	return res
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/0-999/700-799/790-799/796/verifierF.go
+++ b/0-999/700-799/790-799/796/verifierF.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runBinary(binPath, input string) (string, error) {
+	cmd := exec.Command(binPath)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSrc := filepath.Join(dir, "796F.go")
+	refBin := filepath.Join(os.TempDir(), "796F_ref_bin")
+	cmd := exec.Command("go", "build", "-o", refBin, refSrc)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Println("Failed to build reference:", err)
+		fmt.Println(string(out))
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rng := rand.New(rand.NewSource(47))
+
+	for tc := 1; tc <= 100; tc++ {
+		n := rng.Intn(6) + 1
+		m := rng.Intn(8) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		usedX := make(map[int]bool)
+		for i := 0; i < m; i++ {
+			t := rng.Intn(2) + 1
+			if t == 1 {
+				l := rng.Intn(n) + 1
+				r := rng.Intn(n-l+1) + l
+				x := rng.Intn(100)
+				for usedX[x] {
+					x = rng.Intn(100)
+				}
+				usedX[x] = true
+				sb.WriteString(fmt.Sprintf("1 %d %d %d\n", l, r, x))
+			} else {
+				k := rng.Intn(n) + 1
+				d := rng.Intn(100)
+				sb.WriteString(fmt.Sprintf("2 %d %d\n", k, d))
+			}
+		}
+		input := sb.String()
+
+		exp, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Println("Reference solution error on test", tc)
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		got, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("Candidate runtime error on test %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%sGot:%s\n", tc, input, exp, got)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- implement verifier programs for problems A–F of contest 796
- each verifier compiles the provided reference solution and tests 100 random cases against a candidate binary

## Testing
- `go build 0-999/700-799/790-799/796/verifierA.go`
- `go build 0-999/700-799/790-799/796/verifierB.go`
- `go build 0-999/700-799/790-799/796/verifierC.go`
- `go build 0-999/700-799/790-799/796/verifierD.go`
- `go build 0-999/700-799/790-799/796/verifierE.go`
- `go build 0-999/700-799/790-799/796/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883b4bba93c8324b84eb36a199acfb0