### PR TITLE
Add Go solution for 1651A

### DIFF
--- a/1000-1999/1600-1699/1650-1659/1651/1651A.go
+++ b/1000-1999/1600-1699/1650-1659/1651/1651A.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		res := (1 << n) - 1
+		fmt.Fprintln(writer, res)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1651A

## Testing
- `go vet 1000-1999/1600-1699/1650-1659/1651/1651A.go`
- `go build 1000-1999/1600-1699/1650-1659/1651/1651A.go`
- `cat <<EOF | ./1651A ...`

------
https://chatgpt.com/codex/tasks/task_e_6884627e682c8324950003500531d3c7