### PR TITLE
Add Go solution for 1696A

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1696/1696A.go
+++ b/1000-1999/1600-1699/1690-1699/1696/1696A.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// This program solves the problem described in problemA.txt for contest 1696A.
+// We can apply the operation on any element of the array, replacing a[i] with
+// a[i] OR z and updating z to a[i] AND z. Bits removed from z never reappear,
+// so to maximize any element we should apply the operation to that element
+// immediately, yielding value a[i] | z. The best possible maximum value is
+// therefore the maximum of a[i] | z over all i.
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, z int
+		fmt.Fscan(reader, &n, &z)
+		maxVal := 0
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			if v := x | z; v > maxVal {
+				maxVal = v
+			}
+		}
+		fmt.Fprintln(writer, maxVal)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problemA

## Testing
- `go build 1000-1999/1600-1699/1690-1699/1696/1696A.go`
- `go run 1000-1999/1600-1699/1690-1699/1696/1696A.go < /tmp/input.txt`

------
https://chatgpt.com/codex/tasks/task_e_68846b4004a883249da7ed3b69af6606