### PR TITLE
Add Go solution for 1628C

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1628/1628C.go
+++ b/1000-1999/1600-1699/1620-1629/1628/1628C.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		res := 0
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				var x int
+				fmt.Fscan(in, &x)
+				res ^= x
+			}
+		}
+		fmt.Fprintln(out, res)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1628C.go` to compute XOR of all values in the grid

## Testing
- `go run 1000-1999/1600-1699/1620-1629/1628/1628C.go <<EOF
1
2
1 2
3 4
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688438e1feb88324ba43f44758c5be62