### PR TITLE
Add contest 993 solution verifiers

### DIFF
--- a/0-999/900-999/990-999/993/verifierA.go
+++ b/0-999/900-999/990-999/993/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func compileReference() (string, error) {
+	refPath := filepath.Join(os.TempDir(), fmt.Sprintf("refA_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", refPath, "993A.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refPath, nil
+}
+
+func generateTests() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		x := rand.Intn(40) - 20
+		y := rand.Intn(40) - 20
+		size := rand.Intn(10) + 1
+		line1 := fmt.Sprintf("%d %d %d %d %d %d %d %d", x, y, x+size, y, x+size, y+size, x, y+size)
+		x2 := rand.Intn(40) - 20
+		y2 := rand.Intn(40) - 20
+		r := rand.Intn(10) + 1
+		line2 := fmt.Sprintf("%d %d %d %d %d %d %d %d", x2-r, y2, x2, y2-r, x2+r, y2, x2, y2+r)
+		tests[i] = line1 + "\n" + line2 + "\n"
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := compileReference()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		exp, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Printf("reference solution failed on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := runBinary(candidate, t)
+		if err != nil {
+			fmt.Printf("tested binary failed on test %d: %v\n", i+1, err)
+			return
+		}
+		if strings.ToLower(strings.TrimSpace(out)) != strings.ToLower(strings.TrimSpace(exp)) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected: %s\nGot: %s\n", i+1, t, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/900-999/990-999/993/verifierB.go
+++ b/0-999/900-999/990-999/993/verifierB.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func compileReference() (string, error) {
+	refPath := filepath.Join(os.TempDir(), fmt.Sprintf("refB_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", refPath, "993B.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refPath, nil
+}
+
+func generatePair(rng *rand.Rand) [2]int {
+	a := rng.Intn(9) + 1
+	b := rng.Intn(9) + 1
+	for b == a {
+		b = rng.Intn(9) + 1
+	}
+	return [2]int{a, b}
+}
+
+func sharedExactlyOne(A, B [][2]int) bool {
+	for _, a := range A {
+		for _, b := range B {
+			c := 0
+			if a[0] == b[0] || a[0] == b[1] {
+				c++
+			}
+			if a[1] == b[0] || a[1] == b[1] {
+				c++
+			}
+			if c == 1 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		var A, B [][2]int
+		n := rng.Intn(4) + 1
+		m := rng.Intn(4) + 1
+		for {
+			A = make([][2]int, 0, n)
+			B = make([][2]int, 0, m)
+			seenA := map[[2]int]struct{}{}
+			seenB := map[[2]int]struct{}{}
+			for len(A) < n {
+				p := generatePair(rng)
+				if _, ok := seenA[p]; !ok {
+					seenA[p] = struct{}{}
+					A = append(A, p)
+				}
+			}
+			for len(B) < m {
+				p := generatePair(rng)
+				if _, ok := seenB[p]; !ok {
+					seenB[p] = struct{}{}
+					B = append(B, p)
+				}
+			}
+			if sharedExactlyOne(A, B) {
+				break
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i, p := range A {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d %d", p[0], p[1]))
+		}
+		sb.WriteByte('\n')
+		for i, p := range B {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d %d", p[0], p[1]))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := compileReference()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := generateTests()
+	for i, t := range tests {
+		exp, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := runBinary(candidate, t)
+		if err != nil {
+			fmt.Printf("tested binary failed on test %d: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected: %s\nGot: %s\n", i+1, t, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/900-999/990-999/993/verifierC.go
+++ b/0-999/900-999/990-999/993/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func compileReference() (string, error) {
+	refPath := filepath.Join(os.TempDir(), fmt.Sprintf("refC_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", refPath, "993C.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refPath, nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(41)-20))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(41)-20))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := compileReference()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := generateTests()
+	for i, t := range tests {
+		exp, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := runBinary(candidate, t)
+		if err != nil {
+			fmt.Printf("tested binary failed on test %d: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected: %s\nGot: %s\n", i+1, t, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/900-999/990-999/993/verifierD.go
+++ b/0-999/900-999/990-999/993/verifierD.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func compileReference() (string, error) {
+	refPath := filepath.Join(os.TempDir(), fmt.Sprintf("refD_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", refPath, "993D.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refPath, nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(20)+1))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(10)+1))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := compileReference()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := generateTests()
+	for i, t := range tests {
+		exp, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := runBinary(candidate, t)
+		if err != nil {
+			fmt.Printf("tested binary failed on test %d: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected: %s\nGot: %s\n", i+1, t, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/900-999/990-999/993/verifierE.go
+++ b/0-999/900-999/990-999/993/verifierE.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func compileReference() (string, error) {
+	refPath := filepath.Join(os.TempDir(), fmt.Sprintf("refE_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", refPath, "993E.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refPath, nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		x := rng.Intn(11) - 5
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(21)-10))
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := compileReference()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := generateTests()
+	for i, t := range tests {
+		exp, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := runBinary(candidate, t)
+		if err != nil {
+			fmt.Printf("tested binary failed on test %d: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected: %s\nGot: %s\n", i+1, t, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/0-999/900-999/990-999/993/verifierF.go
+++ b/0-999/900-999/990-999/993/verifierF.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func compileReference() (string, error) {
+	refPath := filepath.Join(os.TempDir(), fmt.Sprintf("refF_%d", time.Now().UnixNano()))
+	cmd := exec.Command("go", "build", "-o", refPath, "993F.go")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return refPath, nil
+}
+
+func randomGateType(rng *rand.Rand) string {
+	types := []string{"and", "or", "nand", "nor"}
+	return types[rng.Intn(len(types))]
+}
+
+func makeConn(length int, a, b int) string {
+	s := make([]byte, length)
+	for i := 0; i < length; i++ {
+		s[i] = '.'
+	}
+	s[a] = 'x'
+	s[b] = 'x'
+	return string(s)
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 2
+		m := rng.Intn(3) + 2
+		k := rng.Intn(3) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+		for j := 0; j < m; j++ {
+			a := rng.Intn(n)
+			b := rng.Intn(n)
+			for b == a {
+				b = rng.Intn(n)
+			}
+			sb.WriteString(fmt.Sprintf("%s %s", randomGateType(rng), makeConn(n, a, b)))
+			if j+1 < m {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < k; j++ {
+			a := rng.Intn(m)
+			b := rng.Intn(m)
+			for b == a {
+				b = rng.Intn(m)
+			}
+			sb.WriteString(fmt.Sprintf("%s %s", randomGateType(rng), makeConn(m, a, b)))
+			if j+1 < k {
+				sb.WriteByte(' ')
+			}
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := compileReference()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := generateTests()
+	for i, t := range tests {
+		exp, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			return
+		}
+		out, err := runBinary(candidate, t)
+		if err != nil {
+			fmt.Printf("tested binary failed on test %d: %v\n", i+1, err)
+			return
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected: %s\nGot: %s\n", i+1, t, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for all problems of contest 993
- each verifier compiles the reference solution, generates 100 random tests and checks a target binary

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go vet verifierF.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68842088ae808324b9f3edc7fc48b044