### PR TITLE
Add naive solution for 1625E2

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1625/1625E2.go
+++ b/1000-1999/1600-1699/1620-1629/1625/1625E2.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func countRBS(arr []byte) int {
+	stack := make([]int, 0, len(arr))
+	dp := make([]int, len(arr))
+	ans := 0
+	for i, c := range arr {
+		if c == '(' {
+			stack = append(stack, i)
+		} else if c == ')' {
+			if len(stack) > 0 {
+				open := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				if open > 0 {
+					dp[i] = dp[open-1] + 1
+				} else {
+					dp[i] = 1
+				}
+				ans += dp[i]
+			}
+		}
+	}
+	return ans
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, q int
+	fmt.Fscan(in, &n, &q)
+	sBytes := make([]byte, n)
+	var s string
+	fmt.Fscan(in, &s)
+	copy(sBytes, []byte(s))
+
+	for ; q > 0; q-- {
+		var t, l, r int
+		fmt.Fscan(in, &t, &l, &r)
+		l--
+		r--
+		if t == 1 {
+			if l >= 0 && l < n {
+				sBytes[l] = '.'
+			}
+			if r >= 0 && r < n {
+				sBytes[r] = '.'
+			}
+		} else {
+			sub := sBytes[l : r+1]
+			tmp := make([]byte, 0, len(sub))
+			for _, ch := range sub {
+				if ch == '(' || ch == ')' {
+					tmp = append(tmp, ch)
+				}
+			}
+			res := countRBS(tmp)
+			fmt.Fprintln(out, res)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a simple Go implementation for problem E2

## Testing
- `go build 1000-1999/1600-1699/1620-1629/1625/1625E2.go`
- `go test ./...` *(fails: no Go module)*

------
https://chatgpt.com/codex/tasks/task_e_6884336912fc83248d9456f1494b3d83