### PR TITLE
Add Go solution for 1680A

### DIFF
--- a/1000-1999/1600-1699/1680-1689/1680/1680A.go
+++ b/1000-1999/1600-1699/1680-1689/1680/1680A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var l1, r1, l2, r2 int
+		fmt.Fscan(reader, &l1, &r1, &l2, &r2)
+		if r1 < l2 || r2 < l1 {
+			fmt.Fprintln(writer, l1+l2)
+		} else {
+			if l1 > l2 {
+				fmt.Fprintln(writer, l1)
+			} else {
+				fmt.Fprintln(writer, l2)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement 1680A solution in Go using minimal case analysis

## Testing
- `go build 1000-1999/1600-1699/1680-1689/1680/1680A.go`


------
https://chatgpt.com/codex/tasks/task_e_68842b33f61c8324b795a84313938ea9