### PR TITLE
Add Go solution verifiers for Codeforces contest 920

### DIFF
--- a/verifiers/920/verifierA.go
+++ b/verifiers/920/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func computeAnswer(n int, taps []int) int {
+	ans := 0
+	for i := 1; i <= n; i++ {
+		minDist := n + 1
+		for _, x := range taps {
+			d := x - i
+			if d < 0 {
+				d = -d
+			}
+			if d < minDist {
+				minDist = d
+			}
+		}
+		tm := minDist + 1
+		if tm > ans {
+			ans = tm
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	const tests = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, tests)
+	expected := make([]int, tests)
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(200) + 1
+		k := rand.Intn(n) + 1
+		taps := make([]int, k)
+		used := make(map[int]bool)
+		for i := 0; i < k; i++ {
+			for {
+				v := rand.Intn(n) + 1
+				if !used[v] {
+					used[v] = true
+					taps[i] = v
+					break
+				}
+			}
+		}
+		// sort taps
+		for i := 0; i < k; i++ {
+			for j := i + 1; j < k; j++ {
+				if taps[j] < taps[i] {
+					taps[i], taps[j] = taps[j], taps[i]
+				}
+			}
+		}
+		fmt.Fprintf(&input, "%d %d\n", n, k)
+		for i, v := range taps {
+			if i > 0 {
+				fmt.Fprint(&input, " ")
+			}
+			fmt.Fprint(&input, v)
+		}
+		fmt.Fprintln(&input)
+		expected[t] = computeAnswer(n, taps)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("Failed to run binary:", err)
+		os.Exit(1)
+	}
+	parts := strings.Fields(string(out))
+	if len(parts) != tests {
+		fmt.Printf("Expected %d outputs, got %d\n", tests, len(parts))
+		os.Exit(1)
+	}
+	for i, p := range parts {
+		got, err := strconv.Atoi(p)
+		if err != nil || got != expected[i] {
+			fmt.Printf("Test %d failed: expected %d got %s\n", i+1, expected[i], p)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/verifiers/920/verifierB.go
+++ b/verifiers/920/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func solveB(l, r []int) []int {
+	n := len(l)
+	ans := make([]int, n)
+	cur := 1
+	for i := 0; i < n; i++ {
+		if cur < l[i] {
+			cur = l[i]
+		}
+		if cur > r[i] {
+			ans[i] = 0
+		} else {
+			ans[i] = cur
+			cur++
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(2)
+	const tests = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, tests)
+	expectedAll := make([][]int, tests)
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(20) + 1
+		fmt.Fprintln(&input, n)
+		l := make([]int, n)
+		r := make([]int, n)
+		for i := 0; i < n; i++ {
+			l[i] = rand.Intn(30) + 1
+			r[i] = l[i] + rand.Intn(10)
+			fmt.Fprintf(&input, "%d %d\n", l[i], r[i])
+		}
+		expectedAll[t] = solveB(l, r)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("Failed to run binary:", err)
+		os.Exit(1)
+	}
+	parts := strings.Fields(string(out))
+	// gather expected output count
+	expectedCount := 0
+	for _, arr := range expectedAll {
+		expectedCount += len(arr)
+	}
+	if len(parts) != expectedCount {
+		fmt.Printf("Expected %d numbers, got %d\n", expectedCount, len(parts))
+		os.Exit(1)
+	}
+	idx := 0
+	for t, arr := range expectedAll {
+		for i, exp := range arr {
+			if idx >= len(parts) {
+				fmt.Println("Output ended early")
+				os.Exit(1)
+			}
+			got, err := strconv.Atoi(parts[idx])
+			if err != nil || got != exp {
+				fmt.Printf("Test %d position %d failed: expected %d got %s\n", t+1, i+1, exp, parts[idx])
+				os.Exit(1)
+			}
+			idx++
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/verifiers/920/verifierC.go
+++ b/verifiers/920/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveC(a []int, s string) string {
+	n := len(a)
+	i := 0
+	for i < n-1 {
+		if s[i] == '1' {
+			start := i
+			for i < n-1 && s[i] == '1' {
+				i++
+			}
+			end := i
+			// sort a[start:end+1]
+			for x := start; x <= end; x++ {
+				for y := x + 1; y <= end; y++ {
+					if a[y] < a[x] {
+						a[x], a[y] = a[y], a[x]
+					}
+				}
+			}
+		} else {
+			i++
+		}
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != i+1 {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(10) + 2
+		a := rand.Perm(n)
+		for i := range a {
+			a[i]++
+		}
+		b := make([]int, n)
+		copy(b, a)
+		sbytes := make([]byte, n-1)
+		for i := range sbytes {
+			if rand.Intn(2) == 0 {
+				sbytes[i] = '0'
+			} else {
+				sbytes[i] = '1'
+			}
+		}
+		s := string(sbytes)
+		expected := solveC(b, s)
+		var input bytes.Buffer
+		fmt.Fprintln(&input, n)
+		for i, v := range a {
+			if i > 0 {
+				fmt.Fprint(&input, " ")
+			}
+			fmt.Fprint(&input, v)
+		}
+		fmt.Fprintln(&input)
+		fmt.Fprintln(&input, s)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Println("Failed to run binary:", err)
+			os.Exit(1)
+		}
+		answer := strings.TrimSpace(string(out))
+		if answer != expected {
+			fmt.Printf("Test %d failed: expected %s got %s\n", t+1, expected, answer)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/verifiers/920/verifierD.go
+++ b/verifiers/920/verifierD.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type state struct {
+	vols []int
+}
+
+func encode(v []int) string {
+	b := make([]byte, len(v)*4)
+	p := 0
+	for _, x := range v {
+		b[p] = byte(x)
+		b[p+1] = byte(x >> 8)
+		b[p+2] = byte(x >> 16)
+		b[p+3] = byte(x >> 24)
+		p += 4
+	}
+	return string(b)
+}
+
+func possible(n, k, v int, a []int) bool {
+	queue := [][]int{append([]int(nil), a...)}
+	visited := map[string]bool{encode(a): true}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, x := range cur {
+			if x == v {
+				return true
+			}
+		}
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				if i == j || cur[i] == 0 {
+					continue
+				}
+				take := cur[i]
+				if take > k {
+					take = k
+				}
+				next := append([]int(nil), cur...)
+				next[i] -= take
+				next[j] += take
+				key := encode(next)
+				if !visited[key] {
+					visited[key] = true
+					queue = append(queue, next)
+				}
+			}
+		}
+	}
+	return false
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(4)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(3) + 2
+		k := rand.Intn(5) + 1
+		a := make([]int, n)
+		for i := range a {
+			a[i] = rand.Intn(6)
+		}
+		v := rand.Intn(10)
+		expected := "NO"
+		if possible(n, k, v, a) {
+			expected = "YES"
+		}
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d %d\n", n, k, v)
+		for i, x := range a {
+			if i > 0 {
+				fmt.Fprint(&input, " ")
+			}
+			fmt.Fprint(&input, x)
+		}
+		fmt.Fprintln(&input)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Println("Failed to run binary:", err)
+			os.Exit(1)
+		}
+		answer := strings.Fields(string(out))
+		if len(answer) == 0 {
+			fmt.Printf("Test %d produced no output\n", t+1)
+			os.Exit(1)
+		}
+		if strings.ToUpper(answer[0]) != expected {
+			fmt.Printf("Test %d failed: expected %s got %s\n", t+1, expected, answer[0])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/verifiers/920/verifierE.go
+++ b/verifiers/920/verifierE.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type edge struct{ x, y int }
+
+func solveE(n int, edges []edge) (int, []int) {
+	adj := make([][]bool, n+1)
+	for i := range adj {
+		adj[i] = make([]bool, n+1)
+	}
+	for _, e := range edges {
+		adj[e.x][e.y] = true
+		adj[e.y][e.x] = true
+	}
+	visited := make([]bool, n+1)
+	sizes := []int{}
+	for v := 1; v <= n; v++ {
+		if visited[v] {
+			continue
+		}
+		queue := []int{v}
+		visited[v] = true
+		size := 0
+		for len(queue) > 0 {
+			cur := queue[0]
+			queue = queue[1:]
+			size++
+			for u := 1; u <= n; u++ {
+				if !visited[u] && !adj[cur][u] && u != cur {
+					visited[u] = true
+					queue = append(queue, u)
+				}
+			}
+		}
+		sizes = append(sizes, size)
+	}
+	sort.Ints(sizes)
+	return len(sizes), sizes
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(8) + 2
+		m := rand.Intn(n*(n-1)/2 + 1)
+		exists := make(map[[2]int]bool)
+		edges := make([]edge, m)
+		for i := 0; i < m; i++ {
+			for {
+				x := rand.Intn(n) + 1
+				y := rand.Intn(n) + 1
+				if x == y || exists[[2]int{x, y}] || exists[[2]int{y, x}] {
+					continue
+				}
+				exists[[2]int{x, y}] = true
+				edges[i] = edge{x, y}
+				break
+			}
+		}
+		expectedK, expectedSizes := solveE(n, edges)
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", n, m)
+		for _, e := range edges {
+			fmt.Fprintf(&input, "%d %d\n", e.x, e.y)
+		}
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Println("Failed to run binary:", err)
+			os.Exit(1)
+		}
+		parts := strings.Fields(string(out))
+		if len(parts) < 1 {
+			fmt.Printf("Test %d produced no output\n", t+1)
+			os.Exit(1)
+		}
+		k, err := strconv.Atoi(parts[0])
+		if err != nil || k != expectedK {
+			fmt.Printf("Test %d failed: expected %d components got %s\n", t+1, expectedK, parts[0])
+			os.Exit(1)
+		}
+		if len(parts)-1 != k {
+			fmt.Printf("Test %d failed: expected %d sizes got %d values\n", t+1, k, len(parts)-1)
+			os.Exit(1)
+		}
+		for i := 0; i < k; i++ {
+			val, err := strconv.Atoi(parts[i+1])
+			if err != nil || val != expectedSizes[i] {
+				fmt.Printf("Test %d size %d mismatch: expected %d got %s\n", t+1, i+1, expectedSizes[i], parts[i+1])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/verifiers/920/verifierF.go
+++ b/verifiers/920/verifierF.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func divCount(x int) int {
+	cnt := 0
+	for d := 1; d*d <= x; d++ {
+		if x%d == 0 {
+			cnt += 2
+			if d*d == x {
+				cnt--
+			}
+		}
+	}
+	return cnt
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(6)
+	const tests = 100
+	for t := 0; t < tests; t++ {
+		n := rand.Intn(10) + 1
+		m := rand.Intn(10) + 1
+		arr := make([]int, n)
+		for i := range arr {
+			arr[i] = rand.Intn(20) + 1
+		}
+		queries := make([][3]int, m)
+		sumQueries := 0
+		for i := 0; i < m; i++ {
+			typ := rand.Intn(2) + 1
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			queries[i] = [3]int{typ, l, r}
+			if typ == 2 {
+				sumQueries++
+			}
+		}
+		if sumQueries == 0 {
+			queries[0][0] = 2
+		}
+		// compute expected answers
+		expected := []int{}
+		arrCopy := append([]int(nil), arr...)
+		for _, q := range queries {
+			if q[0] == 1 {
+				for i := q[1] - 1; i < q[2]; i++ {
+					arrCopy[i] = divCount(arrCopy[i])
+				}
+			} else {
+				total := 0
+				for i := q[1] - 1; i < q[2]; i++ {
+					total += arrCopy[i]
+				}
+				expected = append(expected, total)
+			}
+		}
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", n, m)
+		for i, v := range arr {
+			if i > 0 {
+				fmt.Fprint(&input, " ")
+			}
+			fmt.Fprint(&input, v)
+		}
+		fmt.Fprintln(&input)
+		for _, q := range queries {
+			fmt.Fprintf(&input, "%d %d %d\n", q[0], q[1], q[2])
+		}
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Println("Failed to run binary:", err)
+			os.Exit(1)
+		}
+		parts := strings.Fields(string(out))
+		if len(parts) != len(expected) {
+			fmt.Printf("Test %d failed: expected %d outputs got %d\n", t+1, len(expected), len(parts))
+			os.Exit(1)
+		}
+		for i, exp := range expected {
+			val, err := strconv.Atoi(parts[i])
+			if err != nil || val != exp {
+				fmt.Printf("Test %d output %d mismatch: expected %d got %s\n", t+1, i+1, exp, parts[i])
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/verifiers/920/verifierG.go
+++ b/verifiers/920/verifierG.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func primeFactors(n int) []int {
+	f := []int{}
+	for i := 2; i*i <= n; i++ {
+		if n%i == 0 {
+			f = append(f, i)
+			for n%i == 0 {
+				n /= i
+			}
+		}
+	}
+	if n > 1 {
+		f = append(f, n)
+	}
+	return f
+}
+
+func countCoprime(limit int64, factors []int) int64 {
+	if limit <= 0 {
+		return 0
+	}
+	m := len(factors)
+	var bad int64
+	for mask := 1; mask < (1 << m); mask++ {
+		prod := int64(1)
+		bits := 0
+		for i := 0; i < m; i++ {
+			if mask&(1<<i) != 0 {
+				prod *= int64(factors[i])
+				bits++
+			}
+		}
+		if bits%2 == 1 {
+			bad += limit / prod
+		} else {
+			bad -= limit / prod
+		}
+	}
+	return limit - bad
+}
+
+func kth(x, p, k int) int64 {
+	f := primeFactors(p)
+	base := countCoprime(int64(x), f)
+	low := int64(x) + 1
+	high := int64(x) + int64(k*p) + 100
+	for low < high {
+		mid := (low + high) / 2
+		if countCoprime(mid, f)-base >= int64(k) {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+	return low
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(7)
+	const tests = 100
+	var input bytes.Buffer
+	fmt.Fprintln(&input, tests)
+	expected := make([]int64, tests)
+	for i := 0; i < tests; i++ {
+		x := rand.Intn(1000) + 1
+		p := rand.Intn(1000) + 1
+		k := rand.Intn(20) + 1
+		expected[i] = kth(x, p, k)
+		fmt.Fprintf(&input, "%d %d %d\n", x, p, k)
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("Failed to run binary:", err)
+		os.Exit(1)
+	}
+	parts := strings.Fields(string(out))
+	if len(parts) != tests {
+		fmt.Printf("Expected %d numbers, got %d\n", tests, len(parts))
+		os.Exit(1)
+	}
+	for i := 0; i < tests; i++ {
+		val, err := strconv.ParseInt(parts[i], 10, 64)
+		if err != nil || val != expected[i] {
+			fmt.Printf("Test %d failed: expected %d got %s\n", i+1, expected[i], parts[i])
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest 920 problems A–G
- each verifier generates 100 random tests and checks the output of a given binary

## Testing
- `go run verifiers/920/verifierA.go ./920A_bin`
- `go run verifiers/920/verifierB.go ./920B_bin`
- `go run verifiers/920/verifierG.go ./920G_bin`


------
https://chatgpt.com/codex/tasks/task_e_6883f8961bc483248fc1e742b443b4c2