### PR TITLE
Add solution verifiers for contest 1041

### DIFF
--- a/1000-1999/1000-1099/1040-1049/1041/verifierA.go
+++ b/1000-1999/1000-1099/1040-1049/1041/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func solveA(a []int64) int64 {
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	var c int64
+	for i := 0; i+1 < len(a); i++ {
+		diff := a[i+1] - a[i] - 1
+		if diff > 0 {
+			c += diff
+		}
+	}
+	return c
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(100) + 1
+		set := make(map[int64]bool)
+		arr := make([]int64, n)
+		for i := 0; i < n; i++ {
+			v := rand.Int63n(1000)
+			for set[v] {
+				v = rand.Int63n(1000)
+			}
+			arr[i] = v
+			set[v] = true
+		}
+		input := fmt.Sprintf("%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", arr[i])
+		}
+		input += "\n"
+		expect := fmt.Sprintf("%d", solveA(append([]int64(nil), arr...)))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Printf("test %d failed: expected %s got %s\n", t, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1040-1049/1041/verifierB.go
+++ b/1000-1999/1000-1099/1040-1049/1041/verifierB.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveB(a, b, x, y int64) int64 {
+	g := gcd(x, y)
+	x /= g
+	y /= g
+	c := a / x
+	d := b / y
+	if c < d {
+		return c
+	}
+	return d
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(2)
+	for t := 1; t <= 100; t++ {
+		a := rand.Int63n(1000000000) + 1
+		b := rand.Int63n(1000000000) + 1
+		x := rand.Int63n(1000000000) + 1
+		y := rand.Int63n(1000000000) + 1
+		input := fmt.Sprintf("%d %d %d %d\n", a, b, x, y)
+		expect := fmt.Sprintf("%d", solveB(a, b, x, y))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Printf("test %d failed: expected %s got %s\n", t, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1040-1049/1041/verifierC.go
+++ b/1000-1999/1000-1099/1040-1049/1041/verifierC.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type Item struct {
+	release int
+	id      int
+}
+
+type PriorityQueue []Item
+
+func (pq PriorityQueue) Len() int            { return len(pq) }
+func (pq PriorityQueue) Less(i, j int) bool  { return pq[i].release < pq[j].release }
+func (pq PriorityQueue) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *PriorityQueue) Push(x interface{}) { *pq = append(*pq, x.(Item)) }
+func (pq *PriorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	it := old[n-1]
+	*pq = old[:n-1]
+	return it
+}
+
+func solveC(N, M, D int, arr []int) (int, []int) {
+	type pair struct{ t, idx int }
+	arr2 := make([]pair, N)
+	for i := 0; i < N; i++ {
+		arr2[i] = pair{t: arr[i], idx: i}
+	}
+	sort.Slice(arr2, func(i, j int) bool { return arr2[i].t < arr2[j].t })
+	ans := make([]int, N)
+	var pq PriorityQueue
+	heap.Init(&pq)
+	tables := 0
+	for _, e := range arr2 {
+		t, i := e.t, e.idx
+		if pq.Len() > 0 && pq[0].release <= t {
+			item := heap.Pop(&pq).(Item)
+			ans[i] = item.id
+			heap.Push(&pq, Item{release: t + D + 1, id: item.id})
+		} else {
+			tables++
+			ans[i] = tables
+			heap.Push(&pq, Item{release: t + D + 1, id: tables})
+		}
+	}
+	return tables, ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	for t := 1; t <= 100; t++ {
+		N := rand.Intn(20) + 1
+		M := rand.Intn(100) + N
+		D := rand.Intn(M) + 1
+		set := make(map[int]bool)
+		arr := make([]int, N)
+		for i := 0; i < N; i++ {
+			v := rand.Intn(M) + 1
+			for set[v] {
+				v = rand.Intn(M) + 1
+			}
+			arr[i] = v
+			set[v] = true
+		}
+		input := fmt.Sprintf("%d %d %d\n", N, M, D)
+		for i := 0; i < N; i++ {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", arr[i])
+		}
+		input += "\n"
+		tables, ans := solveC(N, M, D, append([]int(nil), arr...))
+		expect := fmt.Sprintf("%d\n", tables)
+		for i, v := range ans {
+			if i+1 < len(ans) {
+				expect += fmt.Sprintf("%d ", v)
+			} else {
+				expect += fmt.Sprintf("%d", v)
+			}
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed:\nexpected:\n%s\n got:\n%s\n", t, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1040-1049/1041/verifierD.go
+++ b/1000-1999/1000-1099/1040-1049/1041/verifierD.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveD(x, y []int64, h int64) int64 {
+	n := len(x)
+	i, j := 0, 0
+	sum := y[0] - x[0]
+	budget := h
+	for j+1 < n {
+		gap := x[j+1] - y[j]
+		if budget-gap > 0 {
+			budget -= gap
+		} else {
+			break
+		}
+		j++
+		sum += gap + (y[j] - x[j])
+	}
+	ans := sum + budget
+	if j == n-1 {
+		return ans
+	}
+	for i < n {
+		i++
+		if i >= n {
+			break
+		}
+		sum -= x[i] - x[i-1]
+		budget += x[i] - y[i-1]
+		for j+1 < n {
+			gap := x[j+1] - y[j]
+			if budget-gap > 0 {
+				budget -= gap
+			} else {
+				break
+			}
+			j++
+			sum += gap + (y[j] - x[j])
+		}
+		ans = maxInt64(ans, sum+budget)
+		if j == n-1 {
+			break
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(4)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(20) + 1
+		h := rand.Int63n(100) + 1
+		x := make([]int64, n)
+		y := make([]int64, n)
+		cur := int64(rand.Intn(10))
+		for i := 0; i < n; i++ {
+			length := int64(rand.Intn(10) + 1)
+			x[i] = cur
+			y[i] = cur + length
+			cur = y[i] + int64(rand.Intn(5)) + 1
+		}
+		input := fmt.Sprintf("%d %d\n", n, h)
+		for i := 0; i < n; i++ {
+			input += fmt.Sprintf("%d %d\n", x[i], y[i])
+		}
+		expect := fmt.Sprintf("%d", solveD(append([]int64(nil), x...), append([]int64(nil), y...), h))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Printf("test %d failed: expected %s got %s\n", t, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1040-1049/1041/verifierE.go
+++ b/1000-1999/1000-1099/1040-1049/1041/verifierE.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type DSU struct{ parent, size []int }
+
+func newDSU(n int) *DSU {
+	p := make([]int, n)
+	s := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = i
+		s[i] = 1
+	}
+	return &DSU{p, s}
+}
+
+func (d *DSU) find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) union(a, b int) {
+	a = d.find(a)
+	b = d.find(b)
+	if a == b {
+		return
+	}
+	if d.size[a] < d.size[b] {
+		a, b = b, a
+	}
+	d.parent[b] = a
+	d.size[a] += d.size[b]
+}
+
+func solveE(n int, pairs [][2]int) (bool, [][2]int) {
+	cnt := make([]int, n+1)
+	for _, p := range pairs {
+		cnt[p[0]]++
+		cnt[p[1]]++
+	}
+	if cnt[n] != n-1 {
+		return false, nil
+	}
+	for i := 1; i <= n; i++ {
+		if cnt[i] > i {
+			return false, nil
+		}
+	}
+	zeros := make([]int, 0)
+	for i := 1; i <= n; i++ {
+		if cnt[i] == 0 {
+			zeros = append(zeros, i)
+		}
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(zeros)))
+	sol := make([][2]int, 0)
+	prv := n
+	idx := 0
+	cntCopy := append([]int(nil), cnt...)
+	for i := n - 1; i >= 1; i-- {
+		if cntCopy[i] == 0 {
+			continue
+		}
+		for cntCopy[i] > 1 {
+			if idx >= len(zeros) {
+				return false, nil
+			}
+			u := prv
+			v := zeros[idx]
+			if v > i {
+				return false, nil
+			}
+			sol = append(sol, [2]int{u, v})
+			prv = v
+			idx++
+			cntCopy[i]--
+		}
+		sol = append(sol, [2]int{i, prv})
+		prv = i
+	}
+	return true, sol
+}
+
+func computePairs(n int, edges [][2]int) [][2]int {
+	res := make([][2]int, len(edges))
+	for i, e := range edges {
+		d := newDSU(n + 1)
+		for j, f := range edges {
+			if i == j {
+				continue
+			}
+			d.union(f[0], f[1])
+		}
+		m1, m2 := 0, 0
+		r1 := d.find(e[0])
+		for v := 1; v <= n; v++ {
+			if d.find(v) == r1 {
+				if v > m1 {
+					m1 = v
+				}
+			} else {
+				if v > m2 {
+					m2 = v
+				}
+			}
+		}
+		if m1 < m2 {
+			res[i] = [2]int{m1, m2}
+		} else {
+			res[i] = [2]int{m2, m1}
+		}
+	}
+	sort.Slice(res, func(i, j int) bool {
+		if res[i][0] == res[j][0] {
+			return res[i][1] < res[j][1]
+		}
+		return res[i][0] < res[j][0]
+	})
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func parseEdges(out string) (bool, [][2]int, error) {
+	parts := strings.Fields(out)
+	if len(parts) == 0 {
+		return false, nil, fmt.Errorf("empty output")
+	}
+	if parts[0] == "NO" {
+		return false, nil, nil
+	}
+	if parts[0] != "YES" {
+		return false, nil, fmt.Errorf("unexpected output")
+	}
+	if (len(parts)-1)%2 != 0 {
+		return false, nil, fmt.Errorf("bad edges")
+	}
+	edges := make([][2]int, (len(parts)-1)/2)
+	idx := 1
+	for i := range edges {
+		if idx+1 >= len(parts) {
+			return false, nil, fmt.Errorf("bad edges")
+		}
+		var a, b int
+		fmt.Sscan(parts[idx], &a)
+		fmt.Sscan(parts[idx+1], &b)
+		edges[i] = [2]int{a, b}
+		idx += 2
+	}
+	return true, edges, nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(8) + 2
+		pairs := make([][2]int, n-1)
+		for i := 0; i < n-1; i++ {
+			a := rand.Intn(n-1) + 1
+			b := rand.Intn(n-1) + 1
+			if a > b {
+				a, b = b, a
+			}
+			if a == b {
+				b++
+				if b > n {
+					b = a
+					a--
+				}
+			}
+			if a < 1 {
+				a = 1
+			}
+			if b > n {
+				b = n
+			}
+			if a >= b {
+				b = a + 1
+				if b > n {
+					b = a
+				}
+			}
+			pairs[i] = [2]int{a, b}
+		}
+		input := fmt.Sprintf("%d\n", n)
+		for i := 0; i < n-1; i++ {
+			input += fmt.Sprintf("%d %d\n", pairs[i][0], pairs[i][1])
+		}
+		ok, expectedEdges := solveE(n, pairs)
+		expectStr := "NO"
+		if ok {
+			expectStr = "YES"
+			for _, e := range expectedEdges {
+				expectStr += fmt.Sprintf(" %d %d", e[0], e[1])
+			}
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		gotOK, edges, err2 := parseEdges(out)
+		if err2 != nil {
+			fmt.Printf("test %d failed: %v\n", t, err2)
+			os.Exit(1)
+		}
+		if ok != gotOK {
+			fmt.Printf("test %d failed: expected %v got %v\n", t, ok, gotOK)
+			os.Exit(1)
+		}
+		if ok {
+			expPairs := computePairs(n, expectedEdges)
+			gotPairs := computePairs(n, edges)
+			if len(gotPairs) != len(expPairs) {
+				fmt.Printf("test %d failed: wrong number of edges\n", t)
+				os.Exit(1)
+			}
+			match := true
+			for i := range expPairs {
+				if expPairs[i] != gotPairs[i] {
+					match = false
+					break
+				}
+			}
+			if !match {
+				fmt.Printf("test %d failed: edges do not correspond\n", t)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1040-1049/1041/verifierF.go
+++ b/1000-1999/1000-1099/1040-1049/1041/verifierF.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var a, b, ta, tb []int
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solve(as, ae, bs, be int) int {
+	cnt0, cnt1 := 0, 0
+	for i := as; i <= ae; i++ {
+		if a[i]&1 == 0 {
+			cnt0++
+		} else {
+			cnt1++
+		}
+	}
+	for i := bs; i <= be; i++ {
+		if (b[i]&1)^1 == 0 {
+			cnt0++
+		} else {
+			cnt1++
+		}
+	}
+	ret := maxInt(cnt0, cnt1)
+	if as > ae || bs > be {
+		return ret
+	}
+	if as == ae && bs == be {
+		return maxInt(ret, 2)
+	}
+	j := as
+	for i := as; i <= ae; i++ {
+		if a[i]&1 == 1 {
+			ta[j] = a[i] >> 1
+			j++
+		}
+	}
+	A := j
+	for i := as; i <= ae; i++ {
+		if a[i]&1 == 0 {
+			ta[j] = a[i] >> 1
+			j++
+		}
+	}
+	for i := as; i <= ae; i++ {
+		a[i] = ta[i]
+	}
+	k := bs
+	for i := bs; i <= be; i++ {
+		if b[i]&1 == 1 {
+			tb[k] = b[i] >> 1
+			k++
+		}
+	}
+	B := k
+	for i := bs; i <= be; i++ {
+		if b[i]&1 == 0 {
+			tb[k] = b[i] >> 1
+			k++
+		}
+	}
+	for i := bs; i <= be; i++ {
+		b[i] = tb[i]
+	}
+	ret = maxInt(ret, solve(as, A-1, bs, B-1))
+	ret = maxInt(ret, solve(A, ae, B, be))
+	return ret
+}
+
+func expected(n int, arrA []int, m int, arrB []int) int {
+	a = arrA
+	b = arrB
+	ta = make([]int, n)
+	tb = make([]int, m)
+	return solve(0, n-1, 0, m-1)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(6)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(10) + 1
+		m := rand.Intn(10) + 1
+		y1 := rand.Intn(100)
+		y2 := y1 + rand.Intn(100) + 1
+		arrA := make([]int, n)
+		for i := 0; i < n; i++ {
+			arrA[i] = rand.Intn(1000)
+		}
+		arrB := make([]int, m)
+		for i := 0; i < m; i++ {
+			arrB[i] = rand.Intn(1000)
+		}
+		input := fmt.Sprintf("%d %d\n", n, y1)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", arrA[i])
+		}
+		input += fmt.Sprintf("\n%d %d\n", m, y2)
+		for i := 0; i < m; i++ {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", arrB[i])
+		}
+		input += "\n"
+		expect := fmt.Sprintf("%d", expected(n, append([]int(nil), arrA...), m, append([]int(nil), arrB...)))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		if out != expect {
+			fmt.Printf("test %d failed: expected %s got %s\n", t, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F in contest 1041
- each verifier runs 100 random tests against an arbitrary binary

## Testing
- `go build 1000-1999/1000-1099/1040-1049/1041/verifierA.go`
- `go build 1000-1999/1000-1099/1040-1049/1041/verifierB.go`
- `go build 1000-1999/1000-1099/1040-1049/1041/verifierC.go`
- `go build 1000-1999/1000-1099/1040-1049/1041/verifierD.go`
- `go build 1000-1999/1000-1099/1040-1049/1041/verifierE.go`
- `go build 1000-1999/1000-1099/1040-1049/1041/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_68845dd7a0c08324b9741bbb30066be6