### PR TITLE
Add Go verifiers for CF contest 1057

### DIFF
--- a/1000-1999/1000-1099/1050-1059/1057/verifierA.go
+++ b/1000-1999/1000-1099/1050-1059/1057/verifierA.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	parents []int // 1-indexed, parents[1] unused
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(100) + 2 // 2..101
+	p := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		p[i] = rng.Intn(i-1) + 1
+	}
+	return testCase{parents: p}
+}
+
+func expected(tc testCase) string {
+	n := len(tc.parents) - 1
+	path := []int{}
+	cur := n
+	for cur != 1 {
+		path = append(path, cur)
+		cur = tc.parents[cur]
+	}
+	var sb strings.Builder
+	sb.WriteString("1")
+	for i := len(path) - 1; i >= 0; i-- {
+		fmt.Fprintf(&sb, " %d", path[i])
+	}
+	return sb.String()
+}
+
+func runCase(bin string, tc testCase) error {
+	n := len(tc.parents) - 1
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 2; i <= n; i++ {
+		if i > 2 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", tc.parents[i])
+	}
+	b.WriteByte('\n')
+
+	got, err := run(bin, b.String())
+	if err != nil {
+		return err
+	}
+	exp := expected(tc)
+	if strings.TrimSpace(got) != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := make([]testCase, 0, 100)
+	// deterministic small cases
+	cases = append(cases, testCase{parents: []int{0, 0, 1}})    // n=2
+	cases = append(cases, testCase{parents: []int{0, 0, 1, 1}}) // n=3 path 1->3
+	cases = append(cases, testCase{parents: []int{0, 0, 1, 2}}) // n=3 path 1->2->3
+	for len(cases) < 100 {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1050-1059/1057/verifierB.go
+++ b/1000-1999/1000-1099/1050-1059/1057/verifierB.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	arr []int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(arr []int) int {
+	n := len(arr)
+	pref := make([]int, n+1)
+	for i, v := range arr {
+		pref[i+1] = pref[i] + v
+	}
+	best := 0
+	for i := 1; i <= n; i++ {
+		for j := 0; j < i; j++ {
+			sum := pref[i] - pref[j]
+			if sum > (i-j)*100 {
+				if i-j > best {
+					best = i - j
+				}
+			}
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(40) + 1 // 1..40
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(201) // 0..200
+	}
+	return testCase{arr}
+}
+
+func runCase(bin string, tc testCase) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d\n", len(tc.arr))
+	for i, v := range tc.arr {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", v)
+	}
+	b.WriteByte('\n')
+
+	got, err := run(bin, b.String())
+	if err != nil {
+		return err
+	}
+	exp := fmt.Sprintf("%d", expected(tc.arr))
+	if strings.TrimSpace(got) != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := make([]testCase, 0, 100)
+	// deterministic cases
+	cases = append(cases, testCase{arr: []int{50}})
+	cases = append(cases, testCase{arr: []int{200, 1}})
+	cases = append(cases, testCase{arr: []int{0, 0, 0}})
+	for len(cases) < 100 {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1050-1059/1057/verifierC.go
+++ b/1000-1999/1000-1099/1050-1059/1057/verifierC.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	s int
+	k int
+	r []int
+	c string
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expected(tc testCase) int {
+	const INF = int(1e9)
+	n, s, k := tc.n, tc.s-1, tc.k
+	dp := make([][]int, n)
+	for i := range dp {
+		dp[i] = make([]int, k)
+		for j := range dp[i] {
+			dp[i][j] = INF
+		}
+	}
+	best := INF
+	for i := 0; i < n; i++ {
+		cost := abs(i - s)
+		if tc.r[i] >= k {
+			best = min(best, cost)
+		} else {
+			if tc.r[i] < k {
+				dp[i][tc.r[i]] = cost
+			}
+		}
+	}
+	for rating := 1; rating <= 50; rating++ {
+		for i := 0; i < n; i++ {
+			if tc.r[i] != rating {
+				continue
+			}
+			for sum := 0; sum < k; sum++ {
+				curr := dp[i][sum]
+				if curr >= INF {
+					continue
+				}
+				for j := 0; j < n; j++ {
+					if tc.r[j] > tc.r[i] && tc.c[i] != tc.c[j] {
+						s2 := sum + tc.r[j]
+						cost2 := curr + abs(j-i)
+						if s2 >= k {
+							best = min(best, cost2)
+						} else if cost2 < dp[j][s2] {
+							dp[j][s2] = cost2
+						}
+					}
+				}
+			}
+		}
+	}
+	if best >= INF {
+		return -1
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(7) + 1
+	s := rng.Intn(n) + 1
+	r := make([]int, n)
+	total := 0
+	for i := range r {
+		r[i] = rng.Intn(50) + 1
+		total += r[i]
+	}
+	k := rng.Intn(total+50) + 1
+	if k > 2000 {
+		k = 2000
+	}
+	var sb strings.Builder
+	colors := []byte{'R', 'G', 'B'}
+	for i := 0; i < n; i++ {
+		sb.WriteByte(colors[rng.Intn(3)])
+	}
+	return testCase{n: n, s: s, k: k, r: r, c: sb.String()}
+}
+
+func runCase(bin string, tc testCase) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %d %d\n", tc.n, tc.s, tc.k)
+	for i, v := range tc.r {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d", v)
+	}
+	b.WriteByte('\n')
+	b.WriteString(tc.c)
+	b.WriteByte('\n')
+
+	got, err := run(bin, b.String())
+	if err != nil {
+		return err
+	}
+	exp := fmt.Sprintf("%d", expected(tc))
+	if strings.TrimSpace(got) != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := make([]testCase, 0, 100)
+	// deterministic simple case
+	cases = append(cases, testCase{n: 1, s: 1, k: 1, r: []int{1}, c: "R"})
+	for len(cases) < 100 {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–C of contest 1057
- each verifier generates at least 100 test cases and checks a provided solution binary

## Testing
- `go run 1000-1999/1000-1099/1050-1059/1057/verifierA.go /tmp/1057A.bin`
- `go run 1000-1999/1000-1099/1050-1059/1057/verifierB.go /tmp/1057B.bin`
- `go run 1000-1999/1000-1099/1050-1059/1057/verifierC.go /tmp/1057C.bin`

------
https://chatgpt.com/codex/tasks/task_e_68846699017c832489fe8c6fb869ac2f