### PR TITLE
Add solution for 1676H1

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1676/1676H1.go
+++ b/1000-1999/1600-1699/1670-1679/1676/1676H1.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		var count int64
+		for i := 0; i < n; i++ {
+			for j := i + 1; j < n; j++ {
+				if a[i] >= a[j] {
+					count++
+				}
+			}
+		}
+		fmt.Fprintln(out, count)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem H1 in contest 1676
- solution counts all pairs `(i,j)` such that `a[i] >= a[j]`

## Testing
- `go vet 1000-1999/1600-1699/1670-1679/1676/1676H1.go`
- `go build 1000-1999/1600-1699/1670-1679/1676/1676H1.go`


------
https://chatgpt.com/codex/tasks/task_e_6883f6ac478c8324a57bdd52b012c035