### PR TITLE
Add Go verifier for CF 948A

### DIFF
--- a/0-999/900-999/940-949/948/testcasesA.txt
+++ b/0-999/900-999/940-949/948/testcasesA.txt
@@ -1,0 +1,110 @@
+1 1 .
+1 1 S
+1 1 W
+1 2 SW
+1 2 WS
+2 2 SW WS
+2 2 S. .W
+2 2 SS WW
+3 3 ... ... ...
+2 3 S.W W.S
+3 2 SW SW .S
+5 5 S.SWS WSWW. WS.WW .SS.S WSSWS
+5 4 .W.W .SS. .W.. .SSW .W.S
+1 2 SW
+5 3 WS. WSS WW. WSW .SS
+3 2 .W WW S.
+4 4 SW.W WSWW SWSW W.WS
+5 4 W.WW .SS. S..S S..S WW.S
+2 3 W.W SWW
+2 4 .SWW W...
+3 1 S S W
+3 3 SWW SW. ..S
+2 5 .SWW. S.WWS
+3 1 S W W
+1 5 WW.W.
+1 5 WWSWS
+1 1 .
+3 5 S..S. WSS.. .W...
+4 1 W . W W
+5 5 ...S. .W..S S..W. WSSWS WSWWS
+5 3 .SW WWS SWS ..W W.W
+4 5 SSSS. .S... SWSS. S.WSW
+4 2 .S .W .. ..
+3 3 SS. W.. .S.
+5 2 SW SS .S W. .S
+4 4 SS.. .W.. WS.W S..S
+3 5 S..W. .SW.W WS.S.
+2 4 S.SS .SWW
+5 3 W.W SWS WS. SS. WSS
+4 2 .W W. WW WW
+4 1 S . S S
+1 5 ..S.S
+3 5 S.WW. W..SW WW.SW
+5 3 WW. WS. S.. ..S WWS
+3 3 SWW .W. W.W
+5 3 W.W ..S .WW ..S .SW
+5 3 WWS WS. ... SSS WSS
+4 4 .SSS SSSW ...W ...W
+2 4 W... WSSW
+5 1 S S . W .
+5 2 WS W. .W SW .S
+4 3 W.. W.S WW. WS.
+2 4 .S.W SSWS
+4 5 WWSWW .S.WW S..SS W.SWS
+1 2 W.
+1 2 S.
+4 5 .WSSW .WSSS SSS.S ..SSW
+5 2 .S .. W. W. WS
+2 5 ..W.. SWS.S
+2 1 W W
+2 2 SW ..
+2 4 SWWW SSSW
+1 1 .
+1 4 .WW.
+5 5 WSW.. .S... S..SS W..W. SWWWS
+4 2 WW SS SS S.
+2 1 S S
+4 5 .W.WS .WWWS .S.S. .S.WS
+3 4 SSSS WS.. ...W
+5 4 S.WW WS.W .WWW SW.W W...
+1 4 .SSW
+5 2 WW S. .. SW WW
+3 3 .SS .SW S..
+2 4 WWWS SW..
+5 1 W W . S .
+2 3 .WS S.S
+1 5 SSSS.
+2 3 ..W .W.
+5 1 W W S . S
+1 1 .
+1 2 S.
+2 3 SWS WW.
+3 1 . S .
+2 1 W W
+2 2 SS ..
+5 5 SS.W. WS.S. W..WW SW.SS W.SWW
+3 3 .WS .WW .S.
+1 4 S.SS
+1 3 S.W
+5 2 SS .S W. SS SW
+5 5 WSW.W .SS.. ..SS. WSWS. .S..S
+5 4 WSS. ..WW SWW. SWW. .W..
+1 3 .SS
+1 2 SS
+5 2 S. W. .. S. SW
+5 5 ..SWW SWSW. .SWS. WS.WS W..SW
+3 4 SWSW .WSW W...
+4 1 S S . .
+1 5 S.W.W
+2 3 WWS ...
+3 5 WS.SS W.W.W S.W..
+3 3 .SS ..S S..
+3 2 SW W. S.
+2 2 S. S.
+2 1 W W
+3 2 S. WS SS
+4 3 WS. W.W .S. ..W
+5 2 WW .. .. WW SS
+4 4 WS.. W.SS .WS. SSS.
+2 4 SWS. WSSW

