### PR TITLE
Add verifiers for contest 1011

### DIFF
--- a/1000-1999/1000-1099/1010-1019/1011/verifierA.go
+++ b/1000-1999/1000-1099/1010-1019/1011/verifierA.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveA(n, k int, s string) int {
+	if k > n || k > 13 {
+		return -1
+	}
+	b := []byte(s)
+	sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
+	const inf = int(^uint(0) >> 1)
+	mn := inf
+	found := false
+	for i := 0; i < n; i++ {
+		cnt := 1
+		prev := b[i]
+		sum := int(b[i] - 'a' + 1)
+		for j := i + 1; j < n && cnt < k; j++ {
+			if b[j]-prev >= 2 {
+				sum += int(b[j] - 'a' + 1)
+				prev = b[j]
+				cnt++
+			}
+		}
+		if cnt == k {
+			found = true
+			if sum < mn {
+				mn = sum
+			}
+		}
+	}
+	if !found {
+		return -1
+	}
+	return mn
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(50) + 1
+	k := rng.Intn(n) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	s := string(b)
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	input.WriteString(s)
+	input.WriteByte('\n')
+	expected := solveA(n, k, s)
+	return input.String(), expected
+}
+
+func runCase(exe string, input string, expected int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(outStr)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1011/verifierB.go
+++ b/1000-1999/1000-1099/1010-1019/1011/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveB(n, m int, a []int) int {
+	if n > m {
+		return 0
+	}
+	freq := make(map[int]int)
+	for _, v := range a {
+		freq[v]++
+	}
+	counts := make([]int, 0, len(freq))
+	for _, v := range freq {
+		counts = append(counts, v)
+	}
+	sort.Slice(counts, func(i, j int) bool { return counts[i] > counts[j] })
+	ans := 0
+	for days := 1; days <= 100; days++ {
+		total := 0
+		for _, c := range counts {
+			total += c / days
+		}
+		if total < n {
+			ans = days - 1
+			break
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1
+	m := rng.Intn(100) + 1
+	a := make([]int, m)
+	for i := range a {
+		a[i] = rng.Intn(100) + 1
+	}
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range a {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		input.WriteString(strconv.Itoa(v))
+	}
+	input.WriteByte('\n')
+	expected := solveB(n, m, a)
+	return input.String(), expected
+}
+
+func runCase(exe string, input string, expected int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(outStr)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier for problem A of contest 1011
- add Go verifier for problem B of contest 1011

## Testing
- `go run verifierA.go ./1011A_bin`
- `go run verifierB.go ./1011B_bin`


------
https://chatgpt.com/codex/tasks/task_e_68844d6d49dc8324b461bfcd1241c433