### PR TITLE
Add verifiers for contest 802

### DIFF
--- a/0-999/800-899/800-809/802/verifierA.go
+++ b/0-999/800-899/800-809/802/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refA*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func joinInts(a []int) string {
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func genTests() []string {
+	rand.Seed(1)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(80) + 1
+		k := rand.Intn(80) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(n) + 1
+		}
+		tests = append(tests, fmt.Sprintf("%d %d\n%s\n", n, k, joinInts(arr)))
+	}
+	tests = append(tests, "1 1\n1\n")
+	tests = append(tests, "2 1\n1 2\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+		if i%10 == 0 {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierB.go
+++ b/0-999/800-899/800-809/802/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refB*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func joinInts(a []int) string {
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func genTests() []string {
+	rand.Seed(2)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50) + 1
+		k := rand.Intn(50) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(n) + 1
+		}
+		tests = append(tests, fmt.Sprintf("%d %d\n%s\n", n, k, joinInts(arr)))
+	}
+	tests = append(tests, "1 1\n1\n")
+	tests = append(tests, "3 1\n1 2 3\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierC.go
+++ b/0-999/800-899/800-809/802/verifierC.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refC*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func joinInts(a []int) string {
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func genTests() []string {
+	rand.Seed(3)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(20) + 1
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rand.Intn(n) + 1
+		}
+		c := make([]int, n)
+		for j := range c {
+			c[j] = rand.Intn(100)
+		}
+		input := fmt.Sprintf("%d %d\n%s\n%s\n", n, k, joinInts(a), joinInts(c))
+		tests = append(tests, input)
+	}
+	tests = append(tests, "1 1\n1\n0\n")
+	tests = append(tests, "2 1\n1 2\n5 5\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierD.go
+++ b/0-999/800-899/800-809/802/verifierD.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refD*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []string {
+	rand.Seed(4)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		vals := make([]int, 250)
+		for j := range vals {
+			vals[j] = rand.Intn(5)
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		for j, v := range vals {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	vals := make([]int, 250)
+	tests = append(tests, "1\n"+strings.Repeat("0 ", 249)+"0\n")
+	for j := range vals {
+		vals[j] = 1
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	for j, v := range vals {
+		if j > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	tests = append(tests, sb.String())
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s got: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierE.go
+++ b/0-999/800-899/800-809/802/verifierE.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refE*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []string {
+	rand.Seed(5)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		vals := make([]int, 250)
+		for j := range vals {
+			vals[j] = rand.Intn(5)
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		for j, v := range vals {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	tests = append(tests, "1\n"+strings.Repeat("0 ", 249)+"0\n")
+	tests = append(tests, "1\n"+strings.Repeat("1 ", 249)+"1\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s got: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierF.go
+++ b/0-999/800-899/800-809/802/verifierF.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refF*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []string {
+	rand.Seed(6)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		vals := make([]int, 250)
+		for j := range vals {
+			vals[j] = rand.Intn(5)
+		}
+		var sb strings.Builder
+		sb.WriteString("1\n")
+		for j, v := range vals {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	tests = append(tests, "1\n"+strings.Repeat("2 ", 249)+"2\n")
+	tests = append(tests, "1\n"+strings.Repeat("3 ", 249)+"3\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s got: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierG.go
+++ b/0-999/800-899/800-809/802/verifierG.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refG*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []string {
+	rand.Seed(7)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteRune(letters[rand.Intn(len(letters))])
+		}
+		tests = append(tests, sb.String()+"\n")
+	}
+	tests = append(tests, "heidi\n")
+	tests = append(tests, "abc\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s got: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierH.go
+++ b/0-999/800-899/800-809/802/verifierH.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refH*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []string {
+	rand.Seed(8)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50) + 1
+		tests = append(tests, fmt.Sprintf("%d\n", n))
+	}
+	tests = append(tests, "1\n")
+	tests = append(tests, "2\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s got: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierI.go
+++ b/0-999/800-899/800-809/802/verifierI.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refI*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802I.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTests() []string {
+	rand.Seed(9)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		t := rand.Intn(3) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", t))
+		for j := 0; j < t; j++ {
+			n := rand.Intn(20) + 1
+			for k := 0; k < n; k++ {
+				sb.WriteRune(letters[rand.Intn(len(letters))])
+			}
+			sb.WriteByte('\n')
+		}
+		tests = append(tests, sb.String())
+	}
+	tests = append(tests, "1\nabc\n")
+	tests = append(tests, "2\na\nb\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s got: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierJ.go
+++ b/0-999/800-899/800-809/802/verifierJ.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refJ*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802J.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randTree(n int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i < n; i++ {
+		p := rand.Intn(i)
+		w := rand.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", p, i, w))
+	}
+	return sb.String()
+}
+
+func genTests() []string {
+	rand.Seed(10)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		tests = append(tests, randTree(n))
+	}
+	tests = append(tests, randTree(1))
+	tests = append(tests, randTree(2))
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierJ.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s got: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierK.go
+++ b/0-999/800-899/800-809/802/verifierK.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refK*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802K.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randTree(n int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, rand.Intn(n)+1))
+	for i := 1; i < n; i++ {
+		p := rand.Intn(i)
+		w := rand.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", p, i, w))
+	}
+	return sb.String()
+}
+
+func genTests() []string {
+	rand.Seed(11)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		tests = append(tests, randTree(n))
+	}
+	tests = append(tests, randTree(1))
+	tests = append(tests, randTree(2))
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierK.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s got: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierL.go
+++ b/0-999/800-899/800-809/802/verifierL.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refL*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802L.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randTree(n int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i < n; i++ {
+		p := rand.Intn(i)
+		w := rand.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", p, i, w))
+	}
+	return sb.String()
+}
+
+func genTests() []string {
+	rand.Seed(12)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		tests = append(tests, randTree(n))
+	}
+	tests = append(tests, randTree(1))
+	tests = append(tests, randTree(2))
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierL.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s got: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierM.go
+++ b/0-999/800-899/800-809/802/verifierM.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refM*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802M.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func joinInts(a []int) string {
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func genTests() []string {
+	rand.Seed(13)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(n) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(100)
+		}
+		input := fmt.Sprintf("%d %d\n%s\n", n, k, joinInts(arr))
+		tests = append(tests, input)
+	}
+	tests = append(tests, "1 1\n5\n")
+	tests = append(tests, "2 1\n1 2\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierM.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s got: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierN.go
+++ b/0-999/800-899/800-809/802/verifierN.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refN*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802N.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func joinInts(a []int64) string {
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func genTests() []string {
+	rand.Seed(14)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(n) + 1
+		a := make([]int64, n)
+		b := make([]int64, n)
+		for j := range a {
+			a[j] = int64(rand.Intn(10))
+			b[j] = int64(rand.Intn(10))
+		}
+		input := fmt.Sprintf("%d %d\n%s\n%s\n", n, k, joinInts(a), joinInts(b))
+		tests = append(tests, input)
+	}
+	tests = append(tests, "1 1\n0\n0\n")
+	tests = append(tests, "2 1\n1 2\n2 1\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierN.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s got: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/800-809/802/verifierO.go
+++ b/0-999/800-899/800-809/802/verifierO.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func compileRef() (string, error) {
+	exe, err := os.CreateTemp("", "refO*")
+	if err != nil {
+		return "", err
+	}
+	exe.Close()
+	os.Remove(exe.Name())
+	cmd := exec.Command("go", "build", "-o", exe.Name(), "802O.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, string(out))
+	}
+	return exe.Name(), nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func joinInts(a []int) string {
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func genTests() []string {
+	rand.Seed(15)
+	tests := make([]string, 0, 102)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(n) + 1
+		a := make([]int, n)
+		b := make([]int, n)
+		for j := range a {
+			a[j] = rand.Intn(10)
+			b[j] = rand.Intn(10)
+		}
+		input := fmt.Sprintf("%d %d\n%s\n%s\n", n, k, joinInts(a), joinInts(b))
+		tests = append(tests, input)
+	}
+	tests = append(tests, "1 1\n0\n0\n")
+	tests = append(tests, "2 1\n1 2\n2 1\n")
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierO.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runProg(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, in)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s got: %s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for contest 802 problems A–O
- each verifier generates 100 random tests and compares a candidate binary with the official solution

## Testing
- `go build verifierA.go`
- `for f in verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go verifierH.go verifierI.go verifierJ.go verifierK.go verifierL.go verifierM.go verifierN.go verifierO.go; do go build $f; done`

------
https://chatgpt.com/codex/tasks/task_e_6883b80426788324a6baffbd4844879f