### PR TITLE
Add Go solution for 1621A

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1621/1621A.go
+++ b/1000-1999/1600-1699/1620-1629/1621/1621A.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		if k > (n+1)/2 {
+			fmt.Fprintln(writer, -1)
+			continue
+		}
+		for i := 0; i < n; i++ {
+			line := make([]byte, n)
+			for j := 0; j < n; j++ {
+				line[j] = '.'
+			}
+			if i%2 == 0 && i/2 < k {
+				line[i] = 'R'
+			}
+			fmt.Fprintln(writer, string(line))
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for 1621A Stable Arrangement of Rooks

## Testing
- `go build 1000-1999/1600-1699/1620-1629/1621/1621A.go`
- `echo -e "2\n3 2\n4 3" | go run 1000-1999/1600-1699/1620-1629/1621/1621A.go`

------
https://chatgpt.com/codex/tasks/task_e_68843c7090108324a30847a377503629