### PR TITLE
Add naive Go solution for 1601D

### DIFF
--- a/1000-1999/1600-1699/1600-1609/1601/1601D.go
+++ b/1000-1999/1600-1699/1600-1609/1601/1601D.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+func main() {
+    reader := bufio.NewReader(os.Stdin)
+    writer := bufio.NewWriter(os.Stdout)
+    defer writer.Flush()
+
+    var n int
+    var d int
+    if _, err := fmt.Fscan(reader, &n, &d); err != nil {
+        return
+    }
+    type pair struct{ s, a int }
+    arr := make([]pair, n)
+    for i := 0; i < n; i++ {
+        fmt.Fscan(reader, &arr[i].s, &arr[i].a)
+    }
+
+    used := make([]bool, n)
+    cur := d
+    ans := 0
+    for {
+        best := -1
+        bestA := 0
+        for i, p := range arr {
+            if used[i] {
+                continue
+            }
+            if cur <= p.s {
+                if best == -1 || p.a < bestA {
+                    best = i
+                    bestA = p.a
+                }
+            }
+        }
+        if best == -1 {
+            break
+        }
+        used[best] = true
+        if arr[best].a > cur {
+            cur = arr[best].a
+        }
+        ans++
+    }
+    fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- add a simple greedy solution for problem 1601D

## Testing
- `go vet` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68841be1a0e08324977bde44689f856c