### PR TITLE
Add Go verifiers for contest 912

### DIFF
--- a/0-999/900-999/910-919/912/verifierA.go
+++ b/0-999/900-999/910-919/912/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(A, B, x, y, z int64) string {
+	needYellow := 2*x + y
+	needBlue := y + 3*z
+	add := int64(0)
+	if needYellow > A {
+		add += needYellow - A
+	}
+	if needBlue > B {
+		add += needBlue - B
+	}
+	return fmt.Sprint(add)
+}
+
+func generateCase(rng *rand.Rand) (int64, int64, int64, int64, int64) {
+	A := rng.Int63n(1000)
+	B := rng.Int63n(1000)
+	x := rng.Int63n(500)
+	y := rng.Int63n(500)
+	z := rng.Int63n(500)
+	return A, B, x, y, z
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		A, B, x, y, z := generateCase(rng)
+		input := fmt.Sprintf("%d %d\n%d %d %d\n", A, B, x, y, z)
+		expect := solveCase(A, B, x, y, z)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/910-919/912/verifierB.go
+++ b/0-999/900-999/910-919/912/verifierB.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, k uint64) string {
+	if k == 1 {
+		return fmt.Sprint(n)
+	}
+	length := bits.Len64(n)
+	ans := uint64(1<<uint(length)) - 1
+	return fmt.Sprint(ans)
+}
+
+func generateCase(rng *rand.Rand) (uint64, uint64) {
+	n := rng.Uint64()%1000000 + 1
+	k := rng.Uint64()%n + 1
+	return n, k
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k := generateCase(rng)
+		input := fmt.Sprintf("%d %d\n", n, k)
+		expect := solveCase(n, k)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/910-919/912/verifierC.go
+++ b/0-999/900-999/910-919/912/verifierC.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Update struct {
+	t int64
+	h int64
+}
+
+type Enemy struct {
+	maxH  int64
+	start int64
+	regen int64
+	ups   []Update
+}
+
+type Event struct {
+	t     int64
+	delta int64
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func addInterval(l, r int64, events *[]Event) {
+	if l > r {
+		return
+	}
+	*events = append(*events, Event{t: l, delta: 1}, Event{t: r + 1, delta: -1})
+}
+
+func processSegment(start, end, h, regen, maxH, damage int64, events *[]Event) {
+	if start >= end || h > damage {
+		return
+	}
+	if regen == 0 || maxH <= damage {
+		addInterval(start, end-1, events)
+		return
+	}
+	if damage < h {
+		return
+	}
+	limit := (damage - h) / regen
+	tEnd := start + limit
+	if tEnd >= end {
+		tEnd = end - 1
+	}
+	if tEnd >= start {
+		addInterval(start, tEnd, events)
+	}
+}
+
+func solveCase(n, m int, bounty, increase, damage int64, enemies []Enemy, updates [][3]int64) string {
+	for i := range enemies {
+		enemies[i].ups = nil
+	}
+	for _, u := range updates {
+		t, id, h := u[0], u[1], u[2]
+		enemies[id].ups = append(enemies[id].ups, Update{t: t, h: h})
+	}
+	const INF int64 = 1 << 60
+	var events []Event
+	infinite := false
+	for i := 0; i < n; i++ {
+		e := &enemies[i]
+		sort.Slice(e.ups, func(a, b int) bool { return e.ups[a].t < e.ups[b].t })
+		prevT := int64(0)
+		prevH := e.start
+		for _, u := range e.ups {
+			processSegment(prevT, u.t, prevH, e.regen, e.maxH, damage, &events)
+			prevT = u.t
+			prevH = u.h
+		}
+		processSegment(prevT, INF, prevH, e.regen, e.maxH, damage, &events)
+		if increase > 0 {
+			finalH := prevH
+			if e.regen > 0 {
+				finalH = e.maxH
+			}
+			if finalH <= damage {
+				infinite = true
+			}
+		}
+	}
+	if infinite {
+		return "-1"
+	}
+	sort.Slice(events, func(i, j int) bool { return events[i].t < events[j].t })
+	var curr int64
+	var ans int64
+	prev := int64(0)
+	for i := 0; i < len(events); {
+		t := events[i].t
+		if curr > 0 && prev <= t-1 {
+			gold := curr * (bounty + increase*(t-1))
+			if gold > ans {
+				ans = gold
+			}
+		}
+		for i < len(events) && events[i].t == t {
+			curr += events[i].delta
+			i++
+		}
+		prev = t
+	}
+	return fmt.Sprint(ans)
+}
+
+func generateCase(rng *rand.Rand) (int, int, int64, int64, int64, []Enemy, [][3]int64) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3)
+	bounty := rng.Int63n(20) + 1
+	increase := rng.Int63n(5)
+	damage := rng.Int63n(20) + 1
+	enemies := make([]Enemy, n)
+	for i := 0; i < n; i++ {
+		maxH := rng.Int63n(20) + 1
+		start := rng.Int63n(maxH) + 1
+		regen := rng.Int63n(maxH + 1)
+		enemies[i] = Enemy{maxH: maxH, start: start, regen: regen}
+	}
+	updates := make([][3]int64, m)
+	for i := 0; i < m; i++ {
+		t := rng.Int63n(10) + 1
+		id := int64(rng.Intn(n))
+		h := rng.Int63n(enemies[id].maxH) + 1
+		updates[i] = [3]int64{t, id, h}
+	}
+	return n, m, bounty, increase, damage, enemies, updates
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, bounty, increase, damage, enemies, updates := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", bounty, increase, damage))
+		for j := 0; j < n; j++ {
+			e := enemies[j]
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", e.maxH, e.start, e.regen))
+		}
+		for j := 0; j < m; j++ {
+			u := updates[j]
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", u[0], u[1]+1, u[2]))
+		}
+		input := sb.String()
+		expect := solveCase(n, m, bounty, increase, damage, append([]Enemy(nil), enemies...), updates)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/910-919/912/verifierD.go
+++ b/0-999/900-999/910-919/912/verifierD.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Node struct {
+	now  int64
+	x, y int64
+	shu  int64
+	flag bool
+}
+
+type MaxHeap []Node
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i].now > h[j].now }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(Node)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func min(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func get(n, m, r, x, y int64) int64 {
+	lx := max(1, x-r+1)
+	ly := max(1, y-r+1)
+	x = min(x, n-r+1)
+	y = min(y, m-r+1)
+	return (x - lx + 1) * (y - ly + 1)
+}
+
+func solveCase(n, m, r, k int64) string {
+	number := (n - r + 1) * (m - r + 1)
+	MAX := get(n, m, r, (n+1)/2, (m+1)/2)
+	var a, b int64
+	if n >= 2*r {
+		a = n - 2*r + 2
+	} else {
+		a = 2*r - n
+	}
+	if m >= 2*r {
+		b = m - 2*r + 2
+	} else {
+		b = 2*r - m
+	}
+	hen := min(n-r+1, r)
+	shu := min(m-r+1, r)
+
+	h := &MaxHeap{}
+	heap.Init(h)
+	heap.Push(h, Node{now: MAX, x: a, y: b, shu: shu, flag: true})
+
+	var ans int64
+	kk := k
+	for {
+		p := heap.Pop(h).(Node)
+		cnt := p.x * p.y
+		if cnt >= kk {
+			ans += p.now * kk
+			break
+		}
+		kk -= cnt
+		ans += p.now * cnt
+		if p.flag && p.now-hen >= 1 {
+			heap.Push(h, Node{now: p.now - hen, x: p.x, y: 2, shu: p.shu - 1, flag: true})
+		}
+		if p.now-p.shu >= 1 {
+			heap.Push(h, Node{now: p.now - p.shu, x: 2, y: p.y, shu: p.shu, flag: false})
+		}
+	}
+	return fmt.Sprintf("%.15f", float64(ans)/float64(number))
+}
+
+func generateCase(rng *rand.Rand) (int64, int64, int64, int64) {
+	n := int64(rng.Intn(10) + 1)
+	m := int64(rng.Intn(10) + 1)
+	r := int64(rng.Intn(int(min(n, m))) + 1)
+	k := int64(rng.Intn(int(min(n*m, 10))) + 1)
+	return n, m, r, k
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, r, k := generateCase(rng)
+		input := fmt.Sprintf("%d %d %d %d\n", n, m, r, k)
+		expect := solveCase(n, m, r, k)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/910-919/912/verifierE.go
+++ b/0-999/900-999/910-919/912/verifierE.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const MAX int64 = 1e18
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generate(pr []int64, idx int, cur int64, res *[]int64) {
+	if idx == len(pr) {
+		*res = append(*res, cur)
+		return
+	}
+	p := pr[idx]
+	val := cur
+	for val <= MAX {
+		generate(pr, idx+1, val, res)
+		if val > MAX/p {
+			break
+		}
+		val *= p
+	}
+}
+
+func countLeq(a, b []int64, x int64) int64 {
+	j := len(b) - 1
+	var cnt int64
+	for _, v := range a {
+		for j >= 0 && v > x/b[j] {
+			j--
+		}
+		if j < 0 {
+			break
+		}
+		cnt += int64(j + 1)
+	}
+	return cnt
+}
+
+func solveCase(primes []int64, k int64) string {
+	n := len(primes)
+	m := n / 2
+	leftPr := primes[:m]
+	rightPr := primes[m:]
+	left := make([]int64, 0)
+	right := make([]int64, 0)
+	generate(leftPr, 0, 1, &left)
+	generate(rightPr, 0, 1, &right)
+	sort.Slice(left, func(i, j int) bool { return left[i] < left[j] })
+	sort.Slice(right, func(i, j int) bool { return right[i] < right[j] })
+
+	l, r := int64(1), MAX
+	for l < r {
+		mid := (l + r) / 2
+		if countLeq(left, right, mid) >= k {
+			r = mid
+		} else {
+			l = mid + 1
+		}
+	}
+	return fmt.Sprint(l)
+}
+
+var primeList = []int64{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97}
+
+func generateCase(rng *rand.Rand) ([]int64, int64) {
+	n := rng.Intn(6) + 1
+	primes := make([]int64, 0, n)
+	perm := rng.Perm(len(primeList))
+	for i := 0; i < n; i++ {
+		primes = append(primes, primeList[perm[i]])
+	}
+	sort.Slice(primes, func(i, j int) bool { return primes[i] < primes[j] })
+	k := int64(rng.Intn(1000) + 1)
+	return primes, k
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		primes, k := generateCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(primes)))
+		for j, p := range primes {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(p))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d\n", k))
+		input := sb.String()
+		expect := solveCase(append([]int64(nil), primes...), k)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883f4356aa0832480bea62a40b42714