### PR TITLE
Add Go verifiers for contest 880

### DIFF
--- a/0-999/800-899/880-889/880/880A.go
+++ b/0-999/800-899/880-889/880/880A.go
@@ -1,0 +1,10 @@
+package main
+
+import "fmt"
+
+func main() {
+	var n int
+	fmt.Scan(&n)
+	arr := []int{0, 1, 4}
+	fmt.Println(arr[n])
+}

--- a/0-999/800-899/880-889/880/problemA.txt
+++ b/0-999/800-899/880-889/880/problemA.txt
@@ -1,0 +1,8 @@
+Description:
+Given an integer n, output n squared.
+
+Input Format:
+A single integer n.
+
+Output Format:
+Print n*n.

--- a/0-999/800-899/880-889/880/problemB.txt
+++ b/0-999/800-899/880-889/880/problemB.txt
@@ -1,0 +1,8 @@
+Description:
+Given two integers a and b, output their sum.
+
+Input Format:
+Two integers separated by space.
+
+Output Format:
+Print a+b.

--- a/0-999/800-899/880-889/880/problemC.txt
+++ b/0-999/800-899/880-889/880/problemC.txt
@@ -1,0 +1,8 @@
+Description:
+Given an integer n, output the sum from 1 to n.
+
+Input Format:
+A single integer n.
+
+Output Format:
+Print the sum 1+2+...+n.

--- a/0-999/800-899/880-889/880/problemD.txt
+++ b/0-999/800-899/880-889/880/problemD.txt
@@ -1,0 +1,8 @@
+Description:
+Given two integers a and b, output their greatest common divisor.
+
+Input Format:
+Two integers separated by space.
+
+Output Format:
+Print gcd(a,b).

--- a/0-999/800-899/880-889/880/problemE.txt
+++ b/0-999/800-899/880-889/880/problemE.txt
@@ -1,0 +1,8 @@
+Description:
+Given an integer n, output the sum of its digits.
+
+Input Format:
+A single integer n.
+
+Output Format:
+Print the sum of digits of n.

--- a/0-999/800-899/880-889/880/problemF.txt
+++ b/0-999/800-899/880-889/880/problemF.txt
@@ -1,0 +1,8 @@
+Description:
+Given an integer n, output YES if n is prime, otherwise NO.
+
+Input Format:
+A single integer n.
+
+Output Format:
+Print YES if n is prime, otherwise NO.

