### PR TITLE
Add Go verifiers for contest 886

### DIFF
--- a/0-999/800-899/880-889/886/verifierA.go
+++ b/0-999/800-899/880-889/886/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func expected(a [6]int) string {
+	sum := 0
+	for _, v := range a {
+		sum += v
+	}
+	if sum%2 != 0 {
+		return "NO"
+	}
+	target := sum / 2
+	for i := 0; i < 6; i++ {
+		for j := i + 1; j < 6; j++ {
+			for k := j + 1; k < 6; k++ {
+				if a[i]+a[j]+a[k] == target {
+					return "YES"
+				}
+			}
+		}
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	var arr [6]int
+	for i := 0; i < 6; i++ {
+		arr[i] = rng.Intn(21) // 0..20
+	}
+	var sb strings.Builder
+	for i := 0; i < 6; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(arr[i]))
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expected: expected(arr)}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		out = strings.ToUpper(strings.TrimSpace(out))
+		if out != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d: expected %s got %s\ninput:\n%s", i+1, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/880-889/886/verifierB.go
+++ b/0-999/800-899/880-889/886/verifierB.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int
+}
+
+func expectedB(arr []int) int {
+	last := make(map[int]int)
+	for i, v := range arr {
+		last[v] = i + 1
+	}
+	res := 0
+	minPos := len(arr) + 1
+	for cafe, pos := range last {
+		if pos < minPos {
+			minPos = pos
+			res = cafe
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(10)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expected: expectedB(arr)}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %d\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/880-889/886/verifierC.go
+++ b/0-999/800-899/880-889/886/verifierC.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int
+}
+
+func expectedC(t []int) int {
+	rooms := map[int]struct{}{0: {}}
+	for i := 1; i <= len(t)-1; i++ {
+		prev := t[i]
+		if _, ok := rooms[prev]; ok {
+			delete(rooms, prev)
+		}
+		rooms[i] = struct{}{}
+	}
+	return len(rooms)
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 1
+	t := make([]int, n+1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		t[i] = rng.Intn(i)
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(t[i]))
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expected: expectedC(t)}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %d\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/880-889/886/verifierD.go
+++ b/0-999/800-899/880-889/886/verifierD.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+const letters = 26
+
+func expectedD(words []string) string {
+	out := make([]int, letters)
+	inDeg := make([]int, letters)
+	used := make([]bool, letters)
+	for i := 0; i < letters; i++ {
+		out[i] = -1
+		inDeg[i] = -1
+	}
+	for _, s := range words {
+		seen := make([]bool, letters)
+		for i := 0; i < len(s); i++ {
+			c := int(s[i] - 'a')
+			used[c] = true
+			if seen[c] {
+				return "NO"
+			}
+			seen[c] = true
+		}
+		for i := 0; i+1 < len(s); i++ {
+			u := int(s[i] - 'a')
+			v := int(s[i+1] - 'a')
+			if out[u] != -1 && out[u] != v {
+				return "NO"
+			}
+			if inDeg[v] != -1 && inDeg[v] != u {
+				return "NO"
+			}
+			out[u] = v
+			inDeg[v] = u
+		}
+	}
+	// detect cycles
+	state := make([]int, letters)
+	var bad bool
+	var dfs func(int)
+	dfs = func(v int) {
+		state[v] = 1
+		if out[v] != -1 {
+			u := out[v]
+			if state[u] == 1 {
+				bad = true
+				return
+			}
+			if state[u] == 0 {
+				dfs(u)
+				if bad {
+					return
+				}
+			}
+		}
+		state[v] = 2
+	}
+	for i := 0; i < letters; i++ {
+		if used[i] && state[i] == 0 {
+			dfs(i)
+			if bad {
+				return "NO"
+			}
+		}
+	}
+	visited := make([]bool, letters)
+	var chains []string
+	for i := 0; i < letters; i++ {
+		if used[i] && inDeg[i] == -1 {
+			cur := i
+			var b []byte
+			for cur != -1 && !visited[cur] {
+				visited[cur] = true
+				b = append(b, byte(cur+'a'))
+				cur = out[cur]
+			}
+			chains = append(chains, string(b))
+		}
+	}
+	for i := 0; i < letters; i++ {
+		if used[i] && !visited[i] {
+			return "NO"
+		}
+	}
+	sort.Strings(chains)
+	res := strings.Join(chains, "")
+	return res
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(3) + 1
+	words := make([]string, n)
+	used := map[string]struct{}{}
+	for i := 0; i < n; i++ {
+		for {
+			var sb strings.Builder
+			for j := 0; j < m; j++ {
+				sb.WriteByte(byte('a' + rng.Intn(4)))
+			}
+			s := sb.String()
+			if _, ok := used[s]; !ok {
+				used[s] = struct{}{}
+				words[i] = s
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, w := range words {
+		sb.WriteString(w)
+		sb.WriteByte('\n')
+	}
+	return testCase{input: sb.String(), expected: expectedD(words)}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if out != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d: expected %s got %s\ninput:\n%s", i+1, tc.expected, out, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/880-889/886/verifierE.go
+++ b/0-999/800-899/880-889/886/verifierE.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1_000_000_007
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+func expectedE(n, k int) int64 {
+	if k >= n {
+		return 0
+	}
+	fact := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % MOD
+	}
+	inv := make([]int64, n)
+	inv[1] = 1
+	for i := 2; i < n; i++ {
+		inv[i] = MOD - (MOD/int64(i))*inv[int(MOD%int64(i))]%MOD
+	}
+	w := make([]int64, k)
+	if k > 0 {
+		w[0] = 1
+	}
+	dpSum := int64(1)
+	for i := 1; i < n; i++ {
+		total := int64(0)
+		for j := 0; j < k; j++ {
+			total += w[j]
+		}
+		total %= MOD
+		new0 := total * inv[i] % MOD
+		for j := k - 1; j >= 1; j-- {
+			w[j] = w[j-1]
+		}
+		if k > 0 {
+			w[0] = new0
+		}
+		dpSum += w[0]
+		if dpSum >= MOD {
+			dpSum -= MOD
+		}
+	}
+	good := fact[n-1] * dpSum % MOD
+	bad := (fact[n] - good) % MOD
+	if bad < 0 {
+		bad += MOD
+	}
+	return bad
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(10) + 1
+	input := fmt.Sprintf("%d %d\n", n, k)
+	return testCase{input: input, expected: expectedE(n, k)}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %d\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/0-999/800-899/880-889/886/verifierF.go
+++ b/0-999/800-899/880-889/886/verifierF.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Point structure copied from solution
+type Point struct {
+	x, y int64
+}
+
+func gcd(a, b int64) int64 {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func isGood(dx, dy int64, pts []Point, sumX, sumY int64, n int) bool {
+	m := make(map[int64]int, n)
+	target := sumX*dx + sumY*dy
+	for _, p := range pts {
+		val := (p.x*dx+p.y*dy)*int64(n) - target
+		m[val]++
+	}
+	for k, v := range m {
+		if m[-k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func expectedF(pts []Point) int {
+	n := len(pts)
+	var sumX, sumY int64
+	for _, p := range pts {
+		sumX += p.x
+		sumY += p.y
+	}
+	sorted := make([]Point, n)
+	copy(sorted, pts)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].x == sorted[j].x {
+			return sorted[i].y < sorted[j].y
+		}
+		return sorted[i].x < sorted[j].x
+	})
+	candX := sorted[0].x + sorted[n-1].x
+	candY := sorted[0].y + sorted[n-1].y
+	symmetric := true
+	for i := 0; i < n; i++ {
+		if sorted[i].x+sorted[n-1-i].x != candX || sorted[i].y+sorted[n-1-i].y != candY {
+			symmetric = false
+			break
+		}
+	}
+	if symmetric {
+		return -1
+	}
+	type pair struct{ x, y int64 }
+	dirs := make(map[pair]struct{})
+	idx := []int{0, 1}
+	if n == 1 {
+		return 0
+	}
+	for _, i := range idx {
+		if i >= n {
+			continue
+		}
+		for j := i + 1; j < n; j++ {
+			ux := (pts[i].x+pts[j].x)*int64(n) - 2*sumX
+			uy := (pts[i].y+pts[j].y)*int64(n) - 2*sumY
+			if ux == 0 && uy == 0 {
+				continue
+			}
+			dx := -uy
+			dy := ux
+			g := gcd(dx, dy)
+			dx /= g
+			dy /= g
+			if dx < 0 || (dx == 0 && dy < 0) {
+				dx = -dx
+				dy = -dy
+			}
+			dirs[pair{dx, dy}] = struct{}{}
+		}
+	}
+	count := 0
+	for d := range dirs {
+		if isGood(d.x, d.y, pts, sumX, sumY, n) {
+			count++
+		}
+	}
+	return count
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(5) + 1
+	pts := make([]Point, 0, n)
+	used := map[[2]int]struct{}{}
+	for len(pts) < n {
+		x := rng.Intn(7) - 3
+		y := rng.Intn(7) - 3
+		key := [2]int{x, y}
+		if _, ok := used[key]; ok {
+			continue
+		}
+		used[key] = struct{}{}
+		pts = append(pts, Point{int64(x), int64(y)})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, p := range pts {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.x, p.y))
+	}
+	return testCase{input: sb.String(), expected: expectedF(pts)}
+}
+
+type testCase struct {
+	input    string
+	expected int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		out, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %d\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers in Go for contest 886 problems A–F
- each verifier executes any binary (or Go source) and checks against 100 random test cases

## Testing
- `go build 0-999/800-899/880-889/886/verifierA.go`
- `go build 0-999/800-899/880-889/886/verifierB.go`
- `go build 0-999/800-899/880-889/886/verifierC.go`
- `go build 0-999/800-899/880-889/886/verifierD.go`
- `go build 0-999/800-899/880-889/886/verifierE.go`
- `go build 0-999/800-899/880-889/886/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883e5fafc3c8324ba817bc8a0c79935