### PR TITLE
Add verifiers for Codeforces 1061

### DIFF
--- a/1000-1999/1000-1099/1060-1069/1061/verifierA.go
+++ b/1000-1999/1000-1099/1060-1069/1061/verifierA.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n, s int64) int64 {
+	return (s + n - 1) / n
+}
+
+func genCase(rng *rand.Rand) (int64, int64) {
+	n := rng.Int63n(100000) + 1
+	s := rng.Int63n(1000000000) + 1
+	return n, s
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, s := genCase(rng)
+		input := fmt.Sprintf("%d %d\n", n, s)
+		expect := solveCase(n, s)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(out, &got); err != nil || got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1060-1069/1061/verifierB.go
+++ b/1000-1999/1000-1099/1060-1069/1061/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(n int, m int64, arr []int64) int64 {
+	orig := make([]int64, n)
+	copy(orig, arr)
+	sum := int64(0)
+	for _, v := range orig {
+		sum += v
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	var maxx int64
+	for i := n - 1; i > 0; i-- {
+		if arr[i-1] >= arr[i]-1 {
+			if arr[i] <= 1 {
+				arr[i-1] = 1
+			} else {
+				arr[i-1] = arr[i] - 1
+			}
+			maxx++
+		} else {
+			maxx += arr[i] - arr[i-1]
+		}
+	}
+	maxx += arr[0]
+	return sum - maxx
+}
+
+func genCase(rng *rand.Rand) (int, int64, []int64) {
+	n := rng.Intn(20) + 1
+	m := int64(rng.Intn(50) + 1)
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(int(m)) + 1)
+	}
+	return n, m, arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, arr := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		expect := solveCase(n, m, append([]int64(nil), arr...))
+		out, err := runCandidate(bin, sb.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(out, &got); err != nil || got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\n", i+1, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1060-1069/1061/verifierC.go
+++ b/1000-1999/1000-1099/1060-1069/1061/verifierC.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOfficial() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	bin := filepath.Join(dir, "officialC.bin")
+	cmd := exec.Command("go", "build", "-o", bin, filepath.Join(dir, "1061C.go"))
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func genCase(rng *rand.Rand) (int, []int) {
+	n := rng.Intn(8) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(1000000) + 1
+	}
+	return n, arr
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	off, err := buildOfficial()
+	if err != nil {
+		fmt.Println("failed to build official solution:", err)
+		return
+	}
+	defer os.Remove(off)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, arr := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j, v := range arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp, err1 := runBinary(off, input)
+		out, err2 := runBinary(candidate, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("Runtime error on test %d\n", i+1)
+			fmt.Println("input:\n" + input)
+			if err1 != nil {
+				fmt.Println("official:", err1)
+			}
+			if err2 != nil {
+				fmt.Println("candidate:", err2)
+			}
+			return
+		}
+		if exp != out {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1060-1069/1061/verifierD.go
+++ b/1000-1999/1000-1099/1060-1069/1061/verifierD.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOfficial() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	bin := filepath.Join(dir, "officialD.bin")
+	cmd := exec.Command("go", "build", "-o", bin, filepath.Join(dir, "1061D.go"))
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func genCase(rng *rand.Rand) (int, int64, int64, [][2]int) {
+	n := rng.Intn(8) + 1
+	x := int64(rng.Intn(20) + 2)
+	y := int64(rng.Intn(int(x-1)) + 1)
+	segs := make([][2]int, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(20) + 1
+		r := l + rng.Intn(20)
+		segs[i] = [2]int{l, r}
+	}
+	return n, x, y, segs
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	off, err := buildOfficial()
+	if err != nil {
+		fmt.Println("failed to build official solution:", err)
+		return
+	}
+	defer os.Remove(off)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, x, y, segs := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x, y))
+		for _, s := range segs {
+			sb.WriteString(fmt.Sprintf("%d %d\n", s[0], s[1]))
+		}
+		input := sb.String()
+		exp, err1 := runBinary(off, input)
+		out, err2 := runBinary(candidate, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("Runtime error on test %d\n", i+1)
+			fmt.Println("input:\n" + input)
+			if err1 != nil {
+				fmt.Println("official:", err1)
+			}
+			if err2 != nil {
+				fmt.Println("candidate:", err2)
+			}
+			return
+		}
+		if exp != out {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1060-1069/1061/verifierE.go
+++ b/1000-1999/1000-1099/1060-1069/1061/verifierE.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildOfficial() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	bin := filepath.Join(dir, "officialE.bin")
+	cmd := exec.Command("go", "build", "-o", bin, filepath.Join(dir, "1061E.go"))
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func genTree(rng *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	return edges
+}
+
+func genCase(rng *rand.Rand) (int, int, int, []int, [][2]int, [][2]int, [][2]int, [][2]int) {
+	n := rng.Intn(6) + 2
+	x := rng.Intn(n) + 1
+	y := rng.Intn(n) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(100) + 1
+	}
+	t1 := genTree(rng, n)
+	t2 := genTree(rng, n)
+	q1 := rng.Intn(n) + 1
+	q2 := rng.Intn(n) + 1
+	dem1 := make([][2]int, q1)
+	used := make(map[int]bool)
+	used[x] = true
+	dem1[0] = [2]int{x, rng.Intn(n) + 1}
+	for i := 1; i < q1; i++ {
+		k := rng.Intn(n) + 1
+		for used[k] {
+			k = rng.Intn(n) + 1
+		}
+		used[k] = true
+		dem1[i] = [2]int{k, rng.Intn(n) + 1}
+	}
+	dem2 := make([][2]int, q2)
+	used = map[int]bool{y: true}
+	dem2[0] = [2]int{y, rng.Intn(n) + 1}
+	for i := 1; i < q2; i++ {
+		k := rng.Intn(n) + 1
+		for used[k] {
+			k = rng.Intn(n) + 1
+		}
+		used[k] = true
+		dem2[i] = [2]int{k, rng.Intn(n) + 1}
+	}
+	return n, x, y, a, t1, t2, dem1, dem2
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	off, err := buildOfficial()
+	if err != nil {
+		fmt.Println("failed to build official solution:", err)
+		return
+	}
+	defer os.Remove(off)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, x, y, a, t1, t2, d1, d2 := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x, y))
+		for j, v := range a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for _, e := range t1 {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		for _, e := range t2 {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", len(d1)))
+		for _, d := range d1 {
+			sb.WriteString(fmt.Sprintf("%d %d\n", d[0], d[1]))
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", len(d2)))
+		for _, d := range d2 {
+			sb.WriteString(fmt.Sprintf("%d %d\n", d[0], d[1]))
+		}
+		input := sb.String()
+		exp, err1 := runBinary(off, input)
+		out, err2 := runBinary(candidate, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("Runtime error on test %d\n", i+1)
+			if err1 != nil {
+				fmt.Println("official:", err1)
+			}
+			if err2 != nil {
+				fmt.Println("candidate:", err2)
+			}
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if exp != out {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:%s\nGot:%s\n", i+1, input, exp, out)
+			return
+		}
+	}
+	fmt.Println("All tests passed!")
+}

--- a/1000-1999/1000-1099/1060-1069/1061/verifierF.go
+++ b/1000-1999/1000-1099/1060-1069/1061/verifierF.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem F is interactive and cannot be automatically verified.")
+}


### PR DESCRIPTION
## Summary
- add Go verifier scripts for contest 1061 problems A–E
- include a stub notifier for interactive problem F

## Testing
- `gofmt -w 1000-1999/1000-1099/1060-1069/1061/*.go`


------
https://chatgpt.com/codex/tasks/task_e_688468c96dbc832488f4f4d6af1e5a74