### PR TITLE
Add verifiers for contest 991

### DIFF
--- a/0-999/900-999/990-999/991/verifierA.go
+++ b/0-999/900-999/990-999/991/verifierA.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedA(a, b, c, n int) int {
+	visited := a + b - c
+	if a < c || b < c || visited >= n || a > n || b > n {
+		return -1
+	}
+	return n - visited
+}
+
+func generateCaseA(rng *rand.Rand) (string, int) {
+	a := rng.Intn(101)
+	b := rng.Intn(101)
+	c := rng.Intn(101)
+	n := rng.Intn(101) + 1
+	input := fmt.Sprintf("%d %d %d %d\n", a, b, c, n)
+	expected := expectedA(a, b, c, n)
+	return input, expected
+}
+
+func runCaseA(bin, input string, expected int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(outStr)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseA(rng)
+		if err := runCaseA(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/991/verifierB.go
+++ b/0-999/900-999/990-999/991/verifierB.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedB(grades []int) int {
+	n := len(grades)
+	sum := 0
+	for _, g := range grades {
+		sum += g
+	}
+	cur := sum * 10
+	target := 45 * n
+	if cur >= target {
+		return 0
+	}
+	sort.Ints(grades)
+	cnt := 0
+	for _, g := range grades {
+		diff := 5 - g
+		cur += diff * 10
+		cnt++
+		if cur >= target {
+			return cnt
+		}
+	}
+	return cnt
+}
+
+func generateCaseB(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1
+	grades := make([]int, n)
+	for i := range grades {
+		grades[i] = rng.Intn(5) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, g := range grades {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(g))
+	}
+	sb.WriteByte('\n')
+	expected := expectedB(append([]int(nil), grades...))
+	return sb.String(), expected
+}
+
+func runCaseB(bin, input string, expected int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(outStr)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseB(rng)
+		if err := runCaseB(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/991/verifierC.go
+++ b/0-999/900-999/990-999/991/verifierC.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func good(n, k int64) bool {
+	candies := n
+	eaten := int64(0)
+	for candies > 0 {
+		if candies < k {
+			eaten += candies
+			break
+		}
+		eaten += k
+		candies -= k
+		petya := candies / 10
+		candies -= petya
+	}
+	return eaten*2 >= n
+}
+
+func expectedC(n int64) int64 {
+	l, r := int64(1), n
+	for l < r {
+		mid := (l + r) / 2
+		if good(n, mid) {
+			r = mid
+		} else {
+			l = mid + 1
+		}
+	}
+	return l
+}
+
+func generateCaseC(rng *rand.Rand) (string, int64) {
+	n := rng.Int63n(1_000_000_000_000) + 1 // up to 1e12
+	input := fmt.Sprintf("%d\n", n)
+	expected := expectedC(n)
+	return input, expected
+}
+
+func runCaseC(bin, input string, expected int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(outStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseC(rng)
+		if err := runCaseC(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/991/verifierD.go
+++ b/0-999/900-999/990-999/991/verifierD.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func expectedD(s1, s2 string) int {
+	n := len(s1)
+	blocked := make([]int, n)
+	for i := 0; i < n; i++ {
+		if s1[i] == 'X' {
+			blocked[i] |= 1
+		}
+		if s2[i] == 'X' {
+			blocked[i] |= 2
+		}
+	}
+	dp := make([][4]int, n+1)
+	for i := 0; i <= n; i++ {
+		for j := 0; j < 4; j++ {
+			dp[i][j] = -1000000
+		}
+	}
+	dp[0][0] = 0
+	for i := 0; i < n; i++ {
+		for mask := 0; mask < 4; mask++ {
+			if dp[i][mask] < 0 {
+				continue
+			}
+			curBlock := blocked[i]
+			dp[i+1][0] = max(dp[i+1][0], dp[i][mask])
+			if i+1 >= n {
+				continue
+			}
+			nxtBlock := blocked[i+1]
+			if (mask&2) == 0 && (curBlock&2) == 0 && (nxtBlock&1) == 0 && (nxtBlock&2) == 0 {
+				dp[i+1][3] = max(dp[i+1][3], dp[i][mask]+1)
+			}
+			if (mask&1) == 0 && (curBlock&1) == 0 && (mask&2) == 0 && (curBlock&2) == 0 && (nxtBlock&2) == 0 {
+				dp[i+1][2] = max(dp[i+1][2], dp[i][mask]+1)
+			}
+			if (mask&1) == 0 && (curBlock&1) == 0 && (nxtBlock&1) == 0 && (nxtBlock&2) == 0 {
+				dp[i+1][3] = max(dp[i+1][3], dp[i][mask]+1)
+			}
+			if (mask&1) == 0 && (curBlock&1) == 0 && (nxtBlock&1) == 0 && (mask&2) == 0 && (curBlock&2) == 0 {
+				dp[i+1][1] = max(dp[i+1][1], dp[i][mask]+1)
+			}
+		}
+	}
+	return dp[n][0]
+}
+
+func generateCaseD(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1
+	var s1, s2 strings.Builder
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			s1.WriteByte('X')
+		} else {
+			s1.WriteByte('0')
+		}
+		if rng.Intn(2) == 0 {
+			s2.WriteByte('X')
+		} else {
+			s2.WriteByte('0')
+		}
+	}
+	input := s1.String() + "\n" + s2.String() + "\n"
+	expected := expectedD(s1.String(), s2.String())
+	return input, expected
+}
+
+func runCaseD(bin, input string, expected int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(outStr)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseD(rng)
+		if err := runCaseD(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/991/verifierE.go
+++ b/0-999/900-999/990-999/991/verifierE.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedE(s string) int64 {
+	cnt := make([]int, 10)
+	for _, ch := range s {
+		cnt[ch-'0']++
+	}
+	digits := []int{}
+	for d := 0; d < 10; d++ {
+		if cnt[d] > 0 {
+			digits = append(digits, d)
+		}
+	}
+	maxLen := len(s)
+	fact := make([]int64, maxLen+1)
+	fact[0] = 1
+	for i := 1; i <= maxLen; i++ {
+		fact[i] = fact[i-1] * int64(i)
+	}
+	cur := make([]int, 10)
+	var ans int64
+	var dfs func(int, int)
+	dfs = func(pos, length int) {
+		if pos == len(digits) {
+			L := length
+			total := fact[L]
+			for _, d := range digits {
+				total /= fact[cur[d]]
+			}
+			if cur[0] > 0 {
+				t := fact[L-1] / fact[cur[0]-1]
+				for _, d := range digits {
+					if d == 0 {
+						continue
+					}
+					t /= fact[cur[d]]
+				}
+				total -= t
+			}
+			ans += total
+			return
+		}
+		d := digits[pos]
+		for c := 1; c <= cnt[d]; c++ {
+			cur[d] = c
+			dfs(pos+1, length+c)
+		}
+		cur[d] = 0
+	}
+	dfs(0, 0)
+	return ans
+}
+
+func generateCaseE(rng *rand.Rand) (string, int64) {
+	length := rng.Intn(18) + 1
+	var sb strings.Builder
+	sb.WriteByte(byte('1' + rng.Intn(9)))
+	for i := 1; i < length; i++ {
+		sb.WriteByte(byte('0' + rng.Intn(10)))
+	}
+	input := sb.String() + "\n"
+	expected := expectedE(sb.String())
+	return input, expected
+}
+
+func runCaseE(bin, input string, expected int64) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(outStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseE(rng)
+		if err := runCaseE(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/990-999/991/verifierF.go
+++ b/0-999/900-999/990-999/991/verifierF.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const limitF int64 = 10000000000
+
+var memoF = make(map[int64]string)
+
+func powInt(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if a > limitF/res {
+			return limitF + 1
+		}
+		res *= a
+		b--
+	}
+	return res
+}
+
+func root(n int64, b int) int64 {
+	if b <= 1 {
+		return -1
+	}
+	x := int64(math.Pow(float64(n), 1.0/float64(b)) + 0.5)
+	if x < 2 {
+		return -1
+	}
+	for {
+		p := powInt(x, int64(b))
+		if p == n {
+			return x
+		}
+		if p > n {
+			x--
+		} else {
+			x++
+		}
+		if x < 2 {
+			return -1
+		}
+		if powInt(x, int64(b)) == n {
+			return x
+		}
+		if powInt(x, int64(b)) > n && powInt(x-1, int64(b)) < n {
+			break
+		}
+	}
+	return -1
+}
+
+func solve(n int64) string {
+	if v, ok := memoF[n]; ok {
+		return v
+	}
+	best := strconv.FormatInt(n, 10)
+	bestLen := len(best)
+	for b := 2; b <= 34; b++ {
+		base := root(n, b)
+		if base > 1 {
+			s1 := solve(base)
+			cand := s1 + "^" + strconv.Itoa(b)
+			if len(cand) < bestLen {
+				best = cand
+				bestLen = len(cand)
+			}
+		}
+	}
+	for i := int64(2); i*i <= n; i++ {
+		if n%i == 0 {
+			s1 := solve(i)
+			s2 := solve(n / i)
+			cand := s1 + "*" + s2
+			if len(cand) < bestLen {
+				best = cand
+				bestLen = len(cand)
+			}
+		}
+	}
+	for k := 1; k <= 10; k++ {
+		p := int64(math.Pow10(k))
+		if p > n {
+			break
+		}
+		q := n / p
+		r := n % p
+		if q == 0 {
+			continue
+		}
+		left := solve(q) + "*" + fmt.Sprintf("10^%d", k)
+		if r == 0 {
+			if len(left) < bestLen {
+				best = left
+				bestLen = len(left)
+			}
+		} else {
+			right := solve(r)
+			cand := left + "+" + right
+			if len(cand) < bestLen {
+				best = cand
+				bestLen = len(cand)
+			}
+		}
+	}
+	for r := int64(1); r <= 9 && r < n; r++ {
+		s1 := solve(n - r)
+		cand := s1 + "+" + strconv.FormatInt(r, 10)
+		if len(cand) < bestLen {
+			best = cand
+			bestLen = len(cand)
+		}
+	}
+	memoF[n] = best
+	return best
+}
+
+func generateCaseF(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_0000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	expected := solve(n)
+	return input, expected
+}
+
+func runCaseF(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCaseF(rng)
+		if err := runCaseF(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for all problems of contest 991
- each verifier runs 100 random test cases and checks against an embedded solution
- verifiers can be executed as `go run verifierX.go /path/to/binary`

## Testing
- `go run 0-999/900-999/990-999/991/verifierA.go /tmp/991A_bin`

------
https://chatgpt.com/codex/tasks/task_e_68841f7000b08324a5436c77b190a121