### PR TITLE
Add solution verifiers for contest 1080

### DIFF
--- a/1000-1999/1000-1099/1080-1089/1080/verifierA.go
+++ b/1000-1999/1000-1099/1080-1089/1080/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1080A.go")
+	bin := filepath.Join(os.TempDir(), "ref1080A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1080))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Int63n(1e6) + 1
+		k := rng.Int63n(1e6) + 1
+		cases[i] = Case{fmt.Sprintf("%d %d\n", n, k)}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1080-1089/1080/verifierB.go
+++ b/1000-1999/1000-1099/1080-1089/1080/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1080B.go")
+	bin := filepath.Join(os.TempDir(), "ref1080B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1081))
+	cases := make([]Case, 100)
+	for i := range cases {
+		q := rng.Intn(10) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", q)
+		for j := 0; j < q; j++ {
+			l := rng.Int63n(1e9) + 1
+			r := l + rng.Int63n(1e9)
+			fmt.Fprintf(&sb, "%d %d\n", l, r)
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1080-1089/1080/verifierC.go
+++ b/1000-1999/1000-1099/1080-1089/1080/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1080C.go")
+	bin := filepath.Join(os.TempDir(), "ref1080C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1082))
+	cases := make([]Case, 100)
+	for i := range cases {
+		t := rng.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for j := 0; j < t; j++ {
+			n := rng.Int63n(20) + 1
+			m := rng.Int63n(20) + 1
+			fmt.Fprintf(&sb, "%d %d\n", n, m)
+			ax1 := rng.Int63n(n) + 1
+			ax2 := ax1 + rng.Int63n(n-ax1+1)
+			ay1 := rng.Int63n(m) + 1
+			ay2 := ay1 + rng.Int63n(m-ay1+1)
+			bx1 := rng.Int63n(n) + 1
+			bx2 := bx1 + rng.Int63n(n-bx1+1)
+			by1 := rng.Int63n(m) + 1
+			by2 := by1 + rng.Int63n(m-by1+1)
+			fmt.Fprintf(&sb, "%d %d %d %d\n", ax1, ay1, ax2, ay2)
+			fmt.Fprintf(&sb, "%d %d %d %d\n", bx1, by1, bx2, by2)
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1080-1089/1080/verifierD.go
+++ b/1000-1999/1000-1099/1080-1089/1080/verifierD.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1080D.go")
+	bin := filepath.Join(os.TempDir(), "ref1080D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1083))
+	cases := make([]Case, 100)
+	for i := range cases {
+		t := rng.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", t)
+		for j := 0; j < t; j++ {
+			n := rng.Int63n(60) + 1
+			k := rng.Int63n(1e6)
+			fmt.Fprintf(&sb, "%d %d\n", n, k)
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1080-1089/1080/verifierE.go
+++ b/1000-1999/1000-1099/1080-1089/1080/verifierE.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1080E.go")
+	bin := filepath.Join(os.TempDir(), "ref1080E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func randomString(rng *rand.Rand, n int) string {
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[rng.Intn(len(letters))])
+	}
+	return sb.String()
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1084))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for j := 0; j < n; j++ {
+			sb.WriteString(randomString(rng, m))
+			sb.WriteByte('\n')
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1080-1089/1080/verifierF.go
+++ b/1000-1999/1000-1099/1080-1089/1080/verifierF.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1080F.go")
+	bin := filepath.Join(os.TempDir(), "ref1080F.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ input string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1085))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		k := rng.Intn(10) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+		for j := 0; j < k; j++ {
+			l := rng.Intn(n) + 1
+			r := l + rng.Intn(n-l+1)
+			p := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "%d %d %d\n", l, r, p)
+		}
+		for j := 0; j < m; j++ {
+			a := rng.Intn(n) + 1
+			b := a + rng.Intn(n-a+1)
+			x := rng.Intn(n) + 1
+			y := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "%d %d %d %d\n", a, b, x, y)
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func runCase(bin, ref string, c Case) error {
+	expected, err := runBinary(ref, c.input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, c.input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(got) != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, c.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for Codeforces contest 1080 problems A–F
- each verifier builds the reference solution, generates 100 random cases and checks a given binary

## Testing
- `go build 1000-1999/1000-1099/1080-1089/1080/verifierA.go`
- `go build 1000-1999/1000-1099/1080-1089/1080/verifierB.go`
- `go build 1000-1999/1000-1099/1080-1089/1080/verifierC.go`
- `go build 1000-1999/1000-1099/1080-1089/1080/verifierD.go`
- `go build 1000-1999/1000-1099/1080-1089/1080/verifierE.go`
- `go build 1000-1999/1000-1099/1080-1089/1080/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884732f463483249863d3b0a4691f58