### PR TITLE
Add Go verifiers for Codeforces 894

### DIFF
--- a/0-999/800-899/890-899/894/verifierA.go
+++ b/0-999/800-899/890-899/894/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(s string) string {
+	n := len(s)
+	cnt := 0
+	for i := 0; i < n; i++ {
+		if s[i] != 'Q' {
+			continue
+		}
+		for j := i + 1; j < n; j++ {
+			if s[j] != 'A' {
+				continue
+			}
+			for k := j + 1; k < n; k++ {
+				if s[k] == 'Q' {
+					cnt++
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("%d", cnt)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		c := 'A' + rune(rng.Intn(26))
+		sb.WriteByte(byte(c))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		expected := solve(strings.TrimSpace(input))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/894/verifierB.go
+++ b/0-999/800-899/890-899/894/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const mod int64 = 1000000007
+const modExp int64 = mod - 1
+
+func powMod(base, exp int64) int64 {
+	res := int64(1)
+	base %= mod
+	for exp > 0 {
+		if exp&1 == 1 {
+			res = res * base % mod
+		}
+		base = base * base % mod
+		exp >>= 1
+	}
+	return res
+}
+
+func solve(n, m, k int64) string {
+	if k == -1 && (n%2 != m%2) {
+		return "0"
+	}
+	e := ((n - 1) % modExp * ((m - 1) % modExp)) % modExp
+	return fmt.Sprintf("%d", powMod(2, e))
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Int63n(1_000_000_000_000) + 1
+	m := rng.Int63n(1_000_000_000_000) + 1
+	k := int64(1)
+	if rng.Intn(2) == 0 {
+		k = -1
+	}
+	return fmt.Sprintf("%d %d %d\n", n, m, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		var n, m, k int64
+		fmt.Sscan(strings.TrimSpace(input), &n, &m, &k)
+		expected := solve(n, m, k)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/894/verifierC.go
+++ b/0-999/800-899/890-899/894/verifierC.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solve(arr []int64) string {
+	if len(arr) == 0 {
+		return "-1"
+	}
+	g := arr[0]
+	for _, v := range arr[1:] {
+		g = gcd(g, v)
+	}
+	if g != arr[0] {
+		return "-1"
+	}
+	var sb strings.Builder
+	n := int64(len(arr))
+	fmt.Fprintf(&sb, "%d\n", 2*n-1)
+	sb.WriteString(fmt.Sprintf("%d", arr[0]))
+	for i := 1; i < len(arr); i++ {
+		sb.WriteString(fmt.Sprintf(" %d %d", arr[i], arr[0]))
+	}
+	sb.WriteByte('\n')
+	return strings.TrimSpace(sb.String())
+}
+
+func genValidCase(rng *rand.Rand) []int64 {
+	m := rng.Intn(5) + 1
+	base := int64(rng.Intn(1000) + 1)
+	set := make(map[int64]struct{})
+	arr := make([]int64, 0, m)
+	arr = append(arr, base)
+	set[base] = struct{}{}
+	for len(arr) < m {
+		v := base * int64(rng.Intn(20)+1)
+		if _, ok := set[v]; ok {
+			continue
+		}
+		set[v] = struct{}{}
+		arr = append(arr, v)
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	return arr
+}
+
+func genInvalidCase(rng *rand.Rand) []int64 {
+	arr := genValidCase(rng)
+	if len(arr) == 1 {
+		arr[0]++
+		return arr
+	}
+	arr[0]++
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	return arr
+}
+
+func buildInput(arr []int64) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(arr))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		var arr []int64
+		if t%2 == 0 {
+			arr = genValidCase(rng)
+		} else {
+			arr = genInvalidCase(rng)
+		}
+		input := buildInput(arr)
+		expected := solve(arr)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/894/verifierD.go
+++ b/0-999/800-899/890-899/894/verifierD.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "894D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 2; i <= n; i++ {
+		L := rng.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", L))
+	}
+	for i := 0; i < m; i++ {
+		a := rng.Intn(n) + 1
+		h := rng.Intn(50)
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, h))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", t+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/894/verifierE.go
+++ b/0-999/800-899/890-899/894/verifierE.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "894E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(8)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(n) + 1
+		w := rng.Intn(20)
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", x, y, w))
+	}
+	s := rng.Intn(n) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", s))
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", t+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for all five problems of contest 894
- each verifier runs 100 random tests and checks output
- complex problems (D and E) compile reference solutions as oracles

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883ea5baff48324bfc62758bdbf6566