### PR TITLE
Add Go verifiers for contest 1044

### DIFF
--- a/1000-1999/1000-1099/1040-1049/1044/verifierA.go
+++ b/1000-1999/1000-1099/1040-1049/1044/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1044A.go")
+	bin := filepath.Join(os.TempDir(), "oracle1044A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5)
+	m := r.Intn(5)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		x := r.Intn(30) + 1
+		fmt.Fprintf(&sb, "%d\n", x)
+	}
+	for i := 0; i < m; i++ {
+		x1 := r.Intn(30) + 1
+		x2 := x1 + r.Intn(31-x1)
+		y := r.Intn(30) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", x1, x2, y)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1000-1099/1040-1049/1044/verifierB.go
+++ b/1000-1999/1000-1099/1040-1049/1044/verifierB.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem B is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1000-1099/1040-1049/1044/verifierC.go
+++ b/1000-1999/1000-1099/1040-1049/1044/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1044C.go")
+	bin := filepath.Join(os.TempDir(), "oracle1044C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genConvexPoints(r *rand.Rand, n int) [][2]int {
+	angles := make([]float64, n)
+	for i := range angles {
+		angles[i] = r.Float64() * 2 * math.Pi
+	}
+	sort.Float64s(angles)
+	pts := make([][2]int, n)
+	for i, a := range angles {
+		x := int(100 * math.Cos(a))
+		y := int(100 * math.Sin(a))
+		pts[i] = [2]int{x, y}
+	}
+	return pts
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(6) + 3 // 3..8
+	pts := genConvexPoints(r, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, p := range pts {
+		fmt.Fprintf(&sb, "%d %d\n", p[0], p[1])
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1000-1099/1040-1049/1044/verifierD.go
+++ b/1000-1999/1000-1099/1040-1049/1044/verifierD.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1044D.go")
+	bin := filepath.Join(os.TempDir(), "oracle1044D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	q := r.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", q)
+	for i := 0; i < q; i++ {
+		if r.Intn(2) == 0 {
+			l := r.Intn(50)
+			rgt := r.Intn(50)
+			x := r.Intn(100)
+			fmt.Fprintf(&sb, "1 %d %d %d\n", l, rgt, x)
+		} else {
+			l := r.Intn(50)
+			rgt := r.Intn(50)
+			fmt.Fprintf(&sb, "2 %d %d\n", l, rgt)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1000-1099/1040-1049/1044/verifierE.go
+++ b/1000-1999/1000-1099/1040-1049/1044/verifierE.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func genGrid(r *rand.Rand) (int, int, [][]int) {
+	n := r.Intn(3) + 3 // 3..5
+	m := r.Intn(3) + 3
+	vals := r.Perm(n * m)
+	grid := make([][]int, n)
+	for i := 0; i < n; i++ {
+		grid[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			grid[i][j] = vals[i*m+j] + 1
+		}
+	}
+	return n, m, grid
+}
+
+func gridInput(n, m int, g [][]int) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", g[i][j])
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func verifyOutput(n, m int, grid [][]int, out string) error {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(strings.TrimSpace(scanner.Text()))
+	if err != nil || k < 0 {
+		return fmt.Errorf("invalid k")
+	}
+	pos := make(map[int][2]int)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			pos[grid[i][j]] = [2]int{i, j}
+		}
+	}
+	total := 0
+	for step := 0; step < k; step++ {
+		if !scanner.Scan() {
+			return fmt.Errorf("missing move %d", step+1)
+		}
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 1 {
+			return fmt.Errorf("bad line for move %d", step+1)
+		}
+		s, err := strconv.Atoi(fields[0])
+		if err != nil || s < 4 || len(fields) != s+1 {
+			return fmt.Errorf("bad cycle length at move %d", step+1)
+		}
+		total += s
+		if total > 100000 {
+			return fmt.Errorf("total cycle length exceeds limit")
+		}
+		seq := make([]int, s)
+		seen := make(map[int]bool)
+		for i := 0; i < s; i++ {
+			v, err := strconv.Atoi(fields[i+1])
+			if err != nil {
+				return fmt.Errorf("bad number in move %d", step+1)
+			}
+			if v < 1 || v > n*m || seen[v] {
+				return fmt.Errorf("invalid or duplicate number in move %d", step+1)
+			}
+			seen[v] = true
+			seq[i] = v
+		}
+		// check adjacency
+		for i := 0; i < s; i++ {
+			a := seq[i]
+			b := seq[(i+1)%s]
+			pa := pos[a]
+			pb := pos[b]
+			if abs(pa[0]-pb[0])+abs(pa[1]-pb[1]) != 1 {
+				return fmt.Errorf("non-adjacent cells in move %d", step+1)
+			}
+		}
+		// apply rotation
+		newPos := make(map[int][2]int)
+		for v, p := range pos {
+			newPos[v] = p
+		}
+		for i := 0; i < s; i++ {
+			from := seq[i]
+			to := pos[seq[(i+1)%s]]
+			newPos[from] = to
+		}
+		// update grid and positions
+		for v, p := range newPos {
+			grid[p[0]][p[1]] = v
+		}
+		pos = newPos
+	}
+	// grid should be sorted
+	val := 1
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] != val {
+				return fmt.Errorf("grid not sorted")
+			}
+			val++
+		}
+	}
+	if scanner.Scan() {
+		return fmt.Errorf("extra output")
+	}
+	return nil
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		n, m, g := genGrid(r)
+		input := gridInput(n, m, g)
+		output, err := run(exe, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := verifyOutput(n, m, g, output); err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, input, output)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1000-1099/1040-1049/1044/verifierF.go
+++ b/1000-1999/1000-1099/1040-1049/1044/verifierF.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1044F.go")
+	bin := filepath.Join(os.TempDir(), "oracle1044F.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTree(r *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := r.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	return edges
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(6) + 3 // 3..8
+	q := r.Intn(10) + 1
+	edges := genTree(r, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	for i := 0; i < q; i++ {
+		u := r.Intn(n) + 1
+		v := r.Intn(n) + 1
+		for u == v {
+			v = r.Intn(n) + 1
+		}
+		// ensure not a tree edge
+		isTree := false
+		for _, e := range edges {
+			if (e[0] == u && e[1] == v) || (e[0] == v && e[1] == u) {
+				isTree = true
+				break
+			}
+		}
+		if isTree {
+			i--
+			continue
+		}
+		fmt.Fprintf(&sb, "%d %d\n", u, v)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1044 problems A–F
- problem B is interactive so verifier just prints a note
- verifiers build the official Go solutions as oracles or check validity
- each verifier runs 100 random test cases

## Testing
- `gofmt -w 1000-1999/1000-1099/1040-1049/1044/verifier*.go`

------
https://chatgpt.com/codex/tasks/task_e_68845f7be06883249c50ae02d42ed668