### PR TITLE
Add verifiers for Codeforces contest 839

### DIFF
--- a/0-999/800-899/830-839/839/verifierA.go
+++ b/0-999/800-899/830-839/839/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(n, k int, arr []int) int {
+	candies := 0
+	total := 0
+	for i := 0; i < n; i++ {
+		candies += arr[i]
+		give := 8
+		if candies < 8 {
+			give = candies
+		}
+		total += give
+		candies -= give
+		if total >= k {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+func genCase(rng *rand.Rand) (int, int, []int) {
+	n := rng.Intn(100) + 1
+	k := rng.Intn(10000) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(100) + 1
+	}
+	return n, k, arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, arr := genCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprint(&sb, v)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want := solveCase(n, k, arr)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Printf("case %d: non-integer output %q\n", i+1, out)
+			return
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %d\ngot: %d\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/839/verifierB.go
+++ b/0-999/800-899/830-839/839/verifierB.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(n int, groups []int) bool {
+	a := append([]int(nil), groups...)
+	sort.Slice(a, func(i, j int) bool { return a[i] > a[j] })
+	count4 := n
+	count2 := 2 * n
+	for _, ai := range a {
+		bestCost := int(1e9)
+		bestX, bestY := 0, 0
+		maxX := ai/4 + 1
+		if maxX > count4 {
+			maxX = count4
+		}
+		for x := 0; x <= maxX; x++ {
+			rem := ai - 4*x
+			y := 0
+			if rem > 0 {
+				y = (rem + 1) / 2
+			}
+			if y > count2 {
+				continue
+			}
+			cost := x + y
+			if cost < bestCost || (cost == bestCost && x > bestX) {
+				bestCost = cost
+				bestX = x
+				bestY = y
+			}
+		}
+		if bestCost > count4+count2 {
+			return false
+		}
+		count4 -= bestX
+		count2 -= bestY
+	}
+	return true
+}
+
+func genCase(rng *rand.Rand) (int, []int) {
+	n := rng.Intn(50) + 1
+	k := rng.Intn(10) + 1
+	groups := make([]int, k)
+	remaining := 8 * n
+	for i := 0; i < k; i++ {
+		maxVal := remaining - (k - i - 1)
+		if maxVal > 10000 {
+			maxVal = 10000
+		}
+		if maxVal < 1 {
+			maxVal = 1
+		}
+		groups[i] = rng.Intn(maxVal) + 1
+		remaining -= groups[i]
+		if remaining < 0 {
+			remaining = 0
+		}
+	}
+	return n, groups
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, groups := genCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, len(groups))
+		for j, v := range groups {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprint(&sb, v)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want := solveCase(n, groups)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		got := strings.ToUpper(strings.TrimSpace(out))
+		expect := "NO"
+		if want {
+			expect = "YES"
+		}
+		if got != expect {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, expect, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/839/verifierC.go
+++ b/0-999/800-899/830-839/839/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expected(u, p int, adj [][]int) float64 {
+	sum := 0.0
+	cnt := 0
+	for _, v := range adj[u] {
+		if v == p {
+			continue
+		}
+		sum += expected(v, u, adj) + 1
+		cnt++
+	}
+	if cnt == 0 {
+		return 0
+	}
+	return sum / float64(cnt)
+}
+
+func genCase(rng *rand.Rand) (int, [][2]int) {
+	n := rng.Intn(20) + 1
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	return n, edges
+}
+
+func solveCase(n int, edges [][2]int) float64 {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	return expected(1, 0, adj)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, edges := genCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for _, e := range edges {
+			fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+		}
+		input := sb.String()
+		want := solveCase(n, edges)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		got, err := strconv.ParseFloat(strings.TrimSpace(out), 64)
+		if err != nil {
+			fmt.Printf("case %d: bad float output %q\n", i+1, out)
+			return
+		}
+		if diff := got - want; diff < -1e-6 || diff > 1e-6 {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %.6f\ngot: %s\n", i+1, input, want, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/839/verifierD.go
+++ b/0-999/800-899/830-839/839/verifierD.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveCase(arr []int) int64 {
+	n := len(arr)
+	var ans int64
+	for mask := 1; mask < (1 << n); mask++ {
+		g := 0
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) != 0 {
+				if g == 0 {
+					g = arr[i]
+				} else {
+					g = gcd(g, arr[i])
+				}
+			}
+		}
+		if g > 1 {
+			k := bits.OnesCount(uint(mask))
+			ans += int64(k) * int64(g)
+			ans %= mod
+		}
+	}
+	return ans % mod
+}
+
+func genCase(rng *rand.Rand) []int {
+	n := rng.Intn(8) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(20) + 1
+	}
+	return arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := genCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", len(arr))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprint(&sb, v)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want := solveCase(arr)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Printf("case %d: bad integer output %q\n", i+1, out)
+			return
+		}
+		if got%mod != want%mod {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %d\ngot: %d\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/830-839/839/verifierE.go
+++ b/0-999/800-899/830-839/839/verifierE.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func maxClique(n int, g [][]bool) int {
+	best := 1
+	for mask := 1; mask < (1 << n); mask++ {
+		ok := true
+		cnt := bits.OnesCount(uint(mask))
+		if cnt <= best {
+			continue
+		}
+		for i := 0; i < n && ok; i++ {
+			if mask&(1<<i) == 0 {
+				continue
+			}
+			for j := i + 1; j < n; j++ {
+				if mask&(1<<j) != 0 && !g[i][j] {
+					ok = false
+					break
+				}
+			}
+		}
+		if ok && cnt > best {
+			best = cnt
+		}
+	}
+	return best
+}
+
+func solveCase(n, k int, g [][]bool) float64 {
+	m := maxClique(n, g)
+	if m == 0 {
+		return 0
+	}
+	return float64(k*k) * float64(m-1) / float64(2*m)
+}
+
+func genCase(rng *rand.Rand) (int, int, [][]bool) {
+	n := rng.Intn(6) + 1
+	k := rng.Intn(100) + 1
+	g := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		g[i] = make([]bool, n)
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if rng.Intn(2) == 1 {
+				g[i][j] = true
+				g[j][i] = true
+			}
+		}
+	}
+	return n, k, g
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, g := genCase(rng)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for x := 0; x < n; x++ {
+			for y := 0; y < n; y++ {
+				if y > 0 {
+					sb.WriteByte(' ')
+				}
+				if g[x][y] {
+					sb.WriteByte('1')
+				} else {
+					sb.WriteByte('0')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		want := solveCase(n, k, g)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\ninput:\n%s", i+1, err, input)
+			return
+		}
+		got, err := strconv.ParseFloat(strings.TrimSpace(out), 64)
+		if err != nil {
+			fmt.Printf("case %d: bad float output %q\n", i+1, out)
+			return
+		}
+		diff := got - want
+		if diff < -1e-6 || diff > 1e-6 {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %.6f\ngot: %s\n", i+1, input, want, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verification programs for problems A–E of contest 839
- each verifier generates 100 random tests and checks any binary

## Testing
- `go vet 0-999/800-899/830-839/839/verifierA.go`
- `go vet 0-999/800-899/830-839/839/verifierB.go`
- `go vet 0-999/800-899/830-839/839/verifierC.go`
- `go vet 0-999/800-899/830-839/839/verifierD.go`
- `go vet 0-999/800-899/830-839/839/verifierE.go`
- `go build 0-999/800-899/830-839/839/verifierA.go`
- `go build 0-999/800-899/830-839/839/verifierB.go`
- `go build 0-999/800-899/830-839/839/verifierC.go`
- `go build 0-999/800-899/830-839/839/verifierD.go`
- `go build 0-999/800-899/830-839/839/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883cc4334ec832486af7710c8adbd72