### PR TITLE
Add Go solution for 1687D

### DIFF
--- a/1000-1999/1600-1699/1680-1689/1687/1687D.go
+++ b/1000-1999/1600-1699/1680-1689/1687/1687D.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+const MAXK = 2000
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+
+	diff := make([]int, MAXK+2)
+	for _, x := range a {
+		sMin := int(math.Sqrt(float64(max(0, x-MAXK)))) - 2
+		if sMin < 0 {
+			sMin = 0
+		}
+		sMax := int(math.Sqrt(float64(x+MAXK))) + 2
+		for s := sMin; s <= sMax; s++ {
+			sq := s * s
+			l := sq - x
+			r := sq + s - x
+			if r < 0 || l > MAXK {
+				continue
+			}
+			if l < 0 {
+				l = 0
+			}
+			if r > MAXK {
+				r = MAXK
+			}
+			diff[l]++
+			diff[r+1]--
+		}
+	}
+
+	cnt := 0
+	for k := 0; k <= MAXK; k++ {
+		cnt += diff[k]
+		if cnt == n {
+			fmt.Println(k)
+			return
+		}
+	}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## Summary
- implement solution for problemD of 1687 in Go

## Testing
- `go build 1000-1999/1600-1699/1680-1689/1687/1687D.go`
- `go vet 1000-1999/1600-1699/1680-1689/1687/1687D.go`


------
https://chatgpt.com/codex/tasks/task_e_68842bc03fe88324b78848e654b54cf2