### PR TITLE
Add Go verifiers for contest 1047

### DIFF
--- a/1000-1999/1000-1099/1040-1049/1047/verifierA.go
+++ b/1000-1999/1000-1099/1040-1049/1047/verifierA.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func validTriple(a, b, c, n int) bool {
+	if a <= 0 || b <= 0 || c <= 0 {
+		return false
+	}
+	if a%3 == 0 || b%3 == 0 || c%3 == 0 {
+		return false
+	}
+	return a+b+c == n
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tests := []int{3, 4, 5, 6, 7, 8, 9, 10, 1000000000}
+	for len(tests) < 100 {
+		n := rng.Intn(1_000_000_000-3+1) + 3
+		tests = append(tests, n)
+	}
+
+	for i, n := range tests {
+		input := fmt.Sprintf("%d\n", n)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != 3 {
+			fmt.Fprintf(os.Stderr, "test %d: expected 3 integers got %q\n", i+1, out)
+			os.Exit(1)
+		}
+		a, err1 := strconv.Atoi(fields[0])
+		b, err2 := strconv.Atoi(fields[1])
+		c, err3 := strconv.Atoi(fields[2])
+		if err1 != nil || err2 != nil || err3 != nil {
+			fmt.Fprintf(os.Stderr, "test %d: cannot parse integers\n", i+1)
+			os.Exit(1)
+		}
+		if !validTriple(a, b, c, n) {
+			fmt.Fprintf(os.Stderr, "test %d failed: n=%d output=%d %d %d\n", i+1, n, a, b, c)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1040-1049/1047/verifierB.go
+++ b/1000-1999/1000-1099/1040-1049/1047/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected int
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	maxv := 0
+	for i := 0; i < n; i++ {
+		x := rng.Intn(1_000_000_000) + 1
+		y := rng.Intn(1_000_000_000) + 1
+		if x+y > maxv {
+			maxv = x + y
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return testCase{input: sb.String(), expected: maxv}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []testCase
+	// deterministic edge cases
+	cases = append(cases, testCase{input: "1\n1 1\n", expected: 2})
+	cases = append(cases, testCase{input: "1\n1000000000 1000000000\n", expected: 2000000000})
+
+	for len(cases) < 100 {
+		cases = append(cases, generateCase(rng))
+	}
+
+	for i, tc := range cases {
+		out, err := runCandidate(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(strings.TrimSpace(out))
+		if len(fields) != 1 {
+			fmt.Fprintf(os.Stderr, "case %d: expected single integer got %q\n", i+1, out)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(fields[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse integer\n", i+1)
+			os.Exit(1)
+		}
+		if val != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, tc.expected, val, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` for problem A of contest 1047
- add `verifierB.go` for problem B of contest 1047
- each verifier generates at least 100 tests and checks any binary

## Testing
- `go run verifierA.go ./1047A_bin`
- `go run verifierB.go ./1047B_bin`


------
https://chatgpt.com/codex/tasks/task_e_6884612027e08324b9178ed5ab418b16