### PR TITLE
Add Go solution verifiers for contest 1056

### DIFF
--- a/1000-1999/1000-1099/1050-1059/1056/verifierA.go
+++ b/1000-1999/1000-1099/1050-1059/1056/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOfficial() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	bin := filepath.Join(dir, "officialA.bin")
+	cmd := exec.Command("go", "build", "-o", bin, filepath.Join(dir, "1056A.go"))
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func genTest() string {
+	var sb strings.Builder
+	t := rand.Intn(5) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		r := rand.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d", r))
+		used := make(map[int]bool)
+		for len(used) < r {
+			x := rand.Intn(10) + 1
+			if !used[x] {
+				used[x] = true
+				sb.WriteString(fmt.Sprintf(" %d", x))
+			}
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func main() {
+	rand.Seed(42)
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	off, err := buildOfficial()
+	if err != nil {
+		fmt.Println("failed to build official solution:", err)
+		return
+	}
+	defer os.Remove(off)
+
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err1 := runBinary(off, input)
+		out, err2 := runBinary(candidate, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("Runtime error on test %d\n", i+1)
+			if err1 != nil {
+				fmt.Println("official:", err1)
+			}
+			if err2 != nil {
+				fmt.Println("candidate:", err2)
+			}
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if exp != out {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1050-1059/1056/verifierB.go
+++ b/1000-1999/1000-1099/1050-1059/1056/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOfficial() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	bin := filepath.Join(dir, "officialB.bin")
+	cmd := exec.Command("go", "build", "-o", bin, filepath.Join(dir, "1056B.go"))
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func genTest() string {
+	n := rand.Int63n(500) + 1
+	m := rand.Int63n(1000) + 1
+	return fmt.Sprintf("%d %d\n", n, m)
+}
+
+func main() {
+	rand.Seed(43)
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+
+	off, err := buildOfficial()
+	if err != nil {
+		fmt.Println("failed to build official solution:", err)
+		return
+	}
+	defer os.Remove(off)
+
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err1 := runBinary(off, input)
+		out, err2 := runBinary(candidate, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("Runtime error on test %d\n", i+1)
+			fmt.Println("input:\n" + input)
+			if err1 != nil {
+				fmt.Println("official:", err1)
+			}
+			if err2 != nil {
+				fmt.Println("candidate:", err2)
+			}
+			return
+		}
+		if exp != out {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1050-1059/1056/verifierC.go
+++ b/1000-1999/1000-1099/1050-1059/1056/verifierC.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOfficial() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	bin := filepath.Join(dir, "officialC.bin")
+	cmd := exec.Command("go", "build", "-o", bin, filepath.Join(dir, "1056C.go"))
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func genTest() string {
+	n := rand.Intn(3) + 1
+	m := rand.Intn(n + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < 2*n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(100)+1))
+	}
+	sb.WriteByte('\n')
+	used := make(map[int]bool)
+	for i := 0; i < m; i++ {
+		var a, b int
+		for {
+			a = rand.Intn(2*n) + 1
+			if !used[a] {
+				used[a] = true
+				break
+			}
+		}
+		for {
+			b = rand.Intn(2*n) + 1
+			if b != a && !used[b] {
+				used[b] = true
+				break
+			}
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	t := rand.Intn(2) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	perm := rand.Perm(2 * n)
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	rand.Seed(44)
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	off, err := buildOfficial()
+	if err != nil {
+		fmt.Println("failed to build official solution:", err)
+		return
+	}
+	defer os.Remove(off)
+
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err1 := runBinary(off, input)
+		out, err2 := runBinary(candidate, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("Runtime error on test %d\n", i+1)
+			fmt.Println("input:\n" + input)
+			if err1 != nil {
+				fmt.Println("official:", err1)
+			}
+			if err2 != nil {
+				fmt.Println("candidate:", err2)
+			}
+			return
+		}
+		if exp != out {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1050-1059/1056/verifierD.go
+++ b/1000-1999/1000-1099/1050-1059/1056/verifierD.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOfficial() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	bin := filepath.Join(dir, "officialD.bin")
+	cmd := exec.Command("go", "build", "-o", bin, filepath.Join(dir, "1056D.go"))
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func genTest() string {
+	n := rand.Intn(9) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 2; i <= n; i++ {
+		if i > 2 {
+			sb.WriteByte(' ')
+		}
+		parent := rand.Intn(i-1) + 1
+		sb.WriteString(fmt.Sprintf("%d", parent))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	rand.Seed(45)
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	off, err := buildOfficial()
+	if err != nil {
+		fmt.Println("failed to build official solution:", err)
+		return
+	}
+	defer os.Remove(off)
+
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err1 := runBinary(off, input)
+		out, err2 := runBinary(candidate, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("Runtime error on test %d\n", i+1)
+			fmt.Println("input:\n" + input)
+			if err1 != nil {
+				fmt.Println("official:", err1)
+			}
+			if err2 != nil {
+				fmt.Println("candidate:", err2)
+			}
+			return
+		}
+		if exp != out {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1050-1059/1056/verifierE.go
+++ b/1000-1999/1000-1099/1050-1059/1056/verifierE.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOfficial() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	bin := filepath.Join(dir, "officialE.bin")
+	cmd := exec.Command("go", "build", "-o", bin, filepath.Join(dir, "1056E.go"))
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rand.Intn(3))
+	}
+	return string(b)
+}
+
+func genTest() string {
+	ls := rand.Intn(5) + 2
+	lt := rand.Intn(10) + 1
+	var sb strings.Builder
+	for i := 0; i < ls; i++ {
+		if rand.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	s := sb.String()
+	t := randString(lt)
+	return fmt.Sprintf("%s\n%s\n", s, t)
+}
+
+func main() {
+	rand.Seed(46)
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	off, err := buildOfficial()
+	if err != nil {
+		fmt.Println("failed to build official solution:", err)
+		return
+	}
+	defer os.Remove(off)
+
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err1 := runBinary(off, input)
+		out, err2 := runBinary(candidate, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("Runtime error on test %d\n", i+1)
+			fmt.Println("input:\n" + input)
+			if err1 != nil {
+				fmt.Println("official:", err1)
+			}
+			if err2 != nil {
+				fmt.Println("candidate:", err2)
+			}
+			return
+		}
+		if exp != out {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1050-1059/1056/verifierF.go
+++ b/1000-1999/1000-1099/1050-1059/1056/verifierF.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOfficial() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	bin := filepath.Join(dir, "officialF.bin")
+	cmd := exec.Command("go", "build", "-o", bin, filepath.Join(dir, "1056F.go"))
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func genTest() string {
+	n := rand.Intn(3) + 1
+	c := float64(rand.Intn(10)+1) / 2
+	tval := float64(rand.Intn(20) + 10)
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	sb.WriteString(fmt.Sprintf("%.1f %.1f\n", c, tval))
+	for i := 0; i < n; i++ {
+		a := rand.Intn(20) + 1
+		p := rand.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, p))
+	}
+	return sb.String()
+}
+
+func main() {
+	rand.Seed(47)
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	off, err := buildOfficial()
+	if err != nil {
+		fmt.Println("failed to build official solution:", err)
+		return
+	}
+	defer os.Remove(off)
+
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err1 := runBinary(off, input)
+		out, err2 := runBinary(candidate, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("Runtime error on test %d\n", i+1)
+			fmt.Println("input:\n" + input)
+			if err1 != nil {
+				fmt.Println("official:", err1)
+			}
+			if err2 != nil {
+				fmt.Println("candidate:", err2)
+			}
+			return
+		}
+		if exp != out {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1050-1059/1056/verifierG.go
+++ b/1000-1999/1000-1099/1050-1059/1056/verifierG.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOfficial() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	bin := filepath.Join(dir, "officialG.bin")
+	cmd := exec.Command("go", "build", "-o", bin, filepath.Join(dir, "1056G.go"))
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func genTest() string {
+	n := rand.Intn(9) + 2
+	m := rand.Intn(n-1) + 1
+	s := rand.Intn(n) + 1
+	tval := rand.Int63n(100) + 1
+	return fmt.Sprintf("%d %d %d %d\n", n, m, s, tval)
+}
+
+func main() {
+	rand.Seed(48)
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	off, err := buildOfficial()
+	if err != nil {
+		fmt.Println("failed to build official solution:", err)
+		return
+	}
+	defer os.Remove(off)
+
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err1 := runBinary(off, input)
+		out, err2 := runBinary(candidate, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("Runtime error on test %d\n", i+1)
+			fmt.Println("input:\n" + input)
+			if err1 != nil {
+				fmt.Println("official:", err1)
+			}
+			if err2 != nil {
+				fmt.Println("candidate:", err2)
+			}
+			return
+		}
+		if exp != out {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1050-1059/1056/verifierH.go
+++ b/1000-1999/1000-1099/1050-1059/1056/verifierH.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOfficial() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	bin := filepath.Join(dir, "officialH.bin")
+	cmd := exec.Command("go", "build", "-o", bin, filepath.Join(dir, "1056H.go"))
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func genCase() string {
+	n := rand.Intn(4) + 1
+	q := rand.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 0; i < q; i++ {
+		k := rand.Intn(n) + 1
+		perm := rand.Perm(n)
+		sb.WriteString(fmt.Sprintf("%d", k))
+		for j := 0; j < k; j++ {
+			sb.WriteString(fmt.Sprintf(" %d", perm[j]+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func genTest() string {
+	return fmt.Sprintf("1\n%s", genCase())
+}
+
+func main() {
+	rand.Seed(49)
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	off, err := buildOfficial()
+	if err != nil {
+		fmt.Println("failed to build official solution:", err)
+		return
+	}
+	defer os.Remove(off)
+
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err1 := runBinary(off, input)
+		out, err2 := runBinary(candidate, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("Runtime error on test %d\n", i+1)
+			fmt.Println("input:\n" + input)
+			if err1 != nil {
+				fmt.Println("official:", err1)
+			}
+			if err2 != nil {
+				fmt.Println("candidate:", err2)
+			}
+			return
+		}
+		if exp != out {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}


### PR DESCRIPTION
## Summary
- implement new Go-based verifiers for contest 1056 problems A–H
- each verifier compiles the reference solution, generates 100 random tests and checks a submitted binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`

------
https://chatgpt.com/codex/tasks/task_e_6884660cf0f88324bfb0eed52eafc17d