### PR TITLE
Add contest 1001 solution verifiers

### DIFF
--- a/1000-1999/1000-1099/1000-1009/1001/verifierA.go
+++ b/1000-1999/1000-1099/1000-1009/1001/verifierA.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	sign := 1
+	if rng.Intn(2) == 0 {
+		sign = -1
+	}
+	input := fmt.Sprintf("%d\n", sign)
+	return input, sign
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, sign := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		var a, b float64
+		if _, err := fmt.Sscan(out, &a, &b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		inv := 1 / math.Sqrt2
+		if math.Abs(a-inv) > 1e-6 || math.Abs(b-inv*float64(sign)) > 1e-6 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %.10f %.10f got %s\ninput:\n%s", i+1, inv, inv*float64(sign), out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1001/verifierB.go
+++ b/1000-1999/1000-1099/1000-1009/1001/verifierB.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	if strings.TrimSpace(out.String()) != "" {
+		return fmt.Errorf("expected no output, got %q", out.String())
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	idx := rng.Intn(4)
+	return fmt.Sprintf("%d\n", idx)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCandidate(bin, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1001/verifierC.go
+++ b/1000-1999/1000-1099/1000-1009/1001/verifierC.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	if strings.TrimSpace(out.String()) != "" {
+		return fmt.Errorf("expected no output, got %q", out.String())
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCandidate(bin, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1001/verifierD.go
+++ b/1000-1999/1000-1099/1000-1009/1001/verifierD.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	state := 1
+	if rng.Intn(2) == 0 {
+		state = -1
+	}
+	input := fmt.Sprintf("%d\n", state)
+	return input, state
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != fmt.Sprintf("%d", exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1001/verifierE.go
+++ b/1000-1999/1000-1099/1000-1009/1001/verifierE.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	idx := rng.Intn(4)
+	input := fmt.Sprintf("%d\n", idx)
+	return input, idx
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != fmt.Sprintf("%d", exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1001/verifierF.go
+++ b/1000-1999/1000-1099/1000-1009/1001/verifierF.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomBits(rng *rand.Rand, n int) string {
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		if rng.Intn(2) == 1 {
+			sb.WriteByte('1')
+		} else {
+			sb.WriteByte('0')
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	b0 := randomBits(rng, n)
+	var b1 string
+	for {
+		b1 = randomBits(rng, n)
+		if b1 != b0 {
+			break
+		}
+	}
+	s := b0
+	expect := "0"
+	if rng.Intn(2) == 0 {
+		s = b1
+		expect = "1"
+	}
+	input := fmt.Sprintf("%d\n%s\n%s\n%s\n", n, b0, b1, s)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1001/verifierG.go
+++ b/1000-1999/1000-1099/1000-1009/1001/verifierG.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	if strings.TrimSpace(out.String()) != "" {
+		return fmt.Errorf("expected no output, got %q", out.String())
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(n)
+	return fmt.Sprintf("%d %d\n", n, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCandidate(bin, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1001/verifierH.go
+++ b/1000-1999/1000-1099/1000-1009/1001/verifierH.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	bits := make([]int, n)
+	parity := 0
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rng.Intn(2)
+		bits[i] = val
+		if val == 1 {
+			parity ^= 1
+		}
+		sb.WriteString(strconv.Itoa(val))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), fmt.Sprintf("%d", parity)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1001/verifierI.go
+++ b/1000-1999/1000-1099/1000-1009/1001/verifierI.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	total := 1 << n
+	constant := rng.Intn(2) == 0
+	vals := make([]int, total)
+	if constant {
+		val := rng.Intn(2)
+		for i := 0; i < total; i++ {
+			vals[i] = val
+		}
+	} else {
+		for i := 0; i < total/2; i++ {
+			vals[i] = 0
+		}
+		for i := total / 2; i < total; i++ {
+			vals[i] = 1
+		}
+		rng.Shuffle(total, func(i, j int) { vals[i], vals[j] = vals[j], vals[i] })
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	expect := "false"
+	if constant {
+		expect = "true"
+	}
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add automated Go verifiers for contest 1001 problems A–I
- each verifier generates 100 random test cases and runs a provided binary
- checks outputs or runtime errors depending on the problem

## Testing
- `go build 1000-1999/1000-1099/1000-1009/1001/verifierA.go`
- `go build 1000-1999/1000-1099/1000-1009/1001/verifierB.go`
- `go build 1000-1999/1000-1099/1000-1009/1001/verifierC.go`
- `go build 1000-1999/1000-1099/1000-1009/1001/verifierD.go`
- `go build 1000-1999/1000-1099/1000-1009/1001/verifierE.go`
- `go build 1000-1999/1000-1099/1000-1009/1001/verifierF.go`
- `go build 1000-1999/1000-1099/1000-1009/1001/verifierG.go`
- `go build 1000-1999/1000-1099/1000-1009/1001/verifierH.go`
- `go build 1000-1999/1000-1099/1000-1009/1001/verifierI.go`


------
https://chatgpt.com/codex/tasks/task_e_688447f4cbdc83249f0e1d8e06df5d2a