### PR TITLE
Add Go solution for 1670B

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1670/1670B.go
+++ b/1000-1999/1600-1699/1670-1679/1670/1670B.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var s string
+		fmt.Fscan(reader, &s)
+		var k int
+		fmt.Fscan(reader, &k)
+		special := make(map[rune]bool)
+		for i := 0; i < k; i++ {
+			var c string
+			fmt.Fscan(reader, &c)
+			special[rune(c[0])] = true
+		}
+		prev := 0
+		ans := 0
+		for i, ch := range s {
+			if special[ch] {
+				gap := (i + 1) - prev
+				if gap > ans {
+					ans = gap
+				}
+				prev = i + 1
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add new Go implementation `1670B.go`
- compute max distance between consecutive special characters

## Testing
- `go build 1000-1999/1600-1699/1670-1679/1670/1670B.go`
- `go vet 1000-1999/1600-1699/1670-1679/1670/1670B.go`


------
https://chatgpt.com/codex/tasks/task_e_6883ee76871c83249b787080ae262371