### PR TITLE
Add Go verifiers for CF 797

### DIFF
--- a/0-999/700-799/790-799/797/verifierA.go
+++ b/0-999/700-799/790-799/797/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// factorize returns prime factors of n in ascending order
+func factorize(n int) []int {
+	factors := []int{}
+	d := 2
+	for d*d <= n {
+		for n%d == 0 {
+			factors = append(factors, d)
+			n /= d
+		}
+		d++
+	}
+	if n > 1 {
+		factors = append(factors, n)
+	}
+	return factors
+}
+
+func generateCase(rng *rand.Rand) (string, int, int, bool) {
+	n := rng.Intn(100000-2+1) + 2
+	k := rng.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	// Determine if solution exists
+	factors := factorize(n)
+	hasSolution := len(factors) >= k
+	return sb.String(), n, k, hasSolution
+}
+
+func runCase(bin string, input string, n, k int, hasSolution bool) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	res := strings.TrimSpace(out.String())
+	if res == "-1" {
+		if hasSolution {
+			return fmt.Errorf("expected solution but got -1")
+		}
+		return nil
+	}
+	fields := strings.Fields(res)
+	if len(fields) != k {
+		return fmt.Errorf("expected %d numbers got %d (%q)", k, len(fields), res)
+	}
+	prod := 1
+	for _, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("non-integer output %q", f)
+		}
+		if v <= 1 {
+			return fmt.Errorf("factor %d not >1", v)
+		}
+		prod *= v
+	}
+	if prod != n {
+		return fmt.Errorf("product mismatch expected %d got %d", n, prod)
+	}
+	if !hasSolution {
+		return fmt.Errorf("should be impossible but got factors")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n, k, ok := generateCase(rng)
+		if err := runCase(bin, in, n, k, ok); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/797/verifierB.go
+++ b/0-999/700-799/790-799/797/verifierB.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedB(arr []int) int {
+	sum := 0
+	const inf = int(1e9)
+	minPosOdd := inf
+	maxNegOdd := -inf
+	for _, x := range arr {
+		if x > 0 {
+			sum += x
+		}
+		if x%2 != 0 {
+			if x > 0 {
+				if x < minPosOdd {
+					minPosOdd = x
+				}
+			} else {
+				if x > maxNegOdd {
+					maxNegOdd = x
+				}
+			}
+		}
+	}
+	if sum%2 == 1 {
+		return sum
+	}
+	best := -inf
+	if minPosOdd != inf {
+		if s := sum - minPosOdd; s%2 != 0 && s > best {
+			best = s
+		}
+	}
+	if maxNegOdd != -inf {
+		if s := sum + maxNegOdd; s%2 != 0 && s > best {
+			best = s
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	hasOdd := false
+	for i := 0; i < n; i++ {
+		v := rng.Intn(21) - 10
+		if v%2 != 0 {
+			hasOdd = true
+		}
+		arr[i] = v
+	}
+	if !hasOdd {
+		idx := rng.Intn(n)
+		if arr[idx]%2 == 0 {
+			arr[idx]++
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	exp := expectedB(arr)
+	return sb.String(), exp
+}
+
+func runCase(bin string, input string, expect int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	resStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(resStr)
+	if err != nil {
+		return fmt.Errorf("bad output %q", resStr)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/797/verifierC.go
+++ b/0-999/700-799/790-799/797/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedC(s string) string {
+	freq := make([]int, 26)
+	for i := 0; i < len(s); i++ {
+		freq[s[i]-'a']++
+	}
+	minIdx := 0
+	for minIdx < 26 && freq[minIdx] == 0 {
+		minIdx++
+	}
+	stack := make([]byte, 0, len(s))
+	result := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		stack = append(stack, c)
+		freq[c-'a']--
+		for minIdx < 26 && freq[minIdx] == 0 {
+			minIdx++
+		}
+		for len(stack) > 0 {
+			top := stack[len(stack)-1]
+			if minIdx >= 26 || top <= byte('a'+minIdx) {
+				result = append(result, top)
+				stack = stack[:len(stack)-1]
+			} else {
+				break
+			}
+		}
+	}
+	for i := len(stack) - 1; i >= 0; i-- {
+		result = append(result, stack[i])
+	}
+	return string(result)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	l := rng.Intn(20) + 1
+	b := make([]byte, l)
+	for i := 0; i < l; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	s := string(b)
+	var sb strings.Builder
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	return sb.String(), expectedC(s)
+}
+
+func runCase(bin string, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	res := strings.TrimSpace(out.String())
+	if res != expect {
+		return fmt.Errorf("expected %q got %q", expect, res)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/797/verifierD.go
+++ b/0-999/700-799/790-799/797/verifierD.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func minInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func expectedD(n int, val, left, right []int) int {
+	child := make([]bool, n+1)
+	for i := 1; i <= n; i++ {
+		if left[i] != -1 {
+			child[left[i]] = true
+		}
+		if right[i] != -1 {
+			child[right[i]] = true
+		}
+	}
+	root := 1
+	for i := 1; i <= n; i++ {
+		if !child[i] {
+			root = i
+			break
+		}
+	}
+	type item struct {
+		idx       int
+		low, high int64
+	}
+	stack := []item{{root, -1 << 62, 1 << 62}}
+	found := make(map[int]bool)
+	freq := make(map[int]int)
+	for i := 1; i <= n; i++ {
+		freq[val[i]]++
+	}
+	for len(stack) > 0 {
+		it := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		v := val[it.idx]
+		if int64(v) > it.low && int64(v) < it.high {
+			found[v] = true
+		}
+		if left[it.idx] != -1 {
+			nh := minInt64(it.high, int64(v))
+			stack = append(stack, item{left[it.idx], it.low, nh})
+		}
+		if right[it.idx] != -1 {
+			nl := maxInt64(it.low, int64(v))
+			stack = append(stack, item{right[it.idx], nl, it.high})
+		}
+	}
+	success := 0
+	for v := range found {
+		success += freq[v]
+	}
+	return n - success
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(7) + 1
+	val := make([]int, n+1)
+	left := make([]int, n+1)
+	right := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		val[i] = rng.Intn(21)
+		left[i] = -1
+		right[i] = -1
+	}
+	for i := 2; i <= n; i++ {
+		for {
+			p := rng.Intn(i-1) + 1
+			if rng.Intn(2) == 0 {
+				if left[p] == -1 {
+					left[p] = i
+					break
+				}
+			} else {
+				if right[p] == -1 {
+					right[p] = i
+					break
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", val[i], left[i], right[i]))
+	}
+	expect := expectedD(n, val, left, right)
+	return sb.String(), expect
+}
+
+func runCase(bin string, input string, expect int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	resStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(resStr)
+	if err != nil {
+		return fmt.Errorf("bad output %q", resStr)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/797/verifierE.go
+++ b/0-999/700-799/790-799/797/verifierE.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedE(a []int, p, k int) int {
+	cnt := 0
+	n := len(a) - 1
+	for p <= n {
+		p = p + a[p] + k
+		cnt++
+	}
+	return cnt
+}
+
+func generateCase(rng *rand.Rand) (string, []int, [][2]int) {
+	n := rng.Intn(20) + 1
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = rng.Intn(n) + 1
+	}
+	q := rng.Intn(20) + 1
+	queries := make([][2]int, q)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		p := rng.Intn(n) + 1
+		k := rng.Intn(n) + 1
+		queries[i] = [2]int{p, k}
+		sb.WriteString(fmt.Sprintf("%d %d\n", p, k))
+	}
+	return sb.String(), a, queries
+}
+
+func runCase(bin string, input string, a []int, queries [][2]int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	resFields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(resFields) != len(queries) {
+		return fmt.Errorf("expected %d outputs got %d (%q)", len(queries), len(resFields), out.String())
+	}
+	for i, f := range resFields {
+		got, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("bad output %q", f)
+		}
+		exp := expectedE(a, queries[i][0], queries[i][1])
+		if got != exp {
+			return fmt.Errorf("query %d expected %d got %d", i+1, exp, got)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, a, qs := generateCase(rng)
+		if err := runCase(bin, in, a, qs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/700-799/790-799/797/verifierF.go
+++ b/0-999/700-799/790-799/797/verifierF.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func expectedF(mice []int64, holes []int64, cap []int) int64 {
+	n := len(mice)
+	m := len(holes)
+	const INF int64 = math.MaxInt64 / 4
+	dp := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		dp[i] = INF
+	}
+	for j := 0; j < m; j++ {
+		prefix := make([]int64, n+1)
+		for i := 1; i <= n; i++ {
+			diff := abs64(mice[i-1] - holes[j])
+			prefix[i] = prefix[i-1] + diff
+		}
+		newDP := make([]int64, n+1)
+		for i := 0; i <= n; i++ {
+			newDP[i] = INF
+		}
+		for i := 0; i <= n; i++ {
+			if dp[i] == INF {
+				continue
+			}
+			for t := 0; t <= cap[j] && i+t <= n; t++ {
+				cost := dp[i] + prefix[i+t] - prefix[i]
+				if cost < newDP[i+t] {
+					newDP[i+t] = cost
+				}
+			}
+		}
+		dp = newDP
+	}
+	if dp[n] >= INF {
+		return -1
+	}
+	return dp[n]
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	mice := make([]int64, n)
+	for i := 0; i < n; i++ {
+		mice[i] = int64(rng.Intn(21) - 10)
+	}
+	holes := make([]int64, m)
+	capc := make([]int, m)
+	for i := 0; i < m; i++ {
+		holes[i] = int64(rng.Intn(21) - 10)
+		capc[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", mice[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", holes[i], capc[i]))
+	}
+	expect := expectedF(append([]int64(nil), mice...), append([]int64(nil), holes...), append([]int(nil), capc...))
+	return sb.String(), expect
+}
+
+func runCase(bin string, input string, expect int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, stderr.String())
+	}
+	resStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(resStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("bad output %q", resStr)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 797 problems A–F
- each verifier generates 100 random tests and checks a given binary

## Testing
- `go build 0-999/700-799/790-799/797/verifierA.go`
- `go build 0-999/700-799/790-799/797/verifierB.go`
- `go build 0-999/700-799/790-799/797/verifierC.go`
- `go build 0-999/700-799/790-799/797/verifierD.go`
- `go build 0-999/700-799/790-799/797/verifierE.go`
- `go build 0-999/700-799/790-799/797/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883b547db0c8324811f1a772da92214