### PR TITLE
Add verifier programs for CF contest 1028

### DIFF
--- a/1000-1999/1000-1099/1020-1029/1028/verifierA.go
+++ b/1000-1999/1000-1099/1020-1029/1028/verifierA.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type rect struct{ r, c int }
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1028A.go")
+	bin := filepath.Join(os.TempDir(), "ref1028A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(10) + 1
+	m := r.Intn(10) + 1
+	maxSide := n
+	if m < maxSide {
+		maxSide = m
+	}
+	if maxSide%2 == 0 {
+		maxSide--
+	}
+	if maxSide <= 0 {
+		maxSide = 1
+	}
+	s := r.Intn((maxSide+1)/2)*2 + 1
+	row := r.Intn(n - s + 1)
+	col := r.Intn(m - s + 1)
+	grid := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]byte, m)
+		for j := 0; j < m; j++ {
+			grid[i][j] = 'W'
+		}
+	}
+	for i := 0; i < s; i++ {
+		for j := 0; j < s; j++ {
+			grid[row+i][col+j] = 'B'
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genCase(rand.New(rand.NewSource(int64(i))))
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1028/verifierB.go
+++ b/1000-1999/1000-1099/1020-1029/1028/verifierB.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1028B.go")
+	bin := filepath.Join(os.TempDir(), "ref1028B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(1000) + 1
+	m := r.Intn(1000) + 1
+	return fmt.Sprintf("%d %d\n", n, m)
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genCase(rand.New(rand.NewSource(int64(i))))
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:%sexpected:%s\ngot:%s\n", i, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1028/verifierC.go
+++ b/1000-1999/1000-1099/1020-1029/1028/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type rect struct{ x1, y1, x2, y2 int }
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) (string, []rect) {
+	n := r.Intn(8) + 2
+	x1 := r.Intn(10) - 5
+	y1 := r.Intn(10) - 5
+	x2 := x1 + r.Intn(5) + 1
+	y2 := y1 + r.Intn(5) + 1
+	rects := make([]rect, n)
+	for i := 0; i < n-1; i++ {
+		a := x1 - r.Intn(3)
+		b := y1 - r.Intn(3)
+		c := x2 + r.Intn(3)
+		d := y2 + r.Intn(3)
+		rects[i] = rect{a, b, c, d}
+	}
+	if r.Intn(2) == 0 {
+		rects[n-1] = rect{x1 - r.Intn(3), y1 - r.Intn(3), x2 + r.Intn(3), y2 + r.Intn(3)}
+	} else {
+		a := x2 + 1 + r.Intn(3)
+		b := y2 + 1 + r.Intn(3)
+		c := a + r.Intn(3) + 1
+		d := b + r.Intn(3) + 1
+		rects[n-1] = rect{a, b, c, d}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, rc := range rects {
+		fmt.Fprintf(&sb, "%d %d %d %d\n", rc.x1, rc.y1, rc.x2, rc.y2)
+	}
+	return sb.String(), rects
+}
+
+func contains(r rect, x, y int) bool {
+	return r.x1 <= x && x <= r.x2 && r.y1 <= y && y <= r.y2
+}
+
+func check(rects []rect, out string) error {
+	f := strings.Fields(out)
+	if len(f) < 2 {
+		return fmt.Errorf("invalid output")
+	}
+	x, err := strconv.Atoi(f[0])
+	if err != nil {
+		return err
+	}
+	y, err := strconv.Atoi(f[1])
+	if err != nil {
+		return err
+	}
+	cnt := 0
+	for _, rc := range rects {
+		if contains(rc, x, y) {
+			cnt++
+		}
+	}
+	if cnt < len(rects)-1 {
+		return fmt.Errorf("point not in at least n-1 rectangles")
+	}
+	return nil
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	for i := 1; i <= 100; i++ {
+		in, rects := genCase(rand.New(rand.NewSource(int64(i))))
+		out, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if err := check(rects, out); err != nil {
+			fmt.Printf("wrong answer on test %d: %v\ninput:\n%soutput:%s\n", i, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1028/verifierD.go
+++ b/1000-1999/1000-1099/1020-1029/1028/verifierD.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type orderBook struct {
+	buys  []int
+	sells []int
+	used  map[int]bool
+}
+
+func insertAsc(arr []int, v int) []int {
+	i := 0
+	for i < len(arr) && arr[i] < v {
+		i++
+	}
+	arr = append(arr, 0)
+	copy(arr[i+1:], arr[i:])
+	arr[i] = v
+	return arr
+}
+
+func insertDesc(arr []int, v int) []int {
+	i := 0
+	for i < len(arr) && arr[i] > v {
+		i++
+	}
+	arr = append(arr, 0)
+	copy(arr[i+1:], arr[i:])
+	arr[i] = v
+	return arr
+}
+
+func genCase(r *rand.Rand) string {
+	steps := r.Intn(20) + 1
+	ob := orderBook{used: make(map[int]bool)}
+	var ops []string
+	for i := 0; i < steps; i++ {
+		if len(ob.buys)+len(ob.sells) > 0 && r.Intn(2) == 0 {
+			// accept
+			if len(ob.buys) > 0 && (len(ob.sells) == 0 || r.Intn(2) == 0) {
+				p := ob.buys[0]
+				ob.buys = ob.buys[1:]
+				ops = append(ops, fmt.Sprintf("ACCEPT %d", p))
+			} else {
+				p := ob.sells[0]
+				ob.sells = ob.sells[1:]
+				ops = append(ops, fmt.Sprintf("ACCEPT %d", p))
+			}
+		} else {
+			bestBuy := -1
+			if len(ob.buys) > 0 {
+				bestBuy = ob.buys[0]
+			}
+			bestSell := math.MaxInt32
+			if len(ob.sells) > 0 {
+				bestSell = ob.sells[0]
+			}
+			dir := r.Intn(2)
+			p := 0
+			for {
+				p = r.Intn(1000) + 1
+				if !ob.used[p] {
+					break
+				}
+			}
+			ob.used[p] = true
+			if dir == 0 { // buy
+				if p >= bestSell {
+					p = bestSell - 1
+				}
+				if p <= 0 {
+					p = 1
+				}
+				ob.buys = insertDesc(ob.buys, p)
+			} else { // sell
+				if p <= bestBuy {
+					p = bestBuy + 1
+				}
+				ob.sells = insertAsc(ob.sells, p)
+			}
+			ops = append(ops, fmt.Sprintf("ADD %d", p))
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(ops)))
+	for _, op := range ops {
+		sb.WriteString(op + "\n")
+	}
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1028D.go")
+	bin := filepath.Join(os.TempDir(), "ref1028D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genCase(rand.New(rand.NewSource(int64(i))))
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1028/verifierE.go
+++ b/1000-1999/1000-1099/1020-1029/1028/verifierE.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1028E.go")
+	bin := filepath.Join(os.TempDir(), "ref1028E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 2
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = r.Intn(20) + 1
+	}
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		b[i] = a[i] % a[(i+1)%n]
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func check(input, output string) error {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) < 2 || strings.ToUpper(strings.TrimSpace(lines[0])) != "YES" {
+		return fmt.Errorf("expected YES")
+	}
+	parts := strings.Fields(lines[1])
+	nfields := len(strings.Fields(strings.Split(input, "\n")[1]))
+	if len(parts) != nfields {
+		return fmt.Errorf("wrong number of elements")
+	}
+	bStr := strings.Fields(strings.Split(input, "\n")[1])
+	b := make([]int, len(parts))
+	for i, s := range bStr {
+		v, _ := strconv.Atoi(s)
+		b[i] = v
+	}
+	a := make([]int64, len(parts))
+	for i, s := range parts {
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return err
+		}
+		if v < 1 {
+			return fmt.Errorf("a_i < 1")
+		}
+		a[i] = v
+	}
+	for i := 0; i < len(a); i++ {
+		if int(a[i]%a[(i+1)%len(a)]) != b[i] {
+			return fmt.Errorf("output does not satisfy condition")
+		}
+	}
+	return nil
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genCase(rand.New(rand.NewSource(int64(i))))
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.ToUpper(strings.TrimSpace(want)) == "NO" {
+			if strings.ToUpper(strings.TrimSpace(got)) != "NO" {
+				fmt.Printf("wrong answer on test %d expected NO\n", i)
+				os.Exit(1)
+			}
+			continue
+		}
+		if err := check(in, got); err != nil {
+			fmt.Printf("wrong answer on test %d: %v\ninput:%soutput:%s\n", i, err, in, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1028/verifierF.go
+++ b/1000-1999/1000-1099/1020-1029/1028/verifierF.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "solF.cpp")
+	bin := filepath.Join(os.TempDir(), "ref1028F.bin")
+	cmd := exec.Command("g++", "-std=c++17", "-O2", "-pipe", "-march=native", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	q := r.Intn(20) + 1
+	type pt struct{ x, y int }
+	points := make([]pt, 0)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		t := r.Intn(3) + 1
+		var x, y int
+		if t == 1 || t == 2 {
+			x = r.Intn(11) - 5
+			y = r.Intn(11) - 5
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", t, x, y))
+			if t == 1 {
+				points = append(points, pt{x, y})
+			}
+			if t == 2 && len(points) > 0 {
+				points = points[1:]
+			}
+		} else {
+			x = r.Intn(11) - 5
+			y = r.Intn(11) - 5
+			sb.WriteString(fmt.Sprintf("3 %d %d\n", x, y))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genCase(rand.New(rand.NewSource(int64(i))))
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1028/verifierG.go
+++ b/1000-1999/1000-1099/1020-1029/1028/verifierG.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1028G.go")
+	bin := filepath.Join(os.TempDir(), "ref1028G.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	x := r.Uint64()
+	return fmt.Sprintf("%d\n", x)
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genCase(rand.New(rand.NewSource(int64(i))))
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:%sexpected:%s\ngot:%s\n", i, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1020-1029/1028/verifierH.go
+++ b/1000-1999/1000-1099/1020-1029/1028/verifierH.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1028H.go")
+	bin := filepath.Join(os.TempDir(), "ref1028H.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return bin, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 2
+	q := r.Intn(5) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = r.Intn(10) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := r.Intn(n-1) + 1
+		rgt := l + r.Intn(n-l) + 1
+		fmt.Fprintf(&sb, "%d %d\n", l, rgt)
+	}
+	return sb.String()
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	for i := 1; i <= 100; i++ {
+		in := genCase(rand.New(rand.NewSource(int64(i))))
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement solution verifiers for problems A–H of contest 1028
- each verifier builds the reference solution and runs 100 random test cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`

------
https://chatgpt.com/codex/tasks/task_e_688456ba8d948324935a12510e6ff748