### PR TITLE
Add Go solution for CF 1923E

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1923/1923E.go
+++ b/1000-1999/1900-1999/1920-1929/1923/1923E.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type frame struct {
+	v, p  int
+	idx   int
+	saved int
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(in, &n)
+		colors := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(in, &colors[i])
+		}
+		adj := make([][]int, n+1)
+		for i := 0; i < n-1; i++ {
+			var u, v int
+			fmt.Fscan(in, &u, &v)
+			adj[u] = append(adj[u], v)
+			adj[v] = append(adj[v], u)
+		}
+		cnt := make([]int, n+1)
+		var ans int64
+		stack := []frame{{v: 1, p: 0, idx: -1, saved: 0}}
+		for len(stack) > 0 {
+			f := &stack[len(stack)-1]
+			c := colors[f.v]
+			if f.idx == -1 {
+				ans += int64(cnt[c])
+				f.saved = cnt[c]
+				f.idx = 0
+			}
+			if f.idx < len(adj[f.v]) {
+				to := adj[f.v][f.idx]
+				f.idx++
+				if to == f.p {
+					continue
+				}
+				cnt[c] = 1
+				stack = append(stack, frame{v: to, p: f.v, idx: -1})
+				continue
+			}
+			cnt[c] = f.saved + 1
+			stack = stack[:len(stack)-1]
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement iterative DFS solution for problem E from contest 1923

## Testing
- `go run 1000-1999/1900-1999/1920-1929/1923/1923E.go <<EOF
4
3
1 2 1
1 2
2 3
5
2 1 2 1 2
1 2
1 3
3 4
4 5
5
1 2 3 4 5
1 2
1 3
3 4
4 5
4
2 2 2 2
3 1
3 2
3 4
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68844fe367a0832498c4b7d5208e5198