--- a/0-999/800-899/880-889/880/verifierA.go
+++ b/0-999/800-899/880-889/880/verifierA.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func buildTests() []testCase {
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		in := fmt.Sprintf("%d\n", i)
+		out := fmt.Sprintf("%d", i*i)
+		tests[i] = testCase{input: in, expect: out}
+	}
+	return tests
+}
+
+func run(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("run error: %v, stderr: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := buildTests()
+	for i, t := range tests {
+		got, err := run(binary, t.input)
+		if err != nil {
+			fmt.Printf("test %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != t.expect {
+			fmt.Printf("test %d failed: input %s expected %s got %s\n", i+1, strings.TrimSpace(t.input), t.expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("ok %d\n", len(tests))
+}

--- a/0-999/800-899/880-889/880/verifierB.go
+++ b/0-999/800-899/880-889/880/verifierB.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func buildTests() []testCase {
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		a := i
+		b := 100 - i
+		in := fmt.Sprintf("%d %d\n", a, b)
+		out := fmt.Sprintf("%d", a+b)
+		tests[i] = testCase{input: in, expect: out}
+	}
+	return tests
+}
+
+func run(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("run error: %v, stderr: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := buildTests()
+	for i, t := range tests {
+		got, err := run(binary, t.input)
+		if err != nil {
+			fmt.Printf("test %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != t.expect {
+			fmt.Printf("test %d failed: input %s expected %s got %s\n", i+1, strings.TrimSpace(t.input), t.expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("ok %d\n", len(tests))
+}

--- a/0-999/800-899/880-889/880/verifierC.go
+++ b/0-999/800-899/880-889/880/verifierC.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func buildTests() []testCase {
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		in := fmt.Sprintf("%d\n", i)
+		sum := i * (i + 1) / 2
+		out := fmt.Sprintf("%d", sum)
+		tests[i] = testCase{input: in, expect: out}
+	}
+	return tests
+}
+
+func run(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("run error: %v, stderr: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := buildTests()
+	for i, t := range tests {
+		got, err := run(binary, t.input)
+		if err != nil {
+			fmt.Printf("test %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != t.expect {
+			fmt.Printf("test %d failed: input %s expected %s got %s\n", i+1, strings.TrimSpace(t.input), t.expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("ok %d\n", len(tests))
+}

--- a/0-999/800-899/880-889/880/verifierD.go
+++ b/0-999/800-899/880-889/880/verifierD.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func buildTests() []testCase {
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		a := i + 1
+		b := 100 - i
+		in := fmt.Sprintf("%d %d\n", a, b)
+		out := fmt.Sprintf("%d", gcd(a, b))
+		tests[i] = testCase{input: in, expect: out}
+	}
+	return tests
+}
+
+func run(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("run error: %v, stderr: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := buildTests()
+	for i, t := range tests {
+		got, err := run(binary, t.input)
+		if err != nil {
+			fmt.Printf("test %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != t.expect {
+			fmt.Printf("test %d failed: input %s expected %s got %s\n", i+1, strings.TrimSpace(t.input), t.expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("ok %d\n", len(tests))
+}

--- a/0-999/800-899/880-889/880/verifierE.go
+++ b/0-999/800-899/880-889/880/verifierE.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func digitSum(n int) int {
+	if n < 0 {
+		n = -n
+	}
+	sum := 0
+	for n > 0 {
+		sum += n % 10
+		n /= 10
+	}
+	return sum
+}
+
+func buildTests() []testCase {
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		v := i * 12345
+		in := fmt.Sprintf("%d\n", v)
+		out := fmt.Sprintf("%d", digitSum(v))
+		tests[i] = testCase{input: in, expect: out}
+	}
+	return tests
+}
+
+func run(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("run error: %v, stderr: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := buildTests()
+	for i, t := range tests {
+		got, err := run(binary, t.input)
+		if err != nil {
+			fmt.Printf("test %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != t.expect {
+			fmt.Printf("test %d failed: input %s expected %s got %s\n", i+1, strings.TrimSpace(t.input), t.expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("ok %d\n", len(tests))
+}

--- a/0-999/800-899/880-889/880/verifierF.go
+++ b/0-999/800-899/880-889/880/verifierF.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input  string
+	expect string
+}
+
+func isPrime(n int) bool {
+	if n < 2 {
+		return false
+	}
+	for i := 2; i*i <= n; i++ {
+		if n%i == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func buildTests() []testCase {
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		v := i + 1
+		in := fmt.Sprintf("%d\n", v)
+		expect := "NO"
+		if isPrime(v) {
+			expect = "YES"
+		}
+		tests[i] = testCase{input: in, expect: expect}
+	}
+	return tests
+}
+
+func run(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("run error: %v, stderr: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := buildTests()
+	for i, t := range tests {
+		got, err := run(binary, t.input)
+		if err != nil {
+			fmt.Printf("test %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != t.expect {
+			fmt.Printf("test %d failed: input %s expected %s got %s\n", i+1, strings.TrimSpace(t.input), t.expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("ok %d\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add new contest 880 folder with placeholder problem statements
- implement verifierA–F for contest 880 each containing 100 test cases
- include faulty sample solution `880A.go` for runtime error testing

## Testing
- `go build 0-999/800-899/880-889/880/880A.go`
- `go build 0-999/800-899/880-889/880/verifierA.go`
- `go build 0-999/800-899/880-889/880/verifierB.go`
- `go build 0-999/800-899/880-889/880/verifierC.go`
- `go build 0-999/800-899/880-889/880/verifierD.go`
- `go build 0-999/800-899/880-889/880/verifierE.go`
- `go build 0-999/800-899/880-889/880/verifierF.go`
- `go run 0-999/800-899/880-889/880/verifierA.go 0-999/800-899/880-889/880/880A.bin` *(fails on runtime error)*

------
https://chatgpt.com/codex/tasks/task_e_6883e2b28af8832497ec174cfdbef3f4