### PR TITLE
Add Go verifiers for contest 1062

### DIFF
--- a/1000-1999/1000-1099/1060-1069/1062/verifierA.go
+++ b/1000-1999/1000-1099/1060-1069/1062/verifierA.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildOracle() (string, error) {
+	oracle := "./oracleA"
+	cmd := exec.Command("go", "build", "-o", oracle, "1062A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(100) + 1
+	nums := rng.Perm(1000)[:n]
+	for i := range nums {
+		nums[i]++
+	}
+	sort.Ints(nums)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range nums {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []string{
+		"1\n500\n",
+		"2\n1 1000\n",
+		"2\n999 1000\n",
+	}
+	for i := 0; i < 100; i++ {
+		tests = append(tests, genCase(rng))
+	}
+
+	for idx, input := range tests {
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle runtime error on case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\n got: %s\ninput:\n%s", idx+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1000-1099/1060-1069/1062/verifierB.go
+++ b/1000-1999/1000-1099/1060-1069/1062/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildOracle() (string, error) {
+	oracle := "./oracleB"
+	cmd := exec.Command("go", "build", "-o", oracle, "1062B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(1000000) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []string{
+		"1\n",
+		"2\n",
+		"3\n",
+		"4\n",
+		"16\n",
+		"999983\n",
+	}
+	for i := 0; i < 100; i++ {
+		tests = append(tests, genCase(rng))
+	}
+
+	for idx, input := range tests {
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle runtime error on case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\n got: %s\ninput:\n%s", idx+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1000-1099/1060-1069/1062/verifierC.go
+++ b/1000-1999/1000-1099/1060-1069/1062/verifierC.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildOracle() (string, error) {
+	oracle := "./oracleC"
+	cmd := exec.Command("go", "build", "-o", oracle, "1062C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	q := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 1 {
+			sb.WriteByte('1')
+		} else {
+			sb.WriteByte('0')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n) + 1
+		if l > r {
+			l, r = r, l
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []string{
+		"1 1\n0\n1 1\n",
+		"2 1\n01\n1 2\n",
+	}
+	for i := 0; i < 100; i++ {
+		tests = append(tests, genCase(rng))
+	}
+
+	for idx, input := range tests {
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle runtime error on case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\n got: %s\ninput:\n%s", idx+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1000-1099/1060-1069/1062/verifierD.go
+++ b/1000-1999/1000-1099/1060-1069/1062/verifierD.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildOracle() (string, error) {
+	oracle := "./oracleD"
+	cmd := exec.Command("go", "build", "-o", oracle, "1062D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10000) + 2
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []string{
+		"2\n",
+		"3\n",
+		"4\n",
+		"5\n",
+		"100000\n",
+	}
+	for i := 0; i < 100; i++ {
+		tests = append(tests, genCase(rng))
+	}
+
+	for idx, input := range tests {
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle runtime error on case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\n got: %s\ninput:\n%s", idx+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1000-1099/1060-1069/1062/verifierE.go
+++ b/1000-1999/1000-1099/1060-1069/1062/verifierE.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildOracle() (string, error) {
+	oracle := "./oracleE"
+	cmd := exec.Command("go", "build", "-o", oracle, "1062E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	q := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	// parents for nodes 2..n
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		if i > 2 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", p))
+	}
+	if n > 1 {
+		sb.WriteByte('\n')
+	} else {
+		sb.WriteString("\n")
+	}
+	for i := 0; i < q; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n) + 1
+		if l > r {
+			l, r = r, l
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []string{
+		"1 1\n\n1 1\n",
+		"2 1\n1\n1 2\n",
+	}
+	for i := 0; i < 100; i++ {
+		tests = append(tests, genCase(rng))
+	}
+
+	for idx, input := range tests {
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle runtime error on case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\n got: %s\ninput:\n%s", idx+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1000-1099/1060-1069/1062/verifierF.go
+++ b/1000-1999/1000-1099/1060-1069/1062/verifierF.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		return out.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildOracle() (string, error) {
+	oracle := "./oracleF"
+	cmd := exec.Command("go", "build", "-o", oracle, "1062F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	maxM := n * (n - 1) / 2
+	m := rng.Intn(maxM + 1)
+	var edges []edge
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			edges = append(edges, edge{i, j})
+		}
+	}
+	rng.Shuffle(len(edges), func(i, j int) { edges[i], edges[j] = edges[j], edges[i] })
+	edges = edges[:m]
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []string{
+		"2 0\n",
+		"2 1\n1 2\n",
+		"3 2\n1 2\n2 3\n",
+	}
+	for i := 0; i < 100; i++ {
+		tests = append(tests, genCase(rng))
+	}
+
+	for idx, input := range tests {
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle runtime error on case %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected: %s\n got: %s\ninput:\n%s", idx+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1062
- each verifier compiles the official solution, generates 100+ random tests and compares outputs

## Testing
- `go run verifierA.go ./testA`
- `go run verifierB.go ./testB`
- `go run verifierC.go ./testC`
- `go run verifierD.go ./testD`
- `go run verifierE.go ./testE`
- `go run verifierF.go ./testF`


------
https://chatgpt.com/codex/tasks/task_e_68846955e06c83249d8bb3af7063e603