### PR TITLE
Add verifiers for Codeforces contest 896

### DIFF
--- a/0-999/800-899/890-899/896/verifierA.go
+++ b/0-999/800-899/890-899/896/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const numTests = 100
+
+func buildRef(dir string) (string, error) {
+	ref := filepath.Join(dir, "refA_bin")
+	cmd := exec.Command("go", "build", "-o", ref, "896A.go")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+
+	ref, err := buildRef(dir)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for t := 1; t <= numTests; t++ {
+		q := rand.Intn(5) + 1
+		var input bytes.Buffer
+		input.WriteString(fmt.Sprintf("%d\n", q))
+		for i := 0; i < q; i++ {
+			n := rand.Intn(100000)
+			k := rand.Int63n(1e18) + 1
+			input.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		}
+		inBytes := input.Bytes()
+
+		out, err := runBinary(target, inBytes)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+
+		refOut, err := runBinary(ref, inBytes)
+		if err != nil {
+			fmt.Printf("Test %d: reference runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+
+		if strings.TrimSpace(out) != strings.TrimSpace(refOut) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", t, string(inBytes), refOut, out)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Printf("Passed %d tests\n", numTests)
+}

--- a/0-999/800-899/890-899/896/verifierB.go
+++ b/0-999/800-899/890-899/896/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const numTests = 100
+
+func isSorted(arr []int) bool {
+	if len(arr) == 0 {
+		return true
+	}
+	if arr[0] == 0 {
+		return false
+	}
+	for i := 1; i < len(arr); i++ {
+		if arr[i] == 0 || arr[i-1] > arr[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+
+	for t := 1; t <= numTests; t++ {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(10) + n
+		c := rand.Intn(5) + 1
+		xs := make([]int, m)
+		var input bytes.Buffer
+		input.WriteString(fmt.Sprintf("%d %d %d\n", n, m, c))
+		for i := 0; i < m; i++ {
+			xs[i] = rand.Intn(c) + 1
+			input.WriteString(fmt.Sprintf("%d\n", xs[i]))
+		}
+		inBytes := input.Bytes()
+
+		cmd := exec.Command(target)
+		cmd.Stdin = bytes.NewReader(inBytes)
+		outBytes, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		outputs := strings.Fields(string(outBytes))
+		arr := make([]int, n)
+		idx := 0
+		success := false
+		for i := 0; i < m; i++ {
+			if idx >= len(outputs) {
+				fmt.Printf("Test %d: insufficient outputs\n", t)
+				os.Exit(1)
+			}
+			pos, err := strconv.Atoi(outputs[idx])
+			idx++
+			if err != nil || pos < 1 || pos > n {
+				fmt.Printf("Test %d: invalid index %q\n", t, outputs[idx-1])
+				os.Exit(1)
+			}
+			arr[pos-1] = xs[i]
+			if isSorted(arr) {
+				success = true
+				if idx != len(outputs) {
+					fmt.Printf("Test %d: extra output after sorted\n", t)
+					os.Exit(1)
+				}
+				break
+			}
+		}
+		if !success && idx != len(outputs) {
+			fmt.Printf("Test %d: extra output lines\n", t)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("Passed %d tests\n", numTests)
+}

--- a/0-999/800-899/890-899/896/verifierC.go
+++ b/0-999/800-899/890-899/896/verifierC.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const numTests = 100
+
+func buildRef(dir string) (string, error) {
+	ref := filepath.Join(dir, "refC_bin")
+	cmd := exec.Command("go", "build", "-o", ref, "896C.go")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+
+	ref, err := buildRef(dir)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for t := 1; t <= numTests; t++ {
+		n := rand.Intn(10) + 1
+		m := rand.Intn(10) + 1
+		seed := rand.Int63n(1000000)
+		vmax := rand.Int63n(1000) + 1
+		input := fmt.Sprintf("%d %d %d %d\n", n, m, seed, vmax)
+		inBytes := []byte(input)
+
+		out, err := runBinary(target, inBytes)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		refOut, err := runBinary(ref, inBytes)
+		if err != nil {
+			fmt.Printf("Test %d: reference runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(refOut) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", t, input, refOut, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("Passed %d tests\n", numTests)
+}

--- a/0-999/800-899/890-899/896/verifierD.go
+++ b/0-999/800-899/890-899/896/verifierD.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const numTests = 100
+
+func buildRef(dir string) (string, error) {
+	ref := filepath.Join(dir, "refD_bin")
+	cmd := exec.Command("go", "build", "-o", ref, "896D.go")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+
+	ref, err := buildRef(dir)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for t := 1; t <= numTests; t++ {
+		n := rand.Intn(20) + 1
+		p := rand.Intn(1000000000) + 2
+		l := rand.Intn(n)
+		r := l + rand.Intn(n-l+1)
+		input := fmt.Sprintf("%d %d %d %d\n", n, p, l, r)
+		inBytes := []byte(input)
+
+		out, err := runBinary(target, inBytes)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		refOut, err := runBinary(ref, inBytes)
+		if err != nil {
+			fmt.Printf("Test %d: reference runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(refOut) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", t, input, refOut, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("Passed %d tests\n", numTests)
+}

--- a/0-999/800-899/890-899/896/verifierE.go
+++ b/0-999/800-899/890-899/896/verifierE.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const numTests = 100
+
+func buildRef(dir string) (string, error) {
+	ref := filepath.Join(dir, "refE_bin")
+	cmd := exec.Command("go", "build", "-o", ref, "896E.go")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+
+	ref, err := buildRef(dir)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for t := 1; t <= numTests; t++ {
+		n := rand.Intn(10) + 1
+		m := rand.Intn(10) + 1
+		var input bytes.Buffer
+		input.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rand.Intn(10) + 1
+			input.WriteString(fmt.Sprintf("%d ", arr[i]))
+		}
+		input.WriteString("\n")
+		for i := 0; i < m; i++ {
+			typ := rand.Intn(2) + 1
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			x := rand.Intn(10) + 1
+			input.WriteString(fmt.Sprintf("%d %d %d %d\n", typ, l, r, x))
+		}
+		inBytes := input.Bytes()
+
+		out, err := runBinary(target, inBytes)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		refOut, err := runBinary(ref, inBytes)
+		if err != nil {
+			fmt.Printf("Test %d: reference runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(refOut) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", t, input.String(), refOut, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("Passed %d tests\n", numTests)
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems of contest 896
- verifiers compile the official solution and run 100 random tests
- interactive problem B has a custom checker

## Testing
- `go build 0-999/800-899/890-899/896/verifierA.go`
- `go build 0-999/800-899/890-899/896/verifierB.go`
- `go build 0-999/800-899/890-899/896/verifierC.go`
- `go build 0-999/800-899/890-899/896/verifierD.go`
- `go build 0-999/800-899/890-899/896/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883eb73e6d48324a14024e80b4171e2