### PR TITLE
Add Go solution for 1684A

### DIFF
--- a/1000-1999/1600-1699/1680-1689/1684/1684A.go
+++ b/1000-1999/1600-1699/1680-1689/1684/1684A.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// This program solves problemA.txt for contest 1684A (Digit Minimization).
+// Alice can rearrange the digits before each removal, effectively choosing
+// which digit survives. Therefore the smallest possible final digit is the
+// minimum digit present in the given number.
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n string
+		fmt.Fscan(reader, &n)
+		minDigit := byte('9')
+		for i := 0; i < len(n); i++ {
+			if n[i] < minDigit {
+				minDigit = n[i]
+			}
+		}
+		fmt.Fprintln(writer, string(minDigit))
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution `1684A.go` for contest 1684 problem A

## Testing
- `go build 1000-1999/1600-1699/1680-1689/1684/1684A.go`


------
https://chatgpt.com/codex/tasks/task_e_6884264716148324802dc7e42fe79605