--- a/0-999/900-999/940-949/948/verifierA.go
+++ b/0-999/900-999/940-949/948/verifierA.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	n, m     int
+	grid     []string
+	solvable bool
+}
+
+func parseTestCases(path string) ([]testCase, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	var cases []testCase
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		tokens := strings.Fields(line)
+		if len(tokens) < 3 {
+			return nil, fmt.Errorf("bad testcase line: %s", line)
+		}
+		n, err := strconv.Atoi(tokens[0])
+		if err != nil {
+			return nil, fmt.Errorf("bad n: %v", err)
+		}
+		m, err := strconv.Atoi(tokens[1])
+		if err != nil {
+			return nil, fmt.Errorf("bad m: %v", err)
+		}
+		if len(tokens) != 2+n {
+			return nil, fmt.Errorf("expected %d rows, got %d", n, len(tokens)-2)
+		}
+		grid := make([]string, n)
+		for i := 0; i < n; i++ {
+			row := tokens[2+i]
+			if len(row) != m {
+				return nil, fmt.Errorf("row %d length mismatch", i)
+			}
+			grid[i] = row
+		}
+		// compute solvable
+		dirs := [][2]int{{0, -1}, {0, 1}, {-1, 0}, {1, 0}}
+		solvable := true
+		for i := 0; i < n && solvable; i++ {
+			for j := 0; j < m; j++ {
+				if grid[i][j] == 'W' {
+					for _, d := range dirs {
+						ni, nj := i+d[0], j+d[1]
+						if ni >= 0 && ni < n && nj >= 0 && nj < m {
+							if grid[ni][nj] == 'S' {
+								solvable = false
+								break
+							}
+						}
+					}
+				}
+			}
+		}
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "%d %d\n", n, m)
+		for _, row := range grid {
+			buf.WriteString(row)
+			buf.WriteByte('\n')
+		}
+		cases = append(cases, testCase{input: buf.String(), n: n, m: m, grid: grid, solvable: solvable})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return cases, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return string(out), nil
+}
+
+func verifyOutput(out string, tc testCase) error {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) == 0 {
+		return fmt.Errorf("no output")
+	}
+	first := strings.TrimSpace(lines[0])
+	if first == "No" || first == "NO" || first == "no" {
+		if tc.solvable {
+			return fmt.Errorf("expected Yes, got No")
+		}
+		return nil
+	}
+	if !(first == "Yes" || first == "YES" || first == "yes") {
+		return fmt.Errorf("first line should be Yes or No")
+	}
+	if !tc.solvable {
+		return fmt.Errorf("expected No, got Yes")
+	}
+	if len(lines)-1 != tc.n {
+		return fmt.Errorf("expected %d grid lines, got %d", tc.n, len(lines)-1)
+	}
+	outGrid := make([][]byte, tc.n)
+	for i := 0; i < tc.n; i++ {
+		row := strings.TrimSpace(lines[i+1])
+		if len(row) != tc.m {
+			return fmt.Errorf("row %d length mismatch", i)
+		}
+		outGrid[i] = []byte(row)
+		for j := 0; j < tc.m; j++ {
+			ch := outGrid[i][j]
+			inCh := tc.grid[i][j]
+			if inCh == 'S' || inCh == 'W' {
+				if ch != inCh {
+					return fmt.Errorf("cell %d,%d changed from %c to %c", i, j, inCh, ch)
+				}
+			} else {
+				if ch != '.' && ch != 'D' {
+					return fmt.Errorf("invalid char %c at %d,%d", ch, i, j)
+				}
+			}
+		}
+	}
+	dirs := [][2]int{{0, -1}, {0, 1}, {-1, 0}, {1, 0}}
+	for i := 0; i < tc.n; i++ {
+		for j := 0; j < tc.m; j++ {
+			if outGrid[i][j] == 'W' {
+				for _, d := range dirs {
+					ni, nj := i+d[0], j+d[1]
+					if ni >= 0 && ni < tc.n && nj >= 0 && nj < tc.m {
+						if outGrid[ni][nj] == 'S' {
+							return fmt.Errorf("wolf at %d,%d adjacent to sheep", i, j)
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, err := filepath.Abs(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	cases, err := parseTestCases("testcasesA.txt")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	for i, tc := range cases {
+		out, err := runBinary(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if err := verifyOutput(out, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s\n", i+1, err, tc.input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to check arbitrary binaries for 948A
- provide 110 input cases in testcasesA.txt for the verifier

## Testing
- `go run verifierA.go ./candidate`

------
https://chatgpt.com/codex/tasks/task_e_688407e84120832488bc06e35dc01e65