### PR TITLE
Add Go solution for 1674D

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1674/1674D.go
+++ b/1000-1999/1600-1699/1670-1679/1674/1674D.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var reader = bufio.NewReader(os.Stdin)
+var writer = bufio.NewWriter(os.Stdout)
+
+func main() {
+	defer writer.Flush()
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		solve()
+	}
+}
+
+func solve() {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	start := n % 2
+	for i := start; i+1 < n; i += 2 {
+		if a[i] > a[i+1] {
+			a[i], a[i+1] = a[i+1], a[i]
+		}
+	}
+	for i := 1; i < n; i++ {
+		if a[i-1] > a[i] {
+			fmt.Fprintln(writer, "NO")
+			return
+		}
+	}
+	fmt.Fprintln(writer, "YES")
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1674D

## Testing
- `go build 1000-1999/1600-1699/1670-1679/1674/1674D.go`
- `echo -e '3\n4\n3 1 5 3\n4\n5 5 5 5\n5\n1 3 2 2 2\n' | go run 1000-1999/1600-1699/1670-1679/1674/1674D.go`

------
https://chatgpt.com/codex/tasks/task_e_6883fd3c9ec48324bc03ba6e9611db2e