### PR TITLE
Add verifiers for contest 917

### DIFF
--- a/0-999/900-999/910-919/917/verifierA.go
+++ b/0-999/900-999/910-919/917/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "917A.go")
+	bin := filepath.Join(os.TempDir(), "ref917A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 2 // length 2..21
+	letters := []byte{'(', ')', '?'}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	userBin := os.Args[1]
+
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := genCase(rand.New(rand.NewSource(int64(i) + time.Now().UnixNano())))
+		want, err1 := runBinary(ref, input)
+		if err1 != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err1)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		got, err2 := runBinary(userBin, input)
+		if err2 != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err2)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/910-919/917/verifierB.go
+++ b/0-999/900-999/910-919/917/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	v int
+	u int
+	c byte
+}
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "917B.go")
+	bin := filepath.Join(os.TempDir(), "ref917B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2 // 2..5
+	edges := make([]edge, 0)
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			if rng.Intn(2) == 0 {
+				edges = append(edges, edge{i, j, byte('a' + rng.Intn(26))})
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %c\n", e.v, e.u, e.c))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	userBin := os.Args[1]
+
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := genCase(rand.New(rand.NewSource(int64(i) + time.Now().UnixNano())))
+		want, err1 := runBinary(ref, input)
+		if err1 != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err1)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		got, err2 := runBinary(userBin, input)
+		if err2 != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err2)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/910-919/917/verifierC.go
+++ b/0-999/900-999/910-919/917/verifierC.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "917C.go")
+	bin := filepath.Join(os.TempDir(), "ref917C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	k := rng.Intn(4) + 1 // 1..4
+	x := rng.Intn(k) + 1
+	n := rng.Intn(40) + k
+	q := 0
+	if n-x > 0 {
+		q = rng.Intn(min(5, n-x) + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", x, k, n, q))
+	for i := 0; i < k; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(10)+1))
+	}
+	sb.WriteByte('\n')
+	used := make(map[int]bool)
+	for i := 0; i < q; i++ {
+		p := rng.Intn(n-x) + x + 1
+		for used[p] {
+			p = rng.Intn(n-x) + x + 1
+		}
+		used[p] = true
+		w := rng.Intn(21) - 10
+		sb.WriteString(fmt.Sprintf("%d %d\n", p, w))
+	}
+	return sb.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	userBin := os.Args[1]
+
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := genCase(rand.New(rand.NewSource(int64(i) + time.Now().UnixNano())))
+		want, err1 := runBinary(ref, input)
+		if err1 != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err1)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		got, err2 := runBinary(userBin, input)
+		if err2 != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err2)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/910-919/917/verifierD.go
+++ b/0-999/900-999/910-919/917/verifierD.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "917D.go")
+	bin := filepath.Join(os.TempDir(), "ref917D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 2 // 2..7
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for v := 2; v <= n; v++ {
+		p := rng.Intn(v-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", p, v))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	userBin := os.Args[1]
+
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := genCase(rand.New(rand.NewSource(int64(i) + time.Now().UnixNano())))
+		want, err1 := runBinary(ref, input)
+		if err1 != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err1)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		got, err2 := runBinary(userBin, input)
+		if err2 != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err2)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/910-919/917/verifierE.go
+++ b/0-999/900-999/910-919/917/verifierE.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "917E.go")
+	bin := filepath.Join(os.TempDir(), "ref917E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTree(rng *rand.Rand, n int) []string {
+	edges := make([]string, n-1)
+	for v := 2; v <= n; v++ {
+		p := rng.Intn(v-1) + 1
+		c := byte('a' + rng.Intn(26))
+		edges[v-2] = fmt.Sprintf("%d %d %c", p, v, c)
+	}
+	return edges
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 2 // 2..7
+	m := rng.Intn(3) + 1
+	q := rng.Intn(4) + 1
+	tree := genTree(rng, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+	for _, e := range tree {
+		sb.WriteString(e)
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < m; i++ {
+		l := rng.Intn(5) + 1
+		word := make([]byte, l)
+		for j := range word {
+			word[j] = byte('a' + rng.Intn(26))
+		}
+		sb.WriteString(string(word))
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < q; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		for b == a {
+			b = rng.Intn(n) + 1
+		}
+		k := rng.Intn(m) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", a, b, k))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	userBin := os.Args[1]
+
+	rand.Seed(time.Now().UnixNano())
+
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("reference compile failed:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	for i := 0; i < 100; i++ {
+		input := genCase(rand.New(rand.NewSource(int64(i) + time.Now().UnixNano())))
+		want, err1 := runBinary(ref, input)
+		if err1 != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err1)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		got, err2 := runBinary(userBin, input)
+		if err2 != nil {
+			fmt.Printf("test %d runtime error: %v\n", i+1, err2)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- create random-test verifiers for contest 917 problems A–E
- each verifier compiles the reference solution and checks 100 generated cases

## Testing
- `go build 0-999/900-999/910-919/917/verifierA.go`
- `go build 0-999/900-999/910-919/917/verifierB.go`
- `go build 0-999/900-999/910-919/917/verifierC.go`
- `go build 0-999/900-999/910-919/917/verifierD.go`
- `go build 0-999/900-999/910-919/917/verifierE.go`
- `go run 0-999/900-999/910-919/917/verifierA.go /tmp/917A.bin`

------
https://chatgpt.com/codex/tasks/task_e_6883f6f1ffc48324b353de9782c74a7b