### PR TITLE
Add Go verifiers for contest 862

### DIFF
--- a/0-999/800-899/860-869/862/verifierA.go
+++ b/0-999/800-899/860-869/862/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n   int
+	x   int
+	arr []int
+}
+
+func generateTests() []Test {
+	rand.Seed(42)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		x := rand.Intn(10)
+		vals := rand.Perm(20)[:n]
+		tests = append(tests, Test{n: n, x: x, arr: vals})
+	}
+	// edge cases
+	tests = append(tests, Test{n: 1, x: 0, arr: []int{1}})
+	tests = append(tests, Test{n: 1, x: 5, arr: []int{0}})
+	tests = append(tests, Test{n: 3, x: 2, arr: []int{0, 3, 4}})
+	return tests
+}
+
+func solve(t Test) int {
+	present := make(map[int]bool)
+	for _, v := range t.arr {
+		present[v] = true
+	}
+	ops := 0
+	for i := 0; i < t.x; i++ {
+		if !present[i] {
+			ops++
+		}
+	}
+	if present[t.x] {
+		ops++
+	}
+	return ops
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: verifierA <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	passed := 0
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.n, t.x)
+		for j, v := range t.arr {
+			if j > 0 {
+				input += " "
+			}
+			input += strconv.Itoa(v)
+		}
+		input += "\n"
+		want := solve(t)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: execution error: %v\n", i+1, err)
+			continue
+		}
+		outStr := strings.TrimSpace(output)
+		got, err := strconv.Atoi(outStr)
+		if err != nil || got != want {
+			fmt.Printf("Test %d: expected %d got %s\n", i+1, want, outStr)
+		} else {
+			passed++
+		}
+	}
+	fmt.Printf("Passed %d/%d tests\n", passed, len(tests))
+}

--- a/0-999/800-899/860-869/862/verifierB.go
+++ b/0-999/800-899/860-869/862/verifierB.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n     int
+	edges [][2]int
+}
+
+func genTree(n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func generateTests() []Test {
+	rand.Seed(43)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(8) + 2
+		edges := genTree(n)
+		tests = append(tests, Test{n: n, edges: edges})
+	}
+	// edge small trees
+	tests = append(tests, Test{n: 2, edges: [][2]int{{1, 2}}})
+	tests = append(tests, Test{n: 3, edges: [][2]int{{1, 2}, {1, 3}}})
+	return tests
+}
+
+func solve(t Test) int64 {
+	adj := make([][]int, t.n+1)
+	for _, e := range t.edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	color := make([]int, t.n+1)
+	for i := range color {
+		color[i] = -1
+	}
+	q := []int{1}
+	color[1] = 0
+	for head := 0; head < len(q); head++ {
+		u := q[head]
+		for _, v := range adj[u] {
+			if color[v] == -1 {
+				color[v] = color[u] ^ 1
+				q = append(q, v)
+			}
+		}
+	}
+	var c0, c1 int64
+	for i := 1; i <= t.n; i++ {
+		if color[i] == 0 {
+			c0++
+		} else {
+			c1++
+		}
+	}
+	return c0*c1 - int64(t.n-1)
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: verifierB <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	passed := 0
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n", t.n)
+		for _, e := range t.edges {
+			input += fmt.Sprintf("%d %d\n", e[0], e[1])
+		}
+		want := solve(t)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: exec error: %v\n", i+1, err)
+			continue
+		}
+		outStr := strings.TrimSpace(output)
+		got, err := strconv.ParseInt(outStr, 10, 64)
+		if err != nil || got != want {
+			fmt.Printf("Test %d: expected %d got %s\n", i+1, want, outStr)
+		} else {
+			passed++
+		}
+	}
+	fmt.Printf("Passed %d/%d tests\n", passed, len(tests))
+}

