### PR TITLE
Add Go verifiers for contest 1019

### DIFF
--- a/1000-1999/1000-1099/1010-1019/1019/verifierA.go
+++ b/1000-1999/1000-1099/1010-1019/1019/verifierA.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Pair struct{ first, second int }
+
+type LaterHeap struct {
+	data  [][]int64
+	items []Pair
+}
+
+func (h LaterHeap) Len() int { return len(h.items) }
+func (h LaterHeap) Less(i, j int) bool {
+	a := h.items[i]
+	b := h.items[j]
+	return h.data[a.first][a.second] < h.data[b.first][b.second]
+}
+func (h LaterHeap) Swap(i, j int)       { h.items[i], h.items[j] = h.items[j], h.items[i] }
+func (h *LaterHeap) Push(x interface{}) { h.items = append(h.items, x.(Pair)) }
+func (h *LaterHeap) Pop() interface{} {
+	old := h.items
+	n := len(old)
+	x := old[n-1]
+	h.items = old[:n-1]
+	return x
+}
+
+func compute(n, m int, party []int, cost []int64) int64 {
+	cp := make([][]int64, m)
+	for i := 0; i < n; i++ {
+		cp[party[i]] = append(cp[party[i]], cost[i])
+	}
+	ps := make([][]int64, m)
+	for i := 0; i < m; i++ {
+		sort.Slice(cp[i], func(a, b int) bool { return cp[i][a] < cp[i][b] })
+		ps[i] = make([]int64, len(cp[i]))
+		for j, v := range cp[i] {
+			if j == 0 {
+				ps[i][j] = v
+			} else {
+				ps[i][j] = ps[i][j-1] + v
+			}
+		}
+	}
+	ans := int64(1 << 62)
+	for b := 0; b <= n; b++ {
+		tot := len(cp[0])
+		cst := int64(0)
+		h := &LaterHeap{data: cp}
+		heap.Init(h)
+		for i := 1; i < m; i++ {
+			sz := len(cp[i])
+			need := sz - b
+			if need < 0 {
+				need = 0
+			}
+			if need > 0 {
+				cst += ps[i][need-1]
+				tot += need
+			}
+			if need < sz {
+				heap.Push(h, Pair{i, need})
+			}
+		}
+		for tot <= b && h.Len() > 0 {
+			top := heap.Pop(h).(Pair)
+			cst += cp[top.first][top.second]
+			if top.second+1 < len(cp[top.first]) {
+				heap.Push(h, Pair{top.first, top.second + 1})
+			}
+			tot++
+		}
+		if tot > b && cst < ans {
+			ans = cst
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 2
+		m := rng.Intn(4) + 2
+		party := make([]int, n)
+		cost := make([]int64, n)
+		for j := 0; j < n; j++ {
+			party[j] = rng.Intn(m)
+			cost[j] = int64(rng.Intn(20) + 1)
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d %d\n", party[j]+1, cost[j])
+		}
+		input := sb.String()
+		expected := compute(n, m, party, cost)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		val, err2 := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err2 != nil || val != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1019/verifierB.go
+++ b/1000-1999/1000-1099/1010-1019/1019/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func compute(a []int) int {
+	n := len(a)
+	half := n / 2
+	for i := 0; i < half; i++ {
+		if a[i] == a[i+half] {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := 2 * (rng.Intn(5) + 1)
+		vals := make([]int, n)
+		vals[0] = rng.Intn(10)
+		for j := 1; j < n; j++ {
+			delta := 1
+			if rng.Intn(2) == 0 {
+				delta = -1
+			}
+			vals[j] = vals[j-1] + delta
+		}
+		// ensure circular difference property
+		if abs(vals[0]-vals[n-1]) != 1 {
+			if vals[n-1] > vals[0] {
+				vals[n-1] = vals[0] - 1
+			} else {
+				vals[n-1] = vals[0] + 1
+			}
+		}
+		var sb strings.Builder
+		fmt.Fprintln(&sb, n)
+		for j, v := range vals {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprint(&sb, v)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := compute(vals)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		val, err2 := strconv.Atoi(strings.TrimSpace(out))
+		if err2 != nil || val != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/1000-1999/1000-1099/1010-1019/1019/verifierC.go
+++ b/1000-1999/1000-1099/1010-1019/1019/verifierC.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func existsValid(n int, edges []edge) bool {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+	}
+	m := 1 << n
+	for mask := 0; mask < m; mask++ {
+		sel := make([]bool, n)
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) != 0 {
+				sel[i] = true
+			}
+		}
+		valid := true
+		for _, e := range edges {
+			if sel[e.u] && sel[e.v] {
+				valid = false
+				break
+			}
+		}
+		if !valid {
+			continue
+		}
+		reach := make([]bool, n)
+		for i := 0; i < n; i++ {
+			if sel[i] {
+				for _, y := range adj[i] {
+					reach[y] = true
+					for _, z := range adj[y] {
+						reach[z] = true
+					}
+				}
+			}
+		}
+		ok := true
+		for v := 0; v < n; v++ {
+			if !sel[v] && !reach[v] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+func verify(n int, edges []edge, output string) bool {
+	scan := bufio.NewScanner(strings.NewReader(output))
+	scan.Split(bufio.ScanWords)
+	if !scan.Scan() {
+		return false
+	}
+	k, err := strconv.Atoi(scan.Text())
+	if err != nil || k < 0 || k > n {
+		return false
+	}
+	chosen := make([]int, 0, k)
+	used := make(map[int]bool)
+	for i := 0; i < k; i++ {
+		if !scan.Scan() {
+			return false
+		}
+		v, err := strconv.Atoi(scan.Text())
+		if err != nil || v < 1 || v > n || used[v] {
+			return false
+		}
+		used[v] = true
+		chosen = append(chosen, v-1)
+	}
+	if scan.Scan() { /* extra tokens allowed? we ignore? but let's ensure none*/
+		return false
+	}
+	adj := make([][]int, n)
+	mat := make([][]bool, n)
+	for i := 0; i < n; i++ {
+		mat[i] = make([]bool, n)
+	}
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		mat[e.u][e.v] = true
+	}
+	sel := make([]bool, n)
+	for _, v := range chosen {
+		sel[v] = true
+	}
+	for i := 0; i < n; i++ {
+		for _, to := range adj[i] {
+			if sel[i] && sel[to] {
+				return false
+			}
+		}
+	}
+	reach := make([]bool, n)
+	for _, x := range chosen {
+		for _, y := range adj[x] {
+			reach[y] = true
+			for _, z := range adj[y] {
+				reach[z] = true
+			}
+		}
+	}
+	for v := 0; v < n; v++ {
+		if !sel[v] && !reach[v] {
+			return false
+		}
+	}
+	return true
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tc := 0; tc < 100; tc++ {
+		for {
+			n := rng.Intn(4) + 2
+			maxEdges := n * (n - 1)
+			m := rng.Intn(maxEdges + 1)
+			edges := make([]edge, 0, m)
+			seen := make(map[[2]int]bool)
+			for len(edges) < m {
+				u := rng.Intn(n)
+				v := rng.Intn(n)
+				if u == v {
+					continue
+				}
+				key := [2]int{u, v}
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				edges = append(edges, edge{u, v})
+			}
+			if existsValid(n, edges) {
+				var sb strings.Builder
+				fmt.Fprintf(&sb, "%d %d\n", n, len(edges))
+				for _, e := range edges {
+					fmt.Fprintf(&sb, "%d %d\n", e.u+1, e.v+1)
+				}
+				input := sb.String()
+				out, err := run(bin, input)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tc+1, err, input)
+					os.Exit(1)
+				}
+				if !verify(n, edges, out) {
+					fmt.Fprintf(os.Stderr, "case %d failed: invalid output\ninput:\n%s\noutput:\n%s", tc+1, input, out)
+					os.Exit(1)
+				}
+				break
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1019/verifierD.go
+++ b/1000-1999/1000-1099/1010-1019/1019/verifierD.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int64 }
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func area2(a, b, c point) int64 { return abs((b.x-a.x)*(c.y-a.y) - (b.y-a.y)*(c.x-a.x)) }
+
+func brute(points []point, p2 int64) (bool, [3]point) {
+	n := len(points)
+	var ans [3]point
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			for k := j + 1; k < n; k++ {
+				if area2(points[i], points[j], points[k]) == p2 {
+					ans = [3]point{points[i], points[j], points[k]}
+					return true, ans
+				}
+			}
+		}
+	}
+	return false, ans
+}
+
+func checkTriple(points []point, p2 int64, coords []point) bool {
+	used := make([]bool, len(points))
+	for _, pt := range coords {
+		found := false
+		for i, p := range points {
+			if !used[i] && p == pt {
+				used[i] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return area2(coords[0], coords[1], coords[2]) == p2
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tc := 0; tc < 100; tc++ {
+		n := rng.Intn(5) + 3
+		p2 := int64(rng.Intn(30) + 1)
+		pts := make([]point, n)
+		for i := 0; i < n; i++ {
+			pts[i] = point{int64(rng.Intn(20)), int64(rng.Intn(20))}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, p2/2)
+		for _, pt := range pts {
+			fmt.Fprintf(&sb, "%d %d\n", pt.x, pt.y)
+		}
+		input := sb.String()
+		exist, _ := brute(pts, p2)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tc+1, err, input)
+			os.Exit(1)
+		}
+		scan := bufio.NewScanner(strings.NewReader(out))
+		scan.Split(bufio.ScanWords)
+		if !scan.Scan() {
+			fmt.Fprintf(os.Stderr, "case %d failed: no output\n", tc+1)
+			os.Exit(1)
+		}
+		tok := strings.ToLower(scan.Text())
+		if exist {
+			if tok != "yes" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected Yes\ninput:\n%s", tc+1, input)
+				os.Exit(1)
+			}
+			coords := make([]point, 0, 3)
+			for i := 0; i < 3; i++ {
+				var x, y int64
+				if !scan.Scan() {
+					fmt.Fprintf(os.Stderr, "case %d failed: missing coord\n", tc+1)
+					os.Exit(1)
+				}
+				xVal, err := strconv.ParseInt(scan.Text(), 10, 64)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "case %d bad output\n", tc+1)
+					os.Exit(1)
+				}
+				if !scan.Scan() {
+					fmt.Fprintf(os.Stderr, "case %d failed: missing coord\n", tc+1)
+					os.Exit(1)
+				}
+				yVal, err2 := strconv.ParseInt(scan.Text(), 10, 64)
+				if err2 != nil {
+					fmt.Fprintf(os.Stderr, "case %d bad output\n", tc+1)
+					os.Exit(1)
+				}
+				x = xVal
+				y = yVal
+				coords = append(coords, point{x, y})
+			}
+			if !checkTriple(pts, p2, coords) {
+				fmt.Fprintf(os.Stderr, "case %d failed: invalid triangle\ninput:\n%s\noutput:\n%s", tc+1, input, out)
+				os.Exit(1)
+			}
+		} else {
+			if tok != "no" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected No\ninput:\n%s", tc+1, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1010-1019/1019/verifierE.go
+++ b/1000-1999/1000-1099/1010-1019/1019/verifierE.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	to   int
+	a, b int64
+}
+
+type form struct{ a, b int64 }
+
+func (f form) eval(t int64) int64 { return f.a*t + f.b }
+
+func dfs(u, p int, aSum, bSum int64, adj [][]edge, res []form) {
+	res[u] = form{aSum, bSum}
+	for _, e := range adj[u] {
+		if e.to != p {
+			dfs(e.to, u, aSum+e.a, bSum+e.b, adj, res)
+		}
+	}
+}
+
+func compute(n int, m int64, adj [][]edge) []int64 {
+	forms := make([][]form, n)
+	for i := 0; i < n; i++ {
+		forms[i] = make([]form, n)
+	}
+	for i := 0; i < n; i++ {
+		dfs(i, -1, 0, 0, adj, forms[i])
+	}
+	ans := make([]int64, m)
+	for t := int64(0); t < m; t++ {
+		best := forms[0][1].eval(t)
+		for i := 0; i < n; i++ {
+			for j := i + 1; j < n; j++ {
+				val := forms[i][j].eval(t)
+				if val > best {
+					best = val
+				}
+			}
+		}
+		ans[t] = best
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tc := 0; tc < 100; tc++ {
+		n := rng.Intn(5) + 2
+		m := int64(rng.Intn(5) + 1)
+		adj := make([][]edge, n)
+		edgesList := make([][4]int64, 0, n-1)
+		for i := 0; i < n-1; i++ {
+			u := i + 1
+			v := rng.Intn(u)
+			a := int64(rng.Intn(3))
+			b := int64(rng.Intn(5))
+			adj[u] = append(adj[u], edge{v, a, b})
+			adj[v] = append(adj[v], edge{u, a, b})
+			edgesList = append(edgesList, [4]int64{int64(u), int64(v), a, b})
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for _, e := range edgesList {
+			fmt.Fprintf(&sb, "%d %d %d %d\n", e[0]+1, e[1]+1, e[2], e[3])
+		}
+		input := sb.String()
+		expected := compute(n, m, adj)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tc+1, err, input)
+			os.Exit(1)
+		}
+		scan := bufio.NewScanner(strings.NewReader(out))
+		scan.Split(bufio.ScanWords)
+		vals := make([]int64, 0, m)
+		for scan.Scan() {
+			v, err := strconv.ParseInt(scan.Text(), 10, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d bad output\n", tc+1)
+				os.Exit(1)
+			}
+			vals = append(vals, v)
+		}
+		if int64(len(vals)) != m {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d values got %d\n", tc+1, m, len(vals))
+			os.Exit(1)
+		}
+		for i := int64(0); i < m; i++ {
+			if vals[i] != expected[i] {
+				fmt.Fprintf(os.Stderr, "case %d failed at t=%d: expected %d got %d\ninput:\n%s", tc+1, i, expected[i], vals[i], input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to simulate bribery counting for 1019A
- add verifierB.go for circular sequence check in 1019B
- add verifierC.go to validate vertex sets in 1019C
- add verifierD.go to verify triangle existence for 1019D
- add verifierE.go computing longest paths over time for 1019E

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_688451cdabec832484d67549b877fe4f