### PR TITLE
Add Go verifiers for contest 978

### DIFF
--- a/0-999/900-999/970-979/978/978A.go
+++ b/0-999/900-999/970-979/978/978A.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	panic("runtime error")
+}

--- a/0-999/900-999/970-979/978/problemA.txt
+++ b/0-999/900-999/970-979/978/problemA.txt
@@ -1,0 +1,2 @@
+Description:
+Given an array of integers, remove all duplicate numbers keeping only the last occurrence of each integer. Output the number of remaining elements and the resulting sequence.

--- a/0-999/900-999/970-979/978/problemB.txt
+++ b/0-999/900-999/970-979/978/problemB.txt
@@ -1,0 +1,2 @@
+Description:
+Given a string consisting of lowercase Latin letters, find the minimal number of characters you need to delete so that the string does not contain the substring "xxx".

--- a/0-999/900-999/970-979/978/problemE.txt
+++ b/0-999/900-999/970-979/978/problemE.txt
@@ -1,0 +1,2 @@
+Description:
+A bus has capacity w. A log records differences of passengers after each stop. Count how many integer values of the initial number of passengers are possible so that the number on the bus never goes negative or exceeds w.

--- a/0-999/900-999/970-979/978/problemF.txt
+++ b/0-999/900-999/970-979/978/problemF.txt
@@ -1,0 +1,2 @@
+Description:
+Each of n students has a rating. There are k pairs of students that know each other. For each student, compute how many other students have a smaller rating and are not among their friends.

