### PR TITLE
Add Go solution for 1650D

### DIFF
--- a/1000-1999/1600-1699/1650-1659/1650/1650D.go
+++ b/1000-1999/1600-1699/1650-1659/1650/1650D.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		d := make([]int, n)
+		for i := n; i >= 1; i-- {
+			pos := 0
+			for j := 0; j < i; j++ {
+				if a[j] == i {
+					pos = j + 1
+					break
+				}
+			}
+			di := pos % i
+			d[i-1] = di
+			if di > 0 {
+				prefix := append([]int{}, a[di:i]...)
+				prefix = append(prefix, a[:di]...)
+				copy(a[:i], prefix)
+			}
+		}
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				writer.WriteByte(' ')
+			}
+			fmt.Fprint(writer, d[i])
+		}
+		writer.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for 1650D

## Testing
- `go run 1000-1999/1600-1699/1650-1659/1650/1650D.go < /tmp/test.in`
- `python3 - <<'PY' ...` (randomized test)

------
https://chatgpt.com/codex/tasks/task_e_68845e1daa2c8324aec96494bb69bba0