### PR TITLE
Add Go solution for 1635A

### DIFF
--- a/1000-1999/1600-1699/1630-1639/1635/1635A.go
+++ b/1000-1999/1600-1699/1630-1639/1635/1635A.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var T int
+	if _, err := fmt.Fscan(reader, &T); err != nil {
+		return
+	}
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		res := 0
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			res |= x
+		}
+		fmt.Fprintln(writer, res)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 1635 problem A

## Testing
- `go build ./1000-1999/1600-1699/1630-1639/1635/1635A.go`

------
https://chatgpt.com/codex/tasks/task_e_6883d3a631288324aba65489bb083f43