### PR TITLE
Add naive Go solution for 1672I

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1672/1672I.go
+++ b/1000-1999/1600-1699/1670-1679/1672/1672I.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	fmt.Fscan(reader, &n)
+	p := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &p[i])
+	}
+	ans := 0
+	for len(p) > 0 {
+		minDiff := 1 << 30
+		idx := 0
+		for i, v := range p {
+			d := abs(i + 1 - v)
+			if d < minDiff {
+				minDiff = d
+				idx = i
+			}
+		}
+		if minDiff > ans {
+			ans = minDiff
+		}
+		val := p[idx]
+		p = append(p[:idx], p[idx+1:]...)
+		for i := 0; i < len(p); i++ {
+			if p[i] > val {
+				p[i]--
+			}
+		}
+	}
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem I (naive approach)

## Testing
- `go run 1000-1999/1600-1699/1670-1679/1672/1672I.go < test.in`

------
https://chatgpt.com/codex/tasks/task_e_68840459ad708324997fc6c146739780