### PR TITLE
Add Go solution for 1690D

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1690/1690D.go
+++ b/1000-1999/1600-1699/1690-1699/1690/1690D.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		var s string
+		fmt.Fscan(reader, &s)
+		cnt := 0
+		for i := 0; i < k; i++ {
+			if s[i] == 'W' {
+				cnt++
+			}
+		}
+		ans := cnt
+		for i := k; i < n; i++ {
+			if s[i-k] == 'W' {
+				cnt--
+			}
+			if s[i] == 'W' {
+				cnt++
+			}
+			if cnt < ans {
+				ans = cnt
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for `1690D` (Black and White Stripe)

## Testing
- `gofmt -w 1000-1999/1600-1699/1690-1699/1690/1690D.go`


------
https://chatgpt.com/codex/tasks/task_e_6884737550348324a97f9165bf94e0a1