### PR TITLE
Add Go verifiers for Codeforces 908

### DIFF
--- a/0-999/900-999/900-909/908/verifierA.go
+++ b/0-999/900-999/900-909/908/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCommand(cmd []string, input string) (string, error) {
+	c := exec.Command(cmd[0], cmd[1:]...)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expectedOutput(input string) string {
+	s := strings.TrimSpace(input)
+	count := 0
+	for _, ch := range s {
+		if strings.ContainsRune("aeiou13579", ch) {
+			count++
+		}
+	}
+	return fmt.Sprintf("%d", count)
+}
+
+func generateTests() []string {
+	rand.Seed(42)
+	tests := make([]string, 100)
+	chars := []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteRune(chars[rand.Intn(len(chars))])
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go <binary>")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	useGoRun := strings.HasSuffix(candidate, ".go")
+
+	tests := generateTests()
+	for idx, input := range tests {
+		var got string
+		var err error
+		if useGoRun {
+			got, err = runCommand([]string{"go", "run", candidate}, input+"\n")
+		} else {
+			err = os.Chmod(candidate, 0755)
+			got, err = runCommand([]string{candidate}, input+"\n")
+		}
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		expect := expectedOutput(input)
+		if got != expect {
+			fmt.Printf("test %d failed: input=%s expected=%s got=%s\n", idx+1, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/900-999/900-909/908/verifierB.go
+++ b/0-999/900-999/900-909/908/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const solutionB = "0-999/900-999/900-909/908/908B.go"
+
+func runCmd(cmd []string, input string) (string, error) {
+	c := exec.Command(cmd[0], cmd[1:]...)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	rand.Seed(42)
+	var tests []string
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(4) + 2
+		m := rand.Intn(4) + 2
+		grid := make([]string, n)
+		sx, sy := rand.Intn(n), rand.Intn(m)
+		ex, ey := rand.Intn(n), rand.Intn(m)
+		for ex == sx && ey == sy {
+			ex, ey = rand.Intn(n), rand.Intn(m)
+		}
+		for r := 0; r < n; r++ {
+			var sb strings.Builder
+			for c := 0; c < m; c++ {
+				ch := '.'
+				if rand.Intn(5) == 0 {
+					ch = '#'
+				}
+				if r == sx && c == sy {
+					ch = 'S'
+				} else if r == ex && c == ey {
+					ch = 'E'
+				}
+				sb.WriteByte(byte(ch))
+			}
+			grid[r] = sb.String()
+		}
+		instrLen := rand.Intn(10) + 1
+		var instr strings.Builder
+		for j := 0; j < instrLen; j++ {
+			instr.WriteByte(byte('0' + rand.Intn(4)))
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for _, row := range grid {
+			sb.WriteString(row)
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(instr.String())
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func runCandidate(path string, input string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		return runCmd([]string{"go", "run", path}, input)
+	}
+	os.Chmod(path, 0755)
+	return runCmd([]string{path}, input)
+}
+
+func expectedOutput(input string) (string, error) {
+	return runCmd([]string{"go", "run", solutionB}, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	tests := generateTests()
+	for idx, t := range tests {
+		exp, err := expectedOutput(t)
+		if err != nil {
+			fmt.Printf("failed to run reference solution on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(cand, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", idx+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/900-999/900-909/908/verifierC.go
+++ b/0-999/900-999/900-909/908/verifierC.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const solutionC = "0-999/900-999/900-909/908/908C.go"
+
+func runCmd(cmd []string, input string) (string, error) {
+	c := exec.Command(cmd[0], cmd[1:]...)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	rand.Seed(42)
+	var tests []string
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(6) + 1
+		r := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, r))
+		for j := 0; j < n; j++ {
+			x := rand.Intn(100)
+			sb.WriteString(fmt.Sprintf("%d ", x))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func runCandidate(path string, input string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		return runCmd([]string{"go", "run", path}, input)
+	}
+	os.Chmod(path, 0755)
+	return runCmd([]string{path}, input)
+}
+
+func expectedOutput(input string) (string, error) {
+	return runCmd([]string{"go", "run", solutionC}, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	tests := generateTests()
+	for idx, t := range tests {
+		exp, err := expectedOutput(t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(cand, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", idx+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/900-999/900-909/908/verifierD.go
+++ b/0-999/900-999/900-909/908/verifierD.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const solutionD = "0-999/900-999/900-909/908/908D.go"
+
+func runCmd(cmd []string, input string) (string, error) {
+	c := exec.Command(cmd[0], cmd[1:]...)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	rand.Seed(42)
+	var tests []string
+	for i := 0; i < 100; i++ {
+		k := rand.Intn(10) + 1
+		pa := rand.Intn(100) + 1
+		pb := rand.Intn(100) + 1
+		tests = append(tests, fmt.Sprintf("%d %d %d\n", k, pa, pb))
+	}
+	return tests
+}
+
+func runCandidate(path string, input string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		return runCmd([]string{"go", "run", path}, input)
+	}
+	os.Chmod(path, 0755)
+	return runCmd([]string{path}, input)
+}
+
+func expectedOutput(input string) (string, error) {
+	return runCmd([]string{"go", "run", solutionD}, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	tests := generateTests()
+	for idx, t := range tests {
+		exp, err := expectedOutput(t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(cand, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s got:%s\n", idx+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/900-999/900-909/908/verifierE.go
+++ b/0-999/900-999/900-909/908/verifierE.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const solutionE = "0-999/900-999/900-909/908/908E.go"
+
+func runCmd(cmd []string, input string) (string, error) {
+	c := exec.Command(cmd[0], cmd[1:]...)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	rand.Seed(42)
+	var tests []string
+	for i := 0; i < 100; i++ {
+		m := rand.Intn(5) + 1
+		n := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", m, n))
+		for j := 0; j < n; j++ {
+			var row strings.Builder
+			for k := 0; k < m; k++ {
+				if rand.Intn(2) == 0 {
+					row.WriteByte('0')
+				} else {
+					row.WriteByte('1')
+				}
+			}
+			sb.WriteString(row.String())
+			sb.WriteByte('\n')
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func runCandidate(path string, input string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		return runCmd([]string{"go", "run", path}, input)
+	}
+	os.Chmod(path, 0755)
+	return runCmd([]string{path}, input)
+}
+
+func expectedOutput(input string) (string, error) {
+	return runCmd([]string{"go", "run", solutionE}, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	tests := generateTests()
+	for idx, t := range tests {
+		exp, err := expectedOutput(t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(cand, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", idx+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/900-999/900-909/908/verifierF.go
+++ b/0-999/900-999/900-909/908/verifierF.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const solutionF = "0-999/900-999/900-909/908/908F.go"
+
+func runCmd(cmd []string, input string) (string, error) {
+	c := exec.Command(cmd[0], cmd[1:]...)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	rand.Seed(42)
+	var tests []string
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		pos := 0
+		for j := 0; j < n; j++ {
+			pos += rand.Intn(10) + 1
+			color := []byte{'R', 'B', 'G'}[rand.Intn(3)]
+			sb.WriteString(fmt.Sprintf("%d %c\n", pos, color))
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func runCandidate(path string, input string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		return runCmd([]string{"go", "run", path}, input)
+	}
+	os.Chmod(path, 0755)
+	return runCmd([]string{path}, input)
+}
+
+func expectedOutput(input string) (string, error) {
+	return runCmd([]string{"go", "run", solutionF}, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	tests := generateTests()
+	for idx, t := range tests {
+		exp, err := expectedOutput(t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(cand, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s got:%s\n", idx+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/900-999/900-909/908/verifierG.go
+++ b/0-999/900-999/900-909/908/verifierG.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const solutionG = "0-999/900-999/900-909/908/908G.go"
+
+func runCmd(cmd []string, input string) (string, error) {
+	c := exec.Command(cmd[0], cmd[1:]...)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	rand.Seed(42)
+	var tests []string
+	for i := 0; i < 100; i++ {
+		length := rand.Intn(10) + 1
+		var sb strings.Builder
+		for j := 0; j < length; j++ {
+			sb.WriteByte(byte('0' + rand.Intn(10)))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func runCandidate(path string, input string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		return runCmd([]string{"go", "run", path}, input)
+	}
+	os.Chmod(path, 0755)
+	return runCmd([]string{path}, input)
+}
+
+func expectedOutput(input string) (string, error) {
+	return runCmd([]string{"go", "run", solutionG}, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	tests := generateTests()
+	for idx, t := range tests {
+		exp, err := expectedOutput(t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(cand, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s got:%s\n", idx+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/0-999/900-999/900-909/908/verifierH.go
+++ b/0-999/900-999/900-909/908/verifierH.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const solutionH = "0-999/900-999/900-909/908/908H.go"
+
+func runCmd(cmd []string, input string) (string, error) {
+	c := exec.Command(cmd[0], cmd[1:]...)
+	c.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	c.Stdout = &out
+	err := c.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	rand.Seed(42)
+	var tests []string
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for r := 0; r < n; r++ {
+			var row strings.Builder
+			for c := 0; c < n; c++ {
+				if r == c {
+					row.WriteByte('A')
+				} else if rand.Intn(2) == 0 {
+					row.WriteByte('A')
+				} else {
+					row.WriteByte('X')
+				}
+			}
+			sb.WriteString(row.String())
+			sb.WriteByte('\n')
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func runCandidate(path string, input string) (string, error) {
+	if strings.HasSuffix(path, ".go") {
+		return runCmd([]string{"go", "run", path}, input)
+	}
+	os.Chmod(path, 0755)
+	return runCmd([]string{path}, input)
+}
+
+func expectedOutput(input string) (string, error) {
+	return runCmd([]string{"go", "run", solutionH}, input)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierH.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	tests := generateTests()
+	for idx, t := range tests {
+		exp, err := expectedOutput(t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runCandidate(cand, t)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s got:%s\n", idx+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- provide verifier scripts for all problems in contest 908
- each verifier generates 100 random tests and checks a provided binary
- examples include verifierA.go through verifierH.go

## Testing
- `go build 0-999/900-999/900-909/908/verifierA.go`
- `go build 0-999/900-999/900-909/908/verifierB.go`
- `go build 0-999/900-999/900-909/908/verifierC.go`
- `go build 0-999/900-999/900-909/908/verifierD.go`
- `go build 0-999/900-999/900-909/908/verifierE.go`
- `go build 0-999/900-999/900-909/908/verifierF.go`
- `go build 0-999/900-999/900-909/908/verifierG.go`
- `go build 0-999/900-999/900-909/908/verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_6883f2050bec8324ab73fce6baad5503