### PR TITLE
Add verifiers for contest 1064

### DIFF
--- a/1000-1999/1000-1099/1060-1069/1064/verifierA.go
+++ b/1000-1999/1000-1099/1060-1069/1064/verifierA.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strings"
+    "time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var stderr bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &stderr
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func solve(a, b, c int) int {
+    if a > b {
+        a, b = b, a
+    }
+    if b > c {
+        b, c = c, b
+    }
+    if a > b {
+        a, b = b, a
+    }
+    if a+b > c {
+        return 0
+    }
+    return c - (a + b) + 1
+}
+
+func generateCase(rng *rand.Rand) (int, int, int) {
+    return rng.Intn(100) + 1, rng.Intn(100) + 1, rng.Intn(100) + 1
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+    tests := []struct{ a, b, c int }{
+        {1, 1, 1},
+        {1, 1, 2},
+        {1, 2, 3},
+        {2, 3, 5},
+        {2, 3, 4},
+        {100, 100, 100},
+        {1, 100, 1},
+        {50, 50, 100},
+        {1, 1, 100},
+        {3, 4, 5},
+    }
+    for i := 0; i < 100; i++ {
+        a, b, c := generateCase(rng)
+        tests = append(tests, struct{ a, b, c int }{a, b, c})
+    }
+
+    for idx, tc := range tests {
+        input := fmt.Sprintf("%d %d %d\n", tc.a, tc.b, tc.c)
+        expected := fmt.Sprintf("%d", solve(tc.a, tc.b, tc.c))
+        out, err := runCandidate(bin, input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, input)
+            os.Exit(1)
+        }
+        if strings.TrimSpace(out) != expected {
+            fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", idx+1, expected, out, input)
+            os.Exit(1)
+        }
+    }
+    fmt.Println("All tests passed")
+}
+

--- a/1000-1999/1000-1099/1060-1069/1064/verifierB.go
+++ b/1000-1999/1000-1099/1060-1069/1064/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/bits"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+    "time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+    var cmd *exec.Cmd
+    if strings.HasSuffix(bin, ".go") {
+        cmd = exec.Command("go", "run", bin)
+    } else {
+        cmd = exec.Command(bin)
+    }
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    var stderr bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &stderr
+    if err := cmd.Run(); err != nil {
+        return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+    }
+    return strings.TrimSpace(out.String()), nil
+}
+
+func solve(x uint64) uint64 {
+    return 1 << bits.OnesCount64(x)
+}
+
+func generateCase(rng *rand.Rand) []uint64 {
+    t := rng.Intn(10) + 1
+    arr := make([]uint64, t)
+    for i := 0; i < t; i++ {
+        arr[i] = uint64(rng.Int63() & ((1 << 30) - 1))
+    }
+    return arr
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+    cases := [][]uint64{
+        {0},
+        {1},
+        {3},
+        {0, 1, (1 << 30) - 1},
+    }
+    for i := 0; i < 100; i++ {
+        cases = append(cases, generateCase(rng))
+    }
+
+    for idx, arr := range cases {
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+        for _, v := range arr {
+            sb.WriteString(fmt.Sprintf("%d\n", v))
+        }
+        input := sb.String()
+        out, err := runCandidate(bin, input)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, input)
+            os.Exit(1)
+        }
+        fields := strings.Fields(out)
+        if len(fields) != len(arr) {
+            fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\ninput:\n%s", idx+1, len(arr), len(fields), input)
+            os.Exit(1)
+        }
+        for j, f := range fields {
+            val, err := strconv.ParseUint(f, 10, 64)
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "case %d failed: bad number %q\n", idx+1, f)
+                os.Exit(1)
+            }
+            expected := solve(arr[j])
+            if val != expected {
+                fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", idx+1, expected, val, input)
+                os.Exit(1)
+            }
+        }
+    }
+    fmt.Println("All tests passed")
+}
+


### PR DESCRIPTION
## Summary
- implement `verifierA.go` and `verifierB.go` for contest 1064
- each verifier runs candidate binaries on 100+ randomly generated tests

## Testing
- `go build 1000-1999/1000-1099/1060-1069/1064/verifierA.go`
- `go run 1000-1999/1000-1099/1060-1069/1064/verifierA.go ./1064A_bin`
- `go build 1000-1999/1000-1099/1060-1069/1064/verifierB.go`
- `go run 1000-1999/1000-1099/1060-1069/1064/verifierB.go ./1064B_bin`

------
https://chatgpt.com/codex/tasks/task_e_68846a6eab588324a0b4becdd679beff