### PR TITLE
Add verifiers for contest 979

### DIFF
--- a/0-999/900-999/970-979/979/verifierA.go
+++ b/0-999/900-999/970-979/979/verifierA.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	m := n + 1
+	if m%2 == 0 {
+		return fmt.Sprintf("%d", m/2)
+	}
+	return fmt.Sprintf("%d", m)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000_000_000_000)
+	input := fmt.Sprintf("%d\n", n)
+	expected := solve(n)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/970-979/979/verifierB.go
+++ b/0-999/900-999/970-979/979/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func maxBeauty(s string, n int) int {
+	freq := make(map[byte]int)
+	for i := 0; i < len(s); i++ {
+		freq[s[i]]++
+	}
+	maxFreq := 0
+	for _, v := range freq {
+		if v > maxFreq {
+			maxFreq = v
+		}
+	}
+	l := len(s)
+	if maxFreq == l && n == 1 {
+		return l - 1
+	}
+	if maxFreq+n > l {
+		return l
+	}
+	return maxFreq + n
+}
+
+func solve(n int, s1, s2, s3 string) string {
+	b1 := maxBeauty(s1, n)
+	b2 := maxBeauty(s2, n)
+	b3 := maxBeauty(s3, n)
+	if b1 > b2 && b1 > b3 {
+		return "Kuro"
+	} else if b2 > b1 && b2 > b3 {
+		return "Shiro"
+	} else if b3 > b1 && b3 > b2 {
+		return "Katie"
+	}
+	return "Draw"
+}
+
+func randString(rng *rand.Rand, l int) string {
+	letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5)
+	l := rng.Intn(10) + 1
+	s1 := randString(rng, l)
+	s2 := randString(rng, l)
+	s3 := randString(rng, l)
+	input := fmt.Sprintf("%d\n%s\n%s\n%s\n", n, s1, s2, s3)
+	expected := solve(n, s1, s2, s3)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/970-979/979/verifierC.go
+++ b/0-999/900-999/970-979/979/verifierC.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type edge struct{ a, b int }
+
+func dfsInfo(root int, adj [][]int) ([]int, []int) {
+	n := len(adj) - 1
+	parent := make([]int, n+1)
+	size := make([]int, n+1)
+	order := make([]int, 0, n)
+	stack := []int{root}
+	parent[root] = 0
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, v)
+		for _, to := range adj[v] {
+			if to == parent[v] {
+				continue
+			}
+			parent[to] = v
+			stack = append(stack, to)
+		}
+	}
+	for i := len(order) - 1; i >= 0; i-- {
+		v := order[i]
+		size[v] = 1
+		for _, to := range adj[v] {
+			if to == parent[v] {
+				continue
+			}
+			size[v] += size[to]
+		}
+	}
+	return parent, size
+}
+
+func solve(n, x, y int, edges []edge) string {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		adj[e.a] = append(adj[e.a], e.b)
+		adj[e.b] = append(adj[e.b], e.a)
+	}
+	parentX, sizeX := dfsInfo(x, adj)
+	parentY, sizeY := dfsInfo(y, adj)
+	xp := y
+	for parentX[xp] != x {
+		xp = parentX[xp]
+	}
+	yq := x
+	for parentY[yq] != y {
+		yq = parentY[yq]
+	}
+	sizeA := n - sizeX[xp]
+	sizeB := n - sizeY[yq]
+	totalPairs := int64(n) * int64(n-1)
+	invalid := int64(sizeA) * int64(sizeB)
+	ans := totalPairs - invalid
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTree(rng *rand.Rand, n int) []edge {
+	edges := make([]edge, 0, n-1)
+	parents := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, edge{p, i})
+		parents[i] = p
+	}
+	return edges
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 2
+	edges := generateTree(rng, n)
+	x := rng.Intn(n) + 1
+	y := rng.Intn(n) + 1
+	for y == x {
+		y = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, x, y)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.a, e.b)
+	}
+	input := sb.String()
+	expected := solve(n, x, y, edges)
+	return input, expected
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/970-979/979/verifierD.go
+++ b/0-999/900-999/970-979/979/verifierD.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "979D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand, oracle string) (string, string, error) {
+	q := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", q)
+	hasQuery := false
+	for i := 0; i < q; i++ {
+		t := rng.Intn(2) + 1
+		if i == q-1 && !hasQuery {
+			t = 2
+		}
+		if t == 1 {
+			u := rng.Intn(100) + 1
+			fmt.Fprintf(&sb, "1 %d\n", u)
+		} else {
+			x := rng.Intn(100) + 1
+			k := rng.Intn(20) + 1
+			s := rng.Intn(200) + 1
+			fmt.Fprintf(&sb, "2 %d %d %d\n", x, k, s)
+			hasQuery = true
+		}
+	}
+	input := sb.String()
+	exp, err := run(oracle, input)
+	return input, exp, err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp, err := generateCase(rng, oracle)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle generation error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/970-979/979/verifierE.go
+++ b/0-999/900-999/970-979/979/verifierE.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "979E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand, oracle string) (string, string, error) {
+	n := rng.Intn(10) + 1
+	p := rng.Intn(2)
+	colors := make([]int, n)
+	for i := range colors {
+		colors[i] = rng.Intn(3) - 1 // -1,0,1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, p)
+	for i, c := range colors {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", c)
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	exp, err := run(oracle, input)
+	return input, exp, err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp, err := generateCase(rng, oracle)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle generation error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 979
- each verifier generates at least 100 random tests and checks output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_688418df03d48324bbfc80f43a78992e