### PR TITLE
Add Go verifiers for Codeforces contest 977

### DIFF
--- a/0-999/900-999/970-979/977/977A.go
+++ b/0-999/900-999/970-979/977/977A.go
@@ -1,0 +1,16 @@
+package main
+
+import "fmt"
+
+func main() {
+	var n, k int
+	fmt.Scan(&n, &k)
+	for i := 0; i < k; i++ {
+		if n%10 == 0 {
+			n /= 10
+		} else {
+			n--
+		}
+	}
+	fmt.Println(n)
+}

--- a/0-999/900-999/970-979/977/977B.go
+++ b/0-999/900-999/970-979/977/977B.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(reader, &n)
+	var s string
+	fmt.Fscan(reader, &s)
+	counts := make(map[string]int)
+	for i := 0; i < n-1; i++ {
+		pair := s[i : i+2]
+		counts[pair]++
+	}
+	best := ""
+	bestCnt := 0
+	for i := 0; i < n-1; i++ {
+		pair := s[i : i+2]
+		if counts[pair] > bestCnt {
+			bestCnt = counts[pair]
+			best = pair
+		}
+	}
+	fmt.Println(best)
+}

--- a/0-999/900-999/970-979/977/977C.go
+++ b/0-999/900-999/970-979/977/977C.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n, k int
+	fmt.Fscan(reader, &n, &k)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+	}
+	sort.Ints(arr)
+	var x int
+	if k == 0 {
+		x = arr[0] - 1
+	} else {
+		x = arr[k-1]
+	}
+	cnt := 0
+	for _, v := range arr {
+		if v <= x {
+			cnt++
+		}
+	}
+	if cnt != k || x < 1 || x > 1000000000 {
+		fmt.Println(-1)
+	} else {
+		fmt.Println(x)
+	}
+}

--- a/0-999/900-999/970-979/977/977D.go
+++ b/0-999/900-999/970-979/977/977D.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(reader, &n)
+	arr := make([]int64, n)
+	m := make(map[int64]int)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+		m[arr[i]] = i
+	}
+	indeg := make(map[int64]int)
+	for _, v := range arr {
+		if _, ok := m[v*2]; ok {
+			indeg[v*2]++
+		}
+		if v%3 == 0 {
+			if _, ok := m[v/3]; ok {
+				indeg[v/3]++
+			}
+		}
+	}
+	var start int64
+	for _, v := range arr {
+		if indeg[v] == 0 {
+			start = v
+			break
+		}
+	}
+	res := make([]int64, 0, n)
+	used := make(map[int64]bool)
+	var dfs func(int64)
+	dfs = func(x int64) {
+		res = append(res, x)
+		used[x] = true
+		if y, ok := m[x*2]; ok && !used[arr[y]] {
+			dfs(arr[y])
+		}
+		if x%3 == 0 {
+			if y, ok := m[x/3]; ok && !used[arr[y]] {
+				dfs(arr[y])
+			}
+		}
+	}
+	dfs(start)
+	writer := bufio.NewWriter(os.Stdout)
+	for i, v := range res {
+		if i > 0 {
+			writer.WriteByte(' ')
+		}
+		fmt.Fprint(writer, v)
+	}
+	writer.WriteByte('\n')
+	writer.Flush()
+}

--- a/0-999/900-999/970-979/977/problemA.txt
+++ b/0-999/900-999/970-979/977/problemA.txt
@@ -1,0 +1,8 @@
+Description:
+You are given two integers n and k. Perform the following operation exactly k times:
+If the last digit of n is nonzero, subtract one from n. Otherwise divide n by ten.
+Print the resulting value of n after performing all operations.
+Input Format:
+Two integers n and k (1 <= n <= 10^9, 1 <= k <= 50).
+Output Format:
+The final value of n.

--- a/0-999/900-999/970-979/977/problemB.txt
+++ b/0-999/900-999/970-979/977/problemB.txt
@@ -1,0 +1,7 @@
+Description:
+Given an integer n and a string s of length n consisting of lowercase letters, find the two-letter substring that appears most frequently in s.
+If several substrings occur the same maximal number of times, output the one whose first occurrence is earliest.
+Input Format:
+Integer n followed by the string s.
+Output Format:
+The most frequent two-letter substring.

--- a/0-999/900-999/970-979/977/problemC.txt
+++ b/0-999/900-999/970-979/977/problemC.txt
@@ -1,0 +1,7 @@
+Description:
+You have n integers a1..an and an integer k. Find an integer x such that exactly k of the numbers are <= x and 1 <= x <= 10^9.
+If there is no such x, output -1.
+Input Format:
+Integers n and k followed by the array a.
+Output Format:
+The integer x or -1 if it does not exist.

--- a/0-999/900-999/970-979/977/problemD.txt
+++ b/0-999/900-999/970-979/977/problemD.txt
@@ -1,0 +1,6 @@
+Description:
+Given n distinct integers, reorder them so that for each adjacent pair (a_i, a_{i+1}) either a_{i+1}=a_i*2 or a_i is divisible by 3 and a_{i+1}=a_i/3.
+Input Format:
+Integer n followed by the n numbers.
+Output Format:
+A permutation that satisfies the condition.

