### PR TITLE
Add Go solution verifiers for contest 898

### DIFF
--- a/0-999/800-899/890-899/898/verifierA.go
+++ b/0-999/800-899/890-899/898/verifierA.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n int
+}
+
+func solveA(n int) string {
+	r := n % 10
+	n -= r
+	if r >= 5 {
+		n += 10
+	}
+	return fmt.Sprintf("%d\n", n)
+}
+
+func genCaseA(rng *rand.Rand) (string, string) {
+	n := rng.Intn(1_000_000_000)
+	in := fmt.Sprintf("%d\n", n)
+	out := solveA(n)
+	return in, out
+}
+
+func runCaseA(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected %s got %s", strings.TrimSpace(exp), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, out := genCaseA(rng)
+		if err := runCaseA(bin, in, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/898/verifierB.go
+++ b/0-999/800-899/890-899/898/verifierB.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n, a, b  int64
+	expectOk bool
+	expectX  int64
+	expectY  int64
+}
+
+func solveB(n, a, b int64) (bool, int64, int64) {
+	for x := int64(0); x*a <= n; x++ {
+		rem := n - x*a
+		if rem%b == 0 {
+			return true, x, rem / b
+		}
+	}
+	return false, 0, 0
+}
+
+func genCaseB(rng *rand.Rand) (string, testCaseB) {
+	n := int64(rng.Intn(10000) + 1)
+	a := int64(rng.Intn(1000) + 1)
+	b := int64(rng.Intn(1000) + 1)
+	ok, x, y := solveB(n, a, b)
+	tc := testCaseB{n: n, a: a, b: b, expectOk: ok, expectX: x, expectY: y}
+	in := fmt.Sprintf("%d\n%d\n%d\n", n, a, b)
+	return in, tc
+}
+
+func runCaseB(bin string, in string, tc testCaseB) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	out := strings.Fields(strings.TrimSpace(buf.String()))
+	if tc.expectOk {
+		if len(out) != 3 || strings.ToUpper(out[0]) != "YES" {
+			return fmt.Errorf("expected YES and two numbers, got %v", out)
+		}
+		x, err1 := strconv.ParseInt(out[1], 10, 64)
+		y, err2 := strconv.ParseInt(out[2], 10, 64)
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("invalid numbers in output: %v %v", err1, err2)
+		}
+		if x < 0 || y < 0 || x*tc.a+y*tc.b != tc.n {
+			return fmt.Errorf("output %d %d does not satisfy equation", x, y)
+		}
+	} else {
+		if len(out) != 1 || strings.ToUpper(out[0]) != "NO" {
+			return fmt.Errorf("expected NO, got %v", out)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, tc := genCaseB(rng)
+		if err := runCaseB(bin, in, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/898/verifierC.go
+++ b/0-999/800-899/890-899/898/verifierC.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type entry struct {
+	name string
+	nums []string
+}
+
+func solveC(entries []entry) map[string][]string {
+	m := make(map[string]map[string]struct{})
+	for _, e := range entries {
+		if _, ok := m[e.name]; !ok {
+			m[e.name] = make(map[string]struct{})
+		}
+		for _, num := range e.nums {
+			m[e.name][num] = struct{}{}
+		}
+	}
+	res := make(map[string][]string)
+	for name, set := range m {
+		nums := make([]string, 0, len(set))
+		for num := range set {
+			nums = append(nums, num)
+		}
+		keep := make([]string, 0, len(nums))
+		for _, x := range nums {
+			drop := false
+			for _, y := range nums {
+				if x != y && len(y) >= len(x) && strings.HasSuffix(y, x) {
+					drop = true
+					break
+				}
+			}
+			if !drop {
+				keep = append(keep, x)
+			}
+		}
+		sort.Strings(keep)
+		res[name] = keep
+	}
+	return res
+}
+
+func genCaseC(rng *rand.Rand) (string, map[string][]string) {
+	n := rng.Intn(4) + 1
+	entries := make([]entry, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("%c%c", 'a'+rune(rng.Intn(26)), 'a'+rune(rng.Intn(26)))
+		k := rng.Intn(3) + 1
+		nums := make([]string, k)
+		for j := 0; j < k; j++ {
+			nums[j] = strconv.Itoa(rng.Intn(1000))
+		}
+		entries[i] = entry{name: name, nums: nums}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, e := range entries {
+		fmt.Fprintf(&sb, "%s %d", e.name, len(e.nums))
+		for _, num := range e.nums {
+			fmt.Fprintf(&sb, " %s", num)
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String(), solveC(entries)
+}
+
+func parseOutputC(out string) (map[string][]string, error) {
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(out)))
+	if !scanner.Scan() {
+		return nil, fmt.Errorf("no output")
+	}
+	m, err := strconv.Atoi(strings.TrimSpace(scanner.Text()))
+	if err != nil {
+		return nil, fmt.Errorf("bad first line: %v", err)
+	}
+	res := make(map[string][]string)
+	for i := 0; i < m; i++ {
+		if !scanner.Scan() {
+			return nil, fmt.Errorf("expected %d lines", m)
+		}
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			return nil, fmt.Errorf("bad line: %q", scanner.Text())
+		}
+		name := fields[0]
+		k, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return nil, fmt.Errorf("bad count: %v", err)
+		}
+		if len(fields)-2 != k {
+			return nil, fmt.Errorf("wrong number of phones for %s", name)
+		}
+		nums := make([]string, k)
+		copy(nums, fields[2:])
+		sort.Strings(nums)
+		res[name] = nums
+	}
+	return res, nil
+}
+
+func runCaseC(bin string, in string, exp map[string][]string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got, err := parseOutputC(buf.String())
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if len(got) != len(exp) {
+		return fmt.Errorf("expected %d contacts got %d", len(exp), len(got))
+	}
+	for name, expNums := range exp {
+		gnums, ok := got[name]
+		if !ok {
+			return fmt.Errorf("missing friend %s", name)
+		}
+		if len(gnums) != len(expNums) {
+			return fmt.Errorf("for %s expected %v got %v", name, expNums, gnums)
+		}
+		for i := range gnums {
+			if gnums[i] != expNums[i] {
+				return fmt.Errorf("for %s expected %v got %v", name, expNums, gnums)
+			}
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseC(rng)
+		if err := runCaseC(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/898/verifierD.go
+++ b/0-999/800-899/890-899/898/verifierD.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveD(a []int, m, k int) int {
+	sort.Ints(a)
+	queue := make([]int, 0, len(a))
+	left := 0
+	removed := 0
+	for _, t := range a {
+		limit := t - m + 1
+		for left < len(queue) && queue[left] < limit {
+			left++
+		}
+		queue = append(queue, t)
+		if len(queue)-left >= k {
+			queue = queue[:len(queue)-1]
+			removed++
+		}
+	}
+	return removed
+}
+
+func genCaseD(rng *rand.Rand) (string, int) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(10) + 1
+	k := rng.Intn(n) + 1
+	times := rng.Perm(100)[:n]
+	for i := range times {
+		times[i]++
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i, v := range times {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteString("\n")
+	return sb.String(), solveD(times, m, k)
+}
+
+func runCaseD(bin, in string, exp int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	gotStr := strings.TrimSpace(buf.String())
+	got, err := strconv.Atoi(gotStr)
+	if err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseD(rng)
+		if err := runCaseD(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/898/verifierE.go
+++ b/0-999/800-899/890-899/898/verifierE.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func isSquare(x int) bool {
+	r := int(math.Sqrt(float64(x)))
+	return r*r == x
+}
+
+func costToSquare(x int) int {
+	r := int(math.Sqrt(float64(x)))
+	c1 := x - r*r
+	c2 := (r+1)*(r+1) - x
+	if c1 < c2 {
+		return c1
+	}
+	return c2
+}
+
+func solveE(a []int) int {
+	n := len(a)
+	squareCosts := []int{}
+	nonsquareCosts := []int{}
+	squares := 0
+	for _, v := range a {
+		if isSquare(v) {
+			squares++
+			if v == 0 {
+				squareCosts = append(squareCosts, 2)
+			} else {
+				squareCosts = append(squareCosts, 1)
+			}
+		} else {
+			nonsquareCosts = append(nonsquareCosts, costToSquare(v))
+		}
+	}
+	target := n / 2
+	if squares == target {
+		return 0
+	}
+	if squares > target {
+		sort.Ints(squareCosts)
+		need := squares - target
+		moves := 0
+		for i := 0; i < need; i++ {
+			moves += squareCosts[i]
+		}
+		return moves
+	}
+	sort.Ints(nonsquareCosts)
+	need := target - squares
+	moves := 0
+	for i := 0; i < need; i++ {
+		moves += nonsquareCosts[i]
+	}
+	return moves
+}
+
+func genCaseE(rng *rand.Rand) (string, int) {
+	n := (rng.Intn(5) + 1) * 2
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(50)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteString("\n")
+	return sb.String(), solveE(a)
+}
+
+func runCaseE(bin, in string, exp int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	gotStr := strings.TrimSpace(buf.String())
+	got, err := strconv.Atoi(gotStr)
+	if err != nil {
+		return fmt.Errorf("invalid output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCaseE(rng)
+		if err := runCaseE(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/898/verifierF.go
+++ b/0-999/800-899/890-899/898/verifierF.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildInputF(rng *rand.Rand) (string, string) {
+	a := rng.Intn(1000)
+	b := rng.Intn(1000)
+	sa := fmt.Sprintf("%d", a)
+	sb := fmt.Sprintf("%d", b)
+	sc := fmt.Sprintf("%d", a+b)
+	s := sa + sb + sc + "\n"
+	return s, sa + "+" + sb + "=" + sc + "\n"
+}
+
+func checkOutputF(in, out string) error {
+	out = strings.TrimSpace(out)
+	plus := strings.IndexByte(out, '+')
+	eq := strings.IndexByte(out, '=')
+	if plus == -1 || eq == -1 || plus > eq {
+		return fmt.Errorf("output format")
+	}
+	a := out[:plus]
+	b := out[plus+1 : eq]
+	c := out[eq+1:]
+	if len(a) == 0 || len(b) == 0 || len(c) == 0 {
+		return fmt.Errorf("empty parts")
+	}
+	if (len(a) > 1 && a[0] == '0') || (len(b) > 1 && b[0] == '0') || (len(c) > 1 && c[0] == '0') {
+		return fmt.Errorf("leading zeros")
+	}
+	if a+b+c != strings.TrimSpace(in) {
+		return fmt.Errorf("digits mismatch")
+	}
+	ai := new(big.Int)
+	bi := new(big.Int)
+	ci := new(big.Int)
+	ai.SetString(a, 10)
+	bi.SetString(b, 10)
+	ci.SetString(c, 10)
+	sum := new(big.Int).Add(ai, bi)
+	if sum.Cmp(ci) != 0 {
+		return fmt.Errorf("not equal")
+	}
+	return nil
+}
+
+func runCaseF(bin, in string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	if err := checkOutputF(in, buf.String()); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, _ := buildInputF(rng)
+		if err := runCaseF(bin, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A through F in contest 898
- each verifier runs 100 randomly generated tests against a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883ec8c54ec832498826b2a9de8a3dc