### PR TITLE
Add Go verifiers for contest 1017

### DIFF
--- a/1000-1999/1000-1099/1010-1019/1017/verifierA.go
+++ b/1000-1999/1000-1099/1010-1019/1017/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10) + 1
+	sums := make([]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		a := rng.Intn(101)
+		b := rng.Intn(101)
+		c := rng.Intn(101)
+		d := rng.Intn(101)
+		fmt.Fprintf(&sb, "%d %d %d %d\n", a, b, c, d)
+		sums[i] = a + b + c + d
+	}
+	target := sums[0]
+	tmp := append([]int(nil), sums...)
+	sort.Ints(tmp)
+	rank := 0
+	for i := len(tmp) - 1; i >= 0; i-- {
+		rank++
+		if tmp[i] == target {
+			break
+		}
+	}
+	return sb.String(), rank
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, expect, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1017/verifierB.go
+++ b/1000-1999/1000-1099/1010-1019/1017/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(8) + 1
+	a := make([]byte, n)
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		a[i] = byte('0' + rng.Intn(2))
+		b[i] = byte('0' + rng.Intn(2))
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n%s\n%s\n", n, string(a), string(b))
+
+	var cnt [2][2]int64
+	for i := 0; i < n; i++ {
+		xi := int(a[i] - '0')
+		yi := int(b[i] - '0')
+		cnt[xi][yi]++
+	}
+	var ans int64
+	for i := 0; i < n; i++ {
+		xi := int(a[i] - '0')
+		yi := int(b[i] - '0')
+		other := xi ^ 1
+		if yi == 0 {
+			ans += cnt[other][1] + cnt[other][0]
+		} else {
+			ans += cnt[other][0]
+		}
+	}
+	ans /= 2
+	return sb.String(), ans
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1017/verifierC.go
+++ b/1000-1999/1000-1099/1010-1019/1017/verifierC.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(30) + 1
+	input := fmt.Sprintf("%d\n", n)
+	return input, n
+}
+
+func checkPermutation(out string, n int) error {
+	fields := strings.Fields(out)
+	if len(fields) != n {
+		return fmt.Errorf("expected %d numbers, got %d", n, len(fields))
+	}
+	seen := make([]bool, n+1)
+	for _, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("bad integer %q", f)
+		}
+		if v < 1 || v > n {
+			return fmt.Errorf("value %d out of range", v)
+		}
+		if seen[v] {
+			return fmt.Errorf("duplicate value %d", v)
+		}
+		seen[v] = true
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if err := checkPermutation(out, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1017/verifierD.go
+++ b/1000-1999/1000-1099/1010-1019/1017/verifierD.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(3) + 1
+	q := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, q)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", rng.Intn(11))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		var s strings.Builder
+		for j := 0; j < n; j++ {
+			s.WriteByte(byte('0' + rng.Intn(2)))
+		}
+		fmt.Fprintf(&sb, "%s\n", s.String())
+	}
+	for i := 0; i < q; i++ {
+		var t strings.Builder
+		for j := 0; j < n; j++ {
+			t.WriteByte(byte('0' + rng.Intn(2)))
+		}
+		fmt.Fprintf(&sb, "%s %d\n", t.String(), rng.Intn(11))
+	}
+	return sb.String(), q
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, q := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		lines := strings.Fields(out)
+		if len(lines) != q {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\ninput:\n%s", i+1, q, len(lines), in)
+			os.Exit(1)
+		}
+		for _, v := range lines {
+			if _, err := fmt.Sscan(v, new(int)); err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: bad number %q\ninput:\n%s", i+1, v, in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1017/verifierE.go
+++ b/1000-1999/1000-1099/1010-1019/1017/verifierE.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 3
+	m := rng.Intn(3) + 3
+	used1 := make(map[[2]int]bool)
+	used2 := make(map[[2]int]bool)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		for {
+			x := rng.Intn(11)
+			y := rng.Intn(11)
+			if !used1[[2]int{x, y}] {
+				used1[[2]int{x, y}] = true
+				fmt.Fprintf(&sb, "%d %d\n", x, y)
+				break
+			}
+		}
+	}
+	for i := 0; i < m; i++ {
+		for {
+			x := rng.Intn(11)
+			y := rng.Intn(11)
+			if !used2[[2]int{x, y}] {
+				used2[[2]int{x, y}] = true
+				fmt.Fprintf(&sb, "%d %d\n", x, y)
+				break
+			}
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		low := strings.ToLower(strings.TrimSpace(out))
+		if low != "yes" && low != "no" {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected YES or NO got %q\ninput:\n%s", i+1, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1017/verifierF.go
+++ b/1000-1999/1000-1099/1010-1019/1017/verifierF.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(50) + 1
+	A := rng.Intn(5)
+	B := rng.Intn(5)
+	C := rng.Intn(5)
+	D := rng.Intn(5)
+	return fmt.Sprintf("%d %d %d %d %d\n", n, A, B, C, D)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if _, err := fmt.Sscan(out, new(uint64)); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad output: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1017/verifierG.go
+++ b/1000-1999/1000-1099/1010-1019/1017/verifierG.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(8) + 2
+	q := rng.Intn(8) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		fmt.Fprintf(&sb, "%d ", p)
+	}
+	sb.WriteByte('\n')
+	cnt := 0
+	for i := 0; i < q; i++ {
+		t := rng.Intn(3) + 1
+		v := rng.Intn(n) + 1
+		fmt.Fprintf(&sb, "%d %d\n", t, v)
+		if t == 3 {
+			cnt++
+		}
+	}
+	return sb.String(), cnt
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, outLines := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		lines := strings.Fields(out)
+		if len(lines) != outLines {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d outputs got %d\ninput:\n%s", i+1, outLines, len(lines), in)
+			os.Exit(1)
+		}
+		for _, s := range lines {
+			lw := strings.ToLower(strings.TrimSpace(s))
+			if lw != "black" && lw != "white" {
+				fmt.Fprintf(os.Stderr, "case %d failed: bad output %q\ninput:\n%s", i+1, s, in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1017/verifierH.go
+++ b/1000-1999/1000-1099/1010-1019/1017/verifierH.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	q := rng.Intn(4) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, q)
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&sb, "%d ", rng.Intn(m)+1)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		k := rng.Intn(5)
+		fmt.Fprintf(&sb, "%d %d %d\n", l, r, k)
+	}
+	return sb.String(), q
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, q := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		lines := strings.Fields(out)
+		if len(lines) != q {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d outputs got %d\ninput:\n%s", i+1, q, len(lines), in)
+			os.Exit(1)
+		}
+		for _, s := range lines {
+			if _, err := fmt.Sscan(s, new(int)); err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: bad number %q\ninput:\n%s", i+1, s, in)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement runtime verifiers for contest 1017 problems A–H
- each verifier generates at least 100 random testcases and validates basic output format

## Testing
- `go build verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go verifierH.go`

------
https://chatgpt.com/codex/tasks/task_e_688450b603fc8324be19e4784d6f252d