### PR TITLE
Add Go solution verifiers for contest 982

### DIFF
--- a/0-999/900-999/980-989/982/verifierA.go
+++ b/0-999/900-999/980-989/982/verifierA.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+func solve(n int, s string) string {
+	for i := 0; i+1 < n; i++ {
+		if s[i] == '1' && s[i+1] == '1' {
+			return "No"
+		}
+	}
+	for i := 0; i < n; i++ {
+		if s[i] == '0' {
+			leftEmpty := i == 0 || s[i-1] == '0'
+			rightEmpty := i == n-1 || s[i+1] == '0'
+			if leftEmpty && rightEmpty {
+				return "No"
+			}
+		}
+	}
+	return "Yes"
+}
+
+func generateTests() []testCase {
+	rand.Seed(1)
+	var tests []testCase
+	// some fixed edge cases
+	fixed := []string{"0", "1", "00", "10", "01", "11", "010", "101", "000", "111"}
+	for _, f := range fixed {
+		n := len(f)
+		tests = append(tests, testCase{
+			input:  fmt.Sprintf("%d\n%s\n", n, f),
+			output: solve(n, f),
+		})
+	}
+	// random cases
+	for len(tests) < 120 { // at least 100
+		n := rand.Intn(10) + 1
+		b := make([]byte, n)
+		for i := range b {
+			if rand.Intn(2) == 0 {
+				b[i] = '0'
+			} else {
+				b[i] = '1'
+			}
+		}
+		s := string(b)
+		tests = append(tests, testCase{
+			input:  fmt.Sprintf("%d\n%s\n", n, s),
+			output: solve(n, s),
+		})
+	}
+	return tests
+}
+
+func runBinary(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := runBinary(binary, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.output {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %q got %q\n", i+1, tc.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/900-999/980-989/982/verifierB.go
+++ b/0-999/900-999/980-989/982/verifierB.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+type row struct {
+	w   int
+	idx int
+}
+
+type maxHeap []row
+
+func (h maxHeap) Len() int            { return len(h) }
+func (h maxHeap) Less(i, j int) bool  { return h[i].w > h[j].w }
+func (h maxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *maxHeap) Push(x interface{}) { *h = append(*h, x.(row)) }
+func (h *maxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func solve(n int, w []int, s string) string {
+	pairs := make([]row, n)
+	for i := 0; i < n; i++ {
+		pairs[i] = row{w[i], i + 1}
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].w < pairs[j].w })
+	h := &maxHeap{}
+	heap.Init(h)
+	p := 0
+	res := make([]int, 0, 2*n)
+	for _, ch := range s {
+		if ch == '0' {
+			r := pairs[p]
+			p++
+			heap.Push(h, r)
+			res = append(res, r.idx)
+		} else {
+			r := heap.Pop(h).(row)
+			res = append(res, r.idx)
+		}
+	}
+	var b strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", v)
+	}
+	return b.String()
+}
+
+func generateTests() []testCase {
+	rand.Seed(2)
+	var tests []testCase
+	// simple edge cases
+	tests = append(tests, testCase{
+		input:  "1\n1\n01\n",
+		output: "1 1",
+	})
+	// random cases
+	for len(tests) < 120 {
+		n := rand.Intn(10) + 1
+		weights := rand.Perm(2*n + 5)
+		w := make([]int, n)
+		for i := 0; i < n; i++ {
+			w[i] = weights[i] + 1
+		}
+		sBytes := make([]byte, 2*n)
+		for i := 0; i < n; i++ {
+			sBytes[i] = '0'
+			sBytes[i+n] = '1'
+		}
+		rand.Shuffle(2*n, func(i, j int) { sBytes[i], sBytes[j] = sBytes[j], sBytes[i] })
+		s := string(sBytes)
+		var b strings.Builder
+		b.WriteString(fmt.Sprintf("%d\n", n))
+		for i, val := range w {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", val)
+		}
+		b.WriteString("\n")
+		b.WriteString(s)
+		b.WriteString("\n")
+		tests = append(tests, testCase{
+			input:  b.String(),
+			output: solve(n, w, s),
+		})
+	}
+	return tests
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := runBinary(binary, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.output {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %q got %q\n", i+1, tc.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/900-999/980-989/982/verifierC.go
+++ b/0-999/900-999/980-989/982/verifierC.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+func solve(n int, edges [][2]int) string {
+	if n%2 == 1 {
+		return "-1"
+	}
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	parent := make([]int, n+1)
+	order := []int{1}
+	for i := 0; i < len(order); i++ {
+		v := order[i]
+		for _, to := range adj[v] {
+			if to != parent[v] {
+				parent[to] = v
+				order = append(order, to)
+			}
+		}
+	}
+	size := make([]int, n+1)
+	ans := 0
+	for i := len(order) - 1; i >= 0; i-- {
+		v := order[i]
+		size[v] = 1
+		for _, to := range adj[v] {
+			if to != parent[v] {
+				size[v] += size[to]
+			}
+		}
+		if v != 1 && size[v]%2 == 0 {
+			ans++
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []testCase {
+	rand.Seed(3)
+	var tests []testCase
+	// simple case n=2
+	tests = append(tests, testCase{input: "2\n1 2\n", output: "1"})
+	// random cases
+	for len(tests) < 120 {
+		n := rand.Intn(10) + 1
+		edges := make([][2]int, 0, n-1)
+		for i := 2; i <= n; i++ {
+			p := rand.Intn(i-1) + 1
+			edges = append(edges, [2]int{p, i})
+		}
+		var b strings.Builder
+		b.WriteString(fmt.Sprintf("%d\n", n))
+		for _, e := range edges {
+			fmt.Fprintf(&b, "%d %d\n", e[0], e[1])
+		}
+		tests = append(tests, testCase{input: b.String(), output: solve(n, edges)})
+	}
+	return tests
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := runBinary(binary, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.output {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %q got %q\n", i+1, tc.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/900-999/980-989/982/verifierD.go
+++ b/0-999/900-999/980-989/982/verifierD.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+type pair struct {
+	val int
+	idx int
+}
+
+func solve(arr []int) string {
+	n := len(arr)
+	ps := make([]pair, n)
+	for i := 0; i < n; i++ {
+		ps[i] = pair{arr[i], i}
+	}
+	sort.Slice(ps, func(i, j int) bool { return ps[i].val < ps[j].val })
+	parent := make([]int, n)
+	sz := make([]int, n)
+	active := make([]bool, n)
+	cnt := map[int]int{}
+	segments := 0
+	bestSeg := 0
+	bestK := 0
+
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	union := func(a, b int) {
+		ra := find(a)
+		rb := find(b)
+		if ra == rb {
+			return
+		}
+		la := sz[ra]
+		lb := sz[rb]
+		cnt[la]--
+		if cnt[la] == 0 {
+			delete(cnt, la)
+		}
+		cnt[lb]--
+		if cnt[lb] == 0 {
+			delete(cnt, lb)
+		}
+		segments--
+		if la < lb {
+			ra, rb = rb, ra
+			la, lb = lb, la
+		}
+		parent[rb] = ra
+		sz[ra] = la + lb
+		cnt[la+lb]++
+	}
+
+	for _, p := range ps {
+		i := p.idx
+		active[i] = true
+		parent[i] = i
+		sz[i] = 1
+		cnt[1]++
+		segments++
+		if i > 0 && active[i-1] {
+			union(i, i-1)
+		}
+		if i+1 < n && active[i+1] {
+			union(i, i+1)
+		}
+		if len(cnt) == 1 {
+			length := 0
+			for k := range cnt {
+				length = k
+			}
+			if cnt[length] == segments {
+				k := p.val + 1
+				if segments > bestSeg || (segments == bestSeg && k < bestK) {
+					bestSeg = segments
+					bestK = k
+				}
+			}
+		}
+	}
+
+	return fmt.Sprintf("%d", bestK)
+}
+
+func generateTests() []testCase {
+	rand.Seed(4)
+	var tests []testCase
+	tests = append(tests, testCase{input: "1\n5\n", output: "6"})
+	for len(tests) < 120 {
+		n := rand.Intn(10) + 1
+		arr := rand.Perm(n*3 + 5)[:n]
+		var b strings.Builder
+		b.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range arr {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", v+1)
+		}
+		b.WriteString("\n")
+		tests = append(tests, testCase{input: b.String(), output: solve(arr)})
+	}
+	return tests
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := runBinary(binary, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.output {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %q got %q\n", i+1, tc.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/900-999/980-989/982/verifierE.go
+++ b/0-999/900-999/980-989/982/verifierE.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+func exgcd(a, b int64) (g, x, y int64) {
+	if b == 0 {
+		return a, 1, 0
+	}
+	g, x1, y1 := exgcd(b, a%b)
+	x = y1
+	y = x1 - y1*(a/b)
+	return
+}
+
+func crt(a1, m1, a2, m2 int64) (int64, bool) {
+	g, x, _ := exgcd(m1, m2)
+	if (a2-a1)%g != 0 {
+		return 0, false
+	}
+	lcm := m1 / g * m2
+	mul := ((a2 - a1) / g * x) % (m2 / g)
+	if mul < 0 {
+		mul += m2 / g
+	}
+	t := (a1 + mul*m1) % lcm
+	if t < 0 {
+		t += lcm
+	}
+	return t, true
+}
+
+func mod(a, m int64) int64 {
+	a %= m
+	if a < 0 {
+		a += m
+	}
+	return a
+}
+
+func solve(n, m, x, y, vx, vy int64) string {
+	if vx == 0 {
+		if x != 0 && x != n {
+			return "-1"
+		}
+		if vy == 1 {
+			return fmt.Sprintf("%d %d", x, m)
+		}
+		return fmt.Sprintf("%d %d", x, 0)
+	}
+	if vy == 0 {
+		if y != 0 && y != m {
+			return "-1"
+		}
+		if vx == 1 {
+			return fmt.Sprintf("%d %d", n, y)
+		}
+		return fmt.Sprintf("%d %d", 0, y)
+	}
+
+	bestT := int64(-1)
+	var ansX, ansY int64
+	rxOptions := []int64{0, n}
+	ryOptions := []int64{0, m}
+	for _, rx := range rxOptions {
+		for _, ry := range ryOptions {
+			t1 := int64(0)
+			if vx == 1 {
+				t1 = mod(rx-x, 2*n)
+			} else {
+				t1 = mod(x-rx, 2*n)
+			}
+			t2 := int64(0)
+			if vy == 1 {
+				t2 = mod(ry-y, 2*m)
+			} else {
+				t2 = mod(y-ry, 2*m)
+			}
+			t, ok := crt(t1, 2*n, t2, 2*m)
+			if !ok {
+				continue
+			}
+			if bestT == -1 || t < bestT {
+				bestT = t
+				ansX = rx
+				ansY = ry
+			}
+		}
+	}
+	if bestT == -1 {
+		return "-1"
+	}
+	return fmt.Sprintf("%d %d", ansX, ansY)
+}
+
+func generateTests() []testCase {
+	rand.Seed(5)
+	var tests []testCase
+	tests = append(tests, testCase{
+		input:  "1 1 0 0 1 1\n",
+		output: "1 1",
+	})
+	for len(tests) < 120 {
+		n := int64(rand.Intn(10) + 1)
+		m := int64(rand.Intn(10) + 1)
+		x := int64(rand.Intn(int(n + 1)))
+		y := int64(rand.Intn(int(m + 1)))
+		vx := int64([]int{-1, 0, 1}[rand.Intn(3)])
+		vy := int64([]int{-1, 0, 1}[rand.Intn(3)])
+		if vx == 0 && vy == 0 {
+			vx = 1
+		}
+		input := fmt.Sprintf("%d %d %d %d %d %d\n", n, m, x, y, vx, vy)
+		tests = append(tests, testCase{input: input, output: solve(n, m, x, y, vx, vy)})
+	}
+	return tests
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := runBinary(binary, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.output {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %q got %q\n", i+1, tc.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/900-999/980-989/982/verifierF.go
+++ b/0-999/900-999/980-989/982/verifierF.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+var (
+	n, m     int
+	edges    [][]int
+	check    []bool
+	c        []int
+	pre      []int
+	p        []int
+	tot      int
+	tag      []bool
+	pos      []int
+	flagArr  []bool
+	sumArr   []int
+	resCount int
+)
+
+func dfs1(x int) {
+	if tot > 0 || check[x] {
+		return
+	}
+	c[x] = -1
+	for _, v := range edges[x] {
+		if check[v] {
+			continue
+		}
+		if c[v] == -1 {
+			y := x
+			for y != v {
+				p = append(p, y)
+				tot++
+				y = pre[y]
+			}
+			p = append(p, v)
+			tot++
+			return
+		}
+		if c[v] == 0 {
+			pre[v] = x
+			dfs1(v)
+			if tot > 0 {
+				return
+			}
+		}
+	}
+	c[x] = 1
+}
+
+func dfs2(S, x int) {
+	if check[x] {
+		return
+	}
+	flagArr[x] = true
+	for _, v := range edges[x] {
+		if check[v] {
+			continue
+		}
+		if tag[v] {
+			if tag[x] && tag[v] {
+				continue
+			}
+			if pos[S] >= pos[v] {
+				continue
+			}
+			resCount++
+			sumArr[1]++
+			sumArr[pos[S]+1]--
+			sumArr[pos[v]]++
+			sumArr[tot+1]--
+		} else if !flagArr[v] {
+			dfs2(S, v)
+		}
+	}
+}
+
+func dfs3(S, x int) {
+	if check[x] {
+		return
+	}
+	flagArr[x] = true
+	for _, v := range edges[x] {
+		if check[v] {
+			continue
+		}
+		if tag[v] {
+			if tag[x] && tag[v] {
+				continue
+			}
+			if pos[S] < pos[v] {
+				continue
+			}
+			resCount++
+			sumArr[pos[v]]++
+			sumArr[pos[S]+1]--
+		} else if !flagArr[v] {
+			dfs3(S, v)
+		}
+	}
+}
+
+func solveInstance() int {
+	c = make([]int, n+1)
+	pre = make([]int, n+1)
+	p = p[:0]
+	tot = 0
+	resCount = 0
+	for i := 1; i <= n && tot == 0; i++ {
+		if c[i] == 0 {
+			dfs1(i)
+		}
+	}
+	if tot == 0 {
+		return 0
+	}
+	for i, j := 0, len(p)-1; i < j; i, j = i+1, j-1 {
+		p[i], p[j] = p[j], p[i]
+	}
+	tag = make([]bool, n+1)
+	pos = make([]int, n+1)
+	sumArr = make([]int, tot+2)
+	for i, v := range p {
+		idx := i + 1
+		tag[v] = true
+		pos[v] = idx
+	}
+	flagArr = make([]bool, n+1)
+	for _, v := range p {
+		dfs2(v, v)
+		for i := range flagArr {
+			flagArr[i] = false
+		}
+	}
+	for i := len(p) - 1; i >= 0; i-- {
+		v := p[i]
+		dfs3(v, v)
+		for j := range flagArr {
+			flagArr[j] = false
+		}
+	}
+	for i := 1; i <= tot; i++ {
+		sumArr[i] += sumArr[i-1]
+		if sumArr[i] == resCount {
+			po := p[i-1]
+			check[po] = true
+			return po
+		}
+	}
+	return 0
+}
+
+func solve(nv int, edgesInput [][2]int) string {
+	n = nv
+	m = len(edgesInput)
+	edges = make([][]int, n+1)
+	check = make([]bool, n+1)
+	for _, e := range edgesInput {
+		a, b := e[0], e[1]
+		edges[a] = append(edges[a], b)
+	}
+	ans := solveInstance()
+	if ans == 0 {
+		return "-1"
+	}
+	if solveInstance() == 0 {
+		return fmt.Sprintf("%d", ans)
+	}
+	return "-1"
+}
+
+func generateTests() []testCase {
+	rand.Seed(6)
+	var tests []testCase
+	tests = append(tests, testCase{input: "1 0\n", output: "1"})
+	for len(tests) < 120 {
+		n := rand.Intn(5) + 1
+		maxEdges := n * n
+		m := rand.Intn(maxEdges + 1)
+		edgeMap := map[[2]int]bool{}
+		edges := make([][2]int, 0, m)
+		for len(edges) < m {
+			a := rand.Intn(n) + 1
+			b := rand.Intn(n) + 1
+			if a == b {
+				continue
+			}
+			e := [2]int{a, b}
+			if edgeMap[e] {
+				continue
+			}
+			edgeMap[e] = true
+			edges = append(edges, e)
+		}
+		var bld strings.Builder
+		bld.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+		for _, e := range edges {
+			fmt.Fprintf(&bld, "%d %d\n", e[0], e[1])
+		}
+		tests = append(tests, testCase{input: bld.String(), output: solve(n, edges)})
+	}
+	return tests
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := runBinary(binary, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.output {
+			fmt.Fprintf(os.Stderr, "test %d failed: expected %q got %q\n", i+1, tc.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for problems A–F of contest 982
- each verifier runs given binary on >100 generated tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68841a8362b48324835059e219de86c6