### PR TITLE
Add verifiers for contest 903

### DIFF
--- a/0-999/900-999/900-909/903/verifierA.go
+++ b/0-999/900-999/900-909/903/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func possible(x int) bool {
+	for a := 0; a <= x; a += 3 {
+		if (x-a)%7 == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func runCase(bin string, x int) error {
+	input := fmt.Sprintf("1\n%d\n", x)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	got := strings.ToUpper(fields[0])
+	want := "NO"
+	if possible(x) {
+		want = "YES"
+	}
+	if got != want {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		x := rng.Intn(200) + 1
+		if err := runCase(bin, x); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/900-909/903/verifierB.go
+++ b/0-999/900-999/900-909/903/verifierB.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct{ h1, a1, c1, h2, a2 int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return out.String(), nil
+}
+
+func solve(tc testCase) []string {
+	h1 := tc.h1
+	a1 := tc.a1
+	c1 := tc.c1
+	h2 := tc.h2
+	a2 := tc.a2
+	actions := []string{}
+	for {
+		needStrikes := (h2 + a1 - 1) / a1
+		survive := (h1 + a2 - 1) / a2
+		if needStrikes <= survive {
+			for i := 0; i < needStrikes; i++ {
+				actions = append(actions, "STRIKE")
+			}
+			break
+		}
+		actions = append(actions, "HEAL")
+		h1 += c1
+		h1 -= a2
+	}
+	return actions
+}
+
+func validate(tc testCase, actions []string) error {
+	h1 := tc.h1
+	a1 := tc.a1
+	c1 := tc.c1
+	h2 := tc.h2
+	a2 := tc.a2
+	for idx, act := range actions {
+		switch act {
+		case "HEAL":
+			h1 += c1
+		case "STRIKE":
+			h2 -= a1
+		default:
+			return fmt.Errorf("invalid action %q", act)
+		}
+		if h2 <= 0 {
+			if idx+1 != len(actions) {
+				return fmt.Errorf("extra actions after kill")
+			}
+			return nil
+		}
+		h1 -= a2
+		if h1 <= 0 {
+			return fmt.Errorf("hero died")
+		}
+	}
+	if h2 > 0 {
+		return fmt.Errorf("monster still alive")
+	}
+	return nil
+}
+
+func runCase(bin string, tc testCase) error {
+	input := fmt.Sprintf("%d %d %d\n%d %d\n", tc.h1, tc.a1, tc.c1, tc.h2, tc.a2)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	reader := strings.NewReader(out)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	actions := make([]string, n)
+	for i := 0; i < n; i++ {
+		if _, err := fmt.Fscan(reader, &actions[i]); err != nil {
+			return fmt.Errorf("bad output: %v", err)
+		}
+	}
+	if err := validate(tc, actions); err != nil {
+		return err
+	}
+	exp := len(solve(tc))
+	if n != exp {
+		return fmt.Errorf("expected %d actions got %d", exp, n)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := testCase{
+			h1: rng.Intn(100) + 1,
+			a1: rng.Intn(100) + 1,
+			c1: rng.Intn(99) + 2,
+			h2: rng.Intn(100) + 1,
+			a2: rng.Intn(99) + 1,
+		}
+		if tc.a2 >= tc.c1 {
+			tc.a2 = tc.c1 - 1
+		}
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/900-909/903/verifierC.go
+++ b/0-999/900-999/900-909/903/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	arr []int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(tc testCase) int {
+	freq := make(map[int]int)
+	maxF := 0
+	for _, v := range tc.arr {
+		freq[v]++
+		if freq[v] > maxF {
+			maxF = freq[v]
+		}
+	}
+	return maxF
+}
+
+func runCase(bin string, tc testCase) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.arr)))
+	for i, v := range tc.arr {
+		sb.WriteString(fmt.Sprintf("%d", v))
+		if i+1 < len(tc.arr) {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	out, err := run(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	var got int
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	exp := solve(tc)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(50) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(1000)
+		}
+		tc := testCase{arr: arr}
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/900-909/903/verifierD.go
+++ b/0-999/900-999/900-909/903/verifierD.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "903D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(40) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(1000) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/900-909/903/verifierE.go
+++ b/0-999/900-999/900-909/903/verifierE.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "903E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) string {
+	k := rng.Intn(3) + 1
+	n := rng.Intn(6) + 2
+	base := randString(rng, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", k, n))
+	invalid := rng.Intn(2) == 0
+	for i := 0; i < k; i++ {
+		b := []byte(base)
+		p := rng.Intn(n)
+		q := rng.Intn(n)
+		b[p], b[q] = b[q], b[p]
+		if invalid && i == 0 {
+			idx := rng.Intn(n)
+			c := byte('a' + rng.Intn(26))
+			if c == b[idx] {
+				c = 'z'
+			}
+			b[idx] = c
+		}
+		sb.WriteString(string(b))
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/900-909/903/verifierF.go
+++ b/0-999/900-999/900-909/903/verifierF.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "903F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 4 // 4..7
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= 4; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", rng.Intn(20)+1))
+	}
+	sb.WriteByte('\n')
+	for r := 0; r < 4; r++ {
+		for c := 0; c < n; c++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('.')
+			} else {
+				sb.WriteByte('*')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/900-909/903/verifierG.go
+++ b/0-999/900-999/900-909/903/verifierG.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleG")
+	cmd := exec.Command("go", "build", "-o", oracle, "903G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	m := rng.Intn(4)
+	q := rng.Intn(4)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+	for i := 0; i < n-1; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", rng.Intn(10)+1, rng.Intn(10)+1))
+	}
+	for i := 0; i < m; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", rng.Intn(n)+1, rng.Intn(n)+1, rng.Intn(10)+1))
+	}
+	for i := 0; i < q; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", rng.Intn(n-1)+1, rng.Intn(10)+1))
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	exp, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–G of contest 903
- each verifier builds the reference solution, runs 100 randomized tests and checks a candidate binary

## Testing
- `go build 0-999/900-999/900-909/903/verifierA.go`
- `go build 0-999/900-999/900-909/903/verifierB.go`
- `go build 0-999/900-999/900-909/903/verifierC.go`
- `go build 0-999/900-999/900-909/903/verifierD.go`
- `go build 0-999/900-999/900-909/903/verifierE.go`
- `go build 0-999/900-999/900-909/903/verifierF.go`
- `go build 0-999/900-999/900-909/903/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6883ef48d8e48324822d3b64c2b3d3e5