### PR TITLE
Add Go solution for 1696B

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1696/1696B.go
+++ b/1000-1999/1600-1699/1690-1699/1696/1696B.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		segs := 0
+		inSeg := false
+		for i := 0; i < n; i++ {
+			if arr[i] != 0 {
+				if !inSeg {
+					segs++
+					inSeg = true
+				}
+			} else {
+				inSeg = false
+			}
+		}
+		if segs > 2 {
+			segs = 2
+		}
+		fmt.Fprintln(writer, segs)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for NIT Destroys the Universe

## Testing
- `go build 1000-1999/1600-1699/1690-1699/1696/1696B.go`
- `go run 1000-1999/1600-1699/1690-1699/1696/1696B.go < input.txt`

------
https://chatgpt.com/codex/tasks/task_e_68846ab3da0c8324af6f100ae50bc20b