### PR TITLE
Add Go solution for Codeforces 1675C

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1675/1675C.go
+++ b/1000-1999/1600-1699/1670-1679/1675/1675C.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var (
+	reader = bufio.NewReader(os.Stdin)
+	writer = bufio.NewWriter(os.Stdout)
+)
+
+func main() {
+	defer writer.Flush()
+	var T int
+	fmt.Fscan(reader, &T)
+	for ; T > 0; T-- {
+		solve()
+	}
+}
+
+func solve() {
+	var s string
+	fmt.Fscan(reader, &s)
+	n := len(s)
+	firstZero := n + 1
+	lastOne := 0
+	for i := 0; i < n; i++ {
+		if s[i] == '0' && firstZero == n+1 {
+			firstZero = i + 1
+		}
+		if s[i] == '1' {
+			lastOne = i + 1
+		}
+	}
+	start := lastOne
+	if start == 0 {
+		start = 1
+	}
+	end := firstZero
+	if end == n+1 {
+		end = n
+	}
+	if end >= start {
+		fmt.Fprintln(writer, end-start+1)
+	} else {
+		fmt.Fprintln(writer, 0)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for problem C in contest 1675

## Testing
- `go run 1000-1999/1600-1699/1670-1679/1675/1675C.go << EOF
4
?
0
1?0
1100
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68840a5ed2f48324a04604b38d84f355