### PR TITLE
Add Go solution for problem 1679A

### DIFF
--- a/1000-1999/1600-1699/1670-1679/1679/1679A.go
+++ b/1000-1999/1600-1699/1670-1679/1679/1679A.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		if n%2 == 1 || n < 4 {
+			fmt.Fprintln(writer, -1)
+			continue
+		}
+		min := (n + 5) / 6
+		max := n / 4
+		fmt.Fprintln(writer, min, max)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `problemA.txt` in contest 1679

## Testing
- `go run 1000-1999/1600-1699/1670-1679/1679/1679A.go <<EOF
1
4
EOF`
- `echo -e "5\n2\n4\n6\n10\n24" | go run 1000-1999/1600-1699/1670-1679/1679/1679A.go`


------
https://chatgpt.com/codex/tasks/task_e_6883ec467dac8324a3bd0fb8c5edee66