### PR TITLE
Add Go solution for 1607C

### DIFF
--- a/1000-1999/1600-1699/1600-1609/1607/1607C.go
+++ b/1000-1999/1600-1699/1600-1609/1607/1607C.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+		ans := arr[0]
+		for i := 1; i < n; i++ {
+			diff := arr[i] - arr[i-1]
+			if diff > ans {
+				ans = diff
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem `1607C` in Go

## Testing
- `go vet 1000-1999/1600-1699/1600-1609/1607/1607C.go`
- `go build 1000-1999/1600-1699/1600-1609/1607/1607C.go`

------
https://chatgpt.com/codex/tasks/task_e_68840fd7ba2c83249e7b4b35f8bfbc43