### PR TITLE
Add contest 820 Go verifiers

### DIFF
--- a/0-999/800-899/820-829/820/verifierA.go
+++ b/0-999/800-899/820-829/820/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int
+}
+
+func expectedDays(c, v0, v1, a, l int) int {
+	days := 1
+	read := v0
+	speed := v0
+	for read < c {
+		days++
+		speed += a
+		if speed > v1 {
+			speed = v1
+		}
+		read += speed - l
+	}
+	return days
+}
+
+func buildCase(c, v0, v1, a, l int) testCase {
+	input := fmt.Sprintf("%d %d %d %d %d\n", c, v0, v1, a, l)
+	return testCase{input: input, expected: expectedDays(c, v0, v1, a, l)}
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	c := rng.Intn(1000) + 1
+	v0 := rng.Intn(1000) + 1
+	l := rng.Intn(v0)
+	v1 := v0 + rng.Intn(1000-v0+1)
+	a := rng.Intn(1001)
+	return buildCase(c, v0, v1, a, l)
+}
+
+func runCase(bin string, tc testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	// deterministic edge cases
+	cases = append(cases, buildCase(1, 1, 1, 0, 0))
+	cases = append(cases, buildCase(5, 4, 4, 0, 0))
+	cases = append(cases, buildCase(12, 4, 5, 1, 3))
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/820-829/820/verifierB.go
+++ b/0-999/800-899/820-829/820/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected [3]int
+}
+
+func expectedTriple(n, a int) [3]int {
+	centerStep := 360.0 / float64(n)
+	center := centerStep
+	minDiff := math.Abs(center/2.0 - float64(a))
+	vC, vS := int64(3), int64(2)
+	ver := int64(3)
+	center += centerStep
+	for center <= 180.0 {
+		diff1 := math.Abs(center/2.0 - float64(a))
+		if diff1 < minDiff {
+			vC = ver + 1
+			vS = ver
+			minDiff = diff1
+		}
+		diff2 := math.Abs(180.0 - center/2.0 - float64(a))
+		if diff2 < minDiff {
+			vC = ver - 1
+			vS = ver
+			minDiff = diff2
+		}
+		ver++
+		center += centerStep
+	}
+	return [3]int{1, int(vC), int(vS)}
+}
+
+func buildCase(n, a int) testCase {
+	input := fmt.Sprintf("%d %d\n", n, a)
+	return testCase{input: input, expected: expectedTriple(n, a)}
+}
+
+func generateRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100000-3+1) + 3
+	a := rng.Intn(180) + 1
+	return buildCase(n, a)
+}
+
+func runCase(bin string, tc testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var v1, v2, v3 int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &v1, &v2, &v3); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if v1 != tc.expected[0] || v2 != tc.expected[1] || v3 != tc.expected[2] {
+		return fmt.Errorf("expected %v got %d %d %d", tc.expected, v1, v2, v3)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	cases = append(cases, buildCase(3, 60))
+	cases = append(cases, buildCase(4, 67))
+	cases = append(cases, buildCase(50, 90))
+
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateRandomCase(rng))
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 820 problems A and B
- each verifier runs 100+ tests, includes deterministic edge cases and random cases

## Testing
- `go run verifierA.go ./820A`
- `go run verifierB.go ./820B`


------
https://chatgpt.com/codex/tasks/task_e_6883c1de2c7c83249360f2254d554bb9