### PR TITLE
Add Go solution for 1689B

### DIFF
--- a/1000-1999/1600-1699/1680-1689/1689/1689B.go
+++ b/1000-1999/1600-1699/1680-1689/1689/1689B.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		p := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &p[i])
+		}
+		if n == 1 {
+			fmt.Fprintln(writer, -1)
+			continue
+		}
+		q := make([]int, n)
+		for i := 0; i < n; i++ {
+			q[i] = i + 1
+		}
+		for i := 0; i < n; i++ {
+			if q[i] == p[i] {
+				if i+1 < n {
+					q[i], q[i+1] = q[i+1], q[i]
+				} else {
+					q[i], q[i-1] = q[i-1], q[i]
+				}
+			}
+		}
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				writer.WriteByte(' ')
+			}
+			fmt.Fprint(writer, q[i])
+		}
+		writer.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1689B: Mystic Permutation

## Testing
- `go build 1000-1999/1600-1699/1680-1689/1689/1689B.go`
- `./1689B << EOF
3
1
1
3
1 2 3
5
3 5 1 4 2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6884298fa40c8324b28ab61cffc24a9c