### PR TITLE
Add Go verifiers for contest 963

### DIFF
--- a/0-999/900-999/960-969/963/verifierA.go
+++ b/0-999/900-999/960-969/963/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	// build reference solution
+	refBin := "./refA.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "963A.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		n := rand.Int63n(1_000_000_000)
+		a := rand.Int63n(1_000_000_000) + 1
+		b := rand.Int63n(1_000_000_000) + 1
+		k := rand.Intn(10) + 1
+		var sb strings.Builder
+		for i := 0; i < k; i++ {
+			if rand.Intn(2) == 0 {
+				sb.WriteByte('+')
+			} else {
+				sb.WriteByte('-')
+			}
+		}
+		s := sb.String()
+		input := fmt.Sprintf("%d %d %d %d\n%s\n", n, a, b, k, s)
+
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/960-969/963/verifierB.go
+++ b/0-999/900-999/960-969/963/verifierB.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin := "./refB.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "963B.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(2)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(50) + 1
+		parents := make([]int, n)
+		for i := 1; i < n; i++ {
+			parents[i] = rand.Intn(i) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+				sb.WriteString(fmt.Sprintf("%d", parents[i]))
+			} else {
+				sb.WriteString("0")
+			}
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/960-969/963/verifierC.go
+++ b/0-999/900-999/960-969/963/verifierC.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin := "./refC.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "963C.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(3)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		used := make(map[[2]int]bool)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			var w, h int
+			for {
+				w = rand.Intn(20) + 1
+				h = rand.Intn(20) + 1
+				if !used[[2]int{w, h}] {
+					used[[2]int{w, h}] = true
+					break
+				}
+			}
+			c := rand.Intn(100) + 1
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", w, h, c))
+		}
+		input := sb.String()
+
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/960-969/963/verifierD.go
+++ b/0-999/900-999/960-969/963/verifierD.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rand.Intn(26))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin := "./refD.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "963D.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(4)
+	for t := 0; t < 100; t++ {
+		s := randString(rand.Intn(20) + 1)
+		m := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%s\n%d\n", s, m))
+		for i := 0; i < m; i++ {
+			k := rand.Intn(3) + 1
+			p := randString(rand.Intn(5) + 1)
+			sb.WriteString(fmt.Sprintf("%d %s\n", k, p))
+		}
+		input := sb.String()
+
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/960-969/963/verifierE.go
+++ b/0-999/900-999/960-969/963/verifierE.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(path string, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	refBin := "./refE.bin"
+	if err := exec.Command("go", "build", "-o", refBin, "963E.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	rand.Seed(5)
+	for t := 0; t < 100; t++ {
+		R := rand.Intn(10)
+		a1 := rand.Intn(1000) + 1
+		a2 := rand.Intn(1000) + 1
+		a3 := rand.Intn(1000) + 1
+		a4 := rand.Intn(1000) + 1
+		input := fmt.Sprintf("%d %d %d %d %d\n", R, a1, a2, a3, a4)
+
+		exp, err := runCmd(refBin, input)
+		if err != nil {
+			fmt.Println("reference solution failed:", err)
+			os.Exit(1)
+		}
+
+		got, err := runCmd(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: candidate runtime error: %v\n", t+1, err)
+			os.Exit(1)
+		}
+
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", t+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A-E of contest 963
- each verifier builds the official solution, generates 100 random tests and checks a target binary

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`


------
https://chatgpt.com/codex/tasks/task_e_6884101e54ec832496fa0eaf45d599ff