### PR TITLE
Add Go solution for problem 1926D

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1926/1926D.go
+++ b/1000-1999/1900-1999/1920-1929/1926/1926D.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mask = (1 << 31) - 1
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		freq := make(map[int]int)
+		pairs := 0
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			c := mask ^ x
+			if freq[c] > 0 {
+				freq[c]--
+				pairs++
+			} else {
+				freq[x]++
+			}
+		}
+		fmt.Fprintln(writer, n-pairs)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for 1926D using complement pairing

## Testing
- `gofmt -w 1000-1999/1900-1999/1920-1929/1926/1926D.go`
- `go build 1000-1999/1900-1999/1920-1929/1926/1926D.go`
- `go vet 1000-1999/1900-1999/1920-1929/1926/1926D.go`


------
https://chatgpt.com/codex/tasks/task_e_68844e3f3bc88324bd4565a57d4d642c