### PR TITLE
Add Go verifiers for CF 887

### DIFF
--- a/0-999/800-899/880-889/887/verifierA.go
+++ b/0-999/800-899/880-889/887/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveCase(s string) string {
+	idx := -1
+	for i := 0; i < len(s); i++ {
+		if s[i] == '1' {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return "no"
+	}
+	zero := 0
+	for i := idx + 1; i < len(s); i++ {
+		if s[i] == '0' {
+			zero++
+		}
+	}
+	if zero >= 6 {
+		return "yes"
+	}
+	return "no"
+}
+
+func runCase(bin, s string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(s + "\n")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCase(strings.TrimSpace(s))
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	cases := []string{
+		"0",
+		"1",
+		"1000000",
+		"1111111",
+		"000000",
+		"100000",
+		"1100000",
+		"1010101010",
+	}
+	for i := len(cases); i < 100; i++ {
+		n := rand.Intn(100) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				sb.WriteByte('0')
+			} else {
+				sb.WriteByte('1')
+			}
+		}
+		cases = append(cases, sb.String())
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/880-889/887/verifierB.go
+++ b/0-999/800-899/880-889/887/verifierB.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveCase(cubes [][10]bool) int {
+	n := len(cubes)
+	isPossible := func(num int) bool {
+		d1 := num % 10
+		num /= 10
+		if num == 0 {
+			for i := 0; i < n; i++ {
+				if cubes[i][d1] {
+					return true
+				}
+			}
+			return false
+		}
+		d2 := num % 10
+		num /= 10
+		if num == 0 {
+			for i := 0; i < n; i++ {
+				if !cubes[i][d2] {
+					continue
+				}
+				for j := 0; j < n; j++ {
+					if i == j {
+						continue
+					}
+					if cubes[j][d1] {
+						return true
+					}
+				}
+			}
+			return false
+		}
+		d3 := num % 10
+		num /= 10
+		if num > 0 || n < 3 {
+			return false
+		}
+		for i := 0; i < n; i++ {
+			if !cubes[i][d3] {
+				continue
+			}
+			for j := 0; j < n; j++ {
+				if j == i || !cubes[j][d2] {
+					continue
+				}
+				for k := 0; k < n; k++ {
+					if k == i || k == j {
+						continue
+					}
+					if cubes[k][d1] {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+
+	ans := 0
+	for i := 1; i <= 999; i++ {
+		if isPossible(i) {
+			ans = i
+		} else {
+			break
+		}
+	}
+	return ans
+}
+
+func runCase(bin string, digits [][]int) error {
+	n := len(digits)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	cubes := make([][10]bool, n)
+	for i := 0; i < n; i++ {
+		for j := 0; j < 6; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", digits[i][j])
+			cubes[i][digits[i][j]] = true
+		}
+		sb.WriteByte('\n')
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	gotStr := strings.TrimSpace(out.String())
+	var got int
+	fmt.Sscanf(gotStr, "%d", &got)
+	exp := solveCase(cubes)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(2)
+	cases := make([][][]int, 100)
+	for i := range cases {
+		n := rand.Intn(3) + 1
+		digits := make([][]int, n)
+		for j := 0; j < n; j++ {
+			digits[j] = make([]int, 6)
+			for k := 0; k < 6; k++ {
+				digits[j][k] = rand.Intn(10)
+			}
+		}
+		cases[i] = digits
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/880-889/887/verifierC.go
+++ b/0-999/800-899/880-889/887/verifierC.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func rotate(c []int, cycles [][]int) []int {
+	res := make([]int, len(c))
+	copy(res, c)
+	for _, cyc := range cycles {
+		tmp := c[cyc[0]]
+		for i := 0; i < len(cyc)-1; i++ {
+			res[cyc[i]] = c[cyc[i+1]]
+		}
+		res[cyc[len(cyc)-1]] = tmp
+	}
+	return res
+}
+
+func solved(c []int) bool {
+	for i := 0; i < 24; i += 4 {
+		if !(c[i] == c[i+1] && c[i] == c[i+2] && c[i] == c[i+3]) {
+			return false
+		}
+	}
+	return true
+}
+
+func solveCase(c []int) string {
+	rotations := [][][]int{
+		{{0, 1, 3, 2}, {4, 5, 8, 9, 12, 13, 16, 17}},
+		{{20, 21, 23, 22}, {6, 7, 18, 19, 14, 15, 10, 11}},
+		{{4, 5, 7, 6}, {2, 3, 16, 18, 21, 20, 9, 8}},
+		{{12, 13, 15, 14}, {0, 1, 11, 9, 22, 23, 18, 16}},
+		{{16, 17, 19, 18}, {0, 2, 4, 6, 20, 22, 15, 13}},
+		{{8, 9, 11, 10}, {1, 3, 14, 12, 23, 21, 7, 5}},
+	}
+	for _, rot := range rotations {
+		cw := rotate(c, rot)
+		if solved(cw) {
+			return "YES"
+		}
+		cc := rotate(cw, rot)
+		cc = rotate(cc, rot)
+		if solved(cc) {
+			return "YES"
+		}
+	}
+	return "NO"
+}
+
+func runCase(bin string, cube []int) error {
+	var sb strings.Builder
+	for i, v := range cube {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCase(cube)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	cases := make([][]int, 100)
+	base := []int{1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6}
+	for i := range cases {
+		arr := make([]int, 24)
+		copy(arr, base)
+		rand.Shuffle(24, func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+		cases[i] = arr
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/880-889/887/verifierD.go
+++ b/0-999/800-899/880-889/887/verifierD.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const inf int64 = 1<<63 - 1
+
+type segTree struct {
+	n    int
+	tree []int64
+}
+
+func newSegTree(arr []int64) *segTree {
+	n := 1
+	for n < len(arr) {
+		n <<= 1
+	}
+	tree := make([]int64, 2*n)
+	for i := range tree {
+		tree[i] = inf
+	}
+	for i, v := range arr {
+		tree[n+i] = v
+	}
+	for i := n - 1; i > 0; i-- {
+		if tree[i<<1] < tree[i<<1|1] {
+			tree[i] = tree[i<<1]
+		} else {
+			tree[i] = tree[i<<1|1]
+		}
+	}
+	return &segTree{n: n, tree: tree}
+}
+
+func (s *segTree) query(l, r int) int64 {
+	if l > r {
+		return inf
+	}
+	l += s.n
+	r += s.n
+	res := inf
+	for l <= r {
+		if l&1 == 1 {
+			if s.tree[l] < res {
+				res = s.tree[l]
+			}
+			l++
+		}
+		if r&1 == 0 {
+			if s.tree[r] < res {
+				res = s.tree[r]
+			}
+			r--
+		}
+		l >>= 1
+		r >>= 1
+	}
+	return res
+}
+
+func solveCase(n int, a, b, c, d, start, length int64, times []int64, typ []int) int64 {
+	before := make([]int64, n)
+	after := make([]int64, n)
+	for i := 0; i < n; i++ {
+		if typ[i] == 1 {
+			before[i] = a
+			after[i] = c
+		} else {
+			before[i] = -b
+			after[i] = -d
+		}
+	}
+	prefBefore := make([]int64, n+1)
+	prefAfter := make([]int64, n+1)
+	minBefore := make([]int64, n+1)
+	prefBefore[0] = start
+	prefAfter[0] = start
+	minBefore[0] = start
+	for i := 0; i < n; i++ {
+		prefBefore[i+1] = prefBefore[i] + before[i]
+		prefAfter[i+1] = prefAfter[i] + after[i]
+		if prefBefore[i+1] < minBefore[i] {
+			minBefore[i+1] = prefBefore[i+1]
+		} else {
+			minBefore[i+1] = minBefore[i]
+		}
+	}
+	diffPrefix := make([]int64, n+1)
+	for i := 0; i <= n; i++ {
+		diffPrefix[i] = prefAfter[i] - prefBefore[i]
+	}
+	seg := newSegTree(prefAfter)
+	candMap := map[int64]struct{}{0: {}}
+	for i := 0; i < n; i++ {
+		t1 := times[i] - length + 1
+		if t1 >= 0 {
+			candMap[t1] = struct{}{}
+		}
+		candMap[times[i]+1] = struct{}{}
+	}
+	cands := make([]int64, 0, len(candMap))
+	for v := range candMap {
+		if v >= 0 {
+			cands = append(cands, v)
+		}
+	}
+	sort.Slice(cands, func(i, j int) bool { return cands[i] < cands[j] })
+	for _, t := range cands {
+		L := sort.Search(len(times), func(i int) bool { return times[i] >= t })
+		Rp := sort.Search(len(times), func(i int) bool { return times[i] >= t+length })
+		R := Rp - 1
+		if minBefore[L] < 0 {
+			continue
+		}
+		if L <= R {
+			segMin := seg.query(L+1, R+1) - diffPrefix[L]
+			if segMin < 0 {
+				continue
+			}
+		}
+		return t
+	}
+	return -1
+}
+
+func runCase(bin string, n int, a, b, c, d, start, length int64, times []int64, typ []int) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d %d %d %d\n", n, a, b, c, d, start, length)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d %d\n", times[i], typ[i])
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	fmt.Fscan(strings.NewReader(out.String()), &got)
+	exp := solveCase(int(n), a, b, c, d, start, length, times, typ)
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(4)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		a := rand.Int63n(50) + 1
+		b := rand.Int63n(50) + 1
+		c := rand.Int63n(50) + 1
+		d := rand.Int63n(50) + 1
+		start := rand.Int63n(100)
+		length := rand.Int63n(50) + 1
+		times := make([]int64, n)
+		typ := make([]int, n)
+		t := int64(0)
+		for j := 0; j < n; j++ {
+			t += rand.Int63n(20) + 1
+			times[j] = t
+			typ[j] = rand.Intn(2)
+		}
+		if err := runCase(bin, n, a, b, c, d, start, length, times, typ); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/880-889/887/verifierE.go
+++ b/0-999/800-899/880-889/887/verifierE.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func solveCase(x1, y1, x2, y2 float64, circles [][3]float64) float64 {
+	mx := (x1 + x2) / 2
+	my := (y1 + y2) / 2
+	dx := x1 - x2
+	dy := y1 - y2
+	w := math.Hypot(dx, dy) / 2
+	vx := -dy
+	vy := dx
+	norm := math.Hypot(vx, vy)
+	vx /= norm
+	vy /= norm
+	get := func(px, py, val float64) float64 {
+		d := func(t float64) float64 {
+			cx := mx + vx*t
+			cy := my + vy*t
+			dist := math.Hypot(px-cx, py-cy)
+			return dist - math.Sqrt(w*w+t*t)
+		}
+		l, r := -1e12, 1e12
+		fl := d(l) > val
+		for i := 0; i < 100; i++ {
+			mid := (l + r) / 2
+			f := d(mid) > val
+			if f == fl {
+				l = mid
+			} else {
+				r = mid
+			}
+		}
+		return r
+	}
+	type pair struct {
+		x float64
+		y int
+	}
+	q := make([]pair, 0, 2*len(circles)+1)
+	q = append(q, pair{0, 0})
+	for _, c := range circles {
+		l := get(c[0], c[1], c[2])
+		rr := get(c[0], c[1], -c[2])
+		if l > rr {
+			l, rr = rr, l
+		}
+		q = append(q, pair{l, 1})
+		q = append(q, pair{rr, -1})
+	}
+	sort.Slice(q, func(i, j int) bool {
+		if q[i].x == q[j].x {
+			return q[i].y < q[j].y
+		}
+		return q[i].x < q[j].x
+	})
+	s := 0
+	mn := 1e12
+	for _, p := range q {
+		if s == 0 {
+			if math.Abs(p.x) < mn {
+				mn = math.Abs(p.x)
+			}
+		}
+		s += p.y
+		if s == 0 {
+			if math.Abs(p.x) < mn {
+				mn = math.Abs(p.x)
+			}
+		}
+	}
+	return math.Sqrt(mn*mn + w*w)
+}
+
+func runCase(bin string, x1, y1, x2, y2 float64, circles [][3]float64) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%f %f %f %f\n", x1, y1, x2, y2)
+	fmt.Fprintf(&sb, "%d\n", len(circles))
+	for _, c := range circles {
+		fmt.Fprintf(&sb, "%f %f %f\n", c[0], c[1], c[2])
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got float64
+	fmt.Fscan(strings.NewReader(out.String()), &got)
+	exp := solveCase(x1, y1, x2, y2, circles)
+	if math.Abs(got-exp) > 1e-4*math.Max(1, math.Abs(exp)) {
+		return fmt.Errorf("expected %.5f got %.5f", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	for i := 0; i < 100; i++ {
+		x1 := rand.Float64()*200 - 100
+		y1 := rand.Float64()*200 - 100
+		x2 := rand.Float64()*200 - 100
+		y2 := rand.Float64()*200 - 100
+		n := rand.Intn(5) + 1
+		circles := make([][3]float64, n)
+		for j := 0; j < n; j++ {
+			circles[j][0] = rand.Float64()*200 - 100
+			circles[j][1] = rand.Float64()*200 - 100
+			circles[j][2] = rand.Float64()*10 + 1
+		}
+		if err := runCase(bin, x1, y1, x2, y2, circles); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/880-889/887/verifierF.go
+++ b/0-999/800-899/880-889/887/verifierF.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func isNice(a []int, k int) bool {
+	n := len(a)
+	next := make([]int, n)
+	stack := make([]int, 0, n)
+	for i := n - 1; i >= 0; i-- {
+		for len(stack) > 0 && a[stack[len(stack)-1]] >= a[i] {
+			stack = stack[:len(stack)-1]
+		}
+		if len(stack) == 0 {
+			next[i] = n
+		} else {
+			next[i] = stack[len(stack)-1]
+		}
+		stack = append(stack, i)
+	}
+	for i := 0; i < n; i++ {
+		if next[i]-i > k {
+			return false
+		}
+	}
+	return true
+}
+
+func solveCase(a []int, k int) string {
+	n := len(a)
+	if k >= n {
+		return "YES"
+	}
+	if isNice(a, k) {
+		return "YES"
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if a[i] <= a[j] {
+				continue
+			}
+			a[i], a[j] = a[j], a[i]
+			if isNice(a, k) {
+				a[i], a[j] = a[j], a[i]
+				return "YES"
+			}
+			a[i], a[j] = a[j], a[i]
+		}
+	}
+	return "NO"
+}
+
+func runCase(bin string, a []int, k int) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", len(a), k)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := solveCase(a, k)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(6)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(10) + 1
+		k := rand.Intn(n) + 1
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rand.Intn(100) + 1
+		}
+		if err := runCase(bin, a, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go through verifierF.go for contest 887
- each verifier generates 100 test cases and checks a provided binary
- fixed formatting issue in verifierE

## Testing
- `go run verifierA.go ./887A_bin`
- `go run verifierB.go ./887B_bin`
- `go run verifierC.go ./887C_bin`
- `go run verifierD.go ./887D_bin`
- `go run verifierE.go ./887E_bin`
- `go run verifierF.go ./887F_bin`


------
https://chatgpt.com/codex/tasks/task_e_6883e687188c83249662d42e2d13e113