### PR TITLE
Add Go solution for problem 1656A

### DIFF
--- a/1000-1999/1600-1699/1650-1659/1656/1656A.go
+++ b/1000-1999/1600-1699/1650-1659/1656/1656A.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		minVal := int(1<<31 - 1)
+		maxVal := -1
+		minIdx := 1
+		maxIdx := 1
+		for i := 1; i <= n; i++ {
+			var v int
+			fmt.Fscan(in, &v)
+			if v < minVal {
+				minVal = v
+				minIdx = i
+			}
+			if v > maxVal {
+				maxVal = v
+				maxIdx = i
+			}
+		}
+		fmt.Fprintf(out, "%d %d\n", minIdx, maxIdx)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for `problemA.txt` of contest 1656

## Testing
- `go vet 1000-1999/1600-1699/1650-1659/1656/1656A.go`
- `go build 1000-1999/1600-1699/1650-1659/1656/1656A.go`
- `echo -e "1\n3\n5 2 7" | go run 1000-1999/1600-1699/1650-1659/1656/1656A.go`

------
https://chatgpt.com/codex/tasks/task_e_688465c6f4408324bc8c153f6ed94879