### PR TITLE
Add Go verifiers for CF contest 899

### DIFF
--- a/0-999/800-899/890-899/899/verifierA.go
+++ b/0-999/800-899/890-899/899/verifierA.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n int
+	fmt.Fscan(reader, &n)
+	ones, twos := 0, 0
+	for i := 0; i < n; i++ {
+		var v int
+		fmt.Fscan(reader, &v)
+		if v == 1 {
+			ones++
+		} else {
+			twos++
+		}
+	}
+	teams := min(ones, twos)
+	ones -= teams
+	teams += ones / 3
+	return fmt.Sprintf("%d", teams)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func generateTests() []test {
+	rand.Seed(8991)
+	var tests []test
+	fixed := []string{
+		"4\n1 1 2 2\n",
+		"7\n2 1 2 1 1 2 1\n",
+	}
+	for _, in := range fixed {
+		tests = append(tests, test{in, solve(in)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(100) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			if rand.Intn(2) == 0 {
+				sb.WriteByte('1')
+			} else {
+				sb.WriteByte('2')
+			}
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\n got:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/890-899/899/verifierB.go
+++ b/0-999/800-899/890-899/899/verifierB.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func isLeap(year int) bool {
+	if year%400 == 0 {
+		return true
+	}
+	if year%100 == 0 {
+		return false
+	}
+	return year%4 == 0
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return ""
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	months := make([]int, 0, 9600)
+	for y := 2000; y < 2800; y++ {
+		feb := 28
+		if isLeap(y) {
+			feb = 29
+		}
+		months = append(months, 31, feb, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+	}
+	found := false
+	for i := 0; i+len(a) <= len(months); i++ {
+		match := true
+		for j := 0; j < n; j++ {
+			if months[i+j] != a[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			found = true
+			break
+		}
+	}
+	if found {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateTests() []test {
+	rand.Seed(8992)
+	var tests []test
+	fixed := []string{
+		"1\n31\n",
+		"2\n31 28\n",
+		"3\n30 31 30\n",
+	}
+	for _, in := range fixed {
+		tests = append(tests, test{in, solve(in)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(24) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			val := 28 + rand.Intn(4)
+			if val == 29 {
+				sb.WriteString("29")
+			} else {
+				sb.WriteString(fmt.Sprintf("%d", val))
+			}
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\n got:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/890-899/899/verifierC.go
+++ b/0-999/800-899/890-899/899/verifierC.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n int
+	fmt.Fscan(reader, &n)
+	if n%2 == 0 {
+		if n == 2 {
+			return "1\n1 1"
+		}
+		var sb strings.Builder
+		if n%4 == 0 {
+			sb.WriteString("0\n")
+		} else {
+			sb.WriteString("1\n")
+		}
+		size := n / 2
+		fmt.Fprintf(&sb, "%d ", size)
+		flag := true
+		for i := 1; i <= n; i += 2 {
+			if flag {
+				fmt.Fprintf(&sb, "%d ", i)
+			} else {
+				fmt.Fprintf(&sb, "%d ", i+1)
+			}
+			flag = !flag
+		}
+		return strings.TrimSpace(sb.String())
+	}
+	if n == 3 {
+		return "0\n1 3"
+	}
+	var sb strings.Builder
+	if n%4 == 1 {
+		sb.WriteString("1\n")
+		fmt.Fprintf(&sb, "%d ", n/2)
+	} else {
+		sb.WriteString("0\n")
+		fmt.Fprintf(&sb, "%d 1 ", n/2+1)
+	}
+	flag := true
+	for i := 2; i <= n; i += 2 {
+		if flag {
+			fmt.Fprintf(&sb, "%d ", i)
+		} else {
+			fmt.Fprintf(&sb, "%d ", i+1)
+		}
+		flag = !flag
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateTests() []test {
+	rand.Seed(8993)
+	var tests []test
+	fixed := []string{
+		"4\n",
+		"3\n",
+		"5\n",
+	}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(60) + 2
+		inp := fmt.Sprintf("%d\n", n)
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\n got:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/890-899/899/verifierD.go
+++ b/0-999/800-899/890-899/899/verifierD.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func countPairs(n, sum int64) int64 {
+	if sum < 2 || sum > 2*n {
+		return 0
+	}
+	iMin := int64(1)
+	if sum-n > iMin {
+		iMin = sum - n
+	}
+	iMax := n
+	if sum-1 < iMax {
+		iMax = sum - 1
+	}
+	maxI := (sum - 1) / 2
+	if iMax > maxI {
+		iMax = maxI
+	}
+	if iMin > iMax {
+		return 0
+	}
+	return iMax - iMin + 1
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n int64
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return ""
+	}
+	pow10 := [10]int64{1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000}
+	for k := 9; k >= 0; k-- {
+		m := pow10[k]
+		r := m - 1
+		var total int64
+		for s := r; s <= 2*n; s += m {
+			if s < 2 {
+				continue
+			}
+			total += countPairs(n, s)
+		}
+		if total > 0 {
+			return fmt.Sprintf("%d", total)
+		}
+	}
+	return "0"
+}
+
+func generateTests() []test {
+	rand.Seed(8994)
+	var tests []test
+	fixed := []string{"10\n", "50\n", "100\n"}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rand.Int63n(1000000) + 1
+		inp := fmt.Sprintf("%d\n", n)
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\n got:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/890-899/899/verifierE.go
+++ b/0-999/800-899/890-899/899/verifierE.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+type Segment struct {
+	length int
+	idx    int
+	val    int
+	left   int
+	right  int
+	alive  bool
+}
+
+var segments []Segment
+
+type PQ []int
+
+func (pq PQ) Len() int { return len(pq) }
+func (pq PQ) Less(i, j int) bool {
+	a := segments[pq[i]]
+	b := segments[pq[j]]
+	if a.length != b.length {
+		return a.length > b.length
+	}
+	return a.idx < b.idx
+}
+func (pq PQ) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PQ) Push(x interface{}) { *pq = append(*pq, x.(int)) }
+func (pq *PQ) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	x := old[n-1]
+	*pq = old[:n-1]
+	return x
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return ""
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+	}
+	segments = make([]Segment, 0)
+	var pq PQ
+	start := 0
+	for start < n {
+		j := start
+		for j < n && arr[j] == arr[start] {
+			j++
+		}
+		segID := len(segments)
+		segments = append(segments, Segment{
+			length: j - start,
+			idx:    start,
+			val:    arr[start],
+			left:   segID - 1,
+			right:  -1,
+			alive:  true,
+		})
+		if segID > 0 {
+			segments[segID-1].right = segID
+		}
+		heap.Push(&pq, segID)
+		start = j
+	}
+	ops := 0
+	for pq.Len() > 0 {
+		id := heap.Pop(&pq).(int)
+		if !segments[id].alive {
+			continue
+		}
+		ops++
+		left := segments[id].left
+		right := segments[id].right
+		segments[id].alive = false
+		if left != -1 {
+			segments[left].right = right
+		}
+		if right != -1 {
+			segments[right].left = left
+		}
+		if left != -1 && right != -1 && segments[left].alive && segments[right].alive && segments[left].val == segments[right].val {
+			newID := len(segments)
+			segments[left].alive = false
+			segments[right].alive = false
+			segments = append(segments, Segment{
+				length: segments[left].length + segments[right].length,
+				idx:    segments[left].idx,
+				val:    segments[left].val,
+				left:   segments[left].left,
+				right:  segments[right].right,
+				alive:  true,
+			})
+			if segments[newID].left != -1 {
+				segments[segments[newID].left].right = newID
+			}
+			if segments[newID].right != -1 {
+				segments[segments[newID].right].left = newID
+			}
+			heap.Push(&pq, newID)
+		}
+	}
+	return fmt.Sprintf("%d", ops)
+}
+
+func generateTests() []test {
+	rand.Seed(8995)
+	var tests []test
+	fixed := []string{"3\n1 2 3\n", "5\n7 7 7 2 2\n"}
+	for _, f := range fixed {
+		tests = append(tests, test{f, solve(f)})
+	}
+	for len(tests) < 100 {
+		n := rand.Intn(30) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rand.Intn(5)))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\n got:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/890-899/899/verifierF.go
+++ b/0-999/800-899/890-899/899/verifierF.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+// BIT implements a Fenwick tree for prefix sums and order statistics.
+type BIT struct {
+	n    int
+	tree []int
+}
+
+func NewBIT(n int) *BIT { return &BIT{n: n, tree: make([]int, n+2)} }
+func (b *BIT) Add(i, delta int) {
+	for x := i; x <= b.n; x += x & -x {
+		b.tree[x] += delta
+	}
+}
+func (b *BIT) Sum(i int) int {
+	s := 0
+	for x := i; x > 0; x -= x & -x {
+		s += b.tree[x]
+	}
+	return s
+}
+func (b *BIT) FindKth(k int) int {
+	pos := 0
+	bitMask := 1
+	for bitMask<<1 <= b.n {
+		bitMask <<= 1
+	}
+	for d := bitMask; d > 0; d >>= 1 {
+		nxt := pos + d
+		if nxt <= b.n && b.tree[nxt] < k {
+			k -= b.tree[nxt]
+			pos = nxt
+		}
+	}
+	return pos + 1
+}
+func (b *BIT) FindNextFrom(l int) int {
+	pre := b.Sum(l - 1)
+	total := b.Sum(b.n)
+	if pre == total {
+		return b.n + 1
+	}
+	return b.FindKth(pre + 1)
+}
+
+func charIndex(ch byte) int {
+	if ch >= 'a' && ch <= 'z' {
+		return int(ch - 'a')
+	}
+	if ch >= 'A' && ch <= 'Z' {
+		return 26 + int(ch-'A')
+	}
+	return 52 + int(ch-'0')
+}
+
+func solve(input string) string {
+	reader := strings.NewReader(input)
+	in := bufio.NewReader(reader)
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return ""
+	}
+	var s string
+	fmt.Fscan(in, &s)
+	bits := make([]*BIT, 62)
+	for i := 0; i < 62; i++ {
+		bits[i] = NewBIT(n)
+	}
+	global := NewBIT(n)
+	alive := make([]bool, n+1)
+	for i := 1; i <= n; i++ {
+		global.Add(i, 1)
+		idx := charIndex(s[i-1])
+		bits[idx].Add(i, 1)
+		alive[i] = true
+	}
+	for op := 0; op < m; op++ {
+		var l, r int
+		var cs string
+		fmt.Fscan(in, &l, &r, &cs)
+		c := cs[0]
+		idx := charIndex(c)
+		lIdx := global.FindKth(l)
+		rIdx := global.FindKth(r)
+		limit := rIdx
+		pos := bits[idx].FindNextFrom(lIdx)
+		for pos <= limit {
+			if alive[pos] {
+				alive[pos] = false
+				global.Add(pos, -1)
+				bits[idx].Add(pos, -1)
+			}
+			pos = bits[idx].FindNextFrom(pos + 1)
+		}
+	}
+	res := make([]byte, 0, n)
+	for i := 1; i <= n; i++ {
+		if alive[i] {
+			res = append(res, s[i-1])
+		}
+	}
+	return string(res)
+}
+
+func generateTests() []test {
+	rand.Seed(8996)
+	var tests []test
+	chars := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	for len(tests) < 100 {
+		n := rand.Intn(20) + 1
+		m := rand.Intn(20) + 1
+		cur := make([]byte, n)
+		for i := 0; i < n; i++ {
+			cur[i] = chars[rand.Intn(len(chars))]
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		sb.Write(cur)
+		sb.WriteByte('\n')
+		for i := 0; i < m; i++ {
+			if len(cur) == 0 {
+				fmt.Fprintf(&sb, "1 1 a\n")
+				cur = cur[:0]
+				continue
+			}
+			l := rand.Intn(len(cur)) + 1
+			r := rand.Intn(len(cur)-l+1) + l
+			c := chars[rand.Intn(len(chars))]
+			fmt.Fprintf(&sb, "%d %d %c\n", l, r, c)
+			filtered := make([]byte, 0, len(cur))
+			for idx, ch := range cur {
+				pos := idx + 1
+				if pos >= l && pos <= r && ch == c {
+					continue
+				}
+				filtered = append(filtered, ch)
+			}
+			cur = filtered
+		}
+		inp := sb.String()
+		tests = append(tests, test{inp, solve(inp)})
+	}
+	return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("time limit")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if out != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%sexpected:%s\n got:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add verifierA–F.go for contest 899
- each verifier generates 100 deterministic tests and checks an arbitrary binary

## Testing
- `go run verifierA.go ./899A_bin`
- `go run verifierB.go ./899B_bin`
- `go run verifierC.go ./899C_bin`
- `go run verifierD.go ./899D_bin`
- `go run verifierE.go ./899E_bin`
- `go run verifierF.go ./899F_bin`


------
https://chatgpt.com/codex/tasks/task_e_6883ed1867bc8324b942c4a262dda64c