### PR TITLE
Add Go solution for 1625B

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1625/1625B.go
+++ b/1000-1999/1600-1699/1620-1629/1625/1625B.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		last := make(map[int]int)
+		ans := -1
+		for i, v := range a {
+			if p, ok := last[v]; ok {
+				d := i - p
+				cand := n - d
+				if cand > ans {
+					ans = cand
+				}
+			}
+			last[v] = i
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution to `1625B` using a map to track previous occurrences
- new file: `1625B.go`

## Testing
- `go build 1000-1999/1600-1699/1620-1629/1625/1625B.go`

------
https://chatgpt.com/codex/tasks/task_e_688432dceb7883249237e7990fd13572