### PR TITLE
Add verifiers for contest 1033

### DIFF
--- a/1000-1999/1000-1099/1030-1039/1033/verifierA.go
+++ b/1000-1999/1000-1099/1030-1039/1033/verifierA.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(bytes.TrimSpace(out)), err
+}
+
+func region(x, y, qx, qy int) int {
+	ans := 0
+	if x < qx {
+		ans = 1
+	}
+	ans <<= 1
+	if y < qy {
+		ans |= 1
+	}
+	return ans
+}
+
+func solveCase(n, qx, qy, bx, by, cx, cy int) string {
+	if region(bx, by, qx, qy) == region(cx, cy, qx, qy) {
+		return "YES"
+	}
+	return "NO"
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Intn(998) + 3 // 3..1000
+	qx := rng.Intn(n) + 1
+	qy := rng.Intn(n) + 1
+	var bx, by, cx, cy int
+	for {
+		bx = rng.Intn(n) + 1
+		by = rng.Intn(n) + 1
+		if bx != qx && by != qy && abs(bx-qx) != abs(by-qy) {
+			break
+		}
+	}
+	for {
+		cx = rng.Intn(n) + 1
+		cy = rng.Intn(n) + 1
+		if cx != qx && cy != qy && abs(cx-qx) != abs(cy-qy) && (cx != bx || cy != by) {
+			break
+		}
+	}
+	return []byte(fmt.Sprintf("%d\n%d %d\n%d %d %d %d\n", n, qx, qy, bx, by, cx, cy))
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref := "./refA.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1033A.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i+1, string(input), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1000-1099/1030-1039/1033/verifierB.go
+++ b/1000-1999/1000-1099/1030-1039/1033/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(bytes.TrimSpace(out)), err
+}
+
+func genCase(rng *rand.Rand) []byte {
+	t := rng.Intn(5) + 1 // 1..5
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		a := rng.Intn(1_000_000-2) + 2
+		b := rng.Intn(a-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref := "./refB.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1033B.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(input), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1000-1099/1030-1039/1033/verifierC.go
+++ b/1000-1999/1000-1099/1030-1039/1033/verifierC.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(bytes.TrimSpace(out)), err
+}
+
+func genPerm(rng *rand.Rand, n int) []int {
+	arr := rng.Perm(n)
+	for i := range arr {
+		arr[i]++
+	}
+	return arr
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Intn(20) + 1
+	perm := genPerm(rng, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref := "./refC.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1033C.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(input), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1000-1099/1030-1039/1033/verifierD.go
+++ b/1000-1999/1000-1099/1030-1039/1033/verifierD.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(bytes.TrimSpace(out)), err
+}
+
+var primes []uint64
+
+func init() {
+	// simple primes up to 1000
+	isPrime := make([]bool, 1001)
+	for i := 2; i <= 1000; i++ {
+		isPrime[i] = true
+	}
+	for p := 2; p*p <= 1000; p++ {
+		if isPrime[p] {
+			for j := p * p; j <= 1000; j += p {
+				isPrime[j] = false
+			}
+		}
+	}
+	for i := 2; i <= 1000; i++ {
+		if isPrime[i] {
+			primes = append(primes, uint64(i))
+		}
+	}
+}
+
+func genNumber(rng *rand.Rand) uint64 {
+	p := primes[rng.Intn(len(primes))]
+	choice := rng.Intn(4)
+	switch choice {
+	case 0:
+		return p * p // p^2 -> 3 divisors
+	case 1:
+		return p * p * p // p^3 -> 4 divisors
+	case 2:
+		q := primes[rng.Intn(len(primes))]
+		for q == p {
+			q = primes[rng.Intn(len(primes))]
+		}
+		return p * q // product of two primes -> 4 divisors
+	default:
+		return p * p * p * p // p^4 -> 5 divisors
+	}
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d\n", genNumber(rng)))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref := "./refD.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1033D.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(input), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1000-1099/1030-1039/1033/verifierE.go
+++ b/1000-1999/1000-1099/1030-1039/1033/verifierE.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type graph struct {
+	n   int
+	adj [][]bool
+}
+
+func genGraph(rng *rand.Rand) graph {
+	n := rng.Intn(5) + 2 // 2..6
+	adj := make([][]bool, n+1)
+	for i := range adj {
+		adj[i] = make([]bool, n+1)
+	}
+	// tree edges
+	for i := 2; i <= n; i++ {
+		j := rng.Intn(i-1) + 1
+		adj[i][j] = true
+		adj[j][i] = true
+	}
+	// extra edges
+	for k := 0; k < n; k++ {
+		if rng.Float64() < 0.3 {
+			a := rng.Intn(n) + 1
+			b := rng.Intn(n) + 1
+			if a != b && !adj[a][b] {
+				adj[a][b] = true
+				adj[b][a] = true
+			}
+		}
+	}
+	return graph{n: n, adj: adj}
+}
+
+func countEdges(sub []int, g graph) int {
+	mark := make([]bool, g.n+1)
+	for _, v := range sub {
+		mark[v] = true
+	}
+	cnt := 0
+	for i := 1; i <= g.n; i++ {
+		if !mark[i] {
+			continue
+		}
+		for j := i + 1; j <= g.n; j++ {
+			if mark[j] && g.adj[i][j] {
+				cnt++
+			}
+		}
+	}
+	return cnt
+}
+
+func bipartiteCheck(g graph) (bool, []int) {
+	color := make([]int, g.n+1)
+	for i := range color {
+		color[i] = -1
+	}
+	queue := []int{1}
+	color[1] = 0
+	for len(queue) > 0 {
+		v := queue[0]
+		queue = queue[1:]
+		for u := 1; u <= g.n; u++ {
+			if !g.adj[v][u] {
+				continue
+			}
+			if color[u] == -1 {
+				color[u] = color[v] ^ 1
+				queue = append(queue, u)
+			} else if color[u] == color[v] {
+				return false, nil
+			}
+		}
+	}
+	return true, color
+}
+
+func parseList(s string) []int {
+	f := strings.Fields(s)
+	if len(f) == 0 {
+		return nil
+	}
+	var k int
+	fmt.Sscanf(f[0], "%d", &k)
+	res := make([]int, 0, k)
+	for i := 1; i < len(f); i++ {
+		var v int
+		fmt.Sscanf(f[i], "%d", &v)
+		res = append(res, v)
+	}
+	return res
+}
+
+func runCase(bin string, g graph) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdin, "%d\n", g.n)
+	reader := bufio.NewReader(stdout)
+	queryCount := 0
+	bip, _ := bipartiteCheck(g)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("read error: %v stderr:%s", err, stderr.String())
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "?") {
+			queryCount++
+			if queryCount > 20000 {
+				return fmt.Errorf("too many queries")
+			}
+			fields := strings.Fields(line)
+			subset := make([]int, 0, len(fields)-1)
+			for _, s := range fields[1:] {
+				var v int
+				fmt.Sscanf(s, "%d", &v)
+				if v < 1 || v > g.n {
+					return fmt.Errorf("bad vertex %d", v)
+				}
+				subset = append(subset, v)
+			}
+			ans := countEdges(subset, g)
+			fmt.Fprintf(stdin, "%d\n", ans)
+		} else if strings.HasPrefix(line, "!") {
+			rest := strings.TrimSpace(line[1:])
+			if bip {
+				if !strings.HasPrefix(strings.ToUpper(rest), "Y") {
+					return fmt.Errorf("expected Y for bipartite")
+				}
+				l1, _ := reader.ReadString('\n')
+				l2, _ := reader.ReadString('\n')
+				g1 := parseList(l1)
+				g2 := parseList(l2)
+				if len(g1)+len(g2) != g.n {
+					return fmt.Errorf("wrong partition size")
+				}
+				assign := make([]int, g.n+1)
+				for _, v := range g1 {
+					assign[v] = 0
+				}
+				for _, v := range g2 {
+					if assign[v] != 0 {
+						return fmt.Errorf("dup vertex")
+					}
+					assign[v] = 1
+				}
+				for i := 1; i <= g.n; i++ {
+					for j := i + 1; j <= g.n; j++ {
+						if g.adj[i][j] && assign[i] == assign[j] {
+							return fmt.Errorf("edge inside partition")
+						}
+					}
+				}
+				stdin.Close()
+				return cmd.Wait()
+			} else {
+				if !strings.HasPrefix(strings.ToUpper(rest), "N") {
+					return fmt.Errorf("expected N for non-bipartite")
+				}
+				l1, _ := reader.ReadString('\n')
+				cyc := parseList(l1)
+				if len(cyc)%2 == 0 || len(cyc) < 3 {
+					return fmt.Errorf("invalid cycle length")
+				}
+				for i := 0; i < len(cyc); i++ {
+					v := cyc[i]
+					if v < 1 || v > g.n {
+						return fmt.Errorf("bad vertex")
+					}
+					u := cyc[(i+1)%len(cyc)]
+					if !g.adj[v][u] {
+						return fmt.Errorf("edge missing")
+					}
+				}
+				stdin.Close()
+				return cmd.Wait()
+			}
+		}
+	}
+}
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		g := genGraph(rng)
+		if err := runCase(bin, g); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1033/verifierF.go
+++ b/1000-1999/1000-1099/1030-1039/1033/verifierF.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(bytes.TrimSpace(out)), err
+}
+
+var ops = []rune{'A', 'O', 'X', 'a', 'o', 'x'}
+
+func genCase(rng *rand.Rand) []byte {
+	w := rng.Intn(5) + 1
+	n := rng.Intn(10) + 1
+	m := rng.Intn(5) + 1
+	size := 1 << w
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", w, n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(size)))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		gate := make([]rune, w)
+		for j := 0; j < w; j++ {
+			gate[j] = ops[rng.Intn(len(ops))]
+		}
+		sb.WriteString(string(gate))
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref := "./refF.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1033F.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(input), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1000-1099/1030-1039/1033/verifierG.go
+++ b/1000-1999/1000-1099/1030-1039/1033/verifierG.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildIfGo(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp, err := os.CreateTemp("", "solbin*")
+		if err != nil {
+			return "", nil, err
+		}
+		tmp.Close()
+		if out, err := exec.Command("go", "build", "-o", tmp.Name(), path).CombinedOutput(); err != nil {
+			os.Remove(tmp.Name())
+			return "", nil, fmt.Errorf("build failed: %v\n%s", err, string(out))
+		}
+		return tmp.Name(), func() { os.Remove(tmp.Name()) }, nil
+	}
+	return path, func() {}, nil
+}
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(bytes.TrimSpace(out)), err
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(100)+1))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand, cleanup, err := buildIfGo(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	ref := "./refG.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1033G.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(input), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for all problems in contest 1033
- verifiers compile candidate solutions, generate at least 100 random tests and check output
- interactive verifier implemented for problem E

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68845976f7248324a6a879ba96aa1972