### PR TITLE
Add Go solution for 1605B

### DIFF
--- a/1000-1999/1600-1699/1600-1609/1605/1605B.go
+++ b/1000-1999/1600-1699/1600-1609/1605/1605B.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Solution to problemB.txt for 1605B (Reverse Sort).
+// We compare the string with its sorted version. If already sorted,
+// no operations are needed. Otherwise we output one operation that
+// reverses all mismatched positions, which form a non-increasing subsequence.
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(in, &n, &s)
+		zeros := strings.Count(s, "0")
+		if zeros == 0 || zeros == n {
+			fmt.Fprintln(out, 0)
+			continue
+		}
+		target := strings.Repeat("0", zeros) + strings.Repeat("1", n-zeros)
+		if s == target {
+			fmt.Fprintln(out, 0)
+			continue
+		}
+		indices := make([]int, 0, n)
+		for i := 0; i < n; i++ {
+			if s[i] != target[i] {
+				indices = append(indices, i+1)
+			}
+		}
+		fmt.Fprintln(out, 1)
+		fmt.Fprint(out, len(indices))
+		for _, idx := range indices {
+			fmt.Fprint(out, " ", idx)
+		}
+		fmt.Fprintln(out)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `problemB.txt` in `1605`
- solution sorts string using at most one operation and outputs indices

## Testing
- `go build 1000-1999/1600-1699/1600-1609/1605/1605B.go`
- `cat <<'EOF' | go run 1000-1999/1600-1699/1600-1609/1605/1605B.go
3
1
0
4
1100
6
010111
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688424a3189883249b6936cf9fda8712