### PR TITLE
Add 1681B Go solution

### DIFF
--- a/1000-1999/1600-1699/1680-1689/1681/1681B.go
+++ b/1000-1999/1600-1699/1680-1689/1681/1681B.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		var m int
+		fmt.Fscan(reader, &m)
+		shift := 0
+		for i := 0; i < m; i++ {
+			var b int
+			fmt.Fscan(reader, &b)
+			shift = (shift + b) % n
+		}
+		fmt.Fprintln(writer, a[shift])
+	}
+}


### PR DESCRIPTION
## Summary
- add `1681B.go` Go solution using rotation sums

## Testing
- `go build 1000-1999/1600-1699/1680-1689/1681/1681B.go`

------
https://chatgpt.com/codex/tasks/task_e_68842e7c69c08324bef813c2b862e473