### PR TITLE
Add Go solution for 1688B

### DIFF
--- a/1000-1999/1600-1699/1680-1689/1688/1688B.go
+++ b/1000-1999/1600-1699/1680-1689/1688/1688B.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		nums := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &nums[i])
+		}
+		evenCnt := 0
+		hasOdd := false
+		minTrailing := 31
+		for _, v := range nums {
+			if v%2 == 1 {
+				hasOdd = true
+			} else {
+				evenCnt++
+				tz := 0
+				for v%2 == 0 {
+					v /= 2
+					tz++
+				}
+				if tz < minTrailing {
+					minTrailing = tz
+				}
+			}
+		}
+		if hasOdd {
+			fmt.Fprintln(writer, evenCnt)
+		} else {
+			fmt.Fprintln(writer, minTrailing+n-1)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1688B

## Testing
- `go build ./1000-1999/1600-1699/1680-1689/1688/1688B.go`
- Ran the binary with a sample input

------
https://chatgpt.com/codex/tasks/task_e_68842f4f6e908324b154314b86c4e267