### PR TITLE
Add verifiers for contest 1037

### DIFF
--- a/1000-1999/1000-1099/1030-1039/1037/verifierA.go
+++ b/1000-1999/1000-1099/1030-1039/1037/verifierA.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(n int64) string {
+	for i := 0; ; i++ {
+		if n < 1<<i {
+			return fmt.Sprintf("%d", i)
+		}
+	}
+}
+
+func genCase(r *rand.Rand) (string, string) {
+	n := r.Int63n(1_000_000_000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	expect := solveCase(n)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1037/verifierB.go
+++ b/1000-1999/1000-1099/1030-1039/1037/verifierB.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(n int, s int, arr []int) string {
+	sort.Ints(arr)
+	mid := n / 2
+	var ans int64
+	if arr[mid] < s {
+		for i := mid; i < n; i++ {
+			if arr[i] < s {
+				ans += int64(s - arr[i])
+			}
+		}
+	} else {
+		for i := 0; i <= mid; i++ {
+			if arr[i] > s {
+				ans += int64(arr[i] - s)
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(r *rand.Rand) (string, string) {
+	n := r.Intn(99)*2 + 1 // odd up to 199
+	s := r.Intn(1_000_000_000) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = r.Intn(1_000_000_000)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, s))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	expect := solveCase(n, s, append([]int(nil), arr...))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1037/verifierC.go
+++ b/1000-1999/1000-1099/1030-1039/1037/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveCase(a, b []byte) string {
+	n := len(a)
+	ans := 0
+	for i := 1; i < n; i++ {
+		if a[i-1] == b[i] && a[i] == b[i-1] && a[i-1] != a[i] {
+			ans++
+			a[i-1] = b[i-1]
+			a[i] = b[i]
+		}
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			ans++
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func genCase(r *rand.Rand) (string, string) {
+	n := r.Intn(100) + 1
+	a := make([]byte, n)
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if r.Intn(2) == 0 {
+			a[i] = '0'
+		} else {
+			a[i] = '1'
+		}
+		if r.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	input := fmt.Sprintf("%d\n%s\n%s\n", n, a, b)
+	expect := solveCase(append([]byte(nil), a...), append([]byte(nil), b...))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1037/verifierD.go
+++ b/1000-1999/1000-1099/1030-1039/1037/verifierD.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func checkBFS(n int, edges [][2]int, order []int) string {
+	if len(order) != n || order[0] != 1 {
+		return "No"
+	}
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	visited := make([]bool, n+1)
+	queue := []int{1}
+	visited[1] = true
+	idx := 1
+	for len(queue) > 0 {
+		u := queue[0]
+		queue = queue[1:]
+		// gather unvisited neighbors
+		var neigh []int
+		for _, v := range adj[u] {
+			if !visited[v] {
+				neigh = append(neigh, v)
+				visited[v] = true
+			}
+		}
+		// check that next len(neigh) numbers in order are exactly these neighbors
+		set := make(map[int]bool)
+		for _, v := range neigh {
+			set[v] = true
+		}
+		for i := 0; i < len(neigh); i++ {
+			if idx >= len(order) || !set[order[idx]] {
+				return "No"
+			}
+			queue = append(queue, order[idx])
+			idx++
+		}
+	}
+	if idx != len(order) {
+		return "No"
+	}
+	return "Yes"
+}
+
+func genCase(r *rand.Rand) (string, string) {
+	n := r.Intn(9) + 2 // at least 2
+	edges := make([][2]int, n-1)
+	// build random tree using union
+	parent := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] == x {
+			return x
+		}
+		parent[x] = find(parent[x])
+		return parent[x]
+	}
+	union := func(a, b int) bool {
+		ra, rb := find(a), find(b)
+		if ra == rb {
+			return false
+		}
+		parent[ra] = rb
+		return true
+	}
+	idx := 0
+	for idx < n-1 {
+		u := r.Intn(n) + 1
+		v := r.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if union(u, v) {
+			edges[idx] = [2]int{u, v}
+			idx++
+		}
+	}
+	// compute bfs order
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	visited := make([]bool, n+1)
+	order := make([]int, 0, n)
+	q := []int{1}
+	visited[1] = true
+	for len(q) > 0 {
+		u := q[0]
+		q = q[1:]
+		order = append(order, u)
+		for _, v := range adj[u] {
+			if !visited[v] {
+				visited[v] = true
+				q = append(q, v)
+			}
+		}
+	}
+	// maybe make invalid
+	if r.Intn(2) == 0 {
+		// shuffle order randomly to make invalid
+		i := r.Intn(n-1) + 1
+		j := r.Intn(n-1) + 1
+		order[i], order[j] = order[j], order[i]
+	}
+	// compute expected
+	expect := checkBFS(n, edges, order)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	for i, v := range order {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runBinary(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1037/verifierE.go
+++ b/1000-1999/1000-1099/1030-1039/1037/verifierE.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	dir := filepath.Dir(os.Args[0])
+	src := filepath.Join(dir, "1037E.go")
+	out := filepath.Join(os.TempDir(), "ref1037E.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runCmd(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(r *rand.Rand) (string, string) {
+	n := r.Intn(5) + 1
+	maxM := n * (n - 1) / 2
+	m := r.Intn(maxM + 1)
+	p := r.Intn(n) + 1
+	edges := make([][2]int, 0, m)
+	seen := make(map[[2]int]bool)
+	for len(edges) < m {
+		u := r.Intn(n) + 1
+		v := r.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		pair := [2]int{u, v}
+		if seen[pair] {
+			continue
+		}
+		seen[pair] = true
+		edges = append(edges, pair)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, p))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	input := sb.String()
+	// run reference to get expected
+	refBin, err := compileRef()
+	if err != nil {
+		panic(err)
+	}
+	exp, err := runCmd(refBin, input)
+	if err != nil {
+		panic(err)
+	}
+	os.Remove(refBin)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCmd(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1037/verifierF.go
+++ b/1000-1999/1000-1099/1030-1039/1037/verifierF.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	dir := filepath.Dir(os.Args[0])
+	src := filepath.Join(dir, "1037F.go")
+	out := filepath.Join(os.TempDir(), "ref1037F.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runCmd(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(r *rand.Rand) (string, string) {
+	n := r.Intn(6) + 1
+	K := r.Intn(n) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = r.Intn(20) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, K))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	refBin, err := compileRef()
+	if err != nil {
+		panic(err)
+	}
+	exp, err := runCmd(refBin, sb.String())
+	if err != nil {
+		panic(err)
+	}
+	os.Remove(refBin)
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCmd(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1037/verifierG.go
+++ b/1000-1999/1000-1099/1030-1039/1037/verifierG.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	dir := filepath.Dir(os.Args[0])
+	src := filepath.Join(dir, "1037G.go")
+	out := filepath.Join(os.TempDir(), "ref1037G.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runCmd(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(r *rand.Rand) (string, string) {
+	n := r.Intn(5) + 1
+	letters := []byte{'a', 'b', 'c'}
+	s := make([]byte, n)
+	for i := range s {
+		s[i] = letters[r.Intn(len(letters))]
+	}
+	m := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s\n%d\n", s, m))
+	for i := 0; i < m; i++ {
+		l := r.Intn(n) + 1
+		rpos := r.Intn(n-l+1) + l
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, rpos))
+	}
+	input := sb.String()
+	refBin, err := compileRef()
+	if err != nil {
+		panic(err)
+	}
+	exp, err := runCmd(refBin, input)
+	if err != nil {
+		panic(err)
+	}
+	os.Remove(refBin)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCmd(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1037/verifierH.go
+++ b/1000-1999/1000-1099/1030-1039/1037/verifierH.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	dir := filepath.Dir(os.Args[0])
+	src := filepath.Join(dir, "1037H.go")
+	out := filepath.Join(os.TempDir(), "ref1037H.bin")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runCmd(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(r *rand.Rand) (string, string) {
+	n := r.Intn(5) + 1
+	letters := []byte{'a', 'b'}
+	s := make([]byte, n)
+	for i := range s {
+		s[i] = letters[r.Intn(len(letters))]
+	}
+	q := r.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s\n%d\n", s, q))
+	for i := 0; i < q; i++ {
+		l := r.Intn(n) + 1
+		rpos := r.Intn(n-l+1) + l
+		// pattern length 1..3
+		plen := r.Intn(3) + 1
+		pat := make([]byte, plen)
+		for j := range pat {
+			pat[j] = letters[r.Intn(len(letters))]
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %s\n", l, rpos, pat))
+	}
+	input := sb.String()
+	refBin, err := compileRef()
+	if err != nil {
+		panic(err)
+	}
+	exp, err := runCmd(refBin, input)
+	if err != nil {
+		panic(err)
+	}
+	os.Remove(refBin)
+	return input, exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := runCmd(bin, in)
+		if err != nil {
+			fmt.Printf("Test %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go-based verifiers for all problems A–H of Codeforces contest 1037
- each verifier generates 100 random cases and checks a supplied binary

## Testing
- `go build 1000-1999/1000-1099/1030-1039/1037/verifierA.go`
- `go build 1000-1999/1000-1099/1030-1039/1037/verifierB.go`
- `go build 1000-1999/1000-1099/1030-1039/1037/verifierC.go`
- `go build 1000-1999/1000-1099/1030-1039/1037/verifierD.go`
- `go build 1000-1999/1000-1099/1030-1039/1037/verifierE.go`
- `go build 1000-1999/1000-1099/1030-1039/1037/verifierF.go`
- `go build 1000-1999/1000-1099/1030-1039/1037/verifierG.go`
- `go build 1000-1999/1000-1099/1030-1039/1037/verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_68845ba736c083248e759725c6f848fe