### PR TITLE
Add Go verifiers for contest 819

### DIFF
--- a/0-999/800-899/810-819/819/verifierA.go
+++ b/0-999/800-899/810-819/819/verifierA.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var alphabet = []byte("abcdefghijklmnopqrstuvwxyz")
+
+type testCaseA struct {
+	a, b int
+	l, r int64
+}
+
+func build(a, b int, ch byte) ([]byte, []byte) {
+	seq := make([]byte, a)
+	for i := 0; i < a; i++ {
+		seq[i] = alphabet[i]
+	}
+	seen := map[string]int{}
+	cycle := 0
+	var start, period int
+	for {
+		for i := 0; i < b; i++ {
+			seq = append(seq, ch)
+		}
+		suffix := seq[len(seq)-a:]
+		used := make(map[byte]bool)
+		for _, c := range suffix {
+			used[c] = true
+		}
+		t := make([]byte, 0, a)
+		for i := 0; i < 26 && len(t) < a; i++ {
+			if !used[alphabet[i]] {
+				t = append(t, alphabet[i])
+			}
+		}
+		seq = append(seq, t...)
+		suffix = seq[len(seq)-a:]
+		cycle++
+		key := string(suffix)
+		if val, ok := seen[key]; ok {
+			start = val
+			period = cycle - val
+			break
+		}
+		seen[key] = cycle
+	}
+	prefixLen := a + (start-1)*(a+b)
+	periodLen := period * (a + b)
+	prefix := append([]byte{}, seq[:prefixLen]...)
+	periodStr := append([]byte{}, seq[prefixLen:prefixLen+periodLen]...)
+	return prefix, periodStr
+}
+
+func uniqueCount(prefix, period []byte, l, r int64) int {
+	ans := map[byte]struct{}{}
+	prefixLen := int64(len(prefix))
+	periodLen := int64(len(period))
+	if l <= prefixLen {
+		end := r
+		if end > prefixLen {
+			end = prefixLen
+		}
+		for i := l - 1; i < end; i++ {
+			ans[prefix[i]] = struct{}{}
+		}
+		if r <= prefixLen {
+			return len(ans)
+		}
+		l = prefixLen + 1
+	}
+	if periodLen == 0 {
+		return len(ans)
+	}
+	if r-l+1 >= periodLen {
+		for _, c := range period {
+			ans[c] = struct{}{}
+		}
+	} else {
+		start := (l - prefixLen - 1) % periodLen
+		for i := int64(0); i < r-l+1; i++ {
+			ans[period[(start+i)%periodLen]] = struct{}{}
+		}
+	}
+	return len(ans)
+}
+
+func solveA(a, b int, l, r int64) int {
+	best := 27
+	for i := 0; i < 26; i++ {
+		prefix, period := build(a, b, alphabet[i])
+		val := uniqueCount(prefix, period, l, r)
+		if val < best {
+			best = val
+		}
+	}
+	return best
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []testCaseA {
+	rand.Seed(42)
+	tests := make([]testCaseA, 100)
+	for i := range tests {
+		a := rand.Intn(5) + 1
+		b := rand.Intn(5) + 1
+		l := rand.Int63n(80) + 1
+		r := l + rand.Int63n(20)
+		tests[i] = testCaseA{a, b, l, r}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d %d %d\n", tc.a, tc.b, tc.l, tc.r)
+		expected := solveA(tc.a, tc.b, tc.l, tc.r)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		var got int
+		fmt.Sscan(output, &got)
+		if got != expected {
+			fmt.Printf("test %d failed:\ninput: %sexpected %d got %s\n", i+1, input, expected, output)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/0-999/800-899/810-819/819/verifierB.go
+++ b/0-999/800-899/810-819/819/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	p []int
+}
+
+func solveB(p []int) (int, int) {
+	n := len(p)
+	bestVal := int(^uint(0) >> 1)
+	bestIdx := 0
+	for k := 0; k < n; k++ {
+		cur := 0
+		for i := 0; i < n; i++ {
+			v := p[(i+n-k)%n]
+			d := v - (i + 1)
+			if d < 0 {
+				d = -d
+			}
+			cur += d
+		}
+		if cur < bestVal {
+			bestVal = cur
+			bestIdx = k
+		}
+	}
+	return bestVal, bestIdx
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []testCaseB {
+	rand.Seed(42)
+	tests := make([]testCaseB, 100)
+	for i := range tests {
+		n := rand.Intn(7) + 2
+		perm := rand.Perm(n)
+		for j := range perm {
+			perm[j]++
+		}
+		tests[i] = testCaseB{perm}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(tc.p)))
+		for j, v := range tc.p {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		val, idx := solveB(tc.p)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		var gotVal, gotIdx int
+		fmt.Sscan(output, &gotVal, &gotIdx)
+		if gotVal != val || gotIdx != idx {
+			fmt.Printf("test %d failed:\ninput:%sexpected %d %d got %s\n", i+1, input, val, idx, output)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/0-999/800-899/810-819/819/verifierC.go
+++ b/0-999/800-899/810-819/819/verifierC.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var primes []int64
+
+func initPrimes() {
+	const maxP = 1000000
+	sieve := make([]bool, maxP+1)
+	for i := 2; i*i <= maxP; i++ {
+		if !sieve[i] {
+			for j := i * i; j <= maxP; j += i {
+				sieve[j] = true
+			}
+		}
+	}
+	for i := 2; i <= maxP; i++ {
+		if !sieve[i] {
+			primes = append(primes, int64(i))
+		}
+	}
+}
+
+func factor(x int64) map[int64]int {
+	res := make(map[int64]int)
+	for _, p := range primes {
+		if p*p > x {
+			break
+		}
+		for x%p == 0 {
+			res[p]++
+			x /= p
+		}
+	}
+	if x > 1 {
+		res[x]++
+	}
+	return res
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		a = -a
+	}
+	return a
+}
+
+func powInt(x int64, e int) int64 {
+	res := int64(1)
+	for e > 0 {
+		res *= x
+		e--
+	}
+	return res
+}
+
+func coprimeCount(M int64, primes []int64) int64 {
+	var dfs func(int, int64, int)
+	ans := int64(0)
+	dfs = func(i int, prod int64, sign int) {
+		if i == len(primes) {
+			if sign == 0 {
+				ans += M / prod
+			} else {
+				ans += int64(sign) * (M / prod)
+			}
+			return
+		}
+		// skip current prime
+		dfs(i+1, prod, sign)
+		// take current prime
+		if prod <= M/primes[i] {
+			if sign == 0 {
+				dfs(i+1, prod*primes[i], 1)
+			} else {
+				dfs(i+1, prod*primes[i], -sign)
+			}
+		}
+	}
+	dfs(0, 1, 0)
+	return ans
+}
+
+func solveOnce(n1, n2, n3, m1, m2, m3, s1, s2, s3 int64) int64 {
+	n := n1 * n2 * n3
+	m := m1 * m2 * m3
+	s := s1 * s2 * s3
+
+	// factorization of n
+	nf := factor(n1)
+	for k, v := range factor(n2) {
+		nf[k] += v
+	}
+	for k, v := range factor(n3) {
+		nf[k] += v
+	}
+	// factorization of 2*s
+	sf := factor(s1)
+	for k, v := range factor(s2) {
+		sf[k] += v
+	}
+	for k, v := range factor(s3) {
+		sf[k] += v
+	}
+	sf[2]++ // multiply by 2
+	twoS := s * 2
+
+	g := gcd(n, twoS)
+	// prepare prime-exponent arrays for n
+	primesN := make([]int64, 0, len(nf))
+	expsN := make([]int, 0, len(nf))
+	index := make(map[int64]int)
+	i := 0
+	for p, e := range nf {
+		primesN = append(primesN, p)
+		expsN = append(expsN, e)
+		index[p] = i
+		i++
+	}
+	// g factors
+	gf := make(map[int64]int)
+	for p, e := range nf {
+		if se, ok := sf[p]; ok {
+			if e < se {
+				gf[p] = e
+			} else {
+				gf[p] = se
+			}
+		}
+	}
+	primesG := make([]int64, 0, len(gf))
+	expsG := make([]int, 0, len(gf))
+	for p, e := range gf {
+		primesG = append(primesG, p)
+		expsG = append(expsG, e)
+	}
+	expsD := make([]int, len(primesN))
+	var ans int64
+	if g == n {
+		ans++ // x=0 case
+	}
+	var dfs func(int, int64)
+	dfs = func(pos int, curr int64) {
+		if pos == len(primesG) {
+			if curr > m {
+				return
+			}
+			M := m / curr
+			if M == 0 {
+				return
+			}
+			var rest []int64
+			for idx, p := range primesN {
+				cnt := expsN[idx] - expsD[idx]
+				if cnt > 0 {
+					rest = append(rest, p)
+				}
+			}
+			ans += coprimeCount(M, rest)
+			return
+		}
+		p := primesG[pos]
+		idx := index[p]
+		power := int64(1)
+		for k := 0; k <= expsG[pos]; k++ {
+			expsD[idx] = k
+			dfs(pos+1, curr*power)
+			power *= p
+		}
+		expsD[idx] = 0
+	}
+	dfs(0, 1)
+	// Stage2: divisors of twoS <= n-1
+	// factorization of 2s is sf
+	primesS := make([]int64, 0, len(sf))
+	expsS := make([]int, 0, len(sf))
+	for p, e := range sf {
+		primesS = append(primesS, p)
+		expsS = append(expsS, e)
+	}
+	var countDiv func(int, int64) int64
+	limit := n - 1
+	countDiv = func(pos int, prod int64) int64 {
+		if prod > limit {
+			return 0
+		}
+		if pos == len(primesS) {
+			if prod >= 1 {
+				return 1
+			}
+			return 0
+		}
+		res := int64(0)
+		p := primesS[pos]
+		val := int64(1)
+		for e := 0; e <= expsS[pos]; e++ {
+			res += countDiv(pos+1, prod*val)
+			val *= p
+			if prod*val > limit {
+				break
+			}
+		}
+		return res
+	}
+	if limit > 0 {
+		ans += countDiv(0, 1)
+	}
+	return ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type testCaseC struct {
+	n1, n2, n3 int64
+	m1, m2, m3 int64
+	s1, s2, s3 int64
+}
+
+func generateTests() []testCaseC {
+	rand.Seed(42)
+	tests := make([]testCaseC, 100)
+	for i := range tests {
+		tests[i] = testCaseC{
+			n1: int64(rand.Intn(5) + 1),
+			n2: int64(rand.Intn(5) + 1),
+			n3: int64(rand.Intn(5) + 1),
+			m1: int64(rand.Intn(5) + 1),
+			m2: int64(rand.Intn(5) + 1),
+			m3: int64(rand.Intn(5) + 1),
+			s1: int64(rand.Intn(5) + 1),
+			s2: int64(rand.Intn(5) + 1),
+			s3: int64(rand.Intn(5) + 1),
+		}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	initPrimes()
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d %d %d\n%d %d %d\n%d %d %d\n", tc.n1, tc.n2, tc.n3, tc.m1, tc.m2, tc.m3, tc.s1, tc.s2, tc.s3)
+		expected := solveOnce(tc.n1, tc.n2, tc.n3, tc.m1, tc.m2, tc.m3, tc.s1, tc.s2, tc.s3)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		var got int64
+		fmt.Sscan(output, &got)
+		if got != expected {
+			fmt.Printf("test %d failed:\ninput:%sexpected %d got %s\n", i+1, input, expected, output)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/0-999/800-899/810-819/819/verifierD.go
+++ b/0-999/800-899/810-819/819/verifierD.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func exgcd(a, b int64) (int64, int64, int64) {
+	if b == 0 {
+		return a, 1, 0
+	}
+	g, x1, y1 := exgcd(b, a%b)
+	x, y := y1, x1-(a/b)*y1
+	return g, x, y
+}
+
+func modInv(a, mod int64) int64 {
+	g, x, _ := exgcd(a, mod)
+	if g != 1 {
+		return 0
+	}
+	x %= mod
+	if x < 0 {
+		x += mod
+	}
+	return x
+}
+
+func floorSum(n, m, a, b int64) int64 {
+	var ans int64
+	for {
+		if a >= m {
+			ans += (n - 1) * n * (a / m) / 2
+			a %= m
+		}
+		if b >= m {
+			ans += n * (b / m)
+			b %= m
+		}
+		yMax := a*n + b
+		if yMax < m {
+			break
+		}
+		n = yMax / m
+		b = yMax % m
+		m, a = a, m
+	}
+	return ans
+}
+
+func countPrefix(n, m, d, R int64) int64 {
+	if R == 0 || n == 0 {
+		return 0
+	}
+	c1 := floorSum(n, m, d, 0)
+	c2 := floorSum(n, m, d, m-R)
+	return n + c1 - c2
+}
+
+func countInterval(l, r, m, d, R int64) int64 {
+	if r < l || R == 0 {
+		return 0
+	}
+	return countPrefix(r+1, m, d, R) - countPrefix(l, m, d, R)
+}
+
+func solveD(T int64, a []int64) []int64 {
+	n := len(a)
+
+	prefix := make([]int64, n)
+	var sum int64
+	for i := 0; i < n; i++ {
+		prefix[i] = sum
+		sum += a[i]
+	}
+	A := sum
+	g := gcd(A, T)
+	A1 := A / g
+	T1 := T / g
+	invT1 := modInv(T1%A1, A1)
+
+	type pair struct {
+		t  int64
+		id int
+	}
+	groups := make(map[int64][]pair)
+	for i, s := range prefix {
+		r := s % g
+		s2 := (s - r) / g
+		tVal := (s2 * invT1) % A1
+		groups[r] = append(groups[r], pair{tVal, i})
+	}
+
+	Q := T / g
+	base := Q / A1
+	R := Q % A1
+	ans := make([]int64, n)
+	invStep := modInv(invT1, A1)
+
+	for _, arr := range groups {
+		// sort by t
+		for i := 0; i < len(arr); i++ {
+			for j := i + 1; j < len(arr); j++ {
+				if arr[j].t < arr[i].t {
+					arr[i], arr[j] = arr[j], arr[i]
+				}
+			}
+		}
+		m := len(arr)
+		tVals := make([]int64, m)
+		ids := make([]int, m)
+		for i := 0; i < m; i++ {
+			tVals[i] = arr[i].t
+			ids[i] = arr[i].id
+		}
+		// full cycle counts
+		cnt := make([]int64, m)
+		cnt[0] += tVals[0] + 1
+		for i := 1; i < m; i++ {
+			cnt[i] += tVals[i] - tVals[i-1]
+		}
+		cnt[0] += A1 - 1 - tVals[m-1]
+		for i := 0; i < m; i++ {
+			ans[ids[i]] += cnt[i] * base
+		}
+		// remainder part
+		for i := 0; i < m; i++ {
+			l := int64(0)
+			if i > 0 {
+				l = tVals[i-1] + 1
+			}
+			r := tVals[i]
+			ans[ids[i]] += countInterval(l, r, A1, invStep, R)
+		}
+		l := tVals[m-1] + 1
+		r := A1 - 1
+		ans[ids[0]] += countInterval(l, r, A1, invStep, R)
+	}
+
+	return ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type testCaseD struct {
+	T int64
+	a []int64
+}
+
+func generateTests() []testCaseD {
+	rand.Seed(42)
+	tests := make([]testCaseD, 100)
+	for i := range tests {
+		n := rand.Intn(4) + 2
+		arr := make([]int64, n)
+		for j := range arr {
+			arr[j] = int64(rand.Intn(10) + 1)
+		}
+		T := int64(rand.Intn(10) + 1)
+		tests[i] = testCaseD{T, arr}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.T, len(tc.a)))
+		for j, v := range tc.a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveD(tc.T, tc.a)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		gotFields := strings.Fields(output)
+		if len(gotFields) != len(expected) {
+			fmt.Printf("test %d failed: wrong number of outputs\n", i+1)
+			return
+		}
+		ok := true
+		for j, str := range gotFields {
+			var v int64
+			fmt.Sscan(str, &v)
+			if v != expected[j] {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			fmt.Printf("test %d failed:\ninput:%sexpected %v got %s\n", i+1, input, expected, output)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/0-999/800-899/810-819/819/verifierE.go
+++ b/0-999/800-899/810-819/819/verifierE.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type node struct{ a, b, c, d int }
+
+var ans []node
+
+func add(n int) {
+	if n&1 == 1 {
+		ans = append(ans, node{n, 0, n + 1, -1})
+		ans = append(ans, node{n, 0, n + 1, -1})
+		for i := 1; i < n; i += 2 {
+			ans = append(ans, node{n, i, n + 1, i + 1})
+			ans = append(ans, node{n, i, n + 1, i + 1})
+		}
+	} else {
+		ans = append(ans, node{n, 0, n + 1, -1})
+		ans = append(ans, node{n, 1, n + 1, -1})
+		ans = append(ans, node{n, 0, n + 1, 1})
+		for i := 2; i < n; i += 2 {
+			ans = append(ans, node{n, i, n + 1, i + 1})
+			ans = append(ans, node{n, i, n + 1, i + 1})
+		}
+	}
+}
+
+func solveE(n int) string {
+	ans = nil
+	if n&1 == 1 {
+		ans = append(ans, node{0, 1, 2, -1})
+		ans = append(ans, node{0, 1, 2, -1})
+		for now := 3; now < n; now += 2 {
+			add(now)
+		}
+	} else {
+		ans = append(ans, node{0, 1, 2, -1})
+		ans = append(ans, node{1, 2, 3, -1})
+		ans = append(ans, node{2, 3, 0, -1})
+		ans = append(ans, node{3, 0, 1, -1})
+		for now := 4; now < n; now += 2 {
+			add(now)
+		}
+	}
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, len(ans))
+	for _, i := range ans {
+		if i.d == -1 {
+			fmt.Fprintln(&buf, 3, i.a+1, i.b+1, i.c+1)
+		} else {
+			fmt.Fprintln(&buf, 4, i.a+1, i.b+1, i.c+1, i.d+1)
+		}
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type testCaseE struct {
+	n int
+}
+
+func generateTests() []testCaseE {
+	rand.Seed(42)
+	tests := make([]testCaseE, 100)
+	for i := range tests {
+		tests[i] = testCaseE{n: rand.Intn(6) + 3}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d\n", tc.n)
+		expected := solveE(tc.n)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(output) != expected {
+			fmt.Printf("test %d failed:\ninput:%sexpected:\n%s\ngot:\n%s\n", i+1, input, expected, output)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–E of contest 819
- each verifier generates 100 random test cases and checks an arbitrary solution binary
- reference implementations are embedded directly in each verifier

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883c15187b88324a81a68103fa16103