### PR TITLE
Add Go solution for 1682A

### DIFF
--- a/1000-1999/1600-1699/1680-1689/1682/1682A.go
+++ b/1000-1999/1600-1699/1680-1689/1682/1682A.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// This program solves problemA.txt for contest 1682A.
+// Given a palindromic string s, it counts how many indices can be removed
+// while keeping the string a palindrome. The answer equals the length of the
+// central block of identical characters because removing a character outside
+// this block breaks the palindrome.
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(in, &n)
+		fmt.Fscan(in, &s)
+		if n%2 == 1 {
+			mid := n / 2
+			ch := s[mid]
+			ans := 1
+			i := mid - 1
+			for i >= 0 && s[i] == ch {
+				ans++
+				i--
+			}
+			j := mid + 1
+			for j < n && s[j] == ch {
+				ans++
+				j++
+			}
+			fmt.Fprintln(out, ans)
+		} else {
+			left := n/2 - 1
+			right := n / 2
+			ch := s[left]
+			ans := 0
+			i := left
+			for i >= 0 && s[i] == ch {
+				ans++
+				i--
+			}
+			j := right
+			for j < n && s[j] == ch {
+				ans++
+				j++
+			}
+			fmt.Fprintln(out, ans)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1682A.go` to solve problemA.txt
- count length of central block in palindromic strings and output it

## Testing
- `go run 1000-1999/1600-1699/1680-1689/1682/1682A.go < /tmp/input.txt`
- `go vet 1000-1999/1600-1699/1680-1689/1682/1682A.go`


------
https://chatgpt.com/codex/tasks/task_e_6884275f5e78832494b31da0127598b1