### PR TITLE
Add solution verifiers for CF contest 980

### DIFF
--- a/verifierA.go
+++ b/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input  string
+	output string
+}
+
+func solveA(s string) string {
+	pearls := 0
+	links := 0
+	for _, ch := range s {
+		if ch == 'o' {
+			pearls++
+		} else if ch == '-' {
+			links++
+		}
+	}
+	if pearls <= 1 || links%pearls == 0 {
+		return "YES\n"
+	}
+	return "NO\n"
+}
+
+func generateTests() []Test {
+	rand.Seed(42)
+	tests := make([]Test, 0, 100)
+	fixed := []string{"o--", "-o-", "ooo", "---", "o-o", "-oo", "--o"}
+	for _, s := range fixed {
+		tests = append(tests, Test{input: s + "\n", output: solveA(s)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(98) + 3
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			if rand.Intn(2) == 0 {
+				b[i] = 'o'
+			} else {
+				b[i] = '-'
+			}
+		}
+		s := string(b)
+		tests = append(tests, Test{input: s + "\n", output: solveA(s)})
+	}
+	return tests
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := run(binary, t.input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.output) {
+			fmt.Printf("Test %d failed. Input: %q\nExpected: %qGot: %q\n", i+1, t.input, t.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/verifierB.go
+++ b/verifierB.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input  string
+	output string
+}
+
+func solveB(n, k int) string {
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	blank := strings.Repeat(".", n)
+	if k%2 == 0 {
+		half := k / 2
+		row := "." + strings.Repeat("#", half) + strings.Repeat(".", n-1-half)
+		sb.WriteString(blank + "\n")
+		sb.WriteString(row + "\n")
+		sb.WriteString(row + "\n")
+		sb.WriteString(blank + "\n")
+	} else if k >= n-2 {
+		sb.WriteString(blank + "\n")
+		row2 := "." + strings.Repeat("#", n-2) + "."
+		rem := k - (n - 2)
+		half := rem / 2
+		midDots := (n - 2) - rem
+		row3 := "." + strings.Repeat("#", half) + strings.Repeat(".", midDots) + strings.Repeat("#", half) + "."
+		sb.WriteString(row2 + "\n")
+		sb.WriteString(row3 + "\n")
+		sb.WriteString(blank + "\n")
+	} else {
+		sb.WriteString(blank + "\n")
+		left := (n - k) / 2
+		row2 := strings.Repeat(".", left) + strings.Repeat("#", k) + strings.Repeat(".", left)
+		sb.WriteString(row2 + "\n")
+		sb.WriteString(blank + "\n")
+		sb.WriteString(blank + "\n")
+	}
+	return sb.String()
+}
+
+func generateTests() []Test {
+	rand.Seed(42)
+	tests := make([]Test, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(10)*2 + 3 // odd between 3 and 21
+		k := rand.Intn(2*(n-2) + 1)
+		input := fmt.Sprintf("%d %d\n", n, k)
+		output := solveB(n, k)
+		tests = append(tests, Test{input: input, output: output})
+	}
+	return tests
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := run(binary, t.input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.output) {
+			fmt.Printf("Test %d failed. Input: %q\nExpected: %qGot: %q\n", i+1, t.input, t.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/verifierC.go
+++ b/verifierC.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input  string
+	output string
+}
+
+func solveC(n, k int, arr []int) string {
+	mapping := make([]int, 256)
+	for i := range mapping {
+		mapping[i] = -1
+	}
+	res := make([]string, n)
+	for i := 0; i < n; i++ {
+		x := arr[i]
+		if mapping[x] == -1 {
+			start := x
+			for start > 0 && x-(start-1)+1 <= k && mapping[start-1] == -1 {
+				start--
+			}
+			if start > 0 && mapping[start-1] != -1 && x-mapping[start-1]+1 <= k {
+				start = mapping[start-1]
+			}
+			for y := start; y <= x; y++ {
+				mapping[y] = start
+			}
+		}
+		res[i] = strconv.Itoa(mapping[x])
+	}
+	return strings.Join(res, " ") + "\n"
+}
+
+func generateTests() []Test {
+	rand.Seed(42)
+	tests := make([]Test, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(10) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rand.Intn(256)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(arr[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		output := solveC(n, k, arr)
+		tests = append(tests, Test{input: input, output: output})
+	}
+	return tests
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := run(binary, t.input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.output) {
+			fmt.Printf("Test %d failed. Input: %q\nExpected: %qGot: %q\n", i+1, t.input, t.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/verifierD.go
+++ b/verifierD.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input  string
+	output string
+}
+
+type Pair struct {
+	sign int
+	val  int
+}
+
+func squareFree(x int) int {
+	if x < 0 {
+		x = -x
+	}
+	res := 1
+	for p := 2; p*p <= x; p++ {
+		cnt := 0
+		for x%p == 0 {
+			x /= p
+			cnt ^= 1
+		}
+		if cnt == 1 {
+			res *= p
+		}
+	}
+	if x > 1 {
+		res *= x
+	}
+	return res
+}
+
+func solveD(arr []int) string {
+	n := len(arr)
+	keys := make([]Pair, n)
+	for i, v := range arr {
+		if v == 0 {
+			keys[i] = Pair{0, 0}
+			continue
+		}
+		sign := 1
+		if v < 0 {
+			sign = -1
+		}
+		sf := squareFree(v)
+		keys[i] = Pair{sign, sf}
+	}
+	ans := make([]int, n+1)
+	for l := 0; l < n; l++ {
+		mp := make(map[Pair]int)
+		groups := 0
+		for r := l; r < n; r++ {
+			k := keys[r]
+			if k.sign != 0 {
+				if mp[k] == 0 {
+					groups++
+				}
+				mp[k]++
+			}
+			g := groups
+			if g == 0 {
+				g = 1
+			}
+			ans[g]++
+		}
+	}
+	out := make([]string, n)
+	for i := 1; i <= n; i++ {
+		out[i-1] = strconv.Itoa(ans[i])
+	}
+	return strings.Join(out, " ") + "\n"
+}
+
+func generateTests() []Test {
+	rand.Seed(42)
+	tests := make([]Test, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(6) + 1
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rand.Intn(11) - 5
+		}
+		var sb strings.Builder
+		sb.WriteString(strconv.Itoa(n) + "\n")
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(arr[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		output := solveD(arr)
+		tests = append(tests, Test{input: input, output: output})
+	}
+	return tests
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := run(binary, t.input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.output) {
+			fmt.Printf("Test %d failed. Input: %q\nExpected: %qGot: %q\n", i+1, t.input, t.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/verifierE.go
+++ b/verifierE.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input  string
+	output string
+}
+
+func solveE(n, k int, edges [][2]int) string {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		a, b := e[0], e[1]
+		adj[a] = append(adj[a], b)
+		adj[b] = append(adj[b], a)
+	}
+	parent := make([]int, n+1)
+	queue := []int{n}
+	parent[n] = 0
+	for head := 0; head < len(queue); head++ {
+		v := queue[head]
+		for _, u := range adj[v] {
+			if u == parent[v] {
+				continue
+			}
+			parent[u] = v
+			queue = append(queue, u)
+		}
+	}
+	need := n - k
+	good := make([]bool, n+1)
+	good[n] = true
+	count := 1
+	for i := n - 1; i >= 1 && count < need; i-- {
+		if good[i] {
+			continue
+		}
+		path := []int{}
+		x := i
+		for !good[x] {
+			path = append(path, x)
+			x = parent[x]
+		}
+		if count+len(path) <= need {
+			for _, v := range path {
+				good[v] = true
+			}
+			count += len(path)
+		}
+	}
+	res := make([]string, 0, k)
+	for i := 1; i <= n; i++ {
+		if !good[i] {
+			res = append(res, strconv.Itoa(i))
+		}
+	}
+	return strings.Join(res, " ") + "\n"
+}
+
+func randomTree(n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func generateTests() []Test {
+	rand.Seed(42)
+	tests := make([]Test, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(n) + 1
+		edges := randomTree(n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		input := sb.String()
+		output := solveE(n, k, edges)
+		tests = append(tests, Test{input: input, output: output})
+	}
+	return tests
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := run(binary, t.input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.output) {
+			fmt.Printf("Test %d failed. Input: %q\nExpected: %qGot: %q\n", i+1, t.input, t.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/verifierF.go
+++ b/verifierF.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input  string
+	output string
+}
+
+func solveF(n int, edges [][2]int) string {
+	g := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], v)
+		g[v] = append(g[v], u)
+	}
+	dist := make([]int, n)
+	q := make([]int, n)
+	ans := make([]int, n)
+	for s := 0; s < n; s++ {
+		for i := 0; i < n; i++ {
+			dist[i] = -1
+		}
+		head, tail := 0, 0
+		dist[s] = 0
+		q[tail] = s
+		tail++
+		for head < tail {
+			u := q[head]
+			head++
+			for _, v := range g[u] {
+				if dist[v] == -1 {
+					dist[v] = dist[u] + 1
+					q[tail] = v
+					tail++
+				}
+			}
+		}
+		maxd := 0
+		for i := 0; i < n; i++ {
+			if dist[i] > maxd {
+				maxd = dist[i]
+			}
+		}
+		ans[s] = maxd
+	}
+	res := make([]string, n)
+	for i := 0; i < n; i++ {
+		res[i] = strconv.Itoa(ans[i])
+	}
+	return strings.Join(res, " ") + "\n"
+}
+
+func randomGraph(n int) [][2]int {
+	edges := make([][2]int, 0)
+	// start with tree edges
+	for i := 1; i < n; i++ {
+		p := rand.Intn(i)
+		edges = append(edges, [2]int{p, i})
+	}
+	// optionally add extra edges
+	extra := rand.Intn(n)
+	for i := 0; i < extra; i++ {
+		a := rand.Intn(n)
+		b := rand.Intn(n)
+		if a != b {
+			edges = append(edges, [2]int{a, b})
+		}
+	}
+	return edges
+}
+
+func generateTests() []Test {
+	rand.Seed(42)
+	tests := make([]Test, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(8) + 1
+		edges := randomGraph(n)
+		m := len(edges)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+		}
+		input := sb.String()
+		output := solveF(n, edges)
+		tests = append(tests, Test{input: input, output: output})
+	}
+	return tests
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		got, err := run(binary, t.input)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(t.output) {
+			fmt.Printf("Test %d failed. Input: %q\nExpected: %qGot: %q\n", i+1, t.input, t.output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 980 problems A–F
- each verifier generates 100 deterministic testcases
- run a provided binary on the tests and compare with the reference output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build -o 980A_bin 0-999/900-999/980-989/980/980A.go`
- `go run verifierA.go ./980A_bin`

------
https://chatgpt.com/codex/tasks/task_e_6884196b59788324907fc487cdf93a1d