### PR TITLE
Add Go verifiers for Codeforces contest 1030

### DIFF
--- a/1000-1999/1000-1099/1030-1039/1030/verifierA.go
+++ b/1000-1999/1000-1099/1030-1039/1030/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solve(nums []int) string {
+	for _, v := range nums {
+		if v == 1 {
+			return "HARD\n"
+		}
+	}
+	return "EASY\n"
+}
+
+func buildCase(nums []int) testCase {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(len(nums)))
+	sb.WriteByte('\n')
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expected: solve(nums)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 1
+	nums := make([]int, n)
+	for i := range nums {
+		nums[i] = rng.Intn(2)
+	}
+	return buildCase(nums)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	if got != tc.expected {
+		return fmt.Errorf("expected %q got %q", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase([]int{0}),
+		buildCase([]int{1, 0, 0}),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1030/verifierB.go
+++ b/1000-1999/1000-1099/1030-1039/1030/verifierB.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type point struct{ x, y int }
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func inside(n, d int, p point) string {
+	if p.x+p.y >= d && p.x+p.y <= 2*n-d && p.y-p.x >= -d && p.y-p.x <= d {
+		return "YES\n"
+	}
+	return "NO\n"
+}
+
+func buildCase(n, d int, pts []point) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, d))
+	sb.WriteString(fmt.Sprintf("%d\n", len(pts)))
+	var expSB strings.Builder
+	for _, pt := range pts {
+		sb.WriteString(fmt.Sprintf("%d %d\n", pt.x, pt.y))
+		expSB.WriteString(inside(n, d, pt))
+	}
+	return testCase{input: sb.String(), expected: expSB.String()}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 1
+	d := rng.Intn(n + 1)
+	m := rng.Intn(20) + 1
+	pts := make([]point, m)
+	for i := range pts {
+		pts[i] = point{rng.Intn(n + 1), rng.Intn(n + 1)}
+	}
+	return buildCase(n, d, pts)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if out.String() != tc.expected {
+		return fmt.Errorf("expected %q got %q", tc.expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase(7, 2, []point{{2, 4}, {4, 5}}),
+		buildCase(1, 0, []point{{0, 0}}),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1030/verifierC.go
+++ b/1000-1999/1000-1099/1030-1039/1030/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveTicket(s string) string {
+	n := len(s)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = int(s[i] - '0')
+	}
+	for i := 1; i < n; i++ {
+		target := 0
+		for j := 0; j < i; j++ {
+			target += a[j]
+		}
+		curr := 0
+		cnt := 0
+		ok := true
+		for j := i; j < n; j++ {
+			curr += a[j]
+			if curr > target {
+				ok = false
+				break
+			}
+			if curr == target {
+				curr = 0
+				cnt++
+			}
+		}
+		if ok && curr == 0 && cnt >= 1 {
+			return "YES\n"
+		}
+	}
+	return "NO\n"
+}
+
+func buildCase(s string) testCase {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(len(s)))
+	sb.WriteByte('\n')
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expected: solveTicket(s)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(20) + 2
+	digits := make([]byte, n)
+	for i := range digits {
+		digits[i] = byte(rng.Intn(10)) + '0'
+	}
+	return buildCase(string(digits))
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if out.String() != tc.expected {
+		return fmt.Errorf("expected %q got %q", tc.expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase("350178"),
+		buildCase("99"),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1030/verifierD.go
+++ b/1000-1999/1000-1099/1030-1039/1030/verifierD.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+type testCase struct {
+	n, m, k  int64
+	input    string
+	possible bool
+}
+
+func solve(n, m, k int64) (bool, [6]int64) {
+	tn, tm, tk := n, m, k
+	tg := gcd(tn, tk)
+	tn /= tg
+	tk /= tg
+	tg = gcd(tm, tk)
+	tm /= tg
+	tk /= tg
+	var pts [6]int64
+	if tk != 1 && tk != 2 {
+		return false, pts
+	}
+	if tk == 2 {
+		pts = [6]int64{0, 0, tn, 0, 0, tm}
+		return true, pts
+	}
+	if tn*2 <= n {
+		tn *= 2
+	} else if tm*2 <= m {
+		tm *= 2
+	} else {
+		return false, pts
+	}
+	pts = [6]int64{0, 0, tn, 0, 0, tm}
+	return true, pts
+}
+
+func buildCase(n, m, k int64) testCase {
+	ok, _ := solve(n, m, k)
+	input := fmt.Sprintf("%d %d %d\n", n, m, k)
+	return testCase{n: n, m: m, k: k, input: input, possible: ok}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Int63n(1000000000) + 1
+	m := rng.Int63n(1000000000) + 1
+	k := rng.Int63n(1000000000-1) + 2
+	return buildCase(n, m, k)
+}
+
+func checkOutput(tc testCase, out string) error {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	first := strings.ToUpper(scanner.Text())
+	if first == "NO" {
+		if tc.possible {
+			return fmt.Errorf("expected YES but got NO")
+		}
+		return nil
+	}
+	if first != "YES" {
+		return fmt.Errorf("invalid first token %s", first)
+	}
+	if !tc.possible {
+		return fmt.Errorf("expected NO but got YES")
+	}
+	vals := make([]int64, 0, 6)
+	for scanner.Scan() {
+		v, err := strconv.ParseInt(scanner.Text(), 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid integer %s", scanner.Text())
+		}
+		vals = append(vals, v)
+	}
+	if len(vals) != 6 {
+		return fmt.Errorf("expected 6 integers, got %d", len(vals))
+	}
+	x1, y1, x2, y2, x3, y3 := vals[0], vals[1], vals[2], vals[3], vals[4], vals[5]
+	if x1 < 0 || x1 > tc.n || x2 < 0 || x2 > tc.n || x3 < 0 || x3 > tc.n ||
+		y1 < 0 || y1 > tc.m || y2 < 0 || y2 > tc.m || y3 < 0 || y3 > tc.m {
+		return fmt.Errorf("points out of range")
+	}
+	area2 := abs((x2-x1)*(y3-y1) - (y2-y1)*(x3-x1))
+	target2 := 2 * tc.n * tc.m / tc.k
+	if area2 != target2 {
+		return fmt.Errorf("wrong area")
+	}
+	return nil
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return checkOutput(tc, out.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase(2, 3, 2),
+		buildCase(1, 1, 2),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1030/verifierE.go
+++ b/1000-1999/1000-1099/1030-1039/1030/verifierE.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solve(arr []uint64) string {
+	n := len(arr)
+	c := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		c[i] = bits.OnesCount64(arr[i-1])
+	}
+	cnt := [2]int64{1, 0}
+	par := 0
+	for i := 1; i <= n; i++ {
+		par ^= c[i] & 1
+		cnt[par]++
+	}
+	ans := cnt[0]*(cnt[0]-1)/2 + cnt[1]*(cnt[1]-1)/2
+	const K = 128
+	for r := 1; r <= n; r++ {
+		sum := 0
+		mx := 0
+		for l := r; l >= 1 && r-l < K; l-- {
+			sum += c[l]
+			if c[l] > mx {
+				mx = c[l]
+			}
+			if sum%2 == 0 && mx*2 > sum {
+				ans--
+			}
+		}
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func buildCase(arr []uint64) testCase {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(len(arr)))
+	sb.WriteByte('\n')
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatUint(v, 10))
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expected: solve(arr)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(30) + 1
+	arr := make([]uint64, n)
+	for i := range arr {
+		arr[i] = rng.Uint64() % (1 << 20)
+	}
+	return buildCase(arr)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if out.String() != tc.expected {
+		return fmt.Errorf("expected %q got %q", tc.expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase([]uint64{1, 2, 3}),
+		buildCase([]uint64{7, 7, 7}),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1030/verifierF.go
+++ b/1000-1999/1000-1099/1030-1039/1030/verifierF.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+type Fenwick struct {
+	n int
+	t []int64
+}
+
+func NewFenwick(n int) *Fenwick {
+	return &Fenwick{n: n, t: make([]int64, n+1)}
+}
+
+func (f *Fenwick) Add(i int, v int64) {
+	for x := i; x <= f.n; x += x & -x {
+		f.t[x] += v
+	}
+}
+
+func (f *Fenwick) Sum(i int) int64 {
+	var s int64
+	for x := i; x > 0; x -= x & -x {
+		s += f.t[x]
+	}
+	return s
+}
+
+func (f *Fenwick) LowerBound(target int64) int {
+	idx := 0
+	var sum int64
+	bit := 1
+	for bit<<1 <= f.n {
+		bit <<= 1
+	}
+	for step := bit; step > 0; step >>= 1 {
+		nxt := idx + step
+		if nxt <= f.n && sum+f.t[nxt] < target {
+			sum += f.t[nxt]
+			idx = nxt
+		}
+	}
+	return idx + 1
+}
+
+type FenwickMod struct {
+	n int
+	t []int64
+}
+
+func NewFenwickMod(n int) *FenwickMod {
+	return &FenwickMod{n: n, t: make([]int64, n+1)}
+}
+
+func (f *FenwickMod) Add(i int, v int64) {
+	v %= MOD
+	if v < 0 {
+		v += MOD
+	}
+	for x := i; x <= f.n; x += x & -x {
+		f.t[x] += v
+		if f.t[x] >= MOD {
+			f.t[x] -= MOD
+		}
+	}
+}
+
+func (f *FenwickMod) Sum(i int) int64 {
+	var s int64
+	for x := i; x > 0; x -= x & -x {
+		s += f.t[x]
+		if s >= MOD {
+			s -= MOD
+		}
+	}
+	return s
+}
+
+func solve(n, q int, a, w []int64, queries [][2]int64) string {
+	B := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		B[i] = a[i] - int64(i)
+	}
+	bitW := NewFenwick(n)
+	bitWB := NewFenwickMod(n)
+	for i := 1; i <= n; i++ {
+		bitW.Add(i, w[i])
+		bi := B[i] % MOD
+		if bi < 0 {
+			bi += MOD
+		}
+		bitWB.Add(i, w[i]%MOD*bi%MOD)
+	}
+	var out strings.Builder
+	for _, qu := range queries {
+		x, y := qu[0], qu[1]
+		if x < 0 {
+			id := int(-x)
+			neww := y
+			delta := neww - w[id]
+			w[id] = neww
+			bitW.Add(id, delta)
+			bi := B[id] % MOD
+			if bi < 0 {
+				bi += MOD
+			}
+			bitWB.Add(id, delta%MOD*bi%MOD)
+		} else {
+			l := int(x)
+			r := int(y)
+			tot := bitW.Sum(r) - bitW.Sum(l-1)
+			half := (tot + 1) / 2
+			base := bitW.Sum(l - 1)
+			m := bitW.LowerBound(base + half)
+			if m > r {
+				m = r
+			}
+			sumWl := bitW.Sum(m) - bitW.Sum(l-1)
+			sumWr := bitW.Sum(r) - bitW.Sum(m)
+			sumWB_l := (bitWB.Sum(m) - bitWB.Sum(l-1) + MOD) % MOD
+			sumWB_r := (bitWB.Sum(r) - bitWB.Sum(m) + MOD) % MOD
+			med := B[m] % MOD
+			if med < 0 {
+				med += MOD
+			}
+			swl := sumWl % MOD
+			swr := sumWr % MOD
+			c1 := (med*swl%MOD - sumWB_l + MOD) % MOD
+			c2 := (sumWB_r - med*swr%MOD + MOD) % MOD
+			res := (c1 + c2) % MOD
+			out.WriteString(fmt.Sprintf("%d\n", res))
+		}
+	}
+	return out.String()
+}
+
+func buildCase(n int, q int, a, w []int64, queries [][2]int64) testCase {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(a[i], 10))
+	}
+	sb.WriteByte('\n')
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(w[i], 10))
+	}
+	sb.WriteByte('\n')
+	for _, qu := range queries {
+		sb.WriteString(fmt.Sprintf("%d %d\n", qu[0], qu[1]))
+	}
+	return testCase{input: sb.String(), expected: solve(n, q, a, w, queries)}
+}
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	q := rng.Intn(10) + 1
+	a := make([]int64, n+1)
+	w := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = int64(rng.Intn(20))
+		w[i] = int64(rng.Intn(10) + 1)
+	}
+	queries := make([][2]int64, q)
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			id := int64(rng.Intn(n) + 1)
+			nw := int64(rng.Intn(10) + 1)
+			queries[i] = [2]int64{-id, nw}
+		} else {
+			l := int64(rng.Intn(n) + 1)
+			r := int64(rng.Intn(n-int(l)+1) + int(l))
+			queries[i] = [2]int64{l, r}
+		}
+	}
+	return buildCase(n, q, a, w, queries)
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if out.String() != tc.expected {
+		return fmt.Errorf("expected %q got %q", tc.expected, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	a := []int64{0, 1}
+	w := []int64{0, 1}
+	cases := []testCase{
+		buildCase(1, 1, a, w, [][2]int64{{1, 1}}),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1030/verifierG.go
+++ b/1000-1999/1000-1099/1030-1039/1030/verifierG.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+const mod = 1000000007
+
+func solve(primes []int) string {
+	seen := make(map[int]bool)
+	prod := int64(1)
+	for _, p := range primes {
+		if !seen[p] {
+			seen[p] = true
+			prod = (prod * int64(p)) % mod
+		}
+	}
+	return fmt.Sprintf("%d\n", prod)
+}
+
+func buildCase(pr []int) testCase {
+	var sb strings.Builder
+	sb.WriteString(strconv.Itoa(len(pr)))
+	sb.WriteByte('\n')
+	for i, v := range pr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return testCase{input: sb.String(), expected: solve(pr)}
+}
+
+func randomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(10) + 1
+	pr := make([]int, n)
+	for i := range pr {
+		pr[i] = randPrime(rng)
+	}
+	return buildCase(pr)
+}
+
+func randPrime(rng *rand.Rand) int {
+	primes := []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47}
+	return primes[rng.Intn(len(primes))]
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{
+		buildCase([]int{2, 3, 5}),
+		buildCase([]int{7, 7, 7, 11}),
+	}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, randomCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for problems A–G in contest 1030
- each verifier generates over 100 tests and validates binaries

## Testing
- `go run verifierA.go ./1030A`
- `go run verifierB.go ./1030B`
- `go run verifierC.go ./1030C`
- `go run verifierD.go ./1030D`
- `go run verifierE.go ./1030E`
- `go run verifierF.go ./1030F`
- `go run verifierG.go ./1030G`


------
https://chatgpt.com/codex/tasks/task_e_688457d2af008324865b72e8b95a3bf4