### PR TITLE
Add Go verifiers for contest 997

### DIFF
--- a/0-999/900-999/990-999/997/verifierA.go
+++ b/0-999/900-999/990-999/997/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+func solveA(n int, x, y int64, s string) int64 {
+	zeros := 0
+	i := 0
+	for i < n {
+		if s[i] == '0' {
+			zeros++
+			for i < n && s[i] == '0' {
+				i++
+			}
+		} else {
+			i++
+		}
+	}
+	if zeros == 0 {
+		return 0
+	}
+	cost1 := int64(zeros) * y
+	cost2 := y + int64(zeros-1)*x
+	if cost1 < cost2 {
+		return cost1
+	}
+	return cost2
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	x := rng.Int63n(10)
+	y := rng.Int63n(10)
+	var sb strings.Builder
+	sb.Grow(n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	s := sb.String()
+	expected := solveA(n, x, y, s)
+	input := fmt.Sprintf("%d %d %d\n%s\n", n, x, y, s)
+	return testCase{input: input, expected: expected}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/997/verifierB.go
+++ b/0-999/900-999/990-999/997/verifierB.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+func solveB(n int64) int64 {
+	pre := []int64{0, 4, 10, 20, 35, 56, 83, 116, 155, 198, 244, 292}
+	if n <= 11 {
+		return pre[n]
+	}
+	return 49*n - 247
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Int63n(1000000000) + 1
+	expected := solveB(n)
+	input := fmt.Sprintf("%d\n", n)
+	return testCase{input: input, expected: expected}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/997/verifierC.go
+++ b/0-999/900-999/990-999/997/verifierC.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func solveC(n int) int64 {
+	fact := make([]int64, n+1)
+	invFact := make([]int64, n+1)
+	pow3 := make([]int64, n+1)
+	fact[0] = 1
+	pow3[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+		pow3[i] = pow3[i-1] * 3 % mod
+	}
+	invFact[n] = modPow(fact[n], mod-2)
+	for i := n - 1; i >= 0; i-- {
+		invFact[i] = invFact[i+1] * int64(i+1) % mod
+	}
+	pow3n := pow3[n]
+	pow3nn := modPow(pow3n, int64(n))
+	invPow3n := modPow(pow3n, mod-2)
+	pow3nm1 := pow3[n-1]
+	invPow3nm1 := modPow(pow3nm1, mod-2)
+	base0 := (pow3nm1 - 1 + mod) % mod
+	p0 := pow3n * modPow(base0, int64(n)) % mod
+	var S int64
+	invPow3nPow := int64(1)
+	invPow3nm1Pow := int64(1)
+	for a := 0; a <= n; a++ {
+		comb := fact[n] * invFact[a] % mod * invFact[n-a] % mod
+		var p int64
+		if a == 0 {
+			p = p0
+		} else {
+			invPow3nPow = invPow3nPow * invPow3n % mod
+			invPow3nm1Pow = invPow3nm1Pow * invPow3nm1 % mod
+			term1 := pow3nn * invPow3nm1Pow % mod
+			base := (pow3[n-a] - 1 + mod) % mod
+			term2 := 3 * modPow(base, int64(n)) % mod
+			term3 := 3 * pow3nn % mod * invPow3nPow % mod
+			p = (term1 + term2 - term3) % mod
+		}
+		add := comb * p % mod
+		if a%2 == 0 {
+			S = (S + add) % mod
+		} else {
+			S = (S - add) % mod
+		}
+	}
+	if S < 0 {
+		S += mod
+	}
+	ans := pow3nn - S
+	ans %= mod
+	if ans < 0 {
+		ans += mod
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(8) + 1
+	expected := solveC(n)
+	input := fmt.Sprintf("%d\n", n)
+	return testCase{input: input, expected: expected}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/997/verifierD.go
+++ b/0-999/900-999/990-999/997/verifierD.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+type Edge struct {
+	to  int
+	rev int
+}
+
+type graph [][]Edge
+
+func polyGeom(f []int64, k int) []int64 {
+	res := make([]int64, k+1)
+	res[0] = 1
+	for d := 1; d <= k; d++ {
+		var sum int64
+		for i := 1; i <= d; i++ {
+			sum += f[i] * res[d-i]
+			sum %= mod
+		}
+		res[d] = sum
+	}
+	return res
+}
+
+func computeClosedWalks(n, k int, edges [][2]int) []int64 {
+	adj := make(graph, n)
+	for _, e := range edges {
+		a, b := e[0], e[1]
+		ai := len(adj[a])
+		bi := len(adj[b])
+		adj[a] = append(adj[a], Edge{to: b, rev: bi})
+		adj[b] = append(adj[b], Edge{to: a, rev: ai})
+	}
+	F := make([][][]int64, n)
+	for v := 0; v < n; v++ {
+		F[v] = make([][]int64, len(adj[v]))
+		for i := range F[v] {
+			F[v][i] = make([]int64, k+1)
+		}
+	}
+	parent := make([]int, n)
+	parentIdx := make([]int, n)
+	for i := range parent {
+		parent[i] = -2
+	}
+	root := 0
+	stack := []int{root}
+	order := []int{}
+	parent[root] = -1
+	parentIdx[root] = -1
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, v)
+		for _, e := range adj[v] {
+			if e.to == parent[v] {
+				continue
+			}
+			parent[e.to] = v
+			parentIdx[e.to] = e.rev
+			stack = append(stack, e.to)
+		}
+	}
+	for i := len(order) - 1; i >= 0; i-- {
+		v := order[i]
+		if parent[v] == -1 {
+			continue
+		}
+		sum := make([]int64, k+1)
+		for _, e := range adj[v] {
+			if e.to == parent[v] {
+				continue
+			}
+			for t := 0; t+2 <= k; t++ {
+				sum[t+2] = (sum[t+2] + F[e.to][e.rev][t]) % mod
+			}
+		}
+		F[v][parentIdx[v]] = polyGeom(sum, k)
+	}
+	cw := make([]int64, k+1)
+	var dfs func(v, p int)
+	dfs = func(v, p int) {
+		deg := len(adj[v])
+		prefix := make([][]int64, deg+1)
+		suffix := make([][]int64, deg+1)
+		for i := 0; i <= deg; i++ {
+			prefix[i] = make([]int64, k+1)
+			suffix[i] = make([]int64, k+1)
+		}
+		for i := 0; i < deg; i++ {
+			copy(prefix[i+1], prefix[i])
+			for t := 0; t+2 <= k; t++ {
+				prefix[i+1][t+2] = (prefix[i+1][t+2] + F[adj[v][i].to][adj[v][i].rev][t]) % mod
+			}
+		}
+		for i := deg - 1; i >= 0; i-- {
+			copy(suffix[i], suffix[i+1])
+			for t := 0; t+2 <= k; t++ {
+				suffix[i][t+2] = (suffix[i][t+2] + F[adj[v][i].to][adj[v][i].rev][t]) % mod
+			}
+		}
+		total := prefix[deg]
+		P := polyGeom(total, k)
+		for t := 0; t <= k; t++ {
+			cw[t] = (cw[t] + P[t]) % mod
+		}
+		for idx := range adj[v] {
+			sum := make([]int64, k+1)
+			for t := 0; t <= k; t++ {
+				sum[t] = (prefix[idx][t] + suffix[idx+1][t]) % mod
+			}
+			F[v][idx] = polyGeom(sum, k)
+		}
+		for _, e := range adj[v] {
+			if e.to == p {
+				continue
+			}
+			dfs(e.to, v)
+		}
+	}
+	dfs(root, -1)
+	return cw
+}
+
+func solveD(n1, n2, k int, edges1, edges2 [][2]int) int64 {
+	cw1 := computeClosedWalks(n1, k, edges1)
+	cw2 := computeClosedWalks(n2, k, edges2)
+	C := make([][]int64, k+1)
+	for i := 0; i <= k; i++ {
+		C[i] = make([]int64, i+1)
+		C[i][0] = 1
+		C[i][i] = 1
+		for j := 1; j < i; j++ {
+			C[i][j] = (C[i-1][j-1] + C[i-1][j]) % mod
+		}
+	}
+	var ans int64
+	for i := 0; i <= k; i++ {
+		ans = (ans + C[k][i]*cw1[i]%mod*cw2[k-i]) % mod
+	}
+	return ans
+}
+
+func genTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges[i-1] = [2]int{p, i}
+	}
+	return edges
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n1 := rng.Intn(4) + 1
+	n2 := rng.Intn(4) + 1
+	k := rng.Intn(4) + 1
+	edges1 := genTree(rng, n1)
+	edges2 := genTree(rng, n2)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n1, n2, k)
+	for _, e := range edges1 {
+		fmt.Fprintf(&sb, "%d %d\n", e[0]+1, e[1]+1)
+	}
+	for _, e := range edges2 {
+		fmt.Fprintf(&sb, "%d %d\n", e[0]+1, e[1]+1)
+	}
+	expected := solveD(n1, n2, k, edges1, edges2)
+	return testCase{input: sb.String(), expected: expected}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/997/verifierE.go
+++ b/0-999/900-999/990-999/997/verifierE.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type query struct {
+	l, r int
+}
+
+type testCase struct {
+	input    string
+	expected []int64
+}
+
+func solveE(p []int, queries []query) []int64 {
+	res := make([]int64, len(queries))
+	for idx, q := range queries {
+		var count int64
+		for i := q.l; i <= q.r; i++ {
+			minVal := p[i]
+			maxVal := p[i]
+			for j := i; j <= q.r; j++ {
+				if p[j] < minVal {
+					minVal = p[j]
+				}
+				if p[j] > maxVal {
+					maxVal = p[j]
+				}
+				if maxVal-minVal == j-i {
+					count++
+				}
+			}
+		}
+		res[idx] = count
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	p := make([]int, n)
+	for i := range p {
+		p[i] = rng.Intn(5) + 1
+	}
+	qcnt := rng.Intn(5) + 1
+	queries := make([]query, qcnt)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", p[i])
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", qcnt)
+	for i := 0; i < qcnt; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n) + 1
+		if l > r {
+			l, r = r, l
+		}
+		queries[i] = query{l: l - 1, r: r - 1}
+		fmt.Fprintf(&sb, "%d %d\n", l, r)
+	}
+	expected := solveE(p, queries)
+	return testCase{input: sb.String(), expected: expected}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != len(tc.expected) {
+		return fmt.Errorf("expected %d numbers got %d", len(tc.expected), len(fields))
+	}
+	for i, f := range fields {
+		var v int64
+		if _, err := fmt.Sscan(f, &v); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		if v != tc.expected[i] {
+			return fmt.Errorf("expected %v got %v", tc.expected, fields)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for Codeforces contest 997 problems A–E
- each verifier generates 100 random tests and compares against the reference logic
- fix compile issues in verifiers D and E

## Testing
- `go run 0-999/900-999/990-999/997/verifierA.go ./997A_bin`
- `go run 0-999/900-999/990-999/997/verifierB.go ./997B_bin`
- `go run 0-999/900-999/990-999/997/verifierC.go ./997C_bin`


------
https://chatgpt.com/codex/tasks/task_e_688422b882a083249b3850f52668f5a6