### PR TITLE
Add Go verifiers for contest 1004

### DIFF
--- a/1000-1999/1000-1099/1000-1009/1004/verifierA.go
+++ b/1000-1999/1000-1099/1000-1009/1004/verifierA.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(n int, d int, a []int) int {
+	count := 2
+	for i := 0; i < n-1; i++ {
+		gap := a[i+1] - a[i]
+		if gap > 2*d {
+			count += 2
+		} else if gap == 2*d {
+			count += 1
+		}
+	}
+	return count
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	type test struct {
+		n, d int
+		a    []int
+	}
+	var cases []test
+	// add deterministic edge cases
+	cases = append(cases, test{1, 1, []int{0}})
+	cases = append(cases, test{2, 1, []int{-2, 2}})
+	cases = append(cases, test{3, 2, []int{-5, 0, 5}})
+	// generate random cases
+	for i := 0; i < 97; i++ {
+		n := rng.Intn(10) + 1
+		d := rng.Intn(10) + 1
+		set := map[int]bool{}
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			for {
+				x := rng.Intn(200) - 100
+				if !set[x] {
+					set[x] = true
+					arr[j] = x
+					break
+				}
+			}
+		}
+		sort.Ints(arr)
+		cases = append(cases, test{n, d, arr})
+	}
+	for idx, tc := range cases {
+		input := fmt.Sprintf("%d %d\n", tc.n, tc.d)
+		for i, v := range tc.a {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		want := fmt.Sprintf("%d", expected(tc.n, tc.d, tc.a))
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", idx+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1000-1009/1004/verifierB.go
+++ b/1000-1999/1000-1099/1000-1009/1004/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type seg struct{ l, r int }
+	type test struct {
+		n, m int
+		segs []seg
+	}
+	var cases []test
+	// deterministic edge cases
+	cases = append(cases, test{1, 1, []seg{{1, 1}}})
+	cases = append(cases, test{2, 1, []seg{{1, 2}}})
+	// random cases
+	for i := 0; i < 98; i++ {
+		n := rng.Intn(20) + 1
+		m := rng.Intn(20) + 1
+		segs := make([]seg, m)
+		for j := 0; j < m; j++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			segs[j] = seg{l, r}
+		}
+		cases = append(cases, test{n, m, segs})
+	}
+	for idx, tc := range cases {
+		input := fmt.Sprintf("%d %d\n", tc.n, tc.m)
+		for _, s := range tc.segs {
+			input += fmt.Sprintf("%d %d\n", s.l, s.r)
+		}
+		want0 := make([]byte, tc.n)
+		want1 := make([]byte, tc.n)
+		for i := 0; i < tc.n; i++ {
+			if i%2 == 0 {
+				want0[i] = '0'
+				want1[i] = '1'
+			} else {
+				want0[i] = '1'
+				want1[i] = '0'
+			}
+		}
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		out := strings.TrimSpace(got)
+		if out != string(want0) && out != string(want1) {
+			fmt.Fprintf(os.Stderr, "case %d failed: output %q not alternating\n", idx+1, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1000-1009/1004/verifierC.go
+++ b/1000-1999/1000-1099/1000-1009/1004/verifierC.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(a []int) int64 {
+	n := len(a)
+	num := make([]int, n+1)
+	seen := map[int]bool{}
+	for i := n - 1; i >= 0; i-- {
+		if !seen[a[i]] {
+			num[i] = num[i+1] + 1
+			seen[a[i]] = true
+		} else {
+			num[i] = num[i+1]
+		}
+	}
+	seen = map[int]bool{}
+	var ans int64
+	for i := 0; i < n-1; i++ {
+		if !seen[a[i]] {
+			ans += int64(num[i+1])
+			seen[a[i]] = true
+		}
+	}
+	return ans
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases [][]int
+	cases = append(cases, []int{1})
+	cases = append(cases, []int{1, 2, 1})
+	for i := 0; i < 98; i++ {
+		n := rng.Intn(20) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(10)
+		}
+		cases = append(cases, arr)
+	}
+	for idx, arr := range cases {
+		input := fmt.Sprintf("%d\n", len(arr))
+		for i, v := range arr {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		want := fmt.Sprintf("%d", expected(arr))
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", idx+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1000-1009/1004/verifierD.go
+++ b/1000-1999/1000-1099/1000-1009/1004/verifierD.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type pos struct{ n, m, x, y int }
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func counts(n, m, x, y int) []int {
+	t := n * m
+	c := make([]int, t)
+	idx := 0
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= m; j++ {
+			c[idx] = abs(i-x) + abs(j-y)
+			idx++
+		}
+	}
+	sort.Ints(c)
+	return c
+}
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func parseOutput(out string) (pos, error) {
+	fields := strings.Fields(out)
+	if len(fields) != 4 {
+		return pos{}, fmt.Errorf("expected 4 numbers")
+	}
+	n, err1 := strconv.Atoi(fields[0])
+	m, err2 := strconv.Atoi(fields[1])
+	x, err3 := strconv.Atoi(fields[2])
+	y, err4 := strconv.Atoi(fields[3])
+	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
+		return pos{}, fmt.Errorf("parse error")
+	}
+	return pos{n, m, x, y}, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct{ n, m, x, y int }
+	var cases []test
+	cases = append(cases, test{1, 1, 1, 1})
+	cases = append(cases, test{2, 2, 1, 2})
+	for i := 0; i < 98; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		x := rng.Intn(n) + 1
+		y := rng.Intn(m) + 1
+		cases = append(cases, test{n, m, x, y})
+	}
+
+	for idx, tc := range cases {
+		arr := counts(tc.n, tc.m, tc.x, tc.y)
+		t := tc.n * tc.m
+		input := fmt.Sprintf("%d\n", t)
+		for i, v := range arr {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		p, err := parseOutput(out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d bad output: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if p.n <= 0 || p.m <= 0 || p.n*p.m != t || p.x < 1 || p.x > p.n || p.y < 1 || p.y > p.m {
+			fmt.Fprintf(os.Stderr, "case %d invalid values\n", idx+1)
+			os.Exit(1)
+		}
+		exp := counts(p.n, p.m, p.x, p.y)
+		if !equal(exp, arr) {
+			fmt.Fprintf(os.Stderr, "case %d failed: matrix doesn't match counts\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}
+
+func equal(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/1000-1999/1000-1099/1000-1009/1004/verifierE.go
+++ b/1000-1999/1000-1099/1000-1009/1004/verifierE.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func max(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+type edge struct{ to, val, next int }
+
+func expected(n, s int, edgesList [][3]int) int64 {
+	head := make([]int, n+1)
+	edges := make([]edge, 2*(n+1))
+	ec := 0
+	for _, e := range edgesList {
+		u, v, w := e[0], e[1], e[2]
+		ec++
+		edges[ec] = edge{v, w, head[u]}
+		head[u] = ec
+		ec++
+		edges[ec] = edge{u, w, head[v]}
+		head[v] = ec
+	}
+	dis := make([]int64, n+1)
+	fa := make([]int, n+1)
+	type pair struct{ x, p int }
+	var farthest func(int) int
+	farthest = func(st int) int {
+		for i := 1; i <= n; i++ {
+			dis[i] = 0
+			fa[i] = 0
+		}
+		stack := []pair{{st, 0}}
+		mx := st
+		for len(stack) > 0 {
+			cur := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			x, p := cur.x, cur.p
+			if dis[x] > dis[mx] {
+				mx = x
+			}
+			for e := head[x]; e != 0; e = edges[e].next {
+				y := edges[e].to
+				if y == p {
+					continue
+				}
+				dis[y] = dis[x] + int64(edges[e].val)
+				fa[y] = x
+				stack = append(stack, pair{y, x})
+			}
+		}
+		return mx
+	}
+	u := farthest(1)
+	v := farthest(u)
+	path := []int{}
+	on := make([]bool, n+1)
+	for x := v; x != 0; x = fa[x] {
+		path = append(path, x)
+		on[x] = true
+	}
+	m := len(path)
+	disU := make([]int64, m)
+	for i, x := range path {
+		disU[i] = dis[x]
+	}
+	mxd := make([]int64, m)
+	type info struct {
+		x, p int
+		d    int64
+	}
+	for i, x := range path {
+		var b int64
+		for e := head[x]; e != 0; e = edges[e].next {
+			y := edges[e].to
+			if on[y] {
+				continue
+			}
+			st := []info{{y, x, int64(edges[e].val)}}
+			for len(st) > 0 {
+				cur := st[len(st)-1]
+				st = st[:len(st)-1]
+				if cur.d > b {
+					b = cur.d
+				}
+				for ee := head[cur.x]; ee != 0; ee = edges[ee].next {
+					yy := edges[ee].to
+					if yy == cur.p {
+						continue
+					}
+					st = append(st, info{yy, cur.x, cur.d + int64(edges[ee].val)})
+				}
+			}
+		}
+		mxd[i] = b
+	}
+	best := int64(1<<63 - 1)
+	dq := []int{}
+	r := 0
+	for l := 0; l < m; l++ {
+		if len(dq) > 0 && dq[0] < l {
+			dq = dq[1:]
+		}
+		for r < m && r-l < s {
+			for len(dq) > 0 && mxd[r] >= mxd[dq[len(dq)-1]] {
+				dq = dq[:len(dq)-1]
+			}
+			dq = append(dq, r)
+			r++
+		}
+		cand := max(max(disU[0]-disU[l], disU[r-1]), mxd[dq[0]])
+		if cand < best {
+			best = cand
+		}
+	}
+	return best
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct {
+		n, s  int
+		edges [][3]int
+	}
+	var cases []test
+	cases = append(cases, test{1, 1, [][3]int{}})
+	cases = append(cases, test{2, 1, [][3]int{{1, 2, 5}}})
+	for i := 0; i < 98; i++ {
+		n := rng.Intn(20) + 1
+		s := rng.Intn(n) + 1
+		edges := make([][3]int, n-1)
+		for j := 1; j < n; j++ {
+			u := j + 1
+			v := rng.Intn(j) + 1
+			w := rng.Intn(10) + 1
+			edges[j-1] = [3]int{u, v, w}
+		}
+		cases = append(cases, test{n, s, edges})
+	}
+
+	for idx, tc := range cases {
+		input := fmt.Sprintf("%d %d\n", tc.n, tc.s)
+		for _, e := range tc.edges {
+			input += fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2])
+		}
+		want := fmt.Sprintf("%d", expected(tc.n, tc.s, tc.edges))
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", idx+1, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1000-1009/1004/verifierF.go
+++ b/1000-1999/1000-1099/1000-1009/1004/verifierF.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func countSub(arr []int, l, r, x int) int64 {
+	var res int64
+	for i := l; i <= r; i++ {
+		or := 0
+		for j := i; j <= r; j++ {
+			or |= arr[j-1]
+			if or >= x {
+				res++
+			}
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type query struct{ typ, x, y int }
+	type test struct {
+		n, m, x int
+		arr     []int
+		qs      []query
+	}
+	var cases []test
+	cases = append(cases, test{1, 1, 1, []int{0}, []query{{2, 1, 1}}})
+	for i := 0; i < 99; i++ {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		x := rng.Intn(16)
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(16)
+		}
+		qs := make([]query, m)
+		for j := 0; j < m; j++ {
+			typ := rng.Intn(2) + 1
+			if typ == 1 {
+				pos := rng.Intn(n) + 1
+				val := rng.Intn(16)
+				qs[j] = query{1, pos, val}
+			} else {
+				l := rng.Intn(n) + 1
+				r := rng.Intn(n-l+1) + l
+				qs[j] = query{2, l, r}
+			}
+		}
+		cases = append(cases, test{n, m, x, arr, qs})
+	}
+
+	for idx, tc := range cases {
+		arr := make([]int, len(tc.arr))
+		copy(arr, tc.arr)
+		input := fmt.Sprintf("%d %d %d\n", tc.n, tc.m, tc.x)
+		for i, v := range tc.arr {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		for _, q := range tc.qs {
+			input += fmt.Sprintf("%d %d %d\n", q.typ, q.x, q.y)
+		}
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		outputs := strings.Fields(got)
+		outIdx := 0
+		for _, q := range tc.qs {
+			if q.typ == 1 {
+				arr[q.x-1] = q.y
+			} else {
+				if outIdx >= len(outputs) {
+					fmt.Fprintf(os.Stderr, "case %d missing output\n", idx+1)
+					os.Exit(1)
+				}
+				want := fmt.Sprintf("%d", countSub(arr, q.x, q.y, tc.x))
+				if outputs[outIdx] != want {
+					fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", idx+1, want, outputs[outIdx])
+					os.Exit(1)
+				}
+				outIdx++
+			}
+		}
+		if outIdx != len(outputs) {
+			fmt.Fprintf(os.Stderr, "case %d extra output\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add verifierA.go with 100+ random/edge tests
- add verifierB.go validating alternating-string output
- add verifierC.go that checks pair count logic
- add verifierD.go verifying reconstructed rhombic matrix
- add verifierE.go with diameter-sliding-window logic
- add verifierF.go using naive subarray OR checking

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68844998659083248a4f3bb0abf87240