### PR TITLE
Add Go solution for 1627D

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1627/1627D.go
+++ b/1000-1999/1600-1699/1620-1629/1627/1627D.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const MAX = 1000000
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	fmt.Fscan(reader, &n)
+
+	present := make([]bool, MAX+1)
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(reader, &x)
+		present[x] = true
+	}
+
+	cnt := make([]int, MAX+1)
+	gval := make([]int, MAX+1)
+
+	for g := 1; g <= MAX; g++ {
+		val := 0
+		c := 0
+		for m := g; m <= MAX; m += g {
+			if present[m] {
+				c++
+				if val == 0 {
+					val = m
+				} else {
+					val = gcd(val, m)
+				}
+			}
+		}
+		cnt[g] = c
+		gval[g] = val
+	}
+
+	ans := 0
+	for g := 1; g <= MAX; g++ {
+		if cnt[g] >= 2 && gval[g] == g && !present[g] {
+			ans++
+		}
+	}
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- add Go solution for 1627D (Not Adding)
- compute gcd of multiples using sieve
- count new numbers produced by gcd operations

## Testing
- `go build 1000-1999/1600-1699/1620-1629/1627/1627D.go`
- `go vet 1000-1999/1600-1699/1620-1629/1627/1627D.go`


------
https://chatgpt.com/codex/tasks/task_e_6884350d5cb08324bae77c6020136a89