### PR TITLE
Add random-case verifiers for contest 811

### DIFF
--- a/0-999/800-899/810-819/811/verifierA.go
+++ b/0-999/800-899/810-819/811/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(a, b int64) string {
+	for turn := int64(1); ; turn++ {
+		if turn%2 == 1 {
+			if a < turn {
+				return "Vladik"
+			}
+			a -= turn
+		} else {
+			if b < turn {
+				return "Valera"
+			}
+			b -= turn
+		}
+	}
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	a := rng.Int63n(1_000_000_000) + 1
+	b := rng.Int63n(1_000_000_000) + 1
+	input := fmt.Sprintf("%d %d\n", a, b)
+	expected := solveCase(a, b)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/810-819/811/verifierB.go
+++ b/0-999/800-899/810-819/811/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, m int, p []int, queries [][3]int) []string {
+	res := make([]string, m)
+	for i, q := range queries {
+		l := q[0] - 1
+		r := q[1] - 1
+		x := q[2] - 1
+		target := p[x]
+		cnt := 0
+		for j := l; j <= r; j++ {
+			if p[j] < target {
+				cnt++
+			}
+		}
+		if l+cnt == x {
+			res[i] = "Yes"
+		} else {
+			res[i] = "No"
+		}
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	queries := make([][3]int, m)
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		x := rng.Intn(r-l+1) + l
+		queries[i] = [3]int{l, r, x}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for _, q := range queries {
+		fmt.Fprintf(&sb, "%d %d %d\n", q[0], q[1], q[2])
+	}
+	expected := strings.Join(solveCase(n, m, perm, queries), "\n")
+	return sb.String(), expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/810-819/811/verifierC.go
+++ b/0-999/800-899/810-819/811/verifierC.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const MaxA = 5000
+
+func solveCase(a []int) int {
+	n := len(a) - 1
+	first := make([]int, MaxA+1)
+	last := make([]int, MaxA+1)
+	for i := 0; i <= MaxA; i++ {
+		first[i] = n + 1
+		last[i] = 0
+	}
+	for i := 1; i <= n; i++ {
+		v := a[i]
+		if first[v] == n+1 {
+			first[v] = i
+		}
+		last[v] = i
+	}
+	dp := make([]int, n+1)
+	visited := make([]bool, MaxA+1)
+	for l := 1; l <= n; l++ {
+		for i := 0; i <= MaxA; i++ {
+			visited[i] = false
+		}
+		xorVal := 0
+		r := l - 1
+		for j := l; j <= n; j++ {
+			v := a[j]
+			if first[v] < l {
+				break
+			}
+			if !visited[v] {
+				visited[v] = true
+				xorVal ^= v
+			}
+			if last[v] > r {
+				r = last[v]
+			}
+			if j == r {
+				if cand := dp[l-1] + xorVal; cand > dp[r] {
+					dp[r] = cand
+				}
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if dp[i] < dp[i-1] {
+			dp[i] = dp[i-1]
+		}
+	}
+	return dp[n]
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 1
+	arr := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		arr[i] = rng.Intn(20)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	expected := fmt.Sprintf("%d", solveCase(arr))
+	return sb.String(), expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/810-819/811/verifierD.go
+++ b/0-999/800-899/810-819/811/verifierD.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int }
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+var dirs = []struct {
+	dx, dy int
+	c      byte
+}{
+	{-1, 0, 'U'},
+	{1, 0, 'D'},
+	{0, -1, 'L'},
+	{0, 1, 'R'},
+}
+
+func bfs(grid []string, n, m int) ([]byte, bool, int, int) {
+	parent := make([][]point, n)
+	move := make([][]byte, n)
+	used := make([][]bool, n)
+	for i := range parent {
+		parent[i] = make([]point, m)
+		move[i] = make([]byte, m)
+		used[i] = make([]bool, m)
+	}
+	q := []point{{0, 0}}
+	used[0][0] = true
+	var fx, fy int
+	found := false
+	for len(q) > 0 && !found {
+		p := q[0]
+		q = q[1:]
+		if grid[p.x][p.y] == 'F' {
+			fx, fy = p.x, p.y
+			found = true
+			break
+		}
+		for _, d := range dirs {
+			nx, ny := p.x+d.dx, p.y+d.dy
+			if nx < 0 || nx >= n || ny < 0 || ny >= m {
+				continue
+			}
+			if grid[nx][ny] == '*' || used[nx][ny] {
+				continue
+			}
+			used[nx][ny] = true
+			parent[nx][ny] = p
+			move[nx][ny] = d.c
+			q = append(q, point{nx, ny})
+		}
+	}
+	if !found {
+		return nil, false, 0, 0
+	}
+	path := []byte{}
+	x, y := fx, fy
+	for x != 0 || y != 0 {
+		path = append(path, move[x][y])
+		p := parent[x][y]
+		x, y = p.x, p.y
+	}
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+	return path, true, fx, fy
+}
+
+func solveCase(n, m int, swapLR, swapUD int, grid []string) string {
+	path, ok, _, _ := bfs(grid, n, m)
+	if !ok {
+		return ""
+	}
+	for i, c := range path {
+		if c == 'L' || c == 'R' {
+			if swapLR == 1 {
+				if c == 'L' {
+					path[i] = 'R'
+				} else {
+					path[i] = 'L'
+				}
+			}
+		} else {
+			if swapUD == 1 {
+				if c == 'U' {
+					path[i] = 'D'
+				} else {
+					path[i] = 'U'
+				}
+			}
+		}
+	}
+	var sb strings.Builder
+	for i, c := range path {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteByte(c)
+	}
+	return sb.String()
+}
+
+func genGrid(rng *rand.Rand, n, m int) ([]string, int, int) {
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]byte, m)
+		for j := 0; j < m; j++ {
+			grid[i][j] = '.'
+		}
+	}
+	fx := rng.Intn(n)
+	fy := rng.Intn(m)
+	grid[fx][fy] = 'F'
+	path := []point{{0, 0}}
+	visited := map[point]bool{{0, 0}: true}
+	for len(path) == 1 || path[len(path)-1] != (point{fx, fy}) {
+		cur := path[len(path)-1]
+		if cur == (point{fx, fy}) {
+			break
+		}
+		var opts []point
+		for _, d := range dirs {
+			nx, ny := cur.x+d.dx, cur.y+d.dy
+			if nx < 0 || nx >= n || ny < 0 || ny >= m {
+				continue
+			}
+			p := point{nx, ny}
+			if !visited[p] {
+				opts = append(opts, p)
+			}
+		}
+		if len(opts) == 0 {
+			break
+		}
+		next := opts[rng.Intn(len(opts))]
+		visited[next] = true
+		path = append(path, next)
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if (i == 0 && j == 0) || (i == fx && j == fy) {
+				continue
+			}
+			if visited[point{i, j}] {
+				continue
+			}
+			if rng.Intn(5) == 0 {
+				grid[i][j] = '*'
+			} else {
+				grid[i][j] = '.'
+			}
+		}
+	}
+	lines := make([]string, n)
+	for i := 0; i < n; i++ {
+		lines[i] = string(grid[i])
+	}
+	return lines, fx, fy
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	m := rng.Intn(5) + 2
+	grid, _, _ := genGrid(rng, n, m)
+	swapLR := rng.Intn(2)
+	swapUD := rng.Intn(2)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", n, m, swapLR, swapUD)
+	for _, row := range grid {
+		sb.WriteString(row)
+		sb.WriteByte('\n')
+	}
+	expected := solveCase(n, m, swapLR, swapUD, grid)
+	return sb.String(), expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/810-819/811/verifierE.go
+++ b/0-999/800-899/810-819/811/verifierE.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type point struct{ x, y int }
+
+func countComponents(grid [][]int, n, m int, l, r int) int {
+	w := r - l + 1
+	vis := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		vis[i] = make([]bool, w)
+	}
+	comp := 0
+	dirs := []struct{ dx, dy int }{{-1, 0}, {1, 0}, {0, -1}, {0, 1}}
+	for i := 0; i < n; i++ {
+		for j := 0; j < w; j++ {
+			if vis[i][j] {
+				continue
+			}
+			comp++
+			val := grid[i][j+l]
+			q := []point{{i, j}}
+			vis[i][j] = true
+			for len(q) > 0 {
+				p := q[0]
+				q = q[1:]
+				for _, d := range dirs {
+					nx, ny := p.x+d.dx, p.y+d.dy
+					if nx < 0 || nx >= n || ny < 0 || ny >= w {
+						continue
+					}
+					if vis[nx][ny] {
+						continue
+					}
+					if grid[nx][ny+l] != val {
+						continue
+					}
+					vis[nx][ny] = true
+					q = append(q, point{nx, ny})
+				}
+			}
+		}
+	}
+	return comp
+}
+
+func solveCase(n, m, q int, grid [][]int, queries [][2]int) []int {
+	ans := make([]int, q)
+	for i, qu := range queries {
+		ans[i] = countComponents(grid, n, m, qu[0]-1, qu[1]-1)
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(6) + 1
+	q := rng.Intn(5) + 1
+	grid := make([][]int, n)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			grid[i][j] = rng.Intn(3) + 1
+		}
+	}
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(m) + 1
+		r := rng.Intn(m-l+1) + l
+		queries[i] = [2]int{l, r}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, q)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", grid[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	for _, qu := range queries {
+		fmt.Fprintf(&sb, "%d %d\n", qu[0], qu[1])
+	}
+	answers := solveCase(n, m, q, grid, queries)
+	var exp strings.Builder
+	for i, a := range answers {
+		if i > 0 {
+			exp.WriteByte('\n')
+		}
+		fmt.Fprintf(&exp, "%d", a)
+	}
+	return sb.String(), exp.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifier programs for contest 811 problems A–E
- each verifier generates 100 random tests and checks any binary
- follow repo style with helper functions and case generators

## Testing
- `go run verifierA.go ./811A.go`
- `go run verifierB.go ./811B.go`
- `go run verifierC.go ./811C.go`
- `go run verifierD.go ./811D.go`
- `go run verifierE.go ./811E.go`


------
https://chatgpt.com/codex/tasks/task_e_6883bcf0e33c832490c3cc3cfd5318d2