### PR TITLE
Add solution verifiers for Codeforces contest 1042

### DIFF
--- a/1000-1999/1000-1099/1040-1049/1042/verifierA.go
+++ b/1000-1999/1000-1099/1040-1049/1042/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseA struct {
+	n int64
+	m int64
+	a []int64
+}
+
+func solveA(tc testCaseA) (int64, int64) {
+	maxx := int64(0)
+	sum := int64(0)
+	for _, v := range tc.a {
+		if v > maxx {
+			maxx = v
+		}
+		sum += v
+	}
+	avg := (sum + tc.m) / int64(tc.n)
+	if (sum+tc.m)%int64(tc.n) != 0 {
+		avg++
+	}
+	if maxx > avg {
+		avg = maxx
+	}
+	return avg, maxx + tc.m
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []testCaseA {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]testCaseA, 100)
+	for i := range tests {
+		n := int64(rng.Intn(10) + 1)
+		m := int64(rng.Intn(50))
+		a := make([]int64, n)
+		for j := range a {
+			a[j] = int64(rng.Intn(20))
+		}
+		tests[i] = testCaseA{n, m, a}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+		for j, v := range tc.a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		exp1, exp2 := solveA(tc)
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		var got1, got2 int64
+		fmt.Sscan(out, &got1, &got2)
+		if got1 != exp1 || got2 != exp2 {
+			fmt.Printf("test %d failed:\ninput:%sexpected %d %d got %s\n", i+1, sb.String(), exp1, exp2, out)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1000-1099/1040-1049/1042/verifierB.go
+++ b/1000-1999/1000-1099/1040-1049/1042/verifierB.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type itemB struct {
+	cost int
+	mask int
+}
+
+type testCaseB struct {
+	items []itemB
+}
+
+func solveB(tc testCaseB) int {
+	const INF = int(1e9)
+	dp := [8]int{}
+	for i := 1; i < 8; i++ {
+		dp[i] = INF
+	}
+	for _, it := range tc.items {
+		for mask := 7; mask >= 0; mask-- {
+			if dp[mask] == INF {
+				continue
+			}
+			nm := mask | it.mask
+			val := dp[mask] + it.cost
+			if val < dp[nm] {
+				dp[nm] = val
+			}
+		}
+		if it.cost < dp[it.mask] {
+			dp[it.mask] = it.cost
+		}
+	}
+	if dp[7] >= INF {
+		return -1
+	}
+	return dp[7]
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []testCaseB {
+	rng := rand.New(rand.NewSource(43))
+	tests := make([]testCaseB, 100)
+	for i := range tests {
+		n := rng.Intn(6) + 1
+		items := make([]itemB, n)
+		for j := range items {
+			cost := rng.Intn(50) + 1
+			mask := 0
+			if rng.Intn(2) == 1 {
+				mask |= 1
+			}
+			if rng.Intn(2) == 1 {
+				mask |= 2
+			}
+			if rng.Intn(2) == 1 {
+				mask |= 4
+			}
+			if mask == 0 {
+				mask = 1 << uint(rng.Intn(3))
+			}
+			items[j] = itemB{cost, mask}
+		}
+		tests[i] = testCaseB{items}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", len(tc.items))
+		for _, it := range tc.items {
+			vitamins := ""
+			if it.mask&1 != 0 {
+				vitamins += "A"
+			}
+			if it.mask&2 != 0 {
+				vitamins += "B"
+			}
+			if it.mask&4 != 0 {
+				vitamins += "C"
+			}
+			fmt.Fprintf(&sb, "%d %s\n", it.cost, vitamins)
+		}
+		exp := solveB(tc)
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", i+1, err)
+			return
+		}
+		var got int
+		fmt.Sscan(out, &got)
+		if got != exp {
+			fmt.Printf("test %d failed:\ninput:%sexpected %d got %s\n", i+1, sb.String(), exp, out)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1000-1099/1040-1049/1042/verifierC.go
+++ b/1000-1999/1000-1099/1040-1049/1042/verifierC.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	arr []int
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func expectedProduct(a []int) *big.Int {
+	zeros := 0
+	negatives := []int{}
+	subset := []int{}
+	for _, v := range a {
+		if v == 0 {
+			zeros++
+		} else {
+			subset = append(subset, v)
+			if v < 0 {
+				negatives = append(negatives, v)
+			}
+		}
+	}
+	if zeros == len(a) {
+		return big.NewInt(0)
+	}
+	if len(negatives)%2 != 0 {
+		idx := -1
+		minAbs := 0
+		for i, v := range subset {
+			if v < 0 {
+				if idx == -1 || abs(v) < minAbs {
+					idx = i
+					minAbs = abs(v)
+				}
+			}
+		}
+		if idx >= 0 {
+			subset = append(subset[:idx], subset[idx+1:]...)
+		}
+		if len(subset) == 0 {
+			return big.NewInt(0)
+		}
+	}
+	prod := big.NewInt(1)
+	for _, v := range subset {
+		prod.Mul(prod, big.NewInt(int64(v)))
+	}
+	return prod
+}
+
+func applyOps(a []int, ops []string) (*big.Int, error) {
+	n := len(a)
+	vals := make([]*big.Int, n)
+	alive := make([]bool, n)
+	for i, v := range a {
+		vals[i] = big.NewInt(int64(v))
+		alive[i] = true
+	}
+	removeUsed := 0
+	for _, op := range ops {
+		parts := strings.Fields(op)
+		if len(parts) == 0 {
+			continue
+		}
+		if parts[0] == "1" {
+			if len(parts) != 3 {
+				return nil, fmt.Errorf("bad op %q", op)
+			}
+			x, _ := strconv.Atoi(parts[1])
+			y, _ := strconv.Atoi(parts[2])
+			x--
+			y--
+			if x < 0 || x >= n || y < 0 || y >= n {
+				return nil, fmt.Errorf("index out of range")
+			}
+			if !alive[x] || !alive[y] {
+				return nil, fmt.Errorf("using removed index")
+			}
+			vals[y].Mul(vals[y], vals[x])
+			alive[x] = false
+			removeUsed++
+		} else if parts[0] == "2" {
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("bad op %q", op)
+			}
+			x, _ := strconv.Atoi(parts[1])
+			x--
+			if x < 0 || x >= n {
+				return nil, fmt.Errorf("index out of range")
+			}
+			if !alive[x] {
+				return nil, fmt.Errorf("removing already removed")
+			}
+			alive[x] = false
+			removeUsed++
+		} else {
+			return nil, fmt.Errorf("bad op %q", op)
+		}
+	}
+	if removeUsed != n-1 {
+		return nil, fmt.Errorf("wrong number of operations")
+	}
+	var res *big.Int
+	count := 0
+	for i := 0; i < n; i++ {
+		if alive[i] {
+			res = vals[i]
+			count++
+		}
+	}
+	if count != 1 {
+		return nil, fmt.Errorf("invalid final state")
+	}
+	return new(big.Int).Set(res), nil
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []testCaseC {
+	rng := rand.New(rand.NewSource(44))
+	tests := make([]testCaseC, 100)
+	for i := range tests {
+		n := rng.Intn(8) + 2
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = rng.Intn(11) - 5
+		}
+		tests[i] = testCaseC{arr}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for idx, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", len(tc.arr))
+		for i, v := range tc.arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		expected := expectedProduct(tc.arr)
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", idx+1, err)
+			return
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		prod, err := applyOps(tc.arr, lines)
+		if err != nil {
+			fmt.Printf("test %d: invalid operations: %v\n", idx+1, err)
+			return
+		}
+		if prod.Cmp(expected) != 0 {
+			fmt.Printf("test %d failed:\ninput:%sexpected %s got %s\n", idx+1, sb.String(), expected.String(), prod.String())
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1000-1099/1040-1049/1042/verifierD.go
+++ b/1000-1999/1000-1099/1040-1049/1042/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseD struct {
+	n   int
+	t   int64
+	arr []int64
+}
+
+func solveD(tc testCaseD) int64 {
+	var cnt int64
+	for l := 0; l < tc.n; l++ {
+		sum := int64(0)
+		for r := l; r < tc.n; r++ {
+			sum += tc.arr[r]
+			if sum < tc.t {
+				cnt++
+			}
+		}
+	}
+	return cnt
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []testCaseD {
+	rng := rand.New(rand.NewSource(45))
+	tests := make([]testCaseD, 100)
+	for i := range tests {
+		n := rng.Intn(20) + 1
+		t := int64(rng.Intn(201) - 100)
+		arr := make([]int64, n)
+		for j := range arr {
+			arr[j] = int64(rng.Intn(101) - 50)
+		}
+		tests[i] = testCaseD{n, t, arr}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for idx, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.t)
+		for i, v := range tc.arr {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(v))
+		}
+		sb.WriteByte('\n')
+		expected := solveD(tc)
+		out, err := run(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d: execution error: %v\n", idx+1, err)
+			return
+		}
+		var got int64
+		fmt.Sscan(out, &got)
+		if got != expected {
+			fmt.Printf("test %d failed:\ninput:%sexpected %d got %s\n", idx+1, sb.String(), expected, out)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1000-1099/1040-1049/1042/verifierE.go
+++ b/1000-1999/1000-1099/1040-1049/1042/verifierE.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	tmp, err := os.CreateTemp("", "refE-*")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	path := tmp.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1042E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build ref failed: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func runExe(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCaseE struct {
+	n, m   int
+	matrix [][]int
+	r, c   int
+}
+
+func generateTests() []testCaseE {
+	rng := rand.New(rand.NewSource(46))
+	tests := make([]testCaseE, 100)
+	for i := range tests {
+		n := rng.Intn(4) + 1
+		m := rng.Intn(4) + 1
+		matrix := make([][]int, n)
+		for x := 0; x < n; x++ {
+			row := make([]int, m)
+			for y := 0; y < m; y++ {
+				row[y] = rng.Intn(10)
+			}
+			matrix[x] = row
+		}
+		r := rng.Intn(n) + 1
+		c := rng.Intn(m) + 1
+		tests[i] = testCaseE{n, m, matrix, r, c}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := generateTests()
+	for idx, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+		for _, row := range tc.matrix {
+			for j, v := range row {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprint(v))
+			}
+			sb.WriteByte('\n')
+		}
+		fmt.Fprintf(&sb, "%d %d\n", tc.r, tc.c)
+		input := sb.String()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("ref error on test %d: %v\n", idx+1, err)
+			return
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", idx+1, err)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected %s got %s\n", idx+1, input, exp, got)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}

--- a/1000-1999/1000-1099/1040-1049/1042/verifierF.go
+++ b/1000-1999/1000-1099/1040-1049/1042/verifierF.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	tmp, err := os.CreateTemp("", "refF-*")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	path := tmp.Name()
+	cmd := exec.Command("go", "build", "-o", path, "1042F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build ref failed: %v\n%s", err, out)
+	}
+	return path, nil
+}
+
+func runExe(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type testCaseF struct {
+	n, k  int
+	edges [][2]int
+}
+
+func generateTests() []testCaseF {
+	rng := rand.New(rand.NewSource(47))
+	tests := make([]testCaseF, 100)
+	for i := range tests {
+		n := rng.Intn(15) + 3
+		k := rng.Intn(5) + 1
+		edges := make([][2]int, n-1)
+		for j := 0; j < n-1; j++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			for v == u {
+				v = rng.Intn(n) + 1
+			}
+			edges[j] = [2]int{u, v}
+		}
+		tests[i] = testCaseF{n, k, edges}
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+	tests := generateTests()
+	for idx, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.k)
+		for _, e := range tc.edges {
+			fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+		}
+		input := sb.String()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("ref error on test %d: %v\n", idx+1, err)
+			return
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", idx+1, err)
+			return
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected %s got %s\n", idx+1, input, exp, got)
+			return
+		}
+	}
+	fmt.Printf("all %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1042
- each verifier generates 100 random tests
- verifiers A–D compute answers directly
- verifiers E and F build the reference Go solution and compare outputs

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_68845e63b300832492dd997846cd4cc5