### PR TITLE
Add Go solution for problem 1649B

### DIFF
--- a/1000-1999/1600-1699/1640-1649/1649/1649B.go
+++ b/1000-1999/1600-1699/1640-1649/1649/1649B.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		var sum, maxVal int64
+		for i := 0; i < n; i++ {
+			var x int64
+			fmt.Fscan(in, &x)
+			sum += x
+			if x > maxVal {
+				maxVal = x
+			}
+		}
+		if sum == 0 {
+			fmt.Fprintln(out, 0)
+			continue
+		}
+		diff := maxVal - (sum - maxVal)
+		if diff <= 0 {
+			fmt.Fprintln(out, 1)
+		} else {
+			fmt.Fprintln(out, diff)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for `1649/problemB.txt`

## Testing
- `go build 1000-1999/1600-1699/1640-1649/1649/1649B.go`
- `go run 1000-1999/1600-1699/1640-1649/1649/1649B.go < /tmp/input.txt`

------
https://chatgpt.com/codex/tasks/task_e_6883e26c7dcc83248c2e8e3536046dc0