### PR TITLE
Add Go verifiers for CF contest 961

### DIFF
--- a/0-999/900-999/960-969/961/verifierA.go
+++ b/0-999/900-999/960-969/961/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSource := filepath.Join(dir, "961A.go")
+	out := filepath.Join(os.TempDir(), "refA.bin")
+	cmd := exec.Command("go", "build", "-o", out, refSource)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(20) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprintf("%d", rand.Intn(n)+1))
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Fprintln(os.Stderr, "reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:", expect)
+			fmt.Println("Got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/960-969/961/verifierB.go
+++ b/0-999/900-999/960-969/961/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSource := filepath.Join(dir, "961B.go")
+	out := filepath.Join(os.TempDir(), "refB.bin")
+	cmd := exec.Command("go", "build", "-o", out, refSource)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	n := rand.Intn(30) + 1
+	k := rand.Intn(n) + 1
+	arr := make([]int, n)
+	tVals := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rand.Intn(10) + 1
+		tVals[i] = rand.Intn(2)
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range arr {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprintf("%d", v))
+	}
+	b.WriteByte('\n')
+	for i, v := range tVals {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprintf("%d", v))
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Println("reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:", expect)
+			fmt.Println("Got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/960-969/961/verifierC.go
+++ b/0-999/900-999/960-969/961/verifierC.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSource := filepath.Join(dir, "961C.go")
+	out := filepath.Join(os.TempDir(), "refC.bin")
+	cmd := exec.Command("go", "build", "-o", out, refSource)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randomBoard(n int) []string {
+	board := make([]string, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 1 {
+				row[j] = '1'
+			} else {
+				row[j] = '0'
+			}
+		}
+		board[i] = string(row)
+	}
+	return board
+}
+
+func genTest() string {
+	n := rand.Intn(3)*2 + 1 // 1,3,5
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", n))
+	for k := 0; k < 4; k++ {
+		brd := randomBoard(n)
+		for _, row := range brd {
+			b.WriteString(row)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Println("reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:", expect)
+			fmt.Println("Got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/960-969/961/verifierD.go
+++ b/0-999/900-999/960-969/961/verifierD.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSource := filepath.Join(dir, "961D.go")
+	out := filepath.Join(os.TempDir(), "refD.bin")
+	cmd := exec.Command("go", "build", "-o", out, refSource)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	n := rand.Intn(20) + 1
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := rand.Intn(21) - 10
+		y := rand.Intn(21) - 10
+		b.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Println("reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:", expect)
+			fmt.Println("Got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/960-969/961/verifierE.go
+++ b/0-999/900-999/960-969/961/verifierE.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSource := filepath.Join(dir, "961E.go")
+	out := filepath.Join(os.TempDir(), "refE.bin")
+	cmd := exec.Command("go", "build", "-o", out, refSource)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	n := rand.Intn(40) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(50) + 1
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprintf("%d", v))
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Println("reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:", expect)
+			fmt.Println("Got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/960-969/961/verifierF.go
+++ b/0-999/900-999/960-969/961/verifierF.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSource := filepath.Join(dir, "961F.go")
+	out := filepath.Join(os.TempDir(), "refF.bin")
+	cmd := exec.Command("go", "build", "-o", out, refSource)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	n := rand.Intn(20) + 2
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rand.Intn(len(letters))])
+	}
+	s := sb.String()
+	return fmt.Sprintf("%d\n%s\n", n, s)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Println("reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:", expect)
+			fmt.Println("Got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/960-969/961/verifierG.go
+++ b/0-999/900-999/960-969/961/verifierG.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	refSource := filepath.Join(dir, "961G.go")
+	out := filepath.Join(os.TempDir(), "refG.bin")
+	cmd := exec.Command("go", "build", "-o", out, refSource)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBinary(path string, input []byte) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTest() string {
+	n := rand.Intn(20) + 1
+	k := rand.Intn(n) + 1
+	w := make([]int, n)
+	for i := 0; i < n; i++ {
+		w[i] = rand.Intn(10) + 1
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range w {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(fmt.Sprintf("%d", v))
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 100; i++ {
+		test := genTest()
+		expect, err1 := runBinary(ref, []byte(test))
+		got, err2 := runBinary(cand, []byte(test))
+		if err2 != nil {
+			fmt.Printf("Test %d: candidate runtime error: %v\n", i+1, err2)
+			fmt.Println("Input:\n" + test)
+			os.Exit(1)
+		}
+		if err1 != nil {
+			fmt.Println("reference runtime error:", err1)
+			os.Exit(1)
+		}
+		if expect != got {
+			fmt.Printf("Test %d failed\n", i+1)
+			fmt.Println("Input:\n" + test)
+			fmt.Println("Expected:", expect)
+			fmt.Println("Got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone solution verifiers for contest 961 problems A-G
- each verifier builds the reference solution, generates 100 random tests and checks a supplied binary

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68840f059d848324b0bfecca5448222a