### PR TITLE
Add Go solution for 1609F

### DIFF
--- a/1000-1999/1600-1699/1600-1609/1609/1609F.go
+++ b/1000-1999/1600-1699/1600-1609/1609/1609F.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/bits"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	a := make([]uint64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+
+	var ans uint64
+	for l := 0; l < n; l++ {
+		mn, mx := a[l], a[l]
+		for r := l; r < n; r++ {
+			if a[r] < mn {
+				mn = a[r]
+			}
+			if a[r] > mx {
+				mx = a[r]
+			}
+			if bits.OnesCount64(mn) == bits.OnesCount64(mx) {
+				ans++
+			}
+		}
+	}
+
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- implement a naive Go solution for problemF in directory `1609`

## Testing
- `go vet 1000-1999/1600-1699/1600-1609/1609/1609F.go`
- `go build 1000-1999/1600-1699/1600-1609/1609/1609F.go`


------
https://chatgpt.com/codex/tasks/task_e_6884132030f0832489da9865f13c5769