### PR TITLE
Add Go solution verifiers for contest 926

### DIFF
--- a/0-999/900-999/920-929/926/verifierA.go
+++ b/0-999/900-999/920-929/926/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	l int64
+	r int64
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("%d %d\n", t.l, t.r)
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "926A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build ref failed: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 102)
+	for i := 0; i < 100; i++ {
+		l := rng.Int63n(2_000_000_000) + 1
+		r := l + rng.Int63n(2_000_000_000-l+1)
+		tests = append(tests, Test{l, r})
+	}
+	tests = append(tests,
+		Test{1, 1},
+		Test{1, 2_000_000_000},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/920-929/926/verifierB.go
+++ b/0-999/900-999/920-929/926/verifierB.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	coords []int64
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.coords)))
+	for i, v := range t.coords {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "926B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build ref failed: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(15) + 3
+		set := make(map[int64]struct{})
+		coords := make([]int64, 0, n)
+		for len(coords) < n {
+			v := rng.Int63n(2000) - 1000
+			if _, ok := set[v]; !ok {
+				set[v] = struct{}{}
+				coords = append(coords, v)
+			}
+		}
+		tests = append(tests, Test{coords: coords})
+	}
+	tests = append(tests, Test{coords: []int64{0, 10, 20}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/920-929/926/verifierC.go
+++ b/0-999/900-999/920-929/926/verifierC.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	seq []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.seq)))
+	for i, v := range t.seq {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "926C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build ref failed: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		seq := make([]int, n)
+		for j := range seq {
+			seq[j] = rng.Intn(2)
+		}
+		tests = append(tests, Test{seq})
+	}
+	tests = append(tests, Test{seq: []int{0, 0, 0, 0}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/920-929/926/verifierD.go
+++ b/0-999/900-999/920-929/926/verifierD.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	rows []string
+}
+
+func (t Test) Input() string {
+	return strings.Join(t.rows, "\n") + "\n"
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "926D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build ref failed: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genRow(rng *rand.Rand) string {
+	seats := []byte("..-..-..")
+	for i := 0; i < 8; i++ {
+		if seats[i] == '-' {
+			continue
+		}
+		if rng.Intn(2) == 0 {
+			seats[i] = '*'
+		} else {
+			seats[i] = '.'
+		}
+	}
+	return string(seats)
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		rows := make([]string, 6)
+		hasVacant := false
+		for j := 0; j < 6; j++ {
+			row := genRow(rng)
+			if strings.Contains(row, ".") {
+				hasVacant = true
+			}
+			rows[j] = row
+		}
+		if !hasVacant {
+			// ensure at least one vacant seat
+			rows[0] = strings.Replace(rows[0], "*", ".", 1)
+		}
+		tests = append(tests, Test{rows})
+	}
+	tests = append(tests, Test{rows: []string{"..-..-..", "..-..-..", "..-..-..", "..-..-..", "..-..-..", "..-..-.."}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/920-929/926/verifierE.go
+++ b/0-999/900-999/920-929/926/verifierE.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	arr []int64
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.arr)))
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "926E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build ref failed: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(30) + 2
+		arr := make([]int64, n)
+		for j := range arr {
+			arr[j] = int64(rng.Intn(5) + 1)
+		}
+		tests = append(tests, Test{arr})
+	}
+	tests = append(tests, Test{arr: []int64{1, 1, 1, 1}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/920-929/926/verifierF.go
+++ b/0-999/900-999/920-929/926/verifierF.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Day struct {
+	d int64
+	t int64
+}
+
+type Test struct {
+	p    int64
+	m    int64
+	days []Day
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", len(t.days), t.p, t.m))
+	for _, d := range t.days {
+		sb.WriteString(fmt.Sprintf("%d %d\n", d.d, d.t))
+	}
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "926F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build ref failed: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := int64(rng.Intn(30) + n)
+		p := int64(rng.Intn(20) + 1)
+		days := make([]Day, n)
+		used := make(map[int64]struct{})
+		last := int64(0)
+		for j := 0; j < n; j++ {
+			last += int64(rng.Intn(3) + 1)
+			if last > m {
+				last = m
+			}
+			if _, ok := used[last]; ok {
+				last++
+			}
+			used[last] = struct{}{}
+			days[j] = Day{d: last, t: int64(rng.Intn(20) + 1)}
+		}
+		tests = append(tests, Test{p: p, m: m, days: days})
+	}
+	tests = append(tests, Test{p: 1, m: 1, days: []Day{{1, 1}}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/920-929/926/verifierG.go
+++ b/0-999/900-999/920-929/926/verifierG.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	bouquets []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.bouquets)))
+	for i, v := range t.bouquets {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "./refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "926G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build ref failed: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(20) + 1
+		}
+		tests = append(tests, Test{bouquets: arr})
+	}
+	tests = append(tests, Test{bouquets: []int{1, 1}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/920-929/926/verifierH.go
+++ b/0-999/900-999/920-929/926/verifierH.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	k      int
+	beauty []int
+	colors string
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	n := len(t.beauty)
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, t.k))
+	for i, v := range t.beauty {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprint(&sb, v)
+	}
+	sb.WriteString("\n")
+	sb.WriteString(t.colors)
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "./refH.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "926H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build ref failed: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	colors := []byte{'R', 'O', 'W'}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		k := rng.Intn(n) + 1
+		beauty := make([]int, n)
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			beauty[j] = rng.Intn(10) + 1
+			sb.WriteByte(colors[rng.Intn(3)])
+		}
+		tests = append(tests, Test{k: k, beauty: beauty, colors: sb.String()})
+	}
+	tests = append(tests, Test{k: 1, beauty: []int{5}, colors: "R"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/920-929/926/verifierI.go
+++ b/0-999/900-999/920-929/926/verifierI.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	times []string
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.times)))
+	for _, tm := range t.times {
+		sb.WriteString(tm)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "./refI.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "926I.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build ref failed: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTime(rng *rand.Rand) string {
+	h := rng.Intn(24)
+	m := rng.Intn(60)
+	return fmt.Sprintf("%02d:%02d", h, m)
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		times := make([]string, n)
+		for j := range times {
+			times[j] = genTime(rng)
+		}
+		tests = append(tests, Test{times})
+	}
+	tests = append(tests, Test{times: []string{"00:00"}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/0-999/900-999/920-929/926/verifierJ.go
+++ b/0-999/900-999/920-929/926/verifierJ.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Segment struct {
+	l int
+	r int
+}
+
+type Test struct {
+	segs []Segment
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.segs)))
+	for _, s := range t.segs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", s.l, s.r))
+	}
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "./refJ.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "926J.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build ref failed: %v: %s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		segs := make([]Segment, n)
+		for j := 0; j < n; j++ {
+			l := rng.Intn(50)
+			r := l + rng.Intn(10)
+			segs[j] = Segment{l, r}
+		}
+		tests = append(tests, Test{segs: segs})
+	}
+	tests = append(tests, Test{segs: []Segment{{0, 0}}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierJ.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:%sExpected:%s\nGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–J in contest 926
- each verifier compiles a reference solution and runs ~100 generated tests
- tests cover random and edge cases and detect runtime errors

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go verifierH.go verifierI.go verifierJ.go`

------
https://chatgpt.com/codex/tasks/task_e_6883fbde6e4083248d55ac0c88e949e8