### PR TITLE
Add Go solution for 1652B

### DIFF
--- a/1000-1999/1600-1699/1650-1659/1652/1652B.go
+++ b/1000-1999/1600-1699/1650-1659/1652/1652B.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// Solution to problemB.txt for 1652B.
+// The algorithm repeatedly removes the longest prefix that
+// appears elsewhere in the current string. This is equivalent
+// to discarding all leading characters that appear more than once.
+// We count character frequencies and skip characters from the start
+// while their remaining frequency is at least two.
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(in, &s)
+		freq := [26]int{}
+		for i := 0; i < len(s); i++ {
+			freq[s[i]-'a']++
+		}
+		idx := 0
+		for idx < len(s) && freq[s[idx]-'a'] >= 2 {
+			freq[s[idx]-'a']--
+			idx++
+		}
+		fmt.Fprintln(out, s[idx:])
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for `problemB.txt` (contest 1652)
- algorithm: drop leading characters that appear more than once

## Testing
- `gofmt -w 1000-1999/1600-1699/1650-1659/1652/1652B.go`


------
https://chatgpt.com/codex/tasks/task_e_688455e854548324bc07ca501d1e4b66