### PR TITLE
Add Go verifiers for CF contest 1043

### DIFF
--- a/1000-1999/1000-1099/1040-1049/1043/verifierA.go
+++ b/1000-1999/1000-1099/1040-1049/1043/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(a []int) string {
+	n := len(a)
+	sum := 0
+	maxa := 0
+	for _, v := range a {
+		sum += v
+		if v > maxa {
+			maxa = v
+		}
+	}
+	k := (2*sum)/n + 1
+	if k < maxa {
+		k = maxa
+	}
+	return fmt.Sprintf("%d", k)
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(want) != got {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tests := [][]int{{1}, {5, 1, 1, 1, 5}}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(100) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(100) + 1
+		}
+		tests = append(tests, arr)
+	}
+
+	for i, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(tc)))
+		for j, v := range tc {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		want := expected(tc)
+		if err := runCase(bin, sb.String(), want); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1040-1049/1043/verifierB.go
+++ b/1000-1999/1000-1099/1040-1049/1043/verifierB.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(arr []int) (int, []int) {
+	n := len(arr)
+	dif := make([]int, n)
+	if n > 0 {
+		dif[0] = arr[0]
+	}
+	for i := 1; i < n; i++ {
+		dif[i] = arr[i] - arr[i-1]
+	}
+	per := make([]bool, n+1)
+	ans := 0
+	for i := 1; i <= n; i++ {
+		per[i] = true
+		for x := 0; x < n; x++ {
+			if dif[x] != dif[x%i] {
+				per[i] = false
+				break
+			}
+		}
+		if per[i] {
+			ans++
+		}
+	}
+	res := make([]int, 0, ans)
+	for i := 1; i <= n; i++ {
+		if per[i] {
+			res = append(res, i)
+		}
+	}
+	return ans, res
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(want) != got {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tests := [][]int{{1, 2, 3, 4}, {1, 3, 6, 7, 9}}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		arr := make([]int, n)
+		cur := rng.Intn(10)
+		for j := 0; j < n; j++ {
+			cur += rng.Intn(5)
+			arr[j] = cur
+		}
+		tests = append(tests, arr)
+	}
+
+	for idx, arr := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+		for i, v := range arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		cnt, vals := solve(arr)
+		want := fmt.Sprintf("%d\n", cnt)
+		for i, v := range vals {
+			if i > 0 {
+				want += " "
+			}
+			want += fmt.Sprintf("%d", v)
+		}
+		want += "\n"
+		if err := runCase(bin, sb.String(), want); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1040-1049/1043/verifierC.go
+++ b/1000-1999/1000-1099/1040-1049/1043/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) string {
+	n := len(s)
+	b := []byte(s)
+	res := make([]int, n)
+	for i := 1; i < n; i++ {
+		rev := false
+		if i == n-1 {
+			if b[i] == 'a' {
+				rev = true
+			}
+		} else {
+			if b[i] != b[i+1] {
+				rev = true
+			}
+		}
+		if rev {
+			res[i] = 1
+			for l, r := 0, i; l < r; l, r = l+1, r-1 {
+				b[l], b[r] = b[r], b[l]
+			}
+		}
+	}
+	var sb strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(want) != got {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tests := []string{"abba", "aaaa"}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		b := make([]byte, n)
+		for j := range b {
+			if rng.Intn(2) == 0 {
+				b[j] = 'a'
+			} else {
+				b[j] = 'b'
+			}
+		}
+		tests = append(tests, string(b))
+	}
+
+	for idx, s := range tests {
+		input := s + "\n"
+		want := expected(s)
+		if err := runCase(bin, input, want); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1040-1049/1043/verifierD.go
+++ b/1000-1999/1000-1099/1040-1049/1043/verifierD.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(perms [][]int) string {
+	M := len(perms)
+	if M == 0 {
+		return "0\n"
+	}
+	N := len(perms[0])
+	a := make([][]int, M)
+	for i := 0; i < M; i++ {
+		a[i] = make([]int, N+2)
+		copy(a[i][1:], perms[i])
+	}
+	father := make([]int, N+1)
+	cnt := make([]int, N+1)
+	for j := 1; j <= N; j++ {
+		father[a[0][j]] = a[0][j+1]
+	}
+	for i := 1; i < M; i++ {
+		for j := 1; j <= N; j++ {
+			if father[a[i][j]] != a[i][j+1] {
+				father[a[i][j]] = 0
+			}
+		}
+	}
+	for i := 1; i <= N; i++ {
+		if father[i] == 0 {
+			father[i] = i
+		}
+	}
+	var getfather func(int) int
+	getfather = func(x int) int {
+		if father[x] != x {
+			father[x] = getfather(father[x])
+		}
+		return father[x]
+	}
+	for i := 1; i <= N; i++ {
+		root := getfather(i)
+		if root != 0 {
+			cnt[root]++
+		}
+	}
+	ans := int64(N)
+	for i := 1; i <= N; i++ {
+		if cnt[i] > 1 {
+			ans += int64(cnt[i]) * int64(cnt[i]-1) / 2
+		}
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(want) != got {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tests := [][][]int{{{1, 2, 3}}}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 1
+		m := rng.Intn(3) + 1
+		casep := make([][]int, m)
+		for j := 0; j < m; j++ {
+			perm := rand.Perm(n)
+			for k := range perm {
+				perm[k]++
+			}
+			casep[j] = perm
+		}
+		tests = append(tests, casep)
+	}
+
+	for idx, tc := range tests {
+		m := len(tc)
+		n := len(tc[0])
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < m; i++ {
+			for j, v := range tc[i] {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", v))
+			}
+			sb.WriteByte('\n')
+		}
+		want := expected(tc)
+		if err := runCase(bin, sb.String(), strings.TrimSpace(want)); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1040-1049/1043/verifierE.go
+++ b/1000-1999/1000-1099/1040-1049/1043/verifierE.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type pair struct {
+	diff int64
+	idx  int
+}
+
+func expected(a, b []int64, forbid [][2]int) string {
+	n := len(a)
+	tab := make([]pair, n)
+	for i := 0; i < n; i++ {
+		tab[i] = pair{b[i] - a[i], i}
+	}
+	sort.Slice(tab, func(i, j int) bool { return tab[i].diff < tab[j].diff })
+	pref := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		pref[i+1] = pref[i] + b[tab[i].idx]
+	}
+	suf := make([]int64, n+1)
+	for i := n - 1; i >= 0; i-- {
+		suf[i] = suf[i+1] + a[tab[i].idx]
+	}
+	wynik := make([]int64, n)
+	for i := 0; i < n; i++ {
+		idx := tab[i].idx
+		wynik[idx] = b[idx]*int64(n-1-i) + a[idx]*int64(i)
+		wynik[idx] += pref[i]
+		wynik[idx] += suf[i+1]
+	}
+	for _, p := range forbid {
+		c, d := p[0], p[1]
+		delta := a[c] + b[d]
+		if a[d]+b[c] < delta {
+			delta = a[d] + b[c]
+		}
+		wynik[c] -= delta
+		wynik[d] -= delta
+	}
+	var sb strings.Builder
+	for i, v := range wynik {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(want) != got {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct {
+		a, b   []int64
+		forbid [][2]int
+	}
+
+	tests := []test{
+		{a: []int64{1, 2}, b: []int64{3, 4}, forbid: nil},
+	}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 2
+		a := make([]int64, n)
+		b := make([]int64, n)
+		for j := 0; j < n; j++ {
+			a[j] = int64(rng.Intn(20) - 10)
+			b[j] = int64(rng.Intn(20) - 10)
+			if a[j] == b[j] && rng.Intn(2) == 0 {
+				b[j]++
+			}
+		}
+		m := rng.Intn(n)
+		forb := make([][2]int, 0, m)
+		used := make(map[[2]int]bool)
+		for j := 0; j < m; j++ {
+			c := rng.Intn(n)
+			d := rng.Intn(n)
+			if c == d {
+				if c+1 < n {
+					d = c + 1
+				} else {
+					d = c - 1
+				}
+			}
+			p := [2]int{c, d}
+			if used[p] {
+				continue
+			}
+			used[p] = true
+			forb = append(forb, p)
+		}
+		tests = append(tests, test{a: a, b: b, forbid: forb})
+	}
+
+	for idx, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", len(tc.a), len(tc.forbid)))
+		for i := 0; i < len(tc.a); i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", tc.a[i], tc.b[i]))
+		}
+		for _, p := range tc.forbid {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p[0]+1, p[1]+1))
+		}
+		want := expected(tc.a, tc.b, tc.forbid)
+		if err := runCase(bin, sb.String(), want); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1040-1049/1043/verifierF.go
+++ b/1000-1999/1000-1099/1040-1049/1043/verifierF.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MX = 300000
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func expected(arr []int) string {
+	n := len(arr)
+	have := make([][]bool, 10)
+	for i := range have {
+		have[i] = make([]bool, MX+1)
+	}
+	for _, v := range arr {
+		if v == 1 {
+			return "1\n"
+		}
+		have[0][v] = true
+	}
+	g := arr[0]
+	for i := 1; i < n; i++ {
+		g = gcd(g, arr[i])
+	}
+	if g > 1 {
+		return "-1\n"
+	}
+	for i := 2; i <= MX; i++ {
+		if !have[0][i] {
+			continue
+		}
+		for j := i + i; j <= MX; j += i {
+			have[0][j] = false
+		}
+	}
+	ini := make([]int, 0)
+	arrs := make([]int, 0)
+	for i := 1; i <= MX; i++ {
+		if have[0][i] {
+			ini = append(ini, i)
+		}
+	}
+	arrs = append(arrs, ini...)
+	for x := 1; x < 10; x++ {
+		nextArr := make([]int, 0)
+		seen := have[x]
+		prevArr := arrs
+		for _, v1 := range prevArr {
+			for _, v2 := range ini {
+				g := gcd(v1, v2)
+				if g == 1 {
+					return fmt.Sprintf("%d\n", x+1)
+				}
+				if !seen[g] {
+					seen[g] = true
+					nextArr = append(nextArr, g)
+				}
+			}
+		}
+		arrs = nextArr
+	}
+	return "-1\n"
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(want) != got {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tests := [][]int{{2, 4, 6}, {6, 10, 15}}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(50) + 1
+		}
+		tests = append(tests, arr)
+	}
+
+	for idx, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(tc)))
+		for i, v := range tc {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		want := expected(tc)
+		if err := runCase(bin, sb.String(), strings.TrimSpace(want)); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1040-1049/1043/verifierG.go
+++ b/1000-1999/1000-1099/1040-1049/1043/verifierG.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	mod1 = 1000000007
+	mod2 = 1000000009
+	base = 91138233
+)
+
+func preprocess(s string) ([]int, []int, []int, []int, [][26]int) {
+	n := len(s)
+	h1 := make([]int, n+1)
+	h2 := make([]int, n+1)
+	pow1 := make([]int, n+1)
+	pow2 := make([]int, n+1)
+	pow1[0], pow2[0] = 1, 1
+	for i := 1; i <= n; i++ {
+		pow1[i] = int((int64(pow1[i-1]) * base) % mod1)
+		pow2[i] = int((int64(pow2[i-1]) * base) % mod2)
+	}
+	for i := 1; i <= n; i++ {
+		c := int(s[i-1])
+		h1[i] = int((int64(h1[i-1])*base + int64(c)) % mod1)
+		h2[i] = int((int64(h2[i-1])*base + int64(c)) % mod2)
+	}
+	cnt := make([][26]int, n+1)
+	for i := 1; i <= n; i++ {
+		for c := 0; c < 26; c++ {
+			cnt[i][c] = cnt[i-1][c]
+		}
+		cnt[i][s[i-1]-'a']++
+	}
+	return h1, h2, pow1, pow2, cnt
+}
+
+func substrHash(h, pow []int, l, r, mod int) int {
+	val := (h[r] - int(int64(h[l-1])*int64(pow[r-l])%int64(mod)) + mod) % mod
+	return val
+}
+
+func expected(n int, s string, qs [][2]int) string {
+	h1, h2, pow1, pow2, cnt := preprocess(s)
+	var sb strings.Builder
+	for _, q := range qs {
+		l, r := q[0], q[1]
+		k := r - l + 1
+		if k < 2 {
+			sb.WriteString("-1\n")
+			continue
+		}
+		distinct := 0
+		hasRepeat := false
+		for c := 0; c < 26; c++ {
+			f := cnt[r][c] - cnt[l-1][c]
+			if f > 0 {
+				distinct++
+				if f > 1 {
+					hasRepeat = true
+				}
+			}
+		}
+		if !hasRepeat {
+			sb.WriteString("-1\n")
+			continue
+		}
+		periodic := false
+		if distinct == 1 {
+			periodic = true
+		} else {
+			getHashEqual := func(d int) bool {
+				h1a := substrHash(h1, pow1, l, r-d, mod1)
+				h1b := substrHash(h1, pow1, l+d, r, mod1)
+				if h1a != h1b {
+					return false
+				}
+				h2a := substrHash(h2, pow2, l, r-d, mod2)
+				h2b := substrHash(h2, pow2, l+d, r, mod2)
+				return h2a == h2b
+			}
+			for di := 1; di*di <= k; di++ {
+				if k%di != 0 {
+					continue
+				}
+				if di > 1 && di < k && getHashEqual(di) {
+					periodic = true
+					break
+				}
+				d2 := k / di
+				if d2 > 1 && d2 < k && d2 != di && getHashEqual(d2) {
+					periodic = true
+					break
+				}
+			}
+		}
+		if periodic {
+			sb.WriteString("1\n")
+			continue
+		}
+		if s[l-1] == s[r-1] || (l+1 <= r && s[l-1] == s[l]) || (r-1 >= l && s[r-1] == s[r-2]) {
+			sb.WriteString("2\n")
+		} else {
+			sb.WriteString("3\n")
+		}
+	}
+	return sb.String()
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(want) != got {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct {
+		n  int
+		s  string
+		qs [][2]int
+	}
+
+	tests := []test{
+		{n: 3, s: "aba", qs: [][2]int{{1, 3}}},
+	}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = byte('a' + rng.Intn(3))
+		}
+		qn := rng.Intn(5) + 1
+		qs := make([][2]int, qn)
+		for j := 0; j < qn; j++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			qs[j] = [2]int{l, r}
+		}
+		tests = append(tests, test{n: n, s: string(b), qs: qs})
+	}
+
+	for idx, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n%s\n%d\n", tc.n, tc.s, len(tc.qs)))
+		for _, p := range tc.qs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+		}
+		want := expected(tc.n, tc.s, tc.qs)
+		if err := runCase(bin, sb.String(), strings.TrimSpace(want)); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers A-G for contest 1043
- verifiers run the candidate binary on 100+ random tests

## Testing
- `go build verifierA.go`
- `go build -o candA 1043A.go`
- `./verifierA ./candA`

------
https://chatgpt.com/codex/tasks/task_e_68845eefd94c8324a957413fef77336b