### PR TITLE
Add Go verifiers for contest 929

### DIFF
--- a/0-999/900-999/920-929/929/verifierA.go
+++ b/0-999/900-999/920-929/929/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedA(n, k int, x []int) int {
+	cnt := 0
+	i := 0
+	for i < n-1 {
+		j := i
+		for j+1 < n && x[j+1]-x[i] <= k {
+			j++
+		}
+		if j == i {
+			return -1
+		}
+		cnt++
+		i = j
+	}
+	return cnt
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(9) + 2 // 2..10
+	k := rng.Intn(20) + 1
+	x := make([]int, n)
+	cur := rng.Intn(5)
+	x[0] = cur
+	for i := 1; i < n; i++ {
+		cur += rng.Intn(5) + 1
+		x[i] = cur
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range x {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	expect := expectedA(n, k, x)
+	return sb.String(), fmt.Sprintf("%d\n", expect)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/929/verifierB.go
+++ b/0-999/900-999/920-929/929/verifierB.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type plane [][]byte
+
+func solveB(n, k int, rows []string) (int, []string) {
+	s := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		s[i] = []byte(rows[i])
+	}
+	kLeft := k
+	for i := 0; i < n; i++ {
+		if kLeft == 0 {
+			break
+		}
+		if s[i][0] == '.' && s[i][1] != 'S' {
+			s[i][0] = 'x'
+			kLeft--
+		}
+		if kLeft == 0 {
+			break
+		}
+		if s[i][11] == '.' && s[i][10] != 'S' {
+			s[i][11] = 'x'
+			kLeft--
+		}
+		if kLeft == 0 {
+			break
+		}
+		for j := 1; j < 11 && kLeft > 0; j++ {
+			if s[i][j] == '.' && s[i][j-1] != 'S' && s[i][j+1] != 'S' {
+				s[i][j] = 'x'
+				kLeft--
+			}
+		}
+	}
+
+	for i := 0; i < n; i++ {
+		if kLeft == 0 {
+			break
+		}
+		if s[i][0] == '.' {
+			s[i][0] = 'x'
+			kLeft--
+		}
+		if kLeft == 0 {
+			break
+		}
+		if s[i][11] == '.' {
+			s[i][11] = 'x'
+			kLeft--
+		}
+		if kLeft == 0 {
+			break
+		}
+		for j := 1; j < 11 && kLeft > 0; j++ {
+			if s[i][j] == '.' && !(s[i][j-1] == 'S' && s[i][j+1] == 'S') {
+				s[i][j] = 'x'
+				kLeft--
+			}
+		}
+	}
+
+	for i := 0; i < n && kLeft > 0; i++ {
+		for j := 0; j < 12 && kLeft > 0; j++ {
+			if s[i][j] == '.' {
+				s[i][j] = 'x'
+				kLeft--
+			}
+		}
+	}
+
+	ans := 0
+	for i := 0; i < n; i++ {
+		if s[i][0] == 'S' {
+			if s[i][1] != '.' && s[i][1] != '-' {
+				ans++
+			}
+		}
+		if s[i][11] == 'S' {
+			if s[i][10] != '.' && s[i][10] != '-' {
+				ans++
+			}
+		}
+		for j := 1; j < 11; j++ {
+			if s[i][j] == 'S' {
+				if s[i][j-1] != '.' && s[i][j-1] != '-' {
+					ans++
+				}
+				if s[i][j+1] != '.' && s[i][j+1] != '-' {
+					ans++
+				}
+			}
+		}
+	}
+
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = string(s[i])
+	}
+	return ans, out
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(10*n + 1)
+	rows := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, 12)
+		for j := 0; j < 12; j++ {
+			if j == 3 || j == 8 {
+				b[j] = '-'
+			} else {
+				if rng.Intn(5) == 0 {
+					b[j] = 'S'
+				} else {
+					b[j] = '.'
+				}
+			}
+		}
+		rows[i] = string(b)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		sb.WriteString(rows[i])
+		sb.WriteByte('\n')
+	}
+	ans, outRows := solveB(n, k, rows)
+	var expect strings.Builder
+	expect.WriteString(strconv.Itoa(ans))
+	expect.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		expect.WriteString(outRows[i])
+		expect.WriteByte('\n')
+	}
+	return sb.String(), expect.String()
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/929/verifierC.go
+++ b/0-999/900-999/920-929/929/verifierC.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type player struct {
+	num  int
+	role int // 0 goalie, 1 defender, 2 forward
+}
+
+func comb(n, k int) int64 {
+	if n < k || k < 0 {
+		return 0
+	}
+	if k > n-k {
+		k = n - k
+	}
+	res := int64(1)
+	for i := 1; i <= k; i++ {
+		res = res * int64(n-k+i) / int64(i)
+	}
+	return res
+}
+
+func solveC(g, d, f int, gNums, dNums, fNums []int) int64 {
+	players := make([]player, g+d+f)
+	idx := 0
+	for i := 0; i < g; i++ {
+		players[idx] = player{gNums[i], 0}
+		idx++
+	}
+	for i := 0; i < d; i++ {
+		players[idx] = player{dNums[i], 1}
+		idx++
+	}
+	for i := 0; i < f; i++ {
+		players[idx] = player{fNums[i], 2}
+		idx++
+	}
+	sort.Slice(players, func(i, j int) bool { return players[i].num < players[j].num })
+	n := len(players)
+	prefixG := make([]int, n+1)
+	prefixD := make([]int, n+1)
+	prefixF := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		prefixG[i+1] = prefixG[i]
+		prefixD[i+1] = prefixD[i]
+		prefixF[i+1] = prefixF[i]
+		switch players[i].role {
+		case 0:
+			prefixG[i+1]++
+		case 1:
+			prefixD[i+1]++
+		case 2:
+			prefixF[i+1]++
+		}
+	}
+	var ans int64
+	j := 0
+	for i := 0; i < n; i++ {
+		if j < i+1 {
+			j = i + 1
+		}
+		for j < n && players[j].num <= 2*players[i].num {
+			j++
+		}
+		numG := prefixG[j] - prefixG[i]
+		numD := prefixD[j] - prefixD[i]
+		numF := prefixF[j] - prefixF[i]
+		switch players[i].role {
+		case 0:
+			if numD >= 2 && numF >= 3 {
+				ans += comb(numD, 2) * comb(numF, 3)
+			}
+		case 1:
+			if numG >= 1 && numD >= 2 && numF >= 3 {
+				ans += int64(numG) * comb(numD-1, 1) * comb(numF, 3)
+			}
+		case 2:
+			if numG >= 1 && numD >= 2 && numF >= 3 {
+				ans += int64(numG) * comb(numD, 2) * comb(numF-1, 2)
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	g := rng.Intn(5) + 1
+	d := rng.Intn(5) + 1
+	f := rng.Intn(5) + 1
+	gNums := make([]int, g)
+	dNums := make([]int, d)
+	fNums := make([]int, f)
+	for i := range gNums {
+		gNums[i] = rng.Intn(100) + 1
+	}
+	for i := range dNums {
+		dNums[i] = rng.Intn(100) + 1
+	}
+	for i := range fNums {
+		fNums[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", g, d, f))
+	for i, v := range gNums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range dNums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range fNums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	ans := solveC(g, d, f, gNums, dNums, fNums)
+	return sb.String(), fmt.Sprintf("%d\n", ans)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/929/verifierD.go
+++ b/0-999/900-999/920-929/929/verifierD.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type state struct {
+	pos  int
+	mask uint64
+	dist int
+}
+
+func solveD(n, a, b int, g, k []int) int {
+	colorID := make(map[int]int)
+	nextID := 0
+	for _, x := range g {
+		if _, ok := colorID[x]; !ok {
+			colorID[x] = nextID
+			nextID++
+		}
+	}
+	for _, x := range k {
+		if _, ok := colorID[x]; !ok {
+			colorID[x] = nextID
+			nextID++
+		}
+	}
+	if nextID > 20 {
+		return -1
+	}
+	gID := make([]int, len(g))
+	for i, x := range g {
+		gID[i] = colorID[x]
+	}
+	kID := make([]int, len(k))
+	for i, x := range k {
+		kID[i] = colorID[x]
+	}
+	startMask := uint64(1) << kID[a-1]
+	q := []state{{a - 1, startMask, 0}}
+	visited := make(map[[2]int]bool)
+	visited[[2]int{a - 1, int(startMask)}] = true
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		mask := cur.mask | (1 << kID[cur.pos])
+		if cur.pos == b-1 {
+			return cur.dist
+		}
+		if cur.pos > 0 && (mask&(1<<gID[cur.pos-1])) != 0 {
+			np := cur.pos - 1
+			nm := mask | (1 << kID[np])
+			key := [2]int{np, int(nm)}
+			if !visited[key] {
+				visited[key] = true
+				q = append(q, state{np, nm, cur.dist + 1})
+			}
+		}
+		if cur.pos < n-1 && (mask&(1<<gID[cur.pos])) != 0 {
+			np := cur.pos + 1
+			nm := mask | (1 << kID[np])
+			key := [2]int{np, int(nm)}
+			if !visited[key] {
+				visited[key] = true
+				q = append(q, state{np, nm, cur.dist + 1})
+			}
+		}
+	}
+	return -1
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2 // 2..9
+	a := rng.Intn(n) + 1
+	b := rng.Intn(n-1) + 1
+	if b >= a {
+		b++
+	}
+	colors := rng.Intn(6) + 1
+	g := make([]int, n-1)
+	for i := range g {
+		g[i] = rng.Intn(colors) + 1
+	}
+	k := make([]int, n)
+	for i := range k {
+		k[i] = rng.Intn(colors) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, a, b))
+	for i, v := range g {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range k {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	ans := solveD(n, a, b, g, k)
+	return sb.String(), fmt.Sprintf("%d\n", ans)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", strings.TrimSpace(expected), strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`, `verifierB.go`, `verifierC.go`, `verifierD.go` in contest 929
- each verifier generates 100 random test cases and checks a given binary
- algorithms replicated from the official Go solutions to compute expected outputs

## Testing
- `go run verifierA.go ./929A`
- `go run verifierB.go ./929B`
- `go run verifierC.go ./929C`
- `go run verifierD.go ./929D`


------
https://chatgpt.com/codex/tasks/task_e_6883fd82ad40832483663edb87b32093