### PR TITLE
Add solution verifiers for Codeforces Round 933

### DIFF
--- a/0-999/900-999/930-939/933/verifierA.go
+++ b/0-999/900-999/930-939/933/verifierA.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedA(a []int) int {
+	n := len(a)
+	pre1 := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		pre1[i] = pre1[i-1]
+		if a[i-1] == 1 {
+			pre1[i]++
+		}
+	}
+	suf2 := make([]int, n+2)
+	for i := n; i >= 1; i-- {
+		suf2[i] = suf2[i+1]
+		if a[i-1] == 2 {
+			suf2[i]++
+		}
+	}
+	ans := 0
+	for r := 1; r <= n; r++ {
+		dp1, dp2 := 0, 0
+		for l := r; l >= 1; l-- {
+			x := a[l-1]
+			if x == 1 {
+				dp1++
+				if dp2 < dp1 {
+					dp2 = dp1
+				}
+			} else {
+				if dp2+1 > dp1+1 {
+					dp2 = dp2 + 1
+				} else {
+					dp2 = dp1 + 1
+				}
+			}
+			cand := pre1[l-1] + dp2 + suf2[r+1]
+			if cand > ans {
+				ans = cand
+			}
+		}
+	}
+	return ans
+}
+
+func generateCaseA(rng *rand.Rand) []int {
+	n := rng.Intn(2000) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		if rng.Intn(2) == 0 {
+			arr[i] = 1
+		} else {
+			arr[i] = 2
+		}
+	}
+	return arr
+}
+
+func runCaseA(bin string, arr []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := expectedA(arr)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	edge := [][]int{
+		{1}, {2}, {1, 1}, {2, 2}, {1, 2}, {2, 1},
+	}
+	for idx, arr := range edge {
+		if err := runCaseA(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		arr := generateCaseA(rng)
+		if err := runCaseA(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/930-939/933/verifierB.go
+++ b/0-999/900-999/930-939/933/verifierB.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func convertNegBase(p, k int64) []int64 {
+	if p == 0 {
+		return []int64{0}
+	}
+	digits := make([]int64, 0)
+	for p != 0 {
+		r := ((p % int64(k)) + int64(k)) % int64(k)
+		digits = append(digits, r)
+		p = (p - r) / -int64(k)
+	}
+	return digits
+}
+
+func generateCaseB(rng *rand.Rand) (int64, int64) {
+	p := rng.Int63n(1_000_000_000_000_000_000) + 1 // 1..1e18
+	k := int64(rng.Intn(1999) + 2)
+	return p, k
+}
+
+func runCaseB(bin string, p, k int64) error {
+	input := fmt.Sprintf("%d %d\n", p, k)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outFields := strings.Fields(out.String())
+	if len(outFields) == 1 && outFields[0] == "-1" {
+		expected := convertNegBase(p, k)
+		if len(expected) != 1 || expected[0] != -1 {
+			return fmt.Errorf("unexpected -1 output")
+		}
+		return nil
+	}
+	if len(outFields) < 1 {
+		return fmt.Errorf("no output")
+	}
+	var d int
+	if _, err := fmt.Sscan(outFields[0], &d); err != nil {
+		return fmt.Errorf("failed to read d: %v", err)
+	}
+	if d != len(outFields)-1 {
+		return fmt.Errorf("length mismatch")
+	}
+	digits := make([]int64, d)
+	for i := 0; i < d; i++ {
+		if _, err := fmt.Sscan(outFields[i+1], &digits[i]); err != nil {
+			return fmt.Errorf("failed to read digit %d", i)
+		}
+	}
+	expected := convertNegBase(p, k)
+	if len(expected) != len(digits) {
+		return fmt.Errorf("expected length %d got %d", len(expected), len(digits))
+	}
+	for i := range expected {
+		if expected[i] != digits[i] {
+			return fmt.Errorf("digit %d expected %d got %d", i, expected[i], digits[i])
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	edge := [][2]int64{{0, 2}, {1, 2}, {12345, 2}, {12345, 3}, {999999999999999999, 2000}}
+	for idx, e := range edge {
+		if err := runCaseB(bin, e[0], e[1]); err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	for i := 0; i < 100; i++ {
+		p, k := generateCaseB(rng)
+		if err := runCaseB(bin, p, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/930-939/933/verifierC.go
+++ b/0-999/900-999/930-939/933/verifierC.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Circle struct{ x, y, r float64 }
+
+type Point struct{ x, y float64 }
+
+const eps = 1e-9
+
+func intersections(a, b Circle) []Point {
+	dx := b.x - a.x
+	dy := b.y - a.y
+	d := math.Hypot(dx, dy)
+	if d > a.r+b.r+eps || d < math.Abs(a.r-b.r)-eps || d == 0 {
+		return nil
+	}
+	alpha := (a.r*a.r - b.r*b.r + d*d) / (2 * d)
+	h2 := a.r*a.r - alpha*alpha
+	if h2 < eps {
+		h2 = 0
+	}
+	xm := a.x + alpha*dx/d
+	ym := a.y + alpha*dy/d
+	if h2 == 0 {
+		return []Point{{xm, ym}}
+	}
+	h := math.Sqrt(h2)
+	rx := -dy * h / d
+	ry := dx * h / d
+	return []Point{{xm + rx, ym + ry}, {xm - rx, ym - ry}}
+}
+
+func addPoint(pts []Point, p Point) ([]Point, int) {
+	for i, q := range pts {
+		if (p.x-q.x)*(p.x-q.x)+(p.y-q.y)*(p.y-q.y) < eps*eps {
+			return pts, i
+		}
+	}
+	return append(pts, p), len(pts)
+}
+
+func find(par []int, x int) int {
+	if par[x] != x {
+		par[x] = find(par, par[x])
+	}
+	return par[x]
+}
+
+func union(par []int, x, y int) {
+	rx := find(par, x)
+	ry := find(par, y)
+	if rx != ry {
+		par[ry] = rx
+	}
+}
+
+func expectedC(n int, circles []Circle) int {
+	points := make([]Point, 0)
+	sets := make([]map[int]struct{}, n)
+	for i := 0; i < n; i++ {
+		sets[i] = make(map[int]struct{})
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			for _, p := range intersections(circles[i], circles[j]) {
+				var idx int
+				points, idx = addPoint(points, p)
+				sets[i][idx] = struct{}{}
+				sets[j][idx] = struct{}{}
+			}
+		}
+	}
+	V := len(points)
+	E := 0
+	loops := 0
+	for i := 0; i < n; i++ {
+		if len(sets[i]) == 0 {
+			loops++
+			E++
+		} else {
+			E += len(sets[i])
+		}
+	}
+	V += loops
+	parent := make([]int, n)
+	for i := 0; i < n; i++ {
+		parent[i] = i
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			for idx := range sets[i] {
+				if _, ok := sets[j][idx]; ok {
+					union(parent, i, j)
+					break
+				}
+			}
+		}
+	}
+	comp := make(map[int]struct{})
+	for i := 0; i < n; i++ {
+		comp[find(parent, i)] = struct{}{}
+	}
+	C := len(comp)
+	return E - V + C + 1
+}
+
+func generateCaseC(rng *rand.Rand) (int, []Circle) {
+	n := rng.Intn(3) + 1
+	circles := make([]Circle, n)
+	used := make(map[[3]int]struct{})
+	for i := 0; i < n; i++ {
+		for {
+			x := rng.Intn(21) - 10
+			y := rng.Intn(21) - 10
+			r := rng.Intn(10) + 1
+			key := [3]int{x, y, r}
+			if _, ok := used[key]; !ok {
+				used[key] = struct{}{}
+				circles[i] = Circle{float64(x), float64(y), float64(r)}
+				break
+			}
+		}
+	}
+	return n, circles
+}
+
+func runCaseC(bin string, n int, circles []Circle) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, c := range circles {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", int(c.x), int(c.y), int(c.r)))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := expectedC(n, circles)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, circles := generateCaseC(rng)
+		if err := runCaseC(bin, n, circles); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/930-939/933/verifierD.go
+++ b/0-999/900-999/930-939/933/verifierD.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+const (
+	inv2  int64 = 500000004
+	inv6  int64 = 166666668
+	inv30 int64 = 233333335
+	inv42 int64 = 23809524
+)
+
+func sum2(n int64) int64 {
+	n %= MOD
+	return n * (n + 1) % MOD * (2*n + 1) % MOD * inv6 % MOD
+}
+
+func sum4(n int64) int64 {
+	n0 := n % MOD
+	a := n0 * (n0 + 1) % MOD * (2*n0 + 1) % MOD
+	t := n0 * n0 % MOD
+	b := (3*t%MOD + 3*n0 - 1) % MOD
+	return a * b % MOD * inv30 % MOD
+}
+
+func sum6(n int64) int64 {
+	n0 := n % MOD
+	a := n0 * (n0 + 1) % MOD * (2*n0 + 1) % MOD
+	t1 := n0 * n0 % MOD
+	t2 := t1 * t1 % MOD
+	t3 := t2 * 3 % MOD
+	t4 := t1 * n0 % MOD
+	t5 := t4 * 6 % MOD
+	b := (t3 + t5 - 3*n0 + 1) % MOD
+	return a * b % MOD * inv42 % MOD
+}
+
+func expectedD(m int64) int64 {
+	sqrtM := int64(math.Sqrt(float64(m)))
+	var S0, S1, S2, S3 int64
+	for x := int64(0); x <= sqrtM; x++ {
+		rX := x * x
+		if rX > m {
+			break
+		}
+		yMax := int64(math.Sqrt(float64(m - rX)))
+		if x == 0 {
+			S0 = (S0 + 1) % MOD
+			continue
+		}
+		x2 := rX % MOD
+		x4 := x2 * x2 % MOD
+		x6 := x4 * x2 % MOD
+		S0 = (S0 + 4) % MOD
+		S1 = (S1 + 4*x2) % MOD
+		S2 = (S2 + 4*x4) % MOD
+		S3 = (S3 + 4*x6) % MOD
+		Y := yMax
+		if Y > x-1 {
+			Y = x - 1
+		}
+		if Y >= 1 {
+			cnt := Y % MOD
+			sumY2 := sum2(Y)
+			sumY4 := sum4(Y)
+			sumY6 := sum6(Y)
+			S0 = (S0 + 8*cnt%MOD) % MOD
+			S1 = (S1 + 8*((cnt*x2%MOD+sumY2)%MOD)) % MOD
+			S2 = (S2 + 8*((cnt*x4%MOD+2*x2*sumY2%MOD+sumY4)%MOD)) % MOD
+			S3 = (S3 + 8*((cnt*x6%MOD+3*x4*sumY2%MOD+3*x2*sumY4%MOD+sumY6)%MOD)) % MOD
+		}
+		if yMax >= x {
+			r := 2 * x * x
+			rm := r % MOD
+			S0 = (S0 + 4) % MOD
+			S1 = (S1 + 4*rm%MOD) % MOD
+			S2 = (S2 + 4*rm%MOD*rm%MOD) % MOD
+			S3 = (S3 + 4*rm%MOD*rm%MOD*rm%MOD) % MOD
+		}
+	}
+	mMod := m % MOD
+	Tm := mMod * (mMod + 1) % MOD * inv2 % MOD
+	Sm := mMod * (mMod + 1) % MOD * (2*mMod + 1) % MOD * inv6 % MOD
+	part1 := (mMod + 1) % MOD * Tm % MOD
+	B := (S2 - S1) % MOD
+	if B < 0 {
+		B += MOD
+	}
+	B = B * inv2 % MOD
+	C := (2*S3%MOD - 3*S2%MOD + S1) % MOD
+	if C < 0 {
+		C += MOD
+	}
+	C = C * inv6 % MOD
+	ans := (S0*(part1-Sm+MOD)%MOD - ((mMod+1)%MOD)*B%MOD + C) % MOD
+	if ans < 0 {
+		ans += MOD
+	}
+	return ans
+}
+
+func generateCaseD(rng *rand.Rand) int64 {
+	return rng.Int63n(1_000_000) + 1
+}
+
+func runCaseD(bin string, m int64) error {
+	input := fmt.Sprintf("%d\n", m)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := expectedD(m)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	edge := []int64{1, 2, 3, 10, 1000000}
+	for idx, m := range edge {
+		if err := runCaseD(bin, m); err != nil {
+			fmt.Fprintf(os.Stderr, "edge case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	for i := 0; i < 100; i++ {
+		m := generateCaseD(rng)
+		if err := runCaseD(bin, m); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/930-939/933/verifierE.go
+++ b/0-999/900-999/930-939/933/verifierE.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expectedCost(n int, a []int64) int64 {
+	f := make([]int64, n+2)
+	for i := 1; i <= n; i++ {
+		fo := a[i]
+		if i-2 >= 0 {
+			fo += f[i-2]
+		}
+		var fe int64
+		if i-3 >= 0 {
+			if a[i] > a[i-1] {
+				fe = a[i]
+			} else {
+				fe = a[i-1]
+			}
+			fe += f[i-3]
+		} else {
+			if a[i] > a[i-1] {
+				fe = a[i]
+			} else {
+				fe = a[i-1]
+			}
+		}
+		if fo <= fe {
+			f[i] = fo
+		} else {
+			f[i] = fe
+		}
+	}
+	if n == 0 {
+		return 0
+	}
+	if f[n-1] < f[n] {
+		return f[n-1]
+	}
+	return f[n]
+}
+
+func generateCaseE(rng *rand.Rand) (int, []int64) {
+	n := rng.Intn(20) + 1
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = rng.Int63n(20)
+	}
+	return n, arr
+}
+
+func runCaseE(bin string, n int, arr []int64) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) == 0 {
+		return fmt.Errorf("no output")
+	}
+	var m int
+	if _, err := fmt.Sscan(lines[0], &m); err != nil {
+		return fmt.Errorf("failed to read m: %v", err)
+	}
+	if m != len(lines)-1 {
+		return fmt.Errorf("line count mismatch")
+	}
+	ops := make([]int, m)
+	for i := 0; i < m; i++ {
+		if _, err := fmt.Sscan(lines[i+1], &ops[i]); err != nil {
+			return fmt.Errorf("bad operation index on line %d", i+2)
+		}
+		if ops[i] < 1 || ops[i] >= n {
+			return fmt.Errorf("invalid operation index %d", ops[i])
+		}
+	}
+	// simulate
+	arrCopy := append([]int64(nil), arr...)
+	var cost int64
+	for _, op := range ops {
+		if arrCopy[op-1] <= 0 || arrCopy[op] <= 0 {
+			return fmt.Errorf("operation on non-positive numbers")
+		}
+		d := min64(arrCopy[op-1], arrCopy[op])
+		arrCopy[op-1] -= d
+		arrCopy[op] -= d
+		cost += d
+	}
+	for i := 0; i < n-1; i++ {
+		if arrCopy[i] > 0 && arrCopy[i+1] > 0 {
+			return fmt.Errorf("game not finished")
+		}
+		if arrCopy[i] < 0 {
+			return fmt.Errorf("negative value")
+		}
+	}
+	if arrCopy[n-1] < 0 {
+		return fmt.Errorf("negative value")
+	}
+	expected := expectedCost(n, append([]int64{0}, arr...))
+	if cost != expected {
+		return fmt.Errorf("expected cost %d got %d", expected, cost)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, arr := generateCaseE(rng)
+		if err := runCaseE(bin, n, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of contest 933
- each verifier generates at least 100 test cases
- verifiers execute any supplied binary and check output using internal implementations of the correct algorithms

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883ffb32c4083249b7bafa0d7d7e743