### PR TITLE
Add verifiers for CF contest 986

### DIFF
--- a/0-999/900-999/980-989/986/verifierA.go
+++ b/0-999/900-999/980-989/986/verifierA.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func solveCase(n, m, k, s int, types []int, edges []edge) string {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e.u-1, e.v-1
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	dist := make([][]int, k)
+	for t := 0; t < k; t++ {
+		dist[t] = make([]int, n)
+		for i := 0; i < n; i++ {
+			dist[t][i] = -1
+		}
+		q := make([]int, 0, n)
+		for i := 0; i < n; i++ {
+			if types[i] == t+1 {
+				dist[t][i] = 0
+				q = append(q, i)
+			}
+		}
+		for head := 0; head < len(q); head++ {
+			v := q[head]
+			nd := dist[t][v] + 1
+			for _, to := range adj[v] {
+				if dist[t][to] == -1 {
+					dist[t][to] = nd
+					q = append(q, to)
+				}
+			}
+		}
+	}
+	ans := make([]int, n)
+	tmp := make([]int, k)
+	for i := 0; i < n; i++ {
+		for t := 0; t < k; t++ {
+			tmp[t] = dist[t][i]
+		}
+		sort.Ints(tmp)
+		sum := 0
+		for j := 0; j < s; j++ {
+			sum += tmp[j]
+		}
+		ans[i] = sum
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", ans[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(4) + 1
+	s := rng.Intn(k) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	types := make([]int, n)
+	for i := 0; i < n; i++ {
+		types[i] = rng.Intn(k) + 1
+	}
+	edgeMap := make(map[[2]int]bool)
+	edges := make([]edge, 0, m)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		key := [2]int{u, v}
+		if edgeMap[key] {
+			continue
+		}
+		edgeMap[key] = true
+		edges = append(edges, edge{u, v})
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d\n", n, m, k, s)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", types[i])
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+	}
+	input := sb.String()
+	expected := solveCase(n, m, k, s, types, edges)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/986/verifierB.go
+++ b/0-999/900-999/980-989/986/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n int, perm []int) string {
+	visited := make([]bool, n+1)
+	cycles := 0
+	for i := 1; i <= n; i++ {
+		if !visited[i] {
+			cycles++
+			for j := i; !visited[j]; j = perm[j] {
+				visited[j] = true
+			}
+		}
+	}
+	parity := (n - cycles) % 2
+	petrParity := n % 2
+	if parity == petrParity {
+		return "Petr\n"
+	}
+	return "Um_nik\n"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	p0 := rng.Perm(n)
+	perm := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		perm[i+1] = p0[i] + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", perm[i])
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expected := solveCase(n, perm)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/986/verifierC.go
+++ b/0-999/900-999/980-989/986/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n int, arr []int) int {
+	m := len(arr)
+	visited := make(map[int]bool)
+	comps := 0
+	for i := 0; i < m; i++ {
+		v := arr[i]
+		if !visited[v] {
+			comps++
+			// bfs
+			q := []int{v}
+			visited[v] = true
+			for len(q) > 0 {
+				cur := q[0]
+				q = q[1:]
+				for j := 0; j < m; j++ {
+					u := arr[j]
+					if !visited[u] && (cur&u) == 0 {
+						visited[u] = true
+						q = append(q, u)
+					}
+				}
+			}
+		}
+	}
+	return comps
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	size := 1 << uint(n)
+	m := rng.Intn(size) + 1
+	used := make(map[int]bool)
+	arr := make([]int, 0, m)
+	for len(arr) < m {
+		v := rng.Intn(size)
+		if !used[v] {
+			used[v] = true
+			arr = append(arr, v)
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expected := fmt.Sprintf("%d\n", solveCase(n, arr))
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/986/verifierD.go
+++ b/0-999/900-999/980-989/986/verifierD.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func maxProductForCost(S int64) *big.Int {
+	var a, b int64
+	switch S % 3 {
+	case 0:
+		b = S / 3
+	case 1:
+		if S < 4 {
+			a = S / 2
+		} else {
+			b = (S - 4) / 3
+			a = 2
+		}
+	case 2:
+		if S < 2 {
+			return big.NewInt(1)
+		}
+		b = (S - 2) / 3
+		a = 1
+	}
+	res := new(big.Int).Exp(big.NewInt(3), big.NewInt(b), nil)
+	if a > 0 {
+		var t big.Int
+		t.Exp(big.NewInt(2), big.NewInt(a), nil)
+		res.Mul(res, &t)
+	}
+	return res
+}
+
+func solveCase(n *big.Int) int64 {
+	if n.Cmp(big.NewInt(1)) == 0 {
+		return 1
+	}
+	lo := int64(1)
+	hi := int64(n.BitLen()*2 + 10)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if maxProductForCost(mid).Cmp(n) >= 0 {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return lo
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := big.NewInt(rng.Int63n(1000000) + 1)
+	input := n.String() + "\n"
+	expected := fmt.Sprintf("%d\n", solveCase(n))
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/986/verifierE.go
+++ b/0-999/900-999/980-989/986/verifierE.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+
+type query struct{ u, v, x int }
+
+type edge struct{ u, v int }
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func findPath(u, v int, adj [][]int) []int {
+	n := len(adj)
+	parent := make([]int, n)
+	for i := 0; i < n; i++ {
+		parent[i] = -1
+	}
+	q := []int{u}
+	parent[u] = u
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		if cur == v {
+			break
+		}
+		for _, to := range adj[cur] {
+			if parent[to] == -1 {
+				parent[to] = cur
+				q = append(q, to)
+			}
+		}
+	}
+	path := []int{v}
+	for path[len(path)-1] != u {
+		path = append(path, parent[path[len(path)-1]])
+	}
+	// reverse
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+	return path
+}
+
+func solveCase(n int, edges []edge, a []int, qs []query) string {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e.u-1, e.v-1
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	var sb strings.Builder
+	for _, q := range qs {
+		p := findPath(q.u-1, q.v-1, adj)
+		res := int64(1)
+		for _, node := range p {
+			res = res * int64(gcd(q.x, a[node])) % MOD
+		}
+		fmt.Fprintf(&sb, "%d\n", res)
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(7) + 1
+	edges := make([]edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, edge{p, i})
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(20) + 1
+	}
+	qcnt := rng.Intn(5) + 1
+	qs := make([]query, qcnt)
+	for i := 0; i < qcnt; i++ {
+		qs[i] = query{rng.Intn(n) + 1, rng.Intn(n) + 1, rng.Intn(20) + 1}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+	}
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteByte('\n')
+	fmt.Fprintf(&sb, "%d\n", qcnt)
+	for _, qu := range qs {
+		fmt.Fprintf(&sb, "%d %d %d\n", qu.u, qu.v, qu.x)
+	}
+	input := sb.String()
+	expected := solveCase(n, edges, a, qs)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/986/verifierF.go
+++ b/0-999/900-999/980-989/986/verifierF.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ n, k int64 }
+
+func feasible(n, k int64) bool {
+	if k == 1 || n == 1 {
+		return false
+	}
+	allowed := []int{}
+	for i := 2; int64(i) <= n; i++ {
+		if k%int64(i) == 0 {
+			allowed = append(allowed, i)
+		}
+	}
+	if len(allowed) == 0 {
+		return false
+	}
+	dp := make([]bool, n+1)
+	dp[0] = true
+	for i := 0; i <= int(n); i++ {
+		if dp[i] {
+			for _, l := range allowed {
+				if i+l <= int(n) {
+					dp[i+l] = true
+				}
+			}
+		}
+	}
+	return dp[n]
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(5) + 1
+	cases := make([]pair, t)
+	for i := 0; i < t; i++ {
+		cases[i] = pair{int64(rng.Intn(8) + 1), int64(rng.Intn(10) + 1)}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for _, c := range cases {
+		fmt.Fprintf(&sb, "%d %d\n", c.n, c.k)
+	}
+	input := sb.String()
+	var out strings.Builder
+	for _, c := range cases {
+		if feasible(c.n, c.k) {
+			out.WriteString("YES\n")
+		} else {
+			out.WriteString("NO\n")
+		}
+	}
+	expected := out.String()
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go based verifiers for problems A–F of contest 986
- each verifier generates 100 random tests and checks a submission binary

## Testing
- `go build 0-999/900-999/980-989/986/verifierA.go`
- `go build 0-999/900-999/980-989/986/verifierB.go`
- `go build 0-999/900-999/980-989/986/verifierC.go`
- `go build 0-999/900-999/980-989/986/verifierD.go`
- `go build 0-999/900-999/980-989/986/verifierE.go`
- `go build 0-999/900-999/980-989/986/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68841cb3b6388324b84b11075ff9a4b5