### PR TITLE
Add Go solution for 1676H2

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1676/1676H2.go
+++ b/1000-1999/1600-1699/1670-1679/1676/1676H2.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func add(bit []int64, idx int, val int64) {
+	for idx < len(bit) {
+		bit[idx] += val
+		idx += idx & -idx
+	}
+}
+
+func sum(bit []int64, idx int) int64 {
+	var res int64
+	for idx > 0 {
+		res += bit[idx]
+		idx -= idx & -idx
+	}
+	return res
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+		}
+		bit := make([]int64, n+2)
+		var ans int64
+		for _, v := range arr {
+			ans += sum(bit, n) - sum(bit, v-1)
+			add(bit, v, 1)
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem H2 of contest 1676
- compute count of pairs `(i,j)` with `i < j` and `a[i] >= a[j]` using a Fenwick tree

## Testing
- `go build 1000-1999/1600-1699/1670-1679/1676/1676H2.go`

------
https://chatgpt.com/codex/tasks/task_e_6883f737eb488324b039857a294b7b8b