### PR TITLE
Add verifiers for contest 925

### DIFF
--- a/0-999/900-999/920-929/925/verifierA.go
+++ b/0-999/900-999/920-929/925/verifierA.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func genTest() []byte {
+	n := rand.Intn(9) + 2 // floors 2..10
+	m := rand.Intn(6) + 5 // sections 5..10
+	cl := rand.Intn(min(2, m-2)) + 1
+	ce := rand.Intn(min(2, m-cl-1)) + 1
+
+	positions := rand.Perm(m)[:cl+ce]
+	stairs := make([]int, cl)
+	elevators := make([]int, ce)
+	for i := 0; i < cl; i++ {
+		stairs[i] = positions[i] + 1
+	}
+	for i := 0; i < ce; i++ {
+		elevators[i] = positions[cl+i] + 1
+	}
+	sort.Ints(stairs)
+	sort.Ints(elevators)
+	v := rand.Intn(n-1) + 1
+	q := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d %d\n", n, m, cl, ce, v))
+	for i, x := range stairs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(x))
+	}
+	sb.WriteByte('\n')
+	for i, x := range elevators {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(x))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	allowed := make([]int, 0)
+	for i := 1; i <= m; i++ {
+		ok := true
+		for _, x := range stairs {
+			if i == x {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			for _, x := range elevators {
+				if i == x {
+					ok = false
+					break
+				}
+			}
+		}
+		if ok {
+			allowed = append(allowed, i)
+		}
+	}
+	if len(allowed) < 2 {
+		allowed = append(allowed, 1, 2)
+	}
+	for i := 0; i < q; i++ {
+		x1 := rand.Intn(n) + 1
+		x2 := rand.Intn(n) + 1
+		y1 := allowed[rand.Intn(len(allowed))]
+		y2 := allowed[rand.Intn(len(allowed))]
+		for x1 == x2 && y1 == y2 {
+			x2 = rand.Intn(n) + 1
+			y2 = allowed[rand.Intn(len(allowed))]
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", x1, y1, x2, y2))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./refA.bin"
+	if err := exec.Command("go", "build", "-o", ref, "925A.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/900-999/920-929/925/verifierB.go
+++ b/0-999/900-999/920-929/925/verifierB.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	n := rand.Intn(6) + 2 // 2..7
+	x1 := rand.Intn(100) + 1
+	x2 := rand.Intn(100) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x1, x2))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rand.Intn(100) + 1))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./refB.bin"
+	if err := exec.Command("go", "build", "-o", ref, "925B.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/900-999/920-929/925/verifierC.go
+++ b/0-999/900-999/920-929/925/verifierC.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	n := rand.Intn(6) + 1 // 1..6 numbers
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rand.Uint64()%100 + 1))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./refC.bin"
+	if err := exec.Command("go", "build", "-o", ref, "925C.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/900-999/920-929/925/verifierD.go
+++ b/0-999/900-999/920-929/925/verifierD.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	n := rand.Intn(5) + 2 // 2..6
+	maxEdges := n * (n - 1) / 2
+	m := rand.Intn(maxEdges + 1)
+	edges := make(map[[2]int]struct{})
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for len(edges) < m {
+		u := rand.Intn(n) + 1
+		v := rand.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		key := [2]int{u, v}
+		if _, ok := edges[key]; ok {
+			continue
+		}
+		edges[key] = struct{}{}
+		sb.WriteString(fmt.Sprintf("%d %d\n", u, v))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./refD.bin"
+	if err := exec.Command("go", "build", "-o", ref, "925D.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/900-999/920-929/925/verifierE.go
+++ b/0-999/900-999/920-929/925/verifierE.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	n := rand.Intn(5) + 2 // 2..6 employees
+	m := rand.Intn(5) + 2 // 2..6 events
+	parents := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		parents[i] = rand.Intn(i-1) + 1
+	}
+	subCnt := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := parents[i]
+		for p != 0 {
+			subCnt[p]++
+			p = parents[p]
+		}
+	}
+	t := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		if subCnt[i] == 0 {
+			t[i] = 0
+		} else {
+			t[i] = rand.Intn(subCnt[i] + 1)
+		}
+	}
+	on := make([]bool, n+1)
+	events := make([]int, 0, m)
+	for len(events) < m {
+		leaveProb := 0
+		for i := 1; i <= n; i++ {
+			if !on[i] {
+				leaveProb++
+			}
+		}
+		takeLeave := rand.Intn(2)
+		if takeLeave == 0 && leaveProb > 0 || len(events) == 0 {
+			// leave
+			var candidates []int
+			for i := 1; i <= n; i++ {
+				if !on[i] {
+					candidates = append(candidates, i)
+				}
+			}
+			x := candidates[rand.Intn(len(candidates))]
+			on[x] = true
+			events = append(events, x)
+		} else {
+			var candidates []int
+			for i := 1; i <= n; i++ {
+				if on[i] {
+					candidates = append(candidates, i)
+				}
+			}
+			if len(candidates) == 0 {
+				continue
+			}
+			x := candidates[rand.Intn(len(candidates))]
+			on[x] = false
+			events = append(events, -x)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 2; i <= n; i++ {
+		if i > 2 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(parents[i]))
+	}
+	if n > 1 {
+		sb.WriteByte('\n')
+	} else {
+		sb.WriteString("\n")
+	}
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(t[i]))
+	}
+	sb.WriteByte('\n')
+	for i, e := range events {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(e))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./refE.bin"
+	if err := exec.Command("go", "build", "-o", ref, "925E.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/0-999/900-999/920-929/925/verifierF.go
+++ b/0-999/900-999/920-929/925/verifierF.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	n := rand.Intn(3) + 2 // 2..4
+	maxEdges := n * (n - 1) / 2
+	m := rand.Intn(maxEdges) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	edges := make(map[[2]int]struct{})
+	for len(edges) < m {
+		x := rand.Intn(n) + 1
+		y := rand.Intn(n) + 1
+		if x == y {
+			continue
+		}
+		if x > y {
+			x, y = y, x
+		}
+		key := [2]int{x, y}
+		if _, ok := edges[key]; ok {
+			continue
+		}
+		edges[key] = struct{}{}
+		a := rand.Intn(3)
+		b := rand.Intn(3)
+		c := rand.Intn(3)
+		d := rand.Intn(3)
+		sb.WriteString(fmt.Sprintf("%d %d %d %d %d %d\n", x, y, a, b, c, d))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	ref := "./refF.bin"
+	if err := exec.Command("go", "build", "-o", ref, "925F.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 925
- each verifier builds the reference solution and compares output of 100 random tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883fb52453c8324960672950bc5251e