### PR TITLE
Add verifiers for contest 992

### DIFF
--- a/0-999/900-999/990-999/992/verifierA.go
+++ b/0-999/900-999/990-999/992/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCaseA struct {
+	input    string
+	expected int
+}
+
+func computeA(arr []int) int {
+	seen := make(map[int]bool)
+	for _, v := range arr {
+		if v != 0 {
+			seen[v] = true
+		}
+	}
+	return len(seen)
+}
+
+func generateCaseA(rng *rand.Rand) testCaseA {
+	n := rng.Intn(20) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(21) - 10
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return testCaseA{input: sb.String(), expected: computeA(arr)}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		tc := generateCaseA(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, tc.input)
+			os.Exit(1)
+		}
+		var val int
+		if _, err := fmt.Sscan(out, &val); err != nil || val != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %s\ninput:\n%s", i, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/992/verifierB.go
+++ b/0-999/900-999/990-999/992/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func computeB(l, r, x, y int64) int {
+	if y%x != 0 {
+		return 0
+	}
+	k := y / x
+	cnt := 0
+	for d := int64(1); d*d <= k; d++ {
+		if k%d == 0 {
+			m := d
+			n := k / d
+			if gcd(m, n) == 1 {
+				a := x * m
+				b := x * n
+				if a >= l && a <= r && b >= l && b <= r {
+					if m == n {
+						cnt++
+					} else {
+						cnt += 2
+					}
+				}
+			}
+		}
+	}
+	return cnt
+}
+
+type testCaseB struct {
+	input    string
+	expected int
+}
+
+func generateCaseB(rng *rand.Rand) testCaseB {
+	l := int64(rng.Intn(50) + 1)
+	r := l + int64(rng.Intn(50))
+	x := int64(rng.Intn(30) + 1)
+	y := int64(rng.Intn(60) + 1)
+	if x > y {
+		x, y = y, x
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", l, r, x, y)
+	return testCaseB{input: sb.String(), expected: computeB(l, r, x, y)}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		tc := generateCaseB(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, tc.input)
+			os.Exit(1)
+		}
+		var val int
+		if _, err := fmt.Sscan(out, &val); err != nil || val != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %s\ninput:\n%s", i, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/992/verifierC.go
+++ b/0-999/900-999/990-999/992/verifierC.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	a %= mod
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func computeC(x, k int64) int64 {
+	if x == 0 {
+		return 0
+	}
+	pow2k := modPow(2, k)
+	pow2k1 := pow2k * 2 % mod
+	ans := (pow2k1*(x%mod)%mod - pow2k + 1) % mod
+	if ans < 0 {
+		ans += mod
+	}
+	return ans
+}
+
+type testCaseC struct {
+	input    string
+	expected int64
+}
+
+func generateCaseC(rng *rand.Rand) testCaseC {
+	x := rng.Int63n(1_000_000_000_000)
+	k := rng.Int63n(1_000_000_000_000)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", x, k)
+	return testCaseC{input: sb.String(), expected: computeC(x, k)}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		tc := generateCaseC(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, tc.input)
+			os.Exit(1)
+		}
+		var val int64
+		if _, err := fmt.Sscan(out, &val); err != nil || val%mod != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %s\ninput:\n%s", i, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/992/verifierD.go
+++ b/0-999/900-999/990-999/992/verifierD.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCaseD struct {
+	input    string
+	expected int64
+}
+
+func computeD(a []int, k int) int64 {
+	n := len(a)
+	var ans int64
+	for i := 0; i < n; i++ {
+		sum := 0
+		prod := int64(1)
+		for j := i; j < n; j++ {
+			sum += a[j]
+			if a[j] > 0 && prod > 2_000_000_000_000_000_000/int64(a[j]) {
+				break
+			}
+			prod *= int64(a[j])
+			if prod%int64(sum) == 0 && prod/int64(sum) == int64(k) {
+				ans++
+			}
+		}
+	}
+	return ans
+}
+
+func generateCaseD(rng *rand.Rand) testCaseD {
+	n := rng.Intn(6) + 1
+	k := rng.Intn(5) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(5) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return testCaseD{input: sb.String(), expected: computeD(a, k)}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		tc := generateCaseD(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, tc.input)
+			os.Exit(1)
+		}
+		var val int64
+		if _, err := fmt.Sscan(out, &val); err != nil || val != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %s\ninput:\n%s", i, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/992/verifierE.go
+++ b/0-999/900-999/990-999/992/verifierE.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type query struct {
+	p int
+	x int
+}
+
+type testCaseE struct {
+	input    string
+	expected []int
+}
+
+func computeE(a []int, qs []query) []int {
+	n := len(a)
+	res := make([]int, len(qs))
+	for idx, q := range qs {
+		a[q.p-1] = q.x
+		sum := 0
+		ans := -1
+		for i := 0; i < n; i++ {
+			if a[i] == sum {
+				ans = i + 1
+				break
+			}
+			sum += a[i]
+		}
+		res[idx] = ans
+	}
+	return res
+}
+
+func generateCaseE(rng *rand.Rand) testCaseE {
+	n := rng.Intn(5) + 1
+	q := rng.Intn(5) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(10)
+	}
+	queries := make([]query, q)
+	for i := 0; i < q; i++ {
+		p := rng.Intn(n) + 1
+		x := rng.Intn(10)
+		queries[i] = query{p: p, x: x}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for _, qu := range queries {
+		sb.WriteString(fmt.Sprintf("%d %d\n", qu.p, qu.x))
+	}
+	return testCaseE{input: sb.String(), expected: computeE(a, queries)}
+}
+
+func parseOutputE(out string, q int) ([]int, error) {
+	lines := strings.Fields(out)
+	if len(lines) != q {
+		return nil, fmt.Errorf("expected %d lines", q)
+	}
+	res := make([]int, q)
+	for i, s := range lines {
+		var v int
+		if _, err := fmt.Sscan(s, &v); err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		tc := generateCaseE(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, tc.input)
+			os.Exit(1)
+		}
+		vals, err := parseOutputE(out, len(tc.expected))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: invalid output\ninput:\n%s", i, tc.input)
+			os.Exit(1)
+		}
+		for j, v := range vals {
+			if v != tc.expected[j] {
+				fmt.Fprintf(os.Stderr, "case %d: expected %v got %v\ninput:\n%s", i, tc.expected, vals, tc.input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for problems A–E of contest 992
- each verifier generates 100 random tests and checks the given binary

## Testing
- `go build 0-999/900-999/990-999/992/verifierA.go`
- `go build 0-999/900-999/990-999/992/verifierB.go`
- `go build 0-999/900-999/990-999/992/verifierC.go`
- `go build 0-999/900-999/990-999/992/verifierD.go`
- `go build 0-999/900-999/990-999/992/verifierE.go`
- `go run 0-999/900-999/990-999/992/verifierA.go ./binA`

------
https://chatgpt.com/codex/tasks/task_e_68841ffc2ba48324b7eb20e90e436a80