### PR TITLE
Add Go verifiers for Codeforces contest 832

### DIFF
--- a/0-999/800-899/830-839/832/verifierA.go
+++ b/0-999/800-899/830-839/832/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int64
+	k int64
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("%d %d\n", t.n, t.k)
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "832A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(time.Now().UnixNano())
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Int63n(1_000_000_000_000_000_000) + 1
+		k := rand.Int63n(n) + 1
+		tests = append(tests, Test{n: n, k: k})
+	}
+	// edge cases
+	tests = append(tests,
+		Test{n: 1, k: 1},
+		Test{n: 2, k: 1},
+		Test{n: 3, k: 3},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.Input())
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/830-839/832/verifierB.go
+++ b/0-999/800-899/830-839/832/verifierB.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	good    string
+	pattern string
+	queries []string
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(t.good + "\n")
+	sb.WriteString(t.pattern + "\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.queries)))
+	for _, q := range t.queries {
+		sb.WriteString(q + "\n")
+	}
+	return sb.String()
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "832B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func randString(alphabet string, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = alphabet[rand.Intn(len(alphabet))]
+	}
+	return string(b)
+}
+
+func genTests() []Test {
+	rand.Seed(time.Now().UnixNano())
+	tests := make([]Test, 0, 100)
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	for i := 0; i < 100; i++ {
+		// good letters
+		gcount := rand.Intn(26) + 1
+		goodSet := make(map[byte]bool)
+		for len(goodSet) < gcount {
+			ch := letters[rand.Intn(26)]
+			goodSet[ch] = true
+		}
+		var good strings.Builder
+		for ch := range goodSet {
+			good.WriteByte(ch)
+		}
+
+		// pattern
+		plen := rand.Intn(10) + 1
+		var pattern strings.Builder
+		hasStar := rand.Intn(4) == 0
+		starPos := -1
+		for j := 0; j < plen; j++ {
+			if hasStar && starPos == -1 && rand.Intn(plen) == 0 {
+				pattern.WriteByte('*')
+				starPos = j
+				continue
+			}
+			r := rand.Intn(26 + 1)
+			if r == 26 {
+				pattern.WriteByte('?')
+			} else {
+				pattern.WriteByte(letters[r])
+			}
+		}
+		if hasStar && starPos == -1 {
+			pattern.WriteByte('*')
+		}
+
+		// queries
+		qnum := rand.Intn(5) + 1
+		qs := make([]string, qnum)
+		for j := 0; j < qnum; j++ {
+			l := rand.Intn(12) + 1
+			qs[j] = randString(letters, l)
+		}
+		tests = append(tests, Test{good: good.String(), pattern: pattern.String(), queries: qs})
+	}
+	// simple case
+	tests = append(tests, Test{good: "abc", pattern: "a?c", queries: []string{"abc"}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/830-839/832/verifierC.go
+++ b/0-999/800-899/830-839/832/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Person struct {
+	x int
+	v int
+	t int
+}
+
+type Test struct {
+	n   int
+	s   int
+	ppl []Person
+}
+
+func (tc Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.s))
+	for _, p := range tc.ppl {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", p.x, p.v, p.t))
+	}
+	return sb.String()
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "832C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(time.Now().UnixNano())
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(4) + 2
+		s := rand.Intn(9) + 2
+		ppl := make([]Person, n)
+		for j := 0; j < n; j++ {
+			x := rand.Intn(1_000_000-1) + 1
+			v := rand.Intn(s-1) + 1
+			t := rand.Intn(2) + 1
+			ppl[j] = Person{x: x, v: v, t: t}
+		}
+		tests = append(tests, Test{n: n, s: s, ppl: ppl})
+	}
+	// simple small test
+	tests = append(tests, Test{n: 2, s: 3, ppl: []Person{{1, 1, 1}, {999999, 1, 2}}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/830-839/832/verifierD.go
+++ b/0-999/800-899/830-839/832/verifierD.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Query struct{ a, b, c int }
+
+type Test struct {
+	n       int
+	parents []int // length n-1 for nodes 2..n
+	q       int
+	queries []Query
+}
+
+func (tc Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.q))
+	for i := 2; i <= tc.n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", tc.parents[i-2]))
+	}
+	sb.WriteByte('\n')
+	for _, qu := range tc.queries {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", qu.a, qu.b, qu.c))
+	}
+	return sb.String()
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "832D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTree(n int) []int {
+	p := make([]int, n-1)
+	for i := 2; i <= n; i++ {
+		p[i-2] = rand.Intn(i-1) + 1
+	}
+	return p
+}
+
+func genTests() []Test {
+	rand.Seed(time.Now().UnixNano())
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(7) + 3
+		parents := genTree(n)
+		q := rand.Intn(5) + 1
+		queries := make([]Query, q)
+		for j := 0; j < q; j++ {
+			a := rand.Intn(n) + 1
+			b := rand.Intn(n) + 1
+			c := rand.Intn(n) + 1
+			queries[j] = Query{a, b, c}
+		}
+		tests = append(tests, Test{n: n, parents: parents, q: q, queries: queries})
+	}
+	// simple tree
+	tests = append(tests, Test{n: 3, parents: []int{1, 1}, q: 1, queries: []Query{{1, 2, 3}}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/830-839/832/verifierE.go
+++ b/0-999/800-899/830-839/832/verifierE.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n       int
+	m       int
+	base    []string
+	q       int
+	queries []string
+}
+
+func (tc Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+	for _, s := range tc.base {
+		sb.WriteString(s + "\n")
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", tc.q))
+	for _, b := range tc.queries {
+		sb.WriteString(b + "\n")
+	}
+	return sb.String()
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "832E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func randString(alphabet string, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = alphabet[rand.Intn(len(alphabet))]
+	}
+	return string(b)
+}
+
+func genTests() []Test {
+	rand.Seed(time.Now().UnixNano())
+	tests := make([]Test, 0, 100)
+	letters := "abcde"
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(3) + 1
+		m := rand.Intn(4) + 1
+		base := make([]string, n)
+		for j := 0; j < n; j++ {
+			base[j] = randString(letters, m)
+		}
+		q := rand.Intn(4) + 1
+		queries := make([]string, q)
+		for j := 0; j < q; j++ {
+			queries[j] = randString(letters, m)
+		}
+		tests = append(tests, Test{n: n, m: m, base: base, q: q, queries: queries})
+	}
+	// edge
+	tests = append(tests, Test{n: 1, m: 1, base: []string{"a"}, q: 1, queries: []string{"a"}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E

Each verifier builds a reference solution from the existing Go files, generates 100 random tests, runs the candidate binary and compares outputs. Usage instructions are printed when run with no arguments.

## Testing
- `go build 0-999/800-899/830-839/832/verifierA.go`
- `go build 0-999/800-899/830-839/832/verifierB.go`
- `go build 0-999/800-899/830-839/832/verifierC.go`
- `go build 0-999/800-899/830-839/832/verifierD.go`
- `go build 0-999/800-899/830-839/832/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883c86f29788324a155275e644612af