### PR TITLE
Add verifiers for Codeforces contest 938

### DIFF
--- a/0-999/900-999/930-939/938/verifierA.go
+++ b/0-999/900-999/930-939/938/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	s string
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("%d\n%s\n", len(t.s), t.s)
+}
+
+func runExe(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "938A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(0)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(100) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteRune(letters[rand.Intn(len(letters))])
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	tests = append(tests, Test{"aeiouy"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.Input())
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/930-939/938/verifierB.go
+++ b/0-999/900-999/930-939/938/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	pos []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(len(t.pos)))
+	sb.WriteByte('\n')
+	for i, v := range t.pos {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runExe(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "938B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(1)
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		vals := make([]int, n)
+		for j := 0; j < n; j++ {
+			vals[j] = rand.Intn(1000000-2) + 2
+		}
+		sort.Ints(vals)
+		tests = append(tests, Test{vals})
+	}
+	tests = append(tests, Test{[]int{500000}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.Input())
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/930-939/938/verifierC.go
+++ b/0-999/900-999/930-939/938/verifierC.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	vals []int64
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(len(t.vals)))
+	sb.WriteByte('\n')
+	for _, v := range t.vals {
+		sb.WriteString(strconv.FormatInt(v, 10))
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runExe(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "938C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(2)
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		t := rand.Intn(3) + 1
+		vals := make([]int64, t)
+		for j := 0; j < t; j++ {
+			vals[j] = int64(rand.Intn(100000))
+		}
+		tests = append(tests, Test{vals})
+	}
+	tests = append(tests, Test{[]int64{0}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.Input())
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/930-939/938/verifierD.go
+++ b/0-999/900-999/930-939/938/verifierD.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Edge struct {
+	u, v int
+	w    int
+}
+
+type Test struct {
+	n     int
+	edges []Edge
+	a     []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, len(t.edges)))
+	for _, e := range t.edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.u, e.v, e.w))
+	}
+	for i, v := range t.a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runExe(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "938D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(3)
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(4) + 2
+		m := rand.Intn(n*(n-1)/2-n+1) + n - 1
+		edges := make([]Edge, 0, m)
+		used := map[[2]int]bool{}
+		for j := 1; j < n; j++ {
+			w := rand.Intn(20) + 1
+			edges = append(edges, Edge{j, j + 1, w})
+			used[[2]int{j, j + 1}] = true
+		}
+		for len(edges) < m {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			if u > v {
+				u, v = v, u
+			}
+			if used[[2]int{u, v}] {
+				continue
+			}
+			used[[2]int{u, v}] = true
+			w := rand.Intn(20) + 1
+			edges = append(edges, Edge{u, v, w})
+		}
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rand.Intn(50) + 1
+		}
+		tests = append(tests, Test{n, edges, a})
+	}
+	// simple case n=2
+	tests = append(tests, Test{2, []Edge{{1, 2, 5}}, []int{3, 4}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.Input())
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/930-939/938/verifierE.go
+++ b/0-999/900-999/930-939/938/verifierE.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	arr []int64
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(len(t.arr)))
+	sb.WriteByte('\n')
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runExe(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "938E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(4)
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(8) + 1
+		arr := make([]int64, n)
+		for j := range arr {
+			arr[j] = int64(rand.Intn(1000) + 1)
+		}
+		tests = append(tests, Test{arr})
+	}
+	tests = append(tests, Test{[]int64{1}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.Input())
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/930-939/938/verifierF.go
+++ b/0-999/900-999/930-939/938/verifierF.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	s string
+}
+
+func (t Test) Input() string {
+	return t.s + "\n"
+}
+
+func runExe(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "938F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(5)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(15) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteRune(letters[rand.Intn(len(letters))])
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	tests = append(tests, Test{"abc"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.Input())
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/930-939/938/verifierG.go
+++ b/0-999/900-999/930-939/938/verifierG.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Edge struct {
+	u, v int
+	w    int
+}
+
+type Query struct {
+	typ int
+	x   int
+	y   int
+	w   int
+}
+
+type Test struct {
+	n     int
+	edges []Edge
+	qs    []Query
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", t.n, len(t.edges)))
+	for _, e := range t.edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.u, e.v, e.w))
+	}
+	sb.WriteString(strconv.Itoa(len(t.qs)))
+	sb.WriteByte('\n')
+	for _, q := range t.qs {
+		if q.typ == 1 {
+			sb.WriteString(fmt.Sprintf("1 %d %d %d\n", q.x, q.y, q.w))
+		} else if q.typ == 2 {
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", q.x, q.y))
+		} else {
+			sb.WriteString(fmt.Sprintf("3 %d %d\n", q.x, q.y))
+		}
+	}
+	return sb.String()
+}
+
+func runExe(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "938G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(6)
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(3) + 2
+		edges := make([]Edge, 0, n-1)
+		for j := 1; j < n; j++ {
+			edges = append(edges, Edge{j, j + 1, rand.Intn(20)})
+		}
+		qs := make([]Query, 0, rand.Intn(4)+1)
+		for j := 0; j < cap(qs); j++ {
+			x := rand.Intn(n) + 1
+			y := rand.Intn(n) + 1
+			for y == x {
+				y = rand.Intn(n) + 1
+			}
+			if x > y {
+				x, y = y, x
+			}
+			qs = append(qs, Query{typ: 3, x: x, y: y})
+		}
+		tests = append(tests, Test{n, edges, qs})
+	}
+	tests = append(tests, Test{2, []Edge{{1, 2, 1}}, []Query{{typ: 3, x: 1, y: 2}}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.Input())
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.Input())
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.Input(), exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 938 problems A–G
- each verifier builds a reference solution and runs 100+ generated tests against a candidate binary

## Testing
- `gofmt -w 0-999/900-999/930-939/938/verifier*.go`

------
https://chatgpt.com/codex/tasks/task_e_6884026f5bc88324861e56fd2a97ab4d