### PR TITLE
Add Go verifiers for contest 985

### DIFF
--- a/0-999/900-999/980-989/985/verifierA.go
+++ b/0-999/900-999/980-989/985/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expectedA(n int, pos []int) int {
+	sort.Ints(pos)
+	m := n / 2
+	black := 0
+	white := 0
+	for i := 0; i < m; i++ {
+		black += abs(pos[i] - (2*i + 1))
+		white += abs(pos[i] - (2 * (i + 1)))
+	}
+	if black < white {
+		return black
+	}
+	return white
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func generateCaseA(rng *rand.Rand) (int, []int) {
+	n := rng.Intn(50)*2 + 2 // even between 2 and 100
+	m := n / 2
+	perm := rng.Perm(n)
+	pos := make([]int, m)
+	for i := 0; i < m; i++ {
+		pos[i] = perm[i] + 1
+	}
+	return n, pos
+}
+
+func runCaseA(bin string, n int, pos []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, p := range pos {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(p))
+	}
+	sb.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expected := expectedA(n, append([]int(nil), pos...))
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, pos := generateCaseA(rng)
+		if err := runCaseA(bin, n, pos); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d\n%v\n", i+1, err, n, pos)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/985/verifierB.go
+++ b/0-999/900-999/980-989/985/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedB(n, m int, grid [][]byte) string {
+	cnt := make([]int, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '1' {
+				cnt[j]++
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		ok := true
+		for j := 0; j < m; j++ {
+			if cnt[j]-int(grid[i][j]-'0') == 0 {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return "YES"
+		}
+	}
+	return "NO"
+}
+
+func generateCaseB(rng *rand.Rand) (int, int, [][]byte) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = '0'
+			} else {
+				row[j] = '1'
+			}
+		}
+		grid[i] = row
+	}
+	// ensure each column has at least one '1'
+	for j := 0; j < m; j++ {
+		has := false
+		for i := 0; i < n; i++ {
+			if grid[i][j] == '1' {
+				has = true
+				break
+			}
+		}
+		if !has {
+			grid[rng.Intn(n)][j] = '1'
+		}
+	}
+	return n, m, grid
+}
+
+func runCaseB(bin string, n, m int, grid [][]byte) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		sb.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedB(n, m, grid)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, grid := generateCaseB(rng)
+		if err := runCaseB(bin, n, m, grid); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			for _, row := range grid {
+				fmt.Fprintln(os.Stderr, string(row))
+			}
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/985/verifierC.go
+++ b/0-999/900-999/980-989/985/verifierC.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expectedC(n, k int, l int64, arr []int64) int64 {
+	m := n * k
+	b := append([]int64(nil), arr...)
+	sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
+	limit := b[0] + l
+	good := 0
+	for good < m && b[good] <= limit {
+		good++
+	}
+	if good < n {
+		return 0
+	}
+	pos := good - 1
+	right := m - 1
+	var result int64
+	for i := 0; i < n; i++ {
+		result += b[pos]
+		pos--
+		for j := 0; j < k-1; j++ {
+			if right > pos {
+				right--
+			} else {
+				pos--
+			}
+		}
+	}
+	return result
+}
+
+func generateCaseC(rng *rand.Rand) (int, int, int64, []int64) {
+	for {
+		n := rng.Intn(5) + 1
+		k := rng.Intn(5) + 1
+		if n*k <= 20 {
+			l := int64(rng.Intn(10))
+			m := n * k
+			arr := make([]int64, m)
+			for i := 0; i < m; i++ {
+				arr[i] = int64(rng.Intn(20)) + 1
+			}
+			return n, k, l, arr
+		}
+	}
+}
+
+func runCaseC(bin string, n, k int, l int64, arr []int64) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, k, l))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expected := expectedC(n, k, l, arr)
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, l, arr := generateCaseC(rng)
+		if err := runCaseC(bin, n, k, l, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/985/verifierD.go
+++ b/0-999/900-999/980-989/985/verifierD.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func maxSum(len, H int64) int64 {
+	if len <= H {
+		return len * (len + 1) / 2
+	}
+	k := (len - H + 2) / 2
+	return k*H + k*(k-1)/2 + (len-k)*(len-k+1)/2
+}
+
+func expectedD(n, H int64) int64 {
+	lo, hi := int64(1), int64(2000000000)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if maxSum(mid, H) >= n {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return lo
+}
+
+func generateCaseD(rng *rand.Rand) (int64, int64) {
+	n := rng.Int63n(1000000) + 1
+	H := rng.Int63n(1000000) + 1
+	return n, H
+}
+
+func runCaseD(bin string, n, H int64) error {
+	input := fmt.Sprintf("%d %d\n", n, H)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expected := expectedD(n, H)
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, H := generateCaseD(rng)
+		if err := runCaseD(bin, n, H); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%d %d\n", i+1, err, n, H)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/985/verifierE.go
+++ b/0-999/900-999/980-989/985/verifierE.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expectedE(n, k, d int, arr []int) string {
+	b := append([]int(nil), arr...)
+	sort.Ints(b)
+	dp := make([]bool, n+1)
+	pref := make([]int, n+1)
+	dp[0] = true
+	pref[0] = 1
+	l := 0
+	for i := 1; i <= n; i++ {
+		for l < i && b[i-1]-b[l] > d {
+			l++
+		}
+		if i >= k {
+			left := l
+			right := i - k
+			if left <= right {
+				sum := pref[right]
+				if left > 0 {
+					sum -= pref[left-1]
+				}
+				if sum > 0 {
+					dp[i] = true
+				}
+			}
+		}
+		pref[i] = pref[i-1]
+		if dp[i] {
+			pref[i]++
+		}
+	}
+	if dp[n] {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCaseE(rng *rand.Rand) (int, int, int, []int) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	d := rng.Intn(10)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(50)
+	}
+	return n, k, d, arr
+}
+
+func runCaseE(bin string, n, k, d int, arr []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, k, d))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := expectedE(n, k, d, arr)
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k, d, arr := generateCaseE(rng)
+		if err := runCaseE(bin, n, k, d, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/985/verifierF.go
+++ b/0-999/900-999/980-989/985/verifierF.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isomorphic(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ma := make(map[byte]byte)
+	mb := make(map[byte]byte)
+	for i := 0; i < len(a); i++ {
+		x := a[i]
+		y := b[i]
+		if v, ok := ma[x]; ok {
+			if v != y {
+				return false
+			}
+		} else {
+			ma[x] = y
+		}
+		if v, ok := mb[y]; ok {
+			if v != x {
+				return false
+			}
+		} else {
+			mb[y] = x
+		}
+	}
+	return true
+}
+
+func expectedF(s string, queries [][3]int) []string {
+	res := make([]string, len(queries))
+	for idx, q := range queries {
+		x, y, l := q[0], q[1], q[2]
+		a := s[x : x+l]
+		b := s[y : y+l]
+		if isomorphic(a, b) {
+			res[idx] = "YES"
+		} else {
+			res[idx] = "NO"
+		}
+	}
+	return res
+}
+
+func generateCaseF(rng *rand.Rand) (string, [][3]int) {
+	n := rng.Intn(10) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	m := rng.Intn(10) + 1
+	qs := make([][3]int, m)
+	for i := 0; i < m; i++ {
+		if n == 1 {
+			qs[i] = [3]int{0, 0, 1}
+			continue
+		}
+		x := rng.Intn(n)
+		y := rng.Intn(n)
+		l := rng.Intn(n-max(x, y)) + 1
+		qs[i] = [3]int{x, y, l}
+	}
+	return string(b), qs
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func runCaseF(bin string, s string, qs [][3]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", len(s), len(qs)))
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	for _, q := range qs {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", q[0]+1, q[1]+1, q[2]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	expectedLines := expectedF(s, qs)
+	if len(gotLines) != len(expectedLines) {
+		return fmt.Errorf("wrong number of lines: expected %d got %d", len(expectedLines), len(gotLines))
+	}
+	for i := range gotLines {
+		if strings.TrimSpace(gotLines[i]) != expectedLines[i] {
+			return fmt.Errorf("line %d: expected %s got %s", i+1, expectedLines[i], strings.TrimSpace(gotLines[i]))
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s, qs := generateCaseF(rng)
+		if err := runCaseF(bin, s, qs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/985/verifierG.go
+++ b/0-999/900-999/980-989/985/verifierG.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ u, v int }
+
+func expectedG(n int, A, B, C uint64, edges []pair) uint64 {
+	conflict := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		conflict[i] = make([]bool, n)
+	}
+	for _, e := range edges {
+		conflict[e.u][e.v] = true
+		conflict[e.v][e.u] = true
+	}
+	var ans uint64
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if conflict[i][j] {
+				continue
+			}
+			for k := j + 1; k < n; k++ {
+				if conflict[i][k] || conflict[j][k] {
+					continue
+				}
+				ans += A*uint64(i) + B*uint64(j) + C*uint64(k)
+			}
+		}
+	}
+	return ans
+}
+
+func generateCaseG(rng *rand.Rand) (int, uint64, uint64, uint64, []pair) {
+	n := rng.Intn(6) + 3
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	A := uint64(rng.Intn(10) + 1)
+	B := uint64(rng.Intn(10) + 1)
+	C := uint64(rng.Intn(10) + 1)
+	used := make(map[pair]bool)
+	edges := make([]pair, 0, m)
+	for len(edges) < m {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		p := pair{u, v}
+		if used[p] {
+			continue
+		}
+		used[p] = true
+		edges = append(edges, p)
+	}
+	return n, A, B, C, edges
+}
+
+func runCaseG(bin string, n int, A, B, C uint64, edges []pair) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", A, B, C))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got uint64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	expected := expectedG(n, A, B, C, edges)
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, A, B, C, edges := generateCaseG(rng)
+		if err := runCaseG(bin, n, A, B, C, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for Codeforces contest 985 problems A–G
- each verifier runs 100 random tests and checks the output of a given binary

## Testing
- `go run 0-999/900-999/980-989/985/verifierA.go ./solA`

------
https://chatgpt.com/codex/tasks/task_e_68841c27d6208324a193beb65a93f1f6