### PR TITLE
Add Go verifiers for contest 847

### DIFF
--- a/0-999/800-899/840-849/847/verifierA.go
+++ b/0-999/800-899/840-849/847/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847A.go"
+	exe := "./_verifier_solA"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string {
+	return strings.TrimSpace(s)
+}
+
+type testCase struct {
+	n     int
+	l     []int
+	r     []int
+	input string
+}
+
+func genTest() testCase {
+	n := rand.Intn(10) + 1
+	nodes := rand.Perm(n)
+	l := make([]int, n+1)
+	r := make([]int, n+1)
+	idx := 0
+	for idx < n {
+		length := rand.Intn(n-idx) + 1
+		for j := 0; j < length; j++ {
+			node := nodes[idx+j] + 1
+			if j == 0 {
+				l[node] = 0
+			} else {
+				l[node] = nodes[idx+j-1] + 1
+			}
+			if j == length-1 {
+				r[node] = 0
+			} else {
+				r[node] = nodes[idx+j+1] + 1
+			}
+		}
+		idx += length
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", l[i], r[i]))
+	}
+	return testCase{n: n, l: l, r: r, input: sb.String()}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		tc := genTest()
+		exp, err := runBinary(solExe, tc.input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}

--- a/0-999/800-899/840-849/847/verifierB.go
+++ b/0-999/800-899/840-849/847/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847B.go"
+	exe := "./_verifier_solB"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func genTest() string {
+	n := rand.Intn(10) + 1
+	arr := rand.Perm(1000)[:n]
+	for i := range arr {
+		arr[i]++
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		input := genTest()
+		exp, err := runBinary(solExe, input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}

--- a/0-999/800-899/840-849/847/verifierC.go
+++ b/0-999/800-899/840-849/847/verifierC.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847C.go"
+	exe := "./_verifier_solC"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	maxk := n * (n - 1) / 2
+	k := rand.Intn(maxk + 1)
+	return fmt.Sprintf("%d %d\n", n, k)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		input := genTest()
+		exp, err := runBinary(solExe, input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}

--- a/0-999/800-899/840-849/847/verifierD.go
+++ b/0-999/800-899/840-849/847/verifierD.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847D.go"
+	exe := "./_verifier_solD"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func genTest() string {
+	n := rand.Intn(10) + 1
+	T := rand.Intn(100) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, T))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(100)+1))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		input := genTest()
+		exp, err := runBinary(solExe, input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}

