### PR TITLE
Add verifiers for contest 939

### DIFF
--- a/0-999/900-999/930-939/939/verifierA.go
+++ b/0-999/900-999/930-939/939/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	in  string
+	out string
+}
+
+func solve(n int, f []int) string {
+	for i := 1; i <= n; i++ {
+		j := f[i]
+		if j >= 1 && j <= n {
+			k := f[j]
+			if k >= 1 && k <= n && f[k] == i {
+				return "YES"
+			}
+		}
+	}
+	return "NO"
+}
+
+func generateTests() []test {
+	rand.Seed(1)
+	tests := make([]test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(8) + 2 // 2..9
+		f := make([]int, n+1)
+		for j := 1; j <= n; j++ {
+			x := rand.Intn(n) + 1
+			if x == j {
+				x = (x % n) + 1
+			}
+			f[j] = x
+		}
+		if i%2 == 0 && n >= 3 {
+			f[1] = 2
+			f[2] = 3
+			f[3] = 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 1; j <= n; j++ {
+			if j > 1 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", f[j])
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, test{in: sb.String(), out: solve(n, f)})
+	}
+	return tests
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return stderr.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := run(bin, t.in)
+		if err != nil {
+			fmt.Printf("Test %d failed to run: %v\n", i+1, err)
+			fmt.Print(out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != t.out {
+			fmt.Printf("Test %d failed. Expected %q, got %q. Input:\n%s", i+1, t.out, out, t.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(tests))
+}

--- a/0-999/900-999/930-939/939/verifierB.go
+++ b/0-999/900-999/930-939/939/verifierB.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	in  string
+	out string
+}
+
+func solveB(n int64, a []int64) string {
+	bestIdx := 1
+	bestCount := n / a[0]
+	maxTransport := bestCount * a[0]
+	for i := 1; i < len(a); i++ {
+		cnt := n / a[i]
+		transported := cnt * a[i]
+		if transported > maxTransport {
+			maxTransport = transported
+			bestIdx = i + 1
+			bestCount = cnt
+		}
+	}
+	return fmt.Sprintf("%d %d", bestIdx, bestCount)
+}
+
+func generateTests() []test {
+	rand.Seed(2)
+	tests := make([]test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Int63n(1_000_000) + 1
+		k := rand.Intn(10) + 1
+		a := make([]int64, k)
+		for j := range a {
+			a[j] = rand.Int63n(1_000_000) + 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j := 0; j < k; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", a[j])
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, test{in: sb.String(), out: solveB(n, a)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return stderr.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := run(bin, t.in)
+		if err != nil {
+			fmt.Printf("Test %d failed to run: %v\n", i+1, err)
+			fmt.Print(out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != t.out {
+			fmt.Printf("Test %d failed. Expected %q, got %q. Input:\n%s", i+1, t.out, out, t.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(tests))
+}

--- a/0-999/900-999/930-939/939/verifierC.go
+++ b/0-999/900-999/930-939/939/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	in  string
+	out string
+}
+
+func solveC(n int, a []int64, s, f int) string {
+	k := f - s
+	prefix := make([]int64, n+k+1)
+	for i := 1; i <= n+k; i++ {
+		prefix[i] = prefix[i-1] + a[(i-1)%n]
+	}
+	bestSum := int64(-1)
+	bestTime := 1
+	for start := 1; start <= n; start++ {
+		sum := prefix[start+k-1] - prefix[start-1]
+		time := (s-start+n)%n + 1
+		if sum > bestSum || (sum == bestSum && time < bestTime) {
+			bestSum = sum
+			bestTime = time
+		}
+	}
+	return fmt.Sprintf("%d", bestTime)
+}
+
+func generateTests() []test {
+	rand.Seed(3)
+	tests := make([]test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(9) + 2 // 2..10
+		a := make([]int64, n)
+		for j := range a {
+			a[j] = rand.Int63n(100) + 1
+		}
+		k := rand.Intn(n-1) + 1
+		s := rand.Intn(n-k+1) + 1
+		f := s + k
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", a[j])
+		}
+		sb.WriteByte('\n')
+		fmt.Fprintf(&sb, "%d %d\n", s, f)
+		tests = append(tests, test{in: sb.String(), out: solveC(n, a, s, f)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return stderr.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := run(bin, t.in)
+		if err != nil {
+			fmt.Printf("Test %d failed to run: %v\n", i+1, err)
+			fmt.Print(out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != t.out {
+			fmt.Printf("Test %d failed. Expected %q, got %q. Input:\n%s", i+1, t.out, out, t.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(tests))
+}

--- a/0-999/900-999/930-939/939/verifierD.go
+++ b/0-999/900-999/930-939/939/verifierD.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	in  string
+	out string
+}
+
+func solveD(n int, s1, s2 string) string {
+	parent := make([]int, 27)
+	for i := 1; i <= 26; i++ {
+		parent[i] = i
+	}
+	var ops [][2]int
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	union := func(a, b int) {
+		pa := find(a)
+		pb := find(b)
+		if pa != pb {
+			parent[pa] = pb
+		}
+	}
+	for i := 0; i < n; i++ {
+		a := int(s1[i] - 'a' + 1)
+		b := int(s2[i] - 'a' + 1)
+		if a != b && find(a) != find(b) {
+			ops = append(ops, [2]int{a, b})
+			union(a, b)
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d", len(ops))
+	for _, op := range ops {
+		sb.WriteByte('\n')
+		fmt.Fprintf(&sb, "%c %c", rune(op[0]-1+'a'), rune(op[1]-1+'a'))
+	}
+	return sb.String()
+}
+
+func generateTests() []test {
+	rand.Seed(4)
+	tests := make([]test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		b := []byte("abcdef")
+		s1b := make([]byte, n)
+		s2b := make([]byte, n)
+		for j := 0; j < n; j++ {
+			s1b[j] = b[rand.Intn(len(b))]
+			s2b[j] = b[rand.Intn(len(b))]
+		}
+		s1 := string(s1b)
+		s2 := string(s2b)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n%s\n%s\n", n, s1, s2)
+		tests = append(tests, test{in: sb.String(), out: solveD(n, s1, s2)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return stderr.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := run(bin, t.in)
+		if err != nil {
+			fmt.Printf("Test %d failed to run: %v\n", i+1, err)
+			fmt.Print(out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != t.out {
+			fmt.Printf("Test %d failed. Expected %q, got %q. Input:\n%s", i+1, t.out, out, t.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(tests))
+}

--- a/0-999/900-999/930-939/939/verifierE.go
+++ b/0-999/900-999/930-939/939/verifierE.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	in  string
+	out string
+}
+
+type op struct {
+	typ int
+	val int64
+}
+
+func solveE(ops []op) string {
+	Q := len(ops)
+	a := make([]int64, Q+5)
+	var idx, cnt int
+	var sum int64
+	var Max int64
+	var aver float64 = 1e18
+	results := make([]string, 0)
+	for _, o := range ops {
+		if o.typ == 1 {
+			idx++
+			a[idx] = o.val
+			Max = o.val
+		} else {
+			aver = float64(sum+a[idx]) / float64(cnt+1)
+			for cnt < idx-1 {
+				tmp := float64(sum+a[idx]+a[cnt+1]) / float64(cnt+2)
+				if tmp < aver {
+					aver = tmp
+					sum += a[cnt+1]
+					cnt++
+				} else {
+					break
+				}
+			}
+			diff := float64(Max) - aver
+			results = append(results, fmt.Sprintf("%.8f", diff))
+		}
+	}
+	return strings.Join(results, "\n")
+}
+
+func generateTests() []test {
+	rand.Seed(5)
+	tests := make([]test, 0, 100)
+	for i := 0; i < 100; i++ {
+		Q := rand.Intn(10) + 1
+		ops := make([]op, 0, Q)
+		hasQuery := false
+		inserted := 0
+		for j := 0; j < Q; j++ {
+			if inserted == 0 || rand.Intn(2) == 0 {
+				v := rand.Int63n(100) + 1
+				ops = append(ops, op{typ: 1, val: v})
+				inserted++
+			} else {
+				ops = append(ops, op{typ: 2})
+				hasQuery = true
+			}
+		}
+		if !hasQuery {
+			ops = append(ops, op{typ: 2})
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", len(ops))
+		for _, o := range ops {
+			if o.typ == 1 {
+				fmt.Fprintf(&sb, "1 %d\n", o.val)
+			} else {
+				sb.WriteString("2\n")
+			}
+		}
+		tests = append(tests, test{in: sb.String(), out: solveE(ops)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return stderr.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := run(bin, t.in)
+		if err != nil {
+			fmt.Printf("Test %d failed to run: %v\n", i+1, err)
+			fmt.Print(out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != t.out {
+			fmt.Printf("Test %d failed. Expected %q, got %q. Input:\n%s", i+1, t.out, out, t.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(tests))
+}

--- a/0-999/900-999/930-939/939/verifierF.go
+++ b/0-999/900-999/930-939/939/verifierF.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	in  string
+	out string
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveF(n int, intervals [][2]int) string {
+	maxT := 2 * n
+	allowed := make([]bool, maxT+1)
+	for _, p := range intervals {
+		for t := p[0]; t <= p[1] && t <= maxT; t++ {
+			allowed[t] = true
+		}
+	}
+	inf := int(1e9)
+	offset := n
+	curA := make([]int, 2*n+1)
+	curB := make([]int, 2*n+1)
+	for i := range curA {
+		curA[i] = inf
+		curB[i] = inf
+	}
+	curA[offset] = 0
+	for t := 0; t < maxT; t++ {
+		nextA := make([]int, 2*n+1)
+		nextB := make([]int, 2*n+1)
+		for i := range nextA {
+			nextA[i] = inf
+			nextB[i] = inf
+		}
+		for d := 0; d <= 2*n; d++ {
+			if curA[d] < inf {
+				if d+1 <= 2*n {
+					nextA[d+1] = min(nextA[d+1], curA[d])
+				}
+				if allowed[t] && d-1 >= 0 {
+					nextB[d-1] = min(nextB[d-1], curA[d]+1)
+				}
+			}
+			if curB[d] < inf {
+				if d-1 >= 0 {
+					nextB[d-1] = min(nextB[d-1], curB[d])
+				}
+				if allowed[t] && d+1 <= 2*n {
+					nextA[d+1] = min(nextA[d+1], curB[d]+1)
+				}
+			}
+		}
+		curA = nextA
+		curB = nextB
+	}
+	ans := min(curA[offset], curB[offset])
+	if ans >= inf {
+		return "Hungry"
+	}
+	return fmt.Sprintf("Full\n%d", ans)
+}
+
+func generateTests() []test {
+	rand.Seed(6)
+	tests := make([]test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(5) + 1
+		k := rand.Intn(4) + 1
+		intervals := make([][2]int, k)
+		for j := 0; j < k; j++ {
+			l := rand.Intn(2*n + 1)
+			r := l + rand.Intn(2*n-l+1)
+			intervals[j] = [2]int{l, r}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for _, p := range intervals {
+			fmt.Fprintf(&sb, "%d %d\n", p[0], p[1])
+		}
+		tests = append(tests, test{in: sb.String(), out: solveF(n, intervals)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return stderr.String(), err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := run(bin, t.in)
+		if err != nil {
+			fmt.Printf("Test %d failed to run: %v\n", i+1, err)
+			fmt.Print(out)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != t.out {
+			fmt.Printf("Test %d failed. Expected %q, got %q. Input:\n%s", i+1, t.out, out, t.in)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed!\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 939 problems A–F
- each verifier generates 100 deterministic tests and checks any binary

## Testing
- `GO111MODULE=off go build verifierA.go`
- `GO111MODULE=off go build verifierB.go`
- `GO111MODULE=off go build verifierC.go`
- `GO111MODULE=off go build verifierD.go`
- `GO111MODULE=off go build verifierE.go`
- `GO111MODULE=off go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688402fb78408324b78b2d08b3fabae0