### PR TITLE
Add Go verifiers for contest 1029

### DIFF
--- a/1000-1999/1000-1099/1020-1029/1029/verifierA.go
+++ b/1000-1999/1000-1099/1020-1029/1029/verifierA.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	Input  string
+	Output string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func prefixFunction(s string) []int {
+	n := len(s)
+	pi := make([]int, n)
+	for i := 1; i < n; i++ {
+		j := pi[i-1]
+		for j > 0 && s[i] != s[j] {
+			j = pi[j-1]
+		}
+		if s[i] == s[j] {
+			j++
+		}
+		pi[i] = j
+	}
+	return pi
+}
+
+func solveA(n, k int, t string) string {
+	pi := prefixFunction(t)
+	l := pi[n-1]
+	p := t[l:]
+	b := strings.Builder{}
+	b.WriteString(t)
+	for i := 1; i < k; i++ {
+		b.WriteString(p)
+	}
+	return b.String()
+}
+
+func randString(n int) string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func generateTests() []TestCase {
+	rand.Seed(42)
+	tests := make([]TestCase, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(50) + 1
+		k := rand.Intn(50) + 1
+		t := randString(n)
+		input := fmt.Sprintf("%d %d\n%s\n", n, k, t)
+		output := solveA(n, k, t)
+		tests[i] = TestCase{Input: input, Output: output}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := runBinary(bin, tc.Input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(tc.Output) {
+			fmt.Fprintf(os.Stderr, "Test %d failed:\ninput:\n%s\nexpected:%s\n got:%s\n", i+1, tc.Input, tc.Output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1020-1029/1029/verifierB.go
+++ b/1000-1999/1000-1099/1020-1029/1029/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	Input  string
+	Output string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(a []int) string {
+	if len(a) == 0 {
+		return "0"
+	}
+	ans := 1
+	cur := 1
+	for i := 1; i < len(a); i++ {
+		if a[i] <= 2*a[i-1] {
+			cur++
+		} else {
+			cur = 1
+		}
+		if cur > ans {
+			ans = cur
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []TestCase {
+	rand.Seed(43)
+	tests := make([]TestCase, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 1
+		arr := make([]int, n)
+		cur := rand.Intn(20) + 1
+		arr[0] = cur
+		for i := 1; i < n; i++ {
+			cur += rand.Intn(20) + 1
+			arr[i] = cur
+		}
+		inputBuilder := strings.Builder{}
+		inputBuilder.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				inputBuilder.WriteByte(' ')
+			}
+			inputBuilder.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		inputBuilder.WriteByte('\n')
+		output := solveB(arr)
+		tests[t] = TestCase{Input: inputBuilder.String(), Output: output}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := runBinary(bin, tc.Input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(tc.Output) {
+			fmt.Fprintf(os.Stderr, "Test %d failed:\ninput:\n%s\nexpected:%s\n got:%s\n", i+1, tc.Input, tc.Output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1020-1029/1029/verifierC.go
+++ b/1000-1999/1000-1099/1020-1029/1029/verifierC.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	Input  string
+	Output string
+}
+
+type Seg struct {
+	l int
+	r int
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(segs []Seg) string {
+	n := len(segs)
+	const INF = int(1e9 + 5)
+	L := make([]int, n)
+	R := make([]int, n)
+	for i := 0; i < n; i++ {
+		if i == 0 {
+			L[i] = segs[i].l
+			R[i] = segs[i].r
+		} else {
+			if segs[i].l > L[i-1] {
+				L[i] = segs[i].l
+			} else {
+				L[i] = L[i-1]
+			}
+			if segs[i].r < R[i-1] {
+				R[i] = segs[i].r
+			} else {
+				R[i] = R[i-1]
+			}
+		}
+	}
+	Ls := make([]int, n)
+	Rs := make([]int, n)
+	for i := n - 1; i >= 0; i-- {
+		if i == n-1 {
+			Ls[i] = segs[i].l
+			Rs[i] = segs[i].r
+		} else {
+			if segs[i].l > Ls[i+1] {
+				Ls[i] = segs[i].l
+			} else {
+				Ls[i] = Ls[i+1]
+			}
+			if segs[i].r < Rs[i+1] {
+				Rs[i] = segs[i].r
+			} else {
+				Rs[i] = Rs[i+1]
+			}
+		}
+	}
+	ans := 0
+	for i := 0; i < n; i++ {
+		l := -INF
+		r := INF
+		if i > 0 {
+			if L[i-1] > l {
+				l = L[i-1]
+			}
+			if R[i-1] < r {
+				r = R[i-1]
+			}
+		}
+		if i+1 < n {
+			if Ls[i+1] > l {
+				l = Ls[i+1]
+			}
+			if Rs[i+1] < r {
+				r = Rs[i+1]
+			}
+		}
+		if r-l > ans {
+			ans = r - l
+		}
+	}
+	if ans < 0 {
+		ans = 0
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []TestCase {
+	rand.Seed(44)
+	tests := make([]TestCase, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 2
+		segs := make([]Seg, n)
+		inputBuilder := strings.Builder{}
+		inputBuilder.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			l := rand.Intn(100)
+			r := l + rand.Intn(20)
+			segs[i] = Seg{l, r}
+			inputBuilder.WriteString(fmt.Sprintf("%d %d\n", l, r))
+		}
+		output := solveC(segs)
+		tests[t] = TestCase{Input: inputBuilder.String(), Output: output}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := runBinary(bin, tc.Input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(tc.Output) {
+			fmt.Fprintf(os.Stderr, "Test %d failed:\ninput:\n%s\nexpected:%s\n got:%s\n", i+1, tc.Input, tc.Output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1020-1029/1029/verifierD.go
+++ b/1000-1999/1000-1099/1020-1029/1029/verifierD.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	Input  string
+	Output string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func digits(x int) int {
+	d := 0
+	for x > 0 {
+		d++
+		x /= 10
+	}
+	return d
+}
+
+func solveD(a []int, k int) string {
+	n := len(a)
+	aMod := make([]int, n)
+	lens := make([]int, n)
+	v := make([][]int, 11)
+	for i := 0; i < n; i++ {
+		d := digits(a[i])
+		lens[i] = d
+		m := a[i] % k
+		aMod[i] = m
+		v[d] = append(v[d], m)
+	}
+	for d := 1; d <= 10; d++ {
+		if len(v[d]) > 1 {
+			sort.Ints(v[d])
+		}
+	}
+	var res int64
+	for i := 0; i < n; i++ {
+		x := aMod[i]
+		for j := 1; j <= 10; j++ {
+			x = (x * 10) % k
+			arr := v[j]
+			if len(arr) == 0 {
+				continue
+			}
+			y := (k - x) % k
+			l := sort.Search(len(arr), func(idx int) bool { return arr[idx] >= y })
+			r := sort.Search(len(arr), func(idx int) bool { return arr[idx] > y })
+			res += int64(r - l)
+			if lens[i] == j && aMod[i] == y {
+				res--
+			}
+		}
+	}
+	return fmt.Sprintf("%d", res)
+}
+
+func generateTests() []TestCase {
+	rand.Seed(45)
+	tests := make([]TestCase, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 1
+		k := rand.Intn(98) + 2
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rand.Intn(1000) + 1
+		}
+		inputBuilder := strings.Builder{}
+		inputBuilder.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				inputBuilder.WriteByte(' ')
+			}
+			inputBuilder.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		inputBuilder.WriteByte('\n')
+		output := solveD(arr, k)
+		tests[t] = TestCase{Input: inputBuilder.String(), Output: output}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := runBinary(bin, tc.Input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(tc.Output) {
+			fmt.Fprintf(os.Stderr, "Test %d failed:\ninput:\n%s\nexpected:%s\n got:%s\n", i+1, tc.Input, tc.Output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1020-1029/1029/verifierE.go
+++ b/1000-1999/1000-1099/1020-1029/1029/verifierE.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	Input  string
+	Output string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Solver struct {
+	n   int
+	adj [][]int
+	f   [][]int
+}
+
+const INF = 0x7f7f7f7f
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func min3(a, b, c int) int { return min(min(a, b), c) }
+
+func (s *Solver) dp(u, fa int) {
+	s.f[u][0], s.f[u][1], s.f[u][2] = 0, 0, 0
+	mn := INF
+	for _, v := range s.adj[u] {
+		if v == fa {
+			continue
+		}
+		s.dp(v, u)
+		m012 := min3(s.f[v][0], s.f[v][1], s.f[v][2])
+		s.f[u][0] += m012
+		m02 := min(s.f[v][0], s.f[v][2])
+		s.f[u][1] += m02
+		s.f[u][2] += m02
+		diff := s.f[v][0] - min(s.f[v][0], s.f[v][2])
+		if diff < mn {
+			mn = diff
+		}
+	}
+	if fa != 1 {
+		s.f[u][0]++
+	}
+	s.f[u][2] += mn
+}
+
+func solveE(n int, edges [][2]int) string {
+	s := Solver{n: n, adj: make([][]int, n+1), f: make([][]int, n+1)}
+	for i := 1; i <= n; i++ {
+		s.f[i] = make([]int, 3)
+	}
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		s.adj[u] = append(s.adj[u], v)
+		s.adj[v] = append(s.adj[v], u)
+	}
+	ans := 0
+	for _, c := range s.adj[1] {
+		s.dp(c, 1)
+		for _, v := range s.adj[c] {
+			ans += min3(s.f[v][0], s.f[v][1], s.f[v][2])
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTree(n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func generateTests() []TestCase {
+	rand.Seed(46)
+	tests := make([]TestCase, 100)
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(15) + 2
+		edges := generateTree(n)
+		inputBuilder := strings.Builder{}
+		inputBuilder.WriteString(fmt.Sprintf("%d\n", n))
+		for _, e := range edges {
+			inputBuilder.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		output := solveE(n, edges)
+		tests[t] = TestCase{Input: inputBuilder.String(), Output: output}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := runBinary(bin, tc.Input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(tc.Output) {
+			fmt.Fprintf(os.Stderr, "Test %d failed:\ninput:\n%s\nexpected:%s\n got:%s\n", i+1, tc.Input, tc.Output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1020-1029/1029/verifierF.go
+++ b/1000-1999/1000-1099/1020-1029/1029/verifierF.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type TestCase struct {
+	Input  string
+	Output string
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("%v: %s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func divisors(x int64) []int64 {
+	var m []int64
+	for i := int64(1); i*i <= x; i++ {
+		if x%i == 0 {
+			m = append(m, i)
+		}
+	}
+	return m
+}
+
+func solveF(a, b int64) string {
+	c := a + b
+	am := divisors(a)
+	bm := divisors(b)
+	cm := divisors(c)
+	for i := len(cm) - 1; i >= 0; i-- {
+		d := cm[i]
+		dd := c / d
+		for _, da := range am {
+			if d >= da && dd >= a/da {
+				return fmt.Sprintf("%d", (d+dd)*2)
+			}
+		}
+		for _, db := range bm {
+			if d >= db && dd >= b/db {
+				return fmt.Sprintf("%d", (d+dd)*2)
+			}
+		}
+	}
+	return ""
+}
+
+func generateTests() []TestCase {
+	rand.Seed(47)
+	tests := make([]TestCase, 100)
+	for t := 0; t < 100; t++ {
+		a := int64(rand.Intn(10000) + 1)
+		b := int64(rand.Intn(10000) + 1)
+		input := fmt.Sprintf("%d %d\n", a, b)
+		output := solveF(a, b)
+		tests[t] = TestCase{Input: input, Output: output}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := runBinary(bin, tc.Input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != strings.TrimSpace(tc.Output) {
+			fmt.Fprintf(os.Stderr, "Test %d failed:\ninput:\n%s\nexpected:%s\n got:%s\n", i+1, tc.Input, tc.Output, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1029
- each verifier runs 100 randomized tests and checks output from a binary

## Testing
- `go run verifierA.go ./1029A.go` *(fails because 1029A.go is not binary, but we would typically compile first)*

------
https://chatgpt.com/codex/tasks/task_e_688457469a7c8324aeeb6c9a89d5388f