### PR TITLE
Add Go solution for 1644A

### DIFF
--- a/1000-1999/1600-1699/1640-1649/1644/1644A.go
+++ b/1000-1999/1600-1699/1640-1649/1644/1644A.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		keys := make(map[rune]bool)
+		ok := true
+		for _, ch := range s {
+			if ch == 'r' || ch == 'g' || ch == 'b' {
+				keys[ch] = true
+			} else {
+				if !keys[ch+32] {
+					ok = false
+					break
+				}
+			}
+		}
+		if ok {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem 1644A

## Testing
- `go vet 1000-1999/1600-1699/1640-1649/1644/1644A.go`
- `go build 1000-1999/1600-1699/1640-1649/1644/1644A.go`


------
https://chatgpt.com/codex/tasks/task_e_6883e8fd71dc83248cac893d806c0172