### PR TITLE
Add Go verifiers for Codeforces Round 1065

### DIFF
--- a/1000-1999/1000-1099/1060-1069/1065/verifierA.go
+++ b/1000-1999/1000-1099/1060-1069/1065/verifierA.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(s, a, b, c int64) int64 {
+	x := s / c
+	return x + (x/a)*b
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]testCase, 0, 100)
+	tests = append(tests, testCase{input: "1\n1 1 1 1\n", expected: fmt.Sprint(solveCase(1, 1, 1, 1))})
+	tests = append(tests, testCase{input: fmt.Sprintf("1\n%d %d %d %d\n", int64(1e9), int64(1e9), int64(1e9), int64(1)), expected: fmt.Sprint(solveCase(1e9, 1e9, 1e9, 1))})
+	for len(tests) < 100 {
+		s := rng.Int63n(1e9) + 1
+		a := rng.Int63n(1e9) + 1
+		b := rng.Int63n(1e9) + 1
+		c := rng.Int63n(1e9) + 1
+		input := fmt.Sprintf("1\n%d %d %d %d\n", s, a, b, c)
+		exp := fmt.Sprint(solveCase(s, a, b, c))
+		tests = append(tests, testCase{input: input, expected: exp})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1060-1069/1065/verifierB.go
+++ b/1000-1999/1000-1099/1060-1069/1065/verifierB.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(n, m int64) (int64, int64) {
+	minIso := n - 2*m
+	if minIso < 0 {
+		minIso = 0
+	}
+	low, high := int64(0), n+1
+	for low < high {
+		mid := (low + high) / 2
+		if mid*(mid-1)/2 >= m {
+			high = mid
+		} else {
+			low = mid + 1
+		}
+	}
+	maxIso := n - low
+	return minIso, maxIso
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(43))
+	tests := make([]testCase, 0, 100)
+	tests = append(tests, testCase{input: "1 0\n", expected: "1 1"})
+	for len(tests) < 100 {
+		n := rng.Int63n(100000) + 1
+		maxM := n * (n - 1) / 2
+		m := rng.Int63n(maxM + 1)
+		in := fmt.Sprintf("%d %d\n", n, m)
+		mi, ma := solveCase(n, m)
+		exp := fmt.Sprintf("%d %d", mi, ma)
+		tests = append(tests, testCase{input: in, expected: exp})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1060-1069/1065/verifierC.go
+++ b/1000-1999/1000-1099/1060-1069/1065/verifierC.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func solveCase(n int, m int64, heights []int64) int {
+	sort.Slice(heights, func(i, j int) bool { return heights[i] > heights[j] })
+	ans := 0
+	i := 0
+	for heights[0] != heights[n-1] {
+		t := i
+		var tot int64
+		for t+1 < n {
+			diff := heights[t] - heights[t+1]
+			cost := diff * int64(t+1)
+			if tot+cost > m {
+				break
+			}
+			tot += cost
+			t++
+		}
+		if t == i {
+			i = t
+		}
+		ans++
+		i = t
+		dec := (m - tot) / int64(i+1)
+		heights[i] -= dec
+	}
+	return ans
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(44))
+	tests := make([]testCase, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		m := rng.Int63n(1000) + int64(n)
+		heights := make([]int64, n)
+		for i := 0; i < n; i++ {
+			heights[i] = rng.Int63n(200) + 1
+		}
+		hcopy := make([]int64, n)
+		copy(hcopy, heights)
+		ans := solveCase(n, m, hcopy)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i, v := range heights {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, testCase{input: sb.String(), expected: fmt.Sprint(ans)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != tc.expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, tc.expected, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1060-1069/1065/verifierD.go
+++ b/1000-1999/1000-1099/1060-1069/1065/verifierD.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(45))
+	tests := make([]string, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(4) + 2
+		size := n * n
+		vals := make([]int, size)
+		for i := 0; i < size; i++ {
+			vals[i] = i + 1
+		}
+		rng.Shuffle(size, func(i, j int) { vals[i], vals[j] = vals[j], vals[i] })
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < size; i++ {
+			sb.WriteString(fmt.Sprintf("%d", vals[i]))
+			if (i+1)%n == 0 {
+				sb.WriteByte('\n')
+			} else {
+				sb.WriteByte(' ')
+			}
+		}
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	if cand == "--" && len(os.Args) >= 3 {
+		cand = os.Args[2]
+	}
+	official := "./officialD"
+	if err := exec.Command("go", "build", "-o", official, "1065D.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := run(official, tc)
+		got, gerr := run(cand, tc)
+		if eerr != nil {
+			fmt.Fprintf(os.Stderr, "official failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\ninput:\n%s", i+1, gerr, tc)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1060-1069/1065/verifierE.go
+++ b/1000-1999/1000-1099/1060-1069/1065/verifierE.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(46))
+	tests := make([]string, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(20) + 2
+		m := rng.Intn(n/2) + 1
+		A := rng.Intn(10) + 1
+		vals := make([]int, m)
+		maxVal := n / 2
+		last := 0
+		for i := 0; i < m; i++ {
+			if last >= maxVal {
+				last = maxVal
+			}
+			step := rng.Intn(maxVal-last) + 1
+			last += step
+			vals[i] = last
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, A))
+		for i, v := range vals {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	if cand == "--" && len(os.Args) >= 3 {
+		cand = os.Args[2]
+	}
+	official := "./officialE"
+	if err := exec.Command("go", "build", "-o", official, "1065E.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := run(official, tc)
+		got, gerr := run(cand, tc)
+		if eerr != nil {
+			fmt.Fprintf(os.Stderr, "official failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\ninput:\n%s", i+1, gerr, tc)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1060-1069/1065/verifierF.go
+++ b/1000-1999/1000-1099/1060-1069/1065/verifierF.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(47))
+	tests := make([]string, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 2
+		k := rng.Intn(n-1) + 1
+		parents := make([]int, n-1)
+		for i := 0; i < n-1; i++ {
+			parents[i] = rng.Intn(i+1) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i, p := range parents {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", p))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	if cand == "--" && len(os.Args) >= 3 {
+		cand = os.Args[2]
+	}
+	official := "./officialF"
+	if err := exec.Command("go", "build", "-o", official, "1065F.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := run(official, tc)
+		got, gerr := run(cand, tc)
+		if eerr != nil {
+			fmt.Fprintf(os.Stderr, "official failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\ninput:\n%s", i+1, gerr, tc)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1060-1069/1065/verifierG.go
+++ b/1000-1999/1000-1099/1060-1069/1065/verifierG.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func fibLengths() [25]int64 {
+	var f [25]int64
+	f[0] = 1
+	f[1] = 1
+	for i := 2; i < 25; i++ {
+		f[i] = f[i-1] + f[i-2]
+	}
+	return f
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(48))
+	tests := make([]string, 0, 100)
+	fl := fibLengths()
+	for len(tests) < 100 {
+		n := rng.Intn(10) + 1
+		maxK := fl[n]
+		if maxK < 1 {
+			maxK = 1
+		}
+		K := rng.Int63n(maxK) + 1
+		m := rng.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, K, m))
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	if cand == "--" && len(os.Args) >= 3 {
+		cand = os.Args[2]
+	}
+	official := "./officialG"
+	if err := exec.Command("go", "build", "-o", official, "1065G.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := run(official, tc)
+		got, gerr := run(cand, tc)
+		if eerr != nil {
+			fmt.Fprintf(os.Stderr, "official failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on test %d: %v\ninput:\n%s", i+1, gerr, tc)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go–verifierG.go for contest 1065
- each verifier generates 100+ tests and can check any executable

## Testing
- `go run verifierA.go -- 1065A.go`
- `go run verifierB.go -- 1065B.go`


------
https://chatgpt.com/codex/tasks/task_e_68846afa163083248dd8fed241010d3f