### PR TITLE
Add Go solution for 1929B

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1929/1929B.go
+++ b/1000-1999/1900-1999/1920-1929/1929/1929B.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, k int64
+		fmt.Fscan(reader, &n, &k)
+		if k == 4*n-2 {
+			fmt.Fprintln(writer, 2*n)
+		} else {
+			fmt.Fprintln(writer, (k+1)/2)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1929B

## Testing
- `go build 1000-1999/1900-1999/1920-1929/1929/1929B.go`


------
https://chatgpt.com/codex/tasks/task_e_6883b501eee08324a4357ecd71afec58