### PR TITLE
Add Go solution for 1607A

### DIFF
--- a/1000-1999/1600-1699/1600-1609/1607/1607A.go
+++ b/1000-1999/1600-1699/1600-1609/1607/1607A.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var layout, s string
+		fmt.Fscan(reader, &layout)
+		fmt.Fscan(reader, &s)
+
+		pos := make([]int, 26)
+		for i := 0; i < 26; i++ {
+			pos[layout[i]-'a'] = i
+		}
+
+		time := 0
+		for i := 1; i < len(s); i++ {
+			time += abs(pos[s[i]-'a'] - pos[s[i-1]-'a'])
+		}
+		fmt.Fprintln(writer, time)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for 1607A Linear Keyboard

## Testing
- `go build 1000-1999/1600-1699/1600-1609/1607/1607A.go`

------
https://chatgpt.com/codex/tasks/task_e_688410f00e8c8324bedb8604c605bc91