### PR TITLE
Add Go solution for 1924C

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1924/1924C.go
+++ b/1000-1999/1900-1999/1920-1929/1924/1924C.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const MOD int64 = 999999893
+
+func modPow(base, exp int64) int64 {
+	res := int64(1)
+	base %= MOD
+	for exp > 0 {
+		if exp&1 == 1 {
+			res = res * base % MOD
+		}
+		base = base * base % MOD
+		exp >>= 1
+	}
+	return res
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int64
+		fmt.Fscan(in, &n)
+		if n == 1 {
+			fmt.Fprintln(out, 0)
+			continue
+		}
+		exp := 2*n - 3
+		denom := (modPow(2, exp) - 1 + MOD) % MOD
+		ans := modPow(denom, MOD-2)
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1924C.go` solution using fast exponentiation

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_6883c197942883249ff944c2de974430