### PR TITLE
Add verifiers for contest 1031

### DIFF
--- a/1000-1999/1000-1099/1030-1039/1031/verifierA.go
+++ b/1000-1999/1000-1099/1030-1039/1031/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expected(w, h, k int) int {
+	res := 0
+	for i := 0; i < k; i++ {
+		res += 2*h + 2*w - 4
+		w -= 4
+		h -= 4
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	w := rng.Intn(98) + 3
+	h := rng.Intn(98) + 3
+	maxK := (min(w, h) + 1) / 4
+	if maxK < 1 {
+		maxK = 1
+	}
+	k := rng.Intn(maxK) + 1
+	input := fmt.Sprintf("%d %d %d\n", w, h, k)
+	out := fmt.Sprintf("%d\n", expected(w, h, k))
+	return input, out
+}
+
+func runCase(bin, in, out string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	exp := strings.TrimSpace(out)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		in, out := generateCase(rng)
+		if err := runCase(bin, in, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1031/verifierB.go
+++ b/1000-1999/1000-1099/1030-1039/1031/verifierB.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func expectedSequence(n int, a, b []int) (bool, []int) {
+	dpPrev := [4]bool{}
+	parent := make([][4]int, n)
+	for v := 0; v < 4; v++ {
+		dpPrev[v] = true
+		parent[0][v] = -1
+	}
+	for i := 0; i < n-1; i++ {
+		var dpCurr [4]bool
+		for v := 0; v < 4; v++ {
+			if !dpPrev[v] {
+				continue
+			}
+			for w := 0; w < 4; w++ {
+				if (v|w) == a[i] && (v&w) == b[i] {
+					if !dpCurr[w] {
+						dpCurr[w] = true
+						parent[i+1][w] = v
+					}
+				}
+			}
+		}
+		dpPrev = dpCurr
+	}
+	endVal := -1
+	for v := 0; v < 4; v++ {
+		if dpPrev[v] {
+			endVal = v
+			break
+		}
+	}
+	if endVal < 0 {
+		return false, nil
+	}
+	t := make([]int, n)
+	t[n-1] = endVal
+	for i := n - 1; i > 0; i-- {
+		t[i-1] = parent[i][t[i]]
+	}
+	return true, t
+}
+
+func generateCase(rng *rand.Rand) (string, bool) {
+	n := rng.Intn(18) + 2 // 2..19
+	a := make([]int, n-1)
+	b := make([]int, n-1)
+	for i := 0; i < n-1; i++ {
+		a[i] = rng.Intn(4)
+		b[i] = rng.Intn(4)
+	}
+	exist, _ := expectedSequence(n, a, b)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n-1; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n-1; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(b[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), exist
+}
+
+func parseSequence(out string, n int) ([]int, error) {
+	fields := strings.Fields(out)
+	if len(fields) < 1 {
+		return nil, fmt.Errorf("empty output")
+	}
+	if strings.ToUpper(fields[0]) == "NO" {
+		if len(fields) != 1 {
+			return nil, fmt.Errorf("unexpected extra tokens after NO")
+		}
+		return nil, nil
+	}
+	if strings.ToUpper(fields[0]) != "YES" {
+		return nil, fmt.Errorf("expected YES/NO got %q", fields[0])
+	}
+	if len(fields) != 1+n {
+		return nil, fmt.Errorf("expected %d numbers got %d", n, len(fields)-1)
+	}
+	seq := make([]int, n)
+	for i := 0; i < n; i++ {
+		v, err := strconv.Atoi(fields[1+i])
+		if err != nil {
+			return nil, fmt.Errorf("invalid int %q", fields[1+i])
+		}
+		if v < 0 || v > 3 {
+			return nil, fmt.Errorf("value out of range: %d", v)
+		}
+		seq[i] = v
+	}
+	return seq, nil
+}
+
+func runCase(bin, input string, expectExist bool, a, b []int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errBuf.String())
+	}
+	seq, err := parseSequence(out.String(), len(b)+1)
+	if err != nil {
+		return err
+	}
+	if seq == nil {
+		if expectExist {
+			return fmt.Errorf("expected YES but got NO")
+		}
+		return nil
+	}
+	if !expectExist {
+		return fmt.Errorf("expected NO but got YES")
+	}
+	// verify sequence
+	n := len(b) + 1
+	for i := 0; i < n-1; i++ {
+		if (seq[i]|seq[i+1]) != a[i] || (seq[i]&seq[i+1]) != b[i] {
+			return fmt.Errorf("sequence invalid at %d", i)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		input, exist := generateCase(rng)
+		// parse arrays for validation
+		lines := strings.Split(strings.TrimSpace(input), "\n")
+		n, _ := strconv.Atoi(strings.TrimSpace(lines[0]))
+		aStr := strings.Fields(lines[1])
+		bStr := strings.Fields(lines[2])
+		aArr := make([]int, n-1)
+		bArr := make([]int, n-1)
+		for j := 0; j < n-1; j++ {
+			aArr[j], _ = strconv.Atoi(aStr[j])
+			bArr[j], _ = strconv.Atoi(bStr[j])
+		}
+		if err := runCase(bin, input, exist, aArr, bArr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1031/verifierC.go
+++ b/1000-1999/1000-1099/1030-1039/1031/verifierC.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func generateCase(rng *rand.Rand) (string, int, int, int) {
+	a := rng.Intn(1000)
+	b := rng.Intn(1000)
+	total := a + b
+	k := int(math.Sqrt(2 * float64(total)))
+	for k*(k+1)/2 > total {
+		k--
+	}
+	for (k+1)*(k+2)/2 <= total {
+		k++
+	}
+	input := fmt.Sprintf("%d %d\n", a, b)
+	return input, a, b, k
+}
+
+func parseOutput(out string) ([]int, []int, error) {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) < 3 {
+		return nil, nil, fmt.Errorf("expected at least 3 lines")
+	}
+	n1, err := strconv.Atoi(strings.TrimSpace(lines[0]))
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid n1")
+	}
+	day1 := []int{}
+	if n1 > 0 {
+		fields := strings.Fields(lines[1])
+		if len(fields) != n1 {
+			return nil, nil, fmt.Errorf("expected %d numbers in day1", n1)
+		}
+		day1 = make([]int, n1)
+		for i := 0; i < n1; i++ {
+			v, err := strconv.Atoi(fields[i])
+			if err != nil {
+				return nil, nil, fmt.Errorf("bad int")
+			}
+			day1[i] = v
+		}
+	}
+	idx := 1
+	if n1 > 0 {
+		idx = 2
+	}
+	if len(lines) <= idx {
+		return nil, nil, fmt.Errorf("missing third line")
+	}
+	n2, err := strconv.Atoi(strings.TrimSpace(lines[idx]))
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid n2")
+	}
+	day2 := []int{}
+	if n2 > 0 {
+		if len(lines) <= idx+1 {
+			return nil, nil, fmt.Errorf("missing day2 numbers")
+		}
+		fields := strings.Fields(lines[idx+1])
+		if len(fields) != n2 {
+			return nil, nil, fmt.Errorf("expected %d numbers in day2", n2)
+		}
+		day2 = make([]int, n2)
+		for i := 0; i < n2; i++ {
+			v, err := strconv.Atoi(fields[i])
+			if err != nil {
+				return nil, nil, fmt.Errorf("bad int")
+			}
+			day2[i] = v
+		}
+	}
+	return day1, day2, nil
+}
+
+func checkCase(a, b, k int, day1, day2 []int) error {
+	used := make(map[int]bool)
+	sum1 := 0
+	for _, v := range day1 {
+		if v < 1 || v > k {
+			return fmt.Errorf("invalid number %d", v)
+		}
+		if used[v] {
+			return fmt.Errorf("duplicate %d", v)
+		}
+		used[v] = true
+		sum1 += v
+	}
+	sum2 := 0
+	for _, v := range day2 {
+		if v < 1 || v > k {
+			return fmt.Errorf("invalid number %d", v)
+		}
+		if used[v] {
+			return fmt.Errorf("duplicate %d", v)
+		}
+		used[v] = true
+		sum2 += v
+	}
+	if len(used) != k {
+		return fmt.Errorf("expected %d total numbers got %d", k, len(used))
+	}
+	if sum1 > a || sum2 > b {
+		return fmt.Errorf("sums exceed limits")
+	}
+	return nil
+}
+
+func runCase(bin, input string, a, b, k int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errBuf.String())
+	}
+	day1, day2, err := parseOutput(out.String())
+	if err != nil {
+		return err
+	}
+	if err := checkCase(a, b, k, day1, day2); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		input, a, b, k := generateCase(rng)
+		if err := runCase(bin, input, a, b, k); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1031/verifierD.go
+++ b/1000-1999/1000-1099/1030-1039/1031/verifierD.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expectedString(n, k int, grid [][]byte) string {
+	inf := n*n + 5
+	dist := make([][]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			dist[i][j] = inf
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			cost := 0
+			if grid[i][j] != 'a' {
+				cost = 1
+			}
+			if i == 0 && j == 0 {
+				dist[i][j] = cost
+			} else {
+				if i > 0 {
+					if d := dist[i-1][j] + cost; d < dist[i][j] {
+						dist[i][j] = d
+					}
+				}
+				if j > 0 {
+					if d := dist[i][j-1] + cost; d < dist[i][j] {
+						dist[i][j] = d
+					}
+				}
+			}
+		}
+	}
+	maxS := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if dist[i][j] <= k {
+				s := i + j + 2
+				if s > maxS {
+					maxS = s
+				}
+			}
+		}
+	}
+	totalLen := 2*n - 1
+	ans := make([]byte, 0, totalLen)
+	var frontier [][2]int
+	vis := make([][]int, n)
+	for i := range vis {
+		vis[i] = make([]int, n)
+	}
+	mark := 1
+	if maxS > 0 {
+		for i := 0; i < maxS-1; i++ {
+			ans = append(ans, 'a')
+		}
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				if dist[i][j] <= k && i+j+2 == maxS {
+					frontier = append(frontier, [2]int{i, j})
+					vis[i][j] = mark
+				}
+			}
+		}
+	} else {
+		ans = append(ans, grid[0][0])
+		frontier = append(frontier, [2]int{0, 0})
+		vis[0][0] = mark
+		maxS = 2
+	}
+	if len(ans) == totalLen {
+		return string(ans)
+	}
+	for len(ans) < totalLen {
+		mark++
+		best := byte('z' + 1)
+		for _, p := range frontier {
+			i, j := p[0], p[1]
+			if i+1 < n {
+				c := grid[i+1][j]
+				if c < best {
+					best = c
+				}
+			}
+			if j+1 < n {
+				c := grid[i][j+1]
+				if c < best {
+					best = c
+				}
+			}
+		}
+		next := make([][2]int, 0)
+		for _, p := range frontier {
+			i, j := p[0], p[1]
+			if i+1 < n && vis[i+1][j] != mark && grid[i+1][j] == best {
+				vis[i+1][j] = mark
+				next = append(next, [2]int{i + 1, j})
+			}
+			if j+1 < n && vis[i][j+1] != mark && grid[i][j+1] == best {
+				vis[i][j+1] = mark
+				next = append(next, [2]int{i, j + 1})
+			}
+		}
+		ans = append(ans, best)
+		frontier = next
+	}
+	return string(ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(15) + 1
+	k := rng.Intn(n*n + 1)
+	grid := make([][]byte, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		row := make([]byte, n)
+		for j := 0; j < n; j++ {
+			row[j] = byte('a' + rng.Intn(3))
+		}
+		grid[i] = row
+		sb.Write(row)
+		sb.WriteByte('\n')
+	}
+	expect := expectedString(n, k, grid)
+	return sb.String(), expect + "\n"
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expect)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1031/verifierE.go
+++ b/1000-1999/1000-1099/1030-1039/1031/verifierE.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func solve(a []int) (bool, [][3]int) {
+	pos := make([]int, 0, len(a))
+	for i, v := range a {
+		if v == 1 {
+			pos = append(pos, i)
+		}
+	}
+	m := len(pos)
+	if m%2 != 0 {
+		return false, nil
+	}
+	ops := make([][3]int, 0, m)
+	for i := 0; i < m/2; i++ {
+		l := pos[i]
+		r := pos[m-1-i]
+		d := r - l
+		if d < 2 {
+			return false, nil
+		}
+		if d%2 == 0 {
+			mid := (l + r) / 2
+			ops = append(ops, [3]int{l + 1, mid + 1, r + 1})
+		} else {
+			mid1 := (l + r - 1) / 2
+			mid2 := mid1 + 1
+			if mid2 > r || mid1 <= l {
+				return false, nil
+			}
+			ops = append(ops, [3]int{l + 1, mid1 + 1, mid2 + 1})
+			ops = append(ops, [3]int{mid1 + 1, mid2 + 1, r + 1})
+		}
+	}
+	return true, ops
+}
+
+func generateCase(rng *rand.Rand) (string, bool, [][3]int) {
+	n := rng.Intn(20) + 3
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(2)
+	}
+	ok, ops := solve(a)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(a[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), ok, ops
+}
+
+func parseOutput(out string) (bool, [][3]int, error) {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) == 0 {
+		return false, nil, fmt.Errorf("empty output")
+	}
+	t := strings.ToUpper(strings.TrimSpace(lines[0]))
+	if t == "NO" {
+		return false, nil, nil
+	}
+	if t != "YES" {
+		return false, nil, fmt.Errorf("expected YES/NO")
+	}
+	if len(lines) < 2 {
+		return false, nil, fmt.Errorf("missing count line")
+	}
+	m, err := strconv.Atoi(strings.TrimSpace(lines[1]))
+	if err != nil {
+		return false, nil, fmt.Errorf("bad count")
+	}
+	ops := make([][3]int, m)
+	if len(lines) != 2+m {
+		return false, nil, fmt.Errorf("wrong number of lines")
+	}
+	for i := 0; i < m; i++ {
+		fields := strings.Fields(lines[2+i])
+		if len(fields) != 3 {
+			return false, nil, fmt.Errorf("bad op line")
+		}
+		x, _ := strconv.Atoi(fields[0])
+		y, _ := strconv.Atoi(fields[1])
+		z, _ := strconv.Atoi(fields[2])
+		ops[i] = [3]int{x, y, z}
+	}
+	return true, ops, nil
+}
+
+func runCase(bin, input string, expectOk bool, expectOps [][3]int) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errBuf.String())
+	}
+	ok, ops, err := parseOutput(out.String())
+	if err != nil {
+		return err
+	}
+	if ok != expectOk {
+		return fmt.Errorf("expected %v but got %v", expectOk, ok)
+	}
+	if !ok {
+		return nil
+	}
+	if len(ops) != len(expectOps) {
+		return fmt.Errorf("expected %d ops got %d", len(expectOps), len(ops))
+	}
+	for i := range ops {
+		if ops[i] != expectOps[i] {
+			return fmt.Errorf("op %d mismatch", i+1)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		in, ok, ops := generateCase(rng)
+		if err := runCase(bin, in, ok, ops); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1031/verifierF.go
+++ b/1000-1999/1000-1099/1030-1039/1031/verifierF.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const N = 1000000
+
+var spf []int
+var dist [][]int
+var patMap map[string]int
+var M int
+
+func buildData() {
+	spf = make([]int, N+1)
+	for i := 2; i <= N; i++ {
+		if spf[i] == 0 {
+			for j := i; j <= N; j += i {
+				if spf[j] == 0 {
+					spf[j] = i
+				}
+			}
+		}
+	}
+	d := make([]int, N+1)
+	d[1] = 1
+	for i := 2; i <= N; i++ {
+		p := spf[i]
+		cnt := 0
+		x := i
+		for x%p == 0 {
+			x /= p
+			cnt++
+		}
+		d[i] = d[x] * (cnt + 1)
+	}
+	maxD := 0
+	for i := 1; i <= N; i++ {
+		if d[i] > maxD {
+			maxD = d[i]
+		}
+	}
+	M = maxD
+	type pat struct {
+		exps []int
+		D    int
+	}
+	patterns := make([]pat, 0)
+	patMap = make(map[string]int)
+	patterns = append(patterns, pat{exps: []int{}, D: 1})
+	patMap[""] = 0
+	var record func([]int, int) int
+	record = func(exps []int, D int) int {
+		var key string
+		for i, e := range exps {
+			if i > 0 {
+				key += ","
+			}
+			key += strconv.Itoa(e)
+		}
+		if id, ok := patMap[key]; ok {
+			return id
+		}
+		id := len(patterns)
+		c := make([]int, len(exps))
+		copy(c, exps)
+		patterns = append(patterns, pat{exps: c, D: D})
+		patMap[key] = id
+		return id
+	}
+	var dfs func(cur []int, lastE, curP int)
+	dfs = func(cur []int, lastE, curP int) {
+		for e := lastE; e >= 1; e-- {
+			np := curP * (e + 1)
+			if np > M {
+				continue
+			}
+			nxt := append(cur, e)
+			id := record(nxt, np)
+			_ = id
+			dfs(nxt, e, np)
+		}
+	}
+	dfs([]int{}, M-1, 1)
+	P := len(patterns)
+	nbr := make([][]int, P)
+	for i, p := range patterns {
+		exps := p.exps
+		for j, e := range exps {
+			var nxt []int
+			if e > 1 {
+				nxt = make([]int, len(exps))
+				copy(nxt, exps)
+				nxt[j] = e - 1
+			} else {
+				nxt = append([]int{}, exps[:j]...)
+				nxt = append(nxt, exps[j+1:]...)
+			}
+			sort.Slice(nxt, func(a, b int) bool { return nxt[a] > nxt[b] })
+			var key string
+			for k, ee := range nxt {
+				if k > 0 {
+					key += ","
+				}
+				key += strconv.Itoa(ee)
+			}
+			if id, ok := patMap[key]; ok {
+				nbr[i] = append(nbr[i], id)
+			}
+		}
+		for j, e := range exps {
+			nxt := make([]int, len(exps))
+			copy(nxt, exps)
+			nxt[j] = e + 1
+			prod := 1
+			for _, ee := range nxt {
+				prod *= (ee + 1)
+				if prod > M {
+					break
+				}
+			}
+			if prod <= M {
+				sort.Slice(nxt, func(a, b int) bool { return nxt[a] > nxt[b] })
+				var key string
+				for k, ee := range nxt {
+					if k > 0 {
+						key += ","
+					}
+					key += strconv.Itoa(ee)
+				}
+				if id, ok := patMap[key]; ok {
+					nbr[i] = append(nbr[i], id)
+				}
+			}
+		}
+		if p.D*2 <= M {
+			nxt := append([]int{}, exps...)
+			nxt = append(nxt, 1)
+			sort.Slice(nxt, func(a, b int) bool { return nxt[a] > nxt[b] })
+			var key string
+			for k, ee := range nxt {
+				if k > 0 {
+					key += ","
+				}
+				key += strconv.Itoa(ee)
+			}
+			if id, ok := patMap[key]; ok {
+				nbr[i] = append(nbr[i], id)
+			}
+		}
+		if len(nbr[i]) > 1 {
+			sort.Ints(nbr[i])
+			u := nbr[i][:1]
+			for _, v := range nbr[i][1:] {
+				if v != u[len(u)-1] {
+					u = append(u, v)
+				}
+			}
+			nbr[i] = u
+		}
+	}
+	INF := 1 << 30
+	dist = make([][]int, M+1)
+	for D := 1; D <= M; D++ {
+		dist[D] = make([]int, P)
+		for i := 0; i < P; i++ {
+			dist[D][i] = INF
+		}
+		var q []int
+		for i, p := range patterns {
+			if p.D == D {
+				dist[D][i] = 0
+				q = append(q, i)
+			}
+		}
+		for qi := 0; qi < len(q); qi++ {
+			u := q[qi]
+			du := dist[D][u]
+			for _, v := range nbr[u] {
+				if dist[D][v] > du+1 {
+					dist[D][v] = du + 1
+					q = append(q, v)
+				}
+			}
+		}
+	}
+}
+
+func sigToPat(n int) int {
+	if n == 1 {
+		return patMap[""]
+	}
+	var exps []int
+	for n > 1 {
+		p := spf[n]
+		cnt := 0
+		for n%p == 0 {
+			n /= p
+			cnt++
+		}
+		exps = append(exps, cnt)
+	}
+	sort.Slice(exps, func(i, j int) bool { return exps[i] > exps[j] })
+	var key string
+	for i, e := range exps {
+		if i > 0 {
+			key += ","
+		}
+		key += strconv.Itoa(e)
+	}
+	return patMap[key]
+}
+
+func solvePair(a, b int) int {
+	INF := 1 << 30
+	pa := sigToPat(a)
+	pb := sigToPat(b)
+	ans := INF
+	for D := 1; D <= M; D++ {
+		da := dist[D][pa]
+		db := dist[D][pb]
+		if da+db < ans {
+			ans = da + db
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	answers := make([]int, t)
+	for i := 0; i < t; i++ {
+		a := rng.Intn(N) + 1
+		b := rng.Intn(N) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+		answers[i] = solvePair(a, b)
+	}
+	var expect bytes.Buffer
+	for i, ans := range answers {
+		if i > 0 {
+			expect.WriteByte('\n')
+		}
+		fmt.Fprintf(&expect, "%d", ans)
+	}
+	expect.WriteByte('\n')
+	return sb.String(), expect.String()
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\nstderr: %s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(expect)
+	if got != exp {
+		return fmt.Errorf("expected %q got %q", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	buildData()
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- provide Go-based verifiers for contest 1031 problems A–F
- each verifier runs 100 generated test cases against a compiled binary

## Testing
- `go build 1000-1999/1000-1099/1030-1039/1031/verifierA.go`
- `go build 1000-1999/1000-1099/1030-1039/1031/verifierB.go`
- `go build 1000-1999/1000-1099/1030-1039/1031/verifierC.go`
- `go build 1000-1999/1000-1099/1030-1039/1031/verifierD.go`
- `go build 1000-1999/1000-1099/1030-1039/1031/verifierE.go`
- `go build 1000-1999/1000-1099/1030-1039/1031/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884585ec06c832497e70d41eed29e51