### PR TITLE
Add Go solution for Codeforces 1603C

### DIFF
--- a/1000-1999/1600-1699/1600-1609/1603/1603C.go
+++ b/1000-1999/1600-1699/1600-1609/1603/1603C.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 998244353
+
+type state struct {
+	val  int
+	cnt  int64
+	cost int64
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		fmt.Fprintln(out, solve(a))
+	}
+}
+
+func solve(a []int) int64 {
+	var ans int64
+	vec := []state{}
+	for i := len(a) - 1; i >= 0; i-- {
+		x := a[i]
+		mp := make(map[int]state)
+		mp[x] = state{val: x, cnt: 1, cost: 0}
+		for _, st := range vec {
+			k := (x + st.val - 1) / st.val
+			newVal := x / k
+			cnt := st.cnt
+			cost := (st.cost + cnt*int64(k-1)) % mod
+			if cur, ok := mp[newVal]; ok {
+				cur.cnt = (cur.cnt + cnt) % mod
+				cur.cost = (cur.cost + cost) % mod
+				mp[newVal] = cur
+			} else {
+				mp[newVal] = state{val: newVal, cnt: cnt % mod, cost: cost}
+			}
+		}
+		vec = vec[:0]
+		for _, st := range mp {
+			vec = append(vec, st)
+			ans = (ans + st.cost) % mod
+		}
+	}
+	return ans % mod
+}


### PR DESCRIPTION
## Summary
- implement solution `1603C.go` solving problem C in contest 1603
- algorithm scans array from right to left and aggregates split options to compute total minimal operations

## Testing
- `go run 1000-1999/1600-1699/1600-1609/1603/1603C.go << EOF
1
3
5 4 3
EOF`
- `python3 - <<'PY'
import random, subprocess
MOD=998244353

def compute_py(a):
    vec=[]; ans=0
    for x in reversed(a):
        mp={x:[1,0]}
        for val,cnt,cost in vec:
            k=(x+val-1)//val
            new=x//k
            if new in mp:
                mp[new][0]=(mp[new][0]+cnt)%MOD
                mp[new][1]=(mp[new][1]+cost+cnt*(k-1))%MOD
            else:
                mp[new]=[(cnt)%MOD,(cost+cnt*(k-1))%MOD]
        vec=[(v,mp[v][0],mp[v][1]) for v in mp]
        ans=(ans+sum(c for _,_,c in vec))%MOD
    return ans

random.seed(0)
for n in range(1,5):
    for _ in range(5):
        a=[random.randint(1,5) for _ in range(n)]
        inp='1\n'+str(n)+'\n'+' '.join(map(str,a))+'\n'
        go_out=subprocess.check_output(['go','run','1000-1999/1600-1699/1600-1609/1603/1603C.go'],input=inp.encode()).decode().strip()
        py_out=str(compute_py(a)%MOD)
        assert go_out==py_out
print('ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_688420ce50c88324a02f8cf6ecf2b47a