### PR TITLE
Add Go solution for 1671A

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1671/1671A.go
+++ b/1000-1999/1600-1699/1670-1679/1671/1671A.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		ok := true
+		for i := 0; i < len(s); {
+			j := i
+			for j < len(s) && s[j] == s[i] {
+				j++
+			}
+			if j-i == 1 {
+				ok = false
+				break
+			}
+			i = j
+		}
+		if ok {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1671A.go` to check if a string can be built from aa/aaa/bb/bbb

## Testing
- `go vet 1000-1999/1600-1699/1670-1679/1671/1671A.go`
- `go build 1000-1999/1600-1699/1670-1679/1671/1671A.go`

------
https://chatgpt.com/codex/tasks/task_e_6883fa8053a08324bd80e0a4c01a00c8