### PR TITLE
Add Go solution for 1631B

### DIFF
--- a/1000-1999/1600-1699/1630-1639/1631/1631B.go
+++ b/1000-1999/1600-1699/1630-1639/1631/1631B.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		ops := 0
+		len := 1
+		for len < n {
+			if a[n-len-1] == a[n-1] {
+				len++
+			} else {
+				ops++
+				len *= 2
+			}
+		}
+		fmt.Fprintln(out, ops)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for Codeforces problem 1631B "Fun with Even Subarrays"

## Testing
- `go build 1000-1999/1600-1699/1630-1639/1631/1631B.go`


------
https://chatgpt.com/codex/tasks/task_e_6883c940d09c83249b39f6dfffcdf1af