### PR TITLE
Add Go verifiers for contest 831

### DIFF
--- a/0-999/800-899/830-839/831/verifierA.go
+++ b/0-999/800-899/830-839/831/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n   int
+	arr []int
+}
+
+func generateCaseA(rng *rand.Rand) (string, testCaseA) {
+	n := rng.Intn(100) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(1000) + 1
+		fmt.Fprintf(&sb, "%d ", arr[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String(), testCaseA{n: n, arr: arr}
+}
+
+func expectedA(tc testCaseA) string {
+	a := tc.arr
+	n := len(a)
+	i := 0
+	for i+1 < n && a[i] < a[i+1] {
+		i++
+	}
+	for i+1 < n && a[i] == a[i+1] {
+		i++
+	}
+	for i+1 < n && a[i] > a[i+1] {
+		i++
+	}
+	if i == n-1 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, tc := generateCaseA(rng)
+		expect := expectedA(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/831/verifierB.go
+++ b/0-999/800-899/830-839/831/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	layout1 string
+	layout2 string
+	text    string
+}
+
+func randomLayout(rng *rand.Rand) string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	rng.Shuffle(len(letters), func(i, j int) { letters[i], letters[j] = letters[j], letters[i] })
+	return string(letters)
+}
+
+func randomText(rng *rand.Rand, length int) string {
+	chars := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	var sb strings.Builder
+	for i := 0; i < length; i++ {
+		sb.WriteByte(chars[rng.Intn(len(chars))])
+	}
+	return sb.String()
+}
+
+func generateCaseB(rng *rand.Rand) (string, testCaseB) {
+	l1 := randomLayout(rng)
+	l2 := randomLayout(rng)
+	length := rng.Intn(1000) + 1
+	text := randomText(rng, length)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s\n%s\n%s\n", l1, l2, text)
+	return sb.String(), testCaseB{layout1: l1, layout2: l2, text: text}
+}
+
+func expectedB(tc testCaseB) string {
+	mapping := make(map[byte]byte, 52)
+	for i := 0; i < 26; i++ {
+		c1 := tc.layout1[i]
+		c2 := tc.layout2[i]
+		mapping[c1] = c2
+		mapping[c1-'a'+'A'] = c2 - 'a' + 'A'
+	}
+	res := make([]byte, len(tc.text))
+	for i := 0; i < len(tc.text); i++ {
+		ch := tc.text[i]
+		if v, ok := mapping[ch]; ok {
+			res[i] = v
+		} else {
+			res[i] = ch
+		}
+	}
+	return string(res)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, tc := generateCaseB(rng)
+		expect := expectedB(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/831/verifierC.go
+++ b/0-999/800-899/830-839/831/verifierC.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	k int
+	n int
+	a []int
+	b []int
+}
+
+func generateCaseC(rng *rand.Rand) (string, testCaseC) {
+	k := rng.Intn(10) + 1
+	n := rng.Intn(k) + 1
+	a := make([]int, k)
+	for i := 0; i < k; i++ {
+		a[i] = rng.Intn(401) - 200 // -200..200
+	}
+	// compute prefix sums
+	pref := make([]int, k)
+	sum := 0
+	for i := 0; i < k; i++ {
+		sum += a[i]
+		pref[i] = sum
+	}
+	offset := rng.Intn(1000) - 500
+	set := make(map[int]struct{})
+	b := make([]int, 0, n)
+	for len(b) < n {
+		if rng.Float64() < 0.8 {
+			val := pref[rng.Intn(k)] + offset
+			if _, ok := set[val]; !ok {
+				set[val] = struct{}{}
+				b = append(b, val)
+			}
+		} else {
+			val := rng.Intn(2000) - 1000
+			if _, ok := set[val]; !ok {
+				set[val] = struct{}{}
+				b = append(b, val)
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", k, n)
+	for i := 0; i < k; i++ {
+		fmt.Fprintf(&sb, "%d ", a[i])
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", b[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String(), testCaseC{k: k, n: n, a: a, b: b}
+}
+
+func expectedC(tc testCaseC) int {
+	pref := make([]int, tc.k)
+	sum := 0
+	for i := 0; i < tc.k; i++ {
+		sum += tc.a[i]
+		pref[i] = sum
+	}
+	prefSet := make(map[int]struct{})
+	for _, v := range pref {
+		prefSet[v] = struct{}{}
+	}
+	candidate := make(map[int]struct{})
+	for _, v := range pref {
+		candidate[tc.b[0]-v] = struct{}{}
+	}
+	count := 0
+	for x := range candidate {
+		ok := true
+		for _, bj := range tc.b {
+			if _, ok2 := prefSet[bj-x]; !ok2 {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			count++
+		}
+	}
+	return count
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, tc := generateCaseC(rng)
+		expect := expectedC(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		var val int
+		if _, err := fmt.Sscan(got, &val); err != nil || val != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go, verifierB.go, verifierC.go under contest 831
- each verifier generates at least 100 random tests and runs candidate binaries

## Testing
- `go build verifierA.go`
- `./verifierA ./solutionA`
- `go build verifierB.go`
- `./verifierB ./solutionB`
- `go build verifierC.go`
- `./verifierC ./solutionC`


------
https://chatgpt.com/codex/tasks/task_e_6883c7e351a483248dda17ed0113a25f