### PR TITLE
Add verifiers for contest 924

### DIFF
--- a/0-999/900-999/920-929/924/verifierA.go
+++ b/0-999/900-999/920-929/924/verifierA.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errb.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	n, m  int
+	grid  []string
+	input string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	grid := make([]string, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = '.'
+			} else {
+				row[j] = '#'
+			}
+		}
+		grid[i] = string(row)
+		sb.WriteString(grid[i])
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	return Test{n: n, m: m, grid: grid, input: sb.String()}
+}
+
+func solve(t Test) string {
+	rowMask := make([]uint64, t.n)
+	colMask := make([]uint64, t.m)
+	for i := 0; i < t.n; i++ {
+		for j := 0; j < t.m; j++ {
+			if t.grid[i][j] == '#' {
+				rowMask[i] |= 1 << uint(j)
+				colMask[j] |= 1 << uint(i)
+			}
+		}
+	}
+	for i := 0; i < t.n; i++ {
+		for j := i + 1; j < t.n; j++ {
+			if rowMask[i]&rowMask[j] != 0 && rowMask[i] != rowMask[j] {
+				return "No"
+			}
+		}
+	}
+	for i := 0; i < t.m; i++ {
+		for j := i + 1; j < t.m; j++ {
+			if colMask[i]&colMask[j] != 0 && colMask[i] != colMask[j] {
+				return "No"
+			}
+		}
+	}
+	return "Yes"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s got:%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/900-999/920-929/924/verifierB.go
+++ b/0-999/900-999/920-929/924/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errb.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	n     int
+	U     int
+	E     []int
+	input string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(7) + 3
+	E := make([]int, n)
+	cur := rng.Intn(5)
+	for i := 0; i < n; i++ {
+		cur += rng.Intn(5) + 1
+		E[i] = cur
+	}
+	U := rng.Intn(E[n-1]-E[0]+1) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, U))
+	for i, v := range E {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return Test{n: n, U: U, E: E, input: sb.String()}
+}
+
+func solve(t Test) string {
+	best := -1.0
+	k := 0
+	for i := 0; i < t.n; i++ {
+		if k < i {
+			k = i
+		}
+		for k+1 < t.n && t.E[k+1]-t.E[i] <= t.U {
+			k++
+		}
+		if k >= i+2 {
+			val := float64(t.E[k]-t.E[i+1]) / float64(t.E[k]-t.E[i])
+			if val > best {
+				best = val
+			}
+		}
+	}
+	if best < 0 {
+		return "-1"
+	}
+	return fmt.Sprintf("%.12f", best)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s got:%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/900-999/920-929/924/verifierC.go
+++ b/0-999/900-999/920-929/924/verifierC.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errb.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	n     int
+	m     []int64
+	input string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(8) + 1
+	mvals := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		maxv := int64(i)
+		if maxv == 0 {
+			maxv = 1
+		}
+		mvals[i] = rng.Int63n(maxv)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", mvals[i]))
+	}
+	sb.WriteByte('\n')
+	return Test{n: n, m: mvals, input: sb.String()}
+}
+
+func solve(t Test) string {
+	n := t.n
+	mvals := t.m
+	d := make([]int64, n)
+	if n > 0 {
+		d[n-1] = mvals[n-1]
+		if d[n-1] < 0 {
+			d[n-1] = 0
+		}
+		for i := n - 2; i >= 0; i-- {
+			need := d[i+1] - 1
+			if need < 0 {
+				need = 0
+			}
+			if mvals[i] > need {
+				d[i] = mvals[i]
+			} else {
+				d[i] = need
+			}
+		}
+	}
+	var sum int64
+	for i := 0; i < n; i++ {
+		sum += d[i]
+	}
+	return fmt.Sprintf("%d", sum)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s got:%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/900-999/920-929/924/verifierD.go
+++ b/0-999/900-999/920-929/924/verifierD.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errb.String(), err
+	}
+	return out.String(), nil
+}
+
+type plane struct {
+	x int
+	v int
+}
+
+type Test struct {
+	n      int
+	w      int
+	planes []plane
+	input  string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(7) + 1
+	w := rng.Intn(10)
+	planes := make([]plane, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, w))
+	for i := 0; i < n; i++ {
+		x := rng.Intn(20) + 1
+		if rng.Intn(2) == 0 {
+			x = -x
+		}
+		v := rng.Intn(20) + w + 1
+		if rng.Intn(2) == 0 {
+			v = -v
+		}
+		if x*v > 0 {
+			v = -v
+		}
+		planes[i] = plane{x: x, v: v}
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, v))
+	}
+	return Test{n: n, w: w, planes: planes, input: sb.String()}
+}
+
+func solve(t Test) string {
+	type pair struct{ a, b int64 }
+	prec := int64(1e9)
+	planes := make([]pair, len(t.planes))
+	for i, p := range t.planes {
+		a := -float64(p.x) / float64(p.v-t.w)
+		b := -float64(p.x) / float64(p.v+t.w)
+		planes[i] = pair{int64(a*float64(prec) + 0.5), int64(b*float64(prec) + 0.5)}
+	}
+	sort.Slice(planes, func(i, j int) bool { return planes[i].a < planes[j].a })
+	bvals := make([]int64, len(planes))
+	for i := range planes {
+		bvals[i] = planes[i].b
+	}
+	uniqMap := map[int64]struct{}{}
+	uniq := make([]int64, 0, len(bvals))
+	for _, v := range bvals {
+		if _, ok := uniqMap[v]; !ok {
+			uniqMap[v] = struct{}{}
+			uniq = append(uniq, v)
+		}
+	}
+	sort.Slice(uniq, func(i, j int) bool { return uniq[i] < uniq[j] })
+	rank := make(map[int64]int, len(uniq))
+	for i, v := range uniq {
+		rank[v] = i + 1
+	}
+	bit := make([]int64, len(uniq)+3)
+	add := func(i int64, val int64) {
+		for i < int64(len(bit)) {
+			bit[i] += val
+			i += i & -i
+		}
+	}
+	sum := func(i int64) int64 {
+		s := int64(0)
+		for i > 0 {
+			s += bit[i]
+			i -= i & -i
+		}
+		return s
+	}
+	total := int64(0)
+	ans := int64(0)
+	i := 0
+	for i < len(planes) {
+		j := i
+		for j < len(planes) && planes[j].a == planes[i].a {
+			j++
+		}
+		for k := i; k < j; k++ {
+			r := int64(rank[planes[k].b])
+			ans += total - sum(r-1)
+		}
+		for k := i; k < j; k++ {
+			r := int64(rank[planes[k].b])
+			add(r, 1)
+			total++
+		}
+		m := int64(j - i)
+		ans += m * (m - 1) / 2
+		i = j
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s got:%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/900-999/920-929/924/verifierE.go
+++ b/0-999/900-999/920-929/924/verifierE.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errb.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	n     int
+	l     int
+	r     int
+	a     []int
+	b     []int
+	input string
+}
+
+func genTest(rng *rand.Rand) Test {
+	n := rng.Intn(8) + 1
+	sum := 0
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(5) + 1
+		sum += a[i]
+	}
+	l := rng.Intn(sum + 1)
+	r := l + rng.Intn(sum-l+1)
+	b := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, l, r))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = 0
+		} else {
+			b[i] = 1
+		}
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", b[i]))
+	}
+	sb.WriteByte('\n')
+	return Test{n: n, l: l, r: r, a: a, b: b, input: sb.String()}
+}
+
+func solve(t Test) string {
+	sum := 0
+	for _, v := range t.a {
+		sum += v
+	}
+	const negInf = -1 << 30
+	dp := make([]int, sum+1)
+	for i := range dp {
+		dp[i] = negInf
+	}
+	dp[0] = 0
+	for i := 0; i < t.n; i++ {
+		h := t.a[i]
+		imp := t.b[i] == 1
+		for s := sum - h; s >= 0; s-- {
+			if dp[s] == negInf {
+				continue
+			}
+			gain := 0
+			if imp && s >= t.l && s <= t.r {
+				gain = 1
+			}
+			if v := dp[s] + gain; v > dp[s+h] {
+				dp[s+h] = v
+			}
+		}
+	}
+	return fmt.Sprintf("%d", dp[sum])
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s got:%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}

