### PR TITLE
Add verifiers for contest 834

### DIFF
--- a/0-999/800-899/830-839/834/verifierA.go
+++ b/0-999/800-899/830-839/834/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expect(start, end byte, n int64) string {
+	pos := map[byte]int{'^': 0, '>': 1, 'v': 2, '<': 3}
+	s := pos[start]
+	e := pos[end]
+	step := int(n % 4)
+	cw := (s + step) % 4
+	ccw := (s - step) % 4
+	if ccw < 0 {
+		ccw += 4
+	}
+	if cw == e && ccw == e {
+		return "undefined"
+	}
+	if cw == e {
+		return "cw"
+	}
+	if ccw == e {
+		return "ccw"
+	}
+	return "undefined"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	letters := []byte{'^', '>', 'v', '<'}
+	start := letters[rng.Intn(4)]
+	end := letters[rng.Intn(4)]
+	n := rng.Int63n(1_000_000_000 + 1)
+	input := fmt.Sprintf("%c %c\n%d\n", start, end, n)
+	exp := expect(start, end, n)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/834/verifierB.go
+++ b/0-999/800-899/830-839/834/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expect(n, k int, s string) string {
+	first := make([]int, 26)
+	last := make([]int, 26)
+	for i := 0; i < 26; i++ {
+		first[i] = -1
+		last[i] = -1
+	}
+	for i, ch := range s {
+		idx := int(ch - 'A')
+		if first[idx] == -1 {
+			first[idx] = i
+		}
+		last[idx] = i
+	}
+	open := make([]bool, 26)
+	openCount := 0
+	for i, ch := range s {
+		idx := int(ch - 'A')
+		if i == first[idx] {
+			if !open[idx] {
+				open[idx] = true
+				openCount++
+			}
+		}
+		if openCount > k {
+			return "YES"
+		}
+		if i == last[idx] {
+			if open[idx] {
+				open[idx] = false
+				openCount--
+			}
+		}
+	}
+	return "NO"
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	if rng.Float64() < 0.2 {
+		n = rng.Intn(100) + 1
+	}
+	k := rng.Intn(26) + 1
+	sb := make([]byte, n)
+	for i := 0; i < n; i++ {
+		sb[i] = byte('A' + rng.Intn(26))
+	}
+	s := string(sb)
+	input := fmt.Sprintf("%d %d\n%s\n", n, k, s)
+	exp := expect(n, k, s)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement verifierA.go for problem A with 100 randomized test cases
- implement verifierB.go for problem B with 100 randomized test cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`

------
https://chatgpt.com/codex/tasks/task_e_6883c986c1dc8324a4ca6510d981572f