### PR TITLE
Add verifiers for Codeforces contest 891

### DIFF
--- a/0-999/800-899/890-899/891/verifierA.go
+++ b/0-999/800-899/890-899/891/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "891A.go")
+	ref := filepath.Join(os.TempDir(), "ref891A")
+	cmd := exec.Command("go", "build", "-o", ref, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	rand.Seed(1)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rand.Intn(9)+1)
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		exp, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("Test %d failed:\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/890-899/891/verifierB.go
+++ b/0-999/800-899/890-899/891/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "891B.go")
+	ref := filepath.Join(os.TempDir(), "ref891B")
+	cmd := exec.Command("go", "build", "-o", ref, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	rand.Seed(2)
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		used := make(map[int]bool)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			v := rand.Intn(1000)
+			for used[v] {
+				v = rand.Intn(1000)
+			}
+			used[v] = true
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		exp, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("Test %d failed:\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/890-899/891/verifierC.go
+++ b/0-999/800-899/890-899/891/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "891C.go")
+	ref := filepath.Join(os.TempDir(), "ref891C")
+	cmd := exec.Command("go", "build", "-o", ref, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	rand.Seed(3)
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(4) + 2
+		m := n - 1 + rand.Intn(3)
+		edges := make([][3]int, m)
+		for i := 1; i < n; i++ {
+			p := rand.Intn(i)
+			w := rand.Intn(5) + 1
+			edges[i-1] = [3]int{p, i, w}
+		}
+		for i := n - 1; i < m; i++ {
+			u := rand.Intn(n)
+			v := rand.Intn(n)
+			if u == v {
+				v = (v + 1) % n
+			}
+			w := rand.Intn(5) + 1
+			edges[i] = [3]int{u, v, w}
+		}
+		q := rand.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for i := 0; i < m; i++ {
+			fmt.Fprintf(&sb, "%d %d %d\n", edges[i][0]+1, edges[i][1]+1, edges[i][2])
+		}
+		fmt.Fprintf(&sb, "%d\n", q)
+		for qi := 0; qi < q; qi++ {
+			k := rand.Intn(m) + 1
+			idx := rand.Perm(m)[:k]
+			fmt.Fprintf(&sb, "%d", k)
+			for _, id := range idx {
+				fmt.Fprintf(&sb, " %d", id+1)
+			}
+			sb.WriteByte('\n')
+		}
+		tests[t] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		exp, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("Test %d failed:\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/890-899/891/verifierD.go
+++ b/0-999/800-899/890-899/891/verifierD.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "891D.go")
+	ref := filepath.Join(os.TempDir(), "ref891D")
+	cmd := exec.Command("go", "build", "-o", ref, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	rand.Seed(4)
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(6) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 1; i < n; i++ {
+			p := rand.Intn(i)
+			fmt.Fprintf(&sb, "%d %d\n", p+1, i+1)
+		}
+		tests[t] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		exp, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("Test %d failed:\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/0-999/800-899/890-899/891/verifierE.go
+++ b/0-999/800-899/890-899/891/verifierE.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "891E.go")
+	ref := filepath.Join(os.TempDir(), "ref891E")
+	cmd := exec.Command("go", "build", "-o", ref, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []string {
+	rand.Seed(5)
+	tests := make([]string, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 1
+		k := rand.Int63n(7) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rand.Intn(10))
+		}
+		sb.WriteByte('\n')
+		tests[t] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := generateTests()
+	for i, t := range tests {
+		exp, err := runBinary(ref, t)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, t)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Printf("Test %d failed:\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add verifierA.go with 100 random tests calling 891A.go
- add verifierB.go with 100 random tests calling 891B.go
- add verifierC.go with random graph tests calling 891C.go
- add verifierD.go generating tree cases using 891D.go
- add verifierE.go with random sequence tests using 891E.go

## Testing
- `go build 0-999/800-899/890-899/891/verifierA.go`
- `go build 0-999/800-899/890-899/891/verifierB.go`
- `go build 0-999/800-899/890-899/891/verifierC.go`
- `go build 0-999/800-899/890-899/891/verifierD.go`
- `go build 0-999/800-899/890-899/891/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6883e8b76ce88324acf510df6fd0c761