### PR TITLE
Add Go solution for 1641A

### DIFF
--- a/1000-1999/1600-1699/1640-1649/1641/1641A.go
+++ b/1000-1999/1600-1699/1640-1649/1641/1641A.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	if _, err := fmt.Fscan(in, &T); err != nil {
+		return
+	}
+	for ; T > 0; T-- {
+		var n int
+		var x int64
+		fmt.Fscan(in, &n, &x)
+		arr := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+		}
+		sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+		freq := make(map[int64]int)
+		for _, v := range arr {
+			freq[v]++
+		}
+		ans := 0
+		for _, v := range arr {
+			if freq[v] == 0 {
+				continue
+			}
+			freq[v]--
+			target := v * x
+			if freq[target] > 0 {
+				freq[target]--
+			} else {
+				ans++
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Great Sequence solution in Go

## Testing
- `go build 1000-1999/1600-1699/1640-1649/1641/1641A.go`
- `go run 1000-1999/1600-1699/1640-1649/1641/1641A.go < /tmp/input.txt`
- `go run 1000-1999/1600-1699/1640-1649/1641/1641A.go < /tmp/input3.txt`


------
https://chatgpt.com/codex/tasks/task_e_6883dcf3f3d88324b43009f80491e4ab