### PR TITLE
Add Go verifiers for Codeforces contest 965

### DIFF
--- a/0-999/900-999/960-969/965/verifierA.go
+++ b/0-999/900-999/960-969/965/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	k, n, s, p int
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("%d %d %d %d\n", t.k, t.n, t.s, t.p)
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "965A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(1)
+	tests := make([]Test, 0, 103)
+	for i := 0; i < 100; i++ {
+		tests = append(tests, Test{
+			k: rand.Intn(10000) + 1,
+			n: rand.Intn(10000) + 1,
+			s: rand.Intn(10000) + 1,
+			p: rand.Intn(10000) + 1,
+		})
+	}
+	tests = append(tests,
+		Test{1, 1, 1, 1},
+		Test{10000, 10000, 1, 1},
+		Test{10000, 10000, 10000, 10000},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/960-969/965/verifierB.go
+++ b/0-999/900-999/960-969/965/verifierB.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n, k int
+	grid []string
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.k))
+	for _, row := range t.grid {
+		sb.WriteString(row)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "965B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(2)
+	tests := make([]Test, 0, 103)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(n) + 1
+		grid := make([]string, n)
+		for r := 0; r < n; r++ {
+			row := make([]byte, n)
+			for c := 0; c < n; c++ {
+				ch := '.'
+				if rand.Intn(3) == 0 {
+					ch = '#'
+				}
+				row[c] = byte(ch)
+			}
+			grid[r] = string(row)
+		}
+		tests = append(tests, Test{n, k, grid})
+	}
+	tests = append(tests,
+		Test{1, 1, []string{"."}},
+		Test{3, 2, []string{"...", "...", "..."}},
+		Test{2, 2, []string{"##", "##"}},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/960-969/965/verifierC.go
+++ b/0-999/900-999/960-969/965/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n, k, m, d int64
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("%d %d %d %d\n", t.n, t.k, t.m, t.d)
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "965C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(3)
+	tests := make([]Test, 0, 103)
+	for i := 0; i < 100; i++ {
+		k := int64(rand.Intn(1000) + 2)
+		m := int64(rand.Intn(1000) + 1)
+		d := int64(rand.Intn(100) + 1)
+		n := int64(rand.Intn(1000000) + 1)
+		maxN := k * m * d
+		if maxN > 0 && n > maxN {
+			n = maxN
+		}
+		if n < 2 {
+			n = 2
+		}
+		if k > n {
+			k = n
+		}
+		if m > n {
+			m = n
+		}
+		if d > n {
+			d = n
+		}
+		tests = append(tests, Test{n, k, m, d})
+	}
+	tests = append(tests,
+		Test{2, 2, 1, 1},
+		Test{1000000, 2, 1000000, 1},
+		Test{1000000, 1000000, 1000000, 1000},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/960-969/965/verifierD.go
+++ b/0-999/900-999/960-969/965/verifierD.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	w, l   int
+	stones []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.w, t.l))
+	for i, v := range t.stones {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "965D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(4)
+	tests := make([]Test, 0, 103)
+	for i := 0; i < 100; i++ {
+		w := rand.Intn(20) + 2
+		l := rand.Intn(w-1) + 1
+		stones := make([]int, w-1)
+		for j := range stones {
+			stones[j] = rand.Intn(20)
+		}
+		tests = append(tests, Test{w, l, stones})
+	}
+	tests = append(tests,
+		Test{2, 1, []int{0}},
+		Test{10, 5, make([]int, 9)},
+		Test{5, 2, []int{10, 0, 10, 0}},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/960-969/965/verifierE.go
+++ b/0-999/900-999/960-969/965/verifierE.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	words []string
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.words)))
+	for _, w := range t.words {
+		sb.WriteString(w)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "965E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func randWord() string {
+	l := rand.Intn(6) + 1
+	b := make([]byte, l)
+	for i := 0; i < l; i++ {
+		b[i] = byte('a' + rand.Intn(26))
+	}
+	return string(b)
+}
+
+func genTests() []Test {
+	rand.Seed(5)
+	tests := make([]Test, 0, 103)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		set := make(map[string]struct{})
+		words := make([]string, 0, n)
+		for len(words) < n {
+			w := randWord()
+			if _, ok := set[w]; ok {
+				continue
+			}
+			set[w] = struct{}{}
+			words = append(words, w)
+		}
+		tests = append(tests, Test{words})
+	}
+	tests = append(tests,
+		Test{[]string{"a"}},
+		Test{[]string{"abc", "abcd", "ab", "abcdef"}},
+		Test{[]string{"x", "y", "z"}},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E in contest 965
- each verifier builds the reference solution, generates over 100 tests and checks another binary

## Testing
- `go run verifierA.go ./candA.bin`
- `go run verifierB.go ./candB.bin`
- `go run verifierC.go ./candC.bin`
- `go run verifierD.go ./candD.bin`
- `go run verifierE.go ./candE.bin`


------
https://chatgpt.com/codex/tasks/task_e_6884113636e08324aab3322ebc51ec8b