### PR TITLE
Add verifiers for contest 878

### DIFF
--- a/0-999/800-899/870-879/878/verifierA.go
+++ b/0-999/800-899/870-879/878/verifierA.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Op struct {
+	op string
+	x  int
+}
+
+type Test struct {
+	ops   []Op
+	input string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(20) + 1
+	ops := make([]Op, n)
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		typ := []string{"&", "|", "^"}[rng.Intn(3)]
+		val := rng.Intn(1024)
+		ops[i] = Op{op: typ, x: val}
+		sb.WriteString(fmt.Sprintf("%s %d\n", typ, val))
+	}
+	return Test{ops: ops, input: sb.String()}
+}
+
+func solve(t Test) string {
+	zero := [10]int{}
+	one := [10]int{}
+	for i := 0; i < 10; i++ {
+		zero[i] = 0
+		one[i] = 1
+	}
+	for _, op := range t.ops {
+		for j := 0; j < 10; j++ {
+			b := (op.x >> j) & 1
+			switch op.op {
+			case "|":
+				zero[j] |= b
+				one[j] |= b
+			case "&":
+				zero[j] &= b
+				one[j] &= b
+			case "^":
+				zero[j] ^= b
+				one[j] ^= b
+			}
+		}
+	}
+	andMask, orMask, xorMask := 0, 0, 0
+	for j := 0; j < 10; j++ {
+		a0 := zero[j]
+		a1 := one[j]
+		if a0 == 0 && a1 == 0 {
+		} else if a0 == 1 && a1 == 1 {
+			andMask |= 1 << j
+			orMask |= 1 << j
+		} else if a0 == 0 && a1 == 1 {
+			andMask |= 1 << j
+		} else {
+			andMask |= 1 << j
+			xorMask |= 1 << j
+		}
+	}
+	return fmt.Sprintf("3\n& %d\n| %d\n^ %d", andMask, orMask, xorMask)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/800-899/870-879/878/verifierB.go
+++ b/0-999/800-899/870-879/878/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	n     int
+	k     int
+	m     int
+	arr   []int
+	input string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(4) + 2
+	m := rng.Intn(4) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, k, m))
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(3) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(arr[i]))
+	}
+	sb.WriteByte('\n')
+	return Test{n: n, k: k, m: m, arr: arr, input: sb.String()}
+}
+
+func solve(t Test) string {
+	type pair struct{ val, cnt int }
+	stack := []pair{}
+	for i := 0; i < t.m; i++ {
+		for _, v := range t.arr {
+			if len(stack) > 0 && stack[len(stack)-1].val == v {
+				stack[len(stack)-1].cnt++
+				if stack[len(stack)-1].cnt == t.k {
+					stack = stack[:len(stack)-1]
+				}
+			} else {
+				stack = append(stack, pair{v, 1})
+			}
+		}
+	}
+	res := 0
+	for _, p := range stack {
+		res += p.cnt
+	}
+	return strconv.Itoa(res)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s got:%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/800-899/870-879/878/verifierC.go
+++ b/0-999/800-899/870-879/878/verifierC.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	n       int
+	k       int
+	players [][]int
+	input   string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(4) + 1
+	players := make([][]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		players[i] = make([]int, k)
+		for j := 0; j < k; j++ {
+			players[i][j] = rng.Intn(10)
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(players[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	return Test{n: n, k: k, players: players, input: sb.String()}
+}
+
+func dominates(a, b []int) bool {
+	for i := range a {
+		if a[i] <= b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func solve(t Test) string {
+	nondom := make([][]int, 0)
+	var sb strings.Builder
+	for i := 0; i < t.n; i++ {
+		p := t.players[i]
+		dominated := false
+		for _, q := range nondom {
+			if dominates(q, p) {
+				dominated = true
+				break
+			}
+		}
+		if !dominated {
+			newSet := nondom[:0]
+			for _, q := range nondom {
+				if !dominates(p, q) {
+					newSet = append(newSet, q)
+				}
+			}
+			nondom = append(newSet, p)
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", len(nondom)))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/800-899/870-879/878/verifierD.go
+++ b/0-999/800-899/870-879/878/verifierD.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Op struct {
+	t int
+	x int
+	y int
+}
+
+type Test struct {
+	n     int
+	k     int
+	q     int
+	a     [][]int
+	ops   []Op
+	input string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(3) + 1
+	k := rng.Intn(3) + 1
+	q := rng.Intn(6) + 1
+	a := make([][]int, k)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, k, q))
+	for i := 0; i < k; i++ {
+		a[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			a[i][j] = rng.Intn(10)
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(a[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	ops := make([]Op, q)
+	cur := k
+	for i := 0; i < q; i++ {
+		ttype := rng.Intn(3) + 1
+		var x, y int
+		if ttype == 1 || ttype == 2 {
+			x = rng.Intn(cur) + 1
+			y = rng.Intn(cur) + 1
+			ops[i] = Op{t: ttype, x: x, y: y}
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", ttype, x, y))
+			cur++
+		} else {
+			x = rng.Intn(cur) + 1
+			y = rng.Intn(n) + 1
+			ops[i] = Op{t: 3, x: x, y: y}
+			sb.WriteString(fmt.Sprintf("3 %d %d\n", x, y))
+		}
+	}
+	return Test{n: n, k: k, q: q, a: a, ops: ops, input: sb.String()}
+}
+
+func solve(t Test) string {
+	creatures := make([][]int, t.k+t.q+1)
+	for i := 1; i <= t.k; i++ {
+		creatures[i] = append([]int(nil), t.a[i-1]...)
+	}
+	cur := t.k + 1
+	var sb strings.Builder
+	for _, op := range t.ops {
+		switch op.t {
+		case 1:
+			vals := make([]int, t.n)
+			for j := 0; j < t.n; j++ {
+				x := creatures[op.x][j]
+				y := creatures[op.y][j]
+				if x >= y {
+					vals[j] = x
+				} else {
+					vals[j] = y
+				}
+			}
+			creatures[cur] = vals
+			cur++
+		case 2:
+			vals := make([]int, t.n)
+			for j := 0; j < t.n; j++ {
+				x := creatures[op.x][j]
+				y := creatures[op.y][j]
+				if x <= y {
+					vals[j] = x
+				} else {
+					vals[j] = y
+				}
+			}
+			creatures[cur] = vals
+			cur++
+		case 3:
+			sb.WriteString(fmt.Sprintf("%d\n", creatures[op.x][op.y-1]))
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/800-899/870-879/878/verifierE.go
+++ b/0-999/800-899/870-879/878/verifierE.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + stderr.String(), err
+	}
+	return out.String(), nil
+}
+
+type Query struct{ l, r int }
+
+type Test struct {
+	n       int
+	q       int
+	arr     []int64
+	queries []Query
+	input   string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(6) + 1
+	q := rng.Intn(4) + 1
+	arr := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(11) - 5)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(arr[i], 10))
+	}
+	sb.WriteByte('\n')
+	queries := make([]Query, q)
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		queries[i] = Query{l: l, r: r}
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return Test{n: n, q: q, arr: arr, queries: queries, input: sb.String()}
+}
+
+const mod = 1000000007
+
+func maxValue(a []int64, l, r int, memo map[[2]int]*big.Int) *big.Int {
+	if l == r {
+		return big.NewInt(a[l-1])
+	}
+	key := [2]int{l, r}
+	if v, ok := memo[key]; ok {
+		return new(big.Int).Set(v)
+	}
+	best := big.NewInt(-1 << 60)
+	for k := l; k < r; k++ {
+		left := maxValue(a, l, k, memo)
+		right := maxValue(a, k+1, r, memo)
+		cand := new(big.Int).Lsh(right, 1)
+		cand.Add(cand, left)
+		if cand.Cmp(best) > 0 {
+			best = cand
+		}
+	}
+	memo[key] = new(big.Int).Set(best)
+	return best
+}
+
+func solve(t Test) string {
+	var sb strings.Builder
+	for _, qu := range t.queries {
+		memo := make(map[[2]int]*big.Int)
+		val := maxValue(t.arr, qu.l, qu.r, memo)
+		val.Mod(val, big.NewInt(mod))
+		if val.Sign() < 0 {
+			val.Add(val, big.NewInt(mod))
+		}
+		sb.WriteString(val.String())
+		sb.WriteByte('\n')
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\noutput:\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:\n%s\nactual:\n%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}


### PR DESCRIPTION
## Summary
- add Go solution verifiers for contest 878 problems A–E

## Testing
- `go vet 0-999/800-899/870-879/878/verifierA.go`
- `go vet 0-999/800-899/870-879/878/verifierB.go`
- `go vet 0-999/800-899/870-879/878/verifierC.go`
- `go vet 0-999/800-899/870-879/878/verifierD.go`
- `go vet 0-999/800-899/870-879/878/verifierE.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_6883e19a609c8324a2900dc8a6569132