### PR TITLE
Add Go verifiers for Codeforces Round 877

### DIFF
--- a/0-999/800-899/870-879/877/verifierA.go
+++ b/0-999/800-899/870-879/877/verifierA.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func generateTest() []byte {
+	length := rand.Intn(100) + 1
+	letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_"
+	var sb strings.Builder
+	for i := 0; i < length; i++ {
+		sb.WriteByte(letters[rand.Intn(len(letters))])
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./refA.bin"
+	if err := exec.Command("go", "build", "-o", ref, "877A.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := generateTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/800-899/870-879/877/verifierB.go
+++ b/0-999/800-899/870-879/877/verifierB.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func generateTest() []byte {
+	n := rand.Intn(50) + 1
+	var sb strings.Builder
+	letters := "ab"
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rand.Intn(2)])
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./refB.bin"
+	if err := exec.Command("go", "build", "-o", ref, "877B.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := generateTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/800-899/870-879/877/verifierC.go
+++ b/0-999/800-899/870-879/877/verifierC.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func generateTest() []byte {
+	n := rand.Intn(100) + 1
+	return []byte(fmt.Sprintf("%d\n", n))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./refC.bin"
+	if err := exec.Command("go", "build", "-o", ref, "877C.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := generateTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/800-899/870-879/877/verifierD.go
+++ b/0-999/800-899/870-879/877/verifierD.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func generateTest() []byte {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(10) + 1
+	k := rand.Intn(5) + 1
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rand.Intn(4) == 0 {
+				row[j] = '#'
+			} else {
+				row[j] = '.'
+			}
+		}
+		grid[i] = string(row)
+	}
+	x1 := rand.Intn(n) + 1
+	y1 := rand.Intn(m) + 1
+	x2 := rand.Intn(n) + 1
+	y2 := rand.Intn(m) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for _, r := range grid {
+		sb.WriteString(r)
+		sb.WriteByte('\n')
+	}
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", x1, y1, x2, y2))
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./refD.bin"
+	if err := exec.Command("go", "build", "-o", ref, "877D.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := generateTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/800-899/870-879/877/verifierE.go
+++ b/0-999/800-899/870-879/877/verifierE.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func generateTest() []byte {
+	n := rand.Intn(30) + 1
+	parents := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		parents[i] = rand.Intn(i-1) + 1
+	}
+	tvals := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		tvals[i] = rand.Intn(2)
+	}
+	q := rand.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		if i > 2 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(parents[i]))
+	}
+	if n >= 2 {
+		sb.WriteByte('\n')
+	} else {
+		sb.WriteString("\n")
+	}
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(tvals[i]))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		v := rand.Intn(n) + 1
+		if rand.Intn(2) == 0 {
+			sb.WriteString(fmt.Sprintf("pow %d\n", v))
+		} else {
+			sb.WriteString(fmt.Sprintf("get %d\n", v))
+		}
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./refE.bin"
+	if err := exec.Command("go", "build", "-o", ref, "877E.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := generateTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/800-899/870-879/877/verifierF.go
+++ b/0-999/800-899/870-879/877/verifierF.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func generateTest() []byte {
+	n := rand.Intn(40) + 1
+	k := rand.Intn(21) - 10
+	tvals := make([]int, n)
+	for i := range tvals {
+		if rand.Intn(2) == 0 {
+			tvals[i] = 1
+		} else {
+			tvals[i] = 2
+		}
+	}
+	avals := make([]int, n)
+	for i := range avals {
+		avals[i] = rand.Intn(21)
+	}
+	q := rand.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range tvals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range avals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		l := rand.Intn(n) + 1
+		r := rand.Intn(n-l+1) + l
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./refF.bin"
+	if err := exec.Command("go", "build", "-o", ref, "877F.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := generateTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`..`verifierF.go` in contest 877 directory
- verifiers generate random tests, compile the reference Go solution and compare it against a candidate binary
- each verifier runs 100 test cases

## Testing
- `go build 0-999/800-899/870-879/877/verifierA.go`
- `go build 0-999/800-899/870-879/877/verifierB.go`
- `go build 0-999/800-899/870-879/877/verifierC.go`
- `go build 0-999/800-899/870-879/877/verifierD.go`
- `go build 0-999/800-899/870-879/877/verifierE.go`
- `go build 0-999/800-899/870-879/877/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883e10e2fd48324a364ce92e5ece270