### PR TITLE
Add verifiers for contest 901

### DIFF
--- a/0-999/900-999/900-909/901/verifierA.go
+++ b/0-999/900-999/900-909/901/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveA(k int, a []int) string {
+	n := k + 1
+	ambIdx := -1
+	for i := 1; i < n; i++ {
+		if a[i-1] > 1 && a[i] > 1 {
+			ambIdx = i
+			break
+		}
+	}
+	if ambIdx == -1 {
+		return "perfect"
+	}
+	var sb strings.Builder
+	sb.WriteString("ambiguous\n")
+	sum := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < a[i]; j++ {
+			fmt.Fprintf(&sb, "%d ", sum)
+		}
+		sum += a[i]
+	}
+	sb.WriteByte('\n')
+	sum = 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < a[i]; j++ {
+			if i == ambIdx && j == 0 {
+				fmt.Fprintf(&sb, "%d ", sum-1)
+			} else {
+				fmt.Fprintf(&sb, "%d ", sum)
+			}
+		}
+		sum += a[i]
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		k := rng.Intn(5) + 1
+		n := k + 1
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(3) + 1
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", k)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", a[i])
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveA(k, a)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/900-909/901/verifierB.go
+++ b/0-999/900-999/900-909/901/verifierB.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func build(seq *[][]int) bool {
+	v := *seq
+	a := v[len(v)-2]
+	b := v[len(v)-1]
+	newB := make([]int, len(b)+1)
+	copy(newB[1:], b)
+	mult := 1
+	for i := 0; i < len(a); i++ {
+		if mult == -1 && ((a[i] == -1 && newB[i] == 1) || (a[i] == 1 && newB[i] == -1)) {
+			return false
+		}
+		if (a[i] == 1 && newB[i] == 1) || (a[i] == -1 && newB[i] == -1) {
+			mult = -1
+		}
+	}
+	for i := 0; i < len(a); i++ {
+		newB[i] += mult * a[i]
+	}
+	*seq = append(*seq, newB)
+	return true
+}
+
+func solveB(n int) (string, bool) {
+	seq := make([][]int, 0, n+2)
+	seq = append(seq, []int{0})
+	seq = append(seq, []int{1})
+	seq = append(seq, []int{0, 1})
+	seq = append(seq, []int{1, 0, 1})
+	for len(seq) < n+2 {
+		if !build(&seq) {
+			return "-1", false
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range seq[n+1] {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", n-1))
+	for i, v := range seq[n] {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	return strings.TrimSpace(sb.String()), true
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(10) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		input := sb.String()
+		expected, ok := solveB(n)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if !ok {
+			if strings.TrimSpace(got) != "-1" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected -1 got %q\n", t+1, got)
+				os.Exit(1)
+			}
+			continue
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\n", t+1, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/900-909/901/verifierC.go
+++ b/0-999/900-999/900-909/901/verifierC.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct{ u, v int }
+
+func isBipartiteSub(n int, edges []Edge, L, R int) bool {
+	color := make(map[int]int)
+	for v := L; v <= R; v++ {
+		if _, ok := color[v]; !ok {
+			queue := []int{v}
+			color[v] = 0
+			for len(queue) > 0 {
+				x := queue[0]
+				queue = queue[1:]
+				for _, e := range edges {
+					a, b := e.u, e.v
+					if a < L || a > R || b < L || b > R {
+						continue
+					}
+					if a == x {
+						if c, ok := color[b]; !ok {
+							color[b] = color[x] ^ 1
+							queue = append(queue, b)
+						} else if c == color[x] {
+							return false
+						}
+					} else if b == x {
+						if c, ok := color[a]; !ok {
+							color[a] = color[x] ^ 1
+							queue = append(queue, a)
+						} else if c == color[x] {
+							return false
+						}
+					}
+				}
+			}
+		}
+	}
+	return true
+}
+
+func solveC(n int, edges []Edge, queries [][2]int) []int64 {
+	res := make([]int64, len(queries))
+	for qi, qr := range queries {
+		L, R := qr[0], qr[1]
+		var count int64
+		for x := L; x <= R; x++ {
+			for y := x; y <= R; y++ {
+				if isBipartiteSub(n, edges, x, y) {
+					count++
+				}
+			}
+		}
+		res[qi] = count
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func distance(n int, edges []Edge, a, b int) int {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	dist := make([]int, n+1)
+	for i := range dist {
+		dist[i] = -1
+	}
+	q := []int{a}
+	dist[a] = 0
+	for len(q) > 0 {
+		v := q[0]
+		q = q[1:]
+		if v == b {
+			return dist[v]
+		}
+		for _, u := range adj[v] {
+			if dist[u] == -1 {
+				dist[u] = dist[v] + 1
+				q = append(q, u)
+			}
+		}
+	}
+	return -1
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(4) + 3
+		edges := make([]Edge, 0)
+		// build tree
+		for i := 2; i <= n; i++ {
+			p := rng.Intn(i-1) + 1
+			edges = append(edges, Edge{p, i})
+		}
+		// maybe add extra edge forming odd cycle
+		if rng.Intn(2) == 0 {
+			for {
+				u := rng.Intn(n) + 1
+				v := rng.Intn(n) + 1
+				if u == v {
+					continue
+				}
+				d := distance(n, edges, u, v)
+				if d != -1 && d%2 == 0 {
+					edges = append(edges, Edge{u, v})
+					break
+				}
+			}
+		}
+		m := len(edges)
+		qn := rng.Intn(5) + 1
+		queries := make([][2]int, qn)
+		for i := 0; i < qn; i++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			queries[i] = [2]int{l, r}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for _, e := range edges {
+			fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+		}
+		fmt.Fprintf(&sb, "%d\n", qn)
+		for _, qr := range queries {
+			fmt.Fprintf(&sb, "%d %d\n", qr[0], qr[1])
+		}
+		input := sb.String()
+		answers := solveC(n, edges, queries)
+		var exp strings.Builder
+		for i, a := range answers {
+			if i > 0 {
+				exp.WriteByte('\n')
+			}
+			fmt.Fprintf(&exp, "%d", a)
+		}
+		expected := exp.String()
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/900-909/901/verifierD.go
+++ b/0-999/900-999/900-909/901/verifierD.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Edge struct{ u, v int }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifySolution(n, m int, c []int, edges []Edge, out string) bool {
+	sc := bufio.NewScanner(strings.NewReader(out))
+	sc.Split(bufio.ScanWords)
+	if !sc.Scan() {
+		return false
+	}
+	tok := sc.Text()
+	if tok != "YES" {
+		return false
+	}
+	weights := make([]int, m)
+	for i := 0; i < m; i++ {
+		if !sc.Scan() {
+			return false
+		}
+		v, err := strconv.Atoi(sc.Text())
+		if err != nil {
+			return false
+		}
+		if v < -2*n*n || v > 2*n*n {
+			return false
+		}
+		weights[i] = v
+	}
+	sums := make([]int, n+1)
+	for i, e := range edges {
+		w := weights[i]
+		sums[e.u] += w
+		sums[e.v] += w
+	}
+	for i := 1; i <= n; i++ {
+		if sums[i] != c[i-1] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(4) + 2
+		edges := make([]Edge, 0)
+		for i := 2; i <= n; i++ {
+			p := rng.Intn(i-1) + 1
+			edges = append(edges, Edge{p, i})
+		}
+		if rng.Intn(2) == 0 {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			for u == v {
+				v = rng.Intn(n) + 1
+			}
+			edges = append(edges, Edge{u, v})
+		}
+		m := len(edges)
+		weights := make([]int, m)
+		for i := 0; i < m; i++ {
+			weights[i] = rng.Intn(21) - 10
+		}
+		c := make([]int, n)
+		for i := 0; i < m; i++ {
+			e := edges[i]
+			c[e.u-1] += weights[i]
+			c[e.v-1] += weights[i]
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", c[i])
+		}
+		sb.WriteByte('\n')
+		for _, e := range edges {
+			fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+		}
+		input := sb.String()
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if !verifySolution(n, m, c, edges, got) {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid solution\ninput:%s\noutput:%s", t+1, input, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/900-909/901/verifierE.go
+++ b/0-999/900-999/900-909/901/verifierE.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func isIndependent(b []int) bool {
+	n := len(b)
+	mat := make([][]float64, n)
+	for i := 0; i < n; i++ {
+		mat[i] = make([]float64, n)
+		for j := 0; j < n; j++ {
+			idx := (j - i + n) % n
+			mat[i][j] = float64(b[idx])
+		}
+	}
+	// Gaussian elimination
+	for col, row := 0, 0; col < n && row < n; col++ {
+		pivot := row
+		for i := row; i < n; i++ {
+			if mat[i][col] != 0 {
+				pivot = i
+				break
+			}
+		}
+		if mat[pivot][col] == 0 {
+			continue
+		}
+		mat[row], mat[pivot] = mat[pivot], mat[row]
+		pv := mat[row][col]
+		for j := col; j < n; j++ {
+			mat[row][j] /= pv
+		}
+		for i := 0; i < n; i++ {
+			if i == row {
+				continue
+			}
+			factor := mat[i][col]
+			for j := col; j < n; j++ {
+				mat[i][j] -= factor * mat[row][j]
+			}
+		}
+		row++
+	}
+	rank := 0
+	for i := 0; i < n; i++ {
+		zero := true
+		for j := 0; j < n; j++ {
+			if math.Abs(mat[i][j]) > 1e-9 {
+				zero = false
+				break
+			}
+		}
+		if !zero {
+			rank++
+		}
+	}
+	return rank == n
+}
+
+func computeC(a, b []int) []int {
+	n := len(a)
+	c := make([]int, n)
+	for i := 0; i < n; i++ {
+		sum := 0
+		for k := 0; k < n; k++ {
+			diff := b[(k-i+n)%n] - a[k]
+			sum += diff * diff
+		}
+		c[i] = sum
+	}
+	return c
+}
+
+func enumerateSolutions(b []int, c []int) [][]int {
+	n := len(b)
+	sol := [][]int{}
+	vals := []int{-2, -1, 0, 1, 2}
+	cur := make([]int, n)
+	var dfs func(int)
+	dfs = func(pos int) {
+		if pos == n {
+			if equalSlices(computeC(cur, b), c) {
+				tmp := make([]int, n)
+				copy(tmp, cur)
+				sol = append(sol, tmp)
+			}
+			return
+		}
+		for _, v := range vals {
+			cur[pos] = v
+			dfs(pos + 1)
+		}
+	}
+	dfs(0)
+	sort.Slice(sol, func(i, j int) bool {
+		for k := 0; k < n; k++ {
+			if sol[i][k] != sol[j][k] {
+				return sol[i][k] < sol[j][k]
+			}
+		}
+		return false
+	})
+	return sol
+}
+
+func equalSlices(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) == 3 && os.Args[1] == "--" {
+		os.Args = append([]string{os.Args[0]}, os.Args[2])
+	}
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(3) + 1
+		var b []int
+		for {
+			b = make([]int, n)
+			for i := 0; i < n; i++ {
+				b[i] = rng.Intn(4)
+			}
+			if isIndependent(b) {
+				break
+			}
+		}
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(5) - 2
+		}
+		c := computeC(a, b)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", b[i])
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", c[i])
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		solutions := enumerateSolutions(b, c)
+		var exp strings.Builder
+		fmt.Fprintf(&exp, "%d", len(solutions))
+		for _, sol := range solutions {
+			exp.WriteByte('\n')
+			for i := 0; i < n; i++ {
+				if i > 0 {
+					exp.WriteByte(' ')
+				}
+				fmt.Fprintf(&exp, "%d", sol[i])
+			}
+		}
+		expected := exp.String()
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %q got %q\ninput:%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E of Codeforces contest 901
- each verifier runs 100 randomized tests and supports running Go sources directly

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883ee30824c8324aba4e60edb6b2920