### PR TITLE
Fix README utility references

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Several helper tools live in the repository root:
 - `auto.go` – convert existing C++ solutions to Go using the Codex CLI.
 - `auto_so.go` – generate Go solutions from problem statements with Codex.
 - `webserver.go` – simple HTTP server for browsing problems and submitting solutions locally.
-- Extra programs like `brute.go` or `probe.go` are helper utilities.
+- Other helper utilities may be added for brute-force testing or instrumentation.
 - `eval.go` – evaluate AI-generated solutions. Supports flags like `-model`,
   `-provider`, `-db` and `-timeout` to control the HTTP request timeout.
 


### PR DESCRIPTION
## Summary
- update README to remove mentions of `brute.go` and `probe.go`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6884445c63848324ae73f4677c90ce51