### PR TITLE
Add verifiers for Codeforces contest 1039

### DIFF
--- a/1000-1999/1000-1099/1030-1039/1039/verifierA.go
+++ b/1000-1999/1000-1099/1030-1039/1039/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]string, 0, 120)
+	for len(tests) < 120 {
+		n := r.Intn(5) + 1
+		t := r.Int63n(10) + 1
+		a := make([]int64, n)
+		cur := r.Int63n(5) + 1
+		for i := 0; i < n; i++ {
+			cur += r.Int63n(5) + 1
+			a[i] = cur
+		}
+		x := make([]int, n)
+		for i := 0; i < n; i++ {
+			if r.Intn(4) == 0 {
+				x[i] = r.Intn(n) + 1
+			} else {
+				x[i] = i + 1 + r.Intn(n-i)
+			}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, t)
+		for i, v := range a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(v, 10))
+		}
+		sb.WriteByte('\n')
+		for i, v := range x {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialA"
+	if err := exec.Command("go", "build", "-o", official, "1039A.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1039/verifierB.go
+++ b/1000-1999/1000-1099/1030-1039/1039/verifierB.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem B is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1000-1099/1030-1039/1039/verifierC.go
+++ b/1000-1999/1000-1099/1030-1039/1039/verifierC.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(2))
+	tests := make([]string, 0, 120)
+	for len(tests) < 120 {
+		n := r.Intn(5) + 1
+		k := r.Intn(4)
+		maxEdges := n * (n - 1) / 2
+		m := r.Intn(maxEdges + 1)
+		keys := make([]int64, n)
+		for i := 0; i < n; i++ {
+			limit := int64(1)
+			if k > 0 {
+				limit = int64(1) << uint(k)
+			}
+			if limit > 1 {
+				keys[i] = r.Int63n(limit)
+			} else {
+				keys[i] = 0
+			}
+		}
+		edges := make(map[[2]int]bool)
+		var edgeList [][2]int
+		for len(edgeList) < m {
+			u := r.Intn(n)
+			v := r.Intn(n)
+			if u == v {
+				continue
+			}
+			if u > v {
+				u, v = v, u
+			}
+			key := [2]int{u, v}
+			if !edges[key] {
+				edges[key] = true
+				edgeList = append(edgeList, key)
+			}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+		for i, v := range keys {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(v, 10))
+		}
+		sb.WriteByte('\n')
+		for _, e := range edgeList {
+			fmt.Fprintf(&sb, "%d %d\n", e[0]+1, e[1]+1)
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialC"
+	if err := exec.Command("go", "build", "-o", official, "1039C.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1039/verifierD.go
+++ b/1000-1999/1000-1099/1030-1039/1039/verifierD.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(3))
+	tests := make([]string, 0, 120)
+	for len(tests) < 120 {
+		n := r.Intn(8) + 2
+		edges := make([][2]int, 0, n-1)
+		for i := 2; i <= n; i++ {
+			p := r.Intn(i-1) + 1
+			edges = append(edges, [2]int{p, i})
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for _, e := range edges {
+			fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialD"
+	if err := exec.Command("go", "build", "-o", official, "1039D.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1000-1099/1030-1039/1039/verifierE.go
+++ b/1000-1999/1000-1099/1030-1039/1039/verifierE.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(4))
+	tests := make([]string, 0, 120)
+	for len(tests) < 120 {
+		n := r.Intn(5) + 1
+		w := r.Intn(20) + 1
+		q := r.Intn(5) + 1
+		xs := make([]int, n)
+		for i := 0; i < n; i++ {
+			xs[i] = r.Intn(30)
+		}
+		ks := make([]int, 0, q)
+		used := make(map[int]bool)
+		for len(ks) < q {
+			val := r.Intn(w) + 1
+			if !used[val] {
+				used[val] = true
+				ks = append(ks, val)
+			}
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, w, q)
+		for i, v := range xs {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		for i, v := range ks {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialE"
+	if err := exec.Command("go", "build", "-o", official, "1039E.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1039 problems A–E
- verifierB prints message because the problem is interactive

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68845cc004b08324a9506ea46da60a08