### PR TITLE
Add Go solution for 1638C

### DIFF
--- a/1000-1999/1600-1699/1630-1639/1638/1638C.go
+++ b/1000-1999/1600-1699/1630-1639/1638/1638C.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		p := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &p[i])
+		}
+		maxVal := 0
+		comps := 0
+		for i := 0; i < n; i++ {
+			if p[i] > maxVal {
+				maxVal = p[i]
+			}
+			if maxVal == i+1 {
+				comps++
+			}
+		}
+		fmt.Fprintln(out, comps)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem C in contest 1638
- use prefix maximum approach to count components

## Testing
- `go build 1000-1999/1600-1699/1630-1639/1638/1638C.go`
- run sample style tests using built binary

------
https://chatgpt.com/codex/tasks/task_e_6883c79c856c832483983f6f66754cc8