### PR TITLE
Add naive Go solution for 1600E

### DIFF
--- a/1000-1999/1600-1699/1600-1609/1600/1600E.go
+++ b/1000-1999/1600-1699/1600-1609/1600/1600E.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type state struct {
+	l    int
+	r    int
+	last int
+}
+
+var (
+	arr  []int
+	memo map[state]bool
+)
+
+func solve(l, r, last int) bool {
+	s := state{l, r, last}
+	if v, ok := memo[s]; ok {
+		return v
+	}
+	lastVal := -int(1 << 60)
+	if last != -1 {
+		lastVal = arr[last]
+	}
+	win := false
+	if l <= r {
+		if arr[l] > lastVal {
+			if !solve(l+1, r, l) {
+				win = true
+			}
+		}
+		if !win && arr[r] > lastVal {
+			if !solve(l, r-1, r) {
+				win = true
+			}
+		}
+	}
+	memo[s] = win
+	return win
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	arr = make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &arr[i])
+	}
+	memo = make(map[state]bool)
+	if solve(0, n-1, -1) {
+		fmt.Print("Alice")
+	} else {
+		fmt.Print("Bob")
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problemE

## Testing
- `gofmt -w 1000-1999/1600-1699/1600-1609/1600/1600E.go`


------
https://chatgpt.com/codex/tasks/task_e_68840c8f4b64832484a8a6028181a345