### PR TITLE
Add Go verifiers for contest 842

### DIFF
--- a/0-999/800-899/840-849/842/verifierA.go
+++ b/0-999/800-899/840-849/842/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestA struct {
+	l, r, x, y, k int64
+}
+
+const maxA = 10000000
+
+func generateTests() []TestA {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]TestA, 0, 120)
+	for i := 0; i < 120; i++ {
+		l := int64(r.Intn(maxA) + 1)
+		rVal := int64(r.Intn(maxA) + 1)
+		if l > rVal {
+			l, rVal = rVal, l
+		}
+		x := int64(r.Intn(maxA) + 1)
+		y := int64(r.Intn(maxA) + 1)
+		if x > y {
+			x, y = y, x
+		}
+		k := int64(r.Intn(maxA) + 1)
+		tests = append(tests, TestA{l, rVal, x, y, k})
+	}
+	return tests
+}
+
+func expected(t TestA) string {
+	low := (t.l + t.k - 1) / t.k
+	high := t.r / t.k
+	if low <= high && max64(low, t.x) <= min64(high, t.y) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d %d %d %d\n", t.l, t.r, t.x, t.y, t.k)
+		want := expected(t)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(strings.ToUpper(got))
+		if got != want {
+			fmt.Printf("Test %d failed:\nInput:%sExpected: %s\nGot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(tests))
+}

--- a/0-999/800-899/840-849/842/verifierB.go
+++ b/0-999/800-899/840-849/842/verifierB.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type piece struct {
+	x, y, r int
+}
+
+type TestB struct {
+	r, d   int
+	pieces []piece
+}
+
+func generateTests() []TestB {
+	rng := rand.New(rand.NewSource(2))
+	tests := make([]TestB, 0, 120)
+	for i := 0; i < 120; i++ {
+		r := rng.Intn(500-1) + 1
+		d := rng.Intn(r)
+		n := rng.Intn(5) + 1
+		pcs := make([]piece, n)
+		for j := 0; j < n; j++ {
+			pcs[j] = piece{
+				x: rng.Intn(1001) - 500,
+				y: rng.Intn(1001) - 500,
+				r: rng.Intn(501),
+			}
+		}
+		tests = append(tests, TestB{r, d, pcs})
+	}
+	return tests
+}
+
+func solve(t TestB) string {
+	outer := float64(t.r)
+	inner := float64(t.r - t.d)
+	count := 0
+	for _, p := range t.pieces {
+		dist := math.Hypot(float64(p.x), float64(p.y))
+		rr := float64(p.r)
+		if dist+rr <= outer && dist-rr >= inner {
+			count++
+		}
+	}
+	return fmt.Sprintf("%d", count)
+}
+
+func (t TestB) input() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %d\n", t.r, t.d)
+	fmt.Fprintf(&b, "%d\n", len(t.pieces))
+	for _, p := range t.pieces {
+		fmt.Fprintf(&b, "%d %d %d\n", p.x, p.y, p.r)
+	}
+	return b.String()
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		want := solve(t)
+		input := t.input()
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(got)
+		if got != want {
+			fmt.Printf("Test %d failed:\nInput:\n%sExpected: %s\nGot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(tests))
+}

--- a/0-999/800-899/840-849/842/verifierC.go
+++ b/0-999/800-899/840-849/842/verifierC.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(3))
+	tests := make([]string, 0, 120)
+	for t := 0; t < 120; t++ {
+		n := r.Intn(20) + 1
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d\n", n)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, "%d ", r.Intn(200)+1)
+		}
+		b.WriteByte('\n')
+		for i := 2; i <= n; i++ {
+			parent := r.Intn(i-1) + 1
+			fmt.Fprintf(&b, "%d %d\n", parent, i)
+		}
+		tests = append(tests, b.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialC"
+	if err := exec.Command("go", "build", "-o", official, "842C.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/840-849/842/verifierD.go
+++ b/0-999/800-899/840-849/842/verifierD.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(4))
+	tests := make([]string, 0, 120)
+	for t := 0; t < 120; t++ {
+		n := r.Intn(10) + 1
+		m := r.Intn(10) + 1
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d %d\n", n, m)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, "%d ", r.Intn(1000))
+		}
+		b.WriteByte('\n')
+		for i := 0; i < m; i++ {
+			fmt.Fprintf(&b, "%d\n", r.Intn(1000))
+		}
+		tests = append(tests, b.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialD"
+	if err := exec.Command("go", "build", "-o", official, "842D.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/800-899/840-849/842/verifierE.go
+++ b/0-999/800-899/840-849/842/verifierE.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(5))
+	tests := make([]string, 0, 120)
+	for t := 0; t < 120; t++ {
+		m := r.Intn(20) + 1
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d\n", m)
+		for i := 0; i < m; i++ {
+			parent := r.Intn(i+1) + 1
+			fmt.Fprintf(&b, "%d\n", parent)
+		}
+		tests = append(tests, b.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialE"
+	if err := exec.Command("go", "build", "-o", official, "842E.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go with 120 random tests and a simple solver
- add verifierB.go to check sausage pieces on the crust
- add verifierC.go compiling 842C.go to judge answers
- add verifierD.go compiling 842D.go to judge answers
- add verifierE.go compiling 842E.go to judge answers

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go run verifierA.go ./842A_bin`
- `go run verifierB.go ./842B_bin`
- `go run verifierC.go ./842C_bin`
- `go run verifierD.go ./842D_bin`
- `go run verifierE.go ./842E_bin`


------
https://chatgpt.com/codex/tasks/task_e_6883cde770008324bbbff0a109ca5ec8