### PR TITLE
Add Go verifiers for contest 854

### DIFF
--- a/0-999/800-899/850-859/854/verifierA.go
+++ b/0-999/800-899/850-859/854/verifierA.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func expected(n int) (int, int) {
+	for a := n / 2; a >= 1; a-- {
+		b := n - a
+		if a < b && gcd(a, b) == 1 {
+			return a, b
+		}
+	}
+	return 0, 0
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, n := range func() []int {
+		arr := make([]int, 0, 100)
+		for x := 3; x < 103; x++ {
+			arr = append(arr, x)
+		}
+		return arr
+	}() {
+		expA, expB := expected(n)
+		got, err := run(bin, fmt.Sprintf("%d\n", n))
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var a, b int
+		if _, err := fmt.Sscanf(got, "%d %d", &a, &b); err != nil {
+			fmt.Printf("test %d: cannot parse output %q\n", i+1, got)
+			os.Exit(1)
+		}
+		if a != expA || b != expB {
+			fmt.Printf("test %d failed: n=%d expected %d %d got %d %d\n", i+1, n, expA, expB, a, b)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/800-899/850-859/854/verifierB.go
+++ b/0-999/800-899/850-859/854/verifierB.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func expected(n, k int64) (int64, int64) {
+	if k == 0 || k == n {
+		return 0, 0
+	}
+	minGood := int64(1)
+	maxGood := n - k
+	if maxGood > 2*k {
+		maxGood = 2 * k
+	}
+	return minGood, maxGood
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() [][2]int64 {
+	tests := make([][2]int64, 0, 100)
+	for i := int64(1); i <= 25; i++ {
+		tests = append(tests, [2]int64{i, 0})
+		tests = append(tests, [2]int64{i + 25, i + 25})
+		tests = append(tests, [2]int64{i + 50, i})
+		tests = append(tests, [2]int64{i + 75, i + 50})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		n, k := t[0], t[1]
+		expMin, expMax := expected(n, k)
+		got, err := run(bin, fmt.Sprintf("%d %d\n", n, k))
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var gMin, gMax int64
+		if _, err := fmt.Sscanf(got, "%d %d", &gMin, &gMax); err != nil {
+			fmt.Printf("test %d: cannot parse output %q\n", i+1, got)
+			os.Exit(1)
+		}
+		if gMin != expMin || gMax != expMax {
+			fmt.Printf("test %d failed: n=%d k=%d expected %d %d got %d %d\n", i+1, n, k, expMin, expMax, gMin, gMax)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for contest 854
- each verifier runs 100 deterministic test cases against a provided binary

## Testing
- `go build 0-999/800-899/850-859/854/verifierA.go`
- `go build 0-999/800-899/850-859/854/verifierB.go`
- `go run 0-999/800-899/850-859/854/verifierA.go 0-999/800-899/850-859/854/solA`
- `go run 0-999/800-899/850-859/854/verifierB.go 0-999/800-899/850-859/854/solB`

------
https://chatgpt.com/codex/tasks/task_e_6883d4785ccc8324a6ed6fee297233e7