### PR TITLE
Add verifiers for Codeforces contest 1077

### DIFF
--- a/1000-1999/1000-1099/1070-1079/1077/verifierA.go
+++ b/1000-1999/1000-1099/1070-1079/1077/verifierA.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(a, b, k int64) int64 {
+	l := k / 2
+	r := k - l
+	return r*a - l*b
+}
+
+func runCase(exe, input string, exp []int64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != len(exp) {
+		return fmt.Errorf("expected %d numbers, got %d", len(exp), len(fields))
+	}
+	for i, f := range fields {
+		v, err := strconv.ParseInt(f, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid integer %q", f)
+		}
+		if v != exp[i] {
+			return fmt.Errorf("mismatch at position %d: expected %d got %d", i+1, exp[i], v)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		q := rng.Intn(20) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", q)
+		exp := make([]int64, q)
+		for i := 0; i < q; i++ {
+			a := rng.Int63n(1e9) + 1
+			b := rng.Int63n(1e9) + 1
+			k := rng.Int63n(1e9) + 1
+			fmt.Fprintf(&sb, "%d %d %d\n", a, b, k)
+			exp[i] = expected(a, b, k)
+		}
+		input := sb.String()
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1070-1079/1077/verifierB.go
+++ b/1000-1999/1000-1099/1070-1079/1077/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(arr []int) int {
+	n := len(arr)
+	b := append([]int(nil), arr...)
+	c := 0
+	for i := 0; i < n; i++ {
+		if b[i] == 0 {
+			if i == 0 || i == n-1 {
+				continue
+			}
+			if b[i-1] == 1 && b[i+1] == 1 {
+				b[i+1] = 0
+				c++
+			}
+		}
+	}
+	return c
+}
+
+func runCase(exe, input string, exp int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	valStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(valStr)
+	if err != nil {
+		return fmt.Errorf("invalid output %q", valStr)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rng.Intn(98) + 3
+		arr := make([]int, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(2)
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(arr[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(arr)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1070-1079/1077/verifierC.go
+++ b/1000-1999/1000-1099/1070-1079/1077/verifierC.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(arr []int64) []int {
+	n := len(arr)
+	sum := int64(0)
+	for _, v := range arr {
+		sum += v
+	}
+	max1, idx1 := arr[0], 0
+	for i := 1; i < n; i++ {
+		if arr[i] > max1 {
+			max1 = arr[i]
+			idx1 = i
+		}
+	}
+	max2 := int64(-1)
+	for i := 0; i < n; i++ {
+		if i == idx1 {
+			continue
+		}
+		if arr[i] > max2 {
+			max2 = arr[i]
+		}
+	}
+	res := []int{}
+	for i := 0; i < n; i++ {
+		if i == idx1 {
+			if sum-arr[i]-max2 == max2 {
+				res = append(res, i+1)
+			}
+		} else {
+			if sum-arr[i]-max1 == max1 {
+				res = append(res, i+1)
+			}
+		}
+	}
+	return res
+}
+
+func runCase(exe string, input string, exp []int, n int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	k, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid count: %q", fields[0])
+	}
+	if k != len(exp) {
+		return fmt.Errorf("expected count %d got %d", len(exp), k)
+	}
+	if len(fields)-1 != k {
+		return fmt.Errorf("expected %d indices, got %d", k, len(fields)-1)
+	}
+	seen := make(map[int]bool)
+	for i := 0; i < k; i++ {
+		idx, err := strconv.Atoi(fields[i+1])
+		if err != nil {
+			return fmt.Errorf("invalid index %q", fields[i+1])
+		}
+		if idx < 1 || idx > n {
+			return fmt.Errorf("index out of range %d", idx)
+		}
+		if seen[idx] {
+			return fmt.Errorf("duplicate index %d", idx)
+		}
+		seen[idx] = true
+		valid := false
+		for _, e := range exp {
+			if e == idx {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return fmt.Errorf("unexpected index %d", idx)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rng.Intn(199) + 2
+		arr := make([]int64, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Int63n(1e6) + 1
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(arr[i], 10))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(arr)
+		if err := runCase(exe, input, exp, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1070-1079/1077/verifierD.go
+++ b/1000-1999/1000-1099/1070-1079/1077/verifierD.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type node struct{ x, w int }
+
+func bestCopies(s []int, k int) int {
+	freq := map[int]int{}
+	maxF := 0
+	for _, v := range s {
+		freq[v]++
+		if freq[v] > maxF {
+			maxF = freq[v]
+		}
+	}
+	nodes := make([]node, 0, len(freq))
+	for val, w := range freq {
+		nodes = append(nodes, node{val, w})
+	}
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].w > nodes[j].w })
+	l, r := 1, maxF
+	for l <= r {
+		mid := (l + r) / 2
+		sum := 0
+		for _, nd := range nodes {
+			sum += nd.w / mid
+			if sum >= k {
+				break
+			}
+		}
+		if sum >= k {
+			l = mid + 1
+		} else {
+			r = mid - 1
+		}
+	}
+	return r
+}
+
+func copiesPossible(s []int, t []int) int {
+	freqS := map[int]int{}
+	for _, v := range s {
+		freqS[v]++
+	}
+	freqT := map[int]int{}
+	for _, v := range t {
+		freqT[v]++
+	}
+	res := math.MaxInt32
+	for val, c := range freqT {
+		q := freqS[val] / c
+		if q < res {
+			res = q
+		}
+	}
+	return res
+}
+
+func runCase(exe string, input string, s []int, k int, expR int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(out.String())
+	if len(fields) != k {
+		return fmt.Errorf("expected %d numbers, got %d", k, len(fields))
+	}
+	tArr := make([]int, k)
+	for i, f := range fields {
+		v, err := strconv.Atoi(f)
+		if err != nil {
+			return fmt.Errorf("invalid integer %q", f)
+		}
+		tArr[i] = v
+	}
+	rActual := copiesPossible(s, tArr)
+	if rActual != expR {
+		return fmt.Errorf("expected copies %d, got %d", expR, rActual)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rng.Intn(100) + 1
+		k := rng.Intn(n) + 1
+		s := make([]int, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for i := 0; i < n; i++ {
+			s[i] = rng.Intn(20) + 1
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(s[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expR := bestCopies(s, k)
+		if err := runCase(exe, input, s, k, expR); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1070-1079/1077/verifierE.go
+++ b/1000-1999/1000-1099/1070-1079/1077/verifierE.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func calc(x, pos int, opt []int) int {
+	sum := 0
+	for pos > 1 && x%2 == 0 && opt[pos-2] >= x/2 {
+		sum += x
+		x /= 2
+		pos--
+	}
+	return sum + x
+}
+
+func expected(a []int) int {
+	sort.Ints(a)
+	var opt []int
+	cnt := 1
+	n := len(a)
+	for i := 1; i < n; i++ {
+		if a[i] != a[i-1] {
+			opt = append(opt, cnt)
+			cnt = 1
+		} else {
+			cnt++
+		}
+	}
+	opt = append(opt, cnt)
+	m := len(opt)
+	if m == 1 {
+		return n
+	}
+	sort.Ints(opt)
+	ans := opt[m-1]
+	if opt[m-1]%2 != 0 {
+		opt[m-1]--
+	}
+	for opt[m-1] > 0 {
+		if ans > opt[m-1]*2 {
+			break
+		}
+		p := calc(opt[m-1], m, opt)
+		if p > ans {
+			ans = p
+		}
+		opt[m-1] -= 2
+	}
+	return ans
+}
+
+func runCase(exe string, input string, exp int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out.String()))
+	if err != nil {
+		return fmt.Errorf("invalid output %q", out.String())
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rng.Intn(200) + 1
+		arr := make([]int, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(1000) + 1
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(arr[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(arr)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1070-1079/1077/verifierF1.go
+++ b/1000-1999/1000-1099/1070-1079/1077/verifierF1.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(n, k, x int, a []int64) int64 {
+	const INF int64 = -1 << 60
+	d := make([][]int64, n+1)
+	for i := range d {
+		d[i] = make([]int64, x+1)
+		for j := range d[i] {
+			d[i][j] = INF
+		}
+	}
+	d[0][0] = 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < x; j++ {
+			if d[i][j] != INF {
+				for z := i + 1; z <= i+k && z <= n; z++ {
+					val := d[i][j] + a[z]
+					if val > d[z][j+1] {
+						d[z][j+1] = val
+					}
+				}
+			}
+		}
+	}
+	ans := INF
+	for i := n - k + 1; i <= n; i++ {
+		if i >= 0 && i <= n && d[i][x] > ans {
+			ans = d[i][x]
+		}
+	}
+	if ans == INF {
+		return math.MinInt64
+	}
+	return ans
+}
+
+func runCase(exe string, input string, exp int64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	valStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(valStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid output %q", valStr)
+	}
+	if exp == math.MinInt64 {
+		if got != -1 {
+			return fmt.Errorf("expected -1 got %d", got)
+		}
+	} else if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF1.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rng.Intn(200) + 1
+		k := rng.Intn(n) + 1
+		x := rng.Intn(n) + 1
+		a := make([]int64, n+1)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, k, x)
+		for i := 1; i <= n; i++ {
+			a[i] = rng.Int63n(1000) + 1
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.FormatInt(a[i], 10))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(n, k, x, a)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1070-1079/1077/verifierF2.go
+++ b/1000-1999/1000-1099/1070-1079/1077/verifierF2.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func expected(n, k, x int, a []int) int64 {
+	if n/k > x {
+		return -1
+	}
+	g := make([]int64, n+2)
+	f := make([]int64, n+2)
+	for i := 1; i <= k && i <= n; i++ {
+		g[i] = int64(a[i])
+	}
+	dui := make([]int, n+2)
+	for l := 2; l <= x; l++ {
+		for i := 1; i <= n; i++ {
+			f[i] = 0
+		}
+		t1, t2 := 0, -1
+		upper := l * k
+		if upper > n {
+			upper = n
+		}
+		for i := l; i <= upper; i++ {
+			for t1 <= t2 && g[i-1] >= g[dui[t2]] {
+				t2--
+			}
+			t2++
+			dui[t2] = i - 1
+			for t1 <= t2 && dui[t1] < i-k {
+				t1++
+			}
+			if t1 <= t2 {
+				f[i] = g[dui[t1]] + int64(a[i])
+			}
+		}
+		for i := 1; i <= n; i++ {
+			g[i] = f[i]
+		}
+	}
+	var ans int64
+	start := max(1, n-k+1)
+	for i := start; i <= n; i++ {
+		if g[i] > ans {
+			ans = g[i]
+		}
+	}
+	if ans == 0 {
+		return -1
+	}
+	return ans
+}
+
+func runCase(exe string, input string, exp int64) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	valStr := strings.TrimSpace(out.String())
+	got, err := strconv.ParseInt(valStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid output %q", valStr)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF2.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rng.Intn(200) + 1
+		k := rng.Intn(n) + 1
+		x := rng.Intn(n) + 1
+		a := make([]int, n+1)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, k, x)
+		for i := 1; i <= n; i++ {
+			a[i] = rng.Intn(1000) + 1
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(a[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp := expected(n, k, x, a)
+		if err := runCase(exe, input, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–F2 in contest 1077
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF1.go`
- `go build verifierF2.go`


------
https://chatgpt.com/codex/tasks/task_e_6884718b0854832486d72d75bc314f69