### PR TITLE
Add verifiers for Codeforces contest 840

### DIFF
--- a/0-999/800-899/840-849/840/verifierA.go
+++ b/0-999/800-899/840-849/840/verifierA.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expected(a, b []int) []int {
+	m := len(a)
+	sort.Ints(a)
+	type pair struct{ val, idx int }
+	arr := make([]pair, m)
+	for i, v := range b {
+		arr[i] = pair{v, i}
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i].val < arr[j].val })
+	res := make([]int, m)
+	for i := 0; i < m; i++ {
+		res[arr[i].idx] = a[m-1-i]
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, []int) {
+	m := rng.Intn(5) + 1
+	a := make([]int, m)
+	b := make([]int, m)
+	maxB := 0
+	for i := 0; i < m; i++ {
+		a[i] = rng.Intn(100) + 1
+	}
+	for i := 0; i < m; i++ {
+		b[i] = rng.Intn(100) + 1
+		if b[i] > maxB {
+			maxB = b[i]
+		}
+	}
+	for i := 0; i < m; i++ {
+		if a[i] < maxB {
+			a[i] = maxB + rng.Intn(5)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(m))
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(b[i]))
+	}
+	sb.WriteByte('\n')
+	exp := expected(append([]int(nil), a...), append([]int(nil), b...))
+	return sb.String(), exp
+}
+
+func parseOutput(out string, m int) ([]int, error) {
+	fields := strings.Fields(out)
+	if len(fields) != m {
+		return nil, fmt.Errorf("expected %d numbers, got %d", m, len(fields))
+	}
+	res := make([]int, m)
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			fmt.Fprintf(os.Stderr, "input:\n%s", input)
+			os.Exit(1)
+		}
+		got, err := parseOutput(out, len(exp))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d invalid output: %v\n", i+1, err)
+			fmt.Fprintf(os.Stderr, "output: %s\n", out)
+			os.Exit(1)
+		}
+		for j := range exp {
+			if got[j] != exp[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %v got %v\ninput:\n%s", i+1, exp, got, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/840-849/840/verifierB.go
+++ b/0-999/800-899/840-849/840/verifierB.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Edge struct{ u, v int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solutionExists(d []int) bool {
+	sum := 0
+	hasNeg := false
+	for _, v := range d {
+		if v == -1 {
+			hasNeg = true
+		} else {
+			sum += v
+		}
+	}
+	if !hasNeg && sum%2 == 1 {
+		return false
+	}
+	return true
+}
+
+func checkSolution(n, m int, d []int, edges []Edge, out string, exists bool) error {
+	out = strings.TrimSpace(out)
+	lines := strings.Split(out, "\n")
+	if len(lines) == 0 || lines[0] == "" {
+		return fmt.Errorf("empty output")
+	}
+	if lines[0] == "-1" {
+		if exists {
+			return fmt.Errorf("declared no solution but one exists")
+		}
+		if len(lines) > 1 && strings.TrimSpace(strings.Join(lines[1:], "")) != "" {
+			return fmt.Errorf("extraneous output after -1")
+		}
+		return nil
+	}
+	k, err := strconv.Atoi(strings.Fields(lines[0])[0])
+	if err != nil {
+		return fmt.Errorf("invalid first line")
+	}
+	if k < 0 || k > m {
+		return fmt.Errorf("invalid k")
+	}
+	if len(lines)-1 < k {
+		return fmt.Errorf("not enough edge indices")
+	}
+	used := make(map[int]bool)
+	deg := make([]int, n+1)
+	for i := 0; i < k; i++ {
+		idxStr := strings.TrimSpace(lines[i+1])
+		idx, err := strconv.Atoi(idxStr)
+		if err != nil {
+			return fmt.Errorf("invalid edge index")
+		}
+		if idx < 1 || idx > m {
+			return fmt.Errorf("edge index out of range")
+		}
+		if used[idx] {
+			return fmt.Errorf("duplicate edge index")
+		}
+		used[idx] = true
+		e := edges[idx-1]
+		deg[e.u]++
+		deg[e.v]++
+	}
+	for i := 1; i <= n; i++ {
+		if d[i] == -1 {
+			continue
+		}
+		if deg[i]%2 != d[i] {
+			return fmt.Errorf("vertex %d parity mismatch", i)
+		}
+	}
+	if !exists {
+		return fmt.Errorf("solution claimed but none should exist")
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (string, int, int, []int, []Edge, bool) {
+	n := rng.Intn(5) + 2
+	m := n - 1 + rng.Intn(3) // up to n+1 edges
+	d := make([]int, n+1)
+	hasNeg := false
+	for i := 1; i <= n; i++ {
+		t := rng.Intn(3) - 1 // -1,0,1
+		d[i] = t
+		if t == -1 {
+			hasNeg = true
+		}
+	}
+	edges := make([]Edge, 0, m)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, Edge{p, i})
+	}
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		edges = append(edges, Edge{u, v})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(d[i]))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	exists := solutionExists(d[1:]) || hasNeg
+	return sb.String(), n, m, d, edges, exists
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, n, m, d, edges, exists := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := checkSolution(n, m, d, edges, out, exists); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/840-849/840/verifierC.go
+++ b/0-999/800-899/840-849/840/verifierC.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MOD int = 1_000_000_007
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func squareFree(x int64) int64 {
+	var res int64 = 1
+	for p := int64(2); p*p <= x; p++ {
+		cnt := 0
+		for x%p == 0 {
+			x /= p
+			cnt++
+		}
+		if cnt%2 == 1 {
+			res *= p
+		}
+	}
+	if x > 1 {
+		res *= x
+	}
+	return res
+}
+
+func expected(a []int64) int {
+	n := len(a)
+	sf := make([]int64, n)
+	for i := range a {
+		sf[i] = squareFree(a[i])
+	}
+	adj := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		adj[i] = make([]bool, n)
+		for j := 0; j < n; j++ {
+			if i != j && sf[i] != sf[j] {
+				adj[i][j] = true
+			}
+		}
+	}
+	full := 1 << n
+	dp := make([][]int, full)
+	for i := range dp {
+		dp[i] = make([]int, n)
+	}
+	for i := 0; i < n; i++ {
+		dp[1<<i][i] = 1
+	}
+	for mask := 0; mask < full; mask++ {
+		for last := 0; last < n; last++ {
+			val := dp[mask][last]
+			if val == 0 {
+				continue
+			}
+			for next := 0; next < n; next++ {
+				if mask&(1<<next) == 0 && adj[last][next] {
+					nm := mask | (1 << next)
+					dp[nm][next] = (dp[nm][next] + val) % MOD
+				}
+			}
+		}
+	}
+	ans := 0
+	finalMask := full - 1
+	for i := 0; i < n; i++ {
+		ans = (ans + dp[finalMask][i]) % MOD
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(6) + 2 // up to 7-8 maybe
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Int63n(50) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(a[i], 10))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), a
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, arr := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d invalid output: %v\n", i+1, err)
+			fmt.Fprintf(os.Stderr, "output: %s\n", out)
+			os.Exit(1)
+		}
+		exp := expected(arr)
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/840-849/840/verifierD.go
+++ b/0-999/800-899/840-849/840/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expected(arr []int, queries [][]int) []int {
+	res := make([]int, len(queries))
+	for qi, q := range queries {
+		l, r, k := q[0], q[1], q[2]
+		freq := make(map[int]int)
+		for i := l - 1; i < r; i++ {
+			freq[arr[i]]++
+		}
+		threshold := (r - l + 1) / k
+		ans := -1
+		for v, c := range freq {
+			if c > threshold {
+				if ans == -1 || v < ans {
+					ans = v
+				}
+			}
+		}
+		res[qi] = ans
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, []int, [][]int) {
+	n := rng.Intn(10) + 1
+	q := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(5) + 1
+	}
+	queries := make([][]int, q)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(arr[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		k := rng.Intn(4) + 1
+		queries[i] = []int{l, r, k}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", l, r, k))
+	}
+	return sb.String(), arr, queries
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, arr, qs := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) != len(qs) {
+			fmt.Fprintf(os.Stderr, "case %d expected %d lines got %d\noutput:%s", i+1, len(qs), len(lines), out)
+			os.Exit(1)
+		}
+		exp := expected(arr, qs)
+		for j, line := range lines {
+			v, err := strconv.Atoi(strings.TrimSpace(line))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d line %d invalid int: %v\n", i+1, j+1, err)
+				os.Exit(1)
+			}
+			if v != exp[j] {
+				fmt.Fprintf(os.Stderr, "case %d query %d failed: expected %d got %d\ninput:\n%s", i+1, j+1, exp[j], v, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/840-849/840/verifierE.go
+++ b/0-999/800-899/840-849/840/verifierE.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Edge struct{ u, v int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expected(n int, a []int, edges []Edge, queries [][2]int) []int {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	parent := make([]int, n+1)
+	depth := make([]int, n+1)
+	stack := []int{1}
+	parent[1] = 0
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, to := range adj[v] {
+			if to == parent[v] {
+				continue
+			}
+			parent[to] = v
+			depth[to] = depth[v] + 1
+			stack = append(stack, to)
+		}
+	}
+	res := make([]int, len(queries))
+	for qi, q := range queries {
+		u, v := q[0], q[1]
+		ans := 0
+		dist := 0
+		cur := v
+		for cur != u {
+			val := a[cur] ^ dist
+			if val > ans {
+				ans = val
+			}
+			cur = parent[cur]
+			dist++
+		}
+		val := a[cur] ^ dist
+		if val > ans {
+			ans = val
+		}
+		res[qi] = ans
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, int, []int, []Edge, [][2]int) {
+	n := rng.Intn(8) + 2
+	q := rng.Intn(10) + 1
+	a := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = rng.Intn(20)
+	}
+	edges := make([]Edge, 0, n-1)
+	parent := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		parent[i] = p
+		edges = append(edges, Edge{p, i})
+	}
+	queries := make([][2]int, q)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(a[i]))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	for i := 0; i < q; i++ {
+		v := rng.Intn(n) + 1
+		// pick ancestor
+		cur := v
+		path := []int{cur}
+		for cur != 1 {
+			cur = parent[cur]
+			path = append(path, cur)
+		}
+		u := path[rng.Intn(len(path))]
+		queries[i] = [2]int{u, v}
+		sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+	}
+	return sb.String(), n, a[1:], edges, queries
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, n, a, edges, qs := genCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) != len(qs) {
+			fmt.Fprintf(os.Stderr, "case %d expected %d lines got %d\n", i+1, len(qs), len(lines))
+			os.Exit(1)
+		}
+		exp := expected(n, a, edges, qs)
+		for j, line := range lines {
+			v, err := strconv.Atoi(strings.TrimSpace(line))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d invalid int on line %d\n", i+1, j+1)
+				os.Exit(1)
+			}
+			if v != exp[j] {
+				fmt.Fprintf(os.Stderr, "case %d query %d failed: expected %d got %d\ninput:\n%s", i+1, j+1, exp[j], v, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go solution verifiers for contest 840 (problems A–E)
- each verifier generates 100 random tests and validates the candidate program

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883cccf4760832490baa72a9d9c77a6