### PR TITLE
Add verifiers for Codeforces contest 976

### DIFF
--- a/0-999/900-999/970-979/976/verifierA.go
+++ b/0-999/900-999/970-979/976/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test string
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "976A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(0)
+	tests := []Test{
+		Test("1\n0\n"),
+		Test("1\n1\n"),
+		Test("4\n1001\n"),
+	}
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(100) + 1
+		var sb strings.Builder
+		if n == 1 {
+			if rand.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		} else {
+			sb.WriteByte('1')
+			for j := 1; j < n; j++ {
+				if rand.Intn(2) == 0 {
+					sb.WriteByte('0')
+				} else {
+					sb.WriteByte('1')
+				}
+			}
+		}
+		tests = append(tests, Test(fmt.Sprintf("%d\n%s\n", n, sb.String())))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/970-979/976/verifierB.go
+++ b/0-999/900-999/970-979/976/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test string
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "976B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(1)
+	tests := []Test{
+		Test("2 2 0\n"),
+	}
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50) + 2
+		if n%2 == 1 {
+			n++
+		}
+		m := rand.Intn(50) + 1
+		k := rand.Int63n(int64(n) * int64(m))
+		tests = append(tests, Test(fmt.Sprintf("%d %d %d\n", n, m, k)))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/970-979/976/verifierC.go
+++ b/0-999/900-999/970-979/976/verifierC.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test string
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "976C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(2)
+	tests := []Test{Test("1\n1 1\n")}
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			l := rand.Intn(100) + 1
+			r := l + rand.Intn(100)
+			sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+		}
+		tests = append(tests, Test(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/970-979/976/verifierD.go
+++ b/0-999/900-999/970-979/976/verifierD.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test string
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "976D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(3)
+	tests := []Test{Test("1\n1\n")}
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		val := rand.Intn(3) + 1
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(val))
+			val += rand.Intn(3) + 1
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/970-979/976/verifierE.go
+++ b/0-999/900-999/970-979/976/verifierE.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test string
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "976E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(4)
+	tests := []Test{Test("1 1 0\n1 1\n")}
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(5) + 1
+		a := rand.Intn(3) + 1
+		b := rand.Intn(n + 1)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, a, b))
+		for j := 0; j < n; j++ {
+			hp := rand.Intn(20) + 1
+			dmg := rand.Intn(20) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", hp, dmg))
+		}
+		tests = append(tests, Test(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/970-979/976/verifierF.go
+++ b/0-999/900-999/970-979/976/verifierF.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test string
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "976F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(5)
+	tests := []Test{Test("1 1 0\n")}
+	for i := 0; i < 100; i++ {
+		n1 := rand.Intn(3) + 1
+		n2 := rand.Intn(3) + 1
+		m := rand.Intn(n1*n2 + 1)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n1, n2, m))
+		for j := 0; j < m; j++ {
+			a := rand.Intn(n1) + 1
+			b := rand.Intn(n2) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+		}
+		tests = append(tests, Test(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- provide Go verifiers for problems 976A–F
- each verifier compiles a reference solution and runs ~100 random tests against any binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884173ac548832492ae981bfb9cbf3f