### PR TITLE
Add Go verifiers for contest 959

### DIFF
--- a/0-999/900-999/950-959/959/verifierA.go
+++ b/0-999/900-999/950-959/959/verifierA.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(n int) string {
+	if n%2 == 0 {
+		return "Mahmoud"
+	}
+	return "Ehab"
+}
+
+func genCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(1_000_000_000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	expect := solveA(n)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := genCaseA(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/950-959/959/verifierB.go
+++ b/0-999/900-999/950-959/959/verifierB.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(data string) string {
+	reader := bufio.NewReader(strings.NewReader(data))
+	var n, k, m int
+	fmt.Fscan(reader, &n, &k, &m)
+	words := make([]string, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &words[i])
+	}
+	costs := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &costs[i])
+	}
+	group := make([]int, n)
+	minCost := make([]int64, k)
+	for g := 0; g < k; g++ {
+		var x int
+		fmt.Fscan(reader, &x)
+		minVal := int64(^uint64(0) >> 1)
+		for j := 0; j < x; j++ {
+			var idx int
+			fmt.Fscan(reader, &idx)
+			idx--
+			group[idx] = g
+			if costs[idx] < minVal {
+				minVal = costs[idx]
+			}
+		}
+		minCost[g] = minVal
+	}
+	wordIndex := make(map[string]int, n)
+	for i, w := range words {
+		wordIndex[w] = i
+	}
+	var total int64
+	for i := 0; i < m; i++ {
+		var w string
+		fmt.Fscan(reader, &w)
+		idx := wordIndex[w]
+		g := group[idx]
+		total += minCost[g]
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+func genCaseB(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n) + 1
+	m := rng.Intn(10) + 1
+	words := make([]string, n)
+	for i := 0; i < n; i++ {
+		words[i] = fmt.Sprintf("w%d", i+1)
+	}
+	costs := make([]int, n)
+	for i := range costs {
+		costs[i] = rng.Intn(1000) + 1
+	}
+	groups := make([][]int, k)
+	perm := rng.Perm(n)
+	for i := 0; i < k; i++ {
+		groups[i] = append(groups[i], perm[i])
+	}
+	for i := k; i < n; i++ {
+		g := rng.Intn(k)
+		groups[g] = append(groups[g], perm[i])
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, k, m))
+	for i, w := range words {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(w)
+	}
+	sb.WriteByte('\n')
+	for i, c := range costs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(c))
+	}
+	sb.WriteByte('\n')
+	for g := 0; g < k; g++ {
+		sb.WriteString(strconv.Itoa(len(groups[g])))
+		for _, idx := range groups[g] {
+			sb.WriteByte(' ')
+			sb.WriteString(strconv.Itoa(idx + 1))
+		}
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		idx := rng.Intn(n)
+		sb.WriteString(words[idx])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCaseB(rng)
+		expect := solveB(in)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/950-959/959/verifierC.go
+++ b/0-999/900-999/950-959/959/verifierC.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(n int) string {
+	var sb strings.Builder
+	if n <= 5 {
+		sb.WriteString("-1\n")
+	} else {
+		tmp := n - 2
+		sb.WriteString("1 2\n")
+		tot := tmp / 2
+		for i := 1; i <= tot; i++ {
+			sb.WriteString(fmt.Sprintf("1 %d\n", i+2))
+		}
+		for i := 1; i <= tmp-tot; i++ {
+			sb.WriteString(fmt.Sprintf("2 %d\n", i+tot+2))
+		}
+	}
+	for i := 2; i <= n; i++ {
+		sb.WriteString(fmt.Sprintf("1 %d\n", i))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genCaseC(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCaseC(rng)
+		n := 0
+		fmt.Sscan(strings.TrimSpace(in), &n)
+		expect := solveC(n)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, expect, strings.TrimSpace(got), in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/950-959/959/verifierD.go
+++ b/0-999/900-999/950-959/959/verifierD.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const limit = 2000005
+
+func linearSieve(n int) ([]int, []int) {
+	spf := make([]int, n+1)
+	primes := make([]int, 0)
+	for i := 2; i <= n; i++ {
+		if spf[i] == 0 {
+			spf[i] = i
+			primes = append(primes, i)
+		}
+		for _, p := range primes {
+			if p > spf[i] || i*p > n {
+				break
+			}
+			spf[i*p] = p
+		}
+	}
+	return primes, spf
+}
+
+func solveD(data string) string {
+	reader := bufio.NewReader(strings.NewReader(data))
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	primes, spf := linearSieve(limit)
+	used := make([]bool, limit+1)
+	ans := make([]int, n)
+	modified := false
+	primeIdx := 0
+	for i := 0; i < n; i++ {
+		if !modified {
+			x := a[i]
+			for ; x <= limit; x++ {
+				ok := true
+				t := x
+				for t > 1 {
+					p := spf[t]
+					if used[p] {
+						ok = false
+						break
+					}
+					for t%p == 0 {
+						t /= p
+					}
+				}
+				if ok {
+					break
+				}
+			}
+			ans[i] = x
+			t := x
+			for t > 1 {
+				p := spf[t]
+				used[p] = true
+				for t%p == 0 {
+					t /= p
+				}
+			}
+			if x > a[i] {
+				modified = true
+			}
+		} else {
+			for primeIdx < len(primes) && used[primes[primeIdx]] {
+				primeIdx++
+			}
+			if primeIdx < len(primes) {
+				ans[i] = primes[primeIdx]
+				used[primes[primeIdx]] = true
+				primeIdx++
+			} else {
+				ans[i] = 2
+			}
+		}
+	}
+	var sb strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func genCaseD(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(50) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCaseD(rng)
+		expect := solveD(in)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/950-959/959/verifierE.go
+++ b/0-999/900-999/950-959/959/verifierE.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveE(n int64) string {
+	m := n - 1
+	var res int64
+	for bit := int64(1); bit <= m; bit <<= 1 {
+		res += bit * (m/bit - m/(bit<<1))
+	}
+	return fmt.Sprintf("%d", res)
+}
+
+func genCaseE(rng *rand.Rand) string {
+	n := rng.Int63n(1_000_000_000_000) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCaseE(rng)
+		n, _ := strconv.ParseInt(strings.TrimSpace(in), 10, 64)
+		expect := solveE(n)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/950-959/959/verifierF.go
+++ b/0-999/900-999/950-959/959/verifierF.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const mod int = 1e9 + 7
+
+type Basis struct {
+	b    [20]int
+	size int
+}
+
+func (bs *Basis) Add(x int) {
+	for i := 19; i >= 0; i-- {
+		if (x>>i)&1 == 0 {
+			continue
+		}
+		if bs.b[i] != 0 {
+			x ^= bs.b[i]
+		} else {
+			bs.b[i] = x
+			bs.size++
+			return
+		}
+	}
+}
+
+func (bs *Basis) Contains(x int) bool {
+	for i := 19; i >= 0; i-- {
+		if (x>>i)&1 == 0 {
+			continue
+		}
+		if bs.b[i] == 0 {
+			return false
+		}
+		x ^= bs.b[i]
+	}
+	return true
+}
+
+func solveF(data string) string {
+	reader := bufio.NewReader(strings.NewReader(data))
+	var n, q int
+	fmt.Fscan(reader, &n, &q)
+	arr := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(reader, &arr[i])
+	}
+	type Query struct {
+		x   int
+		idx int
+	}
+	queries := make([][]Query, n+1)
+	for i := 0; i < q; i++ {
+		var l, x int
+		fmt.Fscan(reader, &l, &x)
+		queries[l] = append(queries[l], Query{x, i})
+	}
+	pow2 := make([]int, n+1)
+	pow2[0] = 1
+	for i := 1; i <= n; i++ {
+		pow2[i] = pow2[i-1] * 2 % mod
+	}
+	ans := make([]int, q)
+	var bs Basis
+	for i := 1; i <= n; i++ {
+		bs.Add(arr[i])
+		for _, qu := range queries[i] {
+			if bs.Contains(qu.x) {
+				ans[qu.idx] = pow2[i-bs.size]
+			} else {
+				ans[qu.idx] = 0
+			}
+		}
+	}
+	var sb strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return sb.String()
+}
+
+func genCaseF(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	q := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(1 << 20)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		x := rng.Intn(1 << 20)
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, x))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCaseF(rng)
+		expect := solveF(in)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, expect, strings.TrimSpace(got), in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go`–`verifierF.go` for contest 959
- each verifier runs 100 random tests using the reference logic
- verifiers accept any binary path as argument

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go run verifierA.go ./candidateA` *(after building candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68840ded5f2483249df4e9b9e50399fc