### PR TITLE
Add verifiers for contest 915

### DIFF
--- a/0-999/900-999/910-919/915/verifierA.go
+++ b/0-999/900-999/910-919/915/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type caseA struct {
+    n, k int
+    buckets []int
+}
+
+func computeA(c caseA) int {
+    best := int(1<<31 - 1)
+    for _, a := range c.buckets {
+        if c.k%a == 0 {
+            hours := c.k / a
+            if hours < best {
+                best = hours
+            }
+        }
+    }
+    return best
+}
+
+func generateA(rng *rand.Rand) (string, int) {
+    n := rng.Intn(10) + 1
+    k := rng.Intn(100) + 1
+    buckets := make([]int, n)
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+    divisor := rng.Intn(100) + 1
+    for divisor == 0 || k%divisor != 0 {
+        divisor = rng.Intn(100) + 1
+    }
+    pos := rng.Intn(n)
+    for i := 0; i < n; i++ {
+        if i == pos {
+            buckets[i] = divisor
+        } else {
+            buckets[i] = rng.Intn(100) + 1
+        }
+        if i > 0 {
+            sb.WriteByte(' ')
+        }
+        sb.WriteString(fmt.Sprintf("%d", buckets[i]))
+    }
+    sb.WriteByte('\n')
+    return sb.String(), computeA(caseA{n: n, k: k, buckets: buckets})
+}
+
+func runCase(bin string, in string, exp int) error {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    var got int
+    if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+        return fmt.Errorf("failed to parse output: %v", err)
+    }
+    if got != exp {
+        return fmt.Errorf("expected %d got %d", exp, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    bin := os.Args[1]
+    for i := 0; i < 100; i++ {
+        in, exp := generateA(rng)
+        if err := runCase(bin, in, exp); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/900-999/910-919/915/verifierB.go
+++ b/0-999/900-999/910-919/915/verifierB.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func computeB(n, pos, l, r int) int {
+    abs := func(x int) int { if x < 0 { return -x }; return x }
+    min := func(a, b int) int { if a < b { return a }; return b }
+    switch {
+    case l == 1 && r == n:
+        return 0
+    case l == 1:
+        return abs(pos-r) + 1
+    case r == n:
+        return abs(pos-l) + 1
+    default:
+        return min(abs(pos-l), abs(pos-r)) + (r - l) + 2
+    }
+}
+
+func generateB(rng *rand.Rand) (string, int) {
+    n := rng.Intn(100) + 1
+    pos := rng.Intn(n) + 1
+    l := rng.Intn(n) + 1
+    r := rng.Intn(n-l+1) + l
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, pos, l, r))
+    return sb.String(), computeB(n, pos, l, r)
+}
+
+func runCase(bin, in string, exp int) error {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    var got int
+    if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+        return fmt.Errorf("failed to parse output: %v", err)
+    }
+    if got != exp {
+        return fmt.Errorf("expected %d got %d", exp, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    bin := os.Args[1]
+    for i := 0; i < 100; i++ {
+        in, exp := generateB(rng)
+        if err := runCase(bin, in, exp); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/900-999/910-919/915/verifierC.go
+++ b/0-999/900-999/910-919/915/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+    "time"
+)
+
+func solveC(aStr, bStr string) string {
+    if len(aStr) < len(bStr) {
+        digits := []byte(aStr)
+        sort.Slice(digits, func(i, j int) bool { return digits[i] > digits[j] })
+        return string(digits)
+    }
+    counts := make([]int, 10)
+    for _, ch := range aStr {
+        counts[ch-'0']++
+    }
+    res := make([]byte, len(bStr))
+    var dfs func(pos int, limit bool) bool
+    dfs = func(pos int, limit bool) bool {
+        if pos == len(bStr) {
+            return true
+        }
+        maxDigit := 9
+        if limit {
+            maxDigit = int(bStr[pos] - '0')
+        }
+        for d := maxDigit; d >= 0; d-- {
+            if counts[d] == 0 {
+                continue
+            }
+            counts[d]--
+            res[pos] = byte('0' + d)
+            if dfs(pos+1, limit && d == maxDigit) {
+                return true
+            }
+            counts[d]++
+        }
+        return false
+    }
+    if dfs(0, true) {
+        return string(res)
+    }
+    return ""
+}
+
+func generateC(rng *rand.Rand) (string, string, string) {
+    l := rng.Intn(18) + 1
+    digits := make([]byte, l)
+    digits[0] = byte('1' + rng.Intn(9))
+    for i := 1; i < l; i++ {
+        digits[i] = byte('0' + rng.Intn(10))
+    }
+    a := string(digits)
+
+    if rng.Intn(2) == 0 {
+        // len(b) > len(a)
+        bl := l + rng.Intn(3) + 1
+        bDigits := make([]byte, bl)
+        bDigits[0] = byte('1' + rng.Intn(9))
+        for i := 1; i < bl; i++ {
+            bDigits[i] = byte('0' + rng.Intn(10))
+        }
+        b := string(bDigits)
+        return a, b, solveC(a, b)
+    }
+    // len(b) == len(a), choose b >= sorted digits ascending to ensure solution
+    digitsB := make([]byte, l)
+    for i := 0; i < l; i++ {
+        digitsB[i] = byte('0' + rng.Intn(10))
+    }
+    b := string(digitsB)
+    // to guarantee existence, set b to a large value by at least digits sorted ascending
+    digitsAsc := []byte(a)
+    sort.Slice(digitsAsc, func(i, j int) bool { return digitsAsc[i] < digitsAsc[j] })
+    if strings.Compare(b, string(digitsAsc)) < 0 {
+        b = string(digitsAsc)
+    }
+    return a, b, solveC(a, b)
+}
+
+func runCase(bin, input, exp string) error {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    got := strings.TrimSpace(out.String())
+    if got != exp {
+        return fmt.Errorf("expected %s got %s", exp, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    bin := os.Args[1]
+    for i := 0; i < 100; i++ {
+        a, b, exp := generateC(rng)
+        input := fmt.Sprintf("%s\n%s\n", a, b)
+        if err := runCase(bin, input, exp); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/900-999/910-919/915/verifierD.go
+++ b/0-999/900-999/910-919/915/verifierD.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type edge struct{ u, v int }
+
+func checkD(n int, adj [][]int, skipU, skipV int) bool {
+    indeg := make([]int, n+1)
+    for u := 1; u <= n; u++ {
+        for _, v := range adj[u] {
+            if u == skipU && v == skipV {
+                continue
+            }
+            indeg[v]++
+        }
+    }
+    q := make([]int, 0, n)
+    for i := 1; i <= n; i++ {
+        if indeg[i] == 0 {
+            q = append(q, i)
+        }
+    }
+    count := 0
+    for head := 0; head < len(q); head++ {
+        v := q[head]
+        count++
+        for _, to := range adj[v] {
+            if v == skipU && to == skipV {
+                continue
+            }
+            indeg[to]--
+            if indeg[to] == 0 {
+                q = append(q, to)
+            }
+        }
+    }
+    return count == n
+}
+
+func findCycle(n int, adj [][]int) ([]edge, bool) {
+    color := make([]int, n+1)
+    stack := make([]int, 0, n)
+    pos := make([]int, n+1)
+    var cycle []edge
+    var found bool
+    var dfs func(int)
+    dfs = func(v int) {
+        color[v] = 1
+        pos[v] = len(stack)
+        stack = append(stack, v)
+        for _, to := range adj[v] {
+            if found {
+                return
+            }
+            if color[to] == 0 {
+                dfs(to)
+            } else if color[to] == 1 {
+                found = true
+                idx := pos[to]
+                nodes := append([]int{}, stack[idx:]...)
+                nodes = append(nodes, to)
+                for i := 0; i < len(nodes)-1; i++ {
+                    cycle = append(cycle, edge{nodes[i], nodes[i+1]})
+                }
+                return
+            }
+        }
+        stack = stack[:len(stack)-1]
+        color[v] = 2
+    }
+    for i := 1; i <= n && !found; i++ {
+        if color[i] == 0 {
+            dfs(i)
+        }
+    }
+    return cycle, found
+}
+
+func solveD(n int, edges []edge) string {
+    adj := make([][]int, n+1)
+    for _, e := range edges {
+        adj[e.u] = append(adj[e.u], e.v)
+    }
+    if checkD(n, adj, -1, -1) {
+        return "YES"
+    }
+    cyc, ok := findCycle(n, adj)
+    if !ok {
+        return "NO"
+    }
+    for _, e := range cyc {
+        if checkD(n, adj, e.u, e.v) {
+            return "YES"
+        }
+    }
+    return "NO"
+}
+
+func generateD(rng *rand.Rand) (string, string) {
+    n := rng.Intn(7) + 2
+    maxM := n * (n - 1)
+    m := rng.Intn(min(maxM, 10)) + 1
+    edges := make([]edge, 0, m)
+    seen := make(map[[2]int]bool)
+    for len(edges) < m {
+        u := rng.Intn(n) + 1
+        v := rng.Intn(n) + 1
+        if u == v {
+            continue
+        }
+        key := [2]int{u, v}
+        if seen[key] {
+            continue
+        }
+        seen[key] = true
+        edges = append(edges, edge{u, v})
+    }
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+    for _, e := range edges {
+        sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+    }
+    return sb.String(), solveD(n, edges)
+}
+
+func min(a, b int) int { if a < b { return a }; return b }
+
+func runCase(bin, input, exp string) error {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    got := strings.TrimSpace(out.String())
+    if got != exp {
+        return fmt.Errorf("expected %s got %s", exp, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+        os.Exit(1)
+    }
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    bin := os.Args[1]
+    for i := 0; i < 100; i++ {
+        in, exp := generateD(rng)
+        if err := runCase(bin, in, exp); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/900-999/910-919/915/verifierE.go
+++ b/0-999/900-999/910-919/915/verifierE.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+type Node struct {
+    left, right *Node
+    sum  int64
+    lazy int8 // -1 none, 0 or 1 set
+}
+
+func newNode() *Node { return &Node{lazy: -1} }
+
+func push(node *Node, l, r int64) {
+    if node.lazy == -1 || l == r {
+        return
+    }
+    mid := (l + r) >> 1
+    if node.left == nil { node.left = newNode() }
+    if node.right == nil { node.right = newNode() }
+    val := int64(node.lazy)
+    node.left.sum = (mid - l + 1) * val
+    node.left.lazy = node.lazy
+    node.right.sum = (r - mid) * val
+    node.right.lazy = node.lazy
+    node.lazy = -1
+}
+
+func update(node *Node, l, r, ql, qr int64, val int8) {
+    if node == nil || ql > r || qr < l { return }
+    if ql <= l && r <= qr {
+        node.sum = (r - l + 1) * int64(val)
+        node.lazy = val
+        node.left, node.right = nil, nil
+        return
+    }
+    push(node, l, r)
+    mid := (l + r) >> 1
+    if ql <= mid {
+        if node.left == nil { node.left = newNode() }
+        update(node.left, l, mid, ql, qr, val)
+    }
+    if qr > mid {
+        if node.right == nil { node.right = newNode() }
+        update(node.right, mid+1, r, ql, qr, val)
+    }
+    node.sum = 0
+    if node.left != nil { node.sum += node.left.sum }
+    if node.right != nil { node.sum += node.right.sum }
+}
+
+func solveE(n int64, ops [][3]int64) string {
+    root := &Node{sum: n, lazy: 1}
+    var sb strings.Builder
+    for _, op := range ops {
+        l, r, k := op[0], op[1], op[2]
+        val := int8(0)
+        if k == 2 {
+            val = 1
+        }
+        update(root, 1, n, l, r, val)
+        sb.WriteString(fmt.Sprintf("%d\n", root.sum))
+    }
+    return strings.TrimRight(sb.String(), "\n")
+}
+
+func generateE(rng *rand.Rand) (string, string) {
+    n := int64(rng.Intn(1000) + 1)
+    q := int64(rng.Intn(20) + 1)
+    ops := make([][3]int64, q)
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+    for i := int64(0); i < q; i++ {
+        l := int64(rng.Intn(int(n)) + 1)
+        r := int64(rng.Intn(int(n-l+1)) + int(l))
+        k := int64(rng.Intn(2) + 1)
+        ops[i] = [3]int64{l, r, k}
+        sb.WriteString(fmt.Sprintf("%d %d %d\n", l, r, k))
+    }
+    return sb.String(), solveE(n, ops)
+}
+
+func runCase(bin, input, exp string) error {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    got := strings.TrimSpace(out.String())
+    if got != exp {
+        return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+        os.Exit(1)
+    }
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    bin := os.Args[1]
+    for i := 0; i < 100; i++ {
+        in, exp := generateE(rng)
+        if err := runCase(bin, in, exp); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/900-999/910-919/915/verifierF.go
+++ b/0-999/900-999/910-919/915/verifierF.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "sort"
+    "strings"
+    "time"
+)
+
+// DSU structure used in original solution
+type DSU struct {
+    parent []int
+    size   []int
+}
+
+func NewDSU(n int) *DSU {
+    d := &DSU{parent: make([]int, n), size: make([]int, n)}
+    for i := 0; i < n; i++ {
+        d.parent[i] = i
+        d.size[i] = 1
+    }
+    return d
+}
+
+func (d *DSU) find(x int) int {
+    for d.parent[x] != x {
+        d.parent[x] = d.parent[d.parent[x]]
+        x = d.parent[x]
+    }
+    return x
+}
+
+func (d *DSU) union(a, b int) int64 {
+    ra := d.find(a)
+    rb := d.find(b)
+    if ra == rb {
+        return 0
+    }
+    if d.size[ra] < d.size[rb] {
+        ra, rb = rb, ra
+    }
+    pairs := int64(d.size[ra]) * int64(d.size[rb])
+    d.parent[rb] = ra
+    d.size[ra] += d.size[rb]
+    return pairs
+}
+
+func solveF(n int, vals []int, edges [][2]int) string {
+    g := make([][]int, n)
+    for _, e := range edges {
+        x, y := e[0], e[1]
+        g[x] = append(g[x], y)
+        g[y] = append(g[y], x)
+    }
+    type node struct{ val, idx int }
+    order := make([]node, n)
+    for i := 0; i < n; i++ {
+        order[i] = node{val: vals[i], idx: i}
+    }
+    sort.Slice(order, func(i, j int) bool { return order[i].val < order[j].val })
+    dsu := NewDSU(n)
+    active := make([]bool, n)
+    var maxSum int64
+    for _, p := range order {
+        v := p.idx
+        active[v] = true
+        for _, to := range g[v] {
+            if active[to] {
+                maxSum += int64(p.val) * dsu.union(v, to)
+            }
+        }
+    }
+    sort.Slice(order, func(i, j int) bool { return order[i].val > order[j].val })
+    dsu = NewDSU(n)
+    for i := range active { active[i] = false }
+    var minSum int64
+    for _, p := range order {
+        v := p.idx
+        active[v] = true
+        for _, to := range g[v] {
+            if active[to] {
+                minSum += int64(p.val) * dsu.union(v, to)
+            }
+        }
+    }
+    return fmt.Sprintf("%d", maxSum-minSum)
+}
+
+func generateTree(rng *rand.Rand, n int) [][2]int {
+    edges := make([][2]int, 0, n-1)
+    for i := 1; i < n; i++ {
+        j := rng.Intn(i)
+        edges = append(edges, [2]int{i, j})
+    }
+    return edges
+}
+
+func generateF(rng *rand.Rand) (string, string) {
+    n := rng.Intn(15) + 1
+    vals := make([]int, n)
+    for i := 0; i < n; i++ {
+        vals[i] = rng.Intn(20) + 1
+    }
+    edges := generateTree(rng, n)
+    var sb strings.Builder
+    sb.WriteString(fmt.Sprintf("%d\n", n))
+    for i := 0; i < n; i++ {
+        if i > 0 { sb.WriteByte(' ') }
+        sb.WriteString(fmt.Sprintf("%d", vals[i]))
+    }
+    sb.WriteByte('\n')
+    for _, e := range edges {
+        sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+    }
+    return sb.String(), solveF(n, vals, edges)
+}
+
+func runCase(bin, in, exp string) error {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    got := strings.TrimSpace(out.String())
+    if got != exp {
+        return fmt.Errorf("expected %s got %s", exp, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+        os.Exit(1)
+    }
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    bin := os.Args[1]
+    for i := 0; i < 100; i++ {
+        in, exp := generateF(rng)
+        if err := runCase(bin, in, exp); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/0-999/900-999/910-919/915/verifierG.go
+++ b/0-999/900-999/910-919/915/verifierG.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+const mod int64 = 1000000007
+
+func powmod(base, exp int64) int64 {
+    res := int64(1)
+    base %= mod
+    for exp > 0 {
+        if exp&1 == 1 {
+            res = res * base % mod
+        }
+        base = base * base % mod
+        exp >>= 1
+    }
+    return res
+}
+
+func solveG(n, k int) string {
+    mu := make([]int, k+1)
+    lp := make([]int, k+1)
+    primes := make([]int, 0)
+    mu[1] = 1
+    for i := 2; i <= k; i++ {
+        if lp[i] == 0 {
+            lp[i] = i
+            primes = append(primes, i)
+            mu[i] = -1
+        }
+        for _, p := range primes {
+            if p > lp[i] || p*i > k {
+                break
+            }
+            lp[p*i] = p
+            if i%p == 0 {
+                mu[p*i] = 0
+                break
+            } else {
+                mu[p*i] = -mu[i]
+            }
+        }
+    }
+    powArr := make([]int64, k+1)
+    for i := 1; i <= k; i++ {
+        powArr[i] = powmod(int64(i), int64(n))
+    }
+    b := make([]int64, k+1)
+    for d := 1; d <= k; d++ {
+        if mu[d] == 0 {
+            continue
+        }
+        md := int64(mu[d])
+        for m := d; m <= k; m += d {
+            b[m] += md * powArr[m/d]
+        }
+    }
+    ans := int64(0)
+    for i := 1; i <= k; i++ {
+        bi := b[i] % mod
+        if bi < 0 {
+            bi += mod
+        }
+        ans = (ans + int64(int(bi)^i)) % mod
+    }
+    return fmt.Sprintf("%d", ans)
+}
+
+func generateG(rng *rand.Rand) (string, string) {
+    n := rng.Intn(5) + 1
+    k := rng.Intn(20) + 1
+    input := fmt.Sprintf("%d %d\n", n, k)
+    return input, solveG(n, k)
+}
+
+func runCase(bin, in, exp string) error {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(in)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    if err := cmd.Run(); err != nil {
+        return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+    }
+    got := strings.TrimSpace(out.String())
+    if got != exp {
+        return fmt.Errorf("expected %s got %s", exp, got)
+    }
+    return nil
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+        os.Exit(1)
+    }
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+    bin := os.Args[1]
+    for i := 0; i < 100; i++ {
+        in, exp := generateG(rng)
+        if err := runCase(bin, in, exp); err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+


### PR DESCRIPTION
## Summary
- add `verifierA.go` through `verifierG.go` for contest 915
- each verifier runs 100 randomized tests against a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6883f5d9e6788324a5f65cc1055d7e7d