### PR TITLE
Add Go solution for 1624C

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1624/1624C.go
+++ b/1000-1999/1600-1699/1620-1629/1624/1624C.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var T int
+	fmt.Fscan(reader, &T)
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		sort.Slice(a, func(i, j int) bool { return a[i] > a[j] })
+		used := make([]bool, n+1)
+		ok := true
+		for _, v := range a {
+			for v > n || (v > 0 && used[v]) {
+				v /= 2
+			}
+			if v == 0 {
+				ok = false
+				break
+			}
+			used[v] = true
+		}
+		if ok {
+			for i := 1; i <= n; i++ {
+				if !used[i] {
+					ok = false
+					break
+				}
+			}
+		}
+		if ok {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for problem 1624C

## Testing
- `go run 1000-1999/1600-1699/1620-1629/1624/1624C.go <<EOF
3
4
1 8 25 2
2
3 1
3
1 1 1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688431c4f7d0832481b6a55a752cf0ab