### PR TITLE
Add verifiers for contest 823

### DIFF
--- a/0-999/800-899/820-829/823/verifierA.go
+++ b/0-999/800-899/820-829/823/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func buildRef() (string, error) {
+    ref := "./refA.bin"
+    cmd := exec.Command("go", "build", "-o", ref, "823A.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+    }
+    return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+    rng := rand.New(rand.NewSource(8230))
+    cases := make([]Case, 100)
+    for i := range cases {
+        n := rng.Intn(18) + 3       // 3..20
+        k := rng.Intn(n-2) + 2      // 2..n-1
+        cases[i] = Case{fmt.Sprintf("%d %d\n", n, k)}
+    }
+    return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+    expected, err := runBinary(ref, c.input)
+    if err != nil {
+        return fmt.Errorf("reference failed: %v", err)
+    }
+    got, err := runBinary(bin, c.input)
+    if err != nil {
+        return err
+    }
+    if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+        return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    if bin == "--" {
+        if len(os.Args) < 3 {
+            fmt.Println("usage: go run verifierA.go /path/to/binary")
+            os.Exit(1)
+        }
+        bin = os.Args[2]
+    }
+    ref, err := buildRef()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(ref)
+    cases := genCases()
+    for i, c := range cases {
+        if err := runCase(bin, ref, c); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/800-899/820-829/823/verifierB.go
+++ b/0-999/800-899/820-829/823/verifierB.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func buildRef() (string, error) {
+    ref := "./refB.bin"
+    cmd := exec.Command("go", "build", "-o", ref, "823B.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+    }
+    return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func randDNA(rng *rand.Rand, n int) string {
+    letters := "ATGC"
+    b := make([]byte, n)
+    for i := range b {
+        b[i] = letters[rng.Intn(4)]
+    }
+    return string(b)
+}
+
+func genCases() []Case {
+    rng := rand.New(rand.NewSource(8231))
+    cases := make([]Case, 100)
+    for i := range cases {
+        n := rng.Intn(10) + 1
+        s := randDNA(rng, n)
+        q := rng.Intn(10) + 1
+        var sb strings.Builder
+        sb.WriteString(s)
+        sb.WriteByte('\n')
+        fmt.Fprintf(&sb, "%d\n", q)
+        for j := 0; j < q; j++ {
+            if rng.Intn(2) == 0 {
+                x := rng.Intn(n) + 1
+                c := randDNA(rng, 1)
+                fmt.Fprintf(&sb, "1 %d %s\n", x, c)
+            } else {
+                l := rng.Intn(n) + 1
+                r := rng.Intn(n-l+1) + l
+                m := rng.Intn(5) + 1
+                e := randDNA(rng, m)
+                fmt.Fprintf(&sb, "2 %d %d %s\n", l, r, e)
+            }
+        }
+        cases[i] = Case{sb.String()}
+    }
+    return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+    expected, err := runBinary(ref, c.input)
+    if err != nil {
+        return fmt.Errorf("reference failed: %v", err)
+    }
+    got, err := runBinary(bin, c.input)
+    if err != nil {
+        return err
+    }
+    if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+        return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    if bin == "--" {
+        if len(os.Args) < 3 {
+            fmt.Println("usage: go run verifierB.go /path/to/binary")
+            os.Exit(1)
+        }
+        bin = os.Args[2]
+    }
+    ref, err := buildRef()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(ref)
+    cases := genCases()
+    for i, c := range cases {
+        if err := runCase(bin, ref, c); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/800-899/820-829/823/verifierC.go
+++ b/0-999/800-899/820-829/823/verifierC.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+func buildRef() (string, error) {
+    ref := "./refC.bin"
+    cmd := exec.Command("go", "build", "-o", ref, "823C.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+    }
+    return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+    rng := rand.New(rand.NewSource(8232))
+    cases := make([]Case, 100)
+    for i := range cases {
+        n := rng.Intn(5) + 1
+        k := rng.Int63n(1000) + 1
+        nums := make([]int64, n)
+        for j := range nums {
+            nums[j] = rng.Int63n(1000) + 1
+        }
+        var sb strings.Builder
+        fmt.Fprintf(&sb, "%d %d\n", n, k)
+        for j, v := range nums {
+            if j > 0 {
+                sb.WriteByte(' ')
+            }
+            sb.WriteString(strconv.FormatInt(v, 10))
+        }
+        sb.WriteByte('\n')
+        cases[i] = Case{sb.String()}
+    }
+    return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+    expected, err := runBinary(ref, c.input)
+    if err != nil {
+        return fmt.Errorf("reference failed: %v", err)
+    }
+    got, err := runBinary(bin, c.input)
+    if err != nil {
+        return err
+    }
+    if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+        return fmt.Errorf("expected %s got %s", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    if bin == "--" {
+        if len(os.Args) < 3 {
+            fmt.Println("usage: go run verifierC.go /path/to/binary")
+            os.Exit(1)
+        }
+        bin = os.Args[2]
+    }
+    ref, err := buildRef()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(ref)
+    cases := genCases()
+    for i, c := range cases {
+        if err := runCase(bin, ref, c); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/800-899/820-829/823/verifierD.go
+++ b/0-999/800-899/820-829/823/verifierD.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func buildRef() (string, error) {
+    ref := "./refD.bin"
+    cmd := exec.Command("go", "build", "-o", ref, "823D.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+    }
+    return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func randVK(rng *rand.Rand, n int) string {
+    letters := "VK?"
+    b := make([]byte, n)
+    for i := range b {
+        b[i] = letters[rng.Intn(3)]
+    }
+    return string(b)
+}
+
+func genCases() []Case {
+    rng := rand.New(rand.NewSource(8233))
+    cases := make([]Case, 100)
+    for i := range cases {
+        t := rng.Intn(3) + 1
+        var sb strings.Builder
+        fmt.Fprintf(&sb, "%d\n", t)
+        for j := 0; j < t; j++ {
+            n := rng.Intn(8) + 1
+            s := randVK(rng, n)
+            fmt.Fprintf(&sb, "%d\n%s\n", n, s)
+        }
+        cases[i] = Case{sb.String()}
+    }
+    return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+    expected, err := runBinary(ref, c.input)
+    if err != nil {
+        return fmt.Errorf("reference failed: %v", err)
+    }
+    got, err := runBinary(bin, c.input)
+    if err != nil {
+        return err
+    }
+    if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+        return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    if bin == "--" {
+        if len(os.Args) < 3 {
+            fmt.Println("usage: go run verifierD.go /path/to/binary")
+            os.Exit(1)
+        }
+        bin = os.Args[2]
+    }
+    ref, err := buildRef()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(ref)
+    cases := genCases()
+    for i, c := range cases {
+        if err := runCase(bin, ref, c); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/800-899/820-829/823/verifierE.go
+++ b/0-999/800-899/820-829/823/verifierE.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func buildRef() (string, error) {
+    ref := "./refE.bin"
+    cmd := exec.Command("go", "build", "-o", ref, "823E.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+    }
+    return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+    rng := rand.New(rand.NewSource(8234))
+    cases := make([]Case, 100)
+    for i := range cases {
+        k := rng.Intn(20) + 1
+        cases[i] = Case{fmt.Sprintf("%d\n", k)}
+    }
+    return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+    expected, err := runBinary(ref, c.input)
+    if err != nil {
+        return fmt.Errorf("reference failed: %v", err)
+    }
+    got, err := runBinary(bin, c.input)
+    if err != nil {
+        return err
+    }
+    if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+        return fmt.Errorf("expected %s got %s", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    if bin == "--" {
+        if len(os.Args) < 3 {
+            fmt.Println("usage: go run verifierE.go /path/to/binary")
+            os.Exit(1)
+        }
+        bin = os.Args[2]
+    }
+    ref, err := buildRef()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(ref)
+    cases := genCases()
+    for i, c := range cases {
+        if err := runCase(bin, ref, c); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/800-899/820-829/823/verifierF.go
+++ b/0-999/800-899/820-829/823/verifierF.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func buildRef() (string, error) {
+    ref := "./refF.bin"
+    cmd := exec.Command("go", "build", "-o", ref, "823F.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+    }
+    return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCase(rng *rand.Rand) Case {
+    n := rng.Intn(6) + 1
+    m := rng.Intn(n*(n-1)/2 + 1)
+    edges := make(map[[2]int]struct{})
+    var sb strings.Builder
+    fmt.Fprintf(&sb, "1\n%d %d\n", n, m)
+    for len(edges) < m {
+        a := rng.Intn(n) + 1
+        b := rng.Intn(n) + 1
+        if a == b {
+            continue
+        }
+        if a > b {
+            a, b = b, a
+        }
+        key := [2]int{a, b}
+        if _, ok := edges[key]; ok {
+            continue
+        }
+        edges[key] = struct{}{}
+        fmt.Fprintf(&sb, "%d %d\n", a, b)
+    }
+    return Case{sb.String()}
+}
+
+func genCases() []Case {
+    rng := rand.New(rand.NewSource(8235))
+    cases := make([]Case, 100)
+    for i := range cases {
+        cases[i] = genCase(rng)
+    }
+    return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+    expected, err := runBinary(ref, c.input)
+    if err != nil {
+        return fmt.Errorf("reference failed: %v", err)
+    }
+    got, err := runBinary(bin, c.input)
+    if err != nil {
+        return err
+    }
+    if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+        return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierF.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    if bin == "--" {
+        if len(os.Args) < 3 {
+            fmt.Println("usage: go run verifierF.go /path/to/binary")
+            os.Exit(1)
+        }
+        bin = os.Args[2]
+    }
+    ref, err := buildRef()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(ref)
+    cases := genCases()
+    for i, c := range cases {
+        if err := runCase(bin, ref, c); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/800-899/820-829/823/verifierG.go
+++ b/0-999/800-899/820-829/823/verifierG.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func buildRef() (string, error) {
+    ref := "./refG.bin"
+    cmd := exec.Command("go", "build", "-o", ref, "823G.go")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+    }
+    return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCase(rng *rand.Rand) Case {
+    n := rng.Intn(5) + 2
+    m := rng.Intn(n * 2)
+    var sb strings.Builder
+    fmt.Fprintf(&sb, "%d %d\n", n, m)
+    for i := 0; i < m; i++ {
+        a := rng.Intn(n) + 1
+        b := rng.Intn(n) + 1
+        l := rng.Intn(5)
+        r := l + rng.Intn(5) + 1
+        fmt.Fprintf(&sb, "%d %d %d %d\n", a, b, l, r)
+    }
+    return Case{sb.String()}
+}
+
+func genCases() []Case {
+    rng := rand.New(rand.NewSource(8236))
+    cases := make([]Case, 100)
+    for i := range cases {
+        cases[i] = genCase(rng)
+    }
+    return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+    expected, err := runBinary(ref, c.input)
+    if err != nil {
+        return fmt.Errorf("reference failed: %v", err)
+    }
+    got, err := runBinary(bin, c.input)
+    if err != nil {
+        return err
+    }
+    if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+        return fmt.Errorf("expected %s got %s", expected, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Println("usage: go run verifierG.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    if bin == "--" {
+        if len(os.Args) < 3 {
+            fmt.Println("usage: go run verifierG.go /path/to/binary")
+            os.Exit(1)
+        }
+        bin = os.Args[2]
+    }
+    ref, err := buildRef()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    defer os.Remove(ref)
+    cases := genCases()
+    for i, c := range cases {
+        if err := runCase(bin, ref, c); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 823 problems A–G
- each verifier builds the reference solution, generates 100 random tests, and checks a target binary
- handle `--` argument for running via `go run`

## Testing
- `go run verifierA.go -- 823A.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6883c381e7bc8324b6d18ad66d8a582d