### PR TITLE
Add Go verifiers for Codeforces contest 975

### DIFF
--- a/0-999/900-999/970-979/975/verifierA.go
+++ b/0-999/900-999/970-979/975/verifierA.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	words []string
+}
+
+func solveCase(words []string) string {
+	roots := make(map[string]struct{})
+	for _, w := range words {
+		seen := [26]bool{}
+		for _, ch := range w {
+			if ch >= 'a' && ch <= 'z' {
+				seen[ch-'a'] = true
+			}
+		}
+		var root []byte
+		for i := 0; i < 26; i++ {
+			if seen[i] {
+				root = append(root, byte('a'+i))
+			}
+		}
+		roots[string(root)] = struct{}{}
+	}
+	return fmt.Sprintf("%d\n", len(roots))
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	words := make([]string, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(8) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('a' + rng.Intn(5))
+		}
+		words[i] = string(b)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, w := range words {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(w)
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveCase(words)
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s", exp, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/970-979/975/verifierB.go
+++ b/0-999/900-999/970-979/975/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(a []int64) string {
+	var best int64
+	for i := 0; i < 14; i++ {
+		if a[i] == 0 {
+			continue
+		}
+		b := make([]int64, 14)
+		copy(b, a)
+		x := b[i]
+		b[i] = 0
+		add := x / 14
+		for j := 0; j < 14; j++ {
+			b[j] += add
+		}
+		r := int(x % 14)
+		for j := 1; j <= r; j++ {
+			idx := (i + j) % 14
+			b[idx]++
+		}
+		var cur int64
+		for j := 0; j < 14; j++ {
+			if b[j]%2 == 0 {
+				cur += b[j]
+			}
+		}
+		if cur > best {
+			best = cur
+		}
+	}
+	return fmt.Sprintf("%d\n", best)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	a := make([]int64, 14)
+	for i := 0; i < 14; i++ {
+		a[i] = rng.Int63n(30)
+	}
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveCase(a)
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s", exp, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/970-979/975/verifierC.go
+++ b/0-999/900-999/970-979/975/verifierC.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, q int
+	a    []int64
+	k    []int64
+}
+
+func solveCase(tc testCase) string {
+	pref := make([]int64, tc.n)
+	var sum int64
+	for i := 0; i < tc.n; i++ {
+		sum += tc.a[i]
+		pref[i] = sum
+	}
+	var dmg int64
+	var sb strings.Builder
+	for _, x := range tc.k {
+		dmg += x
+		if dmg >= pref[tc.n-1] {
+			dmg = 0
+			sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+			continue
+		}
+		idx := sort.Search(len(pref), func(i int) bool { return pref[i] > dmg })
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n-idx))
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	tc := testCase{}
+	tc.n = rng.Intn(10) + 1
+	tc.q = rng.Intn(10) + 1
+	tc.a = make([]int64, tc.n)
+	for i := range tc.a {
+		tc.a[i] = int64(rng.Intn(10) + 1)
+	}
+	tc.k = make([]int64, tc.q)
+	for i := range tc.k {
+		tc.k[i] = int64(rng.Intn(20) + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.q))
+	for i, v := range tc.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for _, v := range tc.k {
+		sb.WriteString(fmt.Sprintf("%d\n", v))
+	}
+	return sb.String(), solveCase(tc)
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/970-979/975/verifierD.go
+++ b/0-999/900-999/970-979/975/verifierD.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type ghost struct {
+	x, vx, vy int64
+}
+
+func solveCase(a, b int64, g []ghost) string {
+	totalByW := make(map[int64]int64)
+	totalByWV := make(map[[2]int64]int64)
+	for _, p := range g {
+		w := p.vy - a*p.vx
+		totalByW[w]++
+		key := [2]int64{w, p.vx}
+		totalByWV[key]++
+	}
+	var collisions int64
+	for _, cnt := range totalByW {
+		collisions += cnt * (cnt - 1) / 2
+	}
+	for _, cnt := range totalByWV {
+		collisions -= cnt * (cnt - 1) / 2
+	}
+	return fmt.Sprintf("%d\n", collisions*2)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	a := int64(rng.Intn(5) - 2)
+	b := int64(rng.Intn(5) - 2)
+	ghosts := make([]ghost, n)
+	for i := 0; i < n; i++ {
+		ghosts[i] = ghost{
+			x:  int64(rng.Intn(11) - 5),
+			vx: int64(rng.Intn(7) - 3),
+			vy: int64(rng.Intn(7) - 3),
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, a, b))
+	for _, g := range ghosts {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", g.x, g.vx, g.vy))
+	}
+	return sb.String(), solveCase(a, b, ghosts)
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s", exp, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/970-979/975/verifierE.go
+++ b/0-999/900-999/970-979/975/verifierE.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// PT represents a point or vector in 2D.
+type PT struct{ x, y float64 }
+
+func (p PT) Add(q PT) PT      { return PT{p.x + q.x, p.y + q.y} }
+func (p PT) Sub(q PT) PT      { return PT{p.x - q.x, p.y - q.y} }
+func (p PT) Mul(t float64) PT { return PT{p.x * t, p.y * t} }
+func (p PT) Div(t float64) PT { return PT{p.x / t, p.y / t} }
+func (p PT) Rot(t float64) PT {
+	c, s := math.Cos(t), math.Sin(t)
+	return PT{p.x*c - p.y*s, p.x*s + p.y*c}
+}
+
+func Dot(p, q PT) float64   { return p.x*q.x + p.y*q.y }
+func Cross(p, q PT) float64 { return p.x*q.y - p.y*q.x }
+func Angle(p, q PT) float64 { return math.Atan2(Cross(p, q), Dot(p, q)) }
+
+// query types
+
+type query struct {
+	typ  int
+	f, t int
+	v    int
+}
+
+type testCase struct {
+	pts []PT
+	qs  []query
+}
+
+func solveCase(tc testCase) string {
+	n := len(tc.pts)
+	pts := make([]PT, n)
+	copy(pts, tc.pts)
+	// compute centroid
+	var cen PT
+	mass := 0.0
+	for i := 2; i < n; i++ {
+		p0 := pts[0]
+		p1 := pts[i-1]
+		p2 := pts[i]
+		temp := PT{(p0.x + p1.x + p2.x) / 3.0, (p0.y + p1.y + p2.y) / 3.0}
+		area2 := math.Abs(Cross(p1.Sub(p0), p2.Sub(p0)))
+		cen = cen.Mul(mass).Add(temp.Mul(area2)).Div(mass + area2)
+		mass += area2
+	}
+	for i := 0; i < n; i++ {
+		pts[i] = pts[i].Sub(cen)
+	}
+	a, b := 0, 1
+	ang := 0.0
+	const twoPi = 2 * math.Pi
+	up := PT{0, 1}
+	var sb strings.Builder
+	for _, qu := range tc.qs {
+		if qu.typ == 1 {
+			c1 := qu.f - 1
+			if b == c1 {
+				a, b = b, a
+			}
+			r := pts[b].Rot(ang)
+			cen = cen.Add(r)
+			tang := Angle(r, up)
+			ang += tang
+			ang = math.Mod(ang, twoPi)
+			if ang < 0 {
+				ang += twoPi
+			}
+			cen = cen.Sub(pts[b].Rot(ang))
+			a = qu.t - 1
+		} else {
+			c := qu.v - 1
+			r := pts[c].Rot(ang)
+			p := r.Add(cen)
+			sb.WriteString(fmt.Sprintf("%.8f %.8f\n", p.x, p.y))
+		}
+	}
+	return sb.String()
+}
+
+func buildCase(tc testCase) (string, string) {
+	var sb strings.Builder
+	n := len(tc.pts)
+	q := len(tc.qs)
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for _, p := range tc.pts {
+		sb.WriteString(fmt.Sprintf("%d %d\n", int(p.x), int(p.y)))
+	}
+	for _, qu := range tc.qs {
+		if qu.typ == 1 {
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", qu.f, qu.t))
+		} else {
+			sb.WriteString(fmt.Sprintf("2 %d\n", qu.v))
+		}
+	}
+	return sb.String(), solveCase(tc)
+}
+
+func randomPolygon(rng *rand.Rand) []PT {
+	n := rng.Intn(3) + 3 // 3..5
+	angles := make([]float64, n)
+	for i := 0; i < n; i++ {
+		angles[i] = rng.Float64() * 2 * math.Pi
+	}
+	sort.Float64s(angles)
+	pts := make([]PT, n)
+	for i, a := range angles {
+		r := float64(rng.Intn(9) + 1)
+		x := math.Round(r * math.Cos(a))
+		y := math.Round(r * math.Sin(a))
+		pts[i] = PT{x, y}
+	}
+	return pts
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	tc := testCase{}
+	tc.pts = randomPolygon(rng)
+	q := rng.Intn(5) + 1
+	tc.qs = make([]query, q)
+	pinned := [2]int{1, 2}
+	has2 := false
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			idx := rng.Intn(2)
+			f := pinned[idx]
+			t := rng.Intn(len(tc.pts)) + 1
+			pinned[idx] = t
+			tc.qs[i] = query{typ: 1, f: f, t: t}
+		} else {
+			v := rng.Intn(len(tc.pts)) + 1
+			tc.qs[i] = query{typ: 2, v: v}
+			has2 = true
+		}
+	}
+	if !has2 {
+		tc.qs[0] = query{typ: 2, v: 1}
+	}
+	return buildCase(tc)
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotFields := strings.Fields(strings.TrimSpace(out.String()))
+	expFields := strings.Fields(strings.TrimSpace(exp))
+	if len(gotFields) != len(expFields) {
+		return fmt.Errorf("expected %d numbers got %d", len(expFields), len(gotFields))
+	}
+	for i := 0; i < len(expFields); i++ {
+		g, err := strconv.ParseFloat(gotFields[i], 64)
+		if err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+		e, _ := strconv.ParseFloat(expFields[i], 64)
+		if math.Abs(g-e) > 1e-4*math.Max(1, math.Abs(e)) {
+			return fmt.Errorf("expected %v got %v", exp, out.String())
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go solution verifiers for contest 975 problems A–E
- each verifier runs at least 100 randomized test cases
- verifiers check candidate binaries for correct output and runtime errors

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_688416aece3483249230b3ea6b50a73d