### PR TITLE
Add verifiers for contest 1051

### DIFF
--- a/1000-1999/1000-1099/1050-1059/1051/verifierA.go
+++ b/1000-1999/1000-1099/1050-1059/1051/verifierA.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(s string) string {
+	b := []byte(s)
+	var U, D, L []int
+	for i, c := range b {
+		switch {
+		case c >= 'A' && c <= 'Z':
+			U = append(U, i)
+		case c >= '0' && c <= '9':
+			D = append(D, i)
+		default:
+			L = append(L, i)
+		}
+	}
+	missingU := len(U) == 0
+	missingD := len(D) == 0
+	missingL := len(L) == 0
+	missing := 0
+	if missingU {
+		missing++
+	}
+	if missingD {
+		missing++
+	}
+	if missingL {
+		missing++
+	}
+	switch missing {
+	case 0:
+		return s
+	case 1:
+		var rep byte
+		if missingU {
+			rep = 'A'
+		} else if missingD {
+			rep = '0'
+		} else {
+			rep = 'a'
+		}
+		if len(U) > 1 {
+			b[U[0]] = rep
+		} else if len(D) > 1 {
+			b[D[0]] = rep
+		} else {
+			b[L[0]] = rep
+		}
+	case 2:
+		miss := make([]byte, 0, 2)
+		if missingU {
+			miss = append(miss, 'A')
+		}
+		if missingD {
+			miss = append(miss, '0')
+		}
+		if missingL {
+			miss = append(miss, 'a')
+		}
+		if len(U) >= 2 {
+			b[U[0]] = miss[0]
+			b[U[1]] = miss[1]
+		} else if len(D) >= 2 {
+			b[D[0]] = miss[0]
+			b[D[1]] = miss[1]
+		} else {
+			b[L[0]] = miss[0]
+			b[L[1]] = miss[1]
+		}
+	}
+	return string(b)
+}
+
+func randChar(rng *rand.Rand, cat int) byte {
+	switch cat {
+	case 0:
+		return byte('a' + rng.Intn(26))
+	case 1:
+		return byte('A' + rng.Intn(26))
+	default:
+		return byte('0' + rng.Intn(10))
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 3 // 3..10
+	chars := make([]byte, n)
+	for i := 0; i < n; i++ {
+		cat := rng.Intn(3)
+		chars[i] = randChar(rng, cat)
+	}
+	return string(chars)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := genCase(rng)
+		in := fmt.Sprintf("1\n%s\n", s)
+		expect := solveCase(s)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, s)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1050-1059/1051/verifierB.go
+++ b/1000-1999/1000-1099/1050-1059/1051/verifierB.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(l, r int64) string {
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	for i := l; i <= r; i += 2 {
+		fmt.Fprintf(&sb, "%d %d\n", i, i+1)
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genCase(rng *rand.Rand) (int64, int64) {
+	pairs := rng.Intn(10) + 1
+	l := rng.Int63n(100) + 1
+	r := l + int64(2*pairs-1)
+	return l, r
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		l, r := genCase(rng)
+		input := fmt.Sprintf("%d %d\n", l, r)
+		expect := solveCase(l, r)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1050-1059/1051/verifierC.go
+++ b/1000-1999/1000-1099/1050-1059/1051/verifierC.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func possible(nums []int) bool {
+	cnt := make([]int, 110)
+	for _, v := range nums {
+		cnt[v]++
+	}
+	calc := make([]int, 4)
+	for _, c := range cnt {
+		if c <= 2 {
+			calc[c]++
+		} else {
+			calc[3]++
+		}
+	}
+	return calc[1]%2 == 0 || calc[3] > 0
+}
+
+func isValid(nums []int, assign string) bool {
+	if len(assign) != len(nums) {
+		return false
+	}
+	cnt := make(map[int]int)
+	for _, v := range nums {
+		cnt[v]++
+	}
+	aNice, bNice := 0, 0
+	for i, ch := range assign {
+		if ch != 'A' && ch != 'B' {
+			return false
+		}
+		if cnt[nums[i]] == 1 {
+			if ch == 'A' {
+				aNice++
+			} else {
+				bNice++
+			}
+		}
+	}
+	return aNice == bNice
+}
+
+func genCase(rng *rand.Rand) []int {
+	n := rng.Intn(8) + 2
+	nums := make([]int, n)
+	for i := 0; i < n; i++ {
+		nums[i] = rng.Intn(10)
+	}
+	return nums
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		nums := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(nums)))
+		for j, v := range nums {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		out, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if lines[0] == "NO" {
+			if possible(nums) {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected YES got NO\n", i+1)
+				os.Exit(1)
+			}
+			continue
+		}
+		if lines[0] != "YES" {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected YES/NO got %s\n", i+1, lines[0])
+			os.Exit(1)
+		}
+		if len(lines) < 2 {
+			fmt.Fprintf(os.Stderr, "case %d failed: missing assignment\n", i+1)
+			os.Exit(1)
+		}
+		assign := strings.TrimSpace(lines[1])
+		if !possible(nums) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected NO but got YES\n", i+1)
+			os.Exit(1)
+		}
+		if !isValid(nums, assign) {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid assignment %s\n", i+1, assign)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1050-1059/1051/verifierD.go
+++ b/1000-1999/1000-1099/1050-1059/1051/verifierD.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD = 998244353
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, k int) int {
+	dp0 := make([][]int, n+1)
+	dp1 := make([][]int, n+1)
+	for i := 0; i <= n; i++ {
+		dp0[i] = make([]int, k+1)
+		dp1[i] = make([]int, k+1)
+	}
+	if k >= 2 {
+		dp0[1][2] = 1
+	}
+	if k >= 1 {
+		dp1[1][1] = 1
+	}
+	for i := 2; i <= n; i++ {
+		for j := 1; j <= k; j++ {
+			v0 := dp0[i-1][j]
+			if j-1 >= 0 {
+				v0 += 2 * dp1[i-1][j-1]
+			}
+			if j-2 >= 0 {
+				v0 += dp0[i-1][j-2]
+			}
+			dp0[i][j] = v0 % MOD
+			v1 := dp1[i-1][j]
+			if j-1 >= 0 {
+				v1 += dp1[i-1][j-1]
+			}
+			v1 += 2 * dp0[i-1][j]
+			dp1[i][j] = v1 % MOD
+		}
+	}
+	res := (dp0[n][k] + dp1[n][k]) * 2 % MOD
+	return res
+}
+
+func genCase(rng *rand.Rand) (int, int) {
+	n := rng.Intn(6) + 1
+	k := rng.Intn(2*n) + 1
+	return n, k
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, k := genCase(rng)
+		input := fmt.Sprintf("%d %d\n", n, k)
+		expect := solveCase(n, k)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(out, &got); err != nil || got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1050-1059/1051/verifierE.go
+++ b/1000-1999/1000-1099/1050-1059/1051/verifierE.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func zfunc(s string) []int {
+	n := len(s)
+	z := make([]int, n)
+	l, r := 0, 0
+	for i := 1; i < n; i++ {
+		if i <= r {
+			z[i] = min(r-i+1, z[i-l])
+		}
+		for i+z[i] < n && s[z[i]] == s[i+z[i]] {
+			z[i]++
+		}
+		if i+z[i]-1 > r {
+			l = i
+			r = i + z[i] - 1
+		}
+	}
+	return z
+}
+
+func solveCase(a, L, R string) int64 {
+	n := len(a)
+	lLen := len(L)
+	rLen := len(R)
+	t1 := L + "#" + a
+	z1 := zfunc(t1)
+	t2 := R + "#" + a
+	z2 := zfunc(t2)
+	dp := make([]int64, n+1)
+	sum := make([]int64, n+2)
+	dp[n] = 1
+	sum[n] = 1
+	for i := n - 1; i >= 0; i-- {
+		if a[i] == '0' {
+			if lLen == 1 && L[0] == '0' {
+				dp[i] = dp[i+1]
+				sum[i] = (sum[i+1] + dp[i]) % mod
+			} else {
+				dp[i] = 0
+				sum[i] = sum[i+1]
+			}
+			continue
+		}
+		if n-i < lLen {
+			dp[i] = 0
+			sum[i] = sum[i+1]
+			continue
+		}
+		indL := lLen + 1 + i
+		indR := rLen + 1 + i
+		lf := i + lLen
+		if z1[indL] != lLen && L[z1[indL]] > a[i+z1[indL]] {
+			lf++
+		}
+		var rg int
+		if n-i < rLen {
+			rg = n
+		} else if z2[indR] == rLen || R[z2[indR]] > a[i+z2[indR]] {
+			rg = i + rLen
+		} else {
+			rg = i + rLen - 1
+		}
+		if rg >= lf {
+			add := (sum[lf] - sum[rg+1] + mod) % mod
+			dp[i] = add
+			sum[i] = (sum[i+1] + add) % mod
+		} else {
+			dp[i] = 0
+			sum[i] = sum[i+1]
+		}
+	}
+	return dp[0] % mod
+}
+
+func genCase(rng *rand.Rand) (string, string, string) {
+	n := rng.Intn(8) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('0' + rng.Intn(10)))
+	}
+	a := sb.String()
+	L := fmt.Sprintf("%d", rng.Intn(100))
+	R := fmt.Sprintf("%d", rng.Intn(100)+rng.Intn(100))
+	if len(L) > len(R) || (len(L) == len(R) && L > R) {
+		L, R = R, L
+	}
+	return a, L, R
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		a, L, R := genCase(rng)
+		input := fmt.Sprintf("%s\n%s\n%s\n", a, L, R)
+		expect := solveCase(a, L, R)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(out, &got); err != nil || got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1050-1059/1051/verifierF.go
+++ b/1000-1999/1000-1099/1050-1059/1051/verifierF.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to   int
+	cost int64
+}
+
+type Item struct {
+	node int
+	dist int64
+	idx  int
+}
+
+type PriorityQueue []Item
+
+func (pq PriorityQueue) Len() int           { return len(pq) }
+func (pq PriorityQueue) Less(i, j int) bool { return pq[i].dist < pq[j].dist }
+func (pq PriorityQueue) Swap(i, j int)      { pq[i], pq[j] = pq[j], pq[i]; pq[i].idx = i; pq[j].idx = j }
+
+func (pq *PriorityQueue) Push(x interface{}) {
+	item := x.(Item)
+	item.idx = len(*pq)
+	*pq = append(*pq, item)
+}
+
+func (pq *PriorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	*pq = old[:n-1]
+	return item
+}
+
+func dijkstra(graph [][]Edge, src, dst int) int64 {
+	const INF int64 = 1<<63 - 1
+	n := len(graph) - 1
+	dist := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = INF
+	}
+	dist[src] = 0
+	pq := &PriorityQueue{}
+	heap.Push(pq, Item{node: src, dist: 0})
+	for pq.Len() > 0 {
+		cur := heap.Pop(pq).(Item)
+		if cur.dist != dist[cur.node] {
+			continue
+		}
+		if cur.node == dst {
+			return cur.dist
+		}
+		for _, e := range graph[cur.node] {
+			nd := cur.dist + e.cost
+			if nd < dist[e.to] {
+				dist[e.to] = nd
+				heap.Push(pq, Item{node: e.to, dist: nd})
+			}
+		}
+	}
+	return dist[dst]
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, m int, edges [][3]int64, queries [][2]int) []int64 {
+	graph := make([][]Edge, n+1)
+	for _, e := range edges {
+		u := int(e[0])
+		v := int(e[1])
+		w := e[2]
+		graph[u] = append(graph[u], Edge{v, w})
+		graph[v] = append(graph[v], Edge{u, w})
+	}
+	res := make([]int64, len(queries))
+	for i, q := range queries {
+		res[i] = dijkstra(graph, q[0], q[1])
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (int, int, [][3]int64, [][2]int) {
+	n := rng.Intn(6) + 2
+	extra := rng.Intn(3)
+	m := n - 1 + extra
+	edges := make([][3]int64, 0, m)
+	// create tree first
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		w := rng.Int63n(20) + 1
+		edges = append(edges, [3]int64{int64(p), int64(i), w})
+	}
+	for i := 0; i < extra; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		for v == u {
+			v = rng.Intn(n) + 1
+		}
+		w := rng.Int63n(20) + 1
+		edges = append(edges, [3]int64{int64(u), int64(v), w})
+	}
+	q := rng.Intn(5) + 1
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		queries[i] = [2]int{u, v}
+	}
+	return n, m, edges, queries
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, edges, queries := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", len(queries)))
+		for _, q := range queries {
+			sb.WriteString(fmt.Sprintf("%d %d\n", q[0], q[1]))
+		}
+		expect := solveCase(n, m, edges, queries)
+		out, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != len(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\n", i+1, len(expect), len(fields))
+			os.Exit(1)
+		}
+		for j, f := range fields {
+			var val int64
+			if _, err := fmt.Sscan(f, &val); err != nil || val != expect[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s at index %d\n", i+1, expect[j], f, j)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1050-1059/1051/verifierG.go
+++ b/1000-1999/1000-1099/1050-1059/1051/verifierG.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// BIT for prefix sums
+type BIT struct {
+	n    int
+	tree []int64
+}
+
+func NewBIT(n int) *BIT {
+	return &BIT{n: n, tree: make([]int64, n+1)}
+}
+
+func (b *BIT) Add(i int, v int64) {
+	for x := i; x <= b.n; x += x & -x {
+		b.tree[x] += v
+	}
+}
+
+func (b *BIT) Sum(i int) int64 {
+	var s int64
+	for x := i; x > 0; x -= x & -x {
+		s += b.tree[x]
+	}
+	return s
+}
+
+func (b *BIT) RangeSum(l, r int) int64 {
+	if l > r {
+		return 0
+	}
+	return b.Sum(r) - b.Sum(l-1)
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(pairs [][2]int) []int64 {
+	n := len(pairs)
+	bitCnt := NewBIT(n)
+	bitSum := NewBIT(n)
+	var totalB, S, sumAb int64
+	low := int64(1<<63 - 1)
+	res := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a := int64(pairs[i][0])
+		b := pairs[i][1]
+		if a < low {
+			low = a
+		}
+		cntGt := bitCnt.RangeSum(b+1, n)
+		sumGt := bitSum.RangeSum(b+1, n)
+		sumLower := totalB - sumGt
+		S += int64(b)*cntGt + sumLower
+		totalB += int64(b)
+		bitCnt.Add(b, 1)
+		bitSum.Add(b, int64(b))
+		sumAb += int64(b) * a
+		res[i] = low*totalB + S - sumAb
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) [][2]int {
+	n := rng.Intn(6) + 1
+	used := make(map[int]bool)
+	pairs := make([][2]int, n)
+	for i := 0; i < n; i++ {
+		a := rng.Intn(20) + 1
+		var b int
+		for {
+			b = rng.Intn(n*2) + 1
+			if !used[b] {
+				used[b] = true
+				break
+			}
+		}
+		pairs[i] = [2]int{a, b}
+	}
+	return pairs
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		pairs := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", len(pairs)))
+		for _, p := range pairs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", p[0], p[1]))
+		}
+		expect := solveCase(pairs)
+		out, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != len(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\n", i+1, len(expect), len(fields))
+			os.Exit(1)
+		}
+		for j, f := range fields {
+			val, err := strconv.ParseInt(f, 10, 64)
+			if err != nil || val != expect[j] {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s at index %d\n", i+1, expect[j], f, j)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1051 problems A–G
- each verifier generates 100 random tests and checks candidate output

## Testing
- `go build 1000-1999/1000-1099/1050-1059/1051/verifierA.go`
- `go build 1000-1999/1000-1099/1050-1059/1051/verifierB.go`
- `go build 1000-1999/1000-1099/1050-1059/1051/verifierC.go`
- `go build 1000-1999/1000-1099/1050-1059/1051/verifierD.go`
- `go build 1000-1999/1000-1099/1050-1059/1051/verifierE.go`
- `go build 1000-1999/1000-1099/1050-1059/1051/verifierF.go`
- `go build 1000-1999/1000-1099/1050-1059/1051/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6884635081608324abbd4a99c5445ae3