### PR TITLE
Add Go solution for 1688C Manipulating History

### DIFF
--- a/1000-1999/1600-1699/1680-1689/1688/1688C.go
+++ b/1000-1999/1600-1699/1680-1689/1688/1688C.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	if _, err := fmt.Fscan(in, &T); err != nil {
+		return
+	}
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(in, &n)
+		cnt := make([]int, 26)
+		for i := 0; i < 2*n; i++ {
+			var s string
+			fmt.Fscan(in, &s)
+			for j := 0; j < len(s); j++ {
+				cnt[s[j]-'a'] ^= 1
+			}
+		}
+		var final string
+		fmt.Fscan(in, &final)
+		for j := 0; j < len(final); j++ {
+			cnt[final[j]-'a'] ^= 1
+		}
+		for i := 0; i < 26; i++ {
+			if cnt[i] == 1 {
+				fmt.Fprintf(out, "%c\n", byte('a'+i))
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `problemC.txt` in contest 1688

## Testing
- `go build ./1000-1999/1600-1699/1680-1689/1688/1688C.go`

------
https://chatgpt.com/codex/tasks/task_e_68842f087d748324950869c9095e4209