### PR TITLE
Add verifiers for contest 988

### DIFF
--- a/0-999/900-999/980-989/988/verifierA.go
+++ b/0-999/900-999/980-989/988/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	n, k int
+	arr  []int
+}
+
+func solve(n, k int, arr []int) string {
+	seen := make(map[int]bool)
+	ans := make([]int, 0, k)
+	for i, v := range arr {
+		if !seen[v] {
+			seen[v] = true
+			if len(ans) < k {
+				ans = append(ans, i+1)
+			}
+		}
+	}
+	var sb strings.Builder
+	if len(ans) >= k {
+		sb.WriteString("YES\n")
+		for i := 0; i < k; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", ans[i])
+		}
+		sb.WriteByte('\n')
+	} else {
+		sb.WriteString("NO\n")
+	}
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d %d\n", tc.n, tc.k)
+	for i, v := range tc.arr {
+		if i > 0 {
+			in.WriteByte(' ')
+		}
+		fmt.Fprintf(&in, "%d", v)
+	}
+	in.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := strings.TrimSpace(solve(tc.n, tc.k, tc.arr))
+	got := strings.TrimSpace(out.String())
+	if expected != got {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	var cases []testCase
+	// some deterministic edge cases
+	cases = append(cases, testCase{n: 1, k: 1, arr: []int{5}})
+	cases = append(cases, testCase{n: 5, k: 2, arr: []int{1, 2, 1, 2, 3}})
+	cases = append(cases, testCase{n: 5, k: 4, arr: []int{1, 1, 1, 1, 1}})
+
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(100) + 1
+		k := rng.Intn(n) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(100) + 1
+		}
+		cases = append(cases, testCase{n: n, k: k, arr: arr})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\n", i+1, err)
+			fmt.Fprintf(os.Stderr, "input n=%d k=%d arr=%v\n", tc.n, tc.k, tc.arr)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/988/verifierC.go
+++ b/0-999/900-999/980-989/988/verifierC.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	seqs [][]int64
+}
+
+func solve(seqs [][]int64) string {
+	type occ struct{ seq, idx int }
+	occMap := make(map[int64]occ)
+	for i, seq := range seqs {
+		var sum int64
+		for _, v := range seq {
+			sum += v
+		}
+		for j, v := range seq {
+			exc := sum - v
+			if prev, ok := occMap[exc]; ok {
+				if prev.seq != i {
+					return fmt.Sprintf("YES\n%d %d\n%d %d\n", prev.seq+1, prev.idx+1, i+1, j+1)
+				}
+			} else {
+				occMap[exc] = occ{i, j}
+			}
+		}
+	}
+	return "NO\n"
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(tc.seqs))
+	for _, seq := range tc.seqs {
+		fmt.Fprintf(&sb, "%d\n", len(seq))
+		for i, v := range seq {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	input := buildInput(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := strings.TrimSpace(solve(tc.seqs))
+	got := strings.TrimSpace(out.String())
+	if expected != got {
+		return fmt.Errorf("expected:\n%s\n-- got:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	var cases []testCase
+	// simple deterministic cases
+	cases = append(cases, testCase{seqs: [][]int64{{1}, {1}}})
+	cases = append(cases, testCase{seqs: [][]int64{{2, 3, 1, 3, 2}, {1, 1, 2, 2, 2, 1}}})
+
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < 100; i++ {
+		k := rng.Intn(4) + 2 // at least 2 sequences
+		seqs := make([][]int64, k)
+		total := 0
+		for j := 0; j < k; j++ {
+			n := rng.Intn(4) + 1
+			total += n
+			seq := make([]int64, n)
+			for t := 0; t < n; t++ {
+				seq[t] = int64(rng.Intn(21) - 10)
+			}
+			seqs[j] = seq
+		}
+		if total > 20 {
+			i--
+			continue
+		}
+		cases = append(cases, testCase{seqs: seqs})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n%s", i+1, err, buildInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/988/verifierD.go
+++ b/0-999/900-999/980-989/988/verifierD.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCase struct {
+	arr []int64
+}
+
+func solve(arr []int64) string {
+	m := make(map[int64]bool, len(arr))
+	for _, v := range arr {
+		m[v] = true
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	uniq := arr[:0]
+	for _, v := range arr {
+		if len(uniq) == 0 || uniq[len(uniq)-1] != v {
+			uniq = append(uniq, v)
+		}
+	}
+	arr = uniq
+	last := arr[len(arr)-1]
+	found2 := false
+	var ansX, ansY int64
+	for _, x := range arr {
+		var prevDiff int64 = -1
+		for diff := int64(1); x+diff <= last; diff <<= 1 {
+			if m[x+diff] {
+				if prevDiff != -1 && diff == prevDiff*2 {
+					return fmt.Sprintf("3\n%d %d %d\n", x, x+prevDiff, x+diff)
+				}
+				prevDiff = diff
+			}
+		}
+		if prevDiff != -1 && !found2 {
+			found2 = true
+			ansX = x
+			ansY = x + prevDiff
+		}
+	}
+	if found2 {
+		return fmt.Sprintf("2\n%d %d\n", ansX, ansY)
+	}
+	return fmt.Sprintf("1\n%d\n", arr[0])
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(tc.arr))
+	for i, v := range tc.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	input := buildInput(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := strings.TrimSpace(solve(append([]int64(nil), tc.arr...)))
+	got := strings.TrimSpace(out.String())
+	if expected != got {
+		return fmt.Errorf("expected:\n%s\n-- got:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	var cases []testCase
+	cases = append(cases, testCase{arr: []int64{7, 3, 5}})
+	cases = append(cases, testCase{arr: []int64{1}})
+	cases = append(cases, testCase{arr: []int64{1, 3}})
+
+	rng := rand.New(rand.NewSource(3))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 1
+		arr := make([]int64, n)
+		for j := 0; j < n; j++ {
+			arr[j] = int64(rng.Intn(41) - 20)
+		}
+		sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+		arr = arr[:n]
+		cases = append(cases, testCase{arr: arr})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput: %s", i+1, err, buildInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/988/verifierE.go
+++ b/0-999/900-999/980-989/988/verifierE.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func minMoves(s string, x, y byte) int {
+	arr := []byte(s)
+	n := len(arr)
+	const INF = int(1e9)
+	best := INF
+	for j := 0; j < n; j++ {
+		if arr[j] != y {
+			continue
+		}
+		costY := n - 1 - j
+		arr1 := append(append([]byte{}, arr[:j]...), arr[j+1:]...)
+		arr1 = append(arr1, y)
+		for i := 0; i < n-1; i++ {
+			if arr1[i] != x {
+				continue
+			}
+			costX := n - 2 - i
+			arr2 := append(append([]byte{}, arr1[:i]...), arr1[i+1:n-1]...)
+			arr2 = append(arr2, x, y)
+			idx := -1
+			for k := 0; k < n-2; k++ {
+				if arr2[k] != '0' {
+					idx = k
+					break
+				}
+			}
+			if idx == -1 {
+				if n == 2 {
+					if arr2[0] == '0' {
+						continue
+					}
+					idx = 0
+				} else {
+					continue
+				}
+			}
+			total := costY + costX + idx
+			if total < best {
+				best = total
+			}
+		}
+	}
+	return best
+}
+
+func solve(s string) string {
+	const INF = int(1e9)
+	ans := INF
+	pairs := [][2]byte{{'0', '0'}, {'2', '5'}, {'5', '0'}, {'7', '5'}}
+	for _, p := range pairs {
+		mv := minMoves(s, p[0], p[1])
+		if mv < ans {
+			ans = mv
+		}
+	}
+	if ans == INF {
+		return "-1\n"
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func runCase(bin string, s string) error {
+	input := s + "\n"
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := strings.TrimSpace(solve(s))
+	got := strings.TrimSpace(out.String())
+	if expected != got {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	cases := []string{"00", "72", "5071"}
+	rng := rand.New(rand.NewSource(4))
+	for i := 0; i < 100; i++ {
+		length := rng.Intn(18) + 1
+		b := make([]byte, length)
+		for j := 0; j < length; j++ {
+			b[j] = byte('0' + rng.Intn(10))
+		}
+		if b[0] == '0' {
+			b[0] = '1'
+		}
+		cases = append(cases, string(b))
+	}
+
+	for i, s := range cases {
+		if err := runCase(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput: %s\n", i+1, err, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/988/verifierF.go
+++ b/0-999/900-999/980-989/988/verifierF.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type segment struct{ l, r int }
+type umbrella struct {
+	x int
+	p int64
+}
+
+type testCase struct {
+	a    int
+	rain []segment
+	umb  []umbrella
+}
+
+func solve(tc testCase) string {
+	a := tc.a
+	rainArr := make([]bool, a)
+	for _, seg := range tc.rain {
+		for x := seg.l; x < seg.r; x++ {
+			rainArr[x] = true
+		}
+	}
+	umbIndex := make([]int, a+1)
+	weights := []int64{0}
+	for _, u := range tc.umb {
+		if u.x < 0 || u.x > a {
+			continue
+		}
+		if umbIndex[u.x] == 0 {
+			weights = append(weights, u.p)
+			umbIndex[u.x] = len(weights) - 1
+		} else if u.p < weights[umbIndex[u.x]] {
+			weights[umbIndex[u.x]] = u.p
+		}
+	}
+	U := len(weights) - 1
+	const INF int64 = 1 << 60
+	dp := make([][]int64, a+1)
+	for i := 0; i <= a; i++ {
+		dp[i] = make([]int64, U+1)
+		for j := 0; j <= U; j++ {
+			dp[i][j] = INF
+		}
+	}
+	dp[0][0] = 0
+	if umbIndex[0] != 0 {
+		dp[0][umbIndex[0]] = 0
+	}
+
+	for pos := 0; pos < a; pos++ {
+		for j := 0; j <= U; j++ {
+			val := dp[pos][j]
+			if val == INF {
+				continue
+			}
+			candidates := []int{}
+			if j != 0 {
+				candidates = append(candidates, j)
+			}
+			if umbIndex[pos] != 0 && umbIndex[pos] != j {
+				candidates = append(candidates, umbIndex[pos])
+			}
+			if !rainArr[pos] {
+				candidates = append(candidates, 0)
+			}
+			if len(candidates) == 0 && rainArr[pos] {
+				continue
+			}
+			used := make(map[int]bool)
+			for _, k := range candidates {
+				if used[k] {
+					continue
+				}
+				used[k] = true
+				if k == 0 && rainArr[pos] {
+					continue
+				}
+				cost := val + weights[k]
+				if cost < dp[pos+1][k] {
+					dp[pos+1][k] = cost
+				}
+				if umbIndex[pos+1] != 0 {
+					idx := umbIndex[pos+1]
+					if cost < dp[pos+1][idx] {
+						dp[pos+1][idx] = cost
+					}
+				}
+				if cost < dp[pos+1][0] {
+					dp[pos+1][0] = cost
+				}
+			}
+		}
+	}
+	ans := INF
+	for j := 0; j <= U; j++ {
+		if dp[a][j] < ans {
+			ans = dp[a][j]
+		}
+	}
+	if ans == INF {
+		return "-1\n"
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func buildInput(tc testCase) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", tc.a, len(tc.rain), len(tc.umb))
+	for _, seg := range tc.rain {
+		fmt.Fprintf(&sb, "%d %d\n", seg.l, seg.r)
+	}
+	for _, u := range tc.umb {
+		fmt.Fprintf(&sb, "%d %d\n", u.x, u.p)
+	}
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	input := buildInput(tc)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := strings.TrimSpace(solve(tc))
+	got := strings.TrimSpace(out.String())
+	if expected != got {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+
+	var cases []testCase
+	cases = append(cases, testCase{a: 1})
+	rng := rand.New(rand.NewSource(5))
+	for i := 0; i < 100; i++ {
+		a := rng.Intn(10) + 1
+		n := rng.Intn(a/2 + 1)
+		m := rng.Intn(a + 1)
+		var rain []segment
+		pos := 0
+		for j := 0; j < n; j++ {
+			l := rng.Intn(a - pos)
+			r := l + rng.Intn(a-l) + 1
+			if r > a {
+				r = a
+			}
+			rain = append(rain, segment{l: l + pos, r: r + pos})
+			pos += r - l
+			if pos >= a {
+				break
+			}
+		}
+		var umb []umbrella
+		for j := 0; j < m; j++ {
+			x := rng.Intn(a + 1)
+			p := int64(rng.Intn(10) + 1)
+			umb = append(umb, umbrella{x: x, p: p})
+		}
+		cases = append(cases, testCase{a: a, rain: rain, umb: umb})
+	}
+
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\ninput:\n%s", i+1, err, buildInput(tc))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A, C, D, E, and F of contest 988
- each verifier runs over 100 randomized tests
- tests are generated deterministically and compare output with a local solve implementation

## Testing
- `go build 0-999/900-999/980-989/988/verifierA.go`
- `go build 0-999/900-999/980-989/988/verifierC.go`
- `go build 0-999/900-999/980-989/988/verifierD.go`
- `go build 0-999/900-999/980-989/988/verifierE.go`
- `go build 0-999/900-999/980-989/988/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68841dcc0d1483249483520717dcc700