### PR TITLE
Add verifiers for contest 1076

### DIFF
--- a/1000-1999/1000-1099/1070-1079/1076/verifierA.go
+++ b/1000-1999/1000-1099/1070-1079/1076/verifierA.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n int, s string) string {
+	idx := -1
+	for i := 0; i+1 < n; i++ {
+		if s[i] > s[i+1] {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		idx = n - 1
+	}
+	return s[:idx] + s[idx+1:]
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(19) + 2 // [2,20]
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	s := string(b)
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	expect := solve(n, s)
+	return input, expect
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1070-1079/1076/verifierB.go
+++ b/1000-1999/1000-1099/1070-1079/1076/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isPrime(n int64) bool {
+	if n < 2 {
+		return false
+	}
+	for i := int64(2); i*i <= n; i++ {
+		if n%i == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func solve(n int64) int64 {
+	if isPrime(n) {
+		return 1
+	}
+	if n%2 == 0 {
+		return n / 2
+	}
+	// find smallest divisor
+	for i := int64(3); i <= n; i += 2 {
+		if n%i == 0 {
+			return 1 + (n-i)/2
+		}
+	}
+	return 1
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000) + 2
+	input := fmt.Sprintf("%d\n", n)
+	expect := fmt.Sprintf("%d", solve(n))
+	return input, expect
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1070-1079/1076/verifierC.go
+++ b/1000-1999/1000-1099/1070-1079/1076/verifierC.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(d float64) string {
+	D := d*d - 4*d
+	if D < 0 {
+		return "N"
+	}
+	sqrtD := math.Sqrt(D)
+	a := (d + sqrtD) / 2
+	b := (d - sqrtD) / 2
+	return fmt.Sprintf("Y %.15f %.15f", a, b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(5) + 1
+	var in strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	var out strings.Builder
+	for i := 0; i < t; i++ {
+		d := float64(rng.Intn(1001))
+		in.WriteString(fmt.Sprintf("%d\n", int(d)))
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		out.WriteString(solveCase(d))
+	}
+	return in.String(), out.String()
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect = strings.TrimSpace(expect)
+	if got != expect {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1070-1079/1076/verifierD.go
+++ b/1000-1999/1000-1099/1070-1079/1076/verifierD.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to, w, idx int
+}
+
+type item struct {
+	node int
+	dist int64
+}
+
+type pq []item
+
+func (p pq) Len() int            { return len(p) }
+func (p pq) Less(i, j int) bool  { return p[i].dist < p[j].dist }
+func (p pq) Swap(i, j int)       { p[i], p[j] = p[j], p[i] }
+func (p *pq) Push(x interface{}) { *p = append(*p, x.(item)) }
+func (p *pq) Pop() interface{} {
+	old := *p
+	v := old[len(old)-1]
+	*p = old[:len(old)-1]
+	return v
+}
+
+func solve(n, m, k int, edges [][4]int) string {
+	adj := make([][]Edge, n+1)
+	for _, e := range edges {
+		a, b, c, idx := e[0], e[1], e[2], e[3]
+		adj[a] = append(adj[a], Edge{b, c, idx})
+		adj[b] = append(adj[b], Edge{a, c, idx})
+	}
+	const inf int64 = 1 << 60
+	dist := make([]int64, n+1)
+	for i := range dist {
+		dist[i] = inf
+	}
+	dist[1] = 0
+	parent := make([]int, n+1)
+	parentEdge := make([]int, n+1)
+	q := &pq{}
+	heap.Push(q, item{1, 0})
+	for q.Len() > 0 {
+		it := heap.Pop(q).(item)
+		if it.dist != dist[it.node] {
+			continue
+		}
+		u := it.node
+		for _, e := range adj[u] {
+			nd := it.dist + int64(e.w)
+			if nd < dist[e.to] {
+				dist[e.to] = nd
+				parent[e.to] = u
+				parentEdge[e.to] = e.idx
+				heap.Push(q, item{e.to, nd})
+			}
+		}
+	}
+	if k > n-1 {
+		k = n - 1
+	}
+	children := make([][]int, n+1)
+	edgesIdx := make([][]int, n+1)
+	for v := 2; v <= n; v++ {
+		p := parent[v]
+		if p != 0 {
+			children[p] = append(children[p], v)
+			edgesIdx[p] = append(edgesIdx[p], parentEdge[v])
+		}
+	}
+	ans := make([]int, 0, k)
+	type stackEntry struct{ u, next int }
+	stack := []stackEntry{{1, 0}}
+	for len(stack) > 0 && len(ans) < k {
+		top := &stack[len(stack)-1]
+		if top.next < len(children[top.u]) {
+			v := children[top.u][top.next]
+			id := edgesIdx[top.u][top.next]
+			top.next++
+			ans = append(ans, id)
+			stack = append(stack, stackEntry{v, 0})
+		} else {
+			stack = stack[:len(stack)-1]
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(ans)))
+	for i, v := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	if len(ans) > 0 {
+		sb.WriteByte('\n')
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	// create tree first
+	edges := make([][4]int, 0)
+	idx := 1
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		w := rng.Intn(20) + 1
+		edges = append(edges, [4]int{p, i, w, idx})
+		idx++
+	}
+	m := len(edges)
+	// add extra edges
+	extra := rng.Intn(3)
+	for e := 0; e < extra; e++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a == b {
+			b = (b % n) + 1
+		}
+		w := rng.Intn(20) + 1
+		edges = append(edges, [4]int{a, b, w, idx})
+		idx++
+	}
+	m = len(edges)
+	k := rng.Intn(m + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+	}
+	expect := solve(n, m, k, edges)
+	return sb.String(), expect
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect = strings.TrimSpace(expect)
+	if got != expect {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1070-1079/1076/verifierE.go
+++ b/1000-1999/1000-1099/1070-1079/1076/verifierE.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func bfs(n int, adj [][]int, start, maxD int, add int64, res []int64) {
+	type node struct{ v, d int }
+	q := []node{{start, 0}}
+	vis := make([]bool, n+1)
+	vis[start] = true
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		res[cur.v] += add
+		if cur.d == maxD {
+			continue
+		}
+		for _, to := range adj[cur.v] {
+			if !vis[to] {
+				vis[to] = true
+				q = append(q, node{to, cur.d + 1})
+			}
+		}
+	}
+}
+
+func solve(n int, edges [][2]int, queries [][3]int64) string {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		a, b := e[0], e[1]
+		adj[a] = append(adj[a], b)
+		adj[b] = append(adj[b], a)
+	}
+	res := make([]int64, n+1)
+	for _, q := range queries {
+		v := int(q[0])
+		d := int(q[1])
+		x := q[2]
+		bfs(n, adj, v, d, x, res)
+	}
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", res[i]))
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	m := rng.Intn(5) + 1
+	queries := make([][3]int64, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		v := rng.Intn(n) + 1
+		d := rng.Intn(3)
+		x := rng.Intn(10) + 1
+		queries[i] = [3]int64{int64(v), int64(d), int64(x)}
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", v, d, x))
+	}
+	expect := solve(n, edges, queries)
+	return sb.String(), expect
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect = strings.TrimSpace(expect)
+	if got != expect {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1070-1079/1076/verifierF.go
+++ b/1000-1999/1000-1099/1070-1079/1076/verifierF.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n int, k int64, x, y []int64) string {
+	var u, v int64
+	for i := 0; i < n; i++ {
+		a := x[i]
+		b := y[i]
+		if (b+1)*k-u < a || (a+1)*k-v < b {
+			return "NO"
+		}
+		if b*k-u < a {
+			u = a - b*k + u
+		} else {
+			u = 0
+		}
+		if a*k-v < b {
+			v = b - a*k + v
+		} else {
+			v = 0
+		}
+	}
+	return "YES"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	k := int64(rng.Intn(5) + 1)
+	x := make([]int64, n)
+	y := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		x[i] = int64(rng.Intn(10) + 1)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", x[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		y[i] = int64(rng.Intn(10) + 1)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", y[i]))
+	}
+	sb.WriteByte('\n')
+	expect := solve(n, k, x, y)
+	return sb.String(), expect
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1070-1079/1076/verifierG.go
+++ b/1000-1999/1000-1099/1070-1079/1076/verifierG.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n, m, q int, arr []int, queries [][]int64) string {
+	a := make([]int, n)
+	copy(a, arr)
+	for _, qu := range queries {
+		if qu[0] == 1 {
+			l := int(qu[1]) - 1
+			r := int(qu[2]) - 1
+			d := qu[3]
+			if d%2 == 1 {
+				for i := l; i <= r; i++ {
+					a[i] ^= 1
+				}
+			}
+		} else {
+			l := int(qu[1]) - 1
+			r := int(qu[2]) - 1
+			xor := 0
+			for i := l; i <= r; i++ {
+				xor ^= a[i]
+			}
+			if xor == 0 {
+				qu[3] = 1
+			} else {
+				qu[3] = 2
+			}
+		}
+	}
+	var sb strings.Builder
+	for _, qu := range queries {
+		if qu[0] == 2 {
+			if sb.Len() > 0 {
+				sb.WriteByte('\n')
+			}
+			sb.WriteString(fmt.Sprintf("%d", qu[3]))
+		}
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	q := rng.Intn(5) + 1
+	arr := make([]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(10) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	queries := make([][]int64, q)
+	type2 := false
+	for i := 0; i < q; i++ {
+		tp := rng.Intn(2) + 1
+		if i == q-1 && !type2 {
+			tp = 2
+		}
+		if tp == 1 {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			d := int64(rng.Intn(5) + 1)
+			queries[i] = []int64{1, int64(l), int64(r), d}
+			sb.WriteString(fmt.Sprintf("1 %d %d %d\n", l, r, d))
+		} else {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			queries[i] = []int64{2, int64(l), int64(r), 0}
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", l, r))
+			type2 = true
+		}
+	}
+	expect := solve(n, m, q, arr, queries)
+	return sb.String(), expect
+}
+
+func runCase(bin, in, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expect = strings.TrimSpace(expect)
+	if got != expect {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect := generateCase(rng)
+		if err := runCase(bin, in, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A-G in contest 1076
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierF.go ./solF`


------
https://chatgpt.com/codex/tasks/task_e_688470fee2108324a5e92e371883b83d