### PR TITLE
Add Go verifiers for contest 955

### DIFF
--- a/0-999/900-999/950-959/955/verifierA.go
+++ b/0-999/900-999/950-959/955/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	hh, mm     int
+	H, D, C, N int
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("%02d %02d\n%d %d %d %d\n", t.hh, t.mm, t.H, t.D, t.C, t.N)
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "955A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(0))
+	tests := make([]Test, 0, 110)
+	for i := 0; i < 100; i++ {
+		tests = append(tests, Test{
+			hh: rng.Intn(24),
+			mm: rng.Intn(60),
+			H:  rng.Intn(500) + 1,
+			D:  rng.Intn(10) + 1,
+			C:  rng.Intn(200) + 1,
+			N:  rng.Intn(10) + 1,
+		})
+	}
+	// edge cases around discount time
+	tests = append(tests,
+		Test{19, 59, 10, 1, 20, 5},
+		Test{20, 0, 10, 2, 15, 3},
+		Test{23, 30, 1, 1, 1, 1},
+		Test{0, 0, 100, 5, 100, 10},
+		Test{19, 0, 200, 3, 50, 5},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n" + input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/950-959/955/verifierB.go
+++ b/0-999/900-999/950-959/955/verifierB.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	s string
+}
+
+func (t Test) Input() string { return t.s + "\n" }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "955B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(30) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		}
+		tests = append(tests, Test{s: sb.String()})
+	}
+	tests = append(tests,
+		Test{s: "a"},
+		Test{s: "ab"},
+		Test{s: strings.Repeat("a", 10)},
+		Test{s: "abcabc"},
+		Test{s: "zz"},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n" + input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:%sexpected:%sgot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/950-959/955/verifierC.go
+++ b/0-999/900-999/950-959/955/verifierC.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Query struct{ L, R int64 }
+
+type Test struct {
+	q  int
+	qs []Query
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t.q))
+	for _, qq := range t.qs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", qq.L, qq.R))
+	}
+	return sb.String()
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "955C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(2))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		q := rng.Intn(5) + 1
+		qs := make([]Query, q)
+		for j := 0; j < q; j++ {
+			l := rng.Int63n(1_000_000) + 1
+			r := l + rng.Int63n(1_000_000)
+			qs[j] = Query{l, r}
+		}
+		tests = append(tests, Test{q: q, qs: qs})
+	}
+	tests = append(tests,
+		Test{q: 1, qs: []Query{{1, 1}}},
+		Test{q: 2, qs: []Query{{1, 10}, {100, 1000}}},
+		Test{q: 1, qs: []Query{{999999, 1000000}}},
+		Test{q: 3, qs: []Query{{5, 5}, {10, 20}, {30, 40}}},
+		Test{q: 1, qs: []Query{{500, 1500}}},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n" + input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:%sexpected:%sgot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/950-959/955/verifierD.go
+++ b/0-999/900-999/950-959/955/verifierD.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n, m, k int
+	s, t    string
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("%d %d %d\n%s\n%s\n", t.n, t.m, t.k, t.s, t.t)
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "955D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func randomString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(3))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		m := rng.Intn(n) + 1
+		k := rng.Intn(m) + 1
+		s := randomString(rng, n)
+		t := randomString(rng, m)
+		tests = append(tests, Test{n: n, m: m, k: k, s: s, t: t})
+	}
+	tests = append(tests,
+		Test{n: 1, m: 1, k: 1, s: "a", t: "a"},
+		Test{n: 5, m: 3, k: 2, s: "abcde", t: "acd"},
+		Test{n: 4, m: 4, k: 4, s: "aaaa", t: "bbbb"},
+		Test{n: 6, m: 2, k: 1, s: "abcdef", t: "af"},
+		Test{n: 8, m: 5, k: 3, s: "abababab", t: "babab"},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n" + input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:%sexpected:%sgot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/950-959/955/verifierE.go
+++ b/0-999/900-999/950-959/955/verifierE.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	n   int
+	arr []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t.n))
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "955E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(4))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(10) + 1
+		}
+		tests = append(tests, Test{n: n, arr: arr})
+	}
+	tests = append(tests,
+		Test{n: 1, arr: []int{1}},
+		Test{n: 2, arr: []int{5, 5}},
+		Test{n: 3, arr: []int{1, 2, 3}},
+		Test{n: 4, arr: []int{10, 10, 10, 10}},
+		Test{n: 5, arr: []int{2, 4, 6, 8, 10}},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n" + input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:%sexpected:%sgot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/950-959/955/verifierF.go
+++ b/0-999/900-999/950-959/955/verifierF.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Edge struct{ u, v int }
+
+type Test struct {
+	n     int
+	edges []Edge
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t.n))
+	for _, e := range t.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	return sb.String()
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "955F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func genTree(rng *rand.Rand, n int) []Edge {
+	edges := make([]Edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, Edge{p, i})
+	}
+	return edges
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(5))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		edges := genTree(rng, n)
+		tests = append(tests, Test{n: n, edges: edges})
+	}
+	tests = append(tests,
+		Test{n: 1, edges: nil},
+		Test{n: 2, edges: []Edge{{1, 2}}},
+		Test{n: 3, edges: []Edge{{1, 2}, {1, 3}}},
+		Test{n: 4, edges: []Edge{{1, 2}, {2, 3}, {3, 4}}},
+		Test{n: 5, edges: []Edge{{1, 2}, {1, 3}, {3, 4}, {4, 5}}},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		want, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n" + input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:%sexpected:%sgot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go..verifierF.go to contest 955
- each verifier builds a reference solution and runs ~100 randomized tests

## Testing
- `go build ./0-999/900-999/950-959/955/verifierA.go`
- `go build ./0-999/900-999/950-959/955/verifierB.go`
- `go build ./0-999/900-999/950-959/955/verifierC.go`
- `go build ./0-999/900-999/950-959/955/verifierD.go`
- `go build ./0-999/900-999/950-959/955/verifierE.go`
- `go build ./0-999/900-999/950-959/955/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68840bbd494c8324b215eacd467cdb4d