--- a/0-999/900-999/970-979/978/verifierA.go
+++ b/0-999/900-999/970-979/978/verifierA.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testA struct {
+	n   int
+	arr []int
+}
+
+func genTestsA() []testA {
+	rand.Seed(42)
+	tests := make([]testA, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(50) - 25
+		}
+		tests[i] = testA{n: n, arr: arr}
+	}
+	return tests
+}
+
+func solveA(tc testA) []int {
+	seen := make(map[int]bool)
+	res := []int{}
+	for i := len(tc.arr) - 1; i >= 0; i-- {
+		v := tc.arr[i]
+		if !seen[v] {
+			seen[v] = true
+			res = append(res, v)
+		}
+	}
+	for i, j := 0, len(res)-1; i < j; i, j = i+1, j-1 {
+		res[i], res[j] = res[j], res[i]
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for i, v := range tc.arr {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expected := make([][]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveA(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		k, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if k != len(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected length %d got %d\n", i+1, len(exp), k)
+			os.Exit(1)
+		}
+		for j := 0; j < k; j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			val, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if val != exp[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/900-999/970-979/978/verifierB.go
+++ b/0-999/900-999/970-979/978/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testB struct {
+	n int
+	s string
+}
+
+func genTestsB() []testB {
+	rand.Seed(43)
+	tests := make([]testB, 100)
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		b := make([]byte, n)
+		for j := range b {
+			if rand.Intn(4) == 0 {
+				b[j] = 'x'
+			} else {
+				b[j] = letters[rand.Intn(len(letters))]
+			}
+		}
+		tests[i] = testB{n: n, s: string(b)}
+	}
+	return tests
+}
+
+func solveB(tc testB) int {
+	cnt := 0
+	run := 0
+	for i := 0; i < tc.n; i++ {
+		if tc.s[i] == 'x' {
+			run++
+			if run >= 3 {
+				cnt++
+			}
+		} else {
+			run = 0
+		}
+	}
+	return cnt
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d\n%s\n", tc.n, tc.s)
+	}
+
+	expected := make([]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveB(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/900-999/970-979/978/verifierC.go
+++ b/0-999/900-999/970-979/978/verifierC.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testC struct {
+	n       int
+	m       int
+	rooms   []int
+	queries []int
+}
+
+func genTestsC() []testC {
+	rand.Seed(44)
+	tests := make([]testC, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 1
+		m := rand.Intn(10) + 1
+		rooms := make([]int, n)
+		for j := range rooms {
+			rooms[j] = rand.Intn(10) + 1
+		}
+		sum := 0
+		for _, v := range rooms {
+			sum += v
+		}
+		queries := make([]int, m)
+		for j := range queries {
+			queries[j] = rand.Intn(sum) + 1
+		}
+		tests[i] = testC{n: n, m: m, rooms: rooms, queries: queries}
+	}
+	return tests
+}
+
+func solveC(tc testC) [][2]int {
+	pref := make([]int, tc.n)
+	total := 0
+	for i, v := range tc.rooms {
+		total += v
+		pref[i] = total
+	}
+	res := make([][2]int, tc.m)
+	for i, q := range tc.queries {
+		idx := 0
+		for idx < tc.n && q > pref[idx] {
+			idx++
+		}
+		prev := 0
+		if idx > 0 {
+			prev = pref[idx-1]
+		}
+		res[i] = [2]int{idx + 1, q - prev}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.m)
+		for i, v := range tc.rooms {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		for i, v := range tc.queries {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expected := make([][][2]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveC(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		for j := range exp {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			dorm, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			room, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if dorm != exp[j][0] || room != exp[j][1] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/900-999/970-979/978/verifierD.go
+++ b/0-999/900-999/970-979/978/verifierD.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testD struct {
+	n   int
+	arr []int
+}
+
+func genTestsD() []testD {
+	rand.Seed(45)
+	tests := make([]testD, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rand.Intn(11) - 5
+		}
+		tests[i] = testD{n: n, arr: arr}
+	}
+	return tests
+}
+
+func solveD(tc testD) int {
+	if tc.n <= 2 {
+		return 0
+	}
+	const inf = int(1e9)
+	res := inf
+	deltas := []int{-1, 0, 1}
+	for _, d1 := range deltas {
+		for _, d2 := range deltas {
+			start := tc.arr[0] + d1
+			diff := (tc.arr[1] + d2) - start
+			changes := 0
+			if d1 != 0 {
+				changes++
+			}
+			if d2 != 0 {
+				changes++
+			}
+			ok := true
+			for i := 2; i < tc.n; i++ {
+				expected := start + diff*i
+				delta := expected - tc.arr[i]
+				if delta < -1 || delta > 1 {
+					ok = false
+					break
+				}
+				if delta != 0 {
+					changes++
+				}
+			}
+			if ok && changes < res {
+				res = changes
+			}
+		}
+	}
+	if res == inf {
+		return -1
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for i, v := range tc.arr {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expected := make([]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveD(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/900-999/970-979/978/verifierE.go
+++ b/0-999/900-999/970-979/978/verifierE.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testE struct {
+	n    int
+	w    int
+	diff []int
+}
+
+func genTestsE() []testE {
+	rand.Seed(46)
+	tests := make([]testE, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 1
+		w := rand.Intn(20) + 1
+		diff := make([]int, n)
+		for j := range diff {
+			diff[j] = rand.Intn(11) - 5
+		}
+		tests[i] = testE{n: n, w: w, diff: diff}
+	}
+	return tests
+}
+
+func solveE(tc testE) int {
+	pref := 0
+	minPref := 0
+	maxPref := 0
+	for _, d := range tc.diff {
+		pref += d
+		if pref < minPref {
+			minPref = pref
+		}
+		if pref > maxPref {
+			maxPref = pref
+		}
+	}
+	res := tc.w - maxPref + minPref + 1
+	if res < 0 {
+		return 0
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.w)
+		for i, v := range tc.diff {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expected := make([]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveE(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/900-999/970-979/978/verifierF.go
+++ b/0-999/900-999/970-979/978/verifierF.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+)
+
+type testF struct {
+	n       int
+	k       int
+	ratings []int
+	pairs   [][2]int
+}
+
+func genTestsF() []testF {
+	rand.Seed(47)
+	tests := make([]testF, 100)
+	for i := range tests {
+		n := rand.Intn(8) + 2
+		k := rand.Intn(n * (n - 1) / 2)
+		ratings := make([]int, n)
+		for j := range ratings {
+			ratings[j] = rand.Intn(100)
+		}
+		pairs := make([][2]int, k)
+		used := make(map[[2]int]bool)
+		for j := 0; j < k; j++ {
+			for {
+				a := rand.Intn(n)
+				b := rand.Intn(n)
+				if a == b {
+					continue
+				}
+				if a > b {
+					a, b = b, a
+				}
+				p := [2]int{a, b}
+				if !used[p] {
+					used[p] = true
+					pairs[j] = [2]int{a + 1, b + 1}
+					break
+				}
+			}
+		}
+		tests[i] = testF{n: n, k: k, ratings: ratings, pairs: pairs}
+	}
+	return tests
+}
+
+func solveF(tc testF) []int {
+	sorted := make([]int, len(tc.ratings))
+	copy(sorted, tc.ratings)
+	sort.Ints(sorted)
+	ans := make([]int, tc.n)
+	for i, r := range tc.ratings {
+		ans[i] = sort.SearchInts(sorted, r)
+	}
+	for _, p := range tc.pairs {
+		u := p[0] - 1
+		v := p[1] - 1
+		if tc.ratings[u] > tc.ratings[v] {
+			ans[u]--
+		} else if tc.ratings[v] > tc.ratings[u] {
+			ans[v]--
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsF()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		for i, v := range tc.ratings {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		for _, p := range tc.pairs {
+			fmt.Fprintf(&input, "%d %d\n", p[0], p[1])
+		}
+	}
+
+	expected := make([][]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveF(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for idx, exp := range expected {
+		tc := tests[idx]
+		for j := 0; j < tc.n; j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", idx+1)
+				os.Exit(1)
+			}
+			val, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", idx+1)
+				os.Exit(1)
+			}
+			if val != exp[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", idx+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/0-999/900-999/970-979/978/verifierG.go
+++ b/0-999/900-999/970-979/978/verifierG.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type examInfo struct {
+	s int
+	d int
+	c int
+}
+
+type testG struct {
+	n     int
+	exams []examInfo
+}
+
+func genTestsG() []testG {
+	rand.Seed(48)
+	tests := make([]testG, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 2
+		m := rand.Intn(n) + 1
+		exams := make([]examInfo, m)
+		usedDays := make(map[int]bool)
+		for j := 0; j < m; j++ {
+			// choose exam day unique
+			var d int
+			for {
+				d = rand.Intn(n-1) + 2
+				if !usedDays[d] {
+					usedDays[d] = true
+					break
+				}
+			}
+			s := rand.Intn(d-1) + 1
+			c := rand.Intn(d-s) + 1
+			exams[j] = examInfo{s: s, d: d, c: c}
+		}
+		tests[i] = testG{n: n, exams: exams}
+	}
+	return tests
+}
+
+type pqExam []exam
+
+type exam struct {
+	d   int
+	idx int
+}
+
+func (p pqExam) Len() int            { return len(p) }
+func (p pqExam) Less(i, j int) bool  { return p[i].d < p[j].d }
+func (p pqExam) Swap(i, j int)       { p[i], p[j] = p[j], p[i] }
+func (p *pqExam) Push(x interface{}) { *p = append(*p, x.(exam)) }
+func (p *pqExam) Pop() interface{} {
+	old := *p
+	n := len(old)
+	x := old[n-1]
+	*p = old[:n-1]
+	return x
+}
+
+func solveG(tc testG) ([]int, bool) {
+	n := tc.n
+	m := len(tc.exams)
+	examDay := make([]int, n+1)
+	start := make([][]int, n+1)
+	left := make([]int, m+1)
+	for i, e := range tc.exams {
+		idx := i + 1
+		examDay[e.d] = idx
+		start[e.s] = append(start[e.s], idx)
+		left[idx] = e.c
+	}
+	res := make([]int, n+1)
+	pq := &pqExam{}
+	heap.Init(pq)
+	for day := 1; day <= n; day++ {
+		for _, idx := range start[day] {
+			heap.Push(pq, exam{d: tc.exams[idx-1].d, idx: idx})
+		}
+		if examDay[day] != 0 {
+			idx := examDay[day]
+			if left[idx] != 0 {
+				return nil, false
+			}
+			res[day] = m + 1
+			continue
+		}
+		if pq.Len() > 0 {
+			e := heap.Pop(pq).(exam)
+			res[day] = e.idx
+			left[e.idx]--
+			if left[e.idx] > 0 {
+				heap.Push(pq, e)
+			}
+		} else {
+			res[day] = 0
+		}
+	}
+	for i := 1; i <= m; i++ {
+		if left[i] != 0 {
+			return nil, false
+		}
+	}
+	return res[1:], true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsG()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, len(tc.exams))
+		for _, e := range tc.exams {
+			fmt.Fprintf(&input, "%d %d %d\n", e.s, e.d, e.c)
+		}
+	}
+
+	expected := make([][]int, len(tests))
+	possible := make([]bool, len(tests))
+	for i, tc := range tests {
+		res, ok := solveG(tc)
+		possible[i] = ok
+		if ok {
+			expected[i] = res
+		}
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, ok := range possible {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if !ok {
+			val := scanner.Text()
+			if val != "-1" {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected -1\n", i+1)
+				os.Exit(1)
+			}
+			continue
+		}
+		// expecting n integers
+		outArr := make([]int, len(expected[i]))
+		first, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		outArr[0] = first
+		for j := 1; j < len(outArr); j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			val, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			outArr[j] = val
+		}
+		for j, v := range expected[i] {
+			if outArr[j] != v {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}


### PR DESCRIPTION
## Summary
- add runtime-error stub `978A.go`
- provide missing problem descriptions
- implement Go verifiers for problems A–G with 100 tests each

## Testing
- `go build 0-999/900-999/970-979/978/verifierA.go`
- `go build 0-999/900-999/970-979/978/verifierB.go`
- `go build 0-999/900-999/970-979/978/verifierC.go`
- `go build 0-999/900-999/970-979/978/verifierD.go`
- `go build 0-999/900-999/970-979/978/verifierE.go`
- `go build 0-999/900-999/970-979/978/verifierF.go`
- `go build 0-999/900-999/970-979/978/verifierG.go`
- `go run 0-999/900-999/970-979/978/verifierA.go ./978A`

------
https://chatgpt.com/codex/tasks/task_e_68841852f7bc83249257dbaec4d5c8e5