### PR TITLE
Add Go verifiers for contest 865

### DIFF
--- a/0-999/800-899/860-869/865/verifierA.go
+++ b/0-999/800-899/860-869/865/verifierA.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(A int) string {
+	if A == 1 {
+		return "1 1\n1"
+	}
+	N := 10 * (A - 1)
+	return fmt.Sprintf("%d 2\n1 10", N)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		A := rng.Intn(1000) + 1
+		input := fmt.Sprintf("%d\n", A)
+		expected := solve(A)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\n---\ngot:\n%s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/865/verifierB.go
+++ b/0-999/800-899/860-869/865/verifierB.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type person struct {
+	s int
+	a int
+	b int
+}
+
+func solve(n, S int, arr []person) int64 {
+	people := make([]struct{ s, diff int }, n)
+	total := 0
+	var base int64
+	for i, p := range arr {
+		people[i] = struct{ s, diff int }{p.s, p.a - p.b}
+		total += p.s
+		base += int64(p.s) * int64(p.b)
+	}
+	sort.Slice(people, func(i, j int) bool { return people[i].diff > people[j].diff })
+	ps := make([]int64, n+1)
+	pg := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		ps[i+1] = ps[i] + int64(people[i].s)
+		pg[i+1] = pg[i] + int64(people[i].s)*int64(people[i].diff)
+	}
+	pizzas := (total + S - 1) / S
+	ans := base
+	for x := 0; x <= pizzas; x++ {
+		t1 := int64(x * S)
+		if t1 > int64(total) {
+			t1 = int64(total)
+		}
+		idx := sort.Search(n, func(i int) bool { return ps[i+1] >= t1 })
+		gain := pg[idx]
+		if idx < n && t1 > ps[idx] {
+			gain += (t1 - ps[idx]) * int64(people[idx].diff)
+		}
+		if base+gain > ans {
+			ans = base + gain
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(20) + 1
+		S := rng.Intn(10) + 1
+		arr := make([]person, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, S)
+		for i := 0; i < n; i++ {
+			arr[i].s = rng.Intn(20) + 1
+			arr[i].a = rng.Intn(20) + 1
+			arr[i].b = rng.Intn(20) + 1
+			fmt.Fprintf(&sb, "%d %d %d\n", arr[i].s, arr[i].a, arr[i].b)
+		}
+		expected := fmt.Sprintf("%d", solve(n, S, arr))
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\n---\ngot:\n%s\n", t+1, sb.String(), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/865/verifierC.go
+++ b/0-999/800-899/860-869/865/verifierC.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solve(n, R int, f, s, p []int) float64 {
+	d := make([]int, n)
+	R2 := R
+	for i := 0; i < n; i++ {
+		d[i] = s[i] - f[i]
+		R2 -= f[i]
+	}
+	dp := make([][]float64, n+1)
+	for i := range dp {
+		dp[i] = make([]float64, R2+1)
+	}
+	check := func(C float64) bool {
+		for i := 0; i <= n; i++ {
+			for j := 0; j <= R2; j++ {
+				dp[i][j] = 0
+			}
+		}
+		for i := n - 1; i >= 0; i-- {
+			pi := float64(p[i]) / 100.0
+			qi := 1 - pi
+			fi := float64(f[i])
+			si := float64(s[i])
+			di := d[i]
+			for t := 0; t <= R2; t++ {
+				f1 := pi * (dp[i+1][t] + fi)
+				var f2 float64
+				if t+di > R2 {
+					f2 = qi * (C + si)
+				} else {
+					f2 = qi * (dp[i+1][t+di] + si)
+				}
+				val := f1 + f2
+				if i > 0 {
+					if val > C {
+						val = C
+					}
+				}
+				dp[i][t] = val
+			}
+		}
+		return dp[0][0] > C
+	}
+	l, r := 0.0, 1e12
+	for i := 0; i < 80; i++ {
+		mid := (l + r) / 2
+		if check(mid) {
+			l = mid
+		} else {
+			r = mid
+		}
+	}
+	return l
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(4) + 1
+		f := make([]int, n)
+		s := make([]int, n)
+		p := make([]int, n)
+		sumF := 0
+		sumS := 0
+		for i := 0; i < n; i++ {
+			f[i] = rng.Intn(5) + 1
+			s[i] = f[i] + rng.Intn(5) + 1
+			p[i] = rng.Intn(20) + 80
+			sumF += f[i]
+			sumS += s[i]
+		}
+		R := rng.Intn(sumS-sumF+1) + sumF
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, R)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%d %d %d\n", f[i], s[i], p[i])
+		}
+		expected := fmt.Sprintf("%.17f", solve(n, R, f, s, p))
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		gf, _ := strconv.ParseFloat(strings.TrimSpace(got), 64)
+		ef, _ := strconv.ParseFloat(expected, 64)
+		if math.Abs(gf-ef) > 1e-6*math.Max(1, math.Abs(ef)) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", t+1, sb.String(), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/865/verifierD.go
+++ b/0-999/800-899/860-869/865/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type maxHeap []int
+
+func (h maxHeap) Len() int            { return len(h) }
+func (h maxHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h maxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *maxHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *maxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+func (h maxHeap) Peek() int { return h[0] }
+
+func solve(prices []int) int64 {
+	h := &maxHeap{}
+	var profit int64
+	n := len(prices)
+	for i := n - 1; i >= 0; i-- {
+		if i < n-1 {
+			heap.Push(h, prices[i+1])
+		}
+		if h.Len() > 0 && h.Peek() > prices[i] {
+			sell := heap.Pop(h).(int)
+			profit += int64(sell - prices[i])
+			heap.Push(h, prices[i])
+		}
+	}
+	return profit
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(50) + 1
+		prices := make([]int, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			prices[i] = rng.Intn(20) + 1
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", prices[i])
+		}
+		sb.WriteByte('\n')
+		expected := fmt.Sprintf("%d", solve(prices))
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\n---\ngot:\n%s\n", t+1, sb.String(), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/865/verifierE.go
+++ b/0-999/800-899/860-869/865/verifierE.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(s string) (string, bool) {
+	L := len(s)
+	digits := make([]int, L)
+	for i := 0; i < L; i++ {
+		c := s[L-1-i]
+		switch {
+		case c >= '0' && c <= '9':
+			digits[i] = int(c - '0')
+		case c >= 'a' && c <= 'f':
+			digits[i] = int(c-'a') + 10
+		case c >= 'A' && c <= 'F':
+			digits[i] = int(c-'A') + 10
+		}
+	}
+	best := uint64(^uint64(0))
+	found := false
+	for _, sign := range []int{1, -1} {
+		type key struct {
+			pos, carry int
+			diff       [16]int
+		}
+		memo := make(map[key]uint64)
+		var dfs func(int, int, [16]int) (uint64, bool)
+		dfs = func(pos, carry int, d [16]int) (uint64, bool) {
+			k := key{pos, carry, d}
+			if v, ok := memo[k]; ok {
+				if v == ^uint64(0) {
+					return 0, false
+				}
+				return v, true
+			}
+			if pos == L {
+				if carry == 0 {
+					for _, x := range d {
+						if x != 0 {
+							memo[k] = ^uint64(0)
+							return 0, false
+						}
+					}
+					memo[k] = 0
+					return 0, true
+				}
+				memo[k] = ^uint64(0)
+				return 0, false
+			}
+			rem := L - pos
+			sumAbs := 0
+			for _, x := range d {
+				if x > rem || -x > rem {
+					memo[k] = ^uint64(0)
+					return 0, false
+				}
+				if x >= 0 {
+					sumAbs += x
+				} else {
+					sumAbs -= x
+				}
+			}
+			if sumAbs > 2*rem {
+				memo[k] = ^uint64(0)
+				return 0, false
+			}
+			bestHere := uint64(^uint64(0))
+			good := false
+			for a := 0; a < 16; a++ {
+				t := 0
+				nextCarry := 0
+				var b int
+				if sign == 1 {
+					t = a + digits[pos] + carry
+					b = t % 16
+					nextCarry = t / 16
+				} else {
+					t = a - digits[pos] - carry
+					if t < 0 {
+						t += 16
+						nextCarry = 1
+					}
+					b = t
+				}
+				d[a]++
+				d[b]--
+				if val, ok := dfs(pos+1, nextCarry, d); ok {
+					cand := val + uint64(a)<<uint(4*pos)
+					if cand < bestHere {
+						bestHere = cand
+					}
+					good = true
+				}
+				d[a]--
+				d[b]++
+			}
+			if good {
+				memo[k] = bestHere
+				return bestHere, true
+			}
+			memo[k] = ^uint64(0)
+			return 0, false
+		}
+		val, ok := dfs(0, 0, [16]int{})
+		if ok {
+			if !found || val < best {
+				best = val
+				found = true
+			}
+		}
+	}
+	if !found {
+		return "", false
+	}
+	out := make([]byte, L)
+	for i := 0; i < L; i++ {
+		d := (best >> uint(4*i)) & 15
+		if d < 10 {
+			out[L-1-i] = byte('0' + d)
+		} else {
+			out[L-1-i] = byte('a' + d - 10)
+		}
+	}
+	return string(out), true
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	digits := []byte("0123456789abcdef")
+	for t := 0; t < 100; t++ {
+		L := rng.Intn(5) + 1
+		b := make([]byte, L)
+		for i := 0; i < L; i++ {
+			b[i] = digits[rng.Intn(16)]
+		}
+		if strings.TrimLeft(string(b), "0") == "" {
+			b[0] = digits[rng.Intn(15)+1]
+		}
+		input := string(b)
+		expectedVal, ok := solve(input)
+		expected := ""
+		if ok {
+			expected = expectedVal
+		} else {
+			expected = "NO"
+		}
+		got, err := run(bin, input+"\n")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\n---\ngot:\n%s\n", t+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/865/verifierF.go
+++ b/0-999/800-899/860-869/865/verifierF.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func probability(order []byte, R, C int) float64 {
+	n := R + C
+	L := 2 * n
+	dp := make([][]float64, R+1)
+	for i := range dp {
+		dp[i] = make([]float64, R+1)
+	}
+	dp[0][0] = 1
+	var winA float64
+	for step := 0; step < L; step++ {
+		next := make([][]float64, R+1)
+		for i := range next {
+			next[i] = make([]float64, R+1)
+		}
+		player := order[step]
+		remaining := L - step
+		for a := 0; a < R; a++ {
+			for b := 0; b < R; b++ {
+				prob := dp[a][b]
+				if prob == 0 {
+					continue
+				}
+				rawUsed := a + b
+				rawLeft := 2*R - rawUsed
+				pRaw := float64(rawLeft) / float64(remaining)
+				pCook := 1 - pRaw
+				if player == 'A' {
+					if a+1 >= R {
+						winA += 0
+					} else {
+						next[a+1][b] += prob * pRaw
+					}
+					next[a][b] += prob * pCook
+				} else {
+					if b+1 >= R {
+						winA += prob * pRaw
+					} else {
+						next[a][b+1] += prob * pRaw
+					}
+					next[a][b] += prob * pCook
+				}
+			}
+		}
+		dp = next
+	}
+	return winA
+}
+
+func solve(R, C int, S string) int64 {
+	n := R + C
+	best := 1e9
+	count := int64(0)
+	seq := make([]byte, len(S))
+	var dfs func(int, int, int)
+	dfs = func(pos, a, b int) {
+		if pos == len(S) {
+			if a == n && b == n {
+				pA := probability(seq, R, C)
+				diff := math.Abs(pA - (1 - pA))
+				if diff < best-1e-12 {
+					best = diff
+					count = 1
+				} else if math.Abs(diff-best) <= 1e-12 {
+					count++
+				}
+			}
+			return
+		}
+		if (S[pos] == 'A' || S[pos] == '?') && a < n {
+			seq[pos] = 'A'
+			dfs(pos+1, a+1, b)
+		}
+		if (S[pos] == 'B' || S[pos] == '?') && b < n {
+			seq[pos] = 'B'
+			dfs(pos+1, a, b+1)
+		}
+	}
+	dfs(0, 0, 0)
+	return count
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		R := rng.Intn(3) + 1
+		C := rng.Intn(3) + 1
+		n := R + C
+		length := 2 * n
+		chars := []byte{'A', 'B', '?'}
+		b := make([]byte, length)
+		for i := 0; i < length; i++ {
+			b[i] = chars[rng.Intn(len(chars))]
+		}
+		S := string(b)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n%s\n", R, C, S)
+		expected := fmt.Sprintf("%d", solve(R, C, S))
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\n---\ngot:\n%s\n", t+1, sb.String(), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/865/verifierG.go
+++ b/0-999/800-899/860-869/865/verifierG.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func polyMul(a, b []int64, d int, c []int) []int64 {
+	tmp := make([]int64, len(a)+len(b)-1)
+	for i, av := range a {
+		if av == 0 {
+			continue
+		}
+		for j, bv := range b {
+			if bv == 0 {
+				continue
+			}
+			tmp[i+j] = (tmp[i+j] + av*bv) % mod
+		}
+	}
+	for len(tmp) > d {
+		k := len(tmp) - 1
+		coeff := tmp[k] % mod
+		tmp = tmp[:k]
+		if coeff != 0 {
+			for _, cj := range c {
+				idx := k - cj
+				tmp[idx] = (tmp[idx] + coeff) % mod
+			}
+		}
+	}
+	if len(tmp) < d {
+		out := make([]int64, d)
+		copy(out, tmp)
+		tmp = out
+	}
+	if len(tmp) > d {
+		tmp = tmp[:d]
+	}
+	return tmp
+}
+
+func polyPow(base []int64, exp int64, d int, c []int) []int64 {
+	res := []int64{1}
+	b := base
+	e := exp
+	for e > 0 {
+		if e&1 == 1 {
+			res = polyMul(res, b, d, c)
+		}
+		b = polyMul(b, b, d, c)
+		e >>= 1
+	}
+	if len(res) < d {
+		out := make([]int64, d)
+		copy(out, res)
+		res = out
+	}
+	if len(res) > d {
+		res = res[:d]
+	}
+	return res
+}
+
+func polyPowX(exp int64, d int, c []int) []int64 {
+	base := []int64{0, 1}
+	base = polyMul([]int64{1}, base, d, c)
+	return polyPow(base, exp, d, c)
+}
+
+func solve(F, B int, N int64, p []int64, c []int) int64 {
+	d := 0
+	for _, ci := range c {
+		if ci > d {
+			d = ci
+		}
+	}
+	P := make([]int64, d)
+	for _, pi := range p {
+		poly := polyPowX(pi, d, c)
+		for i := 0; i < d; i++ {
+			P[i] = (P[i] + poly[i]) % mod
+		}
+	}
+	res := polyPow(P, N, d, c)
+	Bseq := make([]int64, d)
+	Bseq[0] = 1
+	for t := 1; t < d; t++ {
+		var val int64
+		for _, cj := range c {
+			if t-cj >= 0 {
+				val = (val + Bseq[t-cj]) % mod
+			}
+		}
+		Bseq[t] = val
+	}
+	var ans int64
+	for i := 0; i < d; i++ {
+		ans = (ans + res[i]*Bseq[i]) % mod
+	}
+	return ans % mod
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		F := rng.Intn(3) + 1
+		B := rng.Intn(3) + 1
+		N := int64(rng.Intn(5) + 1)
+		p := make([]int64, F)
+		for i := 0; i < F; i++ {
+			p[i] = int64(rng.Intn(5) + 1)
+		}
+		c := make([]int, B)
+		for i := 0; i < B; i++ {
+			c[i] = rng.Intn(5) + 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", F, B, N)
+		for i := 0; i < F; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", p[i])
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < B; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", c[i])
+		}
+		sb.WriteByte('\n')
+		expected := fmt.Sprintf("%d", solve(F, B, N, p, c))
+		got, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\n---\ngot:\n%s\n", t+1, sb.String(), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifier programs for contest 865 problems A–G
- verifiers generate 100 random tests and compare results against reference Go implementations
- allow usage `go run verifierX.go /path/to/binary`

## Testing
- `go run 0-999/800-899/860-869/865/verifierA.go -- 0-999/800-899/860-869/865/865A.go`
- `go run 0-999/800-899/860-869/865/verifierB.go -- 0-999/800-899/860-869/865/865B.go`
- `go run 0-999/800-899/860-869/865/verifierC.go -- 0-999/800-899/860-869/865/865C.go`
- `go run 0-999/800-899/860-869/865/verifierD.go -- 0-999/800-899/860-869/865/865D.go`
- `go run 0-999/800-899/860-869/865/verifierE.go -- 0-999/800-899/860-869/865/865E.go`
- `go run 0-999/800-899/860-869/865/verifierF.go -- 0-999/800-899/860-869/865/865F.go`
- `go run 0-999/800-899/860-869/865/verifierG.go -- 0-999/800-899/860-869/865/865G.go`


------
https://chatgpt.com/codex/tasks/task_e_6883da7d33d483248e153253504c9c85