### PR TITLE
Add solution verifiers for contest 892

### DIFF
--- a/0-999/800-899/890-899/892/verifierA.go
+++ b/0-999/800-899/890-899/892/verifierA.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	a []int64
+	b []int64
+}
+
+func generateTest(i int) testCase {
+	r := rand.New(rand.NewSource(int64(i + 1)))
+	n := r.Intn(50) + 2
+	a := make([]int64, n)
+	b := make([]int64, n)
+	for j := 0; j < n; j++ {
+		a[j] = r.Int63n(1000)
+		b[j] = a[j] + r.Int63n(1000)
+	}
+	return testCase{n: n, a: a, b: b}
+}
+
+func buildTests() []testCase {
+	tests := make([]testCase, 100)
+	for i := range tests {
+		tests[i] = generateTest(i)
+	}
+	return tests
+}
+
+func expected(t testCase) string {
+	var total int64
+	for _, x := range t.a {
+		total += x
+	}
+	// find two largest in b
+	var max1, max2 int64
+	for _, x := range t.b {
+		if x > max1 {
+			max2 = max1
+			max1 = x
+		} else if x > max2 {
+			max2 = x
+		}
+	}
+	if total <= max1+max2 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return out.String(), err
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierA <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := buildTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n", t.n)
+		for j, v := range t.a {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprint(v)
+		}
+		input += "\n"
+		for j, v := range t.b {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprint(v)
+		}
+		input += "\n"
+
+		out, err := runBinary(bin, input)
+		exp := expected(t)
+		got := strings.TrimSpace(strings.ToUpper(out))
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nOutput:%s\n", i+1, err, out)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("Test %d failed: expected %s got %s\n", i+1, exp, got)
+			fmt.Printf("Input:\n%s\n", input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/890-899/892/verifierB.go
+++ b/0-999/800-899/890-899/892/verifierB.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	l []int
+}
+
+func generateTest(i int) testCase {
+	r := rand.New(rand.NewSource(int64(i + 1000)))
+	n := r.Intn(50) + 1
+	l := make([]int, n)
+	for j := 0; j < n; j++ {
+		l[j] = r.Intn(1000)
+	}
+	return testCase{n: n, l: l}
+}
+
+func buildTests() []testCase {
+	tests := make([]testCase, 100)
+	for i := range tests {
+		tests[i] = generateTest(i)
+	}
+	return tests
+}
+
+func expected(t testCase) int {
+	n := t.n
+	left := n + 1
+	alive := 0
+	for i := n; i >= 1; i-- {
+		if i < left {
+			alive++
+		}
+		if v := i - t.l[i-1]; v < left {
+			left = v
+		}
+	}
+	return alive
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return out.String(), err
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierB <binary>")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := buildTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d\n", t.n)
+		for j, v := range t.l {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprint(v)
+		}
+		input += "\n"
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nOutput:%s\n", i+1, err, out)
+			os.Exit(1)
+		}
+		exp := fmt.Sprint(expected(t))
+		got := strings.TrimSpace(out)
+		if got != exp {
+			fmt.Printf("Test %d failed: expected %s got %s\n", i+1, exp, got)
+			fmt.Printf("Input:\n%s\n", input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for Codeforces contest 892
- each verifier generates 100 deterministic test cases and checks a provided binary's output

## Testing
- `go build 0-999/800-899/890-899/892/verifierA.go`
- `go build 0-999/800-899/890-899/892/verifierB.go`
- `go run 0-999/800-899/890-899/892/verifierA.go ./892A_bin`
- `go run 0-999/800-899/890-899/892/verifierB.go ./892B_bin`

------
https://chatgpt.com/codex/tasks/task_e_6883e94386148324869b1fdc89034cdc