### PR TITLE
Add verifiers for Codeforces contest 805

### DIFF
--- a/0-999/800-899/800-809/805/verifierA.go
+++ b/0-999/800-899/800-809/805/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	l, r int
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "805A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []Test {
+	rand.Seed(0)
+	tests := make([]Test, 0, 150)
+	for i := 2; i <= 50; i++ {
+		tests = append(tests, Test{i, i})
+	}
+	for i := 0; i < 100; i++ {
+		l := rand.Intn(50) + 2
+		r := l + rand.Intn(50)
+		tests = append(tests, Test{l, r})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d\n", tc.l, tc.r)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:\n%sactual:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/800-809/805/verifierB.go
+++ b/0-999/800-899/800-809/805/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n int
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []Test {
+	rand.Seed(1)
+	tests := make([]Test, 0, 150)
+	for i := 1; i <= 50; i++ {
+		tests = append(tests, Test{i})
+	}
+	for i := 0; i < 100; i++ {
+		tests = append(tests, Test{rand.Intn(100) + 1})
+	}
+	return tests
+}
+
+func check(n int, out string) error {
+	fields := strings.Fields(out)
+	if len(fields) != 1 {
+		return fmt.Errorf("expected single token output")
+	}
+	s := fields[0]
+	if len(s) != n {
+		return fmt.Errorf("expected length %d got %d", n, len(s))
+	}
+	for i := 0; i < n; i++ {
+		c := s[i]
+		if c != 'a' && c != 'b' && c != 'c' {
+			return fmt.Errorf("invalid character %q", c)
+		}
+		if c == 'c' {
+			return fmt.Errorf("string contains 'c'")
+		}
+		if i+2 < n && s[i] == s[i+2] {
+			return fmt.Errorf("palindrome of length 3 at position %d", i)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d\n", tc.n)
+		out, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(tc.n, out); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:%soutput:%s\n", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` to contest 805
- verifiers run candidate binaries on >100 tests
- A verifier builds `805A.go` as reference
- B verifier checks generated strings for validity

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go run verifierA.go ./805A_bin`
- `go run verifierB.go ./805B_bin`


------
https://chatgpt.com/codex/tasks/task_e_6883b9a861a083249cde566b9b2772ca