### PR TITLE
Add Go solution for 1688A

### DIFF
--- a/1000-1999/1600-1699/1680-1689/1688/1688A.go
+++ b/1000-1999/1600-1699/1680-1689/1688/1688A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var x int
+		fmt.Fscan(in, &x)
+		var y int
+		if x == 1 {
+			y = 3
+		} else if x&1 == 1 {
+			y = 1
+		} else if x&(x-1) == 0 {
+			y = x + 1
+		} else {
+			y = x & -x
+		}
+		fmt.Fprintln(out, y)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for 1688A `Cirno's perfect bitmasks classroom`

## Testing
- `go run 1000-1999/1600-1699/1680-1689/1688/1688A.go <<EOF
2
1
2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68842f949ea48324a26d74736f04a62b