### PR TITLE
Add Go verifiers for contest 1009

### DIFF
--- a/1000-1999/1000-1099/1000-1009/1009/verifierA.go
+++ b/1000-1999/1000-1099/1000-1009/1009/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedAnswerA(n, m int, games, bills []int) int {
+	count := 0
+	j := 0
+	for i := 0; i < n && j < m; i++ {
+		if games[i] <= bills[j] {
+			count++
+			j++
+		}
+	}
+	return count
+}
+
+func genCaseA(rng *rand.Rand) (int, int, []int, []int) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(20) + 1
+	games := make([]int, n)
+	bills := make([]int, m)
+	for i := range games {
+		games[i] = rng.Intn(1000) + 1
+	}
+	for i := range bills {
+		bills[i] = rng.Intn(1000) + 1
+	}
+	return n, m, games, bills
+}
+
+func runCaseA(bin string, n, m int, games, bills []int) error {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	sb.WriteString(strconv.Itoa(m))
+	sb.WriteByte('\n')
+	for i, v := range games {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range bills {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected := strconv.Itoa(expectedAnswerA(n, m, games, bills))
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, g, b := genCaseA(rng)
+		if err := runCaseA(bin, n, m, g, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%v %v\n%v\n%v\n", i+1, err, n, m, g, b)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1009/verifierB.go
+++ b/1000-1999/1000-1099/1000-1009/1009/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedAnswerB(s string) string {
+	cnt1 := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '1' {
+			cnt1++
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] != '1' {
+			sb.WriteByte(s[i])
+		}
+	}
+	s2 := sb.String()
+	idx := strings.IndexByte(s2, '2')
+	if idx == -1 {
+		idx = len(s2)
+	}
+	prefix := s2[:idx]
+	rest := s2[idx:]
+	return prefix + strings.Repeat("1", cnt1) + rest
+}
+
+func genCaseB(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := range b {
+		t := rng.Intn(3)
+		b[i] = byte('0' + t)
+	}
+	return string(b)
+}
+
+func runCaseB(bin, s string) error {
+	input := s + "\n"
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := expectedAnswerB(s)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := genCaseB(rng)
+		if err := runCaseB(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\n", i+1, err, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1009/verifierC.go
+++ b/1000-1999/1000-1099/1000-1009/1009/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedC(n, m int, ops [][2]int) string {
+	var sum int64
+	for i := 0; i < m; i++ {
+		x := int64(ops[i][0])
+		d := int64(ops[i][1])
+		sum += x * int64(n)
+		if d >= 0 {
+			sum += d * int64(n-1) * int64(n) / 2
+		} else {
+			mid := n/2 + 1
+			front := int64(mid - 1)
+			last := int64(n - mid)
+			sum += d * (front*(front+1)/2 + last*(last+1)/2)
+		}
+	}
+	ans := float64(sum) / float64(n)
+	return fmt.Sprintf("%.15f", ans)
+}
+
+func genCaseC(rng *rand.Rand) (int, int, [][2]int) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(10) + 1
+	ops := make([][2]int, m)
+	for i := 0; i < m; i++ {
+		ops[i][0] = rng.Intn(2001) - 1000
+		ops[i][1] = rng.Intn(2001) - 1000
+	}
+	return n, m, ops
+}
+
+func runCaseC(bin string, n, m int, ops [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte(' ')
+	sb.WriteString(strconv.Itoa(m))
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(strconv.Itoa(ops[i][0]))
+		sb.WriteByte(' ')
+		sb.WriteString(strconv.Itoa(ops[i][1]))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := expectedC(n, m, ops)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, ops := genCaseC(rng)
+		if err := runCaseC(bin, n, m, ops); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1009/verifierD.go
+++ b/1000-1999/1000-1099/1000-1009/1009/verifierD.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func isPossible(n, m int) bool {
+	if m < n-1 {
+		return false
+	}
+	if n < 1000 {
+		cnt := 0
+		for i := 1; i <= n; i++ {
+			for j := i + 1; j <= n; j++ {
+				if gcd(i, j) == 1 {
+					cnt++
+				}
+			}
+		}
+		if cnt < m {
+			return false
+		}
+	}
+	return true
+}
+
+func genCaseD(rng *rand.Rand) (int, int) {
+	n := rng.Intn(20) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges) + 1
+	return n, m
+}
+
+func runCaseD(bin string, n, m int) error {
+	input := fmt.Sprintf("%d %d\n", n, m)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	first := strings.TrimSpace(scanner.Text())
+	possible := isPossible(n, m)
+	if !possible {
+		if strings.ToLower(first) != "impossible" {
+			return fmt.Errorf("expected Impossible got %s", first)
+		}
+		return nil
+	}
+	if strings.ToLower(first) != "possible" {
+		return fmt.Errorf("expected Possible got %s", first)
+	}
+	// read edges
+	type pair struct{ u, v int }
+	edges := make(map[pair]struct{})
+	parent := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	union := func(a, b int) {
+		fa, fb := find(a), find(b)
+		if fa != fb {
+			parent[fa] = fb
+		}
+	}
+	count := 0
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			return fmt.Errorf("invalid edge line: %s", line)
+		}
+		u, err1 := strconv.Atoi(parts[0])
+		v, err2 := strconv.Atoi(parts[1])
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("bad ints")
+		}
+		if u < 1 || u > n || v < 1 || v > n || u == v {
+			return fmt.Errorf("invalid vertices")
+		}
+		if gcd(u, v) != 1 {
+			return fmt.Errorf("edge %d %d not coprime", u, v)
+		}
+		key := pair{u, v}
+		if u > v {
+			key = pair{v, u}
+		}
+		if _, ok := edges[key]; ok {
+			return fmt.Errorf("duplicate edge")
+		}
+		edges[key] = struct{}{}
+		union(u, v)
+		count++
+	}
+	if count != m {
+		return fmt.Errorf("expected %d edges got %d", m, count)
+	}
+	root := find(1)
+	for i := 2; i <= n; i++ {
+		if find(i) != root {
+			return fmt.Errorf("graph not connected")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m := genCaseD(rng)
+		if err := runCaseD(bin, n, m); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%d %d\n", i+1, err, n, m)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1009/verifierE.go
+++ b/1000-1999/1000-1099/1000-1009/1009/verifierE.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+func expectedE(arr []int64) string {
+	n := len(arr) - 1
+	var ans, pow int64 = 0, 1
+	for i := n - 1; i >= 1; i-- {
+		term := arr[i] * int64(n-i+2) % mod * pow % mod
+		ans += term
+		if ans >= mod {
+			ans -= mod
+		}
+		pow = pow * 2 % mod
+	}
+	ans += arr[n]
+	ans %= mod
+	return fmt.Sprint(ans)
+}
+
+func genCaseE(rng *rand.Rand) []int64 {
+	n := rng.Intn(10) + 1
+	arr := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		arr[i] = int64(rng.Intn(1000))
+	}
+	arr[0] = int64(n)
+	return arr
+}
+
+func runCaseE(bin string, arr []int64) error {
+	n := int(arr[0])
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(arr[i], 10))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := expectedE(arr)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := genCaseE(rng)
+		if err := runCaseE(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1009/verifierF.go
+++ b/1000-1999/1000-1099/1000-1009/1009/verifierF.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1009F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCaseF(rng *rand.Rand) (int, [][2]int) {
+	n := rng.Intn(15) + 1
+	if n == 1 {
+		return n, nil
+	}
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	return n, edges
+}
+
+func runCaseF(bin, oracle string, n int, edges [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i, e := range edges {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(strconv.Itoa(e[0]))
+		sb.WriteByte(' ')
+		sb.WriteString(strconv.Itoa(e[1]))
+	}
+	if n > 1 {
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	exp, err := runProg(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := runProg(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, edges := genCaseF(rng)
+		if err := runCaseF(bin, oracle, n, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1000-1009/1009/verifierG.go
+++ b/1000-1999/1000-1099/1000-1009/1009/verifierG.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleG")
+	cmd := exec.Command("go", "build", "-o", oracle, "1009G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCaseG(rng *rand.Rand) (string, int, [][2]interface{}) {
+	n := rng.Intn(10) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(6))
+	}
+	m := rng.Intn(n*2 + 1)
+	ops := make([][2]interface{}, m)
+	for i := 0; i < m; i++ {
+		pos := rng.Intn(n) + 1
+		mask := 0
+		letters := rng.Intn(1 << 6)
+		// ensure some letters chosen
+		mask = letters
+		ops[i][0] = pos
+		ops[i][1] = mask
+	}
+	return string(b), m, ops
+}
+
+func formatOps(ops [][2]interface{}) string {
+	var sb strings.Builder
+	for i, op := range ops {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		pos := op[0].(int)
+		mask := op[1].(int)
+		sb.WriteString(strconv.Itoa(pos))
+		sb.WriteByte(' ')
+		if mask == 0 {
+			sb.WriteByte('\n')
+			continue
+		}
+		for j := 0; j < 6; j++ {
+			if mask>>j&1 == 1 {
+				sb.WriteByte(byte('a' + j))
+			}
+		}
+	}
+	if len(ops) > 0 {
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func runCaseG(bin, oracle, s string, m int, ops [][2]interface{}) error {
+	var sb strings.Builder
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	sb.WriteString(strconv.Itoa(m))
+	sb.WriteByte('\n')
+	sb.WriteString(formatOps(ops))
+	input := sb.String()
+	exp, err := runProg(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := runProg(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s, m, ops := genCaseG(rng)
+		if err := runCaseG(bin, oracle, s, m, ops); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement random-case verifiers for problems A–E
- add oracle-based verifiers for problems F and G
- each verifier uses at least 100 test cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68844c54df54832486bf8e49bc49b66a