### PR TITLE
Add verifiers for CF995

### DIFF
--- a/0-999/900-999/990-999/995/verifierA.go
+++ b/0-999/900-999/990-999/995/verifierA.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// structure for a single test case
+
+type caseA struct {
+	n    int
+	k    int
+	spot [4][]int // rows with designated spots (rows 0 and 3) and start positions (rows1 and2?)
+}
+
+func genCaseA(rng *rand.Rand) caseA {
+	n := rng.Intn(10) + 1    // keep small for speed
+	k := rng.Intn(2*n-1) + 1 // ensure at least one empty in inner rows
+	var spot [4][]int
+	for i := 0; i < 4; i++ {
+		spot[i] = make([]int, n)
+	}
+	// assign parking spots in rows 0 and 3
+	usedCols1 := rng.Perm(n)
+	usedCols2 := rng.Perm(n)
+	for id := 1; id <= k; id++ {
+		if rng.Intn(2) == 0 {
+			c := usedCols1[id%n]
+			for spot[0][c] != 0 {
+				c = rng.Intn(n)
+			}
+			spot[0][c] = id
+		} else {
+			c := usedCols2[id%n]
+			for spot[3][c] != 0 {
+				c = rng.Intn(n)
+			}
+			spot[3][c] = id
+		}
+	}
+	// assign starting positions rows 1 and 2 (index 1 and2?)
+	free := make([][2]int, 0, 2*n)
+	for r := 1; r <= 2; r++ {
+		for c := 0; c < n; c++ {
+			free = append(free, [2]int{r, c})
+		}
+	}
+	rng.Shuffle(len(free), func(i, j int) { free[i], free[j] = free[j], free[i] })
+	for id := 1; id <= k; id++ {
+		pos := free[id-1]
+		spot[pos[0]][pos[1]] = id
+	}
+	return caseA{n: n, k: k, spot: spot}
+}
+
+// simulate moves and verify
+func verifyOutput(tc caseA, output string) error {
+	fields := strings.Fields(output)
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	if fields[0] == "-1" {
+		return fmt.Errorf("solution reported impossible")
+	}
+	m, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("bad move count: %v", err)
+	}
+	if m < 0 || m > 20000 {
+		return fmt.Errorf("invalid move count %d", m)
+	}
+	if len(fields) != 1+3*m {
+		return fmt.Errorf("expected %d numbers got %d", 1+3*m, len(fields))
+	}
+	// grid occupancy: rows 0..3, cols 0..n-1
+	grid := make([][]int, 4)
+	for i := 0; i < 4; i++ {
+		grid[i] = make([]int, tc.n)
+		copy(grid[i], tc.spot[i])
+	}
+	// car positions map from id->(r,c) for rows 1 and2 (index 1 and2)
+	pos := make(map[int][2]int)
+	for r := 1; r <= 2; r++ {
+		for c := 0; c < tc.n; c++ {
+			id := grid[r][c]
+			if id != 0 {
+				pos[id] = [2]int{r, c}
+			}
+		}
+	}
+	// clear rows 0 and 3 since they are targets only
+	for _, r := range []int{0, 3} {
+		for c := 0; c < tc.n; c++ {
+			grid[r][c] = 0
+		}
+	}
+	idx := 1
+	for step := 0; step < m; step++ {
+		id, err1 := strconv.Atoi(fields[idx])
+		r, err2 := strconv.Atoi(fields[idx+1])
+		c, err3 := strconv.Atoi(fields[idx+2])
+		if err1 != nil || err2 != nil || err3 != nil {
+			return fmt.Errorf("bad move on line %d", step+1)
+		}
+		idx += 3
+		r--
+		c--
+		if r < 0 || r >= 4 || c < 0 || c >= tc.n {
+			return fmt.Errorf("move out of bounds")
+		}
+		p, ok := pos[id]
+		if !ok {
+			return fmt.Errorf("car %d not found", id)
+		}
+		if abs(p[0]-r)+abs(p[1]-c) != 1 {
+			return fmt.Errorf("illegal move for car %d", id)
+		}
+		if grid[r][c] != 0 {
+			return fmt.Errorf("destination occupied")
+		}
+		if r == 0 || r == 3 {
+			if tc.spot[r][c] != id {
+				return fmt.Errorf("car %d cannot park at %d,%d", id, r+1, c+1)
+			}
+		}
+		// perform move
+		grid[p[0]][p[1]] = 0
+		grid[r][c] = id
+		pos[id] = [2]int{r, c}
+		if r == 0 || r == 3 {
+			delete(pos, id)
+		}
+	}
+	if len(pos) != 0 {
+		return fmt.Errorf("not all cars parked")
+	}
+	return nil
+}
+
+func runCaseA(bin string, tc caseA) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.k)
+	for r := 0; r < 4; r++ {
+		for c := 0; c < tc.n; c++ {
+			if c > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", tc.spot[r][c])
+		}
+		sb.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return verifyOutput(tc, out.String())
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseA(rng)
+		if err := runCaseA(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/995/verifierB.go
+++ b/0-999/900-999/990-999/995/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n   int
+	arr []int
+}
+
+func solveB(arr []int) int {
+	a := make([]int, len(arr))
+	copy(a, arr)
+	swaps := 0
+	for i := 0; i < len(a); i += 2 {
+		if a[i] == a[i+1] {
+			continue
+		}
+		j := i + 1
+		for j < len(a) && a[j] != a[i] {
+			j++
+		}
+		for j > i+1 {
+			a[j], a[j-1] = a[j-1], a[j]
+			j--
+			swaps++
+		}
+	}
+	return swaps
+}
+
+func genCaseB(rng *rand.Rand) testCaseB {
+	n := rng.Intn(20) + 1
+	size := 2 * n
+	arr := make([]int, size)
+	// each id appears twice
+	idxs := rng.Perm(size)
+	for i := 0; i < n; i++ {
+		arr[idxs[2*i]] = i + 1
+		arr[idxs[2*i+1]] = i + 1
+	}
+	return testCaseB{n: n, arr: arr}
+}
+
+func runCaseB(bin string, tc testCaseB) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", tc.n)
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solveB(tc.arr)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseB(rng)
+		if err := runCaseB(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/995/verifierC.go
+++ b/0-999/900-999/990-999/995/verifierC.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type vec struct{ x, y int }
+
+type caseC struct {
+	vs []vec
+}
+
+func genCaseC(rng *rand.Rand) caseC {
+	n := rng.Intn(100) + 1
+	vs := make([]vec, n)
+	for i := 0; i < n; i++ {
+		vs[i] = vec{rng.Intn(2000001) - 1000000, rng.Intn(2000001) - 1000000}
+	}
+	return caseC{vs: vs}
+}
+
+func runCaseC(bin string, tc caseC) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(tc.vs))
+	for _, v := range tc.vs {
+		fmt.Fprintf(&sb, "%d %d\n", v.x, v.y)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != len(tc.vs) {
+		return fmt.Errorf("expected %d numbers got %d", len(tc.vs), len(fields))
+	}
+	sx, sy := int64(0), int64(0)
+	for i, f := range fields {
+		if f != "1" && f != "-1" {
+			return fmt.Errorf("invalid sign %q", f)
+		}
+		sign := int64(1)
+		if f == "-1" {
+			sign = -1
+		}
+		sx += sign * int64(tc.vs[i].x)
+		sy += sign * int64(tc.vs[i].y)
+	}
+	lim := int64(1500000)
+	if sx*sx+sy*sy > lim*lim {
+		return fmt.Errorf("vector length too large: %d", sx*sx+sy*sy)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseC(rng)
+		if err := runCaseC(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/995/verifierD.go
+++ b/0-999/900-999/990-999/995/verifierD.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveD(n int, arr []int64, queries [][2]int64) []float64 {
+	size := 1 << uint(n)
+	sum := int64(0)
+	for _, v := range arr {
+		sum += v
+	}
+	res := make([]float64, len(queries)+1)
+	denom := float64(size)
+	res[0] = float64(sum) / denom
+	for i, q := range queries {
+		x := q[0]
+		y := q[1]
+		sum += y - arr[x]
+		arr[x] = y
+		res[i+1] = float64(sum) / denom
+	}
+	return res
+}
+
+func genCaseD(rng *rand.Rand) (int, []int64, [][2]int64) {
+	n := rng.Intn(6) + 1
+	size := 1 << uint(n)
+	arr := make([]int64, size)
+	for i := 0; i < size; i++ {
+		arr[i] = rng.Int63n(1000)
+	}
+	q := rng.Intn(20) + 1
+	queries := make([][2]int64, q)
+	for i := 0; i < q; i++ {
+		queries[i][0] = int64(rng.Intn(size))
+		queries[i][1] = rng.Int63n(1000)
+	}
+	return n, arr, queries
+}
+
+func runCaseD(bin string, n int, arr []int64, queries [][2]int64) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, len(queries))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for _, q := range queries {
+		fmt.Fprintf(&sb, "%d %d\n", q[0], q[1])
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	expected := solveD(n, append([]int64(nil), arr...), queries)
+	if len(fields) != len(expected) {
+		return fmt.Errorf("expected %d numbers got %d", len(expected), len(fields))
+	}
+	for i, f := range fields {
+		val, err := strconv.ParseFloat(f, 64)
+		if err != nil {
+			return fmt.Errorf("bad float %q", f)
+		}
+		if absFloat(val-expected[i]) > 1e-6*maxFloat(1, absFloat(expected[i])) {
+			return fmt.Errorf("expected %.7f got %.7f", expected[i], val)
+		}
+	}
+	return nil
+}
+
+func absFloat(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+func maxFloat(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, arr, qs := genCaseD(rng)
+		if err := runCaseD(bin, n, arr, qs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/995/verifierE.go
+++ b/0-999/900-999/990-999/995/verifierE.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func modPow(base, exp, mod int64) int64 {
+	res := int64(1)
+	base %= mod
+	for exp > 0 {
+		if exp&1 == 1 {
+			res = res * base % mod
+		}
+		base = base * base % mod
+		exp >>= 1
+	}
+	return res
+}
+
+type caseE struct {
+	u, v, p int64
+}
+
+var primes = []int64{3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37}
+
+func genCaseE(rng *rand.Rand) caseE {
+	p := primes[rng.Intn(len(primes))]
+	u := rng.Int63n(p)
+	v := rng.Int63n(p)
+	return caseE{u: u, v: v, p: p}
+}
+
+func runCaseE(bin string, tc caseE) error {
+	input := fmt.Sprintf("%d %d %d\n", tc.u, tc.v, tc.p)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	l, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid length: %v", err)
+	}
+	if l > 200 || l < 0 {
+		return fmt.Errorf("invalid length %d", l)
+	}
+	if len(fields)-1 != l {
+		return fmt.Errorf("expected %d numbers got %d", l, len(fields)-1)
+	}
+	cur := tc.u
+	for i := 0; i < l; i++ {
+		c := fields[1+i]
+		switch c {
+		case "1":
+			cur = (cur + 1) % tc.p
+		case "2":
+			cur = (cur + tc.p - 1) % tc.p
+		case "3":
+			cur = modPow(cur, tc.p-2, tc.p)
+		default:
+			return fmt.Errorf("invalid command %q", c)
+		}
+	}
+	if cur != tc.v {
+		return fmt.Errorf("final value %d expected %d", cur, tc.v)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseE(rng)
+		if err := runCaseE(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/995/verifierF.go
+++ b/0-999/900-999/990-999/995/verifierF.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	a %= MOD
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		b >>= 1
+	}
+	return res
+}
+
+func solveF(n int, D int64, parent []int) int64 {
+	children := make([][]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := parent[i]
+		children[p] = append(children[p], i)
+	}
+	m := n
+	dp := make([][]int64, n+1)
+	for i := 1; i <= n; i++ {
+		dp[i] = make([]int64, m+1)
+	}
+	order := make([]int, 0, n)
+	stack := []int{1}
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, v)
+		for _, c := range children[v] {
+			stack = append(stack, c)
+		}
+	}
+	for i := len(order) - 1; i >= 0; i-- {
+		v := order[i]
+		for x := 1; x <= m; x++ {
+			prod := int64(1)
+			for _, c := range children[v] {
+				prod = prod * dp[c][x] % MOD
+			}
+			dp[v][x] = (dp[v][x-1] + prod) % MOD
+		}
+	}
+	f := make([]int64, m+1)
+	for i := 0; i <= m; i++ {
+		f[i] = dp[1][i]
+	}
+	if D <= int64(m) {
+		return f[D]
+	}
+	fact := make([]int64, m+1)
+	invFact := make([]int64, m+1)
+	fact[0] = 1
+	for i := 1; i <= m; i++ {
+		fact[i] = fact[i-1] * int64(i) % MOD
+	}
+	invFact[m] = modPow(fact[m], MOD-2)
+	for i := m - 1; i >= 0; i-- {
+		invFact[i] = invFact[i+1] * int64(i+1) % MOD
+	}
+	pre := make([]int64, m+1)
+	suf := make([]int64, m+2)
+	pre[0] = 1
+	for i := 1; i <= m; i++ {
+		val := (D - int64(i-1)) % MOD
+		if val < 0 {
+			val += MOD
+		}
+		pre[i] = pre[i-1] * val % MOD
+	}
+	suf[m+1] = 1
+	for i := m; i >= 0; i-- {
+		val := (D - int64(i)) % MOD
+		if val < 0 {
+			val += MOD
+		}
+		suf[i] = suf[i+1] * val % MOD
+	}
+	ans := int64(0)
+	for i := 0; i <= m; i++ {
+		num := pre[i] * suf[i+1] % MOD
+		term := f[i] * num % MOD
+		term = term * invFact[i] % MOD
+		term = term * invFact[m-i] % MOD
+		if (m-i)%2 == 1 {
+			term = (MOD - term) % MOD
+		}
+		ans = (ans + term) % MOD
+	}
+	return ans
+}
+
+type caseF struct {
+	n      int
+	D      int64
+	parent []int
+}
+
+func genCaseF(rng *rand.Rand) caseF {
+	n := rng.Intn(8) + 1
+	parent := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		parent[i] = rng.Intn(i-1) + 1
+	}
+	D := int64(rng.Intn(15) + 1)
+	return caseF{n: n, D: D, parent: parent}
+}
+
+func runCaseF(bin string, tc caseF) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.D)
+	for i := 2; i <= tc.n; i++ {
+		fmt.Fprintf(&sb, "%d\n", tc.parent[i])
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solveF(tc.n, tc.D, tc.parent)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCaseF(rng)
+		if err := runCaseF(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 995 problems A–F
- generate 100 random cases per problem and check binaries

## Testing
- `go build 0-999/900-999/990-999/995/verifierA.go`
- `go build 0-999/900-999/990-999/995/verifierB.go`
- `go build 0-999/900-999/990-999/995/verifierC.go`
- `go build 0-999/900-999/990-999/995/verifierD.go`
- `go build 0-999/900-999/990-999/995/verifierE.go`
- `go build 0-999/900-999/990-999/995/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688421a0666083248cd6597d963824cc