### PR TITLE
Add Go verifiers for contest 983

### DIFF
--- a/0-999/900-999/980-989/983/verifierA.go
+++ b/0-999/900-999/980-989/983/verifierA.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func finite(p, q, b int64) bool {
+	g := gcd(p, q)
+	q /= g
+	g = gcd(q, b)
+	for g > 1 {
+		for q%g == 0 {
+			q /= g
+		}
+		g = gcd(q, b)
+	}
+	return q == 1
+}
+
+func generateA(rng *rand.Rand) (string, string) {
+	p := rng.Int63n(1e9)
+	q := rng.Int63n(1e9) + 1
+	b := rng.Int63n(1e9-1) + 2
+	exp := "Infinite"
+	if finite(p, q, b) {
+		exp = "Finite"
+	}
+	input := fmt.Sprintf("1\n%d %d %d\n", p, q, b)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		in, exp := generateA(rng)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(in)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("case %d runtime error: %v\n%s", i+1, err, out.String())
+			return
+		}
+		got := strings.TrimSpace(out.String())
+		if got != exp {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/983/verifierB.go
+++ b/0-999/900-999/980-989/983/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func fValue(arr []int) int {
+	tmp := make([]int, len(arr))
+	copy(tmp, arr)
+	for len(tmp) > 1 {
+		next := make([]int, len(tmp)-1)
+		for i := 0; i < len(tmp)-1; i++ {
+			next[i] = tmp[i] ^ tmp[i+1]
+		}
+		tmp = next
+	}
+	return tmp[0]
+}
+
+func maxF(a []int, l, r int) int {
+	maxv := 0
+	for i := l - 1; i < r; i++ {
+		for j := i; j < r; j++ {
+			v := fValue(a[i : j+1])
+			if v > maxv {
+				maxv = v
+			}
+		}
+	}
+	return maxv
+}
+
+func generateB(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(16)
+	}
+	l := rng.Intn(n) + 1
+	r := rng.Intn(n-l+1) + l
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteString("\n1\n")
+	fmt.Fprintf(&sb, "%d %d\n", l, r)
+	res := maxF(a, l, r)
+	return sb.String(), fmt.Sprint(res)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(43))
+	for i := 0; i < 100; i++ {
+		in, exp := generateB(rng)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(in)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("case %d runtime error: %v\n%s", i+1, err, out.String())
+			return
+		}
+		got := strings.TrimSpace(out.String())
+		if got != exp {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/983/verifierC.go
+++ b/0-999/900-999/980-989/983/verifierC.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const base = 5
+
+var pow5 [10]int32
+
+func init() {
+	pow5[0] = 1
+	for i := 1; i < 10; i++ {
+		pow5[i] = pow5[i-1] * base
+	}
+}
+
+type State struct {
+	t     int
+	idx   int16
+	floor int8
+	code  int32
+	size  int8
+}
+
+type PQ []State
+
+func (pq PQ) Len() int            { return len(pq) }
+func (pq PQ) Less(i, j int) bool  { return pq[i].t < pq[j].t }
+func (pq PQ) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PQ) Push(x interface{}) { *pq = append(*pq, x.(State)) }
+func (pq *PQ) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	*pq = old[:n-1]
+	return item
+}
+
+func add(code int32, floor int8, delta int8) int32 {
+	return code + int32(delta)*pow5[floor-1]
+}
+
+func get(code int32, floor int8) int8 {
+	return int8((code / pow5[floor-1]) % base)
+}
+
+func makeKey(idx int16, floor int8, code int32) int64 {
+	return int64(idx)<<32 | int64(floor)<<28 | int64(code)
+}
+
+func solveC(n int, a, b []int8) int {
+	start := State{t: 0, idx: 0, floor: 1, code: 0, size: 0}
+	pq := &PQ{start}
+	heap.Init(pq)
+	dist := make(map[int64]int)
+	dist[makeKey(start.idx, start.floor, start.code)] = 0
+	for pq.Len() > 0 {
+		cur := heap.Pop(pq).(State)
+		key := makeKey(cur.idx, cur.floor, cur.code)
+		if d, ok := dist[key]; ok && d < cur.t {
+			continue
+		}
+		if int(cur.idx) == n && cur.size == 0 {
+			return cur.t
+		}
+		if cur.floor < 9 {
+			next := cur
+			next.t++
+			next.floor++
+			k := makeKey(next.idx, next.floor, next.code)
+			if d, ok := dist[k]; !ok || next.t < d {
+				dist[k] = next.t
+				heap.Push(pq, next)
+			}
+		}
+		if cur.floor > 1 {
+			next := cur
+			next.t++
+			next.floor--
+			k := makeKey(next.idx, next.floor, next.code)
+			if d, ok := dist[k]; !ok || next.t < d {
+				dist[k] = next.t
+				heap.Push(pq, next)
+			}
+		}
+		exits := get(cur.code, cur.floor)
+		idx := cur.idx
+		code := cur.code
+		size := cur.size
+		cost := 0
+		if exits > 0 {
+			code = add(code, cur.floor, -exits)
+			size -= exits
+			cost += int(exits)
+		}
+		for int(idx) < n && a[int(idx)+1] == cur.floor && size < 4 {
+			idx++
+			code = add(code, b[int(idx)], 1)
+			size++
+			cost++
+		}
+		if cost > 0 {
+			next := State{t: cur.t + cost, idx: idx, floor: cur.floor, code: code, size: size}
+			k := makeKey(next.idx, next.floor, next.code)
+			if d, ok := dist[k]; !ok || next.t < d {
+				dist[k] = next.t
+				heap.Push(pq, next)
+			}
+		}
+	}
+	return -1
+}
+
+func generateC(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	a := make([]int8, n+1)
+	b := make([]int8, n+1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 1; i <= n; i++ {
+		ai := int8(rng.Intn(9) + 1)
+		bi := int8(rng.Intn(9) + 1)
+		for bi == ai {
+			bi = int8(rng.Intn(9) + 1)
+		}
+		a[i] = ai
+		b[i] = bi
+		fmt.Fprintf(&sb, "%d %d\n", ai, bi)
+	}
+	res := solveC(n, a, b)
+	return sb.String(), fmt.Sprint(res)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(44))
+	for i := 0; i < 100; i++ {
+		in, exp := generateC(rng)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(in)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("case %d runtime error: %v\n%s", i+1, err, out.String())
+			return
+		}
+		got := strings.TrimSpace(out.String())
+		if got != exp {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/983/verifierD.go
+++ b/0-999/900-999/980-989/983/verifierD.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type Node struct {
+	covered bool
+	c       [4]*Node
+}
+
+func (node *Node) update(x1, x2, y1, y2, xl, xr, yl, yr int) {
+	if node.covered || x2 <= xl || xr <= x1 || y2 <= yl || yr <= y1 {
+		return
+	}
+	if x1 <= xl && xr <= x2 && y1 <= yl && yr <= y2 {
+		node.covered = true
+		node.c = [4]*Node{}
+		return
+	}
+	if xl+1 == xr && yl+1 == yr {
+		node.covered = true
+		node.c = [4]*Node{}
+		return
+	}
+	mx := (xl + xr) / 2
+	my := (yl + yr) / 2
+	if node.c[0] == nil {
+		node.c[0] = &Node{}
+		node.c[1] = &Node{}
+		node.c[2] = &Node{}
+		node.c[3] = &Node{}
+	}
+	node.c[0].update(x1, x2, y1, y2, xl, mx, yl, my)
+	node.c[1].update(x1, x2, y1, y2, xl, mx, my, yr)
+	node.c[2].update(x1, x2, y1, y2, mx, xr, yl, my)
+	node.c[3].update(x1, x2, y1, y2, mx, xr, my, yr)
+	if node.c[0].covered && node.c[1].covered && node.c[2].covered && node.c[3].covered {
+		node.covered = true
+		node.c = [4]*Node{}
+	}
+}
+
+func (node *Node) query(x1, x2, y1, y2, xl, xr, yl, yr int) bool {
+	if x2 <= xl || xr <= x1 || y2 <= yl || yr <= y1 {
+		return true
+	}
+	if node.covered {
+		return true
+	}
+	if xl+1 == xr && yl+1 == yr {
+		return node.covered
+	}
+	mx := (xl + xr) / 2
+	my := (yl + yr) / 2
+	if node.c[0] == nil {
+		return false
+	}
+	return node.c[0].query(x1, x2, y1, y2, xl, mx, yl, my) &&
+		node.c[1].query(x1, x2, y1, y2, xl, mx, my, yr) &&
+		node.c[2].query(x1, x2, y1, y2, mx, xr, yl, my) &&
+		node.c[3].query(x1, x2, y1, y2, mx, xr, my, yr)
+}
+
+type Rect struct{ x1, y1, x2, y2 int }
+
+func uniqueInts(a []int) []int {
+	if len(a) == 0 {
+		return a
+	}
+	j := 1
+	for i := 1; i < len(a); i++ {
+		if a[i] != a[i-1] {
+			a[j] = a[i]
+			j++
+		}
+	}
+	return a[:j]
+}
+
+func solveD(rects []Rect) int {
+	n := len(rects)
+	xs := make([]int, 0, 2*n)
+	ys := make([]int, 0, 2*n)
+	for _, r := range rects {
+		xs = append(xs, r.x1, r.x2)
+		ys = append(ys, r.y1, r.y2)
+	}
+	sort.Ints(xs)
+	xs = uniqueInts(xs)
+	sort.Ints(ys)
+	ys = uniqueInts(ys)
+	toIndex := func(arr []int, v int) int { return sort.SearchInts(arr, v) }
+	root := &Node{}
+	visible := 1
+	seen := make([]bool, n)
+	for i := n - 1; i >= 0; i-- {
+		r := rects[i]
+		x1 := toIndex(xs, r.x1)
+		x2 := toIndex(xs, r.x2)
+		y1 := toIndex(ys, r.y1)
+		y2 := toIndex(ys, r.y2)
+		if !root.query(x1, x2, y1, y2, 0, len(xs)-1, 0, len(ys)-1) {
+			visible++
+			seen[i] = true
+		}
+		root.update(x1, x2, y1, y2, 0, len(xs)-1, 0, len(ys)-1)
+	}
+	_ = seen
+	return visible
+}
+
+func generateD(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	rects := make([]Rect, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		x1 := rng.Intn(10)
+		y1 := rng.Intn(10)
+		x2 := x1 + rng.Intn(5) + 1
+		y2 := y1 + rng.Intn(5) + 1
+		rects[i] = Rect{x1, y1, x2, y2}
+		fmt.Fprintf(&sb, "%d %d %d %d\n", x1, y1, x2, y2)
+	}
+	res := solveD(rects)
+	return sb.String(), fmt.Sprint(res)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(45))
+	for i := 0; i < 100; i++ {
+		in, exp := generateD(rng)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(in)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("case %d runtime error: %v\n%s", i+1, err, out.String())
+			return
+		}
+		got := strings.TrimSpace(out.String())
+		if got != exp {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/980-989/983/verifierE.go
+++ b/0-999/900-999/980-989/983/verifierE.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const maxLog = 20
+
+type pair struct{ a, b int }
+
+func solveE(n int, parents []int, routes []pair, query pair) int {
+	g := make([][]int, n)
+	parent := make([][maxLog]int, n)
+	depth := make([]int, n)
+	for i := 1; i < n; i++ {
+		p := parents[i-1]
+		g[p] = append(g[p], i)
+		g[i] = append(g[i], p)
+		parent[i][0] = p
+	}
+	stack := []int{0}
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, to := range g[v] {
+			if to == parent[v][0] && v != 0 {
+				continue
+			}
+			parent[to][0] = v
+			depth[to] = depth[v] + 1
+			stack = append(stack, to)
+		}
+	}
+	for j := 1; j < maxLog; j++ {
+		for i := 0; i < n; i++ {
+			parent[i][j] = parent[parent[i][j-1]][j-1]
+		}
+	}
+	lca := func(a, b int) int {
+		if depth[a] < depth[b] {
+			a, b = b, a
+		}
+		diff := depth[a] - depth[b]
+		for i := 0; i < maxLog; i++ {
+			if diff>>i&1 == 1 {
+				a = parent[a][i]
+			}
+		}
+		if a == b {
+			return a
+		}
+		for i := maxLog - 1; i >= 0; i-- {
+			if parent[a][i] != parent[b][i] {
+				a = parent[a][i]
+				b = parent[b][i]
+			}
+		}
+		return parent[a][0]
+	}
+
+	m := len(routes)
+	routeNodes := make([][]int, m)
+	cityRoutes := make([][]int, n)
+	for i, r := range routes {
+		a := r.a
+		b := r.b
+		gNode := lca(a, b)
+		path := []int{}
+		x := a
+		for x != gNode {
+			path = append(path, x)
+			x = parent[x][0]
+		}
+		tmp := []int{}
+		y := b
+		for y != gNode {
+			tmp = append(tmp, y)
+			y = parent[y][0]
+		}
+		path = append(path, gNode)
+		for j := len(tmp) - 1; j >= 0; j-- {
+			path = append(path, tmp[j])
+		}
+		routeNodes[i] = path
+		for _, v := range path {
+			cityRoutes[v] = append(cityRoutes[v], i)
+		}
+	}
+
+	u := query.a
+	v := query.b
+	tot := n + m
+	dist := make([]int, tot)
+	for i := range dist {
+		dist[i] = -1
+	}
+	dq := list.New()
+	dist[u] = 0
+	dq.PushBack(u)
+	for dq.Len() > 0 {
+		e := dq.Front()
+		dq.Remove(e)
+		x := e.Value.(int)
+		if x == v {
+			break
+		}
+		if x < n {
+			for _, r := range cityRoutes[x] {
+				y := n + r
+				if dist[y] == -1 || dist[y] > dist[x]+1 {
+					dist[y] = dist[x] + 1
+					dq.PushBack(y)
+				}
+			}
+		} else {
+			r := x - n
+			for _, y := range routeNodes[r] {
+				if dist[y] == -1 || dist[y] > dist[x] {
+					dist[y] = dist[x]
+					dq.PushFront(y)
+				}
+			}
+		}
+	}
+	return dist[v]
+}
+
+func generateE(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	parents := make([]int, n-1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		parents[i-1] = p
+		fmt.Fprintf(&sb, "%d\n", p+1)
+	}
+	m := rng.Intn(3) + 1
+	routes := make([]pair, m)
+	for i := 0; i < m; i++ {
+		a := rng.Intn(n)
+		b := rng.Intn(n)
+		fmt.Fprintf(&sb, "%d %d\n", a+1, b+1)
+		routes[i] = pair{a, b}
+	}
+	fmt.Fprintf(&sb, "1\n")
+	u := rng.Intn(n)
+	v := rng.Intn(n)
+	fmt.Fprintf(&sb, "%d %d\n", u+1, v+1)
+	res := solveE(n, parents, routes, pair{u, v})
+	return sb.String(), fmt.Sprint(res)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(46))
+	for i := 0; i < 100; i++ {
+		in, exp := generateE(rng)
+		cmd := exec.Command(bin)
+		cmd.Stdin = strings.NewReader(in)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("case %d runtime error: %v\n%s", i+1, err, out.String())
+			return
+		}
+		got := strings.TrimSpace(out.String())
+		if got != exp {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, exp, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement dynamic solution verifiers for Codeforces contest 983 (problems A–E)
- each verifier runs 100 random tests against a provided binary

## Testing
- `go run 0-999/900-999/980-989/983/verifierA.go ./983A_bin`
- `go run 0-999/900-999/980-989/983/verifierB.go ./983B_bin`
- `go run 0-999/900-999/980-989/983/verifierC.go ./983C_bin`
- `go run 0-999/900-999/980-989/983/verifierD.go ./983D_bin`
- `go run 0-999/900-999/980-989/983/verifierE.go ./983E_bin` *(fails: runtime error from binary)*

------
https://chatgpt.com/codex/tasks/task_e_68841b0febb083248e630fa9c8c4d438