### PR TITLE
Add contest 809 Go solution verifiers

### DIFF
--- a/0-999/800-899/800-809/809/verifierA.go
+++ b/0-999/800-899/800-809/809/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func expectedA(xs []int64) int64 {
+	n := len(xs)
+	sort.Slice(xs, func(i, j int) bool { return xs[i] < xs[j] })
+	pow2 := make([]int64, n+1)
+	pow2[0] = 1
+	for i := 1; i <= n; i++ {
+		pow2[i] = (pow2[i-1] * 2) % mod
+	}
+	var ans int64
+	for j := 1; j < n; j++ {
+		ans = (ans + xs[j]*(pow2[j]-1)) % mod
+	}
+	for i := 0; i < n-1; i++ {
+		ans = (ans - xs[i]*(pow2[n-1-i]-1)) % mod
+	}
+	if ans < 0 {
+		ans += mod
+	}
+	return ans
+}
+
+func generateCaseA(rng *rand.Rand) []int64 {
+	n := rng.Intn(8) + 2 // 2..9
+	xs := make([]int64, n)
+	for i := range xs {
+		xs[i] = int64(rng.Intn(1000) + 1)
+	}
+	return xs
+}
+
+func runCase(bin string, xs []int64) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", len(xs)))
+	for i, v := range xs {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprint(v))
+	}
+	input.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(bytes.NewReader(out.Bytes()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	expect := expectedA(append([]int64(nil), xs...))
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		xs := generateCaseA(rng)
+		if err := runCase(bin, xs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%v\n", i+1, err, xs)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/800-809/809/verifierB.go
+++ b/0-999/800-899/800-809/809/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testB struct {
+	n      int
+	dishes []int
+}
+
+func generateCaseB(rng *rand.Rand) testB {
+	n := rng.Intn(50) + 2
+	k := rng.Intn(n-1) + 2 // at least 2
+	perm := rng.Perm(n)
+	dishes := make([]int, k)
+	for i := 0; i < k; i++ {
+		dishes[i] = perm[i] + 1
+	}
+	return testB{n, dishes}
+}
+
+func runCase(bin string, tc testB) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d %d\n", tc.n, len(tc.dishes)))
+	for i, v := range tc.dishes {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprint(v))
+	}
+	input.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var t int
+	var x, y int
+	if _, err := fmt.Fscan(bytes.NewReader(out.Bytes()), &t, &x, &y); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if t != 2 || x < 1 || x > tc.n || y < 1 || y > tc.n || x == y {
+		return fmt.Errorf("bad output values")
+	}
+	okx, oky := false, false
+	for _, d := range tc.dishes {
+		if d == x {
+			okx = true
+		}
+		if d == y {
+			oky = true
+		}
+	}
+	if !okx || !oky {
+		return fmt.Errorf("indices not from ordered set")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseB(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: n=%d k=%d dishes=%v\n", i+1, err, tc.n, len(tc.dishes), tc.dishes)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/800-809/809/verifierC.go
+++ b/0-999/800-899/800-809/809/verifierC.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+var A, B, limitK int64
+var memo [31][2][2][2]struct {
+	cnt int64
+	sum int64
+}
+var used [31][2][2][2]bool
+
+func dfs(pos int, la, lb, lk bool) (int64, int64) {
+	if pos < 0 {
+		return 1, 0
+	}
+	iLa, iLb, iLk := 0, 0, 0
+	if la {
+		iLa = 1
+	}
+	if lb {
+		iLb = 1
+	}
+	if lk {
+		iLk = 1
+	}
+	if used[pos][iLa][iLb][iLk] {
+		res := memo[pos][iLa][iLb][iLk]
+		return res.cnt, res.sum
+	}
+	bitA := (A >> pos) & 1
+	bitB := (B >> pos) & 1
+	bitK := (limitK >> pos) & 1
+	var resCnt, resSum int64
+	for da := int64(0); da <= 1; da++ {
+		if la && da > bitA {
+			continue
+		}
+		nLa := la && da == bitA
+		for db := int64(0); db <= 1; db++ {
+			if lb && db > bitB {
+				continue
+			}
+			nLb := lb && db == bitB
+			xr := da ^ db
+			if lk && xr > bitK {
+				continue
+			}
+			nLk := lk && xr == bitK
+			c, s := dfs(pos-1, nLa, nLb, nLk)
+			resCnt += c
+			resSum = (resSum + s + (c%mod)*((xr<<pos)%mod)) % mod
+		}
+	}
+	used[pos][iLa][iLb][iLk] = true
+	memo[pos][iLa][iLb][iLk] = struct{ cnt, sum int64 }{resCnt, resSum}
+	return resCnt, resSum
+}
+
+func calc(a, b, k int64) int64 {
+	if a < 0 || b < 0 || k <= 0 {
+		return 0
+	}
+	A, B = a, b
+	limitK = k - 1
+	for i := range used {
+		for j := range used[i] {
+			for l := range used[i][j] {
+				used[i][j][l][0] = false
+				used[i][j][l][1] = false
+			}
+		}
+	}
+	cnt, sum := dfs(30, true, true, true)
+	return (sum + cnt) % mod
+}
+
+func query(x1, y1, x2, y2, k int64) int64 {
+	res := calc(x2-1, y2-1, k)
+	res -= calc(x1-2, y2-1, k)
+	res -= calc(x2-1, y1-2, k)
+	res += calc(x1-2, y1-2, k)
+	res %= mod
+	if res < 0 {
+		res += mod
+	}
+	return res
+}
+
+func generateCaseC(rng *rand.Rand) string {
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		x1 := rng.Intn(20) + 1
+		x2 := rng.Intn(20-x1+1) + x1
+		y1 := rng.Intn(20) + 1
+		y2 := rng.Intn(20-y1+1) + y1
+		k := rng.Intn(30) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d %d %d\n", x1, y1, x2, y2, k))
+	}
+	return sb.String()
+}
+
+func runCase(bin string, input string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	// compute expected
+	rdr := strings.NewReader(input)
+	var q int
+	fmt.Fscan(rdr, &q)
+	expOut := make([]string, q)
+	for i := 0; i < q; i++ {
+		var x1, y1, x2, y2, k int64
+		fmt.Fscan(rdr, &x1, &y1, &x2, &y2, &k)
+		expOut[i] = fmt.Sprint(query(x1, y1, x2, y2, k))
+	}
+	gotLines := strings.Fields(strings.TrimSpace(out.String()))
+	if len(gotLines) != q {
+		return fmt.Errorf("expected %d lines got %d", q, len(gotLines))
+	}
+	for i := 0; i < q; i++ {
+		if gotLines[i] != expOut[i] {
+			return fmt.Errorf("case line %d: expected %s got %s", i+1, expOut[i], gotLines[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCaseC(rng)
+		if err := runCase(bin, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/800-809/809/verifierD.go
+++ b/0-999/800-899/800-809/809/verifierD.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedD(intervals [][2]int64) int {
+	const INF int64 = 1 << 60
+	n := len(intervals)
+	dp := make([]int64, n+2)
+	for i := 1; i < len(dp); i++ {
+		dp[i] = INF
+	}
+	dp[0] = -INF
+	maxLen := 0
+	for _, it := range intervals {
+		l, r := it[0], it[1]
+		for j := maxLen; j >= 0; j-- {
+			if dp[j] == INF {
+				continue
+			}
+			x := dp[j] + 1
+			if x < l {
+				x = l
+			}
+			if x <= r && x < dp[j+1] {
+				dp[j+1] = x
+				if j+1 > maxLen {
+					maxLen = j + 1
+				}
+			}
+		}
+	}
+	return maxLen
+}
+
+func generateCaseD(rng *rand.Rand) [][2]int64 {
+	n := rng.Intn(10) + 1
+	res := make([][2]int64, n)
+	base := int64(rng.Intn(50))
+	for i := 0; i < n; i++ {
+		l := base + int64(rng.Intn(20))
+		r := l + int64(rng.Intn(10))
+		res[i] = [2]int64{l, r}
+	}
+	return res
+}
+
+func runCase(bin string, intervals [][2]int64) error {
+	var input strings.Builder
+	n := len(intervals)
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		input.WriteString(fmt.Sprintf("%d %d\n", intervals[i][0], intervals[i][1]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(bytes.NewReader(out.Bytes()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	expect := expectedD(intervals)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		intervals := generateCaseD(rng)
+		if err := runCase(bin, intervals); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%v\n", i+1, err, intervals)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/800-809/809/verifierE.go
+++ b/0-999/800-899/800-809/809/verifierE.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func phi(n int) int {
+	result := n
+	p := 2
+	for p*p <= n {
+		if n%p == 0 {
+			for n%p == 0 {
+				n /= p
+			}
+			result -= result / p
+		}
+		p++
+	}
+	if n > 1 {
+		result -= result / n
+	}
+	return result
+}
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func distance(adj [][]int, u, v int) int {
+	q := []int{u}
+	dist := make([]int, len(adj))
+	for i := range dist {
+		dist[i] = -1
+	}
+	dist[u] = 0
+	for len(q) > 0 {
+		x := q[0]
+		q = q[1:]
+		if x == v {
+			return dist[x]
+		}
+		for _, to := range adj[x] {
+			if dist[to] == -1 {
+				dist[to] = dist[x] + 1
+				q = append(q, to)
+			}
+		}
+	}
+	return 0
+}
+
+func expectedE(n int, a []int, edges [][2]int) int64 {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		x, y := e[0]-1, e[1]-1
+		adj[x] = append(adj[x], y)
+		adj[y] = append(adj[y], x)
+	}
+	sum := int64(0)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			d := distance(adj, i, j)
+			val := phi(a[i] * a[j])
+			sum += int64(val * d)
+		}
+	}
+	numerator := sum * 2 % MOD
+	denom := int64(n) * int64(n-1) % MOD
+	return numerator * modPow(denom, MOD-2) % MOD
+}
+
+func generateCaseE(rng *rand.Rand) (int, []int, [][2]int) {
+	n := rng.Intn(5) + 2
+	perm := rng.Perm(n)
+	a := make([]int, n)
+	for i, v := range perm {
+		a[i] = v + 1
+	}
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{i, p}
+	}
+	return n, a, edges
+}
+
+func runCase(bin string, n int, a []int, edges [][2]int) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(fmt.Sprint(v))
+	}
+	input.WriteByte('\n')
+	for _, e := range edges {
+		input.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(bytes.NewReader(out.Bytes()), &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	expect := expectedE(n, a, edges)
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, a, edges := generateCaseE(rng)
+		if err := runCase(bin, n, a, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 809
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883bbd8bd448324bf16f718c9f30135