### PR TITLE
Add Go verifiers for CF contest 893

### DIFF
--- a/0-999/800-899/890-899/893/verifierA.go
+++ b/0-999/800-899/890-899/893/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(wins []int) string {
+	p1, p2, s := 1, 2, 3
+	for _, w := range wins {
+		if w != p1 && w != p2 {
+			return "NO"
+		}
+		var loser int
+		if w == p1 {
+			loser = p2
+		} else {
+			loser = p1
+		}
+		p1, p2, s = w, s, loser
+	}
+	return "YES"
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(100) + 1
+	wins := make([]int, n)
+	spectators := make([]int, n)
+	p1, p2, s := 1, 2, 3
+	for i := 0; i < n; i++ {
+		if r.Intn(2) == 0 {
+			wins[i] = p1
+			spectators[i] = s
+			p1, p2, s = p1, s, p2
+		} else {
+			wins[i] = p2
+			spectators[i] = s
+			p1, p2, s = p2, s, p1
+		}
+	}
+	if r.Intn(2) == 0 {
+		idx := r.Intn(n)
+		wins[idx] = spectators[idx]
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprint(wins[i]))
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	sb.WriteByte('\n')
+	expect := solveCase(wins)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/893/verifierB.go
+++ b/0-999/800-899/890-899/893/verifierB.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(n int) int {
+	beautiful := []int{}
+	for k := 0; ; k++ {
+		val := (1<<(k+1) - 1) * (1 << k)
+		if val > 100000 {
+			break
+		}
+		beautiful = append(beautiful, val)
+	}
+	ans := 1
+	for i := len(beautiful) - 1; i >= 0; i-- {
+		if n%beautiful[i] == 0 {
+			ans = beautiful[i]
+			break
+		}
+	}
+	return ans
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(100000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	expect := fmt.Sprint(solveCase(n))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/893/verifierC.go
+++ b/0-999/800-899/890-899/893/verifierC.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(n, m int, cost []int64, edges [][2]int) int64 {
+	g := make([][]int, n)
+	for _, e := range edges {
+		a, b := e[0], e[1]
+		g[a] = append(g[a], b)
+		g[b] = append(g[b], a)
+	}
+	visited := make([]bool, n)
+	q := make([]int, 0)
+	var ans int64
+	for i := 0; i < n; i++ {
+		if visited[i] {
+			continue
+		}
+		visited[i] = true
+		q = append(q[:0], i)
+		minCost := cost[i]
+		for len(q) > 0 {
+			v := q[0]
+			q = q[1:]
+			if cost[v] < minCost {
+				minCost = cost[v]
+			}
+			for _, to := range g[v] {
+				if !visited[to] {
+					visited[to] = true
+					q = append(q, to)
+				}
+			}
+		}
+		ans += minCost
+	}
+	return ans
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(20) + 1
+	maxEdges := n * (n - 1) / 2
+	m := r.Intn(maxEdges + 1)
+	cost := make([]int64, n)
+	for i := range cost {
+		cost[i] = int64(r.Intn(100) + 1)
+	}
+	edges := make([][2]int, 0, m)
+	used := make(map[[2]int]bool)
+	for len(edges) < m {
+		a := r.Intn(n)
+		b := r.Intn(n)
+		if a == b {
+			continue
+		}
+		if a > b {
+			a, b = b, a
+		}
+		key := [2]int{a, b}
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		edges = append(edges, [2]int{a, b})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(cost[i]))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+	}
+	expect := fmt.Sprint(solveCase(n, m, cost, edges))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/893/verifierD.go
+++ b/0-999/800-899/890-899/893/verifierD.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(n int, d int64, a []int64) int {
+	pref := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		pref[i+1] = pref[i] + a[i]
+	}
+	maxAfter := make([]int64, n+1)
+	maxAfter[n] = pref[n]
+	for i := n - 1; i >= 0; i-- {
+		if pref[i] > maxAfter[i+1] {
+			maxAfter[i] = pref[i]
+		} else {
+			maxAfter[i] = maxAfter[i+1]
+		}
+	}
+	shift := int64(0)
+	count := 0
+	for i := 1; i <= n; i++ {
+		cur := pref[i] + shift
+		if cur > d {
+			return -1
+		}
+		if a[i-1] == 0 && cur < 0 {
+			limit := d - maxAfter[i]
+			if limit < -pref[i] {
+				return -1
+			}
+			if shift < limit {
+				shift = limit
+				count++
+			}
+			cur = pref[i] + shift
+			if cur < 0 || cur > d {
+				return -1
+			}
+		}
+	}
+	return count
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(20) + 1
+	d := int64(r.Intn(50) + 1)
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = int64(r.Intn(21) - 10)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, d))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteByte('\n')
+	expect := fmt.Sprint(solveCase(n, d, a))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/893/verifierE.go
+++ b/0-999/800-899/890-899/893/verifierE.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+const MAXN int = 1000020
+
+var fac [MAXN + 1]int64
+var ifac [MAXN + 1]int64
+var primes []int
+
+func modPow(a, e int64) int64 {
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % MOD
+		}
+		a = a * a % MOD
+		e >>= 1
+	}
+	return res
+}
+
+func initFactorials() {
+	fac[0] = 1
+	for i := 1; i <= MAXN; i++ {
+		fac[i] = fac[i-1] * int64(i) % MOD
+	}
+	ifac[MAXN] = modPow(fac[MAXN], MOD-2)
+	for i := MAXN; i > 0; i-- {
+		ifac[i-1] = ifac[i] * int64(i) % MOD
+	}
+}
+
+func C(n, k int) int64 {
+	if k < 0 || k > n {
+		return 0
+	}
+	return fac[n] * ifac[k] % MOD * ifac[n-k] % MOD
+}
+
+func sievePrimes(limit int) {
+	isPrime := make([]bool, limit+1)
+	for i := 2; i <= limit; i++ {
+		isPrime[i] = true
+	}
+	for p := 2; p*p <= limit; p++ {
+		if isPrime[p] {
+			for j := p * p; j <= limit; j += p {
+				isPrime[j] = false
+			}
+		}
+	}
+	for i := 2; i <= limit; i++ {
+		if isPrime[i] {
+			primes = append(primes, i)
+		}
+	}
+}
+
+type pair struct {
+	p int
+	e int
+}
+
+func factorize(x int) []pair {
+	res := []pair{}
+	tmp := x
+	for _, p := range primes {
+		if p*p > tmp {
+			break
+		}
+		if tmp%p == 0 {
+			cnt := 0
+			for tmp%p == 0 {
+				tmp /= p
+				cnt++
+			}
+			res = append(res, pair{p, cnt})
+		}
+	}
+	if tmp > 1 {
+		res = append(res, pair{tmp, 1})
+	}
+	return res
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveQuery(x, y int) int64 {
+	factors := factorize(x)
+	ans := modPow(2, int64(y-1))
+	for _, pe := range factors {
+		ans = ans * C(pe.e+y-1, y-1) % MOD
+	}
+	return ans
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	q := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	answers := make([]string, q)
+	for i := 0; i < q; i++ {
+		x := r.Intn(1000000) + 1
+		y := r.Intn(1000) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+		answers[i] = fmt.Sprint(solveQuery(x, y))
+	}
+	return sb.String(), strings.Join(answers, "\n")
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	sievePrimes(1000000)
+	initFactorials()
+	bin := os.Args[1]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(r)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/893/verifierF.go
+++ b/0-999/800-899/890-899/893/verifierF.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type SegTree struct {
+	n    int
+	tree []int64
+}
+
+func NewSegTree(n int) *SegTree {
+	size := 1
+	for size < n {
+		size <<= 1
+	}
+	t := &SegTree{n: size, tree: make([]int64, size<<1)}
+	const INF = int64(1 << 60)
+	for i := range t.tree {
+		t.tree[i] = INF
+	}
+	return t
+}
+
+func (t *SegTree) Update(pos int, val int64) {
+	idx := pos + t.n
+	t.tree[idx] = val
+	for idx >>= 1; idx > 0; idx >>= 1 {
+		if t.tree[idx<<1] < t.tree[idx<<1|1] {
+			t.tree[idx] = t.tree[idx<<1]
+		} else {
+			t.tree[idx] = t.tree[idx<<1|1]
+		}
+	}
+}
+
+func (t *SegTree) Query(l, r int) int64 {
+	const INF = int64(1 << 60)
+	res := INF
+	l += t.n
+	r += t.n + 1
+	for l < r {
+		if l&1 == 1 {
+			if t.tree[l] < res {
+				res = t.tree[l]
+			}
+			l++
+		}
+		if r&1 == 1 {
+			r--
+			if t.tree[r] < res {
+				res = t.tree[r]
+			}
+		}
+		l >>= 1
+		r >>= 1
+	}
+	return res
+}
+
+var (
+	g       [][]int
+	tin     []int
+	tout    []int
+	depth   []int
+	order   int
+	byDepth [][]int
+)
+
+func dfs(u, p, d int) {
+	depth[u] = d
+	if d >= len(byDepth) {
+		tmp := make([][]int, d+1)
+		copy(tmp, byDepth)
+		byDepth = tmp
+	}
+	byDepth[d] = append(byDepth[d], u)
+	order++
+	tin[u] = order
+	for _, v := range g[u] {
+		if v == p {
+			continue
+		}
+		dfs(v, u, d+1)
+	}
+	tout[u] = order
+}
+
+func solveCase(n, rroot int, a []int64, edges [][2]int, queries [][2]int) []int64 {
+	g = make([][]int, n+1)
+	for _, e := range edges {
+		x, y := e[0], e[1]
+		g[x] = append(g[x], y)
+		g[y] = append(g[y], x)
+	}
+	tin = make([]int, n+1)
+	tout = make([]int, n+1)
+	depth = make([]int, n+1)
+	byDepth = make([][]int, 1)
+	order = 0
+	dfs(rroot, 0, 0)
+	maxDepth := len(byDepth) - 1
+
+	seg := NewSegTree(n + 2)
+	curDepth := -1
+	last := 0
+	res := make([]int64, len(queries))
+	for i, pq := range queries {
+		p, q := pq[0], pq[1]
+		x := (p+last)%n + 1
+		k := (q + last) % n
+		t := depth[x] + k
+		if t > maxDepth {
+			t = maxDepth
+		}
+		for curDepth < t {
+			curDepth++
+			for _, v := range byDepth[curDepth] {
+				seg.Update(tin[v], a[v])
+			}
+		}
+		ans := seg.Query(tin[x], tout[x])
+		res[i] = ans
+		last = int(ans)
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	r := rng.Intn(n) + 1
+	a := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = int64(rng.Intn(100) + 1)
+	}
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{i, p})
+	}
+	m := rng.Intn(10) + 1
+	queries := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		queries[i][0] = rng.Intn(n)
+		queries[i][1] = rng.Intn(n)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, r))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(a[i]))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for _, pq := range queries {
+		sb.WriteString(fmt.Sprintf("%d %d\n", pq[0], pq[1]))
+	}
+	res := solveCase(n, r, a, edges, queries)
+	answers := make([]string, m)
+	for i := range res {
+		answers[i] = fmt.Sprint(res[i])
+	}
+	return sb.String(), strings.Join(answers, "\n")
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for contest 893 problems A–F
- each verifier runs 100 randomized tests and checks a provided binary

## Testing
- `go build 0-999/800-899/890-899/893/verifierA.go`
- `go build 0-999/800-899/890-899/893/verifierB.go`
- `go build 0-999/800-899/890-899/893/verifierC.go`
- `go build 0-999/800-899/890-899/893/verifierD.go`
- `go build 0-999/800-899/890-899/893/verifierE.go`
- `go build 0-999/800-899/890-899/893/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883e9cf94f483249bacbdafd3e65835