### PR TITLE
Add naive recursive solution for 1621G

### DIFF
--- a/1000-1999/1600-1699/1620-1629/1621/1621G.go
+++ b/1000-1999/1600-1699/1620-1629/1621/1621G.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const MOD int = 1_000_000_007
+
+func weight(a []int, idx []int) int {
+	if len(idx) == 0 {
+		return 0
+	}
+	last := idx[len(idx)-1]
+	maxAfter := 0
+	for i := last + 1; i < len(a); i++ {
+		if a[i] > maxAfter {
+			maxAfter = a[i]
+		}
+	}
+	w := 0
+	for _, p := range idx {
+		if a[p] < maxAfter {
+			w++
+		}
+	}
+	return w % MOD
+}
+
+func dfs(a []int, start int, subseq []int, ans *int) {
+	if len(subseq) > 0 {
+		*ans = (*ans + weight(a, subseq)) % MOD
+	}
+	for i := start; i < len(a); i++ {
+		if len(subseq) == 0 || a[i] > a[subseq[len(subseq)-1]] {
+			subseq = append(subseq, i)
+			dfs(a, i+1, subseq, ans)
+			subseq = subseq[:len(subseq)-1]
+		}
+	}
+}
+
+func solve(a []int) int {
+	ans := 0
+	dfs(a, 0, []int{}, &ans)
+	return ans % MOD
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		fmt.Fprintln(writer, solve(a))
+	}
+}


### PR DESCRIPTION
## Summary
- implement a naive backtracking solution for problem 1621G

## Testing
- `gofmt -w 1000-1999/1600-1699/1620-1629/1621/1621G.go`

------
https://chatgpt.com/codex/tasks/task_e_68843b9e6810832483707291b5caf02e