### PR TITLE
Add Go solution for 1678B1

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1678/1678B1.go
+++ b/1000-1999/1600-1699/1670-1679/1678/1678B1.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var s string
+		fmt.Fscan(reader, &s)
+		ops := 0
+		for i := 0; i < n; i += 2 {
+			if s[i] != s[i+1] {
+				ops++
+			}
+		}
+		fmt.Fprintln(writer, ops)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1678B1

## Testing
- `go build 1000-1999/1600-1699/1670-1679/1678/1678B1.go`
- `go vet 1000-1999/1600-1699/1670-1679/1678/1678B1.go`


------
https://chatgpt.com/codex/tasks/task_e_6883fb0c456483248016ca8bb2d956f3