### PR TITLE
Add Go verifiers for contest 923

### DIFF
--- a/0-999/900-999/920-929/923/verifierA.go
+++ b/0-999/900-999/920-929/923/verifierA.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func linearSieve(n int) []int {
+	spf := make([]int, n+1)
+	primes := make([]int, 0)
+	for i := 2; i <= n; i++ {
+		if spf[i] == 0 {
+			spf[i] = i
+			primes = append(primes, i)
+		}
+		for _, p := range primes {
+			if p > spf[i] || i*p > n {
+				break
+			}
+			spf[i*p] = p
+		}
+	}
+	return spf
+}
+
+func primeFactors(n int, spf []int) []int {
+	res := make([]int, 0)
+	for n > 1 {
+		p := spf[n]
+		res = append(res, p)
+		for n%p == 0 {
+			n /= p
+		}
+	}
+	return res
+}
+
+var sieve = linearSieve(1000000)
+
+func solve(x2 int) int {
+	factors2 := primeFactors(x2, sieve)
+	best := x2
+	for _, p2 := range factors2 {
+		start := x2 - p2 + 1
+		if start < 3 {
+			start = 3
+		}
+		for x1 := start; x1 <= x2; x1++ {
+			if p2 >= x1 {
+				continue
+			}
+			if (x2-x1)%p2 != 0 {
+				continue
+			}
+			factors1 := primeFactors(x1, sieve)
+			for _, p1 := range factors1 {
+				if p1 >= x1 {
+					continue
+				}
+				cand := x1 - p1 + 1
+				if cand < p1+1 {
+					cand = p1 + 1
+				}
+				if cand < 3 {
+					cand = 3
+				}
+				if cand <= x1 && cand < best {
+					best = cand
+				}
+			}
+		}
+	}
+	return best
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		x2 := rng.Intn(1000-4) + 4
+		// ensure composite
+		for sieve[x2] == x2 {
+			x2 = rng.Intn(1000-4) + 4
+		}
+		input := fmt.Sprintf("%d\n", x2)
+		expected := fmt.Sprintf("%d", solve(x2))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/923/verifierB.go
+++ b/0-999/900-999/920-929/923/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testB struct {
+	n int
+	v []int64
+	t []int64
+}
+
+func solveB(tc testB) []int64 {
+	piles := make([]int64, 0)
+	res := make([]int64, tc.n)
+	for day := 0; day < tc.n; day++ {
+		piles = append(piles, tc.v[day])
+		melt := int64(0)
+		newPiles := make([]int64, 0, len(piles))
+		for _, val := range piles {
+			if val > tc.t[day] {
+				melt += tc.t[day]
+				newPiles = append(newPiles, val-tc.t[day])
+			} else {
+				melt += val
+			}
+		}
+		piles = newPiles
+		res[day] = melt
+	}
+	return res
+}
+
+func genTest(rng *rand.Rand) testB {
+	n := rng.Intn(8) + 1
+	v := make([]int64, n)
+	t := make([]int64, n)
+	for i := 0; i < n; i++ {
+		v[i] = int64(rng.Intn(20))
+	}
+	for i := 0; i < n; i++ {
+		t[i] = int64(rng.Intn(20) + 1)
+	}
+	return testB{n, v, t}
+}
+
+func formatInput(tc testB) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", tc.n)
+	for i, x := range tc.v {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", x)
+	}
+	sb.WriteByte('\n')
+	for i, x := range tc.t {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", x)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genTest(rng)
+		input := formatInput(tc)
+		expVals := solveB(tc)
+		var exp strings.Builder
+		for j, v := range expVals {
+			if j > 0 {
+				exp.WriteByte(' ')
+			}
+			fmt.Fprintf(&exp, "%d", v)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp.String() {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp.String(), got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/923/verifierC.go
+++ b/0-999/900-999/920-929/923/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testC struct {
+	n int
+	A []int
+	P []int
+}
+
+func solveC(tc testC) []int {
+	n := tc.n
+	used := make([]bool, n)
+	res := make([]int, n)
+	for i, a := range tc.A {
+		bestVal := int(^uint(0) >> 1)
+		bestIdx := -1
+		for j, p := range tc.P {
+			if used[j] {
+				continue
+			}
+			v := a ^ p
+			if v < bestVal {
+				bestVal = v
+				bestIdx = j
+			}
+		}
+		res[i] = bestVal
+		used[bestIdx] = true
+	}
+	return res
+}
+
+func genTest(rng *rand.Rand) testC {
+	n := rng.Intn(8) + 1
+	A := make([]int, n)
+	P := make([]int, n)
+	for i := 0; i < n; i++ {
+		A[i] = rng.Intn(256)
+	}
+	for i := 0; i < n; i++ {
+		P[i] = rng.Intn(256)
+	}
+	return testC{n, A, P}
+}
+
+func formatInput(tc testC) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", tc.n)
+	for i, v := range tc.A {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range tc.P {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genTest(rng)
+		input := formatInput(tc)
+		expVals := solveC(tc)
+		var exp strings.Builder
+		for j, v := range expVals {
+			if j > 0 {
+				exp.WriteByte(' ')
+			}
+			fmt.Fprintf(&exp, "%d", v)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp.String() {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp.String(), got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/923/verifierD.go
+++ b/0-999/900-999/920-929/923/verifierD.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func applyRules(s string) []string {
+	res := make([]string, 0)
+	n := len(s)
+	for i := 0; i < n; i++ {
+		switch s[i] {
+		case 'A':
+			res = append(res, s[:i]+"BC"+s[i+1:])
+		case 'B':
+			res = append(res, s[:i]+"AC"+s[i+1:])
+		case 'C':
+			res = append(res, s[:i]+"AB"+s[i+1:])
+		}
+	}
+	for i := 0; i+3 <= n; i++ {
+		if s[i:i+3] == "AAA" {
+			res = append(res, s[:i]+s[i+3:])
+		}
+	}
+	return res
+}
+
+func canTransform(src, tgt string) bool {
+	const maxLen = 10
+	vis := map[string]bool{src: true}
+	q := list.New()
+	q.PushBack(src)
+	for q.Len() > 0 {
+		cur := q.Remove(q.Front()).(string)
+		if cur == tgt {
+			return true
+		}
+		if len(cur) > maxLen {
+			continue
+		}
+		for _, nxt := range applyRules(cur) {
+			if len(nxt) > maxLen {
+				continue
+			}
+			if !vis[nxt] {
+				vis[nxt] = true
+				q.PushBack(nxt)
+			}
+		}
+	}
+	return false
+}
+
+type testD struct {
+	S       string
+	T       string
+	queries [][4]int
+}
+
+func genString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	letters := []byte{'A', 'B', 'C'}
+	for i := 0; i < n; i++ {
+		b[i] = letters[rng.Intn(3)]
+	}
+	return string(b)
+}
+
+func genTest(rng *rand.Rand) testD {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	s := genString(rng, n)
+	t := genString(rng, m)
+	q := rng.Intn(3) + 1
+	queries := make([][4]int, q)
+	for i := 0; i < q; i++ {
+		a := rng.Intn(n) + 1
+		b := a + rng.Intn(n-a+1)
+		c := rng.Intn(m) + 1
+		d := c + rng.Intn(m-c+1)
+		queries[i] = [4]int{a, b, c, d}
+	}
+	return testD{s, t, queries}
+}
+
+func solveD(tc testD) string {
+	var sb strings.Builder
+	for _, q := range tc.queries {
+		sSub := tc.S[q[0]-1 : q[1]]
+		tSub := tc.T[q[2]-1 : q[3]]
+		if canTransform(sSub, tSub) {
+			sb.WriteByte('1')
+		} else {
+			sb.WriteByte('0')
+		}
+	}
+	return sb.String()
+}
+
+func formatInput(tc testD) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s\n%s\n%d\n", tc.S, tc.T, len(tc.queries))
+	for _, q := range tc.queries {
+		fmt.Fprintf(&sb, "%d %d %d %d\n", q[0], q[1], q[2], q[3])
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genTest(rng)
+		input := formatInput(tc)
+		expected := solveD(tc)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/923/verifierE.go
+++ b/0-999/900-999/920-929/923/verifierE.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	a %= mod
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func inv(a int64) int64 {
+	return modPow(a, mod-2)
+}
+
+func step(dp []int64, invs []int64) []int64 {
+	n := len(dp) - 1
+	prefix := int64(0)
+	res := make([]int64, n+1)
+	for i := n; i >= 0; i-- {
+		prefix = (prefix + dp[i]*invs[i]) % mod
+		res[i] = prefix
+	}
+	return res
+}
+
+func solveE(n, m int, p []int64) []int64 {
+	invs := make([]int64, n+1)
+	for i := 0; i <= n; i++ {
+		invs[i] = inv(int64(i + 1))
+	}
+	dp := make([]int64, n+1)
+	copy(dp, p)
+	for stepNum := 0; stepNum < m; stepNum++ {
+		dp = step(dp, invs)
+	}
+	for i := range dp {
+		dp[i] = (dp[i]%mod + mod) % mod
+	}
+	return dp
+}
+
+func genTest(rng *rand.Rand) (int, int, []int64) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	p := make([]int64, n+1)
+	for i := range p {
+		p[i] = int64(rng.Intn(100)) % mod
+	}
+	return n, m, p
+}
+
+func formatInput(n, m int, p []int64) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i, v := range p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, p := genTest(rng)
+		input := formatInput(n, m, p)
+		expVals := solveE(n, m, p)
+		var exp strings.Builder
+		for j, v := range expVals {
+			if j > 0 {
+				exp.WriteByte(' ')
+			}
+			fmt.Fprintf(&exp, "%d", v)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != exp.String() {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp.String(), got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/900-999/920-929/923/verifierF.go
+++ b/0-999/900-999/920-929/923/verifierF.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+type testF struct {
+	n     int
+	bus   []edge
+	train []edge
+}
+
+func genTreeEdges(rng *rand.Rand, offset, n int) []edge {
+	edges := make([]edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		u := rng.Intn(i-1) + 1
+		edges = append(edges, edge{offset + u - 1, offset + i - 1})
+	}
+	return edges
+}
+
+func genTest(rng *rand.Rand) testF {
+	n := rng.Intn(4) + 2 // 2..5
+	bus := genTreeEdges(rng, 1, n)
+	train := genTreeEdges(rng, n+1, n)
+	return testF{n, bus, train}
+}
+
+func solveF(tc testF) (bool, []int) {
+	n := tc.n
+	trainSet := make(map[[2]int]bool)
+	for _, e := range tc.train {
+		a, b := e.u, e.v
+		if a > b {
+			a, b = b, a
+		}
+		trainSet[[2]int{a, b}] = true
+	}
+	perm := make([]int, n)
+	used := make([]bool, n)
+	nodes := make([]int, n)
+	for i := 0; i < n; i++ {
+		nodes[i] = n + 1 + i
+	}
+	var res []int
+	var dfs func(int) bool
+	dfs = func(pos int) bool {
+		if pos == n {
+			res = append([]int(nil), perm...)
+			return true
+		}
+		for i, v := range nodes {
+			if used[i] {
+				continue
+			}
+			perm[pos] = v
+			valid := true
+			for _, e := range tc.bus {
+				if e.u-1 == pos && used[e.v-1] {
+					a := perm[pos]
+					b := perm[e.v-1]
+					if a > b {
+						a, b = b, a
+					}
+					if trainSet[[2]int{a, b}] {
+						valid = false
+						break
+					}
+				} else if e.v-1 == pos && used[e.u-1] {
+					a := perm[e.u-1]
+					b := perm[pos]
+					if a > b {
+						a, b = b, a
+					}
+					if trainSet[[2]int{a, b}] {
+						valid = false
+						break
+					}
+				}
+			}
+			if valid {
+				used[i] = true
+				if dfs(pos + 1) {
+					return true
+				}
+				used[i] = false
+			}
+		}
+		return false
+	}
+	if dfs(0) {
+		return true, res
+	}
+	return false, nil
+}
+
+func formatInput(tc testF) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", tc.n)
+	for _, e := range tc.bus {
+		fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+	}
+	for _, e := range tc.train {
+		fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genTest(rng)
+		input := formatInput(tc)
+		ok, mapping := solveF(tc)
+		var exp strings.Builder
+		if !ok {
+			exp.WriteString("No")
+		} else {
+			exp.WriteString("Yes\n")
+			for j, v := range mapping {
+				if j > 0 {
+					exp.WriteByte(' ')
+				}
+				fmt.Fprintf(&exp, "%d", v)
+			}
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp.String()) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp.String(), got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–F of contest 923
- each verifier runs 100 randomized tests and checks a candidate binary

## Testing
- `go vet 0-999/900-999/920-929/923/verifierA.go`
- `go build 0-999/900-999/920-929/923/verifierA.go`
- `go build 0-999/900-999/920-929/923/verifierB.go`
- `go build 0-999/900-999/920-929/923/verifierC.go`
- `go build 0-999/900-999/920-929/923/verifierD.go`
- `go build 0-999/900-999/920-929/923/verifierE.go`
- `go build 0-999/900-999/920-929/923/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883fa3a253c8324a1e5c8ad3ecfef1e