### PR TITLE
Add Go solution for 1675B

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1675/1675B.go
+++ b/1000-1999/1600-1699/1670-1679/1675/1675B.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var (
+	reader = bufio.NewReader(os.Stdin)
+	writer = bufio.NewWriter(os.Stdout)
+)
+
+func main() {
+	defer writer.Flush()
+	var T int
+	fmt.Fscan(reader, &T)
+	for ; T > 0; T-- {
+		solve()
+	}
+}
+
+func solve() {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	ops := 0
+	for i := n - 2; i >= 0; i-- {
+		for a[i] >= a[i+1] && a[i] > 0 {
+			a[i] /= 2
+			ops++
+		}
+		if a[i] >= a[i+1] {
+			fmt.Fprintln(writer, -1)
+			return
+		}
+	}
+	fmt.Fprintln(writer, ops)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem B in contest 1675

## Testing
- `go run 1000-1999/1600-1699/1670-1679/1675/1675B.go < /tmp/test.input`
- `go run 1000-1999/1600-1699/1670-1679/1675/1675B.go < /tmp/test2.input`


------
https://chatgpt.com/codex/tasks/task_e_68840aeaf65c83248eee14f46d81c2e9