### PR TITLE
Add Go solution for 1626B

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1626/1626B.go
+++ b/1000-1999/1600-1699/1620-1629/1626/1626B.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func solve(x string) string {
+	bs := []byte(x)
+	n := len(bs)
+	// Look for the rightmost pair with sum >= 10
+	for i := n - 1; i >= 1; i-- {
+		d1 := int(bs[i-1] - '0')
+		d2 := int(bs[i] - '0')
+		sum := d1 + d2
+		if sum >= 10 {
+			res := make([]byte, 0, n)
+			res = append(res, bs[:i-1]...)
+			res = append(res, byte('0'+sum/10))
+			res = append(res, byte('0'+sum%10))
+			res = append(res, bs[i+1:]...)
+			return string(res)
+		}
+	}
+	// Otherwise use the first pair
+	sum := int(bs[0] - '0' + bs[1] - '0')
+	res := make([]byte, 0, n-1)
+	res = append(res, byte('0'+sum))
+	res = append(res, bs[2:]...)
+	return string(res)
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(in, &s)
+		fmt.Println(solve(s))
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for `1626B` problem Minor Reduction

## Testing
- `go build 1000-1999/1600-1699/1620-1629/1626/1626B.go`
- `cat <<EOF | go run 1000-1999/1600-1699/1620-1629/1626/1626B.go
5
10057
21
99
13
100
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68843dcee26c83248dd59cbd1b89df11