### PR TITLE
Add Go verifiers for contest 962

### DIFF
--- a/0-999/900-999/960-969/962/verifierA.go
+++ b/0-999/900-999/960-969/962/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n   int
+	arr []int
+}
+
+func solveCase(tc testCase) int {
+	total := 0
+	for _, v := range tc.arr {
+		total += v
+	}
+	need := (total + 1) / 2
+	sum := 0
+	for i, v := range tc.arr {
+		sum += v
+		if sum >= need {
+			return i + 1
+		}
+	}
+	return tc.n
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	input := fmt.Sprintf("%d\n", n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(10) + 1
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", arr[i])
+	}
+	input += "\n"
+	tc := testCase{n, arr}
+	out := solveCase(tc)
+	expected := fmt.Sprintf("%d\n", out)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/960-969/962/verifierB.go
+++ b/0-999/900-999/960-969/962/verifierB.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	a int
+	b int
+	s string
+}
+
+func solveCase(tc testCase) int {
+	a := tc.a
+	b := tc.b
+	prev := 0
+	ans := 0
+	for i := 0; i < tc.n; i++ {
+		if tc.s[i] == '*' {
+			prev = 0
+			continue
+		}
+		if prev == 1 {
+			if b > 0 {
+				b--
+				ans++
+				prev = 2
+			} else {
+				prev = 0
+			}
+		} else if prev == 2 {
+			if a > 0 {
+				a--
+				ans++
+				prev = 1
+			} else {
+				prev = 0
+			}
+		} else {
+			if a >= b {
+				if a > 0 {
+					a--
+					ans++
+					prev = 1
+				} else if b > 0 {
+					b--
+					ans++
+					prev = 2
+				} else {
+					prev = 0
+				}
+			} else {
+				if b > 0 {
+					b--
+					ans++
+					prev = 2
+				} else if a > 0 {
+					a--
+					ans++
+					prev = 1
+				} else {
+					prev = 0
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	a := rng.Intn(n + 1)
+	b := rng.Intn(n + 1)
+	bs := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			bs[i] = '.'
+		} else {
+			bs[i] = '*'
+		}
+	}
+	s := string(bs)
+	input := fmt.Sprintf("%d %d %d\n%s\n", n, a, b, s)
+	tc := testCase{n, a, b, s}
+	out := solveCase(tc)
+	expected := fmt.Sprintf("%d\n", out)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/960-969/962/verifierC.go
+++ b/0-999/900-999/960-969/962/verifierC.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func isSubsequence(target, source string) bool {
+	j := 0
+	for i := 0; i < len(source) && j < len(target); i++ {
+		if source[i] == target[j] {
+			j++
+		}
+	}
+	return j == len(target)
+}
+
+func solveCase(nStr string) int {
+	n, _ := strconv.Atoi(nStr)
+	limit := int(math.Sqrt(float64(n)))
+	best := len(nStr) + 1
+	for i := 1; i <= limit; i++ {
+		sq := i * i
+		sqStr := strconv.Itoa(sq)
+		if isSubsequence(sqStr, nStr) {
+			ops := len(nStr) - len(sqStr)
+			if ops < best {
+				best = ops
+			}
+		}
+	}
+	if best == len(nStr)+1 {
+		return -1
+	}
+	return best
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	length := rng.Intn(9) + 1
+	bs := make([]byte, length)
+	bs[0] = byte(rng.Intn(9)+1) + '0'
+	for i := 1; i < length; i++ {
+		bs[i] = byte(rng.Intn(10)) + '0'
+	}
+	nStr := string(bs)
+	input := fmt.Sprintf("%s\n", nStr)
+	out := solveCase(nStr)
+	expected := fmt.Sprintf("%d\n", out)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/960-969/962/verifierD.go
+++ b/0-999/900-999/960-969/962/verifierD.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(arr []int64) []int64 {
+	pos := make(map[int64]int)
+	removed := make([]bool, len(arr))
+	for i := 0; i < len(arr); i++ {
+		v := arr[i]
+		for {
+			if j, ok := pos[v]; ok {
+				delete(pos, v)
+				removed[j] = true
+				v *= 2
+			} else {
+				break
+			}
+		}
+		arr[i] = v
+		pos[v] = i
+	}
+	var res []int64
+	for i := 0; i < len(arr); i++ {
+		if !removed[i] {
+			res = append(res, arr[i])
+		}
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	arr := make([]int64, n)
+	input := fmt.Sprintf("%d\n", n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(10) + 1)
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", arr[i])
+	}
+	input += "\n"
+	outArr := solveCase(append([]int64(nil), arr...))
+	res := fmt.Sprintf("%d\n", len(outArr))
+	for i, v := range outArr {
+		if i > 0 {
+			res += " "
+		}
+		res += fmt.Sprintf("%d", v)
+	}
+	if len(outArr) > 0 {
+		res += "\n"
+	}
+	return input, res
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/960-969/962/verifierE.go
+++ b/0-999/900-999/960-969/962/verifierE.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(xs []int64, cs []byte) int64 {
+	n := len(xs)
+	var pIdx []int
+	for i, c := range cs {
+		if c == 'P' {
+			pIdx = append(pIdx, i)
+		}
+	}
+	if len(pIdx) == 0 {
+		var ans int64
+		var lastB int64
+		var haveB bool
+		var lastR int64
+		var haveR bool
+		for i := 0; i < n; i++ {
+			switch cs[i] {
+			case 'B':
+				if haveB {
+					ans += xs[i] - lastB
+				}
+				lastB = xs[i]
+				haveB = true
+			case 'R':
+				if haveR {
+					ans += xs[i] - lastR
+				}
+				lastR = xs[i]
+				haveR = true
+			}
+		}
+		return ans
+	}
+	ans := int64(0)
+	firstP := pIdx[0]
+	lastP := pIdx[len(pIdx)-1]
+	firstB, firstR := int64(0), int64(0)
+	haveB := false
+	haveR := false
+	for i := 0; i < firstP; i++ {
+		if cs[i] == 'B' && !haveB {
+			firstB = xs[i]
+			haveB = true
+		}
+		if cs[i] == 'R' && !haveR {
+			firstR = xs[i]
+			haveR = true
+		}
+	}
+	if haveB {
+		ans += xs[firstP] - firstB
+	}
+	if haveR {
+		ans += xs[firstP] - firstR
+	}
+	lastBpos, lastRpos := int64(0), int64(0)
+	haveB = false
+	haveR = false
+	for i := n - 1; i > lastP; i-- {
+		if cs[i] == 'B' && !haveB {
+			lastBpos = xs[i]
+			haveB = true
+		}
+		if cs[i] == 'R' && !haveR {
+			lastRpos = xs[i]
+			haveR = true
+		}
+	}
+	if haveB {
+		ans += lastBpos - xs[lastP]
+	}
+	if haveR {
+		ans += lastRpos - xs[lastP]
+	}
+	for idx := 0; idx < len(pIdx)-1; idx++ {
+		i := pIdx[idx]
+		j := pIdx[idx+1]
+		L := xs[i]
+		R := xs[j]
+		seg := R - L
+		maxB := int64(0)
+		prev := L
+		var hasB bool
+		for t := i + 1; t < j; t++ {
+			if cs[t] == 'B' {
+				hasB = true
+				if xs[t]-prev > maxB {
+					maxB = xs[t] - prev
+				}
+				prev = xs[t]
+			}
+		}
+		if R-prev > maxB {
+			maxB = R - prev
+		}
+		maxR := int64(0)
+		prev = L
+		var hasR bool
+		for t := i + 1; t < j; t++ {
+			if cs[t] == 'R' {
+				hasR = true
+				if xs[t]-prev > maxR {
+					maxR = xs[t] - prev
+				}
+				prev = xs[t]
+			}
+		}
+		if R-prev > maxR {
+			maxR = R - prev
+		}
+		cost2 := 3*seg - maxB - maxR
+		if hasB && hasR {
+			cost1 := 2 * seg
+			if cost1 < cost2 {
+				ans += cost1
+			} else {
+				ans += cost2
+			}
+		} else {
+			ans += cost2
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 2
+	xs := make([]int64, n)
+	cs := make([]byte, n)
+	cur := int64(0)
+	for i := 0; i < n; i++ {
+		cur += int64(rng.Intn(5) + 1)
+		xs[i] = cur
+		switch rng.Intn(3) {
+		case 0:
+			cs[i] = 'B'
+		case 1:
+			cs[i] = 'R'
+		default:
+			cs[i] = 'P'
+		}
+	}
+	input := fmt.Sprintf("%d\n", n)
+	for i := 0; i < n; i++ {
+		input += fmt.Sprintf("%d %c\n", xs[i], cs[i])
+	}
+	out := solve(xs, cs)
+	expected := fmt.Sprintf("%d\n", out)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/960-969/962/verifierF.go
+++ b/0-999/900-999/960-969/962/verifierF.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to int
+	id int
+}
+
+func solve(n int, edges [][2]int) []int {
+	m := len(edges)
+	g := make([][]Edge, n+1)
+	for i, e := range edges {
+		u, v := e[0], e[1]
+		id := i + 1
+		g[u] = append(g[u], Edge{v, id})
+		g[v] = append(g[v], Edge{u, id})
+	}
+	disc := make([]int, n+1)
+	low := make([]int, n+1)
+	isBridge := make([]bool, m+1)
+	timer := 0
+	var dfs func(u, parentEdge int)
+	dfs = func(u, parentEdge int) {
+		timer++
+		disc[u] = timer
+		low[u] = timer
+		for _, e := range g[u] {
+			if e.id == parentEdge {
+				continue
+			}
+			v := e.to
+			if disc[v] == 0 {
+				dfs(v, e.id)
+				if low[v] < low[u] {
+					low[u] = low[v]
+				}
+				if low[v] > disc[u] {
+					isBridge[e.id] = true
+				}
+			} else {
+				if disc[v] < low[u] {
+					low[u] = disc[v]
+				}
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if disc[i] == 0 {
+			dfs(i, -1)
+		}
+	}
+	visited := make([]bool, n+1)
+	edgeVisited := make([]bool, m+1)
+	var ans []int
+	var dfs2 func(int, *int, *[]int)
+	dfs2 = func(u int, vertexCount *int, edges *[]int) {
+		visited[u] = true
+		*vertexCount = *vertexCount + 1
+		for _, e := range g[u] {
+			if isBridge[e.id] {
+				continue
+			}
+			if !edgeVisited[e.id] {
+				edgeVisited[e.id] = true
+				*edges = append(*edges, e.id)
+			}
+			if !visited[e.to] {
+				dfs2(e.to, vertexCount, edges)
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if !visited[i] {
+			tempEdges := []int{}
+			count := 0
+			dfs2(i, &count, &tempEdges)
+			if len(tempEdges) == count {
+				ans = append(ans, tempEdges...)
+			}
+		}
+	}
+	sort.Ints(ans)
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	edges := make([][2]int, 0, m)
+	used := make(map[[2]int]bool)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		e := [2]int{u, v}
+		if used[e] {
+			continue
+		}
+		used[e] = true
+		edges = append(edges, e)
+	}
+	input := fmt.Sprintf("%d %d\n", n, m)
+	for _, e := range edges {
+		input += fmt.Sprintf("%d %d\n", e[0], e[1])
+	}
+	ans := solve(n, edges)
+	expected := fmt.Sprintf("%d\n", len(ans))
+	for i, id := range ans {
+		if i > 0 {
+			expected += " "
+		}
+		expected += fmt.Sprintf("%d", id)
+	}
+	if len(ans) > 0 {
+		expected += "\n"
+	}
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/960-969/962/verifierG.go
+++ b/0-999/900-999/960-969/962/verifierG.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Point struct{ x, y int }
+type Rect struct{ x1, y1, x2, y2 int }
+
+func insideRect(p Point, r Rect) bool {
+	return p.x > r.x1 && p.x < r.x2 && p.y > r.y2 && p.y < r.y1
+}
+
+func pointInPolygon(pt Point, poly []Point) bool {
+	inside := false
+	n := len(poly)
+	for i, j := 0, n-1; i < n; j, i = i, i+1 {
+		xi, yi := poly[i].x, poly[i].y
+		xj, yj := poly[j].x, poly[j].y
+		if (yi > pt.y) != (yj > pt.y) {
+			if int64(pt.x-xi) < int64(xj-xi)*int64(pt.y-yi)/int64(yj-yi) {
+				inside = !inside
+			}
+		}
+	}
+	return inside
+}
+
+func solve(r Rect, poly []Point) int {
+	cross := 0
+	n := len(poly)
+	for i := 0; i < n; i++ {
+		a := poly[i]
+		b := poly[(i+1)%n]
+		ia := insideRect(a, r)
+		ib := insideRect(b, r)
+		if ia != ib {
+			cross++
+			continue
+		}
+		if ia || ib {
+			continue
+		}
+		if a.x == b.x {
+			x := a.x
+			if x > r.x1 && x < r.x2 {
+				low, high := a.y, b.y
+				if low > high {
+					low, high = high, low
+				}
+				if low < r.y2 && high > r.y2 {
+					cross++
+				}
+				if low < r.y1 && high > r.y1 {
+					cross++
+				}
+			}
+		} else if a.y == b.y {
+			y := a.y
+			if y > r.y2 && y < r.y1 {
+				low, high := a.x, b.x
+				if low > high {
+					low, high = high, low
+				}
+				if low < r.x1 && high > r.x1 {
+					cross++
+				}
+				if low < r.x2 && high > r.x2 {
+					cross++
+				}
+			}
+		}
+	}
+	if cross > 0 {
+		return cross / 2
+	}
+	center := Point{(r.x1 + r.x2) / 2, (r.y1 + r.y2) / 2}
+	if pointInPolygon(center, poly) || insideRect(poly[0], r) {
+		return 1
+	}
+	return 0
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	x1 := rng.Intn(20)
+	x2 := x1 + rng.Intn(5) + 1
+	y2 := rng.Intn(20)
+	y1 := y2 + rng.Intn(5) + 1
+	r := Rect{x1, y1, x2, y2}
+	// polygon as rectangle
+	px1 := rng.Intn(20)
+	py2 := rng.Intn(20)
+	px2 := px1 + rng.Intn(5) + 1
+	py1 := py2 + rng.Intn(5) + 1
+	poly := []Point{{px1, py1}, {px2, py1}, {px2, py2}, {px1, py2}}
+	n := len(poly)
+	input := fmt.Sprintf("%d %d %d %d\n%d\n", r.x1, r.y1, r.x2, r.y2, n)
+	for _, p := range poly {
+		input += fmt.Sprintf("%d %d\n", p.x, p.y)
+	}
+	out := solve(r, poly)
+	expected := fmt.Sprintf("%d\n", out)
+	return input, expected
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %s got %s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces contest 962 problems A–G
- each verifier generates 100 random test cases and checks a given binary

## Testing
- `go vet verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go`

------
https://chatgpt.com/codex/tasks/task_e_68840f921a84832498be3013e016540f