--- a/0-999/900-999/970-979/977/verifierA.go
+++ b/0-999/900-999/970-979/977/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "977A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(1_000_000_000) + 1
+	k := rng.Intn(50) + 1
+	return fmt.Sprintf("%d %d\n", n, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:%sexpected:%s got:%s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/970-979/977/verifierB.go
+++ b/0-999/900-999/970-979/977/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "977B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(98) + 2 // length at least 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		c := byte('a' + rng.Intn(26))
+		sb.WriteByte(c)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:%sexpected:%s got:%s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/970-979/977/verifierC.go
+++ b/0-999/900-999/970-979/977/verifierC.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "977C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(30) + 1
+	k := rng.Intn(n + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rng.Intn(1_000_000_000) + 1
+		sb.WriteString(fmt.Sprintf("%d", val))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(3))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:%sexpected:%s got:%s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/970-979/977/verifierD.go
+++ b/0-999/900-999/970-979/977/verifierD.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(9) + 2 // 2..10
+	seq := make([]int64, n)
+	seq[0] = int64(rng.Intn(20) + 1)
+	for i := 1; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			seq[i] = seq[i-1] * 2
+		} else {
+			val := seq[i-1]
+			if val%3 == 0 {
+				seq[i] = val / 3
+			} else {
+				seq[i] = val * 2
+			}
+		}
+	}
+	// shuffle order for input
+	perm := rng.Perm(n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, idx := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(seq[idx]))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func parseInts(fields []string) ([]int64, error) {
+	res := make([]int64, len(fields))
+	for i, s := range fields {
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func check(input, output string) error {
+	ins := strings.Fields(input)
+	n, _ := strconv.Atoi(ins[0])
+	nums, err := parseInts(ins[1:])
+	if err != nil {
+		return fmt.Errorf("bad input")
+	}
+	if len(nums) != n {
+		return fmt.Errorf("input mismatch")
+	}
+	outNums, err := parseInts(strings.Fields(output))
+	if err != nil {
+		return fmt.Errorf("invalid output")
+	}
+	if len(outNums) != n {
+		return fmt.Errorf("expected %d numbers", n)
+	}
+	used := make(map[int64]bool)
+	for _, v := range nums {
+		used[v] = false
+	}
+	for _, v := range outNums {
+		if _, ok := used[v]; !ok {
+			return fmt.Errorf("number %d not in input", v)
+		}
+		if used[v] {
+			return fmt.Errorf("number %d repeated", v)
+		}
+		used[v] = true
+	}
+	for i := 0; i < n-1; i++ {
+		x := outNums[i]
+		y := outNums[i+1]
+		if x*2 != y && !(x%3 == 0 && x/3 == y) {
+			return fmt.Errorf("invalid step from %d to %d", x, y)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(4))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(in, out); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:%soutput:%s\n", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/970-979/977/verifierE.go
+++ b/0-999/900-999/970-979/977/verifierE.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "977E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(n * 2)
+	edges := make(map[[2]int]bool)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		e := [2]int{u, v}
+		if edges[e] {
+			continue
+		}
+		edges[e] = true
+		sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(5))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("case %d failed\ninput:%sexpected:%s got:%s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/970-979/977/verifierF.go
+++ b/0-999/900-999/970-979/977/verifierF.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(30)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func maxLen(a []int) int {
+	m := make(map[int]int)
+	best := 0
+	for _, v := range a {
+		m[v] = m[v-1] + 1
+		if m[v] > best {
+			best = m[v]
+		}
+	}
+	return best
+}
+
+func check(input, output string) error {
+	scan := bufio.NewScanner(strings.NewReader(input))
+	scan.Split(bufio.ScanWords)
+	scan.Scan()
+	n, _ := strconv.Atoi(scan.Text())
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		scan.Scan()
+		arr[i], _ = strconv.Atoi(scan.Text())
+	}
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) < 1 {
+		return fmt.Errorf("empty output")
+	}
+	wantLen, err := strconv.Atoi(strings.TrimSpace(lines[0]))
+	if err != nil {
+		return fmt.Errorf("invalid length")
+	}
+	idx := []int{}
+	if wantLen > 0 {
+		if len(lines) < 2 {
+			return fmt.Errorf("missing index line")
+		}
+		for _, f := range strings.Fields(lines[1]) {
+			v, err := strconv.Atoi(f)
+			if err != nil {
+				return fmt.Errorf("bad index")
+			}
+			idx = append(idx, v)
+		}
+		if len(idx) != wantLen {
+			return fmt.Errorf("length mismatch")
+		}
+		prev := 0
+		for _, v := range idx {
+			if v < 1 || v > n {
+				return fmt.Errorf("index out of range")
+			}
+			if v <= prev {
+				return fmt.Errorf("indices not strictly increasing")
+			}
+			prev = v
+		}
+		for i := 1; i < wantLen; i++ {
+			if arr[idx[i]-1] != arr[idx[i-1]-1]+1 {
+				return fmt.Errorf("values not consecutive")
+			}
+		}
+	}
+	if wantLen != maxLen(arr) {
+		return fmt.Errorf("reported length incorrect")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(6))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := check(in, out); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:%soutput:%s\n", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add reference Go solutions for 977A–D
- provide brief problem statements for 977A–D
- implement Go verifiers for problems A–F using 100 randomized tests each

## Testing
- `go build 0-999/900-999/970-979/977/977A.go`
- `go build 0-999/900-999/970-979/977/verifierA.go`
- `go build 0-999/900-999/970-979/977/verifierB.go`
- `go build 0-999/900-999/970-979/977/verifierC.go`
- `go build 0-999/900-999/970-979/977/verifierD.go`
- `go build 0-999/900-999/970-979/977/verifierE.go`
- `go build 0-999/900-999/970-979/977/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688417c6e9708324960723e7bc316143