### PR TITLE
Add Go verifiers for contest 873

### DIFF
--- a/0-999/800-899/870-879/873/verifierA.go
+++ b/0-999/800-899/870-879/873/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type TestA struct {
+	n, k, x int
+	arr     []int
+}
+
+func (t TestA) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", t.n, t.k, t.x))
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func expectedA(t TestA) string {
+	sum := 0
+	for i := 0; i < t.n-t.k; i++ {
+		sum += t.arr[i]
+	}
+	sum += t.k * t.x
+	return strconv.Itoa(sum)
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func genTests() []TestA {
+	rand.Seed(1)
+	tests := make([]TestA, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(100) + 1
+		k := rand.Intn(n) + 1
+		arr := make([]int, n)
+		arr[0] = rand.Intn(99) + 2
+		for j := 1; j < n; j++ {
+			val := arr[j-1] + rand.Intn(3)
+			if val > 100 {
+				val = 100
+			}
+			arr[j] = val
+		}
+		x := rand.Intn(arr[0]-1) + 1
+		tests = append(tests, TestA{n: n, k: k, x: x, arr: arr})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		exp := strings.TrimSpace(expectedA(tc))
+		gotRaw, err := run(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i+1, err, gotRaw)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(gotRaw)
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/870-879/873/verifierB.go
+++ b/0-999/800-899/870-879/873/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type TestB struct {
+	n int
+	s string
+}
+
+func (t TestB) Input() string {
+	return fmt.Sprintf("%d\n%s\n", t.n, t.s)
+}
+
+func expectedB(t TestB) string {
+	diffPos := map[int]int{0: 0}
+	diff := 0
+	best := 0
+	for i := 1; i <= t.n; i++ {
+		if t.s[i-1] == '1' {
+			diff++
+		} else {
+			diff--
+		}
+		if pos, ok := diffPos[diff]; ok {
+			if i-pos > best {
+				best = i - pos
+			}
+		} else {
+			diffPos[diff] = i
+		}
+	}
+	return strconv.Itoa(best)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func genTests() []TestB {
+	rand.Seed(2)
+	tests := make([]TestB, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(100) + 1
+		b := make([]byte, n)
+		for j := range b {
+			if rand.Intn(2) == 0 {
+				b[j] = '0'
+			} else {
+				b[j] = '1'
+			}
+		}
+		tests = append(tests, TestB{n: n, s: string(b)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		exp := strings.TrimSpace(expectedB(tc))
+		gotRaw, err := run(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i+1, err, gotRaw)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(gotRaw)
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/870-879/873/verifierC.go
+++ b/0-999/800-899/870-879/873/verifierC.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type TestC struct {
+	n, m, k int
+	mat     [][]int
+}
+
+func (t TestC) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", t.n, t.m, t.k))
+	for i := 0; i < t.n; i++ {
+		for j := 0; j < t.m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(t.mat[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func expectedC(t TestC) string {
+	totalScore := 0
+	totalRemove := 0
+	n, m, k := t.n, t.m, t.k
+	for col := 0; col < m; col++ {
+		prefix := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			prefix[i] = prefix[i-1] + t.mat[i-1][col]
+		}
+		bestScore := 0
+		bestRemove := 0
+		for row := 1; row <= n; row++ {
+			if t.mat[row-1][col] == 1 {
+				onesAbove := prefix[row-1]
+				end := row + k - 1
+				if end > n {
+					end = n
+				}
+				score := prefix[end] - prefix[row-1]
+				if score > bestScore || (score == bestScore && onesAbove < bestRemove) {
+					bestScore = score
+					bestRemove = onesAbove
+				}
+			}
+		}
+		totalScore += bestScore
+		totalRemove += bestRemove
+	}
+	return fmt.Sprintf("%d %d", totalScore, totalRemove)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func genTests() []TestC {
+	rand.Seed(3)
+	tests := make([]TestC, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(8) + 1
+		m := rand.Intn(8) + 1
+		k := rand.Intn(n) + 1
+		mat := make([][]int, n)
+		for r := 0; r < n; r++ {
+			row := make([]int, m)
+			for c := 0; c < m; c++ {
+				row[c] = rand.Intn(2)
+			}
+			mat[r] = row
+		}
+		tests = append(tests, TestC{n: n, m: m, k: k, mat: mat})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		exp := strings.TrimSpace(expectedC(tc))
+		gotRaw, err := run(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i+1, err, gotRaw)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(gotRaw)
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/870-879/873/verifierD.go
+++ b/0-999/800-899/870-879/873/verifierD.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type TestD struct {
+	n, k int
+}
+
+func (t TestD) Input() string {
+	return fmt.Sprintf("%d %d\n", t.n, t.k)
+}
+
+func solveRec(l, r, k, L, R int, ans *[]int) {
+	if k == 1 {
+		for i := L; i <= R; i++ {
+			*ans = append(*ans, i)
+		}
+		return
+	}
+	mid := (l + r - 1) >> 1
+	Mid := (L + R + 2) >> 1
+	leftCnt := mid - l + 1
+	if 2*leftCnt-1 >= k-2 {
+		solveRec(l, mid, k-2, Mid, R, ans)
+		solveRec(mid+1, r, 1, L, Mid-1, ans)
+	} else {
+		solveRec(l, mid, 2*leftCnt-1, Mid, R, ans)
+		solveRec(mid+1, r, k-2*leftCnt, L, Mid-1, ans)
+	}
+}
+
+func expectedD(t TestD) string {
+	n, k := t.n, t.k
+	if k%2 == 0 || n*2 <= k {
+		return "-1"
+	}
+	ans := make([]int, 0, n)
+	solveRec(1, n, k, 1, n, &ans)
+	var sb strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func genTests() []TestD {
+	rand.Seed(4)
+	tests := make([]TestD, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(2*n - 1)
+		if k%2 == 0 {
+			k++
+			if k >= 2*n {
+				k -= 2
+			}
+		}
+		if k <= 0 {
+			k = 1
+		}
+		tests = append(tests, TestD{n: n, k: k})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		exp := strings.TrimSpace(expectedD(tc))
+		gotRaw, err := run(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i+1, err, gotRaw)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(gotRaw)
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected: %s\ngot: %s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/870-879/873/verifierE.go
+++ b/0-999/800-899/870-879/873/verifierE.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type pair struct{ first, second int }
+
+type TestE struct {
+	n   int
+	arr []int
+}
+
+func (t TestE) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t.n))
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func maxPair(a, b pair) pair {
+	if a.first > b.first {
+		return a
+	}
+	return b
+}
+
+func expectedE(t TestE) string {
+	n := t.n
+	a := make([]pair, n+5)
+	for i := 1; i <= n; i++ {
+		a[i] = pair{-t.arr[i-1], i}
+	}
+	arr := a[1 : n+1]
+	sort.Slice(arr, func(i, j int) bool { return arr[i].first < arr[j].first })
+	const K = 12
+	f := make([][]pair, K)
+	for k := 0; k < K; k++ {
+		f[k] = make([]pair, n+5)
+	}
+	for i := 1; i <= n; i++ {
+		f[0][i] = pair{a[i+1].first - a[i].first, i}
+	}
+	for k := 1; k < K; k++ {
+		shift := 1 << (k - 1)
+		for i := 1; i <= n; i++ {
+			if i+shift <= n {
+				f[k][i] = maxPair(f[k-1][i], f[k-1][i+shift])
+			} else {
+				f[k][i] = f[k-1][i]
+			}
+		}
+	}
+	lg := make([]int, n+5)
+	for i := 3; i <= n; i++ {
+		lg[i] = lg[(i+1)>>1] + 1
+	}
+	rmq := func(l, r int) pair {
+		length := r - l + 1
+		k := lg[length]
+		b1 := f[k][l]
+		b2 := f[k][r-(1<<k)+1]
+		if b1.first > b2.first {
+			return b1
+		}
+		return b2
+	}
+	const INF = 1000000000
+	d1, d2, d3 := -INF, -INF, -INF
+	p1, p2, p3 := 0, 0, 0
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			len1 := j - i
+			if i > 2*len1 || len1 > 2*i {
+				continue
+			}
+			m := i
+			if len1 > m {
+				m = len1
+			}
+			l := (m + 1) >> 1
+			r := m * 2
+			rem := n - j
+			if r > rem {
+				r = rem
+			}
+			if l <= r && j+l <= n {
+				x := rmq(j+l, j+r)
+				d1cand := a[i+1].first - a[i].first
+				d2cand := a[j+1].first - a[j].first
+				if d1cand > d1 || (d1cand == d1 && (d2cand > d2 || (d2cand == d2 && x.first > d3))) {
+					d1 = d1cand
+					p1 = i
+					d2 = d2cand
+					p2 = j
+					d3 = x.first
+					p3 = x.second
+				}
+			}
+		}
+	}
+	ans := make([]int, n+1)
+	for i := 1; i <= p1; i++ {
+		ans[a[i].second] = 1
+	}
+	for i := p1 + 1; i <= p2; i++ {
+		ans[a[i].second] = 2
+	}
+	for i := p2 + 1; i <= p3; i++ {
+		ans[a[i].second] = 3
+	}
+	for i := p3 + 1; i <= n; i++ {
+		ans[a[i].second] = -1
+	}
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(ans[i]))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func genTests() []TestE {
+	rand.Seed(5)
+	tests := make([]TestE, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 3
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rand.Intn(5000) + 1
+		}
+		tests = append(tests, TestE{n: n, arr: arr})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		exp := strings.TrimSpace(expectedE(tc))
+		gotRaw, err := run(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i+1, err, gotRaw)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(gotRaw)
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/870-879/873/verifierF.go
+++ b/0-999/800-899/870-879/873/verifierF.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const alpha = 26
+
+type state struct {
+	next   [alpha]int
+	link   int
+	length int
+	cnt    int64
+}
+
+var st []state
+var size int
+var last int
+var pos []int
+
+func initSAM(maxLen int) {
+	st = make([]state, 2*maxLen+5)
+	for i := range st {
+		for j := 0; j < alpha; j++ {
+			st[i].next[j] = -1
+		}
+		st[i].link = -1
+	}
+	size = 1
+	last = 0
+	st[0].link = -1
+	st[0].length = 0
+}
+
+func saExtend(c int) {
+	cur := size
+	size++
+	st[cur].length = st[last].length + 1
+	for i := 0; i < alpha; i++ {
+		st[cur].next[i] = -1
+	}
+	st[cur].cnt = 0
+	p := last
+	for p != -1 && st[p].next[c] == -1 {
+		st[p].next[c] = cur
+		p = st[p].link
+	}
+	if p == -1 {
+		st[cur].link = 0
+	} else {
+		q := st[p].next[c]
+		if st[p].length+1 == st[q].length {
+			st[cur].link = q
+		} else {
+			clone := size
+			size++
+			st[clone] = st[q]
+			st[clone].length = st[p].length + 1
+			st[clone].cnt = 0
+			for p != -1 && st[p].next[c] == q {
+				st[p].next[c] = clone
+				p = st[p].link
+			}
+			st[q].link = clone
+			st[cur].link = clone
+		}
+	}
+	last = cur
+}
+
+func expectedF(n int, s, t string) string {
+	initSAM(n)
+	pos = make([]int, n+1)
+	for i := 0; i < n; i++ {
+		saExtend(int(s[i] - 'a'))
+		pos[i+1] = last
+	}
+	st = st[:size]
+	maxLen := 0
+	for i := 0; i < size; i++ {
+		if st[i].length > maxLen {
+			maxLen = st[i].length
+		}
+	}
+	cntLen := make([]int, maxLen+1)
+	for i := 0; i < size; i++ {
+		cntLen[st[i].length]++
+	}
+	for i := 1; i <= maxLen; i++ {
+		cntLen[i] += cntLen[i-1]
+	}
+	order := make([]int, size)
+	for i := size - 1; i >= 0; i-- {
+		l := st[i].length
+		cntLen[l]--
+		order[cntLen[l]] = i
+	}
+	for i := 1; i <= n; i++ {
+		if t[i-1] == '0' {
+			st[pos[i]].cnt++
+		}
+	}
+	for i := size - 1; i > 0; i-- {
+		v := order[i]
+		p := st[v].link
+		if p >= 0 {
+			st[p].cnt += st[v].cnt
+		}
+	}
+	var ans int64
+	for i := 1; i < size; i++ {
+		if st[i].cnt > 0 {
+			val := int64(st[i].length) * st[i].cnt
+			if val > ans {
+				ans = val
+			}
+		}
+	}
+	return strconv.FormatInt(ans, 10)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+type TestF struct {
+	n int
+	s string
+	t string
+}
+
+func (tc TestF) Input() string {
+	return fmt.Sprintf("%d\n%s\n%s\n", tc.n, tc.s, tc.t)
+}
+
+func genTests() []TestF {
+	rand.Seed(6)
+	tests := make([]TestF, 0, 100)
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = letters[rand.Intn(26)]
+		}
+		forb := make([]byte, n)
+		for j := range forb {
+			if rand.Intn(2) == 0 {
+				forb[j] = '0'
+			} else {
+				forb[j] = '1'
+			}
+		}
+		tests = append(tests, TestF{n: n, s: string(b), t: string(forb)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := genTests()
+	for i, tc := range tests {
+		exp := strings.TrimSpace(expectedF(tc.n, tc.s, tc.t))
+		gotRaw, err := run(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n%s", i+1, err, gotRaw)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(gotRaw)
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for contest 873 problems A–F
- each verifier generates 100 deterministic tests and checks a candidate solution

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`
- `go run verifierF.go ./solF`


------
https://chatgpt.com/codex/tasks/task_e_6883deddd6ec832485b6dd2aa48cb120