--- a/0-999/800-899/860-869/862/verifierC.go
+++ b/0-999/800-899/860-869/862/verifierC.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	n int
+	x int
+}
+
+func generateTests() []Test {
+	rand.Seed(44)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(6) + 1
+		x := rand.Intn(20)
+		tests = append(tests, Test{n: n, x: x})
+	}
+	tests = append(tests, Test{n: 2, x: 0})
+	return tests
+}
+
+func hasSolution(n, x int) bool {
+	return !(n == 2 && x == 0)
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func parseInts(s string) ([]int, error) {
+	fields := strings.Fields(s)
+	res := make([]int, len(fields))
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func xorAll(arr []int) int {
+	x := 0
+	for _, v := range arr {
+		x ^= v
+	}
+	return x
+}
+
+func allDistinct(arr []int) bool {
+	m := make(map[int]bool)
+	for _, v := range arr {
+		if m[v] {
+			return false
+		}
+		m[v] = true
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: verifierC <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	passed := 0
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.n, t.x)
+		wantExists := hasSolution(t.n, t.x)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: exec error %v\n", i+1, err)
+			continue
+		}
+		lines := strings.Split(strings.TrimSpace(output), "\n")
+		if !wantExists {
+			if strings.TrimSpace(lines[0]) != "NO" {
+				fmt.Printf("Test %d: expected NO got %s\n", i+1, lines[0])
+				continue
+			}
+			passed++
+			continue
+		}
+		if strings.TrimSpace(lines[0]) != "YES" {
+			fmt.Printf("Test %d: expected YES got %s\n", i+1, lines[0])
+			continue
+		}
+		numsLine := ""
+		if len(lines) > 1 {
+			numsLine = strings.Join(lines[1:], " ")
+		}
+		nums, err := parseInts(numsLine)
+		if err != nil || len(nums) != t.n || !allDistinct(nums) || xorAll(nums) != t.x {
+			fmt.Printf("Test %d: invalid set %v\n", i+1, nums)
+			continue
+		}
+		ok := true
+		for _, v := range nums {
+			if v < 0 || v > 1000000 {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			fmt.Printf("Test %d: numbers out of range\n", i+1)
+			continue
+		}
+		passed++
+	}
+	fmt.Printf("Passed %d/%d tests\n", passed, len(tests))
+}

--- a/0-999/800-899/860-869/862/verifierD.go
+++ b/0-999/800-899/860-869/862/verifierD.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	s string
+}
+
+func generateTests() []Test {
+	rand.Seed(45)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 2
+		for {
+			b := make([]byte, n)
+			has0, has1 := false, false
+			for j := 0; j < n; j++ {
+				if rand.Intn(2) == 0 {
+					b[j] = '0'
+					has0 = true
+				} else {
+					b[j] = '1'
+					has1 = true
+				}
+			}
+			if has0 && has1 {
+				tests = append(tests, Test{s: string(b)})
+				break
+			}
+		}
+	}
+	tests = append(tests, Test{s: "01"})
+	tests = append(tests, Test{s: "10"})
+	return tests
+}
+
+func solve(t Test) (int, int) {
+	pos0, pos1 := -1, -1
+	for i, ch := range t.s {
+		if ch == '0' && pos0 == -1 {
+			pos0 = i + 1
+		}
+		if ch == '1' && pos1 == -1 {
+			pos1 = i + 1
+		}
+	}
+	return pos0, pos1
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: verifierD <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	passed := 0
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n%s\n", len(t.s), t.s)
+		want0, want1 := solve(t)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d exec err %v\n", i+1, err)
+			continue
+		}
+		outStr := strings.TrimSpace(output)
+		nums := strings.Fields(outStr)
+		if len(nums) != 2 {
+			fmt.Printf("Test %d bad output %s\n", i+1, outStr)
+			continue
+		}
+		g0, err0 := strconv.Atoi(nums[0])
+		g1, err1 := strconv.Atoi(nums[1])
+		if err0 != nil || err1 != nil || g0 != want0 || g1 != want1 {
+			fmt.Printf("Test %d expected %d %d got %s\n", i+1, want0, want1, outStr)
+			continue
+		}
+		passed++
+	}
+	fmt.Printf("Passed %d/%d tests\n", passed, len(tests))
+}

