### PR TITLE
Add Go verifiers for contest 1023

### DIFF
--- a/1000-1999/1000-1099/1020-1029/1023/verifierA.go
+++ b/1000-1999/1000-1099/1020-1029/1023/verifierA.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1023A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		if !strings.Contains(bin, "/") {
+			bin = "./" + bin
+		}
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"8 10\ncode*ces\ncodeforces\n",
+		"5 5\nvkcup\nvkcup\n",
+		"1 1\nv\nk\n",
+	}
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	withStar := rng.Intn(3) == 0
+	var sb strings.Builder
+	if withStar {
+		star := rng.Intn(n)
+		for i := 0; i < n; i++ {
+			if i == star {
+				sb.WriteByte('*')
+			} else {
+				sb.WriteByte(byte('a' + rng.Intn(3)))
+			}
+		}
+	} else {
+		sb.WriteString(randString(rng, n))
+	}
+	s := sb.String()
+	m := rng.Intn(10) + 1
+	t := randString(rng, m)
+	return fmt.Sprintf("%d %d\n%s\n%s\n", len(s), len(t), s, t)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[len(os.Args)-1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1023/verifierB.go
+++ b/1000-1999/1000-1099/1020-1029/1023/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1023B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		if !strings.Contains(bin, "/") {
+			bin = "./" + bin
+		}
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"5 5\n",
+		"15 15\n",
+		"10 3\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Int63n(1e6) + 1
+	k := rng.Int63n(2*n + 1)
+	return fmt.Sprintf("%d %d\n", n, k)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[len(os.Args)-1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1023/verifierC.go
+++ b/1000-1999/1000-1099/1020-1029/1023/verifierC.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1023C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		if !strings.Contains(bin, "/") {
+			bin = "./" + bin
+		}
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"4 2\n()()\n",
+		"6 4\n(())()\n",
+	}
+}
+
+func genRegular(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	bal := 0
+	for i := 0; i < n; i++ {
+		rem := n - i - 1
+		if bal == 0 {
+			b[i] = '('
+			bal++
+			continue
+		}
+		if bal == rem+1 {
+			b[i] = ')'
+			bal--
+			continue
+		}
+		if rng.Intn(2) == 0 {
+			b[i] = '('
+			bal++
+		} else {
+			b[i] = ')'
+			bal--
+		}
+	}
+	return string(b)
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := (rng.Intn(10) + 1) * 2
+	s := genRegular(rng, n)
+	k := 2 * (rng.Intn(n/2) + 1)
+	return fmt.Sprintf("%d %d\n%s\n", n, k, s)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[len(os.Args)-1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1023/verifierD.go
+++ b/1000-1999/1000-1099/1020-1029/1023/verifierD.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1023D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		if !strings.Contains(bin, "/") {
+			bin = "./" + bin
+		}
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"3 2\n0 0 0\n",
+		"5 3\n1 0 2 0 3\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	q := rng.Intn(5) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(q + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[len(os.Args)-1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1023/verifierE.go
+++ b/1000-1999/1000-1099/1020-1029/1023/verifierE.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1023E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		if !strings.Contains(bin, "/") {
+			bin = "./" + bin
+		}
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"2\n..\n..\n",
+		"3\n...\n...\n...\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			sb.WriteByte('.')
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[len(os.Args)-1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1023/verifierF.go
+++ b/1000-1999/1000-1099/1020-1029/1023/verifierF.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1023F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		if !strings.Contains(bin, "/") {
+			bin = "./" + bin
+		}
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"2 1 0\n1 2\n\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	k := n - 1
+	m := rng.Intn(3)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, k, m))
+	for i := 1; i <= k; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", i, i+1))
+	}
+	type edge struct{ a, b, w int }
+	edges := make([]edge, m)
+	for i := 0; i < m; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		for b == a {
+			b = rng.Intn(n) + 1
+		}
+		w := rng.Intn(10) + 1
+		edges[i] = edge{a, b, w}
+	}
+	sort.Slice(edges, func(i, j int) bool { return edges[i].w < edges[j].w })
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.a, e.b, e.w))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[len(os.Args)-1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1023/verifierG.go
+++ b/1000-1999/1000-1099/1020-1029/1023/verifierG.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1023G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		if !strings.Contains(bin, "/") {
+			bin = "./" + bin
+		}
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n\n1\n1 1 1\n",
+	}
+}
+
+func randomCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n-1; i++ {
+		u := i + 1
+		v := i + 2
+		l := rng.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", u, v, l))
+	}
+	k := rng.Intn(5) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", k))
+	for i := 0; i < k; i++ {
+		d := rng.Intn(10) + 1
+		f := rng.Intn(5) + 1
+		p := rng.Intn(n) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", d, f, p))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate := os.Args[len(os.Args)-1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, in := range cases {
+		exp, err := run(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := run(candidate, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d wrong answer\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for all problems of contest 1023
- each verifier builds a reference solution and compares outputs on 100 random cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go run verifierA.go -- 1023A.go`

------
https://chatgpt.com/codex/tasks/task_e_688453fe081c83249a4eb5674039b1c6