### PR TITLE
Add Go verifiers for contest 989

### DIFF
--- a/0-999/900-999/980-989/989/verifierA.go
+++ b/0-999/900-999/980-989/989/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func expected(s string) string {
+	n := len(s)
+	for i := 0; i+2 < n; i++ {
+		hasA, hasB, hasC := false, false, false
+		for j := 0; j < 3; j++ {
+			switch s[i+j] {
+			case 'A':
+				hasA = true
+			case 'B':
+				hasB = true
+			case 'C':
+				hasC = true
+			}
+		}
+		if hasA && hasB && hasC {
+			return "Yes"
+		}
+	}
+	return "No"
+}
+
+func generate() []testCase {
+	const T = 100
+	rand.Seed(1)
+	cases := make([]testCase, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(100) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			ch := "ABC."[rand.Intn(4)]
+			sb.WriteByte(ch)
+		}
+		s := sb.String()
+		cases[i] = testCase{
+			in:  s + "\n",
+			out: expected(s),
+		}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generate()
+	for idx, tc := range cases {
+		got, err := run(bin, tc.in)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(tc.out) {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", idx+1, tc.out, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/900-999/980-989/989/verifierB.go
+++ b/0-999/900-999/980-989/989/verifierB.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func expected(n, p int, s string) string {
+	a := []byte(s)
+	possible := false
+	idx := -1
+	for i := 0; i < n-p; i++ {
+		x, y := a[i], a[i+p]
+		if x == '.' || y == '.' || x != y {
+			possible = true
+			idx = i
+			break
+		}
+	}
+	if !possible {
+		return "No"
+	}
+	x, y := a[idx], a[idx+p]
+	if x == '.' && y == '.' {
+		a[idx] = '0'
+		a[idx+p] = '1'
+	} else if x == '.' {
+		if y == '0' {
+			a[idx] = '1'
+		} else {
+			a[idx] = '0'
+		}
+	} else if y == '.' {
+		if x == '0' {
+			a[idx+p] = '1'
+		} else {
+			a[idx+p] = '0'
+		}
+	}
+	for i := 0; i < n; i++ {
+		if a[i] == '.' {
+			a[i] = '0'
+		}
+	}
+	return string(a)
+}
+
+func generate() []testCase {
+	const T = 100
+	rand.Seed(2)
+	cases := make([]testCase, T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(20) + 1
+		p := rand.Intn(n) + 1
+		var s string
+		for {
+			var sb strings.Builder
+			for j := 0; j < n; j++ {
+				sb.WriteByte("01."[rand.Intn(3)])
+			}
+			s = sb.String()
+			if strings.ContainsRune(s, '.') {
+				break
+			}
+		}
+		cases[i] = testCase{
+			in:  fmt.Sprintf("%d %d\n%s\n", n, p, s),
+			out: expected(n, p, s),
+		}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generate()
+	for idx, tc := range cases {
+		got, err := run(bin, tc.in)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(tc.out) {
+			fmt.Printf("case %d failed\nexpected:\n%s\n\ngot:\n%s\n", idx+1, tc.out, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/900-999/980-989/989/verifierC.go
+++ b/0-999/900-999/980-989/989/verifierC.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func expected(a, b, c, d int) string {
+	m := make([][]byte, 50)
+	for i := 0; i < 50; i++ {
+		m[i] = make([]byte, 50)
+		for j := 0; j < 50; j++ {
+			m[i][j] = '#'
+		}
+	}
+	f := func(x, y int, ch byte) {
+		w := 0
+		for i := 1; i <= x; i++ {
+			row := y - 1 + w%3
+			col := i
+			m[row][col] = ch
+			w++
+		}
+	}
+	ff := func(k, x, y int, ch byte) {
+		w := 0
+		for i := 1; i <= x; i++ {
+			row := y - 1 + w%3
+			col := i + k - 1
+			m[row][col] = ch
+			w++
+		}
+	}
+	for i := 1; i <= 5; i++ {
+		m[i-1][0] = 'A'
+	}
+	for i := 1; i <= 50; i++ {
+		m[0][i-1] = 'A'
+	}
+	for i := 1; i <= 40; i++ {
+		m[i-1][49] = 'A'
+	}
+	for i := 2; i <= 50; i++ {
+		m[30][i-1] = 'A'
+	}
+	for i := 31; i <= 45; i++ {
+		m[i-1][0] = 'D'
+	}
+	if a > 90 {
+		ff(3, a-90, 27, 'A')
+		a = 90
+	}
+	if b > 90 {
+		ff(14, b-90, 27, 'B')
+		b = 90
+	}
+	if c > 90 {
+		ff(25, c-90, 27, 'C')
+		c = 90
+	}
+	if a > 45 {
+		f(45, 7, 'A')
+		a -= 45
+	}
+	f(a, 3, 'A')
+	if b > 45 {
+		f(45, 11, 'B')
+		b -= 45
+	}
+	f(b, 15, 'B')
+	if c > 45 {
+		f(45, 19, 'C')
+		c -= 45
+	}
+	f(c, 23, 'C')
+	if d > 90 {
+		ff(3, d-90, 32, 'D')
+		d = 90
+	}
+	if d > 45 {
+		ff(3, 45, 36, 'D')
+		d -= 45
+	}
+	f(d, 45, 'D')
+	for i := 1; i <= 31; i++ {
+		for j := 1; j <= 50; j++ {
+			if m[i-1][j-1] == '#' {
+				m[i-1][j-1] = 'D'
+			}
+		}
+	}
+	for i := 31; i <= 50; i++ {
+		for j := 1; j <= 50; j++ {
+			if m[i-1][j-1] == '#' {
+				m[i-1][j-1] = 'A'
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "50 50\n")
+	for i := 0; i < 50; i++ {
+		sb.Write(m[i])
+		sb.WriteByte('\n')
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generate() []testCase {
+	const T = 100
+	rand.Seed(3)
+	cases := make([]testCase, T)
+	for i := 0; i < T; i++ {
+		a := rand.Intn(100) + 1
+		b := rand.Intn(100) + 1
+		c := rand.Intn(100) + 1
+		d := rand.Intn(100) + 1
+		cases[i] = testCase{
+			in:  fmt.Sprintf("%d %d %d %d\n", a, b, c, d),
+			out: expected(a, b, c, d),
+		}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generate()
+	for idx, tc := range cases {
+		got, err := run(bin, tc.in)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.out {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:\n%s\n\ngot:\n%s\n", idx+1, tc.in, tc.out, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/900-999/980-989/989/verifierD.go
+++ b/0-999/900-999/980-989/989/verifierD.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func expected(n int, l, wmax float64, xs []float64, vs []int) string {
+	idx := make([]int, n)
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(i, j int) bool { return xs[idx[i]] < xs[idx[j]] })
+	ans := 0
+	for ii := 0; ii < n; ii++ {
+		i := idx[ii]
+		for jj := ii + 1; jj < n; jj++ {
+			j := idx[jj]
+			if vs[i] == vs[j] {
+				continue
+			}
+			vi := float64(vs[i])
+			vj := float64(vs[j])
+			denom := xs[i] - xs[j]
+			if denom == 0 {
+				continue
+			}
+			w := ((xs[j]+l/2)*vi - (xs[i]+l/2)*vj) / denom
+			if math.Abs(w) > wmax {
+				continue
+			}
+			di := vi + w
+			dj := vj + w
+			if di == 0 || dj == 0 {
+				continue
+			}
+			t := -(xs[i] + l/2) / di
+			if t <= 0 {
+				continue
+			}
+			ans++
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generate() []testCase {
+	const T = 100
+	rand.Seed(4)
+	cases := make([]testCase, T)
+	for t := 0; t < T; t++ {
+		n := rand.Intn(6) + 2
+		l := float64(rand.Intn(10) + 1)
+		wmax := float64(rand.Intn(5) + 1)
+		xs := make([]float64, n)
+		vs := make([]int, n)
+		pos := rand.Intn(10) - 5
+		xs[0] = float64(pos)
+		for i := 1; i < n; i++ {
+			pos += int(l) + rand.Intn(5) + 1
+			xs[i] = float64(pos)
+		}
+		for i := 0; i < n; i++ {
+			if rand.Intn(2) == 0 {
+				vs[i] = -1
+			} else {
+				vs[i] = 1
+			}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %.0f %.0f\n", n, l, wmax)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&sb, "%.0f %d\n", xs[i], vs[i])
+		}
+		cases[t] = testCase{
+			in:  sb.String(),
+			out: expected(n, l, wmax, xs, vs),
+		}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generate()
+	for idx, tc := range cases {
+		got, err := run(bin, tc.in)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(tc.out) {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:\n%s\n\ngot:\n%s\n", idx+1, tc.in, tc.out, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/0-999/900-999/980-989/989/verifierE.go
+++ b/0-999/900-999/980-989/989/verifierE.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Line struct {
+	points []int
+}
+
+type testCase struct {
+	in  string
+	out string
+}
+
+func gcd(a, b int) int {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		a = -a
+	}
+	return a
+}
+
+func matMul(a, b [][]float64) [][]float64 {
+	n := len(a)
+	c := make([][]float64, n)
+	for i := 0; i < n; i++ {
+		c[i] = make([]float64, n)
+	}
+	for i := 0; i < n; i++ {
+		for k := 0; k < n; k++ {
+			if a[i][k] == 0 {
+				continue
+			}
+			for j := 0; j < n; j++ {
+				c[i][j] += a[i][k] * b[k][j]
+			}
+		}
+	}
+	return c
+}
+
+func matVecMul(a [][]float64, v []float64) []float64 {
+	n := len(a)
+	res := make([]float64, n)
+	for i := 0; i < n; i++ {
+		sum := 0.0
+		row := a[i]
+		for j := 0; j < n; j++ {
+			sum += row[j] * v[j]
+		}
+		res[i] = sum
+	}
+	return res
+}
+
+func expected(n int, x, y []int, queries [][2]int) string {
+	type key struct{ dx, dy, c int }
+	lineMap := make(map[key]map[int]struct{})
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			dx := x[j] - x[i]
+			dy := y[j] - y[i]
+			g := gcd(dx, dy)
+			dx /= g
+			dy /= g
+			if dx < 0 || (dx == 0 && dy < 0) {
+				dx = -dx
+				dy = -dy
+			}
+			c := dy*x[i] - dx*y[i]
+			k := key{dx, dy, c}
+			if lineMap[k] == nil {
+				lineMap[k] = make(map[int]struct{})
+			}
+			lineMap[k][i] = struct{}{}
+			lineMap[k][j] = struct{}{}
+		}
+	}
+	lines := make([]Line, 0, len(lineMap))
+	for _, m := range lineMap {
+		pts := make([]int, 0, len(m))
+		for p := range m {
+			pts = append(pts, p)
+		}
+		if len(pts) >= 2 {
+			lines = append(lines, Line{pts})
+		}
+	}
+	pointLines := make([][]int, n)
+	for idx, ln := range lines {
+		for _, p := range ln.points {
+			pointLines[p] = append(pointLines[p], idx)
+		}
+	}
+	P := make([][]float64, n)
+	for i := 0; i < n; i++ {
+		P[i] = make([]float64, n)
+	}
+	for i := 0; i < n; i++ {
+		deg := len(pointLines[i])
+		if deg == 0 {
+			continue
+		}
+		for _, li := range pointLines[i] {
+			pts := lines[li].points
+			prob := 1.0 / float64(deg) / float64(len(pts))
+			for _, j := range pts {
+				P[i][j] += prob
+			}
+		}
+	}
+	maxM := 10000
+	mats := make([][][]float64, 0)
+	mats = append(mats, P)
+	for (1 << uint(len(mats))) <= maxM {
+		next := matMul(mats[len(mats)-1], mats[len(mats)-1])
+		mats = append(mats, next)
+	}
+	var sb strings.Builder
+	for _, q := range queries {
+		t := q[0] - 1
+		m := q[1]
+		step := m - 1
+		w := make([]float64, n)
+		w[t] = 1
+		bit := 0
+		for step > 0 {
+			if step&1 == 1 {
+				w = matVecMul(mats[bit], w)
+			}
+			step >>= 1
+			bit++
+		}
+		ans := 0.0
+		for _, ln := range lines {
+			sum := 0.0
+			for _, p := range ln.points {
+				sum += w[p]
+			}
+			prob := sum / float64(len(ln.points))
+			if prob > ans {
+				ans = prob
+			}
+		}
+		sb.WriteString(fmt.Sprintf("%.9f\n", ans))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generate() []testCase {
+	const T = 100
+	rng := rand.New(rand.NewSource(5))
+	cases := make([]testCase, T)
+	for i := 0; i < T; i++ {
+		n := rng.Intn(4) + 2
+		pts := make(map[[2]int]struct{})
+		x := make([]int, n)
+		y := make([]int, n)
+		for j := 0; j < n; j++ {
+			for {
+				xx := rng.Intn(11) - 5
+				yy := rng.Intn(11) - 5
+				key := [2]int{xx, yy}
+				if _, ok := pts[key]; !ok {
+					pts[key] = struct{}{}
+					x[j] = xx
+					y[j] = yy
+					break
+				}
+			}
+		}
+		qn := rng.Intn(3) + 1
+		queries := make([][2]int, qn)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d %d\n", x[j], y[j])
+		}
+		fmt.Fprintf(&sb, "%d\n", qn)
+		for j := 0; j < qn; j++ {
+			t := rng.Intn(n) + 1
+			m := rng.Intn(10) + 1
+			queries[j] = [2]int{t, m}
+			fmt.Fprintf(&sb, "%d %d\n", t, m)
+		}
+		cases[i] = testCase{
+			in:  sb.String(),
+			out: expected(n, x, y, queries),
+		}
+	}
+	return cases
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := generate()
+	for idx, tc := range cases {
+		got, err := run(bin, tc.in)
+		if err != nil {
+			fmt.Printf("case %d: runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.out {
+			fmt.Printf("case %d failed\ninput:\n%s\nexpected:\n%s\n\ngot:\n%s\n", idx+1, tc.in, tc.out, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for Codeforces contest 989 problems A–E
- each verifier generates at least 100 tests and compares the output of a solution binary with an expected output computed inside the verifier

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_68841e57e1808324bdd4215838a28179