### PR TITLE
Add solution verifiers for contest 818

### DIFF
--- a/0-999/800-899/810-819/818/verifierA.go
+++ b/0-999/800-899/810-819/818/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "818A.go")
+	bin := filepath.Join(os.TempDir(), "ref818A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type Test struct{ n, k int64 }
+
+func genTests() []Test {
+	rand.Seed(1)
+	tests := make([]Test, 0, 100)
+	tests = append(tests, Test{1, 1}, Test{2, 1})
+	for len(tests) < 100 {
+		n := rand.Int63n(1_000_000) + 1
+		k := rand.Int63n(1_000_000) + 1
+		tests = append(tests, Test{n, k})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.n, t.k)
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/810-819/818/verifierB.go
+++ b/0-999/800-899/810-819/818/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type Test struct {
+	n, m    int
+	leaders []int
+}
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "818B.go")
+	bin := filepath.Join(os.TempDir(), "ref818B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rand.Seed(2)
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50) + 1
+		m := rand.Intn(50) + 1
+		leaders := make([]int, m)
+		for j := range leaders {
+			leaders[j] = rand.Intn(n) + 1
+		}
+		tests[i] = Test{n, m, leaders}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.m))
+		for j, v := range t.leaders {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/810-819/818/verifierC.go
+++ b/0-999/800-899/810-819/818/verifierC.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type Sofa struct{ x1, y1, x2, y2 int }
+
+type Test struct {
+	d, n, m                int
+	sofas                  []Sofa
+	cntl, cntr, cntt, cntb int
+}
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "818C.go")
+	bin := filepath.Join(os.TempDir(), "ref818C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rand.Seed(3)
+	tests := make([]Test, 100)
+	for idx := 0; idx < 100; idx++ {
+		n := rand.Intn(4) + 2
+		m := rand.Intn(4) + 2
+		maxPairs := n * m / 2
+		d := rand.Intn(maxPairs) + 1
+		// generate positions
+		type Pair [4]int
+		var pairs []Pair
+		for x := 1; x <= n; x++ {
+			for y := 1; y <= m; y++ {
+				if x < n {
+					pairs = append(pairs, Pair{x, y, x + 1, y})
+				}
+				if y < m {
+					pairs = append(pairs, Pair{x, y, x, y + 1})
+				}
+			}
+		}
+		rand.Shuffle(len(pairs), func(i, j int) { pairs[i], pairs[j] = pairs[j], pairs[i] })
+		used := make([][]bool, n+1)
+		for i := range used {
+			used[i] = make([]bool, m+1)
+		}
+		sofas := make([]Sofa, 0, d)
+		for _, p := range pairs {
+			if len(sofas) == d {
+				break
+			}
+			x1, y1, x2, y2 := p[0], p[1], p[2], p[3]
+			if used[x1][y1] || used[x2][y2] {
+				continue
+			}
+			used[x1][y1] = true
+			used[x2][y2] = true
+			sofas = append(sofas, Sofa{x1, y1, x2, y2})
+		}
+		d = len(sofas)
+		cntl := rand.Intn(d + 1)
+		cntr := rand.Intn(d + 1)
+		cntt := rand.Intn(d + 1)
+		cntb := rand.Intn(d + 1)
+		tests[idx] = Test{d, n, m, sofas, cntl, cntr, cntt, cntb}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", t.d))
+		sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.m))
+		for _, s := range t.sofas {
+			sb.WriteString(fmt.Sprintf("%d %d %d %d\n", s.x1, s.y1, s.x2, s.y2))
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", t.cntl, t.cntr, t.cntt, t.cntb))
+		input := sb.String()
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/810-819/818/verifierD.go
+++ b/0-999/800-899/810-819/818/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type Test struct {
+	n     int
+	alice int
+	cars  []int
+}
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "818D.go")
+	bin := filepath.Join(os.TempDir(), "ref818D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rand.Seed(4)
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50) + 1
+		cars := make([]int, n)
+		for j := range cars {
+			cars[j] = rand.Intn(10) + 1
+		}
+		alice := rand.Intn(10) + 1
+		tests[i] = Test{n, alice, cars}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.alice))
+		for j, c := range t.cars {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(c))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/810-819/818/verifierE.go
+++ b/0-999/800-899/810-819/818/verifierE.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type Test struct {
+	n   int
+	k   int
+	arr []int
+}
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "818E.go")
+	bin := filepath.Join(os.TempDir(), "ref818E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rand.Seed(5)
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50) + 1
+		k := rand.Intn(50) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(50) + 1
+		}
+		tests[i] = Test{n, k, arr}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.k))
+		for j, v := range t.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/810-819/818/verifierF.go
+++ b/0-999/800-899/810-819/818/verifierF.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type Test struct {
+	q  int
+	ns []int64
+}
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "818F.go")
+	bin := filepath.Join(os.TempDir(), "ref818F.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rand.Seed(6)
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		q := rand.Intn(3) + 1
+		ns := make([]int64, q)
+		for j := range ns {
+			ns[j] = rand.Int63n(1_000_000_000) + 1
+		}
+		tests[i] = Test{q, ns}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", t.q))
+		for _, n := range t.ns {
+			sb.WriteString(fmt.Sprintf("%d\n", n))
+		}
+		input := sb.String()
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/810-819/818/verifierG.go
+++ b/0-999/800-899/810-819/818/verifierG.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type Test struct {
+	n   int
+	arr []int
+}
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "818G.go")
+	bin := filepath.Join(os.TempDir(), "ref818G.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rand.Seed(7)
+	tests := make([]Test, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 4
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(50) + 1
+		}
+		tests[i] = Test{n, arr}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", t.n))
+		for j, v := range t.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:%sexpected:%s\nactual:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- implement automated verifiers for all problems of contest 818
- each verifier builds the official Go solution and runs at least 100 randomized tests against a user supplied binary
- verifiers created for problems A through G under `0-999/800-899/810-819/818/`

## Testing
- `go run 0-999/800-899/810-819/818/verifierA.go /tmp/818A.bin`
- `go run 0-999/800-899/810-819/818/verifierB.go /tmp/818B.bin`


------
https://chatgpt.com/codex/tasks/task_e_6883c0c572808324874890a4de29a6e1