### PR TITLE
Add verifiers for Codeforces Round 864

### DIFF
--- a/0-999/800-899/860-869/864/verifierA.go
+++ b/0-999/800-899/860-869/864/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveA(nums []int) string {
+	counts := make(map[int]int)
+	for _, x := range nums {
+		counts[x]++
+	}
+	if len(counts) != 2 {
+		return "NO"
+	}
+	vals := make([]int, 0, 2)
+	for k := range counts {
+		vals = append(vals, k)
+	}
+	if counts[vals[0]] != counts[vals[1]] {
+		return "NO"
+	}
+	sort.Ints(vals)
+	return fmt.Sprintf("YES\n%d %d", vals[0], vals[1])
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50)*2 + 2 // even between 2 and 100
+	nums := make([]int, n)
+	for i := range nums {
+		nums[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	exp := solveA(nums)
+	return sb.String(), exp
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/864/verifierB.go
+++ b/0-999/800-899/860-869/864/verifierB.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(s string) string {
+	maxDistinct := 0
+	seen := make(map[rune]bool)
+	for _, ch := range s {
+		if ch >= 'a' && ch <= 'z' {
+			seen[ch] = true
+		} else {
+			if len(seen) > maxDistinct {
+				maxDistinct = len(seen)
+			}
+			seen = make(map[rune]bool)
+		}
+	}
+	if len(seen) > maxDistinct {
+		maxDistinct = len(seen)
+	}
+	return fmt.Sprintf("%d", maxDistinct)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(200) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		} else {
+			sb.WriteByte(byte('A' + rng.Intn(26)))
+		}
+	}
+	s := sb.String()
+	input := fmt.Sprintf("%d\n%s\n", len(s), s)
+	return input, solveB(s)
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/864/verifierC.go
+++ b/0-999/800-899/860-869/864/verifierC.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveC(a, b, f, k int) string {
+	fuel := b
+	refuels := 0
+	for i := 1; i <= k; i++ {
+		if i%2 == 1 { // 0->a
+			if fuel < f {
+				return "-1"
+			}
+			fuel -= f
+			dist := 0
+			if i == k {
+				dist = a - f
+			} else {
+				dist = 2 * (a - f)
+			}
+			if b < dist {
+				return "-1"
+			}
+			if fuel < dist {
+				refuels++
+				fuel = b
+			}
+			fuel -= a - f
+		} else { // a->0
+			if fuel < a-f {
+				return "-1"
+			}
+			fuel -= a - f
+			dist := 0
+			if i == k {
+				dist = f
+			} else {
+				dist = 2 * f
+			}
+			if b < dist {
+				return "-1"
+			}
+			if fuel < dist {
+				refuels++
+				fuel = b
+			}
+			fuel -= f
+		}
+	}
+	return fmt.Sprintf("%d", refuels)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	a := rng.Intn(1000) + 1
+	f := rng.Intn(a-1) + 1
+	b := rng.Intn(1000) + 1
+	k := rng.Intn(10) + 1
+	input := fmt.Sprintf("%d %d %d %d\n", a, b, f, k)
+	return input, solveC(a, b, f, k)
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/864/verifierD.go
+++ b/0-999/800-899/860-869/864/verifierD.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveD(a []int) (string, []int) {
+	n := len(a)
+	freq := make([]int, n+1)
+	for _, v := range a {
+		if v >= 1 && v <= n {
+			freq[v]++
+		}
+	}
+	missing := make([]int, 0)
+	for v := 1; v <= n; v++ {
+		if freq[v] == 0 {
+			missing = append(missing, v)
+		}
+	}
+	missIdx := 0
+	used := make([]bool, n+1)
+	changes := 0
+	for i := 0; i < n; i++ {
+		v := a[i]
+		if v < 1 || v > n {
+			a[i] = missing[missIdx]
+			missIdx++
+			changes++
+			continue
+		}
+		if !used[v] {
+			if freq[v] == 1 {
+				used[v] = true
+				continue
+			}
+			if missIdx < len(missing) && missing[missIdx] < v {
+				freq[v]--
+				a[i] = missing[missIdx]
+				missIdx++
+				changes++
+			} else {
+				used[v] = true
+				freq[v]--
+			}
+		} else {
+			freq[v]--
+			a[i] = missing[missIdx]
+			missIdx++
+			changes++
+		}
+	}
+	return fmt.Sprintf("%d", changes), a
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 2
+	a := make([]int, n)
+	for i := range a {
+		if rng.Intn(2) == 0 {
+			a[i] = rng.Intn(n*2) + 1
+		} else {
+			a[i] = rng.Intn(n) + 1
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	expChanges, arr := solveD(append([]int(nil), a...))
+	var out strings.Builder
+	out.WriteString(expChanges)
+	out.WriteByte('\n')
+	for i, v := range arr {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		out.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String(), out.String()
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/864/verifierE.go
+++ b/0-999/800-899/860-869/864/verifierE.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type pair struct {
+	profit int64
+	used   []bool
+}
+
+func solveE(tt []int, dd []int, pp []int64) (int64, []int) {
+	n := len(tt)
+	idx := make([]int, n)
+	for i := 0; i < n; i++ {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(i, j int) bool { return dd[idx[i]] < dd[idx[j]] })
+	maxD := 0
+	for _, d := range dd {
+		if d > maxD {
+			maxD = d
+		}
+	}
+	dp := make([]pair, maxD+1)
+	for t := range dp {
+		dp[t].used = make([]bool, n)
+	}
+	best := pair{used: make([]bool, n)}
+	for _, x := range idx {
+		t := tt[x]
+		d := dd[x]
+		p := pp[x]
+		for tim := d - t - 1; tim >= 0; tim-- {
+			cur := dp[tim]
+			newProfit := cur.profit + p
+			newT := tim + t
+			if newProfit > dp[newT].profit {
+				newUsed := make([]bool, n)
+				copy(newUsed, cur.used)
+				newUsed[x] = true
+				dp[newT].profit = newProfit
+				dp[newT].used = newUsed
+				if newProfit > best.profit {
+					best.profit = newProfit
+					best.used = newUsed
+				}
+			}
+		}
+	}
+	list := []int{}
+	for i := 0; i < n; i++ {
+		if best.used[i] {
+			list = append(list, i)
+		}
+	}
+	sort.Slice(list, func(i, j int) bool { return dd[list[i]] < dd[list[j]] })
+	return best.profit, list
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	tt := make([]int, n)
+	dd := make([]int, n)
+	pp := make([]int64, n)
+	for i := 0; i < n; i++ {
+		tt[i] = rng.Intn(20) + 1
+		dd[i] = rng.Intn(200) + tt[i] + 1
+		pp[i] = int64(rng.Intn(20) + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", tt[i], dd[i], pp[i]))
+	}
+	profit, list := solveE(tt, dd, pp)
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("%d\n", profit))
+	out.WriteString(fmt.Sprintf("%d\n", len(list)))
+	for _, v := range list {
+		out.WriteString(fmt.Sprintf("%d ", v+1))
+	}
+	return sb.String(), strings.TrimSpace(out.String())
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/864/verifierF.go
+++ b/0-999/800-899/860-869/864/verifierF.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func computePath(n int, edges [][2]int, s, t int) []int {
+	adj := make([][]int, n+1)
+	rev := make([][]int, n+1)
+	for _, e := range edges {
+		x, y := e[0], e[1]
+		adj[x] = append(adj[x], y)
+		rev[y] = append(rev[y], x)
+	}
+	for i := 1; i <= n; i++ {
+		sort.Ints(adj[i])
+	}
+	reachable := make([]bool, n+1)
+	queue := []int{t}
+	reachable[t] = true
+	for head := 0; head < len(queue); head++ {
+		v := queue[head]
+		for _, u := range rev[v] {
+			if !reachable[u] {
+				reachable[u] = true
+				queue = append(queue, u)
+			}
+		}
+	}
+	if !reachable[s] {
+		return nil
+	}
+	visited := make([]bool, n+1)
+	curr := s
+	visited[curr] = true
+	path := []int{curr}
+	for curr != t {
+		found := false
+		for _, v := range adj[curr] {
+			if reachable[v] {
+				curr = v
+				if visited[curr] {
+					return nil
+				}
+				visited[curr] = true
+				path = append(path, curr)
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil
+		}
+	}
+	return path
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 2
+	m := rng.Intn(n * (n - 1))
+	edges := make([][2]int, 0, m)
+	edgeSet := make(map[[2]int]bool)
+	for len(edges) < m {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a == b {
+			continue
+		}
+		e := [2]int{a, b}
+		if edgeSet[e] {
+			continue
+		}
+		edgeSet[e] = true
+		edges = append(edges, e)
+	}
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, len(edges), q))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	var out strings.Builder
+	for i := 0; i < q; i++ {
+		s := rng.Intn(n) + 1
+		t := rng.Intn(n) + 1
+		for t == s {
+			t = rng.Intn(n) + 1
+		}
+		k := rng.Intn(n) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", s, t, k))
+		path := computePath(n, edges, s, t)
+		if path == nil || k > len(path) {
+			out.WriteString("-1\n")
+		} else {
+			out.WriteString(fmt.Sprintf("%d\n", path[k-1]))
+		}
+	}
+	return sb.String(), strings.TrimSpace(out.String())
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implemented Go verifiers for each problem in contest 864
- verifiers generate at least 100 random tests and run a given binary
- supported problems A–F

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go vet ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_6883d9f1a0188324af99d603989a530c