### PR TITLE
Add Go solution for 1650A

### DIFF
--- a/1000-1999/1600-1699/1650-1659/1650/1650A.go
+++ b/1000-1999/1600-1699/1650-1659/1650/1650A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s, c string
+		fmt.Fscan(reader, &s)
+		fmt.Fscan(reader, &c)
+		res := "NO"
+		for i := 0; i < len(s); i++ {
+			if s[i] == c[0] && i%2 == 0 {
+				res = "YES"
+				break
+			}
+		}
+		fmt.Fprintln(writer, res)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem 1650A "Deletions of Two Adjacent Letters"

## Testing
- `gofmt -w 1000-1999/1600-1699/1650-1659/1650/1650A.go`


------
https://chatgpt.com/codex/tasks/task_e_68845fc1ed8c8324a7f1f281dda3322a