--- a/0-999/900-999/920-929/924/verifierF.go
+++ b/0-999/900-999/920-929/924/verifierF.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errb.String(), err
+	}
+	return out.String(), nil
+}
+
+type Test struct {
+	queries []query
+	input   string
+}
+
+type query struct {
+	l int64
+	r int64
+	k int
+}
+
+func genTest(rng *rand.Rand) Test {
+	q := rng.Intn(5) + 1
+	qs := make([]query, q)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		l := rng.Int63n(100) + 1
+		r := l + rng.Int63n(20)
+		k := rng.Intn(10)
+		qs[i] = query{l: l, r: r, k: k}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", l, r, k))
+	}
+	return Test{queries: qs, input: sb.String()}
+}
+
+func isKBeautiful(x int64, k int) bool {
+	if x == 0 {
+		return k >= 0
+	}
+	digits := []int{}
+	for x > 0 {
+		digits = append(digits, int(x%10))
+		x /= 10
+	}
+	sum := 0
+	for _, d := range digits {
+		sum += d
+	}
+	dp := make([]bool, sum+1)
+	dp[0] = true
+	for _, d := range digits {
+		next := make([]bool, sum+1)
+		for s := 0; s <= sum; s++ {
+			if dp[s] {
+				next[s] = true
+				if s+d <= sum {
+					next[s+d] = true
+				}
+			}
+		}
+		dp = next
+	}
+	for s := 0; s <= sum; s++ {
+		if dp[s] {
+			diff := sum - 2*s
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff <= k {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func solve(t Test) string {
+	var sb strings.Builder
+	for _, qu := range t.queries {
+		count := int64(0)
+		for x := qu.l; x <= qu.r; x++ {
+			if isKBeautiful(x, qu.k) {
+				count++
+			}
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", count))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		t := genTest(rng)
+		expected := solve(t)
+		out, err := run(bin, t.input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:\n%s\nexpected:%s got:%s\n", i+1, t.input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok 100 tests")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 924
- each verifier generates random tests and checks a binary against the reference solution

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`
- `go run verifierF.go ./solF`


------
https://chatgpt.com/codex/tasks/task_e_6883fac63b148324b6dc852d1dbc9111