### PR TITLE
Add Go verifiers for contest 952

### DIFF
--- a/0-999/900-999/950-959/952/verifierA.go
+++ b/0-999/900-999/950-959/952/verifierA.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if input != "" {
+		cmd.Stdin = strings.NewReader(input)
+	}
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expected(a int) string {
+	if a%2 == 1 {
+		return "1"
+	}
+	return "0"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := []int{}
+	for i := 10; i < 30; i++ {
+		tests = append(tests, i)
+	}
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n", t)
+		want := expected(t)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed: expected %q, got %q\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/900-999/950-959/952/verifierB.go
+++ b/0-999/900-999/950-959/952/verifierB.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string) (string, error) {
+	cmd := exec.Command(bin)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 10; i++ {
+		got, err := run(bin)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != "normal" {
+			fmt.Printf("Test %d failed: expected %q, got %q\n", i+1, "normal", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/900-999/950-959/952/verifierC.go
+++ b/0-999/900-999/950-959/952/verifierC.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveC(arr []int) string {
+	expected := make([]int, len(arr))
+	copy(expected, arr)
+	sort.Slice(expected, func(i, j int) bool { return expected[i] > expected[j] })
+
+	a := make([]int, len(arr))
+	copy(a, arr)
+	output := make([]int, 0, len(arr))
+
+	for len(a) > 0 {
+		changed := true
+		for changed {
+			changed = false
+			for i := 0; i < len(a)-1; i++ {
+				if a[i]-a[i+1] >= 2 {
+					a[i]--
+					a[i+1]++
+					changed = true
+				} else if a[i+1]-a[i] >= 2 {
+					a[i+1]--
+					a[i]++
+					changed = true
+				}
+			}
+		}
+		idx := 0
+		for i := 1; i < len(a); i++ {
+			if a[i] > a[idx] {
+				idx = i
+			}
+		}
+		output = append(output, a[idx])
+		a = append(a[:idx], a[idx+1:]...)
+	}
+
+	for i := 0; i < len(arr); i++ {
+		if output[i] != expected[i] {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := [][]int{
+		{1},
+		{2},
+		{1, 1},
+		{2, 1},
+		{1, 2, 3},
+		{10, 10, 10},
+		{3, 1, 3, 1},
+		{4, 5, 6, 7},
+		{9, 8, 7, 6, 5},
+		{1, 2, 1, 2, 1},
+		{3, 3, 3, 3, 3, 3},
+		{1, 3, 2, 4, 3, 5, 6},
+		{2, 4, 6, 8, 10, 12, 14, 16},
+		{16, 15, 14, 13, 12, 11, 10, 9},
+		{1, 1, 2, 2, 3, 3, 4, 4, 5},
+		{5, 4, 3, 2, 1, 1, 2, 3, 4},
+		{10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
+		{5, 5, 5, 5, 5, 5, 5, 5, 5, 5},
+		{1, 100, 1, 100, 1, 100, 1, 100, 1, 100},
+		{100, 99, 98, 97, 96, 95, 94, 93, 92, 91},
+	}
+
+	for i, arr := range tests {
+		input := fmt.Sprintf("%d\n", len(arr))
+		for j, v := range arr {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		want := solveC(arr)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed: expected %q, got %q\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/900-999/950-959/952/verifierD.go
+++ b/0-999/900-999/950-959/952/verifierD.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string) (string, error) {
+	cmd := exec.Command(bin)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i := 0; i < 10; i++ {
+		got, err := run(bin)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != "Odd" {
+			fmt.Printf("Test %d failed: expected %q, got %q\n", i+1, "Odd", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/900-999/950-959/952/verifierE.go
+++ b/0-999/900-999/950-959/952/verifierE.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type tcE []string
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveE(types []string) string {
+	soft, hard := 0, 0
+	for _, t := range types {
+		if t == "soft" {
+			soft++
+		} else {
+			hard++
+		}
+	}
+	for size := 1; ; size++ {
+		total := size * size
+		w := (total + 1) / 2
+		b := total / 2
+		if (soft <= w && hard <= b) || (soft <= b && hard <= w) {
+			return fmt.Sprint(size)
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := []tcE{
+		{"soft"},
+		{"hard"},
+		{"soft", "hard"},
+		{"soft", "soft"},
+		{"hard", "hard"},
+		{"soft", "hard", "hard"},
+		{"hard", "hard", "hard"},
+		{"soft", "soft", "hard", "hard"},
+		{"soft", "soft", "soft", "soft"},
+		{"hard", "hard", "hard", "hard"},
+		{"soft", "hard", "hard", "hard", "hard"},
+		{"soft", "soft", "soft", "soft", "hard"},
+		{"soft", "soft", "hard", "hard", "hard", "hard"},
+		{"soft", "soft", "soft", "soft", "soft", "soft"},
+		{"hard", "hard", "hard", "hard", "hard", "hard"},
+		{"soft", "soft", "hard", "hard", "hard", "hard", "hard"},
+		{"soft", "soft", "soft", "soft", "hard", "hard", "hard", "hard"},
+		{"hard", "hard", "hard", "hard", "hard", "hard", "hard", "hard", "hard"},
+		{"soft", "soft", "soft", "soft", "soft", "soft", "soft", "soft", "soft", "soft"},
+		{"hard", "hard", "hard", "hard", "hard", "hard", "hard", "hard", "hard", "hard"},
+	}
+
+	for i, types := range tests {
+		input := fmt.Sprintf("%d\n", len(types))
+		for j, t := range types {
+			name := fmt.Sprintf("c%d", j)
+			input += fmt.Sprintf("%s %s\n", name, t)
+		}
+		want := solveE(types)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed: expected %q, got %q\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/900-999/950-959/952/verifierF.go
+++ b/0-999/900-999/950-959/952/verifierF.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func bugEval(expr string) string {
+	expr += "+"
+	var result, cur int64
+	sign := int64(1)
+	for i := 0; i < len(expr); i++ {
+		c := expr[i]
+		if c == '+' || c == '-' {
+			result += sign * cur
+			cur = 0
+		}
+		if c == '-' {
+			sign = -1
+		}
+		if c == '+' {
+			sign = 1
+		}
+		cur = cur*10 + int64(int(c)-int('0'))
+	}
+	return fmt.Sprint(result)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := []string{
+		"1+1",
+		"10+20-5",
+		"0-0+0",
+		"255-255+255-255",
+		"12+34+56",
+		"100-50-25",
+		"3-2+1-0",
+		"9+8-7+6-5+4-3+2-1+0",
+		"200-100+50-25+12-6+3-1",
+		"1-2-3-4-5",
+	}
+
+	for i, expr := range tests {
+		input := expr + "\n"
+		want := bugEval(expr)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed: expected %q, got %q\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/900-999/950-959/952/verifierG.go
+++ b/0-999/900-999/950-959/952/verifierG.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type row struct{ a, b, c byte }
+
+func gen(s string) string {
+	rows := []row{{'.', '.', '.'}}
+	rows = append(rows, row{'.', 'X', 'X'})
+	cur := 0
+	for i := 0; i < len(s); i++ {
+		target := int(s[i])
+		diff := (cur - target + 256) % 256
+		for j := 0; j < diff; j++ {
+			rows = append(rows, row{'.', '.', '.'})
+			rows = append(rows, row{'.', 'X', '.'})
+		}
+		rows = append(rows, row{'.', 'X', '.'})
+		cur = target
+	}
+	rows = append(rows, row{'.', '.', '.'})
+
+	var b strings.Builder
+	for i, r := range rows {
+		b.WriteByte(r.a)
+		b.WriteByte(r.b)
+		b.WriteByte(r.c)
+		if i+1 < len(rows) {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := []string{
+		"A",
+		"Hello",
+		"World!",
+		"Test123",
+		"GoLang",
+		"Contest",
+		"1234567890",
+		"!@#$%^&*",
+		"abcdefg",
+		"XYZxyz",
+	}
+
+	for i, s := range tests {
+		input := s + "\n"
+		want := gen(s)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed: expected:\n%s\nGot:\n%s\n", i+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 952 problems A-G
- each verifier runs a binary over many test cases (100 total)

## Testing
- `go build verifierA.go`
- `for f in verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go; do go build $f || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_68840a19783883249ce1934c8395ea58