### PR TITLE
Add Go verifiers for contest 863

### DIFF
--- a/0-999/800-899/860-869/863/verifierA.go
+++ b/0-999/800-899/860-869/863/verifierA.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func expectedA(x string) string {
+    for len(x) > 0 && x[len(x)-1] == '0' {
+        x = x[:len(x)-1]
+    }
+    isPal := true
+    for i := 0; i < len(x)/2; i++ {
+        if x[i] != x[len(x)-1-i] {
+            isPal = false
+            break
+        }
+    }
+    if isPal {
+        return "YES"
+    }
+    return "NO"
+}
+
+func genTestsA() []string {
+    rand.Seed(1)
+    tests := make([]string, 0, 100)
+    specials := []string{"1", "10", "100", "11", "101", "1001", "1234321", "200000000", "1000000000"}
+    tests = append(tests, specials...)
+    for len(tests) < 100 {
+        x := rand.Intn(1_000_000_000) + 1
+        tests = append(tests, fmt.Sprintf("%d", x))
+    }
+    return tests
+}
+
+func runBinary(bin string, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintf(os.Stderr, "Usage: go run verifierA.go <binary>\n")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsA()
+    for i, t := range tests {
+        input := t + "\n"
+        want := expectedA(t)
+        got, err := runBinary(bin, input)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != want {
+            fmt.Printf("Test %d failed. Input: %s Expected: %s Got: %s\n", i+1, t, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/0-999/800-899/860-869/863/verifierB.go
+++ b/0-999/800-899/860-869/863/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+)
+
+func expectedB(n int, w []int) int {
+    sort.Ints(w)
+    ans := math.MaxInt32
+    for i := 0; i < 2*n; i++ {
+        for j := i + 1; j < 2*n; j++ {
+            arr := make([]int, 0, 2*n-2)
+            for k := 0; k < 2*n; k++ {
+                if k == i || k == j {
+                    continue
+                }
+                arr = append(arr, w[k])
+            }
+            sum := 0
+            for k := 0; k < len(arr); k += 2 {
+                sum += arr[k+1] - arr[k]
+            }
+            if sum < ans {
+                ans = sum
+            }
+        }
+    }
+    return ans
+}
+
+func genTestsB() []string {
+    rand.Seed(2)
+    tests := make([]string, 0, 100)
+    for len(tests) < 100 {
+        n := rand.Intn(49) + 2
+        w := make([]int, 2*n)
+        for i := range w {
+            w[i] = rand.Intn(1000) + 1
+        }
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for i, val := range w {
+            if i > 0 {
+                sb.WriteString(" ")
+            }
+            sb.WriteString(fmt.Sprintf("%d", val))
+        }
+        sb.WriteString("\n")
+        tests = append(tests, sb.String())
+    }
+    return tests
+}
+
+func runBinary(bin string, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func parseWeights(line string) []int {
+    parts := strings.Fields(line)
+    res := make([]int, len(parts))
+    for i, p := range parts {
+        fmt.Sscanf(p, "%d", &res[i])
+    }
+    return res
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintf(os.Stderr, "Usage: go run verifierB.go <binary>\n")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsB()
+    for idx, t := range tests {
+        lines := strings.Split(strings.TrimSpace(t), "\n")
+        var n int
+        fmt.Sscanf(lines[0], "%d", &n)
+        weights := parseWeights(lines[1])
+        want := fmt.Sprintf("%d", expectedB(n, append([]int(nil), weights...)))
+        got, err := runBinary(bin, t)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != want {
+            fmt.Printf("Test %d failed.\nInput:\n%s\nExpected: %s\nGot: %s\n", idx+1, t, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/0-999/800-899/860-869/863/verifierC.go
+++ b/0-999/800-899/860-869/863/verifierC.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type matrices struct{
+    A [4][4]int
+    B [4][4]int
+}
+
+func expectedC(k int64, a, b int, mat matrices) (int64,int64) {
+    nextA := mat.A
+    nextB := mat.B
+    visitedStep := [4][4]int64{}
+    visitedA := [4][4]int64{}
+    visitedB := [4][4]int64{}
+    for i:=1;i<=3;i++{
+        for j:=1;j<=3;j++{
+            visitedStep[i][j] = -1
+        }
+    }
+    var scoreA, scoreB int64
+    var step int64
+    curA, curB := a, b
+    for step < k {
+        if visitedStep[curA][curB] != -1 {
+            prev := visitedStep[curA][curB]
+            cycleLen := step - prev
+            cycleScoreA := scoreA - visitedA[curA][curB]
+            cycleScoreB := scoreB - visitedB[curA][curB]
+            if cycleLen > 0 {
+                times := (k - step) / cycleLen
+                if times > 0 {
+                    scoreA += cycleScoreA * times
+                    scoreB += cycleScoreB * times
+                    step += cycleLen * times
+                }
+            }
+        }
+        if step >= k {
+            break
+        }
+        visitedStep[curA][curB] = step
+        visitedA[curA][curB] = scoreA
+        visitedB[curA][curB] = scoreB
+        if curA != curB {
+            if curA == 1 && curB == 3 || curA == 2 && curB == 1 || curA == 3 && curB == 2 {
+                scoreA++
+            } else {
+                scoreB++
+            }
+        }
+        step++
+        na := nextA[curA][curB]
+        nb := nextB[curA][curB]
+        curA, curB = na, nb
+    }
+    return scoreA, scoreB
+}
+
+func genTestsC() []string {
+    rand.Seed(3)
+    tests := make([]string, 0, 100)
+    for len(tests) < 100 {
+        k := rand.Int63n(50) + 1
+        a := rand.Intn(3) + 1
+        b := rand.Intn(3) + 1
+        matA := [4][4]int{}
+        matB := [4][4]int{}
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d %d %d\n", k, a, b))
+        for i:=1;i<=3;i++{
+            for j:=1;j<=3;j++{
+                matA[i][j] = rand.Intn(3)+1
+                sb.WriteString(fmt.Sprintf("%d ", matA[i][j]))
+            }
+            sb.WriteString("\n")
+        }
+        for i:=1;i<=3;i++{
+            for j:=1;j<=3;j++{
+                matB[i][j] = rand.Intn(3)+1
+                sb.WriteString(fmt.Sprintf("%d ", matB[i][j]))
+            }
+            sb.WriteString("\n")
+        }
+        tests = append(tests, sb.String())
+    }
+    return tests
+}
+
+func runBinary(bin string, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func parseMatrices(lines []string) matrices {
+    var res matrices
+    idx := 0
+    for i:=1;i<=3;i++{
+        parts := strings.Fields(lines[idx])
+        for j:=1;j<=3;j++{
+            fmt.Sscanf(parts[j-1], "%d", &res.A[i][j])
+        }
+        idx++
+    }
+    for i:=1;i<=3;i++{
+        parts := strings.Fields(lines[idx])
+        for j:=1;j<=3;j++{
+            fmt.Sscanf(parts[j-1], "%d", &res.B[i][j])
+        }
+        idx++
+    }
+    return res
+}
+
+func main(){
+    if len(os.Args) != 2 {
+        fmt.Fprintf(os.Stderr, "Usage: go run verifierC.go <binary>\n")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsC()
+    for idx, t := range tests {
+        lines := strings.Split(strings.TrimSpace(t), "\n")
+        var k int64
+        var a,b int
+        fmt.Sscanf(lines[0], "%d %d %d", &k, &a, &b)
+        mats := parseMatrices(lines[1:])
+        sa,sb := expectedC(k,a,b,mats)
+        want := fmt.Sprintf("%d %d", sa,sb)
+        got, err := runBinary(bin, t)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got) != want {
+            fmt.Printf("Test %d failed.\nInput:\n%s\nExpected: %s\nGot: %s\n", idx+1, t, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/0-999/800-899/860-869/863/verifierD.go
+++ b/0-999/800-899/860-869/863/verifierD.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func expectedD(n,q,m int, a []int, t,l,r []int, b []int) string {
+    res := make([]int, m)
+    for idx:=0; idx<m; idx++ {
+        pos := b[idx]
+        for i:=q-1; i>=0; i-- {
+            if pos < l[i] || pos > r[i] {
+                continue
+            }
+            if t[i]==1 {
+                if pos == l[i] {
+                    pos = r[i]
+                } else {
+                    pos--
+                }
+            } else {
+                pos = l[i] + r[i] - pos
+            }
+        }
+        res[idx] = a[pos]
+    }
+    var sb strings.Builder
+    for i,v := range res {
+        if i>0 { sb.WriteByte(' ') }
+        sb.WriteString(fmt.Sprintf("%d", v))
+    }
+    return sb.String()
+}
+
+func genTestsD() []string {
+    rand.Seed(4)
+    tests := make([]string,0,100)
+    for len(tests) < 100 {
+        n := rand.Intn(5)+1
+        q := rand.Intn(5)+1
+        m := rand.Intn(5)+1
+        a := make([]int,n+1)
+        for i:=1;i<=n;i++ { a[i] = rand.Intn(100)+1 }
+        tArr := make([]int,q)
+        lArr := make([]int,q)
+        rArr := make([]int,q)
+        for i:=0;i<q;i++ {
+            tArr[i] = rand.Intn(2)+1
+            lArr[i] = rand.Intn(n)+1
+            rArr[i] = rand.Intn(n-lArr[i]+1)+lArr[i]
+        }
+        b := make([]int,m)
+        for i:=0;i<m;i++ { b[i] = rand.Intn(n)+1 }
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d %d %d\n", n,q,m))
+        for i:=1;i<=n;i++ {
+            if i>1 { sb.WriteByte(' ') }
+            sb.WriteString(fmt.Sprintf("%d", a[i]))
+        }
+        sb.WriteString("\n")
+        for i:=0;i<q;i++ {
+            sb.WriteString(fmt.Sprintf("%d %d %d\n", tArr[i], lArr[i], rArr[i]))
+        }
+        for i:=0;i<m;i++ {
+            if i>0 { sb.WriteByte(' ') }
+            sb.WriteString(fmt.Sprintf("%d", b[i]))
+        }
+        sb.WriteString("\n")
+        tests = append(tests, sb.String())
+    }
+    return tests
+}
+
+func runBinary(bin string, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func parseInts(line string) []int {
+    parts := strings.Fields(line)
+    res := make([]int,len(parts))
+    for i,p := range parts { fmt.Sscanf(p, "%d", &res[i]) }
+    return res
+}
+
+func main(){
+    if len(os.Args)!=2 {
+        fmt.Fprintf(os.Stderr,"Usage: go run verifierD.go <binary>\n")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsD()
+    for idx,t := range tests {
+        lines := strings.Split(strings.TrimSpace(t),"\n")
+        var n,q,m int
+        fmt.Sscanf(lines[0],"%d %d %d", &n,&q,&m)
+        a := make([]int,n+1)
+        vals := parseInts(lines[1])
+        copy(a[1:],vals)
+        tArr := make([]int,q)
+        lArr := make([]int,q)
+        rArr := make([]int,q)
+        for i:=0;i<q;i++ {
+            fmt.Sscanf(lines[2+i],"%d %d %d", &tArr[i], &lArr[i], &rArr[i])
+        }
+        b := parseInts(lines[2+q])
+        want := expectedD(n,q,m,a,tArr,lArr,rArr,b)
+        got, err := runBinary(bin,t)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got)!=want {
+            fmt.Printf("Test %d failed.\nInput:\n%s\nExpected: %s\nGot: %s\n", idx+1, t, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/0-999/800-899/860-869/863/verifierE.go
+++ b/0-999/800-899/860-869/863/verifierE.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+)
+
+func expectedE(n int, l,r []int) string {
+    p := make([]int,n)
+    for i:=0;i<n;i++ { p[i] = i }
+    sort.Slice(p, func(i,j int) bool {
+        if l[p[i]] == l[p[j]] {
+            return r[p[i]] < r[p[j]]
+        }
+        return l[p[i]] < l[p[j]]
+    })
+    for i:=1;i<n;i++ {
+        if l[p[i-1]] == l[p[i]] { return fmt.Sprintf("%d", p[i-1]+1) }
+        if r[p[i-1]] >= r[p[i]] { return fmt.Sprintf("%d", p[i]+1) }
+    }
+    for i:=1;i+1<n;i++ {
+        if r[p[i-1]]+1 >= l[p[i+1]] { return fmt.Sprintf("%d", p[i]+1) }
+    }
+    return "-1"
+}
+
+func genTestsE() []string {
+    rand.Seed(5)
+    tests := make([]string,0,100)
+    for len(tests) < 100 {
+        n := rand.Intn(8)+2
+        l := make([]int,n)
+        r := make([]int,n)
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", n))
+        for i:=0;i<n;i++ {
+            l[i] = rand.Intn(100)+1
+            r[i] = l[i] + rand.Intn(20)
+            sb.WriteString(fmt.Sprintf("%d %d\n", l[i], r[i]))
+        }
+        tests = append(tests, sb.String())
+    }
+    return tests
+}
+
+func runBinary(bin string, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main(){
+    if len(os.Args)!=2 {
+        fmt.Fprintf(os.Stderr,"Usage: go run verifierE.go <binary>\n")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := genTestsE()
+    for idx,t := range tests {
+        lines := strings.Split(strings.TrimSpace(t),"\n")
+        var n int
+        fmt.Sscanf(lines[0], "%d", &n)
+        l := make([]int,n)
+        r := make([]int,n)
+        for i:=0;i<n;i++ {
+            fmt.Sscanf(lines[1+i], "%d %d", &l[i], &r[i])
+        }
+        want := expectedE(n,l,r)
+        got, err := runBinary(bin,t)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got)!=want {
+            fmt.Printf("Test %d failed.\nInput:\n%s\nExpected: %s\nGot: %s\n", idx+1, t, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/0-999/800-899/860-869/863/verifierF.go
+++ b/0-999/800-899/860-869/863/verifierF.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+    "bytes"
+    "container/heap"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+type Edge struct {
+    to, rev, cap int
+    cost       int
+}
+
+type Graph [][]*Edge
+
+func (g Graph) AddEdge(u, v, cap, cost int) {
+    g[u] = append(g[u], &Edge{to: v, rev: len(g[v]), cap: cap, cost: cost})
+    g[v] = append(g[v], &Edge{to: u, rev: len(g[u]) - 1, cap: 0, cost: -cost})
+}
+
+type Item struct {
+    v    int
+    dist int
+}
+
+type PriorityQueue []Item
+
+func (pq PriorityQueue) Len() int            { return len(pq) }
+func (pq PriorityQueue) Less(i, j int) bool  { return pq[i].dist < pq[j].dist }
+func (pq PriorityQueue) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PriorityQueue) Push(x interface{}) { *pq = append(*pq, x.(Item)) }
+func (pq *PriorityQueue) Pop() interface{} {
+    old := *pq
+    n := len(old)
+    it := old[n-1]
+    *pq = old[:n-1]
+    return it
+}
+
+func minCostFlow(g Graph, s, t, maxf int) (int, int) {
+    n := len(g)
+    h := make([]int, n)
+    prevv := make([]int, n)
+    preve := make([]int, n)
+    flow, cost := 0, 0
+    const INF = int(1 << 60)
+    for flow < maxf {
+        dist := make([]int, n)
+        for i := range dist { dist[i] = INF }
+        dist[s] = 0
+        pq := &PriorityQueue{}
+        heap.Init(pq)
+        heap.Push(pq, Item{v: s, dist: 0})
+        for pq.Len() > 0 {
+            it := heap.Pop(pq).(Item)
+            v := it.v
+            if dist[v] < it.dist { continue }
+            for i,e := range g[v] {
+                if e.cap > 0 && dist[e.to] > dist[v]+e.cost+h[v]-h[e.to] {
+                    dist[e.to] = dist[v] + e.cost + h[v] - h[e.to]
+                    prevv[e.to] = v
+                    preve[e.to] = i
+                    heap.Push(pq, Item{v:e.to, dist:dist[e.to]})
+                }
+            }
+        }
+        if dist[t] == INF { break }
+        for v:=0; v<n; v++ { if dist[v] < INF { h[v] += dist[v] } }
+        d := maxf - flow
+        for v:=t; v!=s; v = prevv[v] {
+            if d > g[prevv[v]][preve[v]].cap {
+                d = g[prevv[v]][preve[v]].cap
+            }
+        }
+        flow += d
+        cost += d * h[t]
+        for v:=t; v!=s; v = prevv[v] {
+            e := g[prevv[v]][preve[v]]
+            e.cap -= d
+            g[v][e.rev].cap += d
+        }
+    }
+    return flow, cost
+}
+
+func expectedF(n,q int, queries [][4]int) string {
+    lb := make([]int,n)
+    ub := make([]int,n)
+    for i:=0;i<n;i++ { lb[i]=1; ub[i]=n }
+    for _,qr := range queries {
+        t,l,r,v := qr[0],qr[1]-1,qr[2]-1,qr[3]
+        if t==1 {
+            for j:=l;j<=r;j++ { if lb[j] < v { lb[j]=v } }
+        } else {
+            for j:=l;j<=r;j++ { if ub[j] > v { ub[j]=v } }
+        }
+    }
+    for i:=0;i<n;i++ { if lb[i]>ub[i] { return "-1" } }
+    V := 2*n+2
+    s := 0
+    posBase := 1
+    valBase := posBase+n
+    tIdx := valBase+n
+    g := make(Graph,V)
+    for i:=0;i<n;i++ {
+        g.AddEdge(s,posBase+i,1,0)
+        for v:=lb[i]; v<=ub[i]; v++ { g.AddEdge(posBase+i,valBase+(v-1),1,0) }
+    }
+    for v:=0; v<n; v++ {
+        for k:=1; k<=n; k++ {
+            cost := 2*k - 1
+            g.AddEdge(valBase+v,tIdx,1,cost)
+        }
+    }
+    flow,cost := minCostFlow(g,s,tIdx,n)
+    if flow < n { return "-1" }
+    return fmt.Sprintf("%d", cost)
+}
+
+func genTestsF() []string {
+    rand.Seed(6)
+    tests := make([]string,0,100)
+    for len(tests)<100 {
+        n := rand.Intn(3)+1
+        q := rand.Intn(3)
+        var queries [][4]int
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d %d\n", n,q))
+        for i:=0;i<q;i++ {
+            t := rand.Intn(2)+1
+            l := rand.Intn(n)+1
+            r := rand.Intn(n-l+1)+l
+            v := rand.Intn(n)+1
+            sb.WriteString(fmt.Sprintf("%d %d %d %d\n", t,l,r,v))
+            queries = append(queries,[4]int{t,l,r,v})
+        }
+        tests = append(tests, sb.String())
+    }
+    return tests
+}
+
+func runBinary(bin string, input string) (string,error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func parseQueries(lines []string) [][4]int {
+    res := make([][4]int,len(lines))
+    for i,l := range lines {
+        fmt.Sscanf(l, "%d %d %d %d", &res[i][0],&res[i][1],&res[i][2],&res[i][3])
+    }
+    return res
+}
+
+func main(){
+    if len(os.Args)!=2 { fmt.Fprintf(os.Stderr,"Usage: go run verifierF.go <binary>\n"); os.Exit(1) }
+    bin := os.Args[1]
+    tests := genTestsF()
+    for idx,t := range tests {
+        lines := strings.Split(strings.TrimSpace(t),"\n")
+        var n,q int
+        fmt.Sscanf(lines[0],"%d %d", &n,&q)
+        queries := parseQueries(lines[1:1+q])
+        want := expectedF(n,q,queries)
+        got, err := runBinary(bin,t)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got)!=want {
+            fmt.Printf("Test %d failed.\nInput:\n%s\nExpected: %s\nGot: %s\n", idx+1, t, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/0-999/800-899/860-869/863/verifierG.go
+++ b/0-999/800-899/860-869/863/verifierG.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func genPaths(m int, a []int) [][]int {
+    orient := make([]int,m)
+    cur := make([]int,m)
+    path := [][]int{}
+    var rec func(level int)
+    rec = func(level int) {
+        if level==0 {
+            s := make([]int,m)
+            copy(s,cur)
+            path = append(path,s)
+            return
+        }
+        n := a[level-1]
+        for i:=0;i<n;i++ {
+            if orient[level-1]==0 { cur[level-1]=i } else { cur[level-1]=n-1-i }
+            rec(level-1)
+            if i!=n-1 && level>=2 { orient[level-2]^=1 }
+        }
+    }
+    rec(m)
+    return path
+}
+
+func diffInstr(x,y []int) string {
+    m := len(x)
+    for i:=0;i<m;i++ {
+        if x[i]!=y[i] {
+            if y[i]==x[i]+1 { return fmt.Sprintf("inc %d", i+1) }
+            return fmt.Sprintf("dec %d", i+1)
+        }
+    }
+    return ""
+}
+
+func expectedG(m int, a,b []int) string {
+    for i:=0;i<m;i++ { b[i]-- }
+    path := genPaths(m,a)
+    p := len(path)
+    pos :=0
+    for i:=0;i<p;i++ {
+        ok := true
+        for j:=0;j<m;j++ { if path[i][j]!=b[j] { ok=false; break } }
+        if ok { pos=i; break }
+    }
+    rotated := append(path[pos:], path[:pos]...)
+    var sb strings.Builder
+    sb.WriteString("Path\n")
+    for i:=0;i<p-1;i++ {
+        sb.WriteString(diffInstr(rotated[i],rotated[i+1]))
+        sb.WriteString("\n")
+    }
+    return strings.TrimSpace(sb.String())
+}
+
+func genTestsG() []string {
+    rand.Seed(7)
+    tests := make([]string,0,100)
+    for len(tests)<100 {
+        m := rand.Intn(3)+1
+        a := make([]int,m)
+        b := make([]int,m)
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", m))
+        for i:=0;i<m;i++ {
+            a[i] = rand.Intn(3)+1
+            sb.WriteString(fmt.Sprintf("%d ", a[i]))
+        }
+        sb.WriteString("\n")
+        for i:=0;i<m;i++ {
+            b[i] = rand.Intn(a[i])+1
+            sb.WriteString(fmt.Sprintf("%d ", b[i]))
+        }
+        sb.WriteString("\n")
+        tests = append(tests,sb.String())
+    }
+    return tests
+}
+
+func runBinary(bin string, input string) (string,error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func parseInputG(t string) (int,[]int,[]int) {
+    lines := strings.Split(strings.TrimSpace(t),"\n")
+    var m int
+    fmt.Sscanf(lines[0], "%d", &m)
+    aParts := strings.Fields(lines[1])
+    bParts := strings.Fields(lines[2])
+    a := make([]int,m)
+    b := make([]int,m)
+    for i:=0;i<m;i++ {
+        fmt.Sscanf(aParts[i], "%d", &a[i])
+        fmt.Sscanf(bParts[i], "%d", &b[i])
+    }
+    return m,a,b
+}
+
+func main(){
+    if len(os.Args)!=2 { fmt.Fprintf(os.Stderr,"Usage: go run verifierG.go <binary>\n"); os.Exit(1) }
+    bin := os.Args[1]
+    tests := genTestsG()
+    for idx,t := range tests {
+        m,a,b := parseInputG(t)
+        want := expectedG(m, append([]int(nil), a...), append([]int(nil), b...))
+        got, err := runBinary(bin,t)
+        if err != nil {
+            fmt.Printf("Test %d: runtime error: %v\n", idx+1, err)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(got)!=want {
+            fmt.Printf("Test %d failed.\nInput:\n%s\nExpected:\n%s\nGot:\n%s\n", idx+1, t, want, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–G of contest 863
- each verifier generates 100 random tests and checks a given binary

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`


------
https://chatgpt.com/codex/tasks/task_e_6883d9651a1483249edaed99f7c01b76