### PR TITLE
Add Go verifiers for contest 804

### DIFF
--- a/0-999/800-899/800-809/804/verifierA.go
+++ b/0-999/800-899/800-809/804/verifierA.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveA(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(in, &n)
+	return fmt.Sprintf("%d", (n-1)/2)
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(100000) + 1
+		tests[i] = fmt.Sprintf("%d\n", n)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		expected := solveA(t)
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed. input: %sexpected %s got %s\n", i+1, t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/800-809/804/verifierB.go
+++ b/0-999/800-899/800-809/804/verifierB.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod int = 1000000007
+
+func solveB(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var s string
+	fmt.Fscan(in, &s)
+	cur := 0
+	ans := 0
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == 'b' {
+			cur++
+			if cur >= mod {
+				cur -= mod
+			}
+		} else {
+			ans += cur
+			if ans >= mod {
+				ans -= mod
+			}
+			cur <<= 1
+			if cur >= mod {
+				cur %= mod
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(2))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		length := r.Intn(20) + 1
+		var sb strings.Builder
+		for j := 0; j < length; j++ {
+			if r.Intn(2) == 0 {
+				sb.WriteByte('a')
+			} else {
+				sb.WriteByte('b')
+			}
+		}
+		tests[i] = sb.String() + "\n"
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		expected := solveB(t)
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed. input: %sexpected %s got %s\n", i+1, t, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/800-809/804/verifierC.go
+++ b/0-999/800-899/800-809/804/verifierC.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveC(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n, m int
+	fmt.Fscan(in, &n, &m)
+	s := make([]int, n+1)
+	a := make([][]int, n+1)
+	cnt := 0
+	root := 0
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(in, &s[i])
+		if s[i] > cnt {
+			cnt = s[i]
+			root = i
+		}
+		if s[i] > 0 {
+			a[i] = make([]int, s[i])
+			for j := 0; j < s[i]; j++ {
+				fmt.Fscan(in, &a[i][j])
+			}
+		}
+	}
+	g := make([][]int, n+1)
+	for i := 1; i < n; i++ {
+		var u, v int
+		fmt.Fscan(in, &u, &v)
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	used := make([]int, m+2)
+	col := make([]int, m+2)
+	parent := make([]int, n+1)
+	stack := []int{root}
+	for len(stack) > 0 {
+		x := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, y := range a[x] {
+			if col[y] != 0 {
+				used[col[y]] = x
+			}
+		}
+		j := 1
+		for _, y := range a[x] {
+			if col[y] != 0 {
+				continue
+			}
+			for used[j] == x {
+				j++
+			}
+			col[y] = j
+			j++
+		}
+		for _, y := range g[x] {
+			if y != parent[x] {
+				parent[y] = x
+				stack = append(stack, y)
+			}
+		}
+	}
+	if cnt == 0 {
+		cnt = 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", cnt))
+	for i := 1; i <= m; i++ {
+		if col[i] == 0 {
+			col[i] = 1
+		}
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", col[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	r := rand.New(rand.NewSource(rand.Int63()))
+	n := r.Intn(3) + 1
+	m := n
+	lines := []string{fmt.Sprintf("%d %d", n, m)}
+	for i := 1; i <= n; i++ {
+		lines = append(lines, fmt.Sprintf("1 %d", i))
+	}
+	for i := 1; i < n; i++ {
+		lines = append(lines, fmt.Sprintf("%d %d", i, i+1))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func generateTests() []string {
+	tests := make([]string, 100)
+	rand.Seed(3)
+	for i := 0; i < 100; i++ {
+		tests[i] = genTest()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		expected := strings.TrimSpace(solveC(t))
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Printf("test %d failed. expected %s got %s\ninput:\n%s", i+1, expected, got, t)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/800-809/804/verifierD.go
+++ b/0-999/800-899/800-809/804/verifierD.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const INF = 1000000000
+
+var (
+	adj  [][]int
+	num  []int
+	cool []bool
+	tot  []int
+	sr   [][]int
+	ssr  [][]int64
+	down []int
+	ds   []int
+	mem  map[int64]float64
+)
+
+func dfs(v, c int) (int, int) {
+	num[v] = c
+	cnt, sum := 1, len(adj[v])
+	for _, w := range adj[v] {
+		if num[w] != -1 {
+			continue
+		}
+		a, b := dfs(w, c)
+		cnt += a
+		sum += b
+	}
+	return cnt, sum
+}
+
+func dfs2(v, pr int) {
+	down[v] = 0
+	for _, w := range adj[v] {
+		if w == pr {
+			continue
+		}
+		dfs2(w, v)
+		if down[w]+1 > down[v] {
+			down[v] = down[w] + 1
+		}
+	}
+}
+
+func dfs3(v, pr, sof, h int, cur *[]int) {
+	ds[v] = down[v]
+	if sof+h > ds[v] {
+		ds[v] = sof + h
+	}
+	if h > ds[v] {
+		ds[v] = h
+	}
+	*cur = append(*cur, ds[v])
+	mx, mx2 := -INF, -INF
+	for _, w := range adj[v] {
+		if w == pr {
+			continue
+		}
+		if down[w] > mx {
+			mx2 = mx
+			mx = down[w]
+		} else if down[w] > mx2 {
+			mx2 = down[w]
+		}
+	}
+	for _, w := range adj[v] {
+		if w == pr {
+			continue
+		}
+		nx := sof
+		if down[w] != mx {
+			if mx-h+1 > nx {
+				nx = mx - h + 1
+			}
+		} else {
+			if mx2-h+1 > nx {
+				nx = mx2 - h + 1
+			}
+		}
+		dfs3(w, v, nx, h+1, cur)
+	}
+}
+
+func prepare(s, c int) {
+	dfs2(s, -1)
+	cur := make([]int, 0, 16)
+	dfs3(s, -1, -INF, 0, &cur)
+	maxd := 0
+	for _, d := range cur {
+		if d > maxd {
+			maxd = d
+		}
+	}
+	tot[c] = len(cur)
+	sr[c] = make([]int, maxd+1)
+	ssr[c] = make([]int64, maxd+1)
+	for _, d := range cur {
+		sr[c][d]++
+	}
+	for i := maxd - 1; i >= 0; i-- {
+		sr[c][i] += sr[c][i+1]
+	}
+	for i := maxd; i >= 0; i-- {
+		ssr[c][i] = int64(sr[c][i])
+		if i < maxd {
+			ssr[c][i] += ssr[c][i+1]
+		}
+	}
+}
+
+func solveComp(a, b int) float64 {
+	if a > b {
+		a, b = b, a
+	}
+	key := int64(a)*1234567 + int64(a^b)
+	if v, ok := mem[key]; ok {
+		return v
+	}
+	if len(sr[a]) > len(sr[b]) {
+		a, b = b, a
+	}
+	da := len(sr[a]) - 1
+	db := len(sr[b]) - 1
+	r := da
+	if db > r {
+		r = db
+	}
+	var sum float64
+	for i := 0; i < len(sr[a]); i++ {
+		need := r - i
+		if need < 0 {
+			need = 0
+		}
+		cc := sr[a][i]
+		if i+1 < len(sr[a]) {
+			cc -= sr[a][i+1]
+		}
+		if cc == 0 {
+			continue
+		}
+		if need >= len(sr[b]) {
+			sum += float64(tot[b]) * float64(cc) * float64(r)
+		} else {
+			cnt := sr[b][need]
+			lf := tot[b] - cnt
+			sum += float64(lf) * float64(cc) * float64(r)
+			d0 := need + i + 1
+			sum += float64(d0) * float64(cc) * float64(cnt)
+			if need+1 < len(sr[b]) {
+				sum += float64(cc) * float64(ssr[b][need+1])
+			}
+		}
+	}
+	res := sum / float64(tot[a]*tot[b])
+	mem[key] = res
+	return res
+}
+
+func solveD(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n, m, k int
+	fmt.Fscan(in, &n, &m, &k)
+	adj = make([][]int, n)
+	for i := 0; i < m; i++ {
+		var a, b int
+		fmt.Fscan(in, &a, &b)
+		a--
+		b--
+		adj[a] = append(adj[a], b)
+		adj[b] = append(adj[b], a)
+	}
+	num = make([]int, n)
+	for i := range num {
+		num[i] = -1
+	}
+	cool = make([]bool, n)
+	tot = make([]int, n)
+	sr = make([][]int, n)
+	ssr = make([][]int64, n)
+	down = make([]int, n)
+	ds = make([]int, n)
+	mem = make(map[int64]float64)
+	cid := 0
+	for i := 0; i < n; i++ {
+		if num[i] != -1 {
+			continue
+		}
+		cnt, sum := dfs(i, cid)
+		if sum == cnt*2-2 {
+			cool[cid] = true
+			prepare(i, cid)
+		}
+		cid++
+	}
+	var sb strings.Builder
+	for i := 0; i < k; i++ {
+		var a, b int
+		fmt.Fscan(in, &a, &b)
+		a--
+		b--
+		va := num[a]
+		vb := num[b]
+		if va == vb || !cool[va] || !cool[vb] {
+			sb.WriteString("-1\n")
+		} else {
+			ans := solveComp(va, vb)
+			sb.WriteString(fmt.Sprintf("%.9f\n", ans))
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type edge struct{ u, v int }
+
+func genTest() string {
+	r := rand.New(rand.NewSource(rand.Int63()))
+	n := r.Intn(4) + 2
+	m := n - 1
+	k := r.Intn(n) + 1
+	lines := []string{fmt.Sprintf("%d %d %d", n, m, k)}
+	for i := 2; i <= n; i++ {
+		p := r.Intn(i-1) + 1
+		lines = append(lines, fmt.Sprintf("%d %d", i, p))
+	}
+	for i := 0; i < k; i++ {
+		a := r.Intn(n) + 1
+		b := r.Intn(n) + 1
+		lines = append(lines, fmt.Sprintf("%d %d", a, b))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func generateTests() []string {
+	tests := make([]string, 100)
+	rand.Seed(4)
+	for i := 0; i < 100; i++ {
+		tests[i] = genTest()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		expected := solveD(t)
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Printf("test %d failed. expected %s got %s\ninput:\n%s", i+1, expected, got, t)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/800-809/804/verifierE.go
+++ b/0-999/800-899/800-809/804/verifierE.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveE(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(in, &n)
+	if n%4 == 2 || n%4 == 3 {
+		return "NO"
+	}
+	var sb strings.Builder
+	sb.WriteString("YES")
+	if n == 1 {
+		return sb.String()
+	}
+	sb.WriteByte('\n')
+	ans4 := [][2]int{{2, 4}, {1, 3}, {2, 3}, {1, 4}, {1, 2}, {3, 4}}
+	ans5 := [][2]int{{3, 5}, {1, 3}, {4, 5}, {2, 3}, {1, 2}, {1, 5}, {2, 5}, {3, 4}, {2, 4}, {1, 4}}
+	t44 := [][2]int{{4, 5}, {1, 6}, {3, 6}, {1, 7}, {1, 5}, {3, 8}, {3, 5}, {1, 8}, {2, 6}, {4, 7}, {2, 7}, {2, 5}, {3, 7}, {4, 6}, {4, 8}, {2, 8}}
+	t45 := [][2]int{{3, 7}, {1, 6}, {2, 9}, {1, 7}, {1, 5}, {3, 6}, {2, 7}, {4, 9}, {3, 9}, {3, 8}, {3, 5}, {4, 5}, {4, 6}, {2, 6}, {4, 7}, {4, 8}, {1, 8}, {1, 9}, {2, 8}, {2, 5}}
+	type seg struct{ l, r int }
+	var v []seg
+	for i := 1; i <= n; i += 4 {
+		if i+3 == n-1 {
+			v = append(v, seg{i, i + 4})
+			break
+		}
+		v = append(v, seg{i, i + 3})
+	}
+	for i := 0; i < len(v); i++ {
+		s := v[i]
+		delta := s.l - 1
+		size := s.r - s.l + 1
+		if size == 4 {
+			for _, p := range ans4 {
+				sb.WriteString(fmt.Sprintf("%d %d\n", p[0]+delta, p[1]+delta))
+			}
+		} else {
+			for _, p := range ans5 {
+				sb.WriteString(fmt.Sprintf("%d %d\n", p[0]+delta, p[1]+delta))
+			}
+		}
+		for j := i + 1; j < len(v); j++ {
+			t := v[j]
+			dj := t.l - 5
+			size2 := t.r - t.l + 1
+			if size2 == 4 {
+				for _, p := range t44 {
+					sb.WriteString(fmt.Sprintf("%d %d\n", p[0]+delta, p[1]+dj))
+				}
+			} else {
+				for _, p := range t45 {
+					sb.WriteString(fmt.Sprintf("%d %d\n", p[0]+delta, p[1]+dj))
+				}
+			}
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	r := rand.New(rand.NewSource(rand.Int63()))
+	n := r.Intn(10) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func generateTests() []string {
+	rand.Seed(5)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		tests[i] = genTest()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		expected := solveE(t)
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Printf("test %d failed. expected %s got %s\ninput:%s", i+1, expected, got, t)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/800-809/804/verifierF.go
+++ b/0-999/800-899/800-809/804/verifierF.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const MOD int = 1000000007
+
+func modPow(a, e int) int {
+	res := 1
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func modInv(a int) int { return modPow(a, MOD-2) }
+
+func solveF(input string) string {
+	in := bufio.NewReader(strings.NewReader(input))
+	var n, a, b int
+	fmt.Fscan(in, &n, &a, &b)
+	g := make([]string, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &g[i])
+	}
+	L := make([]int, n)
+	R := make([]int, n)
+	maxN := n
+	for i := 0; i < n; i++ {
+		var s int
+		var str string
+		fmt.Fscan(in, &s, &str)
+		R[i] = s
+		cnt := 0
+		for j := 0; j < len(str); j++ {
+			if str[j] == '0' {
+				cnt++
+			}
+		}
+		L[i] = cnt
+		if s > maxN {
+			maxN = s
+		}
+	}
+	fact := make([]int, maxN+1)
+	invFact := make([]int, maxN+1)
+	fact[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fact[i] = fact[i-1] * i % MOD
+	}
+	invFact[maxN] = modInv(fact[maxN])
+	for i := maxN - 1; i >= 0; i-- {
+		invFact[i] = invFact[i+1] * (i + 1) % MOD
+	}
+	comb := func(n, k int) int {
+		if n < 0 || k < 0 || k > n {
+			return 0
+		}
+		return fact[n] * invFact[k] % MOD * invFact[n-k] % MOD
+	}
+	cntTop := 0
+	for i := 0; i < n; i++ {
+		rank := 1
+		for j := 0; j < n; j++ {
+			if i == j {
+				continue
+			}
+			if L[j] > R[i] {
+				rank++
+			}
+		}
+		if rank <= a {
+			cntTop++
+		}
+	}
+	ans := comb(cntTop, b)
+	return fmt.Sprintf("%d", ans)
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	r := rand.New(rand.NewSource(rand.Int63()))
+	n := r.Intn(4) + 2
+	a := r.Intn(n) + 1
+	b := r.Intn(a) + 1
+	mat := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		mat[i] = make([]byte, n)
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if r.Intn(2) == 0 {
+				mat[i][j] = '1'
+				mat[j][i] = '0'
+			} else {
+				mat[i][j] = '0'
+				mat[j][i] = '1'
+			}
+		}
+		mat[i][i] = '0'
+	}
+	lines := []string{fmt.Sprintf("%d %d %d", n, a, b)}
+	for i := 0; i < n; i++ {
+		lines = append(lines, string(mat[i]))
+	}
+	for i := 0; i < n; i++ {
+		s := r.Intn(3) + 1
+		var sb strings.Builder
+		for j := 0; j < s; j++ {
+			if r.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		lines = append(lines, fmt.Sprintf("%d %s", s, sb.String()))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func generateTests() []string {
+	rand.Seed(6)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		tests[i] = genTest()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		expected := solveF(t)
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Printf("test %d failed. expected %s got %s\ninput:\n%s", i+1, expected, got, t)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for Codeforces contest 804 problems A–F
- each verifier generates 100 random tests and checks a given binary

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6883b91c4a6883248c5350f7bada7b5c