### PR TITLE
Add Go solution for 1659C

### DIFF
--- a/1000-1999/1600-1699/1650-1659/1659/1659C.go
+++ b/1000-1999/1600-1699/1650-1659/1659/1659C.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var a, b int64
+		fmt.Fscan(in, &n, &a, &b)
+		x := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &x[i])
+		}
+
+		var cur int64
+		var cost int64
+		for i := 0; i < n; i++ {
+			dist := x[i] - cur
+			cost += b * dist
+			remain := int64(n - i - 1)
+			if a < b*remain {
+				cost += a * dist
+				cur = x[i]
+			}
+		}
+		fmt.Fprintln(out, cost)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for Line Empire (problem C)

## Testing
- `go build 1000-1999/1600-1699/1650-1659/1659/1659C.go`
- `go vet 1000-1999/1600-1699/1650-1659/1659/1659C.go`

------
https://chatgpt.com/codex/tasks/task_e_688458a4d1d08324980b34885d670daa