--- a/0-999/800-899/860-869/862/verifierE.go
+++ b/0-999/800-899/860-869/862/verifierE.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Query struct {
+	l, r int
+	x    int64
+}
+
+type Test struct {
+	n, m, q int
+	a       []int64
+	b       []int64
+	queries []Query
+}
+
+func generateTests() []Test {
+	rand.Seed(46)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(3) + 2 // 2..4
+		m := n + rand.Intn(3) // >=n
+		q := rand.Intn(3) + 1 // 1..3
+		a := make([]int64, n)
+		b := make([]int64, m)
+		for j := range a {
+			a[j] = int64(rand.Intn(5))
+		}
+		for j := range b {
+			b[j] = int64(rand.Intn(5))
+		}
+		queries := make([]Query, q)
+		for j := 0; j < q; j++ {
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			x := int64(rand.Intn(5) - 2)
+			queries[j] = Query{l, r, x}
+		}
+		tests = append(tests, Test{n: n, m: m, q: q, a: a, b: b, queries: queries})
+	}
+	// simple edge case
+	tests = append(tests, Test{n: 2, m: 3, q: 1, a: []int64{1, 2}, b: []int64{2, 3, 4}, queries: []Query{{1, 2, 1}}})
+	return tests
+}
+
+func minAbs(arr []int64, x int64) int64 {
+	i := sort.Search(len(arr), func(i int) bool { return arr[i] >= x })
+	best := int64(1<<63 - 1)
+	if i < len(arr) {
+		diff := arr[i] - x
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff < best {
+			best = diff
+		}
+	}
+	if i > 0 {
+		diff := x - arr[i-1]
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff < best {
+			best = diff
+		}
+	}
+	return best
+}
+
+func solve(t Test) []int64 {
+	A := int64(0)
+	for i, v := range t.a {
+		if (i+1)%2 == 1 {
+			A += v
+		} else {
+			A -= v
+		}
+	}
+	bPrefix := make([]int64, t.m+1)
+	for i := 1; i <= t.m; i++ {
+		v := t.b[i-1]
+		if i%2 == 1 {
+			bPrefix[i] = bPrefix[i-1] + v
+		} else {
+			bPrefix[i] = bPrefix[i-1] - v
+		}
+	}
+	arr := make([]int64, t.m-t.n+1)
+	for j := 0; j <= t.m-t.n; j++ {
+		val := bPrefix[j+t.n] - bPrefix[j]
+		if j%2 == 1 {
+			val = -val
+		}
+		arr[j] = val
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	res := make([]int64, 0, t.q+1)
+	res = append(res, minAbs(arr, A))
+	for _, qu := range t.queries {
+		if (qu.r-qu.l+1)%2 == 1 {
+			if qu.l%2 == 1 {
+				A += qu.x
+			} else {
+				A -= qu.x
+			}
+		}
+		res = append(res, minAbs(arr, A))
+	}
+	return res
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: verifierE <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	passed := 0
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d %d\n", t.n, t.m, t.q)
+		for _, v := range t.a {
+			input += fmt.Sprintf("%d ", v)
+		}
+		input += "\n"
+		for _, v := range t.b {
+			input += fmt.Sprintf("%d ", v)
+		}
+		input += "\n"
+		for _, qu := range t.queries {
+			input += fmt.Sprintf("%d %d %d\n", qu.l, qu.r, qu.x)
+		}
+		wants := solve(t)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d exec err %v\n", i+1, err)
+			continue
+		}
+		lines := strings.Fields(strings.TrimSpace(output))
+		if len(lines) != len(wants) {
+			fmt.Printf("Test %d wrong number lines got %v\n", i+1, output)
+			continue
+		}
+		ok := true
+		for k, w := range wants {
+			g, err := strconv.ParseInt(lines[k], 10, 64)
+			if err != nil || g != w {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			fmt.Printf("Test %d expected %v got %s\n", i+1, wants, output)
+			continue
+		}
+		passed++
+	}
+	fmt.Printf("Passed %d/%d tests\n", passed, len(tests))
+}

