### PR TITLE
Add Go verifiers for contest 922

### DIFF
--- a/0-999/900-999/920-929/922/verifierA.go
+++ b/0-999/900-999/920-929/922/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseA struct {
+	x int64
+	y int64
+}
+
+func expectedA(x, y int64) string {
+	if y == 0 {
+		return "No"
+	}
+	if y == 1 {
+		if x == 0 {
+			return "Yes"
+		}
+		return "No"
+	}
+	if x >= y-1 && (x-y+1)%2 == 0 {
+		return "Yes"
+	}
+	return "No"
+}
+
+func genTestsA() []testCaseA {
+	rand.Seed(1)
+	tests := make([]testCaseA, 0, 100)
+	// some fixed edge cases
+	fixed := []testCaseA{{0, 0}, {0, 1}, {1, 0}, {1, 1}, {2, 1}, {3, 2}, {5, 3}, {10, 1}}
+	tests = append(tests, fixed...)
+	for len(tests) < 100 {
+		x := rand.Int63n(1_000_000_000)
+		y := rand.Int63n(1_000_000_000)
+		tests = append(tests, testCaseA{x: x, y: y})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseA) error {
+	input := fmt.Sprintf("%d %d\n", tc.x, tc.y)
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedA(tc.x, tc.y)
+	if got != expect {
+		return fmt.Errorf("for input %d %d expected %q got %q", tc.x, tc.y, expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/922/verifierB.go
+++ b/0-999/900-999/920-929/922/verifierB.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseB struct {
+	n int
+}
+
+func expectedB(n int) int64 {
+	var count int64
+	for a := 1; a <= n; a++ {
+		for b := a; b <= n; b++ {
+			c := a ^ b
+			if c < b || c > n {
+				continue
+			}
+			if a+b <= c {
+				continue
+			}
+			count++
+		}
+	}
+	return count
+}
+
+func genTestsB() []testCaseB {
+	rand.Seed(2)
+	tests := make([]testCaseB, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(2500) + 1 // 1..2500
+		tests = append(tests, testCaseB{n: n})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseB) error {
+	input := fmt.Sprintf("%d\n", tc.n)
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := fmt.Sprint(expectedB(tc.n))
+	if got != expect {
+		return fmt.Errorf("n=%d expected %s got %s", tc.n, expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/922/verifierC.go
+++ b/0-999/900-999/920-929/922/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseC struct {
+	n uint64
+	k uint64
+}
+
+func gcd(a, b uint64) uint64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func expectedC(n, k uint64) string {
+	l := uint64(1)
+	limit := n + 1
+	for i := uint64(2); i <= k && l <= limit; i++ {
+		g := gcd(l, i)
+		if l/g > limit/i {
+			l = limit + 1
+			break
+		}
+		l = l / g * i
+	}
+	if l <= limit && limit%l == 0 {
+		return "Yes"
+	}
+	return "No"
+}
+
+func genTestsC() []testCaseC {
+	rand.Seed(3)
+	tests := make([]testCaseC, 0, 100)
+	fixed := []testCaseC{{1, 1}, {10, 1}, {10, 2}, {10, 5}, {100, 10}}
+	tests = append(tests, fixed...)
+	for len(tests) < 100 {
+		n := uint64(rand.Int63n(1_000_000_000_000)) + 1
+		k := uint64(rand.Intn(5000) + 1)
+		tests = append(tests, testCaseC{n: n, k: k})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseC) error {
+	input := fmt.Sprintf("%d %d\n", tc.n, tc.k)
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedC(tc.n, tc.k)
+	if got != expect {
+		return fmt.Errorf("n=%d k=%d expected %s got %s", tc.n, tc.k, expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/922/verifierD.go
+++ b/0-999/900-999/920-929/922/verifierD.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCaseD struct {
+	strs []string
+}
+
+type strInfo struct {
+	s     string
+	cntS  int64
+	cntH  int64
+	noise int64
+}
+
+func calcInfo(t string) strInfo {
+	var cntS, cntH, noise int64
+	for _, ch := range t {
+		if ch == 's' {
+			cntS++
+		} else {
+			noise += cntS
+			cntH++
+		}
+	}
+	return strInfo{s: t, cntS: cntS, cntH: cntH, noise: noise}
+}
+
+func expectedD(arr []string) int64 {
+	infos := make([]strInfo, len(arr))
+	for i, t := range arr {
+		infos[i] = calcInfo(t)
+	}
+	sort.Slice(infos, func(i, j int) bool {
+		a := infos[i]
+		b := infos[j]
+		return a.cntS*b.cntH > b.cntS*a.cntH
+	})
+	var res, sCount int64
+	for _, it := range infos {
+		res += it.noise
+	}
+	for _, it := range infos {
+		res += sCount * it.cntH
+		sCount += it.cntS
+	}
+	return res
+}
+
+func genTestsD() []testCaseD {
+	rand.Seed(4)
+	tests := make([]testCaseD, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(20) + 1
+		strs := make([]string, n)
+		for i := 0; i < n; i++ {
+			l := rand.Intn(10) + 1
+			var sb strings.Builder
+			for j := 0; j < l; j++ {
+				if rand.Intn(2) == 0 {
+					sb.WriteByte('s')
+				} else {
+					sb.WriteByte('h')
+				}
+			}
+			strs[i] = sb.String()
+		}
+		tests = append(tests, testCaseD{strs: strs})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseD) error {
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", len(tc.strs)))
+	for _, s := range tc.strs {
+		input.WriteString(s)
+		input.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	expect := fmt.Sprint(expectedD(tc.strs))
+	if gotStr != expect {
+		return fmt.Errorf("expected %s got %s", expect, gotStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/922/verifierE.go
+++ b/0-999/900-999/920-929/922/verifierE.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseE struct {
+	n    int
+	W    int64
+	B    int64
+	X    int64
+	c    []int
+	cost []int64
+}
+
+func expectedE(tc testCaseE) int {
+	n := tc.n
+	W := tc.W
+	B := tc.B
+	X := tc.X
+	c := tc.c
+	cost := tc.cost
+	sum := 0
+	for _, v := range c {
+		sum += v
+	}
+	const neg = int64(-1 << 60)
+	dp := make([]int64, sum+1)
+	for i := 1; i <= sum; i++ {
+		dp[i] = neg
+	}
+	dp[0] = W
+	maxBirds := 0
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			for j := 0; j <= maxBirds; j++ {
+				if dp[j] < 0 {
+					continue
+				}
+				cap := W + int64(j)*B
+				val := dp[j] + X
+				if val > cap {
+					val = cap
+				}
+				dp[j] = val
+			}
+		}
+		newdp := make([]int64, sum+1)
+		for k := 0; k <= sum; k++ {
+			newdp[k] = neg
+		}
+		for j := 0; j <= maxBirds; j++ {
+			if dp[j] < 0 {
+				continue
+			}
+			maxT := c[i]
+			if maxT+j > sum {
+				maxT = sum - j
+			}
+			for t := 0; t <= maxT; t++ {
+				req := int64(t) * cost[i]
+				if req > dp[j] {
+					break
+				}
+				val := dp[j] - req
+				if val > newdp[j+t] {
+					newdp[j+t] = val
+				}
+			}
+		}
+		maxBirds += c[i]
+		dp = newdp
+	}
+	ans := 0
+	for j := maxBirds; j >= 0; j-- {
+		if dp[j] >= 0 {
+			ans = j
+			break
+		}
+	}
+	return ans
+}
+
+func genTestsE() []testCaseE {
+	rand.Seed(5)
+	tests := make([]testCaseE, 0, 100)
+	for len(tests) < 100 {
+		n := rand.Intn(5) + 1
+		W := int64(rand.Intn(20))
+		B := int64(rand.Intn(10))
+		X := int64(rand.Intn(10))
+		c := make([]int, n)
+		cost := make([]int64, n)
+		for i := 0; i < n; i++ {
+			c[i] = rand.Intn(5)
+			cost[i] = int64(rand.Intn(10))
+		}
+		tests = append(tests, testCaseE{n: n, W: W, B: B, X: X, c: c, cost: cost})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseE) error {
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d %d %d %d\n", tc.n, tc.W, tc.B, tc.X)
+	for i, v := range tc.c {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprint(&input, v)
+	}
+	input.WriteByte('\n')
+	for i, v := range tc.cost {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprint(&input, v)
+	}
+	input.WriteByte('\n')
+
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input.String())
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	expect := fmt.Sprint(expectedE(tc))
+	if gotStr != expect {
+		return fmt.Errorf("expected %s got %s", expect, gotStr)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/922/verifierF.go
+++ b/0-999/900-999/920-929/922/verifierF.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCaseF struct {
+	N int
+	K int
+}
+
+func expectedF(N, K int) string {
+	A := make([]int, N+2)
+	s := 0
+	n := 0
+	for i := 1; i <= N; i++ {
+		for j := i * 2; j <= N; j += i {
+			A[j]++
+		}
+		s += A[i]
+		if s >= K {
+			n = i
+			break
+		}
+	}
+	if s < K {
+		return "No"
+	}
+	s -= K
+	k := n
+	removed := make([]bool, n+2)
+	for i := 2; i <= n && s > 0; i++ {
+		cost := A[i] + n/i - 1
+		if s >= cost {
+			s -= cost
+			removed[i] = true
+			k--
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("Yes\n")
+	sb.WriteString(fmt.Sprintf("%d\n", k))
+	for i := 1; i <= n; i++ {
+		if !removed[i] {
+			sb.WriteString(fmt.Sprintf("%d ", i))
+		}
+	}
+	sb.WriteByte('\n')
+	return strings.TrimSpace(sb.String())
+}
+
+func genTestsF() []testCaseF {
+	rand.Seed(6)
+	tests := make([]testCaseF, 0, 100)
+	for len(tests) < 100 {
+		N := rand.Intn(100) + 2
+		maxPairs := N * (N - 1) / 2
+		K := rand.Intn(maxPairs + 1)
+		if rand.Intn(5) == 0 { // sometimes impossible
+			K = maxPairs + rand.Intn(100) + 1
+		}
+		tests = append(tests, testCaseF{N: N, K: K})
+	}
+	return tests
+}
+
+func runCase(bin string, tc testCaseF) error {
+	input := fmt.Sprintf("%d %d\n", tc.N, tc.K)
+	cmd := exec.Command(bin)
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect := expectedF(tc.N, tc.K)
+	if got != expect {
+		return fmt.Errorf("N=%d K=%d expected:\n%s\n\ngot:\n%s", tc.N, tc.K, expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsF()
+	for i, tc := range tests {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement new verifiers for contest 922 problems A–F
- each verifier generates 100 deterministic tests and checks a candidate binary

## Testing
- `go run verifierA.go ./solutionA`
- `go run verifierB.go ./solutionB`
- `go run verifierF.go ./solutionF`


------
https://chatgpt.com/codex/tasks/task_e_6883f9ae470c8324ae36cffa138fcc3f