### PR TITLE
Add verifiers for Codeforces 1006

### DIFF
--- a/1000-1999/1000-1099/1000-1009/1006/verifierA.go
+++ b/1000-1999/1000-1099/1000-1009/1006/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(arr []int) []int {
+	res := make([]int, len(arr))
+	for i, x := range arr {
+		if x%2 == 0 {
+			x--
+		}
+		res[i] = x
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(100) + 1
+		arr := make([]int, n)
+		input := fmt.Sprintf("%d\n", n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(1000000000) + 1
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", arr[j])
+		}
+		input += "\n"
+		expectedSlice := solve(arr)
+		expected := ""
+		for j, v := range expectedSlice {
+			if j > 0 {
+				expected += " "
+			}
+			expected += fmt.Sprintf("%d", v)
+		}
+		expected = strings.TrimSpace(expected)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1006/verifierB.go
+++ b/1000-1999/1000-1099/1000-1009/1006/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n, k int, arr []int) (int, []int) {
+	tmp := make([]int, n)
+	copy(tmp, arr)
+	sort.Slice(tmp, func(i, j int) bool { return tmp[i] > tmp[j] })
+	sum := 0
+	maxv := make([]int, k)
+	for i := 0; i < k; i++ {
+		sum += tmp[i]
+		maxv[i] = tmp[i]
+	}
+	segments := make([]int, 0, k)
+	prev := -1
+	idx := 0
+	for i := 0; i < n && len(maxv) > 0; i++ {
+		for j := 0; j < len(maxv); j++ {
+			if arr[i] == maxv[j] {
+				segments = append(segments, i-prev)
+				prev = i
+				maxv = append(maxv[:j], maxv[j+1:]...)
+				idx = i + 1
+				break
+			}
+		}
+	}
+	if len(segments) > 0 {
+		segments[len(segments)-1] += n - idx
+	}
+	return sum, segments
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(n) + 1
+		arr := make([]int, n)
+		input := fmt.Sprintf("%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(2000) + 1
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", arr[j])
+		}
+		input += "\n"
+		sum, seg := solve(n, k, arr)
+		expected := fmt.Sprintf("%d\n", sum)
+		for j, v := range seg {
+			if j > 0 {
+				expected += " "
+			}
+			expected += fmt.Sprintf("%d", v)
+		}
+		expected = strings.TrimSpace(expected)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1006/verifierC.go
+++ b/1000-1999/1000-1099/1000-1009/1006/verifierC.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(arr []int64) int64 {
+	n := len(arr)
+	if n == 0 {
+		return 0
+	}
+	suml := arr[0]
+	sumr := arr[n-1]
+	ans := int64(0)
+	l, r := 0, n-1
+	for l < r {
+		if suml < sumr {
+			l++
+			suml += arr[l]
+		} else if sumr < suml {
+			r--
+			sumr += arr[r]
+		} else {
+			ans = suml
+			l++
+			suml += arr[l]
+			r--
+			sumr += arr[r]
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(50) + 1
+		arr := make([]int64, n)
+		input := fmt.Sprintf("%d\n", n)
+		for j := 0; j < n; j++ {
+			arr[j] = int64(rng.Intn(1000) + 1)
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", arr[j])
+		}
+		input += "\n"
+		expected := fmt.Sprintf("%d", solve(arr))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1006/verifierD.go
+++ b/1000-1999/1000-1099/1000-1009/1006/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func get(a, b, c, d byte) int {
+	var cnt [256]int
+	cnt[a]++
+	cnt[b]++
+	cnt[c]++
+	cnt[d]++
+	freqs := make([]int, 0, 4)
+	for _, ch := range []byte{a, b, c, d} {
+		if f := cnt[ch]; f > 0 {
+			freqs = append(freqs, f)
+			cnt[ch] = 0
+		}
+	}
+	switch len(freqs) {
+	case 1:
+		return 0
+	case 2:
+		if freqs[0] == 2 && freqs[1] == 2 {
+			return 0
+		}
+		return 1
+	case 3:
+		return 1
+	case 4:
+		return 2
+	}
+	return 0
+}
+
+func solve(s0, s1 string) int {
+	n := len(s0)
+	ans := 0
+	for i := 0; i < n/2; i++ {
+		ans += get(s0[i], s1[i], s0[n-i-1], s1[n-i-1])
+	}
+	if n%2 == 1 && s0[n/2] != s1[n/2] {
+		ans++
+	}
+	return ans
+}
+
+func randString(rng *rand.Rand, n int) string {
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(30) + 1
+		s0 := randString(rng, n)
+		s1 := randString(rng, n)
+		input := fmt.Sprintf("%d\n%s\n%s\n", n, s0, s1)
+		expected := fmt.Sprintf("%d", solve(s0, s1))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1006/verifierE.go
+++ b/1000-1999/1000-1099/1000-1009/1006/verifierE.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildTree(n int, parents []int) [][]int {
+	children := make([][]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := parents[i-2]
+		children[p] = append(children[p], i)
+	}
+	for i := 1; i <= n; i++ {
+		if len(children[i]) > 1 {
+			sort.Ints(children[i])
+		}
+	}
+	return children
+}
+
+func dfsOrder(children [][]int) ([]int, []int, []int) {
+	n := len(children) - 1
+	st := make([]int, n+1)
+	ed := make([]int, n+1)
+	id := make([]int, n+2)
+	type frame struct{ node, idx int }
+	stack := []frame{{1, 0}}
+	num := 0
+	for len(stack) > 0 {
+		top := &stack[len(stack)-1]
+		if top.idx == 0 {
+			num++
+			st[top.node] = num
+			id[num] = top.node
+		}
+		if top.idx < len(children[top.node]) {
+			child := children[top.node][top.idx]
+			top.idx++
+			stack = append(stack, frame{child, 0})
+		} else {
+			ed[top.node] = num
+			stack = stack[:len(stack)-1]
+		}
+	}
+	return st, ed, id
+}
+
+func answerQueries(children [][]int, queries [][2]int) []int {
+	st, ed, id := dfsOrder(children)
+	res := make([]int, len(queries))
+	for i, q := range queries {
+		u := q[0]
+		k := q[1]
+		pos := st[u] + k - 1
+		if pos <= ed[u] {
+			res[i] = id[pos]
+		} else {
+			res[i] = -1
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(50) + 1
+		q := rng.Intn(50) + 1
+		parents := make([]int, n-1)
+		for j := 0; j < n-1; j++ {
+			parents[j] = rng.Intn(j+1) + 1
+		}
+		children := buildTree(n, parents)
+		queries := make([][2]int, q)
+		input := fmt.Sprintf("%d %d\n", n, q)
+		for j := 0; j < n-1; j++ {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", parents[j])
+		}
+		input += "\n"
+		for j := 0; j < q; j++ {
+			u := rng.Intn(n) + 1
+			k := rng.Intn(n) + 1
+			queries[j] = [2]int{u, k}
+			input += fmt.Sprintf("%d %d\n", u, k)
+		}
+		expectedVals := answerQueries(children, queries)
+		expected := strings.TrimSpace(strings.Join(func() []string {
+			tmp := make([]string, len(expectedVals))
+			for i, v := range expectedVals {
+				tmp[i] = fmt.Sprintf("%d", v)
+			}
+			return tmp
+		}(), "\n"))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\nget\n%s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1006/verifierF.go
+++ b/1000-1999/1000-1099/1000-1009/1006/verifierF.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solve(n, m int, k int64, A [][]int64) int64 {
+	d := min(n, m)
+	total := n * m
+	var ans int64
+	if total == 1 {
+		if A[0][0] == k {
+			ans = 1
+		}
+		return ans
+	}
+	C := make([][]map[int64]int, n)
+	for i := range C {
+		C[i] = make([]map[int64]int, m)
+		for j := range C[i] {
+			C[i][j] = make(map[int64]int)
+		}
+	}
+	var dfs1 func(r, c, depth, inc, t int, sum int64)
+	dfs1 = func(r, c, depth, inc, t int, sum int64) {
+		if r < 0 || r >= n || c < 0 || c >= m {
+			return
+		}
+		sum ^= A[r][c]
+		if depth == t {
+			C[r][c][sum]++
+			return
+		}
+		dfs1(r+inc, c, depth+1, inc, t, sum)
+		dfs1(r, c+inc, depth+1, inc, t, sum)
+	}
+	var dfs2 func(r, c, depth, inc, t int, sum int64)
+	dfs2 = func(r, c, depth, inc, t int, sum int64) {
+		if r < 0 || r >= n || c < 0 || c >= m {
+			return
+		}
+		sum ^= A[r][c]
+		if depth == t {
+			if r+inc >= 0 && r+inc < n {
+				ans += int64(C[r+inc][c][sum^k])
+			}
+			if c+inc >= 0 && c+inc < m {
+				ans += int64(C[r][c+inc][sum^k])
+			}
+			return
+		}
+		dfs2(r+inc, c, depth+1, inc, t, sum)
+		dfs2(r, c+inc, depth+1, inc, t, sum)
+	}
+	dfs1(0, 0, 0, 1, d-1, 0)
+	dfs2(n-1, m-1, 0, -1, n+m-2-d, 0)
+	return ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		k := rng.Int63n(10)
+		A := make([][]int64, n)
+		input := fmt.Sprintf("%d %d %d\n", n, m, k)
+		for r := 0; r < n; r++ {
+			A[r] = make([]int64, m)
+			for c := 0; c < m; c++ {
+				A[r][c] = rng.Int63n(10)
+				if c > 0 {
+					input += " "
+				}
+				input += fmt.Sprintf("%d", A[r][c])
+			}
+			input += "\n"
+		}
+		expected := fmt.Sprintf("%d", solve(n, m, k, A))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1006 problems A–F
- verifiers generate 100 random tests and run any provided binary

## Testing
- `go build verifierA.go`
- `./verifierA 1006A.go`
- `go build verifierB.go`
- `./verifierB 1006B.go`
- `go build verifierC.go`
- `./verifierC 1006C.go`
- `go build verifierD.go`
- `./verifierD 1006D.go`
- `go build verifierE.go`
- `./verifierE 1006E.go`
- `go build verifierF.go`
- `./verifierF 1006F.go`


------
https://chatgpt.com/codex/tasks/task_e_68844ab0ada8832499bef2de88e236c1