### PR TITLE
Add Go verifiers for CF Round 817

### DIFF
--- a/0-999/800-899/810-819/817/verifierA.go
+++ b/0-999/800-899/810-819/817/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func expected(x1, y1, x2, y2, x, y int) string {
+	dx := abs(x2 - x1)
+	dy := abs(y2 - y1)
+	if dx%x != 0 || dy%y != 0 {
+		return "NO"
+	}
+	kx := dx / x
+	ky := dy / y
+	if kx%2 == ky%2 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runBin(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	x1 := rng.Intn(200001) - 100000
+	y1 := rng.Intn(200001) - 100000
+	x2 := rng.Intn(200001) - 100000
+	y2 := rng.Intn(200001) - 100000
+	x := rng.Intn(100000) + 1
+	y := rng.Intn(100000) + 1
+	input := fmt.Sprintf("%d %d %d %d\n%d %d\n", x1, y1, x2, y2, x, y)
+	exp := expected(x1, y1, x2, y2, x, y)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := runBin(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s\n", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/810-819/817/verifierB.go
+++ b/0-999/800-899/810-819/817/verifierB.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func choose(n int64, k int) int64 {
+	if k == 0 {
+		return 1
+	}
+	switch k {
+	case 1:
+		return n
+	case 2:
+		return n * (n - 1) / 2
+	case 3:
+		return n * (n - 1) * (n - 2) / 6
+	}
+	return 0
+}
+
+func expected(arr []int) int64 {
+	sort.Ints(arr)
+	v1 := arr[0]
+	cnt1 := 0
+	for cnt1 < len(arr) && arr[cnt1] == v1 {
+		cnt1++
+	}
+	if cnt1 >= 3 {
+		return choose(int64(cnt1), 3)
+	}
+	v2 := arr[cnt1]
+	cnt2 := 0
+	idx := cnt1
+	for idx < len(arr) && arr[idx] == v2 {
+		cnt2++
+		idx++
+	}
+	if cnt1 == 2 {
+		return choose(2, 2) * int64(cnt2)
+	}
+	if cnt2 >= 2 {
+		return choose(int64(cnt2), 2)
+	}
+	cnt3 := 0
+	v3 := arr[idx]
+	for idx < len(arr) && arr[idx] == v3 {
+		cnt3++
+		idx++
+	}
+	return int64(cnt3)
+}
+
+func runBin(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 3
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(1000)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	exp := fmt.Sprintf("%d", expected(arr))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := runBin(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s\n", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/810-819/817/verifierC.go
+++ b/0-999/800-899/810-819/817/verifierC.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func sumDigits(x int64) int64 {
+	var s int64
+	for x > 0 {
+		s += x % 10
+		x /= 10
+	}
+	return s
+}
+
+func expected(n, s int64) int64 {
+	low, high := int64(1), n
+	for low <= high {
+		mid := (low + high) / 2
+		if mid-sumDigits(mid) >= s {
+			high = mid - 1
+		} else {
+			low = mid + 1
+		}
+	}
+	if low > n {
+		return 0
+	}
+	return n - low + 1
+}
+
+func runBin(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000_000) + 1
+	s := rng.Int63n(n) + 1
+	input := fmt.Sprintf("%d %d\n", n, s)
+	exp := fmt.Sprintf("%d", expected(n, s))
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := runBin(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s\n", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/810-819/817/verifierD.go
+++ b/0-999/800-899/810-819/817/verifierD.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(a []int64) int64 {
+	n := len(a)
+	lmax := make([]int, n)
+	rmax := make([]int, n)
+	lmin := make([]int, n)
+	rmin := make([]int, n)
+	stack := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		for len(stack) > 0 && a[stack[len(stack)-1]] <= a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == 0 {
+			lmax[i] = -1
+		} else {
+			lmax[i] = stack[len(stack)-1]
+		}
+		stack = append(stack, i)
+	}
+	stack = stack[:0]
+	for i := n - 1; i >= 0; i-- {
+		for len(stack) > 0 && a[stack[len(stack)-1]] < a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == 0 {
+			rmax[i] = n
+		} else {
+			rmax[i] = stack[len(stack)-1]
+		}
+		stack = append(stack, i)
+	}
+	stack = stack[:0]
+	for i := 0; i < n; i++ {
+		for len(stack) > 0 && a[stack[len(stack)-1]] >= a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == 0 {
+			lmin[i] = -1
+		} else {
+			lmin[i] = stack[len(stack)-1]
+		}
+		stack = append(stack, i)
+	}
+	stack = stack[:0]
+	for i := n - 1; i >= 0; i-- {
+		for len(stack) > 0 && a[stack[len(stack)-1]] > a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == 0 {
+			rmin[i] = n
+		} else {
+			rmin[i] = stack[len(stack)-1]
+		}
+		stack = append(stack, i)
+	}
+	var result int64
+	for i := 0; i < n; i++ {
+		leftMax := i - lmax[i]
+		rightMax := rmax[i] - i
+		leftMin := i - lmin[i]
+		rightMin := rmin[i] - i
+		contrib := int64(leftMax)*int64(rightMax) - int64(leftMin)*int64(rightMin)
+		result += contrib * a[i]
+	}
+	return result
+}
+
+func runBin(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Int63n(100) - 50
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	exp := fmt.Sprintf("%d", expected(arr))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := runBin(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s\n", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/810-819/817/verifierE.go
+++ b/0-999/800-899/810-819/817/verifierE.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type op struct {
+	t int
+	p int
+	l int
+}
+
+func simulate(ops []op) []int {
+	counts := map[int]int{}
+	res := []int{}
+	for _, op := range ops {
+		switch op.t {
+		case 1:
+			counts[op.p]++
+		case 2:
+			counts[op.p]--
+			if counts[op.p] <= 0 {
+				delete(counts, op.p)
+			}
+		case 3:
+			cnt := 0
+			for v, c := range counts {
+				if v^op.p < op.l {
+					cnt += c
+				}
+			}
+			res = append(res, cnt)
+		}
+	}
+	return res
+}
+
+func runBin(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	q := rng.Intn(20) + 1
+	ops := make([]op, 0, q)
+	counts := map[int]int{}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		t := rng.Intn(3) + 1
+		if t == 2 && len(counts) == 0 {
+			t = 1
+		}
+		if t == 1 {
+			p := rng.Intn(100) + 1
+			ops = append(ops, op{t: 1, p: p})
+			counts[p]++
+			sb.WriteString(fmt.Sprintf("1 %d\n", p))
+		} else if t == 2 {
+			var key int
+			idx := rng.Intn(len(counts))
+			j := 0
+			for k := range counts {
+				if j == idx {
+					key = k
+					break
+				}
+				j++
+			}
+			ops = append(ops, op{t: 2, p: key})
+			counts[key]--
+			if counts[key] <= 0 {
+				delete(counts, key)
+			}
+			sb.WriteString(fmt.Sprintf("2 %d\n", key))
+		} else {
+			p := rng.Intn(100) + 1
+			l := rng.Intn(100) + 1
+			ops = append(ops, op{t: 3, p: p, l: l})
+			sb.WriteString(fmt.Sprintf("3 %d %d\n", p, l))
+		}
+	}
+	results := simulate(ops)
+	var exp strings.Builder
+	for i, v := range results {
+		if i > 0 {
+			exp.WriteByte('\n')
+		}
+		exp.WriteString(strconv.Itoa(v))
+	}
+	return sb.String(), exp.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := runBin(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s\n", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/810-819/817/verifierF.go
+++ b/0-999/800-899/810-819/817/verifierF.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type op struct {
+	t int
+	l int
+	r int
+}
+
+func mex(set map[int]bool) int {
+	m := 1
+	for {
+		if !set[m] {
+			return m
+		}
+		m++
+	}
+}
+
+func simulate(ops []op) []int {
+	set := map[int]bool{}
+	res := []int{}
+	for _, op := range ops {
+		switch op.t {
+		case 1:
+			for i := op.l; i <= op.r; i++ {
+				set[i] = true
+			}
+		case 2:
+			for i := op.l; i <= op.r; i++ {
+				delete(set, i)
+			}
+		case 3:
+			for i := op.l; i <= op.r; i++ {
+				set[i] = !set[i]
+			}
+		}
+		res = append(res, mex(set))
+	}
+	return res
+}
+
+func runBin(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	q := rng.Intn(20) + 1
+	ops := make([]op, 0, q)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		t := rng.Intn(3) + 1
+		l := rng.Intn(50) + 1
+		r := rng.Intn(50) + 1
+		if l > r {
+			l, r = r, l
+		}
+		ops = append(ops, op{t: t, l: l, r: r})
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", t, l, r))
+	}
+	results := simulate(ops)
+	var exp strings.Builder
+	for i, v := range results {
+		if i > 0 {
+			exp.WriteByte('\n')
+		}
+		exp.WriteString(strconv.Itoa(v))
+	}
+	return sb.String(), exp.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := runBin(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\ninput:\n%s\n", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers `verifierA.go`..`verifierF.go` for contest 817
- each verifier generates 100 random test cases and checks a candidate binary

## Testing
- `go run verifierA.go ./0-999/800-899/810-819/817/817A_bin`
- `go run verifierB.go ./0-999/800-899/810-819/817/817B_bin`
- `go run verifierC.go ./0-999/800-899/810-819/817/817C_bin`
- `go run verifierD.go ./0-999/800-899/810-819/817/817D_bin`
- `go run verifierE.go ./0-999/800-899/810-819/817/817E_bin`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6883c03979108324aaf4c25d175f02ac