### PR TITLE
Add contest 833 solution verifiers

### DIFF
--- a/0-999/800-899/830-839/833/verifierA.go
+++ b/0-999/800-899/830-839/833/verifierA.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func cbrtInt(x int64) int64 {
+	r := int64(math.Round(math.Cbrt(float64(x))))
+	for (r+1)*(r+1)*(r+1) <= x {
+		r++
+	}
+	for r*r*r > x {
+		r--
+	}
+	return r
+}
+
+func checkPair(a, b int64) string {
+	prod := a * b
+	c := cbrtInt(prod)
+	if c*c*c != prod || a%c != 0 || b%c != 0 {
+		return "No"
+	}
+	x := a / c
+	y := b / c
+	if x*y == c {
+		return "Yes"
+	}
+	return "No"
+}
+
+func solveCase(n int, pairs [][2]int64) string {
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(checkPair(pairs[i][0], pairs[i][1]))
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	pairs := make([][2]int64, n)
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		var a, b int64
+		if rng.Intn(2) == 0 { // generate valid case
+			x := int64(rng.Intn(10) + 1)
+			y := int64(rng.Intn(10) + 1)
+			c := x * y
+			a = x * c
+			b = y * c
+		} else {
+			a = int64(rng.Intn(1000000) + 1)
+			b = int64(rng.Intn(1000000) + 1)
+		}
+		pairs[i][0] = a
+		pairs[i][1] = b
+		input.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	expected := solveCase(n, pairs)
+	if !strings.HasSuffix(expected, "\n") {
+		expected += "\n"
+	}
+	return input.String(), expected
+}
+
+func runCase(bin, in, exp string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	if outStr != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %q got %q", exp, outStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/833/verifierB.go
+++ b/0-999/800-899/830-839/833/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref, err := os.CreateTemp("", "refB-*")
+	if err != nil {
+		return "", err
+	}
+	ref.Close()
+	path := ref.Name()
+	cmd := exec.Command("go", "build", "-o", path, "833B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(min(n, 5)) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(n)+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := generateCase(rng)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\ngot:\n%s\ninput:\n%s", t+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/833/verifierC.go
+++ b/0-999/800-899/830-839/833/verifierC.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	tmp, err := os.CreateTemp("", "refC-*")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	path := tmp.Name()
+	cmd := exec.Command("go", "build", "-o", path, "833C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	L := rng.Int63n(1_000_000) + 1
+	R := L + rng.Int63n(1000)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", L, R))
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\ngot:\n%s\ninput:%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/833/verifierD.go
+++ b/0-999/800-899/830-839/833/verifierD.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	u, v int
+	w    int64
+	c    int
+}
+
+func buildRef() (string, error) {
+	tmp, err := os.CreateTemp("", "refD-*")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	path := tmp.Name()
+	cmd := exec.Command("go", "build", "-o", path, "833D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2 // 2..6 nodes
+	edges := make([]edge, n-1)
+	for i := 1; i < n; i++ {
+		edges[i-1].u = i + 1
+		edges[i-1].v = rng.Intn(i) + 1
+		edges[i-1].w = int64(rng.Intn(10) + 1)
+		edges[i-1].c = rng.Intn(2)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", e.u, e.v, e.w, e.c))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\ngot:\n%s\ninput:%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/833/verifierE.go
+++ b/0-999/800-899/830-839/833/verifierE.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type cloud struct {
+	l, r int64
+	c    int64
+}
+
+func earliest(k int64, clouds []cloud, C int64) int64 {
+	n := len(clouds)
+	best := int64(1 << 62)
+	for mask := 0; mask < (1 << n); mask++ {
+		if bits.OnesCount(uint(mask)) > 2 {
+			continue
+		}
+		var cost int64
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) != 0 {
+				cost += clouds[i].c
+			}
+		}
+		if cost > C {
+			continue
+		}
+		var segs [][2]int64
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) == 0 {
+				segs = append(segs, [2]int64{clouds[i].l, clouds[i].r})
+			}
+		}
+		sort.Slice(segs, func(i, j int) bool { return segs[i][0] < segs[j][0] })
+		merged := make([][2]int64, 0, len(segs))
+		for _, s := range segs {
+			if len(merged) == 0 || s[0] > merged[len(merged)-1][1] {
+				merged = append(merged, s)
+			} else if s[1] > merged[len(merged)-1][1] {
+				merged[len(merged)-1][1] = s[1]
+			}
+		}
+		t := computeEarliest(k, merged)
+		if t < best {
+			best = t
+		}
+	}
+	return best
+}
+
+func computeEarliest(k int64, segs [][2]int64) int64 {
+	var cum int64
+	prev := int64(0)
+	for _, s := range segs {
+		if prev < s[0] {
+			sunny := s[0] - prev
+			if cum+sunny >= k {
+				return prev + (k - cum)
+			}
+			cum += sunny
+		}
+		if s[1] > prev {
+			prev = s[1]
+		}
+	}
+	return prev + (k - cum)
+}
+
+func solveCase(n int, C int64, clouds []cloud, ks []int64) string {
+	var sb strings.Builder
+	for i, k := range ks {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fmt.Sprintf("%d", earliest(k, clouds, C)))
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4)
+	C := int64(rng.Intn(20))
+	clouds := make([]cloud, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, C))
+	for i := 0; i < n; i++ {
+		l := int64(rng.Intn(10))
+		r := l + int64(rng.Intn(10)+1)
+		c := int64(rng.Intn(10))
+		clouds[i] = cloud{l, r, c}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", l, r, c))
+	}
+	m := rng.Intn(3) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	ks := make([]int64, m)
+	for i := 0; i < m; i++ {
+		ks[i] = int64(rng.Intn(20) + 1)
+		sb.WriteString(fmt.Sprintf("%d\n", ks[i]))
+	}
+	expected := solveCase(n, C, clouds, ks)
+	if !strings.HasSuffix(expected, "\n") {
+		expected += "\n"
+	}
+	return sb.String(), expected
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := generateCase(rng)
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\ngot:\n%s\ninput:%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go` generating random tests for problem A
- implement `verifierB.go`/`verifierC.go`/`verifierD.go` using compiled reference solutions
- implement `verifierE.go` with a small brute-force solver
- each verifier runs 100 test cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883c8faaca88324af2a24324bccfac8