### PR TITLE
Add Go verifiers for contest 937

### DIFF
--- a/0-999/900-999/930-939/937/verifierA.go
+++ b/0-999/900-999/930-939/937/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	scores []int
+}
+
+func generateA(rng *rand.Rand) testCaseA {
+	n := rng.Intn(100) + 1 // 1..100
+	arr := make([]int, n)
+	hasPos := false
+	for i := range arr {
+		arr[i] = rng.Intn(601) // 0..600
+		if arr[i] > 0 {
+			hasPos = true
+		}
+	}
+	if !hasPos {
+		arr[0] = rng.Intn(600) + 1
+	}
+	return testCaseA{scores: arr}
+}
+
+func expectedA(tc testCaseA) int {
+	uniq := make(map[int]struct{})
+	for _, v := range tc.scores {
+		if v > 0 {
+			uniq[v] = struct{}{}
+		}
+	}
+	return len(uniq)
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, tc testCaseA) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", len(tc.scores))
+	for i, v := range tc.scores {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, v)
+	}
+	b.WriteByte('\n')
+	expected := fmt.Sprintf("%d", expectedA(tc))
+	got, err := run(bin, b.String())
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateA(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/930-939/937/verifierB.go
+++ b/0-999/900-999/930-939/937/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	p int
+	y int
+}
+
+func generateB(rng *rand.Rand) testCaseB {
+	p := rng.Intn(40) + 2     // 2..41
+	y := p + rng.Intn(60) + 1 // p+1 .. p+60
+	return testCaseB{p: p, y: y}
+}
+
+func expectedB(p, y int) int {
+	for cand := y; cand > p; cand-- {
+		limit := int(math.Sqrt(float64(cand)))
+		ok := true
+		for d := 2; d <= p && d <= limit; d++ {
+			if cand%d == 0 {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return cand
+		}
+	}
+	return -1
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, tc testCaseB) error {
+	input := fmt.Sprintf("%d %d\n", tc.p, tc.y)
+	expected := fmt.Sprintf("%d", expectedB(tc.p, tc.y))
+	got, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateB(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/930-939/937/verifierC.go
+++ b/0-999/900-999/930-939/937/verifierC.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	k float64
+	d float64
+	t float64
+}
+
+func generateC(rng *rand.Rand) testCaseC {
+	k := float64(rng.Intn(1000) + 1)
+	d := float64(rng.Intn(1000) + 1)
+	t := float64(rng.Intn(1000) + 1)
+	return testCaseC{k: k, d: d, t: t}
+}
+
+func expectedC(k, d, t float64) float64 {
+	cycle := math.Ceil(k/d) * d
+	totalNeed := 2 * t
+	perCycle := k + cycle
+	full := math.Floor(totalNeed / perCycle)
+	rem := totalNeed - perCycle*full
+	var extra float64
+	if rem <= 2*k {
+		extra = rem / 2
+	} else {
+		extra = k + (rem - 2*k)
+	}
+	return full*cycle + extra
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, tc testCaseC) error {
+	input := fmt.Sprintf("%g %g %g\n", tc.k, tc.d, tc.t)
+	expected := expectedC(tc.k, tc.d, tc.t)
+	gotStr, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	got, err := strconv.ParseFloat(strings.TrimSpace(gotStr), 64)
+	if err != nil {
+		return fmt.Errorf("invalid float output: %v", err)
+	}
+	if math.Abs(got-expected) > 1e-6 {
+		return fmt.Errorf("expected %.6f got %s", expected, gotStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateC(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/930-939/937/verifierD.go
+++ b/0-999/900-999/930-939/937/verifierD.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ---------------- Helpers to compute expected output -----------------
+
+type testCaseD struct {
+	n     int
+	edges [][]int
+	start int
+}
+
+func generateD(rng *rand.Rand) testCaseD {
+	n := rng.Intn(4) + 2 // 2..5
+	edges := make([][]int, n+1)
+	for i := 1; i <= n; i++ {
+		c := rng.Intn(n) // allow 0..n-1 edges
+		edges[i] = make([]int, c)
+		for j := 0; j < c; j++ {
+			v := rng.Intn(n) + 1
+			for v == i {
+				v = rng.Intn(n) + 1
+			}
+			edges[i][j] = v
+		}
+	}
+	start := rng.Intn(n) + 1
+	return testCaseD{n: n, edges: edges, start: start}
+}
+
+func solveD(tc testCaseD) (string, []int) {
+	n := tc.n
+	adj := tc.edges
+	vis := make([][2]bool, n+1)
+	path := []int{tc.start}
+	var ans []int
+	var found bool
+	var dfs func(u, mk int)
+	dfs = func(u, mk int) {
+		if found {
+			return
+		}
+		for _, v := range adj[u] {
+			if vis[v][mk^1] {
+				continue
+			}
+			vis[v][mk^1] = true
+			path = append(path, v)
+			if mk == 0 && len(adj[v]) == 0 {
+				ans = append([]int(nil), path...)
+				found = true
+				return
+			}
+			dfs(v, mk^1)
+			path = path[:len(path)-1]
+		}
+	}
+	dfs(tc.start, 0)
+	if found {
+		return "Win", ans
+	}
+	// tarjan to detect cycle
+	dfn := make([]int, n+1)
+	low := make([]int, n+1)
+	inStack := make([]bool, n+1)
+	stack := make([]int, 0)
+	timer := 0
+	maxComp := 0
+	var tarjan func(u int)
+	tarjan = func(u int) {
+		timer++
+		dfn[u] = timer
+		low[u] = timer
+		inStack[u] = true
+		stack = append(stack, u)
+		for _, v := range adj[u] {
+			if dfn[v] == 0 {
+				tarjan(v)
+				if low[v] < low[u] {
+					low[u] = low[v]
+				}
+			} else if inStack[v] {
+				if dfn[v] < low[u] {
+					low[u] = dfn[v]
+				}
+			}
+		}
+		if low[u] == dfn[u] {
+			cnt := 0
+			for {
+				w := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				inStack[w] = false
+				cnt++
+				if w == u {
+					break
+				}
+			}
+			if cnt > maxComp {
+				maxComp = cnt
+			}
+		}
+	}
+	tarjan(tc.start)
+	if maxComp > 1 {
+		return "Draw", nil
+	}
+	return "Lose", nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func formatInput(tc testCaseD) string {
+	var b strings.Builder
+	m := 0
+	for i := 1; i <= tc.n; i++ {
+		m += len(tc.edges[i])
+	}
+	fmt.Fprintf(&b, "%d %d\n", tc.n, m)
+	for i := 1; i <= tc.n; i++ {
+		fmt.Fprintf(&b, "%d", len(tc.edges[i]))
+		for _, v := range tc.edges[i] {
+			fmt.Fprintf(&b, " %d", v)
+		}
+		b.WriteByte('\n')
+	}
+	fmt.Fprintf(&b, "%d\n", tc.start)
+	return b.String()
+}
+
+func parsePath(line string) ([]int, error) {
+	if strings.TrimSpace(line) == "" {
+		return nil, fmt.Errorf("empty path line")
+	}
+	parts := strings.Fields(line)
+	res := make([]int, len(parts))
+	for i, p := range parts {
+		v, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = v
+	}
+	return res, nil
+}
+
+func runCase(bin string, tc testCaseD) error {
+	input := formatInput(tc)
+	expectedType, expectedPath := solveD(tc)
+	gotStr, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(strings.TrimSpace(gotStr), "\n")
+	if len(lines) == 0 {
+		return fmt.Errorf("no output")
+	}
+	outType := strings.TrimSpace(lines[0])
+	if outType != expectedType {
+		return fmt.Errorf("expected %s got %s", expectedType, outType)
+	}
+	if expectedType == "Win" {
+		if len(lines) < 2 {
+			return fmt.Errorf("missing path line")
+		}
+		path, err := parsePath(lines[1])
+		if err != nil {
+			return fmt.Errorf("bad path: %v", err)
+		}
+		if len(path) != len(expectedPath) {
+			return fmt.Errorf("expected path %v got %v", expectedPath, path)
+		}
+		for i := range path {
+			if path[i] != expectedPath[i] {
+				return fmt.Errorf("expected path %v got %v", expectedPath, path)
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateD(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/930-939/937/verifierE.go
+++ b/0-999/900-999/930-939/937/verifierE.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseE struct {
+	n           int
+	s           string
+	t           string
+	hasSolution bool
+}
+
+func isPerm(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	cnt := make([]int, 26)
+	for _, c := range a {
+		cnt[c-'a']++
+	}
+	for _, c := range b {
+		cnt[c-'a']--
+	}
+	for _, v := range cnt {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func generateE(rng *rand.Rand) testCaseE {
+	n := rng.Intn(10) + 1
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	sb := make([]byte, n)
+	tb := make([]byte, n)
+	for i := 0; i < n; i++ {
+		sb[i] = letters[rng.Intn(5)]
+	}
+	if rng.Intn(2) == 0 {
+		// permutation
+		tb = append([]byte(nil), sb...)
+		rng.Shuffle(n, func(i, j int) { tb[i], tb[j] = tb[j], tb[i] })
+	} else {
+		for i := 0; i < n; i++ {
+			tb[i] = letters[rng.Intn(5)]
+		}
+		for isPerm(string(sb), string(tb)) { // ensure not permutation
+			for i := 0; i < n; i++ {
+				tb[i] = letters[rng.Intn(5)]
+			}
+		}
+	}
+	hs := isPerm(string(sb), string(tb))
+	return testCaseE{n: n, s: string(sb), t: string(tb), hasSolution: hs}
+}
+
+func applyShift(p string, x int) string {
+	n := len(p)
+	if x < 0 || x > n {
+		return p
+	}
+	alpha := p[:n-x]
+	beta := p[n-x:]
+	// reverse beta
+	rb := []byte(beta)
+	for i, j := 0, len(rb)-1; i < j; i, j = i+1, j-1 {
+		rb[i], rb[j] = rb[j], rb[i]
+	}
+	return string(rb) + alpha
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, tc testCaseE) error {
+	input := fmt.Sprintf("%d\n%s\n%s\n", tc.n, tc.s, tc.t)
+	gotStr, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	scanner := bufio.NewScanner(strings.NewReader(gotStr))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	kStr := scanner.Text()
+	k, err := strconv.Atoi(kStr)
+	if err != nil {
+		return fmt.Errorf("invalid k")
+	}
+	if k == -1 {
+		if tc.hasSolution {
+			return fmt.Errorf("should be solvable")
+		}
+		if scanner.Scan() {
+			return fmt.Errorf("extra output after -1")
+		}
+		return nil
+	}
+	if !tc.hasSolution {
+		return fmt.Errorf("expected -1, got %d", k)
+	}
+	if k < 0 || k > 6100 {
+		return fmt.Errorf("invalid k value")
+	}
+	ops := make([]int, k)
+	for i := 0; i < k; i++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("missing op %d", i)
+		}
+		v, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("invalid op")
+		}
+		if v < 0 || v > tc.n {
+			return fmt.Errorf("op out of range")
+		}
+		ops[i] = v
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	cur := tc.s
+	for _, x := range ops {
+		cur = applyShift(cur, x)
+	}
+	if cur != tc.t {
+		return fmt.Errorf("result mismatch")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateE(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for Codeforces contest 937
- support running any binary or Go source
- each verifier generates 100 random tests and checks output

## Testing
- `go build 0-999/900-999/930-939/937/verifierA.go`
- `go build 0-999/900-999/930-939/937/verifierB.go`
- `go build 0-999/900-999/930-939/937/verifierC.go`
- `go build 0-999/900-999/930-939/937/verifierD.go`
- `go build 0-999/900-999/930-939/937/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_688401e34cd48324964356231684e23a