### PR TITLE
Add verifiers for contest 869

### DIFF
--- a/0-999/800-899/860-869/869/verifierA.go
+++ b/0-999/800-899/860-869/869/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(x, y []int) string {
+	present := make(map[int]struct{}, len(x)+len(y))
+	for _, v := range x {
+		present[v] = struct{}{}
+	}
+	for _, v := range y {
+		present[v] = struct{}{}
+	}
+	count := 0
+	for _, a := range x {
+		for _, b := range y {
+			if _, ok := present[a^b]; ok {
+				count++
+			}
+		}
+	}
+	if count%2 == 0 {
+		return "Karen"
+	}
+	return "Koyomi"
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		used := make(map[int]bool)
+		x := make([]int, n)
+		y := make([]int, n)
+		for j := 0; j < n; {
+			v := rng.Intn(2_000_000) + 1
+			if !used[v] {
+				used[v] = true
+				x[j] = v
+				j++
+			}
+		}
+		for j := 0; j < n; {
+			v := rng.Intn(2_000_000) + 1
+			if !used[v] {
+				used[v] = true
+				y[j] = v
+				j++
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range x {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		for j, v := range y {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveA(x, y)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/869/verifierB.go
+++ b/0-999/800-899/860-869/869/verifierB.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(a, b uint64) uint64 {
+	if b-a >= 5 {
+		return 0
+	}
+	res := uint64(1)
+	for i := a + 1; i <= b; i++ {
+		res = (res * (i % 10)) % 10
+	}
+	return res % 10
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const max = uint64(1e18)
+	for i := 0; i < 100; i++ {
+		a := rng.Uint64() % (max - 10)
+		diff := rng.Uint64() % 10
+		b := a + diff
+		if b > max {
+			b = max
+		}
+		input := fmt.Sprintf("%d %d\n", a, b)
+		expected := fmt.Sprintf("%d", solveB(a, b))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/869/verifierC.go
+++ b/0-999/800-899/860-869/869/verifierC.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modC = 998244353
+
+func modPow(x, y int) int {
+	res := 1
+	x %= modC
+	for y > 0 {
+		if y&1 == 1 {
+			res = res * x % modC
+		}
+		x = x * x % modC
+		y >>= 1
+	}
+	return res
+}
+
+func solveC(a, b, c int) int {
+	maxN := a
+	if b > maxN {
+		maxN = b
+	}
+	if c > maxN {
+		maxN = c
+	}
+	fact := make([]int, maxN+1)
+	invFact := make([]int, maxN+1)
+	fact[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fact[i] = fact[i-1] * i % modC
+	}
+	invFact[maxN] = modPow(fact[maxN], modC-2)
+	for i := maxN; i >= 1; i-- {
+		invFact[i-1] = invFact[i] * i % modC
+	}
+	comb := func(n, k int) int {
+		if k < 0 || k > n {
+			return 0
+		}
+		return fact[n] * invFact[k] % modC * invFact[n-k] % modC
+	}
+	F := func(x, y int) int {
+		limit := x
+		if y < limit {
+			limit = y
+		}
+		res := 0
+		for i := 0; i <= limit; i++ {
+			add := comb(x, i)
+			add = add * comb(y, i) % modC
+			add = add * fact[i] % modC
+			res += add
+			if res >= modC {
+				res -= modC
+			}
+		}
+		return res
+	}
+	ans := F(a, b)
+	ans = ans * F(a, c) % modC
+	ans = ans * F(b, c) % modC
+	return ans
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		a := rng.Intn(20) + 1
+		b := rng.Intn(20) + 1
+		c := rng.Intn(20) + 1
+		input := fmt.Sprintf("%d %d %d\n", a, b, c)
+		expected := fmt.Sprintf("%d", solveC(a, b, c))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/869/verifierD.go
+++ b/0-999/800-899/860-869/869/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modD int64 = 1000000007
+
+func countPaths(n int, edges [][2]int) int64 {
+	adj := make([][]int, n)
+	for i := 2; i <= n; i++ {
+		p := i / 2
+		adj[i-1] = append(adj[i-1], p-1)
+		adj[p-1] = append(adj[p-1], i-1)
+	}
+	for _, e := range edges {
+		u := e[0] - 1
+		v := e[1] - 1
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	var res int64
+	visited := make([]bool, n)
+	var dfs func(int)
+	dfs = func(u int) {
+		res++
+		if res >= modD {
+			res -= modD
+		}
+		visited[u] = true
+		for _, v := range adj[u] {
+			if !visited[v] {
+				dfs(v)
+			}
+		}
+		visited[u] = false
+	}
+	for i := 0; i < n; i++ {
+		dfs(i)
+	}
+	return res % modD
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 1
+		m := rng.Intn(5)
+		edges := make([][2]int, m)
+		for j := 0; j < m; j++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			for v == u {
+				v = rng.Intn(n) + 1
+			}
+			edges[j] = [2]int{u, v}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		input := sb.String()
+		expected := fmt.Sprintf("%d", countPaths(n, edges))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/860-869/869/verifierE.go
+++ b/0-999/800-899/860-869/869/verifierE.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Fenwick2D struct {
+	n, m int
+	tree [][]uint64
+}
+
+func NewFenwick2D(n, m int) *Fenwick2D {
+	tree := make([][]uint64, n+2)
+	for i := range tree {
+		tree[i] = make([]uint64, m+2)
+	}
+	return &Fenwick2D{n: n + 1, m: m + 1, tree: tree}
+}
+
+func (f *Fenwick2D) add(x, y int, val uint64) {
+	for i := x; i <= f.n; i += i & -i {
+		row := f.tree[i]
+		for j := y; j <= f.m; j += j & -j {
+			row[j] ^= val
+		}
+	}
+}
+
+func (f *Fenwick2D) RangeAdd(x1, y1, x2, y2 int, val uint64) {
+	f.add(x1, y1, val)
+	f.add(x1, y2+1, val)
+	f.add(x2+1, y1, val)
+	f.add(x2+1, y2+1, val)
+}
+
+func (f *Fenwick2D) Query(x, y int) uint64 {
+	var res uint64
+	for i := x; i > 0; i -= i & -i {
+		row := f.tree[i]
+		for j := y; j > 0; j -= j & -j {
+			res ^= row[j]
+		}
+	}
+	return res
+}
+
+type Rect struct{ r1, c1, r2, c2 int }
+
+func solveE(n, m int, ops []struct {
+	t, r1, c1, r2, c2 int
+}) []string {
+	fw := NewFenwick2D(n+2, m+2)
+	rectID := make(map[Rect]uint64)
+	rand.Seed(time.Now().UnixNano())
+	var res []string
+	for _, op := range ops {
+		switch op.t {
+		case 1:
+			id := rand.Uint64()
+			rectID[Rect{op.r1, op.c1, op.r2, op.c2}] = id
+			fw.RangeAdd(op.r1, op.c1, op.r2, op.c2, id)
+		case 2:
+			rect := Rect{op.r1, op.c1, op.r2, op.c2}
+			if id, ok := rectID[rect]; ok {
+				fw.RangeAdd(op.r1, op.c1, op.r2, op.c2, id)
+				delete(rectID, rect)
+			}
+		case 3:
+			v1 := fw.Query(op.r1, op.c1)
+			v2 := fw.Query(op.r2, op.c2)
+			if v1 == v2 {
+				res = append(res, "Yes")
+			} else {
+				res = append(res, "No")
+			}
+		}
+	}
+	return res
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 4
+		m := rng.Intn(10) + 4
+		q := rng.Intn(20) + 1
+		var ops []struct {
+			t, r1, c1, r2, c2 int
+		}
+		active := make(map[Rect]struct{})
+		for j := 0; j < q; j++ {
+			t := rng.Intn(3) + 1
+			if t == 1 || (t == 2 && len(active) == 0) {
+				t = 1
+			}
+			if t == 1 {
+				r1 := rng.Intn(n-2) + 2
+				r2 := rng.Intn(n-r1) + r1
+				c1 := rng.Intn(m-2) + 2
+				c2 := rng.Intn(m-c1) + c1
+				ops = append(ops, struct{ t, r1, c1, r2, c2 int }{1, r1, c1, r2, c2})
+				active[Rect{r1, c1, r2, c2}] = struct{}{}
+			} else if t == 2 {
+				idx := rng.Intn(len(active))
+				k := 0
+				var rect Rect
+				for r := range active {
+					if k == idx {
+						rect = r
+						break
+					}
+					k++
+				}
+				ops = append(ops, struct{ t, r1, c1, r2, c2 int }{2, rect.r1, rect.c1, rect.r2, rect.c2})
+				delete(active, rect)
+			} else {
+				r1 := rng.Intn(n) + 1
+				c1 := rng.Intn(m) + 1
+				r2 := rng.Intn(n) + 1
+				c2 := rng.Intn(m) + 1
+				ops = append(ops, struct{ t, r1, c1, r2, c2 int }{3, r1, c1, r2, c2})
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+		for _, op := range ops {
+			sb.WriteString(fmt.Sprintf("%d %d %d %d %d\n", op.t, op.r1, op.c1, op.r2, op.c2))
+		}
+		input := sb.String()
+		answers := solveE(n, m, ops)
+		expected := strings.Join(answers, "\n")
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 869 problems A–E
- verifiers generate 100 randomized test cases each and check a provided binary

## Testing
- `go run verifierA.go ./869A`

------
https://chatgpt.com/codex/tasks/task_e_6883dcad7f8483248f7674c9fab40983