### PR TITLE
Add verifiers for contest 852

### DIFF
--- a/0-999/800-899/850-859/852/verifierA.go
+++ b/0-999/800-899/850-859/852/verifierA.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func parseAndSum(expr string, allowLeadingZero bool) (int, error) {
+	if len(expr) == 0 || expr[0] == '+' || expr[len(expr)-1] == '+' || strings.Contains(expr, "++") {
+		return 0, fmt.Errorf("invalid expression")
+	}
+	parts := strings.Split(expr, "+")
+	sum := 0
+	for _, p := range parts {
+		if len(p) == 0 {
+			return 0, fmt.Errorf("empty part")
+		}
+		if !allowLeadingZero && len(p) > 1 && p[0] == '0' {
+			return 0, fmt.Errorf("leading zero")
+		}
+		for _, ch := range p {
+			if ch < '0' || ch > '9' {
+				return 0, fmt.Errorf("bad char")
+			}
+		}
+		v, err := strconv.Atoi(p)
+		if err != nil {
+			return 0, err
+		}
+		sum += v
+	}
+	return sum, nil
+}
+
+func validate(input, output string) error {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 3 {
+		return fmt.Errorf("expected three lines of output")
+	}
+	sc := bufio.NewScanner(strings.NewReader(input))
+	sc.Split(bufio.ScanWords)
+	if !sc.Scan() {
+		return fmt.Errorf("bad input")
+	}
+	n, _ := strconv.Atoi(sc.Text())
+	if !sc.Scan() {
+		return fmt.Errorf("bad input")
+	}
+	digits := sc.Text()
+	if len(digits) != n {
+		return fmt.Errorf("bad input length")
+	}
+	if strings.ReplaceAll(lines[0], "+", "") != digits {
+		return fmt.Errorf("first line does not match original number")
+	}
+	sum1, err := parseAndSum(lines[0], true)
+	if err != nil {
+		return fmt.Errorf("step1: %v", err)
+	}
+	if strings.ReplaceAll(lines[1], "+", "") != strconv.Itoa(sum1) {
+		return fmt.Errorf("second line mismatch")
+	}
+	sum2, err := parseAndSum(lines[1], false)
+	if err != nil {
+		return fmt.Errorf("step2: %v", err)
+	}
+	if strings.ReplaceAll(lines[2], "+", "") != strconv.Itoa(sum2) {
+		return fmt.Errorf("third line mismatch")
+	}
+	sum3, err := parseAndSum(lines[2], false)
+	if err != nil {
+		return fmt.Errorf("step3: %v", err)
+	}
+	if sum3 < 0 || sum3 > 9 {
+		return fmt.Errorf("final result not single digit")
+	}
+	return nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n5\n",
+		"2\n99\n",
+		"3\n123\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if i == 0 {
+			b[i] = byte(rng.Intn(9)+1) + '0'
+		} else {
+			b[i] = byte(rng.Intn(10)) + '0'
+		}
+	}
+	return fmt.Sprintf("%d\n%s\n", n, string(b))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if err := validate(in, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/852/verifierB.go
+++ b/0-999/800-899/850-859/852/verifierB.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "852B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1 2 2\n0\n0\n0\n",
+		"2 3 5\n1 2\n3 4\n5 6\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	N := rng.Intn(4) + 1
+	L := rng.Intn(4) + 2
+	M := rng.Intn(8) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", N, L, M))
+	for i := 0; i < N; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(M)))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < N; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(M)))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < N; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(M)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/852/verifierC.go
+++ b/0-999/800-899/850-859/852/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "852C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{"2\n0 1\n"}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(9) + 2
+	arr := rng.Perm(n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/852/verifierD.go
+++ b/0-999/800-899/850-859/852/verifierD.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "852D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{"2 1 1 1\n1\n1 2 1\n"}
+}
+
+func randomCase(rng *rand.Rand) string {
+	V := rng.Intn(4) + 2
+	maxEdges := V * (V - 1) / 2
+	E := rng.Intn(maxEdges-(V-1)+1) + (V - 1)
+	N := rng.Intn(V) + 1
+	K := rng.Intn(V) + 1
+	starts := rng.Perm(V)[:N]
+	edges := make([][3]int, 0, E)
+	used := make(map[[2]int]bool)
+	for i := 1; i < V; i++ {
+		w := rng.Intn(9) + 1
+		edges = append(edges, [3]int{i, i + 1, w})
+		used[[2]int{i, i + 1}] = true
+	}
+	for len(edges) < E {
+		a := rng.Intn(V) + 1
+		b := rng.Intn(V) + 1
+		if a == b || used[[2]int{a, b}] || used[[2]int{b, a}] {
+			continue
+		}
+		w := rng.Intn(9) + 1
+		edges = append(edges, [3]int{a, b, w})
+		used[[2]int{a, b}] = true
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", V, len(edges), N, K))
+	for i, s := range starts {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", s+1))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/852/verifierE.go
+++ b/0-999/800-899/850-859/852/verifierE.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "852E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{"2\n1 2\n"}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", p, i))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/852/verifierF.go
+++ b/0-999/800-899/850-859/852/verifierF.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "852F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{"1 1 2 3\n"}
+}
+
+func randomCase(rng *rand.Rand) string {
+	N := rng.Intn(5) + 1
+	M := rng.Intn(5) + 1
+	a := rng.Int63n(5) + 2
+	Q := rng.Int63n(30) + 2
+	return fmt.Sprintf("%d %d %d %d\n", N, M, a, Q)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/852/verifierG.go
+++ b/0-999/800-899/850-859/852/verifierG.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "852G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{"1 1\na\na\n"}
+}
+
+func randWord(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(rng.Intn(5)) + 'a'
+	}
+	return string(b)
+}
+
+func randPattern(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		if rng.Intn(4) == 0 {
+			b[i] = '?'
+		} else {
+			b[i] = byte(rng.Intn(5)) + 'a'
+		}
+	}
+	return string(b)
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(randWord(rng, rng.Intn(3)+1))
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < m; i++ {
+		sb.WriteString(randPattern(rng, rng.Intn(3)+1))
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/852/verifierH.go
+++ b/0-999/800-899/850-859/852/verifierH.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refH.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "852H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{"3 3\n0 0\n1 0\n0 1\n"}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 3
+	K := rng.Intn(n-2) + 3
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, K))
+	for i := 0; i < n; i++ {
+		x := rng.Intn(5)
+		y := rng.Intn(5)
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/852/verifierI.go
+++ b/0-999/800-899/850-859/852/verifierI.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refI.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "852I.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{"1\n1\n1\n1 2\n1\n1 1\n"}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteString("1 ")
+		} else {
+			sb.WriteString("2 ")
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rng.Intn(5)+1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n-1; i++ {
+		a := i + 1
+		b := rng.Intn(i) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", a+1, b))
+	}
+	q := rng.Intn(5) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–I in contest 852
- verifiers run candidate binaries with 100+ test cases
- problem A verifier validates steps directly

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build verifierI.go`


------
https://chatgpt.com/codex/tasks/task_e_6883d3602ce483248347187b7fdc63aa