--- a/0-999/800-899/840-849/847/verifierE.go
+++ b/0-999/800-899/840-849/847/verifierE.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847E.go"
+	exe := "./_verifier_solE"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func genTest() string {
+	n := rand.Intn(10) + 1
+	sb := strings.Builder{}
+	for i := 0; i < n; i++ {
+		switch rand.Intn(3) {
+		case 0:
+			sb.WriteByte('.')
+		case 1:
+			sb.WriteByte('*')
+		default:
+			sb.WriteByte('P')
+		}
+	}
+	return fmt.Sprintf("%d\n%s\n", n, sb.String())
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		input := genTest()
+		exp, err := runBinary(solExe, input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}

--- a/0-999/800-899/840-849/847/verifierF.go
+++ b/0-999/800-899/840-849/847/verifierF.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847F.go"
+	exe := "./_verifier_solF"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func genTest() string {
+	n := rand.Intn(5) + 2
+	k := rand.Intn(n) + 1
+	m := rand.Intn(5) + n
+	a := rand.Intn(m + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, k, m, a))
+	for i := 0; i < a; i++ {
+		v := rand.Intn(n) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	if a > 0 {
+		sb.WriteByte('\n')
+	} else {
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		input := genTest()
+		exp, err := runBinary(solExe, input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}

--- a/0-999/800-899/840-849/847/verifierG.go
+++ b/0-999/800-899/840-849/847/verifierG.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847G.go"
+	exe := "./_verifier_solG"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func genTest() string {
+	n := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		for j := 0; j < 7; j++ {
+			if rand.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		input := genTest()
+		exp, err := runBinary(solExe, input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}

--- a/0-999/800-899/840-849/847/verifierH.go
+++ b/0-999/800-899/840-849/847/verifierH.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847H.go"
+	exe := "./_verifier_solH"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func genTest() string {
+	n := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(20)))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		input := genTest()
+		exp, err := runBinary(solExe, input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}

--- a/0-999/800-899/840-849/847/verifierI.go
+++ b/0-999/800-899/840-849/847/verifierI.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847I.go"
+	exe := "./_verifier_solI"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func genTest() string {
+	n := rand.Intn(3) + 1
+	m := rand.Intn(3) + 1
+	q := rand.Intn(3) + 1
+	p := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, q, p))
+	letters := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			r := rand.Intn(4)
+			switch r {
+			case 0:
+				sb.WriteByte('.')
+			case 1:
+				sb.WriteByte('*')
+			case 2:
+				sb.WriteByte(letters[rand.Intn(len(letters))])
+			default:
+				sb.WriteByte('.')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		input := genTest()
+		exp, err := runBinary(solExe, input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}

--- a/0-999/800-899/840-849/847/verifierJ.go
+++ b/0-999/800-899/840-849/847/verifierJ.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847J.go"
+	exe := "./_verifier_solJ"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(n*(n-1)/2 + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		u := rand.Intn(n) + 1
+		v := rand.Intn(n) + 1
+		for v == u {
+			v = rand.Intn(n) + 1
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierJ.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		input := genTest()
+		exp, err := runBinary(solExe, input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}

--- a/0-999/800-899/840-849/847/verifierK.go
+++ b/0-999/800-899/840-849/847/verifierK.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847K.go"
+	exe := "./_verifier_solK"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	a := rand.Intn(5) + 1
+	b := rand.Intn(5) + 1
+	k := rand.Intn(3) + 1
+	f := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d %d\n", n, a, b, k, f))
+	stops := []string{"A", "B", "C", "D", "E", "F"}
+	for i := 0; i < n; i++ {
+		s := stops[rand.Intn(len(stops))]
+		t := stops[rand.Intn(len(stops))]
+		sb.WriteString(fmt.Sprintf("%s %s\n", s, t))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierK.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		input := genTest()
+		exp, err := runBinary(solExe, input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}

--- a/0-999/800-899/840-849/847/verifierL.go
+++ b/0-999/800-899/840-849/847/verifierL.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847L.go"
+	exe := "./_verifier_solL"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func genTest() string {
+	n := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		groups := rand.Intn(3) + 1
+		for g := 0; g < groups; g++ {
+			tot := rand.Intn(3) + 1
+			sb.WriteString(fmt.Sprintf("%d:", tot))
+			for j := 0; j < tot; j++ {
+				sb.WriteString(fmt.Sprintf("%d", rand.Intn(n)+1))
+				if j+1 < tot {
+					sb.WriteByte(',')
+				}
+			}
+			if g+1 < groups {
+				sb.WriteByte('-')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierL.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		input := genTest()
+		exp, err := runBinary(solExe, input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}

--- a/0-999/800-899/840-849/847/verifierM.go
+++ b/0-999/800-899/840-849/847/verifierM.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildSolution() (string, error) {
+	sol := "847M.go"
+	exe := "./_verifier_solM"
+	cmd := exec.Command("go", "build", "-o", exe, sol)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string { return strings.TrimSpace(s) }
+
+func genTest() string {
+	n := rand.Intn(10) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(20)))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierM.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	solExe, err := buildSolution()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(solExe)
+
+	for t := 1; t <= 100; t++ {
+		input := genTest()
+		exp, err := runBinary(solExe, input)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", t, err)
+			return
+		}
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", t, err)
+			return
+		}
+		if normalize(exp) != normalize(out) {
+			fmt.Printf("wrong answer on test %d\nexpected:\n%s\nactual:\n%s\n", t, exp, out)
+			return
+		}
+	}
+	fmt.Println("tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verification programs for all problems of contest 847
- each verifier builds the reference solution, generates 100 random tests and compares outputs

## Testing
- `go build 0-999/800-899/840-849/847/verifierA.go`
- `go build 0-999/800-899/840-849/847/verifierM.go`


------
https://chatgpt.com/codex/tasks/task_e_6883d0a3c5cc832490fd72f48f545321