### PR TITLE
Add Go solution for 1670A

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1670/1670A.go
+++ b/1000-1999/1600-1699/1670-1679/1670/1670A.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var (
+	reader = bufio.NewReader(os.Stdin)
+	writer = bufio.NewWriter(os.Stdout)
+)
+
+func main() {
+	defer writer.Flush()
+	var T int
+	fmt.Fscan(reader, &T)
+	for ; T > 0; T-- {
+		solve()
+	}
+}
+
+func solve() {
+	var n int
+	fmt.Fscan(reader, &n)
+	a := make([]int, n)
+	neg := 0
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+		if a[i] < 0 {
+			a[i] = -a[i]
+			neg++
+		}
+	}
+	for i := 0; i < neg; i++ {
+		a[i] = -a[i]
+	}
+	ok := true
+	for i := 1; i < n; i++ {
+		if a[i-1] > a[i] {
+			ok = false
+			break
+		}
+	}
+	if ok {
+		fmt.Fprintln(writer, "YES")
+	} else {
+		fmt.Fprintln(writer, "NO")
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem 1670A

## Testing
- `go vet ./1000-1999/1600-1699/1670-1679/1670/1670A.go`
- `go build ./1000-1999/1600-1699/1670-1679/1670/1670A.go`


------
https://chatgpt.com/codex/tasks/task_e_6883ef02a3ac8324a859eaf270d17a88