### PR TITLE
Add contest 1058A verifier

### DIFF
--- a/1000-1999/1050-1059/1058/1058A.go
+++ b/1000-1999/1050-1059/1058/1058A.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(in, &n)
+	hard := false
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(in, &x)
+		if x == 1 {
+			hard = true
+		}
+	}
+	if hard {
+		fmt.Println("HARD")
+	} else {
+		fmt.Println("EASY")
+	}
+}

--- a/1000-1999/1050-1059/1058/problemA.txt
+++ b/1000-1999/1050-1059/1058/problemA.txt
@@ -1,0 +1,7 @@
+Description:
+Given n opinions about a problem difficulty (0 for easy, 1 for hard), output "EASY" if all opinions are 0, otherwise output "HARD".
+Input Format:
+First line n (1 <= n <= 100).
+Second line contains n integers 0 or 1.
+Output Format:
+"EASY" if all inputs are 0, otherwise "HARD".

--- a/1000-1999/1050-1059/1058/verifierA.go
+++ b/1000-1999/1050-1059/1058/verifierA.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1058A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(100) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		if r.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}


### PR DESCRIPTION
## Summary
- add contest 1058 directory
- implement problem A solution (1058A.go)
- add verifierA.go with 100 random test cases
- include short problem statement for A

## Testing
- `go build 1000-1999/1050-1059/1058/1058A.go`
- `go run verifierA.go /tmp/sol`


------
https://chatgpt.com/codex/tasks/task_e_6884672522b8832496788c4042069954