### PR TITLE
Add solution verifiers for contest 1012

### DIFF
--- a/1000-1999/1000-1099/1010-1019/1012/verifierA.go
+++ b/1000-1999/1000-1099/1010-1019/1012/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierA.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refA")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1012A.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(100) + 1
+		total := 2 * n
+		vals := make([]int, total)
+		for i := range vals {
+			vals[i] = rand.Intn(1_000_000_000) + 1
+		}
+		var b bytes.Buffer
+		fmt.Fprintf(&b, "%d\n", n)
+		for i, v := range vals {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", v)
+		}
+		b.WriteByte('\n')
+		input := b.String()
+
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1012/verifierB.go
+++ b/1000-1999/1000-1099/1010-1019/1012/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierB.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refB")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1012B.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		m := rand.Intn(10) + 1
+		maxQ := n * m
+		if maxQ > 50 {
+			maxQ = 50
+		}
+		q := rand.Intn(maxQ + 1)
+		used := make(map[[2]int]bool)
+		var b bytes.Buffer
+		fmt.Fprintf(&b, "%d %d %d\n", n, m, q)
+		for i := 0; i < q; i++ {
+			var r, c int
+			for {
+				r = rand.Intn(n) + 1
+				c = rand.Intn(m) + 1
+				if !used[[2]int{r, c}] {
+					used[[2]int{r, c}] = true
+					break
+				}
+			}
+			fmt.Fprintf(&b, "%d %d\n", r, c)
+		}
+		input := b.String()
+
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1012/verifierC.go
+++ b/1000-1999/1000-1099/1010-1019/1012/verifierC.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierC.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refC")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1012C.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(30) + 1
+		var b bytes.Buffer
+		fmt.Fprintf(&b, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", rand.Intn(100)+1)
+		}
+		b.WriteByte('\n')
+		input := b.String()
+
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1012/verifierD.go
+++ b/1000-1999/1000-1099/1010-1019/1012/verifierD.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+const letters = "ab"
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(2)]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierD.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refD")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1012D.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 1
+		m := rand.Intn(20) + 1
+		s := randString(n)
+		tStr := randString(m)
+		if !strings.ContainsRune(s, 'a') {
+			s = "a" + s[1:]
+		}
+		if !strings.ContainsRune(tStr, 'b') {
+			tStr = "b" + tStr[1:]
+		}
+		var b bytes.Buffer
+		fmt.Fprintln(&b, s)
+		fmt.Fprintln(&b, tStr)
+		input := b.String()
+
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1012/verifierE.go
+++ b/1000-1999/1000-1099/1010-1019/1012/verifierE.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierE.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refE")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1012E.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		sLimit := rand.Intn(20) + 1
+		var b bytes.Buffer
+		fmt.Fprintf(&b, "%d %d\n", n, sLimit)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			fmt.Fprintf(&b, "%d", rand.Intn(20)+1)
+		}
+		b.WriteByte('\n')
+		input := b.String()
+
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1012/verifierF.go
+++ b/1000-1999/1000-1099/1010-1019/1012/verifierF.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: go run verifierF.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	ref := filepath.Join(dir, "refF")
+	cmd := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1012F.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		N := rand.Intn(5) + 1
+		P := rand.Intn(2) + 1
+		var b bytes.Buffer
+		fmt.Fprintf(&b, "%d %d\n", N, P)
+		start := 1
+		for i := 0; i < N; i++ {
+			lenTrip := rand.Intn(5) + 1
+			proc := rand.Intn(5) + 1
+			fmt.Fprintf(&b, "%d %d %d\n", start, lenTrip, proc)
+			start += lenTrip + rand.Intn(3) + 1
+		}
+		input := b.String()
+
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: candidate error: %v\n", t+1, cErr)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "test %d: reference error: %v\n", t+1, rErr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(candOut) != strings.TrimSpace(refOut) {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–F of contest 1012
- each verifier builds the official Go solution and runs 100 random tests comparing outputs

## Testing
- `GO111MODULE=off go build 1000-1999/1000-1099/1010-1019/1012/verifierA.go`
- `GO111MODULE=off go build 1000-1999/1000-1099/1010-1019/1012/verifierB.go`
- `GO111MODULE=off go build 1000-1999/1000-1099/1010-1019/1012/verifierC.go`
- `GO111MODULE=off go build 1000-1999/1000-1099/1010-1019/1012/verifierD.go`
- `GO111MODULE=off go build 1000-1999/1000-1099/1010-1019/1012/verifierE.go`
- `GO111MODULE=off go build 1000-1999/1000-1099/1010-1019/1012/verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_68844df923e48324924daae0e03e5063