### PR TITLE
Add solution verifiers for contest 999

### DIFF
--- a/0-999/900-999/990-999/999/verifierA.go
+++ b/0-999/900-999/990-999/999/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "999A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), stderr.String(), err
+}
+
+type testCase struct{ input string }
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(100) + 1
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte(' ')
+	sb.WriteString(strconv.Itoa(k))
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(100) + 1))
+	}
+	sb.WriteByte('\n')
+	return testCase{sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase, idx int) error {
+	expOut, expErr, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
+	}
+	gotOut, gotErr, err := runBinary(bin, tc.input)
+	if err != nil {
+		return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
+	}
+	if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
+		return fmt.Errorf("test %d failed\nexpected: %s\n got: %s", idx, expOut, gotOut)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(99))
+	for i := 1; i <= 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, ref, tc, i); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/999/verifierB.go
+++ b/0-999/900-999/990-999/999/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "999B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), stderr.String(), err
+}
+
+type testCase struct{ input string }
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 1
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		ch := byte('a' + rng.Intn(26))
+		sb.WriteByte(ch)
+	}
+	sb.WriteByte('\n')
+	return testCase{sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase, idx int) error {
+	expOut, expErr, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
+	}
+	gotOut, gotErr, err := runBinary(bin, tc.input)
+	if err != nil {
+		return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
+	}
+	if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
+		return fmt.Errorf("test %d failed\nexpected: %s\n got: %s", idx, expOut, gotOut)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(99))
+	for i := 1; i <= 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, ref, tc, i); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/999/verifierC.go
+++ b/0-999/900-999/990-999/999/verifierC.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "999C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), stderr.String(), err
+}
+
+type testCase struct{ input string }
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 1
+	k := rng.Intn(n + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		ch := byte('a' + rng.Intn(26))
+		sb.WriteByte(ch)
+	}
+	sb.WriteByte('\n')
+	return testCase{sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase, idx int) error {
+	expOut, expErr, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
+	}
+	gotOut, gotErr, err := runBinary(bin, tc.input)
+	if err != nil {
+		return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
+	}
+	if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
+		return fmt.Errorf("test %d failed\nexpected: %s\n got: %s", idx, expOut, gotOut)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(99))
+	for i := 1; i <= 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, ref, tc, i); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/999/verifierD.go
+++ b/0-999/900-999/990-999/999/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "999D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), stderr.String(), err
+}
+
+type testCase struct{ input string }
+
+func genCase(rng *rand.Rand) testCase {
+	m := rng.Intn(10) + 1
+	n := (rng.Intn(10) + 1) * m
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(strconv.Itoa(rng.Intn(20) - 10))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return testCase{sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase, idx int) error {
+	expOut, expErr, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
+	}
+	gotOut, gotErr, err := runBinary(bin, tc.input)
+	if err != nil {
+		return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
+	}
+	if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
+		return fmt.Errorf("test %d failed\nexpected: %s\n got: %s", idx, expOut, gotOut)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(99))
+	for i := 1; i <= 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, ref, tc, i); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/999/verifierE.go
+++ b/0-999/900-999/990-999/999/verifierE.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "999E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), stderr.String(), err
+}
+
+type testCase struct{ input string }
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(n*n + 1)
+	s := rng.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, s))
+	for i := 0; i < m; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+	}
+	return testCase{sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase, idx int) error {
+	expOut, expErr, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
+	}
+	gotOut, gotErr, err := runBinary(bin, tc.input)
+	if err != nil {
+		return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
+	}
+	if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
+		return fmt.Errorf("test %d failed\nexpected: %s\n got: %s", idx, expOut, gotOut)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(99))
+	for i := 1; i <= 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, ref, tc, i); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/999/verifierF.go
+++ b/0-999/900-999/990-999/999/verifierF.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "999F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), stderr.String(), err
+}
+
+type testCase struct{ input string }
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	total := n * k
+	for i := 0; i < total; i++ {
+		sb.WriteString(strconv.Itoa(rng.Intn(5) + 1))
+		if i+1 < total {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(5) + 1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < k; i++ {
+		sb.WriteString(strconv.Itoa(rng.Intn(7)))
+		if i+1 < k {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return testCase{sb.String()}
+}
+
+func runCase(bin, ref string, tc testCase, idx int) error {
+	expOut, expErr, err := runBinary(ref, tc.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v\nstderr: %s", err, expErr)
+	}
+	gotOut, gotErr, err := runBinary(bin, tc.input)
+	if err != nil {
+		return fmt.Errorf("test %d: runtime error: %v\nstderr: %s", idx, err, gotErr)
+	}
+	if strings.TrimSpace(gotOut) != strings.TrimSpace(expOut) {
+		return fmt.Errorf("test %d failed\nexpected: %s\n got: %s", idx, expOut, gotOut)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(99))
+	for i := 1; i <= 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, ref, tc, i); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F in contest 999
- each verifier compiles the reference solution and checks 100 randomized test cases

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go vet verifierF.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688423d0dcb4832486d273835d882270