### PR TITLE
Add Go verifiers for CF contest 856

### DIFF
--- a/0-999/800-899/850-859/856/verifierA.go
+++ b/0-999/800-899/850-859/856/verifierA.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const maxValA = 1000000
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func primesUpTo(n int) []int {
+	sieve := make([]bool, n+1)
+	var primes []int
+	for i := 2; i <= n; i++ {
+		if !sieve[i] {
+			primes = append(primes, i)
+			for j := i * 2; j <= n; j += i {
+				sieve[j] = true
+			}
+		}
+	}
+	return primes
+}
+
+var primeListA = primesUpTo(1000000)
+
+func findPrimeStep(a []int) int {
+	diff := make([]bool, maxValA+1)
+	n := len(a)
+	for i := 0; i < n; i++ {
+		for j := 0; j < i; j++ {
+			d := a[i] - a[j]
+			if d < 0 {
+				d = -d
+			}
+			if d <= maxValA {
+				diff[d] = true
+			}
+		}
+	}
+	for _, p := range primeListA {
+		ok := true
+		for x := p; x <= maxValA; x += p {
+			if diff[x] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return p
+		}
+	}
+	return 0
+}
+
+func checkCaseA(input, output string) error {
+	in := bufio.NewReader(strings.NewReader(input))
+	var t, n int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return err
+	}
+	if t != 1 {
+		return errors.New("expected one test case")
+	}
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return err
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		if _, err := fmt.Fscan(in, &a[i]); err != nil {
+			return err
+		}
+	}
+	expectPossible := findPrimeStep(a) > 0
+
+	tokens := strings.Fields(output)
+	if len(tokens) == 0 {
+		return errors.New("no output")
+	}
+	if tokens[0] == "NO" {
+		if expectPossible {
+			return errors.New("expected YES but got NO")
+		}
+		if len(tokens) != 1 {
+			return errors.New("extra data after NO")
+		}
+		return nil
+	}
+	if tokens[0] != "YES" {
+		return errors.New("first token should be YES or NO")
+	}
+	if !expectPossible {
+		return errors.New("expected NO but got YES")
+	}
+	if len(tokens) != 1+n {
+		return fmt.Errorf("expected %d numbers, got %d", n, len(tokens)-1)
+	}
+	b := make([]int, n)
+	used := map[int]bool{}
+	for i := 0; i < n; i++ {
+		x, err := strconv.Atoi(tokens[1+i])
+		if err != nil {
+			return fmt.Errorf("bad number %q", tokens[1+i])
+		}
+		if x < 1 || x > maxValA {
+			return fmt.Errorf("number %d out of range", x)
+		}
+		if used[x] {
+			return fmt.Errorf("duplicate number %d", x)
+		}
+		used[x] = true
+		b[i] = x
+	}
+	sums := map[int]bool{}
+	for _, x := range a {
+		for _, y := range b {
+			s := x + y
+			if sums[s] {
+				return fmt.Errorf("duplicate sum %d", s)
+			}
+			sums[s] = true
+		}
+	}
+	return nil
+}
+
+func generateCaseA(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rng.Intn(maxValA) + 1
+		sb.WriteString(strconv.Itoa(val))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []string
+	// some fixed cases
+	cases = append(cases, "1\n1\n1\n")
+	cases = append(cases, "1\n2\n1 2\n")
+	cases = append(cases, "1\n3\n1 2 3\n")
+
+	for len(cases) < 100 {
+		cases = append(cases, generateCaseA(rng))
+	}
+
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if err := checkCaseA(tc, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, tc, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/856/verifierB.go
+++ b/0-999/800-899/850-859/856/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef(src, out string) error {
+	cmd := exec.Command("go", "build", "-o", out, src)
+	return cmd.Run()
+}
+
+func generateCaseB(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		l := rng.Intn(5) + 1
+		for j := 0; j < l; j++ {
+			sb.WriteByte(byte('a' + rng.Intn(3)))
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCaseB(bin, ref, input string) error {
+	expect, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference error: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, got)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expect), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./refB.bin"
+	if err := buildRef("856B.go", ref); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseB(rng)
+		if err := runCaseB(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/856/verifierC.go
+++ b/0-999/800-899/850-859/856/verifierC.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef(src, out string) error {
+	cmd := exec.Command("go", "build", "-o", out, src)
+	return cmd.Run()
+}
+
+func generateCaseC(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rng.Intn(1000) + 1
+		sb.WriteString(strconv.Itoa(val))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCaseC(bin, ref, input string) error {
+	expect, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference error: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, got)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expect), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./refC.bin"
+	if err := buildRef("856C.go", ref); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseC(rng)
+		if err := runCaseC(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/856/verifierD.go
+++ b/0-999/800-899/850-859/856/verifierD.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef(src, out string) error {
+	cmd := exec.Command("go", "build", "-o", out, src)
+	return cmd.Run()
+}
+
+func generateCaseD(rng *rand.Rand) string {
+	n := rng.Intn(6) + 3
+	m := rng.Intn(5)
+	parents := make([]int, n+1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		parents[i] = p
+		if i > 2 {
+			sb.WriteByte(' ')
+		}
+		if i == 2 {
+			fmt.Fprintf(&sb, "%d", p)
+		} else {
+			fmt.Fprintf(&sb, "%d", p)
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		for v == u {
+			v = rng.Intn(n) + 1
+		}
+		w := rng.Intn(10) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", u, v, w)
+	}
+	return sb.String()
+}
+
+func runCaseD(bin, ref, input string) error {
+	expect, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference error: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, got)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expect), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./refD.bin"
+	if err := buildRef("856D.go", ref); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseD(rng)
+		if err := runCaseD(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/856/verifierE.go
+++ b/0-999/800-899/850-859/856/verifierE.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef(src, out string) error {
+	cmd := exec.Command("go", "build", "-o", out, src)
+	return cmd.Run()
+}
+
+func generateCaseE(rng *rand.Rand) string {
+	r := rng.Intn(5) + 1
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", r, n)
+	nextID := 1
+	active := make([]int, 0)
+	coords := map[[2]int]bool{}
+	for i := 0; i < n; i++ {
+		typ := rng.Intn(3) + 1
+		if typ == 1 || len(active) < 2 {
+			typ = 1
+		}
+		if typ == 1 {
+			x := rng.Intn(10) + r + 1
+			y := rng.Intn(10) + 1
+			for coords[[2]int{x, y}] {
+				x = rng.Intn(10) + r + 1
+				y = rng.Intn(10) + 1
+			}
+			coords[[2]int{x, y}] = true
+			fmt.Fprintf(&sb, "1 %d %d\n", x, y)
+			active = append(active, nextID)
+			nextID++
+		} else if typ == 2 {
+			idx := rng.Intn(len(active))
+			id := active[idx]
+			active = append(active[:idx], active[idx+1:]...)
+			fmt.Fprintf(&sb, "2 %d\n", id)
+		} else {
+			i1 := rng.Intn(len(active))
+			j1 := rng.Intn(len(active) - 1)
+			if j1 >= i1 {
+				j1++
+			}
+			fmt.Fprintf(&sb, "3 %d %d\n", active[i1], active[j1])
+		}
+	}
+	return sb.String()
+}
+
+func runCaseE(bin, ref, input string) error {
+	expect, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference error: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, got)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expect), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./refE.bin"
+	if err := buildRef("856E.go", ref); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseE(rng)
+		if err := runCaseE(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/856/verifierF.go
+++ b/0-999/800-899/850-859/856/verifierF.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef(src, out string) error {
+	cmd := exec.Command("go", "build", "-o", out, src)
+	return cmd.Run()
+}
+
+func generateCaseF(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	C := rng.Int63n(10)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, C)
+	for i := 0; i < n; i++ {
+		a := rng.Int63n(20)
+		b := a + rng.Int63n(5) + 1
+		fmt.Fprintf(&sb, "%d %d\n", a, b)
+	}
+	for i := 0; i < m; i++ {
+		c := rng.Int63n(20)
+		d := c + rng.Int63n(5) + 1
+		fmt.Fprintf(&sb, "%d %d\n", c, d)
+	}
+	return sb.String()
+}
+
+func runCaseF(bin, ref, input string) error {
+	expect, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference error: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, got)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expect), strings.TrimSpace(got))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := "./refF.bin"
+	if err := buildRef("856F.go", ref); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCaseF(rng)
+		if err := runCaseF(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go with custom output validator
- add verifiers B–F using reference solutions for correctness
- each verifier generates at least 100 test cases

## Testing
- `go build 0-999/800-899/850-859/856/verifierA.go`
- `go build 0-999/800-899/850-859/856/verifierB.go`
- `go build 0-999/800-899/850-859/856/verifierC.go`
- `go build 0-999/800-899/850-859/856/verifierD.go`
- `go build 0-999/800-899/850-859/856/verifierE.go`
- `go build 0-999/800-899/850-859/856/verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6883d5908e9c8324a2f5113fa634981d