### PR TITLE
Add verifiers for contest 902

### DIFF
--- a/0-999/900-999/900-909/902/verifierA.go
+++ b/0-999/900-999/900-909/902/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type teleport struct{ a, b int }
+
+func solveCase(n, m int, tele []teleport) string {
+	maxReach := 0
+	for _, t := range tele {
+		if t.a <= maxReach && t.b > maxReach {
+			maxReach = t.b
+		}
+	}
+	if maxReach >= m {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	m := rng.Intn(100) + 1
+	tele := make([]teleport, n)
+	for i := range tele {
+		a := rng.Intn(m + 1)
+		b := a + rng.Intn(m-a+1)
+		tele[i] = teleport{a, b}
+	}
+	sort.Slice(tele, func(i, j int) bool { return tele[i].a < tele[j].a })
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for _, t := range tele {
+		fmt.Fprintf(&sb, "%d %d\n", t.a, t.b)
+	}
+	return sb.String(), solveCase(n, m, tele)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	got := strings.ToUpper(fields[0])
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/900-909/902/verifierB.go
+++ b/0-999/900-999/900-909/902/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(parent, color []int) int {
+	n := len(parent) - 1
+	steps := 1
+	for i := 2; i <= n; i++ {
+		if color[i] != color[parent[i]] {
+			steps++
+		}
+	}
+	return steps
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1
+	parent := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		parent[i] = rng.Intn(i-1) + 1
+	}
+	color := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		color[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 2; i <= n; i++ {
+		if i > 2 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", parent[i])
+	}
+	if n >= 2 {
+		sb.WriteByte('\n')
+	}
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", color[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveCase(parent, color)
+}
+
+func runCase(bin, input string, expected int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	var got int
+	if _, err := fmt.Sscan(fields[0], &got); err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, exp := generateCase(rng)
+		if err := runCase(bin, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add new Go verifiers for problems 902A and 902B
- verifiers randomly generate at least 100 tests each
- allow verifying either a Go source file or any binary

## Testing
- `go run verifierA.go -- 902A.go`
- `go run verifierB.go -- 902B.go`


------
https://chatgpt.com/codex/tasks/task_e_6883eebc99d88324b601e72ecc5438a6