### PR TITLE
Add Go verifiers for CF contest 949

### DIFF
--- a/0-999/900-999/940-949/949/verifierA.go
+++ b/0-999/900-999/940-949/949/verifierA.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type test struct {
+	s string
+}
+
+func genTests() []test {
+	rand.Seed(1)
+	tests := make([]test, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		tests[i] = test{sb.String()}
+	}
+	return tests
+}
+
+func runBinary(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", path)
+	} else {
+		cmd = exec.CommandContext(ctx, path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+// reference solve from 949A.go
+func solveRef(s string) ([][]int, bool) {
+	n := len(s)
+	nxt := make([]int, n+2)
+	vst := make([]bool, n+2)
+	a0 := make([]int, 0, n)
+	a1 := make([]int, 0, n)
+	m := 0
+	for i := 1; i <= n; i++ {
+		c := s[i-1]
+		if c == '0' {
+			if len(a1) > 0 {
+				u := a1[len(a1)-1]
+				a1 = a1[:len(a1)-1]
+				nxt[u] = i
+				a0 = append(a0, i)
+			} else {
+				a0 = append(a0, i)
+				m++
+			}
+		} else {
+			if len(a0) > 0 {
+				u := a0[len(a0)-1]
+				a0 = a0[:len(a0)-1]
+				nxt[u] = i
+				a1 = append(a1, i)
+			} else {
+				return nil, false
+			}
+		}
+	}
+	if len(a1) > 0 {
+		return nil, false
+	}
+	res := make([][]int, 0, m)
+	for i := 1; i <= n; i++ {
+		if vst[i] {
+			continue
+		}
+		seq := []int{}
+		for u := i; u != 0; u = nxt[u] {
+			seq = append(seq, u)
+			vst[u] = true
+		}
+		res = append(res, seq)
+	}
+	return res, true
+}
+
+func checkOutput(s string, out string, possible bool) bool {
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(out)))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return false
+	}
+	tok := scanner.Text()
+	if tok == "-1" {
+		if possible {
+			return false
+		}
+		if scanner.Scan() {
+			return false
+		}
+		return true
+	}
+	k, err := strconv.Atoi(tok)
+	if err != nil || k <= 0 || k > len(s) {
+		return false
+	}
+	used := make([]bool, len(s)+1)
+	for i := 0; i < k; i++ {
+		if !scanner.Scan() {
+			return false
+		}
+		li, err := strconv.Atoi(scanner.Text())
+		if err != nil || li <= 0 {
+			return false
+		}
+		prev := 0
+		for j := 0; j < li; j++ {
+			if !scanner.Scan() {
+				return false
+			}
+			idx, err := strconv.Atoi(scanner.Text())
+			if err != nil || idx < 1 || idx > len(s) || idx <= prev {
+				return false
+			}
+			if used[idx] {
+				return false
+			}
+			used[idx] = true
+			prev = idx
+		}
+	}
+	if scanner.Scan() {
+		return false
+	}
+	for i := 1; i <= len(s); i++ {
+		if !used[i] {
+			return false
+		}
+	}
+	// validate zebra property
+	scanner = bufio.NewScanner(strings.NewReader(strings.TrimSpace(out)))
+	scanner.Split(bufio.ScanWords)
+	scanner.Scan() // skip k
+	for i := 0; i < k; i++ {
+		scanner.Scan()
+		li, _ := strconv.Atoi(scanner.Text())
+		prev := -1
+		for j := 0; j < li; j++ {
+			scanner.Scan()
+			x, _ := strconv.Atoi(scanner.Text())
+			if j == 0 && s[x-1] != '0' {
+				return false
+			}
+			if j == li-1 && s[x-1] != '0' {
+				return false
+			}
+			if prev != -1 && s[x-1] == s[prev-1] {
+				return false
+			}
+			prev = x
+		}
+	}
+	if !possible {
+		return false
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := t.s + "\n"
+		out, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		_, ok := solveRef(t.s)
+		if !checkOutput(t.s, out, ok) {
+			fmt.Printf("test %d failed\ninput:\n%s\noutput:\n%s\n", i+1, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/940-949/949/verifierB.go
+++ b/0-999/900-999/940-949/949/verifierB.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type test struct {
+	n  int64
+	q  int
+	xs []int64
+}
+
+func genTests() []test {
+	rand.Seed(2)
+	tests := make([]test, 100)
+	for i := range tests {
+		n := rand.Int63n(1_000_000) + 1
+		q := rand.Intn(5) + 1
+		xs := make([]int64, q)
+		for j := 0; j < q; j++ {
+			xs[j] = rand.Int63n(n) + 1
+		}
+		tests[i] = test{n, q, xs}
+	}
+	return tests
+}
+
+func runBinary(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", path)
+	} else {
+		cmd = exec.CommandContext(ctx, path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func solve(n, x int64) int64 {
+	if x%2 == 1 {
+		return (x + 1) / 2
+	}
+	if n%2 == 0 {
+		return n/2 + solve(n/2, x/2)
+	}
+	m := n / 2
+	i := x / 2
+	if i == 1 {
+		return m + 1 + solve(m, m)
+	}
+	return m + 1 + solve(m, i-1)
+}
+
+func expected(t test) []int64 {
+	res := make([]int64, t.q)
+	for i, x := range t.xs {
+		res[i] = solve(t.n, x)
+	}
+	return res
+}
+
+func buildInput(t test) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, t.q))
+	for _, x := range t.xs {
+		sb.WriteString(fmt.Sprintf("%d\n", x))
+	}
+	return sb.String()
+}
+
+func parseOutput(out string, q int) ([]int64, bool) {
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(out)))
+	scanner.Split(bufio.ScanWords)
+	vals := make([]int64, 0, q)
+	for scanner.Scan() {
+		v, err := strconv.ParseInt(scanner.Text(), 10, 64)
+		if err != nil {
+			return nil, false
+		}
+		vals = append(vals, v)
+	}
+	if len(vals) != q {
+		return nil, false
+	}
+	return vals, true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := buildInput(t)
+		out, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, ok := parseOutput(out, t.q)
+		if !ok {
+			fmt.Printf("test %d: could not parse output\n", i+1)
+			os.Exit(1)
+		}
+		exp := expected(t)
+		match := true
+		for j := 0; j < t.q; j++ {
+			if got[j] != exp[j] {
+				match = false
+				break
+			}
+		}
+		if !match {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%v\noutput:%v\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/940-949/949/verifierC.go
+++ b/0-999/900-999/940-949/949/verifierC.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type test struct {
+	n, m, h int
+	w       []int
+	edges   [][2]int
+}
+
+func genTests() []test {
+	rand.Seed(3)
+	tests := make([]test, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 2
+		h := rand.Intn(9) + 2
+		m := rand.Intn(n*(n-1)/2 + 1)
+		w := make([]int, n)
+		for j := 0; j < n; j++ {
+			w[j] = rand.Intn(h)
+		}
+		edges := make([][2]int, m)
+		for j := 0; j < m; j++ {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			for v == u {
+				v = rand.Intn(n) + 1
+			}
+			edges[j] = [2]int{u, v}
+		}
+		tests[i] = test{n, m, h, w, edges}
+	}
+	return tests
+}
+
+func runBinary(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", path)
+	} else {
+		cmd = exec.CommandContext(ctx, path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+// reference solution from 949C.go
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveRef(t test) []int {
+	n, h := t.n, t.h
+	w := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		w[i] = t.w[i-1]
+	}
+	graph := make([][]int, n+1)
+	for _, e := range t.edges {
+		u, v := e[0], e[1]
+		if (w[u]+1)%h == w[v] {
+			graph[u] = append(graph[u], v)
+		}
+		if (w[v]+1)%h == w[u] {
+			graph[v] = append(graph[v], u)
+		}
+	}
+	dfn := make([]int, n+1)
+	low := make([]int, n+1)
+	onStack := make([]bool, n+1)
+	stack := make([]int, 0, n)
+	var index, sccCount int
+	sccId := make([]int, n+1)
+	size := make([]int, n+1)
+	var dfs func(u int)
+	dfs = func(u int) {
+		index++
+		dfn[u] = index
+		low[u] = index
+		stack = append(stack, u)
+		onStack[u] = true
+		for _, v := range graph[u] {
+			if dfn[v] == 0 {
+				dfs(v)
+				low[u] = min(low[u], low[v])
+			} else if onStack[v] {
+				low[u] = min(low[u], dfn[v])
+			}
+		}
+		if low[u] == dfn[u] {
+			sccCount++
+			for {
+				sz := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				onStack[sz] = false
+				sccId[sz] = sccCount
+				size[sccCount]++
+				if sz == u {
+					break
+				}
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if dfn[i] == 0 {
+			dfs(i)
+		}
+	}
+	outDeg := make([]int, sccCount+1)
+	for u := 1; u <= n; u++ {
+		for _, v := range graph[u] {
+			if sccId[u] != sccId[v] {
+				outDeg[sccId[u]]++
+			}
+		}
+	}
+	bestSize := n + 1
+	bestId := 0
+	for i := 1; i <= sccCount; i++ {
+		if outDeg[i] == 0 && size[i] < bestSize {
+			bestSize = size[i]
+			bestId = i
+		}
+	}
+	res := []int{}
+	for i := 1; i <= n; i++ {
+		if sccId[i] == bestId {
+			res = append(res, i)
+		}
+	}
+	sort.Ints(res)
+	return res
+}
+
+func buildInput(t test) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", t.n, t.m, t.h))
+	for i, v := range t.w {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for _, e := range t.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func parseOutput(out string) ([]int, bool) {
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(out)))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return nil, false
+	}
+	k, err := strconv.Atoi(scanner.Text())
+	if err != nil || k < 0 {
+		return nil, false
+	}
+	vals := make([]int, 0, k)
+	for scanner.Scan() {
+		v, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return nil, false
+		}
+		vals = append(vals, v)
+	}
+	if len(vals) != k {
+		return nil, false
+	}
+	sort.Ints(vals)
+	return vals, true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := buildInput(t)
+		out, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, ok := parseOutput(out)
+		if !ok {
+			fmt.Printf("test %d: bad output\n", i+1)
+			os.Exit(1)
+		}
+		exp := solveRef(t)
+		if len(got) != len(exp) {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%v\noutput:%v\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+		match := true
+		for j := range got {
+			if got[j] != exp[j] {
+				match = false
+				break
+			}
+		}
+		if !match {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%v\noutput:%v\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/940-949/949/verifierD.go
+++ b/0-999/900-999/940-949/949/verifierD.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type test struct {
+	n, d, b int
+	a       []int
+}
+
+func genTests() []test {
+	rand.Seed(4)
+	tests := make([]test, 100)
+	for i := range tests {
+		n := rand.Intn(20) + 2
+		d := rand.Intn(n-1) + 1
+		b := rand.Intn(10) + 1
+		a := make([]int, n)
+		sum := n * b
+		for j := 0; j < n-1; j++ {
+			val := rand.Intn(2*b + 1)
+			if val > sum {
+				val = sum
+			}
+			a[j] = val
+			sum -= val
+		}
+		a[n-1] = sum
+		tests[i] = test{n, d, b, a}
+	}
+	return tests
+}
+
+func runBinary(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", path)
+	} else {
+		cmd = exec.CommandContext(ctx, path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func compute(arr []int, rooms, d, b int) int {
+	n := len(arr)
+	p := 0
+	var avail int64
+	miss := 0
+	for i := 1; i <= rooms; i++ {
+		limit := i * (d + 1)
+		if limit > n {
+			limit = n
+		}
+		for p < limit {
+			avail += int64(arr[p])
+			p++
+		}
+		if avail >= int64(b) {
+			avail -= int64(b)
+		} else {
+			miss++
+		}
+	}
+	return miss
+}
+
+func solveRef(t test) int {
+	a := make([]int, len(t.a))
+	copy(a, t.a)
+	leftRooms := (t.n + 1) / 2
+	rightRooms := t.n / 2
+	left := compute(a, leftRooms, t.d, t.b)
+	rev := make([]int, len(a))
+	for i := 0; i < len(a); i++ {
+		rev[i] = a[len(a)-1-i]
+	}
+	right := compute(rev, rightRooms, t.d, t.b)
+	if left > right {
+		return left
+	}
+	return right
+}
+
+func buildInput(t test) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", t.n, t.d, t.b))
+	for i, v := range t.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func parseOutput(out string) (int, bool) {
+	s := strings.TrimSpace(out)
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := buildInput(t)
+		out, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, ok := parseOutput(out)
+		if !ok {
+			fmt.Printf("test %d: bad output\n", i+1)
+			os.Exit(1)
+		}
+		exp := solveRef(t)
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%d got:%d\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/940-949/949/verifierE.go
+++ b/0-999/900-999/940-949/949/verifierE.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type test struct {
+	n   int
+	arr []int
+}
+
+func genTests() []test {
+	rand.Seed(5)
+	tests := make([]test, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rand.Intn(21) - 10
+		}
+		tests[i] = test{n, arr}
+	}
+	return tests
+}
+
+func runBinary(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", path)
+	} else {
+		cmd = exec.CommandContext(ctx, path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+// reference from 949E.go
+var (
+	pw  [20]int
+	b   [20][]bool
+	c   [20]int
+	ans int
+	v   []int
+)
+
+func dfs(k, ds int) {
+	if k == 17 {
+		if b[k][0] {
+			c[17] = -1
+			ds++
+		} else if b[k][2] {
+			c[17] = 1
+			ds++
+		} else {
+			c[17] = 0
+		}
+		if ds < ans {
+			ans = ds
+			v = v[:0]
+			for i := 0; i <= 17; i++ {
+				if c[i] == 1 {
+					v = append(v, 1<<i)
+				} else if c[i] == -1 {
+					v = append(v, -(1 << i))
+				}
+			}
+		}
+		c[17] = 0
+		return
+	}
+	flag := false
+	for i := 1; i <= pw[18-k]; i += 2 {
+		if b[k][i] {
+			flag = true
+			break
+		}
+	}
+	if !flag {
+		for i := 0; i <= pw[17-k]; i++ {
+			b[k+1][i] = b[k][i<<1]
+		}
+		c[k] = 0
+		dfs(k+1, ds)
+		return
+	}
+	for i, j := pw[17-k], 0; i <= pw[18-k]; i, j = i+2, j+1 {
+		b[k+1][pw[16-k]+j] = b[k][i] || b[k][i+1]
+	}
+	for i, j := pw[17-k]-1, 1; i >= 0; i, j = i-2, j+1 {
+		b[k+1][pw[16-k]-j] = b[k][i] || b[k][i-1]
+	}
+	c[k] = 1
+	dfs(k+1, ds+1)
+	for i, j := pw[17-k], 0; i >= 0; i, j = i-2, j+1 {
+		b[k+1][pw[16-k]-j] = b[k][i] || b[k][i-1]
+	}
+	for i, j := pw[17-k]+1, 1; i <= pw[18-k]; i, j = i+2, j+1 {
+		b[k+1][pw[16-k]+j] = b[k][i] || b[k][i+1]
+	}
+	c[k] = -1
+	dfs(k+1, ds+1)
+}
+
+func solveRef(t test) (int, []int) {
+	pw[0] = 1
+	for i := 1; i < 20; i++ {
+		pw[i] = pw[i-1] << 1
+	}
+	maxSz := pw[18] + 1
+	for i := range b {
+		b[i] = make([]bool, maxSz)
+	}
+	for _, val := range t.arr {
+		b[0][val+pw[17]] = true
+	}
+	ans = 30
+	dfs(0, 0)
+	sort.Ints(v)
+	return ans, append([]int(nil), v...)
+}
+
+func buildInput(t test) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t.n))
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func parseOutput(out string) (int, []int, bool) {
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(out)))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return 0, nil, false
+	}
+	k, err := strconv.Atoi(scanner.Text())
+	if err != nil || k < 0 {
+		return 0, nil, false
+	}
+	vals := make([]int, 0, k)
+	for scanner.Scan() {
+		v, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return 0, nil, false
+		}
+		vals = append(vals, v)
+	}
+	if len(vals) != k {
+		return 0, nil, false
+	}
+	sort.Ints(vals)
+	return k, vals, true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	tests := genTests()
+	for i, t := range tests {
+		input := buildInput(t)
+		out, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		gotK, gotArr, ok := parseOutput(out)
+		if !ok {
+			fmt.Printf("test %d: bad output\n", i+1)
+			os.Exit(1)
+		}
+		expK, expArr := solveRef(t)
+		if gotK != expK || len(gotArr) != len(expArr) {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%v %v\noutput:%d %v\n", i+1, input, expK, expArr, gotK, gotArr)
+			os.Exit(1)
+		}
+		for j := range gotArr {
+			if gotArr[j] != expArr[j] {
+				fmt.Printf("test %d failed\ninput:\n%s\nexpected:%v %v\noutput:%d %v\n", i+1, input, expK, expArr, gotK, gotArr)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to validate binary solutions for problem 949A
- add verifierB.go to validate problem 949B
- add verifierC.go to validate problem 949C
- add verifierD.go to validate problem 949D
- add verifierE.go to validate problem 949E

All verifiers generate 100 random test cases and compare the candidate output with the reference implementation derived from the provided Go solutions.

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68840874764883248d7fc6387806aa5d