### PR TITLE
Add Go solution for 1634B

### DIFF
--- a/1000-1999/1600-1699/1630-1639/1634/1634B.go
+++ b/1000-1999/1600-1699/1630-1639/1634/1634B.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		var x, y int64
+		fmt.Fscan(reader, &n, &x, &y)
+		parity := int64(0)
+		for i := 0; i < n; i++ {
+			var a int64
+			fmt.Fscan(reader, &a)
+			parity ^= a & 1
+		}
+		aliceParity := (x & 1) ^ parity
+		if aliceParity == (y & 1) {
+			fmt.Fprintln(writer, "Alice")
+		} else {
+			fmt.Fprintln(writer, "Bob")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1634B.go` for fortune telling

## Testing
- `go run 1000-1999/1600-1699/1630-1639/1634/1634B.go < /tmp/input.txt`

------
https://chatgpt.com/codex/tasks/task_e_6883da373e408324940b2ca20a6e42eb