### PR TITLE
Add Go verifiers for contest 837

### DIFF
--- a/0-999/800-899/830-839/837/verifierA.go
+++ b/0-999/800-899/830-839/837/verifierA.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func genCase(rng *rand.Rand) (string, string) {
+	numWords := rng.Intn(5) + 1
+	words := make([]string, numWords)
+	maxCap := 0
+	for i := 0; i < numWords; i++ {
+		l := rng.Intn(10) + 1
+		b := make([]byte, l)
+		caps := 0
+		for j := 0; j < l; j++ {
+			if rng.Intn(2) == 0 {
+				b[j] = byte('a' + rng.Intn(26))
+			} else {
+				b[j] = byte('A' + rng.Intn(26))
+				caps++
+			}
+		}
+		if caps > maxCap {
+			maxCap = caps
+		}
+		words[i] = string(b)
+	}
+	text := strings.Join(words, " ")
+	n := len(text)
+	input := fmt.Sprintf("%d\n%s\n", n, text)
+	expected := fmt.Sprintf("%d", maxCap)
+	return input, expected
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/837/verifierB.go
+++ b/0-999/800-899/830-839/837/verifierB.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func checkHorizontal(n, m int, g [][]byte) bool {
+	if n%3 != 0 {
+		return false
+	}
+	h := n / 3
+	colors := make(map[byte]bool)
+	for k := 0; k < 3; k++ {
+		col := g[k*h][0]
+		for i := k * h; i < (k+1)*h; i++ {
+			for j := 0; j < m; j++ {
+				if g[i][j] != col {
+					return false
+				}
+			}
+		}
+		if colors[col] {
+			return false
+		}
+		colors[col] = true
+	}
+	return len(colors) == 3
+}
+
+func checkVertical(n, m int, g [][]byte) bool {
+	if m%3 != 0 {
+		return false
+	}
+	w := m / 3
+	colors := make(map[byte]bool)
+	for k := 0; k < 3; k++ {
+		col := g[0][k*w]
+		for j := k * w; j < (k+1)*w; j++ {
+			for i := 0; i < n; i++ {
+				if g[i][j] != col {
+					return false
+				}
+			}
+		}
+		if colors[col] {
+			return false
+		}
+		colors[col] = true
+	}
+	return len(colors) == 3
+}
+
+func expected(n, m int, g [][]byte) string {
+	if checkHorizontal(n, m, g) || checkVertical(n, m, g) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(6) + 1
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			switch rng.Intn(3) {
+			case 0:
+				row[j] = 'R'
+			case 1:
+				row[j] = 'G'
+			default:
+				row[j] = 'B'
+			}
+		}
+		grid[i] = row
+	}
+	// Occasionally generate a correct flag
+	if rng.Intn(2) == 0 {
+		if rng.Intn(2) == 0 {
+			// horizontal stripes
+			n = 3
+			m = rng.Intn(6) + 1
+			grid = make([][]byte, n)
+			colors := []byte{'R', 'G', 'B'}
+			rng.Shuffle(3, func(i, j int) { colors[i], colors[j] = colors[j], colors[i] })
+			for i := 0; i < 3; i++ {
+				row := make([]byte, m)
+				for j := 0; j < m; j++ {
+					row[j] = colors[i]
+				}
+				grid[i] = row
+			}
+		} else {
+			// vertical stripes
+			m = 3
+			n = rng.Intn(6) + 1
+			grid = make([][]byte, n)
+			colors := []byte{'R', 'G', 'B'}
+			rng.Shuffle(3, func(i, j int) { colors[i], colors[j] = colors[j], colors[i] })
+			for i := 0; i < n; i++ {
+				row := make([]byte, m)
+				for j := 0; j < 3; j++ {
+					row[j] = colors[j]
+				}
+				grid[i] = row
+			}
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		sb.WriteByte('\n')
+	}
+	return sb.String(), expected(n, m, grid)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/837/verifierC.go
+++ b/0-999/800-899/830-839/837/verifierC.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func expected(n, a, b int, x, y []int) string {
+	best := 0
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			for r1 := 0; r1 < 2; r1++ {
+				w1, h1 := x[i], y[i]
+				if r1 == 1 {
+					w1, h1 = y[i], x[i]
+				}
+				for r2 := 0; r2 < 2; r2++ {
+					w2, h2 := x[j], y[j]
+					if r2 == 1 {
+						w2, h2 = y[j], x[j]
+					}
+					if w1+w2 <= a && max(h1, h2) <= b {
+						area := w1*h1 + w2*h2
+						if area > best {
+							best = area
+						}
+					}
+					if max(w1, w2) <= a && h1+h2 <= b {
+						area := w1*h1 + w2*h2
+						if area > best {
+							best = area
+						}
+					}
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("%d", best)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 2
+	a := rng.Intn(10) + 1
+	b := rng.Intn(10) + 1
+	x := make([]int, n)
+	y := make([]int, n)
+	for i := 0; i < n; i++ {
+		x[i] = rng.Intn(10) + 1
+		y[i] = rng.Intn(10) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, a, b))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", x[i], y[i]))
+	}
+	return sb.String(), expected(n, a, b, x, y)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/837/verifierD.go
+++ b/0-999/800-899/830-839/837/verifierD.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, k int, arr []int64) string {
+	two := make([]int, n)
+	five := make([]int, n)
+	maxFive := 0
+	for i := 0; i < n; i++ {
+		x := arr[i]
+		c2, c5 := 0, 0
+		for x%2 == 0 {
+			c2++
+			x /= 2
+		}
+		for x%5 == 0 {
+			c5++
+			x /= 5
+		}
+		two[i] = c2
+		five[i] = c5
+		maxFive += c5
+	}
+	dp := make([][]int, k+1)
+	for i := 0; i <= k; i++ {
+		dp[i] = make([]int, maxFive+1)
+		for j := range dp[i] {
+			dp[i][j] = -1
+		}
+	}
+	dp[0][0] = 0
+	for idx := 0; idx < n; idx++ {
+		t2, f5 := two[idx], five[idx]
+		for j := k; j >= 1; j-- {
+			for f := maxFive; f >= f5; f-- {
+				if dp[j-1][f-f5] >= 0 {
+					val := dp[j-1][f-f5] + t2
+					if val > dp[j][f] {
+						dp[j][f] = val
+					}
+				}
+			}
+		}
+	}
+	ans := 0
+	for f := 0; f <= maxFive; f++ {
+		val := dp[k][f]
+		if val < 0 {
+			continue
+		}
+		if val < f {
+			if val > ans {
+				ans = val
+			}
+		} else {
+			if f > ans {
+				ans = f
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(n) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Int63n(1000000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", arr[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(n, k, arr)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/837/verifierE.go
+++ b/0-999/800-899/830-839/837/verifierE.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func primeFactors(n int64) []int64 {
+	factors := []int64{}
+	for i := int64(2); i*i <= n; i++ {
+		if n%i == 0 {
+			factors = append(factors, i)
+			for n%i == 0 {
+				n /= i
+			}
+		}
+	}
+	if n > 1 {
+		factors = append(factors, n)
+	}
+	return factors
+}
+
+func expected(x, y int64) string {
+	primes := primeFactors(x)
+	var ans int64
+	for y > 0 {
+		g := gcd(x, y)
+		x1 := x / g
+		if x1 == 1 {
+			ans += y / g
+			break
+		}
+		yg := y / g
+		rmin := yg
+		for _, p := range primes {
+			if x1%p == 0 {
+				r := yg % p
+				if r < rmin {
+					rmin = r
+				}
+			}
+		}
+		ans += rmin
+		y -= rmin * g
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	x := rng.Int63n(100000) + 1
+	y := rng.Int63n(100000) + 1
+	input := fmt.Sprintf("%d %d\n", x, y)
+	return input, expected(x, y)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/837/verifierF.go
+++ b/0-999/800-899/830-839/837/verifierF.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func mulDiv(a, b, div uint64) uint64 {
+	hi, lo := bits.Mul64(a, b)
+	q, _ := bits.Div64(hi, lo, div)
+	return q
+}
+
+func expected(n int, k uint64, arr []uint64) string {
+	rev := make([]uint64, n)
+	for i := 0; i < n; i++ {
+		rev[n-1-i] = arr[i]
+	}
+	limit := k
+	has := func(t uint64) bool {
+		var sum uint64
+		comb := uint64(1)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				if t == 0 {
+					break
+				}
+				comb = mulDiv(comb, t+uint64(j-1), uint64(j))
+				if comb > limit {
+					comb = limit + 1
+				}
+			}
+			if rev[j] != 0 {
+				if comb > limit/rev[j] {
+					return true
+				}
+				sum += comb * rev[j]
+				if sum >= limit {
+					return true
+				}
+			}
+			if comb == 0 {
+				break
+			}
+		}
+		return sum >= limit
+	}
+	lo, hi := uint64(0), k
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if has(mid) {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return fmt.Sprintf("%d", lo)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	k := uint64(rng.Intn(1000) + 1)
+	arr := make([]uint64, n)
+	for i := range arr {
+		arr[i] = uint64(rng.Intn(1000))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expected(n, k, arr)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/837/verifierG.go
+++ b/0-999/800-899/830-839/837/verifierG.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Func struct {
+	x1, x2       int
+	y1, a, b, y2 int64
+}
+
+func eval(f Func, x int64) int64 {
+	if x <= int64(f.x1) {
+		return f.y1
+	}
+	if x <= int64(f.x2) {
+		return f.a*x + f.b
+	}
+	return f.y2
+}
+
+func expected(n int, funcs []Func, queries [][3]int64) string {
+	var last int64
+	const mod int64 = 1000000000
+	var sb strings.Builder
+	for _, q := range queries {
+		l := int(q[0])
+		r := int(q[1])
+		x := (q[2] + last) % mod
+		sum := int64(0)
+		for j := l - 1; j < r; j++ {
+			sum += eval(funcs[j], x)
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", sum))
+		last = sum
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	funcs := make([]Func, n)
+	for i := 0; i < n; i++ {
+		x1 := rng.Intn(10)
+		x2 := x1 + rng.Intn(5) + 1
+		y1 := int64(rng.Intn(20))
+		a := int64(rng.Intn(5))
+		b := int64(rng.Intn(20))
+		y2 := int64(rng.Intn(20))
+		funcs[i] = Func{x1, x2, y1, a, b, y2}
+	}
+	m := rng.Intn(5) + 1
+	queries := make([][3]int64, m)
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		x := int64(rng.Intn(50))
+		queries[i] = [3]int64{int64(l), int64(r), x}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		f := funcs[i]
+		sb.WriteString(fmt.Sprintf("%d %d %d %d %d %d\n", f.x1, f.x2, f.y1, f.a, f.b, f.y2))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		q := queries[i]
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", q[0], q[1], q[2]))
+	}
+	return sb.String(), expected(n, funcs, queries)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp {
+			fmt.Fprintf(os.Stderr, "test %d failed:\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, strings.TrimSpace(got), in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go through verifierG.go for contest 837
- each verifier runs 100 randomized tests against a provided binary

## Testing
- `go build 0-999/800-899/830-839/837/verifierA.go`
- `go build 0-999/800-899/830-839/837/verifierB.go`
- `go build 0-999/800-899/830-839/837/verifierC.go`
- `go build 0-999/800-899/830-839/837/verifierD.go`
- `go build 0-999/800-899/830-839/837/verifierE.go`
- `go build 0-999/800-899/830-839/837/verifierF.go`
- `go build 0-999/800-899/830-839/837/verifierG.go`

------
https://chatgpt.com/codex/tasks/task_e_6883cb2b0a7c8324b150cc9b2c6c52ea