### PR TITLE
Add Go verifiers for CF 838

### DIFF
--- a/0-999/800-899/830-839/838/verifierA.go
+++ b/0-999/800-899/830-839/838/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "838A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2 // 2..5
+	m := rng.Intn(4) + 2 // 2..5
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/838/verifierB.go
+++ b/0-999/800-899/830-839/838/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "838B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 2; i <= n; i++ {
+		parent := rng.Intn(i-1) + 1
+		w := rng.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", parent, i, w))
+	}
+	for i := 2; i <= n; i++ {
+		w := rng.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d 1 %d\n", i, w))
+	}
+	m := 2*n - 2
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			idx := rng.Intn(m) + 1
+			w := rng.Intn(10) + 1
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", idx, w))
+		} else {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", u, v))
+		}
+	}
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/838/verifierC.go
+++ b/0-999/800-899/830-839/838/verifierC.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "838C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+var primes = []int{109, 113, 127, 131, 137, 139, 149, 157, 163, 173}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(5) + 1
+	p := primes[rng.Intn(len(primes))]
+	return fmt.Sprintf("%d %d %d\n", n, k, p)
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/838/verifierD.go
+++ b/0-999/800-899/830-839/838/verifierD.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "838D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(n) + 1
+	return fmt.Sprintf("%d %d\n", n, m)
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/838/verifierE.go
+++ b/0-999/800-899/830-839/838/verifierE.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "838E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 3                // 3..6
+	radius := float64(rng.Intn(20) + 5) // 5..24
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := n - 1; i >= 0; i-- { // clockwise order
+		angle := 2 * math.Pi * float64(i) / float64(n)
+		x := int(math.Round(radius * math.Cos(angle)))
+		y := int(math.Round(radius * math.Sin(angle)))
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/838/verifierF.go
+++ b/0-999/800-899/830-839/838/verifierF.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "838F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	X := rng.Intn(1000001)
+	weights := make([]int, n+1)
+	total := 0
+	for i := 0; i <= n; i++ {
+		weights[i] = rng.Intn(100) + 1
+		total += weights[i]
+	}
+	p := make([]int, n+1)
+	sum := 0
+	for i := 0; i < n; i++ {
+		p[i] = weights[i] * 1000000 / total
+		sum += p[i]
+	}
+	p[n] = 1000000 - sum
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, X))
+	for i := 0; i <= n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", p[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(exe, ref, input string) error {
+	cmdRef := exec.Command(ref)
+	cmdRef.Stdin = strings.NewReader(input)
+	var refOut bytes.Buffer
+	cmdRef.Stdout = &refOut
+	cmdRef.Stderr = &refOut
+	if err := cmdRef.Run(); err != nil {
+		return fmt.Errorf("reference runtime error: %v\n%s", err, refOut.String())
+	}
+	expected := strings.TrimSpace(refOut.String())
+
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected\n%s\ngot\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(exe, ref, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- added verifierA.go-F.go for contest 838
- each verifier compiles the provided reference solution and tests 100 random cases
- allows running e.g. `go run verifierA.go /path/to/binary` to check correctness

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883cbb791908324baf39618b94f2a31