--- a/0-999/800-899/860-869/862/verifierF.go
+++ b/0-999/800-899/860-869/862/verifierF.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Query struct {
+	t int
+	a int
+	b int
+	y string
+}
+
+type Test struct {
+	n       int
+	q       int
+	s       []string
+	queries []Query
+}
+
+func generateTests() []Test {
+	rand.Seed(47)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(3) + 2
+		q := rand.Intn(3) + 1
+		s := make([]string, n)
+		for j := 0; j < n; j++ {
+			s[j] = randString(rand.Intn(3) + 1)
+		}
+		queries := make([]Query, q)
+		for k := 0; k < q; k++ {
+			if rand.Intn(2) == 0 {
+				a := rand.Intn(n) + 1
+				b := rand.Intn(n-a+1) + a
+				queries[k] = Query{t: 1, a: a, b: b}
+			} else {
+				x := rand.Intn(n) + 1
+				y := randString(rand.Intn(3) + 1)
+				queries[k] = Query{t: 2, a: x, y: y}
+			}
+		}
+		tests = append(tests, Test{n: n, q: q, s: s, queries: queries})
+	}
+	tests = append(tests, Test{n: 2, q: 1, s: []string{"a", "b"}, queries: []Query{{t: 1, a: 1, b: 2}}})
+	return tests
+}
+
+const letters = "abc"
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func lcp(a, b string) int {
+	if len(a) > len(b) {
+		a, b = b, a
+	}
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return len(a)
+}
+
+func maxArea(heights []int) int {
+	n := len(heights)
+	stack := make([]int, 0, n)
+	maxA := 0
+	for i := 0; i <= n; i++ {
+		var h int
+		if i < n {
+			h = heights[i]
+		} else {
+			h = -1
+		}
+		for len(stack) > 0 && h < heights[stack[len(stack)-1]] {
+			top := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			left := -1
+			if len(stack) > 0 {
+				left = stack[len(stack)-1]
+			}
+			width := i - left
+			area := width * heights[top]
+			if area > maxA {
+				maxA = area
+			}
+		}
+		stack = append(stack, i)
+	}
+	return maxA
+}
+
+func solveQuery(s []string, q Query) int {
+	if q.t == 2 {
+		s[q.a-1] = q.y
+		return -1
+	}
+	a, b := q.a-1, q.b-1
+	ans := 0
+	for i := a; i <= b; i++ {
+		if len(s[i]) > ans {
+			ans = len(s[i])
+		}
+	}
+	if a < b {
+		heights := make([]int, b-a)
+		for i := a; i < b; i++ {
+			heights[i-a] = lcp(s[i], s[i+1])
+		}
+		area := maxArea(heights)
+		if area > ans {
+			ans = area
+		}
+	}
+	return ans
+}
+
+func solve(t Test) []int {
+	res := make([]int, 0, len(t.queries))
+	s := append([]string(nil), t.s...)
+	for _, qu := range t.queries {
+		val := solveQuery(s, qu)
+		if qu.t == 1 {
+			res = append(res, val)
+		}
+	}
+	return res
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: verifierF <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	passed := 0
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.n, t.q)
+		for _, str := range t.s {
+			input += str + " "
+		}
+		input += "\n"
+		for _, qu := range t.queries {
+			if qu.t == 1 {
+				input += fmt.Sprintf("1 %d %d\n", qu.a, qu.b)
+			} else {
+				input += fmt.Sprintf("2 %d %s\n", qu.a, qu.y)
+			}
+		}
+		wants := solve(t)
+		output, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d exec err %v\n", i+1, err)
+			continue
+		}
+		outLines := strings.Fields(strings.TrimSpace(output))
+		if len(outLines) != len(wants) {
+			fmt.Printf("Test %d expected %d outputs got %d\n", i+1, len(wants), len(outLines))
+			continue
+		}
+		ok := true
+		for k, w := range wants {
+			g, err := strconv.Atoi(outLines[k])
+			if err != nil || g != w {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			fmt.Printf("Test %d wrong output got %s expected %v\n", i+1, output, wants)
+			continue
+		}
+		passed++
+	}
+	fmt.Printf("Passed %d/%d tests\n", passed, len(tests))
+}


### PR DESCRIPTION
## Summary
- Add verifier programs in Go for each problem A–F of contest 862
- Each verifier generates at least 100 random test cases and checks an external binary
- Simple algorithms from reference solutions are reimplemented to compare outputs

## Testing
- `go build verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`
- `go run verifierA.go ./solutionA` (after building `862A.go`)


------
https://chatgpt.com/codex/tasks/task_e_6883d8d90088832480252d774367e7a1