### PR TITLE
Add solution verifiers for Codeforces 884

### DIFF
--- a/0-999/800-899/880-889/884/verifierA.go
+++ b/0-999/800-899/880-889/884/verifierA.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solve(n int, t int, a []int) int {
+	for i := 0; i < n; i++ {
+		t -= 86400 - a[i]
+		if t <= 0 {
+			return i + 1
+		}
+	}
+	return n
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for tc := 0; tc < 100; tc++ {
+		n := rand.Intn(100) + 1
+		t := rand.Intn(1000000) + 1
+		a := make([]int, n)
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", n, t)
+		for i := 0; i < n; i++ {
+			a[i] = rand.Intn(86401)
+			fmt.Fprintf(&input, "%d ", a[i])
+		}
+		fmt.Fprintln(&input)
+		expected := solve(n, t, a)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Println("error running binary:", err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		exp := fmt.Sprint(expected)
+		if got != exp {
+			fmt.Println("wrong answer on test", tc+1)
+			fmt.Println("input:\n" + input.String())
+			fmt.Println("expected:", exp)
+			fmt.Println("got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/800-899/880-889/884/verifierB.go
+++ b/0-999/800-899/880-889/884/verifierB.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solve(n int, x int, a []int) string {
+	sum := 0
+	for _, v := range a {
+		sum += v
+	}
+	if sum+n-1 == x {
+		return "YES"
+	}
+	return "NO"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(2)
+	for tc := 0; tc < 100; tc++ {
+		n := rand.Intn(50) + 1
+		a := make([]int, n)
+		sum := 0
+		for i := 0; i < n; i++ {
+			a[i] = rand.Intn(10000) + 1
+			sum += a[i]
+		}
+		var x int
+		if rand.Intn(2) == 0 {
+			x = sum + n - 1
+		} else {
+			delta := rand.Intn(10) + 1
+			if rand.Intn(2) == 0 {
+				x = sum + n - 1 + delta
+			} else {
+				x = sum + n - 1 - delta
+				if x < 1 {
+					x = 1
+				}
+			}
+		}
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", n, x)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&input, "%d ", a[i])
+		}
+		fmt.Fprintln(&input)
+		expected := solve(n, x, a)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Println("error running binary:", err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != expected {
+			fmt.Println("wrong answer on test", tc+1)
+			fmt.Println("input:\n" + input.String())
+			fmt.Println("expected:", expected)
+			fmt.Println("got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/800-899/880-889/884/verifierC.go
+++ b/0-999/800-899/880-889/884/verifierC.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func solve(n int, p []int) int64 {
+	visited := make([]bool, n)
+	var cycles []int
+	for i := 0; i < n; i++ {
+		if !visited[i] {
+			cnt := 0
+			j := i
+			for !visited[j] {
+				visited[j] = true
+				j = p[j]
+				cnt++
+			}
+			cycles = append(cycles, cnt)
+		}
+	}
+	sort.Ints(cycles)
+	if len(cycles) >= 2 {
+		a := cycles[len(cycles)-1]
+		b := cycles[len(cycles)-2]
+		cycles = cycles[:len(cycles)-2]
+		cycles = append(cycles, a+b)
+	}
+	var ans int64
+	for _, c := range cycles {
+		ans += int64(c) * int64(c)
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	for tc := 0; tc < 100; tc++ {
+		n := rand.Intn(50) + 1
+		p := rand.Perm(n)
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d\n", n)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&input, "%d ", p[i]+1)
+		}
+		fmt.Fprintln(&input)
+		expected := solve(n, p)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Println("error running binary:", err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != fmt.Sprint(expected) {
+			fmt.Println("wrong answer on test", tc+1)
+			fmt.Println("input:\n" + input.String())
+			fmt.Println("expected:", expected)
+			fmt.Println("got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/800-899/880-889/884/verifierD.go
+++ b/0-999/800-899/880-889/884/verifierD.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type IntHeap []int64
+
+func (h IntHeap) Len() int            { return len(h) }
+func (h IntHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h IntHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *IntHeap) Push(x interface{}) { *h = append(*h, x.(int64)) }
+func (h *IntHeap) Pop() interface{} {
+	old := *h
+	x := old[len(old)-1]
+	*h = old[:len(old)-1]
+	return x
+}
+
+func solve(a []int64) int64 {
+	h := &IntHeap{}
+	heap.Init(h)
+	for _, v := range a {
+		heap.Push(h, v)
+	}
+	n := len(a)
+	if n == 1 {
+		return 0
+	}
+	if n%2 == 0 {
+		heap.Push(h, 0)
+	}
+	var cost int64
+	for h.Len() > 1 {
+		x := heap.Pop(h).(int64)
+		y := heap.Pop(h).(int64)
+		z := heap.Pop(h).(int64)
+		sum := x + y + z
+		cost += sum
+		heap.Push(h, sum)
+	}
+	return cost
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(4)
+	for tc := 0; tc < 100; tc++ {
+		n := rand.Intn(50) + 1
+		a := make([]int64, n)
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d\n", n)
+		for i := 0; i < n; i++ {
+			a[i] = int64(rand.Intn(1000) + 1)
+			fmt.Fprintf(&input, "%d ", a[i])
+		}
+		fmt.Fprintln(&input)
+		expected := solve(a)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Println("error running binary:", err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != fmt.Sprint(expected) {
+			fmt.Println("wrong answer on test", tc+1)
+			fmt.Println("input:\n" + input.String())
+			fmt.Println("expected:", expected)
+			fmt.Println("got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/800-899/880-889/884/verifierE.go
+++ b/0-999/800-899/880-889/884/verifierE.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func components(grid [][]bool, n, m int) int {
+	visited := make([][]bool, n)
+	for i := range visited {
+		visited[i] = make([]bool, m)
+	}
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	comp := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] && !visited[i][j] {
+				comp++
+				queue := [][2]int{{i, j}}
+				visited[i][j] = true
+				for head := 0; head < len(queue); head++ {
+					x, y := queue[head][0], queue[head][1]
+					for _, d := range dirs {
+						nx, ny := x+d[0], y+d[1]
+						if nx >= 0 && nx < n && ny >= 0 && ny < m && grid[nx][ny] && !visited[nx][ny] {
+							visited[nx][ny] = true
+							queue = append(queue, [2]int{nx, ny})
+						}
+					}
+				}
+			}
+		}
+	}
+	return comp
+}
+
+func hexRow(m int, s string) []bool {
+	row := make([]bool, m)
+	col := 0
+	for i := 0; i < len(s); i++ {
+		var v int
+		ch := s[i]
+		if ch >= '0' && ch <= '9' {
+			v = int(ch - '0')
+		} else {
+			v = int(ch-'A') + 10
+		}
+		for b := 3; b >= 0; b-- {
+			row[col] = (v>>uint(b))&1 == 1
+			col++
+		}
+	}
+	return row
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	for tc := 0; tc < 100; tc++ {
+		n := rand.Intn(10) + 1
+		mWords := rand.Intn(3) + 1 // each word => 4 columns
+		m := mWords * 4
+		grid := make([][]bool, n)
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", n, m)
+		for i := 0; i < n; i++ {
+			var rowStr strings.Builder
+			for j := 0; j < mWords; j++ {
+				val := rand.Intn(16)
+				rowStr.WriteString(fmt.Sprintf("%X", val))
+			}
+			line := rowStr.String()
+			fmt.Fprintln(&input, line)
+			grid[i] = hexRow(m, line)
+		}
+		expected := components(grid, n, m)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Println("error running binary:", err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != fmt.Sprint(expected) {
+			fmt.Println("wrong answer on test", tc+1)
+			fmt.Println("input:\n" + input.String())
+			fmt.Println("expected:", expected)
+			fmt.Println("got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}

--- a/0-999/800-899/880-889/884/verifierF.go
+++ b/0-999/800-899/880-889/884/verifierF.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type edge struct {
+	to   int
+	rev  int
+	cap  int
+	cost int
+}
+
+type MCMF struct {
+	n     int
+	graph [][]edge
+	dist  []int
+	prevv []int
+	preve []int
+}
+
+func NewMCMF(n int) *MCMF {
+	g := make([][]edge, n)
+	return &MCMF{n: n, graph: g, dist: make([]int, n), prevv: make([]int, n), preve: make([]int, n)}
+}
+
+func (f *MCMF) AddEdge(u, v, cap, cost int) {
+	f.graph[u] = append(f.graph[u], edge{to: v, rev: len(f.graph[v]), cap: cap, cost: cost})
+	f.graph[v] = append(f.graph[v], edge{to: u, rev: len(f.graph[u]) - 1, cap: 0, cost: -cost})
+}
+
+const INF = int(1e18)
+
+func (f *MCMF) MinCostMaxFlow(s, t int) int {
+	res := 0
+	for {
+		for i := 0; i < f.n; i++ {
+			f.dist[i] = INF
+		}
+		inq := make([]bool, f.n)
+		q := make([]int, 0)
+		f.dist[s] = 0
+		inq[s] = true
+		q = append(q, s)
+		for idx := 0; idx < len(q); idx++ {
+			v := q[idx]
+			inq[v] = false
+			for i, e := range f.graph[v] {
+				if e.cap > 0 && f.dist[e.to] > f.dist[v]+e.cost {
+					f.dist[e.to] = f.dist[v] + e.cost
+					f.prevv[e.to] = v
+					f.preve[e.to] = i
+					if !inq[e.to] {
+						q = append(q, e.to)
+						inq[e.to] = true
+					}
+				}
+			}
+		}
+		if f.dist[t] >= 0 || f.dist[t] == INF {
+			break
+		}
+		d := 1
+		for v := t; v != s; v = f.prevv[v] {
+			if f.graph[f.prevv[v]][f.preve[v]].cap < d {
+				d = f.graph[f.prevv[v]][f.preve[v]].cap
+			}
+		}
+		for v := t; v != s; v = f.prevv[v] {
+			e := &f.graph[f.prevv[v]][f.preve[v]]
+			e.cap -= d
+			rev := &f.graph[v][e.rev]
+			rev.cap += d
+		}
+		res += d * f.dist[t]
+	}
+	return -res
+}
+
+func solve(n int, s string, b []int) int {
+	freq := make([]int, 26)
+	for i := 0; i < n; i++ {
+		freq[int(s[i]-'a')]++
+	}
+	letters := make([]int, 0)
+	idx := make([]int, 26)
+	for i := 0; i < 26; i++ {
+		if freq[i] > 0 {
+			idx[i] = len(letters)
+			letters = append(letters, i)
+		} else {
+			idx[i] = -1
+		}
+	}
+	L := len(letters)
+	pairs := n / 2
+	total := 1 + L + pairs*L + n + 1
+	source := 0
+	letterStart := 1
+	pairLetterStart := letterStart + L
+	posStart := pairLetterStart + pairs*L
+	sink := total - 1
+
+	flow := NewMCMF(total)
+	for k, l := range letters {
+		flow.AddEdge(source, letterStart+k, freq[l], 0)
+	}
+	for p := 0; p < pairs; p++ {
+		i := p
+		j := n - 1 - p
+		for k, l := range letters {
+			node := pairLetterStart + p*L + k
+			flow.AddEdge(letterStart+k, node, 1, 0)
+			if int(s[i]-'a') == l {
+				flow.AddEdge(node, posStart+i, 1, -b[i])
+			} else {
+				flow.AddEdge(node, posStart+i, 1, 0)
+			}
+			if int(s[j]-'a') == l {
+				flow.AddEdge(node, posStart+j, 1, -b[j])
+			} else {
+				flow.AddEdge(node, posStart+j, 1, 0)
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		flow.AddEdge(posStart+i, sink, 1, 0)
+	}
+
+	return flow.MinCostMaxFlow(source, sink)
+}
+
+func generateString(n int) (string, string) {
+	t := make([]byte, n)
+	for i := 0; i < n/2; i++ {
+		a := byte('a' + rand.Intn(26))
+		b := byte('a' + rand.Intn(26))
+		for b == a {
+			b = byte('a' + rand.Intn(26))
+		}
+		t[i] = a
+		t[n-1-i] = b
+	}
+	perm := rand.Perm(n)
+	s := make([]byte, n)
+	for i := 0; i < n; i++ {
+		s[i] = t[perm[i]]
+	}
+	return string(s), string(t)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(6)
+	for tc := 0; tc < 100; tc++ {
+		n := rand.Intn(10)*2 + 2 // even >=2
+		s, _ := generateString(n)
+		b := make([]int, n)
+		for i := 0; i < n; i++ {
+			b[i] = rand.Intn(100) + 1
+		}
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d\n", n)
+		fmt.Fprintln(&input, s)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&input, "%d ", b[i])
+		}
+		fmt.Fprintln(&input)
+		expected := solve(n, s, b)
+		cmd := exec.Command(bin)
+		cmd.Stdin = bytes.NewReader(input.Bytes())
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Println("error running binary:", err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out.String())
+		if got != fmt.Sprint(expected) {
+			fmt.Println("wrong answer on test", tc+1)
+			fmt.Println("input:\n" + input.String())
+			fmt.Println("expected:", expected)
+			fmt.Println("got:", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("ok")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–F of contest 884
- each verifier generates 100 deterministic random tests and checks a given binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6883e4e2cd0c83249802fb8513762cdd