### PR TITLE
Add verifiers for contest 827

### DIFF
--- a/0-999/800-899/820-829/827/verifierA.go
+++ b/0-999/800-899/820-829/827/verifierA.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "827A.go")
+	bin := filepath.Join(os.TempDir(), "ref827A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(n int) string {
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func genCase() string {
+	L := rand.Intn(20) + 5
+	final := make([]byte, L)
+	for i := range final {
+		final[i] = byte('a' + rand.Intn(26))
+	}
+	n := rand.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		l := rand.Intn(4) + 1
+		if l > L {
+			l = L
+		}
+		start := rand.Intn(L-l+1) + 1
+		t := string(final[start-1 : start-1+l])
+		var occ []int
+		for j := 1; j <= L-l+1; j++ {
+			if string(final[j-1:j-1+l]) == t {
+				occ = append(occ, j)
+			}
+		}
+		k := rand.Intn(len(occ)) + 1
+		rand.Shuffle(len(occ), func(a, b int) { occ[a], occ[b] = occ[b], occ[a] })
+		pos := occ[:k]
+		sort.Ints(pos)
+		sb.WriteString(t)
+		sb.WriteString(fmt.Sprintf(" %d", k))
+		for _, p := range pos {
+			sb.WriteString(fmt.Sprintf(" %d", p))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	userBin := os.Args[1]
+	rand.Seed(1)
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		want, err1 := runBinary(ref, input)
+		if err1 != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err1)
+			return
+		}
+		got, err2 := runBinary(userBin, input)
+		if err2 != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err2)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/820-829/827/verifierD.go
+++ b/0-999/800-899/820-829/827/verifierD.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "827D.go")
+	bin := filepath.Join(os.TempDir(), "ref827D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase() string {
+	n := rand.Intn(6) + 2     // 2..7
+	m := n - 1 + rand.Intn(n) // ensure connected
+	type pair struct{ u, v int }
+	used := make(map[pair]bool)
+	edges := make([][3]int, 0, m)
+	// tree
+	for i := 2; i <= n; i++ {
+		j := rand.Intn(i-1) + 1
+		w := rand.Intn(20) + 1
+		edges = append(edges, [3]int{i, j, w})
+		a, b := i, j
+		if a > b {
+			a, b = b, a
+		}
+		used[pair{a, b}] = true
+	}
+	for len(edges) < m {
+		u := rand.Intn(n) + 1
+		v := rand.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		a, b := u, v
+		if a > b {
+			a, b = b, a
+		}
+		if used[pair{a, b}] {
+			continue
+		}
+		used[pair{a, b}] = true
+		w := rand.Intn(20) + 1
+		edges = append(edges, [3]int{u, v, w})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	userBin := os.Args[1]
+	rand.Seed(1)
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		want, err1 := runBinary(ref, input)
+		if err1 != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err1)
+			return
+		}
+		got, err2 := runBinary(userBin, input)
+		if err2 != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err2)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 827 problems A and D
- verifiers compile the provided reference solutions and run at least 100 randomized test cases

## Testing
- `go run 0-999/800-899/820-829/827/verifierA.go /tmp/Aprog`

------
https://chatgpt.com/codex/tasks/task_e_6883c5b230fc83249b1af09afbf3bcab