### PR TITLE
Add verifiers for contest 859

### DIFF
--- a/0-999/800-899/850-859/859/verifierA.go
+++ b/0-999/800-899/850-859/859/verifierA.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type CaseA struct {
+	input    string
+	expected int
+}
+
+func expectedA(k int, ranks []int) int {
+	maxRank := 0
+	for _, r := range ranks {
+		if r > maxRank {
+			maxRank = r
+		}
+	}
+	if maxRank < 25 {
+		return 0
+	}
+	return maxRank - 25
+}
+
+func generateCaseA(rng *rand.Rand) CaseA {
+	k := rng.Intn(25) + 1
+	m := make(map[int]bool)
+	ranks := make([]int, 0, k)
+	for len(ranks) < k {
+		r := rng.Intn(1_000_000) + 1
+		if !m[r] {
+			m[r] = true
+			ranks = append(ranks, r)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", k))
+	for i, r := range ranks {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", r))
+	}
+	sb.WriteByte('\n')
+	return CaseA{sb.String(), expectedA(k, ranks)}
+}
+
+func runCase(exe string, input string, expected int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	var got int
+	if _, err := fmt.Sscan(outStr, &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v\n%s", err, outStr)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	cases := []CaseA{
+		{"25\n1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25\n", 0},
+		{"3\n25 26 27\n", 2},
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseA(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(exe, tc.input, tc.expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/859/verifierB.go
+++ b/0-999/800-899/850-859/859/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type CaseB struct {
+	input    string
+	expected int
+}
+
+func expectedB(n int) int {
+	best := math.MaxInt32
+	limit := int(math.Sqrt(float64(n)))
+	for w := 1; w <= limit; w++ {
+		h := (n + w - 1) / w
+		p := 2 * (w + h)
+		if p < best {
+			best = p
+		}
+	}
+	return best
+}
+
+func generateCaseB(rng *rand.Rand) CaseB {
+	n := rng.Intn(1_000_000) + 1
+	return CaseB{fmt.Sprintf("%d\n", n), expectedB(n)}
+}
+
+func runCase(exe string, input string, expected int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(strings.TrimSpace(out.String())), &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	cases := []CaseB{
+		{"1\n", 4},
+		{"6\n", 10},
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseB(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(exe, tc.input, tc.expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/859/verifierC.go
+++ b/0-999/800-899/850-859/859/verifierC.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type CaseC struct {
+	input string
+	alice int64
+	bob   int64
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expectedC(s []int64) (int64, int64) {
+	n := len(s)
+	total := int64(0)
+	for _, v := range s {
+		total += v
+	}
+	dp := make([][2]int64, n+1)
+	for i := n - 1; i >= 0; i-- {
+		val := s[i]
+		dp[i][0] = max64(val+dp[i+1][1], -val+dp[i+1][0])
+		dp[i][1] = min64(-val+dp[i+1][0], val+dp[i+1][1])
+	}
+	diff := dp[0][1]
+	alice := (total + diff) / 2
+	bob := total - alice
+	return alice, bob
+}
+
+func generateCaseC(rng *rand.Rand) CaseC {
+	n := rng.Intn(50) + 1
+	slices := make([]int64, n)
+	for i := range slices {
+		slices[i] = rng.Int63n(100_000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range slices {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	a, b := expectedC(slices)
+	return CaseC{sb.String(), a, b}
+}
+
+func runCase(exe string, input string, alice, bob int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	var ga, gb int64
+	if _, err := fmt.Sscan(outStr, &ga, &gb); err != nil {
+		return fmt.Errorf("cannot parse output: %v\n%s", err, outStr)
+	}
+	if ga != alice || gb != bob {
+		return fmt.Errorf("expected %d %d got %d %d", alice, bob, ga, gb)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	slices := []int64{1, 2, 3}
+	a, b := expectedC(slices)
+	cases := []CaseC{
+		{"3\n1 2 3\n", a, b},
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseC(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(exe, tc.input, tc.alice, tc.bob); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/859/verifierD.go
+++ b/0-999/800-899/850-859/859/verifierD.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type CaseD struct {
+	input    string
+	expected float64
+}
+
+func solveD(n int, mat [][]int) float64 {
+	size := 1 << n
+	prob := make([][]float64, size)
+	for i := range prob {
+		prob[i] = make([]float64, size)
+		for j := 0; j < size; j++ {
+			prob[i][j] = float64(mat[i][j]) / 100.0
+		}
+	}
+	v := make([][][2]int, n+1)
+	dp := make([][][2]float64, n+1)
+	used := make([][]bool, n+1)
+	for lvl := 0; lvl <= n; lvl++ {
+		v[lvl] = make([][2]int, size)
+		dp[lvl] = make([][2]float64, size)
+		used[lvl] = make([]bool, size)
+	}
+
+	var buildSegments func(level, l, r int)
+	buildSegments = func(level, l, r int) {
+		if level < 0 {
+			return
+		}
+		for i := l; i <= r; i++ {
+			v[level][i][0] = l
+			v[level][i][1] = r
+		}
+		if level == 0 {
+			return
+		}
+		mid := (l + r) / 2
+		buildSegments(level-1, l, mid)
+		buildSegments(level-1, mid+1, r)
+	}
+
+	var getDp func(x, b int) (float64, float64)
+	getDp = func(x, b int) (float64, float64) {
+		if used[x][b] {
+			return dp[x][b][0], dp[x][b][1]
+		}
+		if x == 0 {
+			used[x][b] = true
+			dp[x][b][0] = 0
+			dp[x][b][1] = 1
+			return 0, 1
+		}
+		pF, pS := getDp(x-1, b)
+		var bestF, sumS float64
+		l, r := v[x][b][0], v[x][b][1]
+		for i := l; i <= r; i++ {
+			if v[x-1][b][0] <= i && i <= v[x-1][b][1] {
+				continue
+			}
+			tmpF, tmpS := getDp(x-1, i)
+			sumS += tmpS * prob[b][i]
+			if tmpF+pF > bestF {
+				bestF = tmpF + pF
+			}
+		}
+		sumS *= pS
+		score := float64(int64(1) << uint(x-1))
+		bestF += sumS * score
+		used[x][b] = true
+		dp[x][b][0] = bestF
+		dp[x][b][1] = sumS
+		return bestF, sumS
+	}
+
+	buildSegments(n, 0, size-1)
+	ans := 0.0
+	for i := 0; i < size; i++ {
+		f, _ := getDp(n, i)
+		if f > ans {
+			ans = f
+		}
+	}
+	return ans
+}
+
+func generateCaseD(rng *rand.Rand) CaseD {
+	n := rng.Intn(5) + 2 // 2..6
+	size := 1 << n
+	mat := make([][]int, size)
+	for i := range mat {
+		mat[i] = make([]int, size)
+		for j := 0; j < size; j++ {
+			mat[i][j] = rng.Intn(101)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < size; i++ {
+		for j := 0; j < size; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", mat[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	return CaseD{sb.String(), solveD(n, mat)}
+}
+
+func runCase(exe, input string, expected float64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	if _, err := fmt.Fscan(strings.NewReader(strings.TrimSpace(out.String())), &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	if math.Abs(got-expected) > 1e-6 {
+		return fmt.Errorf("expected %.6f got %.6f", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	// deterministic simple case
+	mat := [][]int{{0, 50, 50, 50}, {50, 0, 50, 50}, {50, 50, 0, 50}, {50, 50, 50, 0}}
+	n := 2
+	var sb strings.Builder
+	sb.WriteString("2\n")
+	for i := 0; i < 4; i++ {
+		for j := 0; j < 4; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", mat[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	cases := []CaseD{{sb.String(), solveD(n, mat)}}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseD(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(exe, tc.input, tc.expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			fmt.Fprint(os.Stderr, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/859/verifierE.go
+++ b/0-999/800-899/850-859/859/verifierE.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modE int = 1000000007
+
+type CaseE struct {
+	input    string
+	expected int
+}
+
+func solveE(n int, pairs [][2]int) int {
+	seatIndex := make(map[int]int)
+	idx := 0
+	for _, p := range pairs {
+		if _, ok := seatIndex[p[0]]; !ok {
+			seatIndex[p[0]] = idx
+			idx++
+		}
+		if _, ok := seatIndex[p[1]]; !ok {
+			seatIndex[p[1]] = idx
+			idx++
+		}
+	}
+	m := idx
+	parent := make([]int, n+m)
+	size := make([]int, n+m)
+	for i := range parent {
+		parent[i] = i
+		size[i] = 1
+	}
+	var find func(int) int
+	find = func(x int) int {
+		for parent[x] != x {
+			parent[x] = parent[parent[x]]
+			x = parent[x]
+		}
+		return x
+	}
+	union := func(a, b int) {
+		a = find(a)
+		b = find(b)
+		if a == b {
+			return
+		}
+		if size[a] < size[b] {
+			a, b = b, a
+		}
+		parent[b] = a
+		size[a] += size[b]
+	}
+	for i, p := range pairs {
+		union(i, n+seatIndex[p[0]])
+		union(i, n+seatIndex[p[1]])
+	}
+	type comp struct {
+		t, s int
+		self bool
+	}
+	comps := make(map[int]*comp)
+	for i, p := range pairs {
+		r := find(i)
+		if comps[r] == nil {
+			comps[r] = &comp{}
+		}
+		c := comps[r]
+		c.t++
+		if p[0] == p[1] {
+			c.self = true
+		}
+	}
+	for _, idx := range seatIndex {
+		r := find(n + idx)
+		if comps[r] == nil {
+			comps[r] = &comp{}
+		}
+		comps[r].s++
+	}
+	res := 1
+	for _, c := range comps {
+		if c.s == c.t+1 {
+			res = res * c.s % modE
+		} else if c.s == c.t {
+			if c.self {
+				res = res * 1 % modE
+			} else {
+				res = res * 2 % modE
+			}
+		}
+	}
+	return res % modE
+}
+
+func generateCaseE(rng *rand.Rand) CaseE {
+	n := rng.Intn(20) + 1
+	pairs := make([][2]int, n)
+	for i := range pairs {
+		x := rng.Intn(50) + 1
+		y := rng.Intn(50) + 1
+		pairs[i] = [2]int{x, y}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, p := range pairs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+	}
+	return CaseE{sb.String(), solveE(n, pairs)}
+}
+
+func runCase(exe, input string, expected int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(strings.TrimSpace(out.String())), &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	pairs := [][2]int{{1, 2}}
+	cases := []CaseE{{"1\n1 2\n", solveE(1, pairs)}}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseE(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(exe, tc.input, tc.expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/859/verifierF.go
+++ b/0-999/800-899/850-859/859/verifierF.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Item and heaps from 859F solution
+
+type Item struct {
+	t   int64
+	f   int64
+	idx int
+}
+
+type minHeap []Item
+
+func (h minHeap) Len() int           { return len(h) }
+func (h minHeap) Less(i, j int) bool { return h[i].t < h[j].t }
+func (h minHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *minHeap) Push(x any)        { *h = append(*h, x.(Item)) }
+func (h *minHeap) Pop() any          { n := len(*h); v := (*h)[n-1]; *h = (*h)[:n-1]; return v }
+
+type maxHeap []Item
+
+func (h maxHeap) Len() int           { return len(h) }
+func (h maxHeap) Less(i, j int) bool { return h[i].f > h[j].f }
+func (h maxHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *maxHeap) Push(x any)        { *h = append(*h, x.(Item)) }
+func (h *maxHeap) Pop() any          { n := len(*h); v := (*h)[n-1]; *h = (*h)[:n-1]; return v }
+
+func minimalShirts(n int, C int64, single []int64, multi []int64) int64 {
+	multiExt := make([]int64, n+1)
+	for i := 1; i < n; i++ {
+		multiExt[i] = multi[i-1]
+	}
+	S1 := make([]int64, n+1)
+	S2 := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		S1[i] = S1[i-1] + single[i-1]
+	}
+	for i := 1; i <= n; i++ {
+		S2[i] = S2[i-1] + multiExt[i]
+	}
+	PS := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		PS[i] = S1[i] + S2[i-1]
+	}
+	dp := make([]int64, n+1)
+	satMax := int64(-1 << 62)
+	uheap := &maxHeap{}
+	theap := &minHeap{}
+	heap.Init(uheap)
+	heap.Init(theap)
+	active := make([]bool, n+1)
+
+	for i := 1; i <= n; i++ {
+		F1 := dp[i-1] - PS[i-1] - multiExt[i-1]
+		T := PS[i-1] + multiExt[i-1] + C
+		it := Item{t: T, f: F1, idx: i}
+		heap.Push(uheap, it)
+		heap.Push(theap, it)
+		active[i] = true
+		for theap.Len() > 0 && (*theap)[0].t <= PS[i] {
+			v := heap.Pop(theap).(Item)
+			if !active[v.idx] {
+				continue
+			}
+			active[v.idx] = false
+			val := dp[v.idx-1] + C
+			if val > satMax {
+				satMax = val
+			}
+		}
+		for uheap.Len() > 0 && !active[(*uheap)[0].idx] {
+			heap.Pop(uheap)
+		}
+		bestUnsat := int64(-1 << 62)
+		if uheap.Len() > 0 {
+			bestUnsat = (*uheap)[0].f + PS[i]
+		}
+		if satMax > bestUnsat {
+			dp[i] = satMax
+		} else {
+			dp[i] = bestUnsat
+		}
+	}
+	return dp[n]
+}
+
+func solveF(n int, C int64, values []int64) int64 {
+	single := make([]int64, n)
+	multi := make([]int64, n-1)
+	for i := 0; i < n; i++ {
+		single[i] = values[2*i]
+		if i < n-1 {
+			multi[i] = values[2*i+1]
+		}
+	}
+	return minimalShirts(n, C, single, multi)
+}
+
+type CaseF struct {
+	input    string
+	expected int64
+}
+
+func generateCaseF(rng *rand.Rand) CaseF {
+	n := rng.Intn(20) + 1
+	C := rng.Int63n(1_000_000) + 1
+	values := make([]int64, 2*n-1)
+	for i := range values {
+		values[i] = rng.Int63n(1000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, C))
+	for i, v := range values {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return CaseF{sb.String(), solveF(n, C, values)}
+}
+
+func runCase(exe, input string, expected int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(strings.TrimSpace(out.String())), &got); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	values := []int64{1}
+	cases := []CaseF{{"1 1\n1\n", solveF(1, 1, values)}}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseF(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(exe, tc.input, tc.expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/850-859/859/verifierG.go
+++ b/0-999/800-899/850-859/859/verifierG.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func fft(a []complex128, invert bool) {
+	n := len(a)
+	j := 0
+	for i := 1; i < n; i++ {
+		bit := n >> 1
+		for ; j&bit != 0; bit >>= 1 {
+			j ^= bit
+		}
+		j ^= bit
+		if i < j {
+			a[i], a[j] = a[j], a[i]
+		}
+	}
+	for length := 2; length <= n; length <<= 1 {
+		ang := 2 * math.Pi / float64(length)
+		if invert {
+			ang = -ang
+		}
+		wlen := complex(math.Cos(ang), math.Sin(ang))
+		for i := 0; i < n; i += length {
+			w := complex(1, 0)
+			for j := 0; j < length/2; j++ {
+				u := a[i+j]
+				v := a[i+j+length/2] * w
+				a[i+j] = u + v
+				a[i+j+length/2] = u - v
+				w *= wlen
+			}
+		}
+	}
+	if invert {
+		invN := complex(1/float64(n), 0)
+		for i := range a {
+			a[i] *= invN
+		}
+	}
+}
+
+func convolution(a, b []complex128) []complex128 {
+	n := 1
+	for n < len(a)+len(b) {
+		n <<= 1
+	}
+	fa := make([]complex128, n)
+	fb := make([]complex128, n)
+	copy(fa, a)
+	copy(fb, b)
+	fft(fa, false)
+	fft(fb, false)
+	for i := 0; i < n; i++ {
+		fa[i] *= fb[i]
+	}
+	fft(fa, true)
+	return fa
+}
+
+func bluestein(a []complex128) []complex128 {
+	n := len(a)
+	m := 1
+	for m < 2*n-1 {
+		m <<= 1
+	}
+	A := make([]complex128, m)
+	B := make([]complex128, m)
+	wBase := math.Pi / float64(n)
+	for j := 0; j < n; j++ {
+		angle := -wBase * float64(j*j)
+		c := complex(math.Cos(angle), math.Sin(angle))
+		A[j] = a[j] * c
+	}
+	B[n-1] = 1
+	for j := 1; j < n; j++ {
+		angle := wBase * float64(j*j)
+		c := complex(math.Cos(angle), math.Sin(angle))
+		B[n-1+j] = c
+		B[n-1-j] = c
+	}
+	conv := convolution(A, B)
+	res := make([]complex128, n)
+	for k := 0; k < n; k++ {
+		angle := -wBase * float64(k*k)
+		c := complex(math.Cos(angle), math.Sin(angle))
+		res[k] = conv[n-1+k] * c
+	}
+	return res
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func cmplxAbs(z complex128) float64 {
+	return math.Hypot(real(z), imag(z))
+}
+
+func solveG(n int, s string) string {
+	a := make([]complex128, n)
+	for i := 0; i < n; i++ {
+		a[i] = complex(float64(s[i]-'0'), 0)
+	}
+	res := bluestein(a)
+	eps := 1e-6 * float64(n)
+	for k := 1; k < n; k++ {
+		if gcd(k, n) == 1 {
+			if cmplxAbs(res[k]) > eps {
+				return "NO"
+			}
+		}
+	}
+	return "YES"
+}
+
+type CaseG struct {
+	input    string
+	expected string
+}
+
+func generateCaseG(rng *rand.Rand) CaseG {
+	n := rng.Intn(28) + 3
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('0' + rng.Intn(10))
+	}
+	s := string(b)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+	return CaseG{sb.String(), solveG(n, s)}
+}
+
+func runCase(exe, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(exe, ".go") {
+		cmd = exec.Command("go", "run", exe)
+	} else {
+		cmd = exec.Command(exe)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	cases := []CaseG{{"3\n000\n", "YES"}}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseG(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(exe, tc.input, tc.expected); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement randomized solution verifiers for problems A–G of contest 859
- each verifier generates over 100 test cases and checks any binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6883d734c0808324a61feefed640bd8e