### PR TITLE
Add verifiers for Codeforces contest 897

### DIFF
--- a/0-999/800-899/890-899/897/verifierA.go
+++ b/0-999/800-899/890-899/897/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(reader *bufio.Reader) string {
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return ""
+	}
+	var s string
+	fmt.Fscan(reader, &s)
+	b := []byte(s)
+	for i := 0; i < m; i++ {
+		var l, r int
+		var c1, c2 string
+		fmt.Fscan(reader, &l, &r, &c1, &c2)
+		for j := l - 1; j < r; j++ {
+			if string(b[j]) == c1 {
+				b[j] = c2[0]
+			}
+		}
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	m := rng.Intn(100) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('a' + rng.Intn(26)))
+	}
+	s := sb.String()
+	input := fmt.Sprintf("%d %d\n%s\n", n, m, s)
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		c1 := string(byte('a' + rng.Intn(26)))
+		c2 := string(byte('a' + rng.Intn(26)))
+		input += fmt.Sprintf("%d %d %s %s\n", l, r, c1, c2)
+	}
+	expect := solve(bufio.NewReader(strings.NewReader(input)))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/897/verifierB.go
+++ b/0-999/800-899/890-899/897/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func makePal(x int) int64 {
+	res := int64(x)
+	y := x
+	for y > 0 {
+		res = res*10 + int64(y%10)
+		y /= 10
+	}
+	return res
+}
+
+func solve(reader *bufio.Reader) string {
+	var k int
+	var p int64
+	if _, err := fmt.Fscan(reader, &k, &p); err != nil {
+		return ""
+	}
+	var sum int64
+	for i := 1; i <= k; i++ {
+		sum = (sum + makePal(i)) % p
+	}
+	return fmt.Sprint(sum % p)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	k := rng.Intn(100000) + 1
+	p := rng.Int63n(1_000_000_000) + 1
+	input := fmt.Sprintf("%d %d\n", k, p)
+	expect := solve(bufio.NewReader(strings.NewReader(input)))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go and verifierB.go
- each verifier generates 100 random tests and checks a given binary

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`


------
https://chatgpt.com/codex/tasks/task_e_6883ec00d55c8324ac2a199423bc5dba