### PR TITLE
Add Go verifiers for contest 1081

### DIFF
--- a/1000-1999/1000-1099/1080-1089/1081/verifierA.go
+++ b/1000-1999/1000-1099/1080-1089/1081/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1081A.go")
+	bin := filepath.Join(os.TempDir(), "oracle1081A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(1000) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	cases := []string{
+		"1\n",
+		"2\n",
+		"3\n",
+	}
+	for i := 0; i < 97; i++ {
+		cases = append(cases, genCase(r))
+	}
+	for idx, input := range cases {
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1080-1089/1081/verifierC.go
+++ b/1000-1999/1000-1099/1080-1089/1081/verifierC.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1081C.go")
+	bin := filepath.Join(os.TempDir(), "oracle1081C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(20) + 1
+	m := r.Intn(20) + 1
+	k := r.Intn(n)
+	return fmt.Sprintf("%d %d %d\n", n, m, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	cases := []string{
+		"1 1 0\n",
+		"2 2 1\n",
+		"5 3 2\n",
+	}
+	for i := 0; i < 97; i++ {
+		cases = append(cases, genCase(r))
+	}
+	for idx, input := range cases {
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1080-1089/1081/verifierD.go
+++ b/1000-1999/1000-1099/1080-1089/1081/verifierD.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1081D.go")
+	bin := filepath.Join(os.TempDir(), "oracle1081D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(6) + 2
+	m := n - 1 + r.Intn(n)
+	k := r.Intn(n-1) + 1
+	// ensure k unique specials
+	specials := make([]int, k)
+	used := make(map[int]bool)
+	for i := 0; i < k; i++ {
+		for {
+			v := r.Intn(n) + 1
+			if !used[v] {
+				used[v] = true
+				specials[i] = v
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 0; i < k; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", specials[i])
+	}
+	sb.WriteByte('\n')
+	edges := make(map[[2]int]bool)
+	for i := 0; i < m; i++ {
+		u := r.Intn(n) + 1
+		v := r.Intn(n) + 1
+		if u == v {
+			i--
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		if edges[[2]int{u, v}] {
+			i--
+			continue
+		}
+		edges[[2]int{u, v}] = true
+		w := r.Intn(10) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", u, v, w)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	cases := []string{
+		"2 1 1\n1\n1 2 5\n",
+		"3 3 2\n1 2\n1 2 1\n2 3 2\n1 3 3\n",
+		"4 4 2\n1 3\n1 2 1\n2 3 2\n3 4 3\n1 4 4\n",
+	}
+	for i := 0; i < 97; i++ {
+		cases = append(cases, genCase(r))
+	}
+	for idx, input := range cases {
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1080-1089/1081/verifierE.go
+++ b/1000-1999/1000-1099/1080-1089/1081/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1081E.go")
+	bin := filepath.Join(os.TempDir(), "oracle1081E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(10)*2 + 2 // even between 2 and 20
+	half := n / 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < half; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", r.Intn(100)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	cases := []string{
+		"2\n1\n",
+		"4\n1 1\n",
+		"6\n2 4 6\n",
+	}
+	for i := 0; i < 97; i++ {
+		cases = append(cases, genCase(r))
+	}
+	for idx, input := range cases {
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1080-1089/1081/verifierF.go
+++ b/1000-1999/1000-1099/1080-1089/1081/verifierF.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem F is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1000-1099/1080-1089/1081/verifierG.go
+++ b/1000-1999/1000-1099/1080-1089/1081/verifierG.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1081G.go")
+	bin := filepath.Join(os.TempDir(), "oracle1081G.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 1
+	k := r.Intn(4) + 1
+	q := 998244353 // fixed prime
+	return fmt.Sprintf("%d %d %d\n", n, k, q)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	cases := []string{
+		"1 1 998244353\n",
+		"2 1 998244353\n",
+		"3 2 998244353\n",
+	}
+	for i := 0; i < 97; i++ {
+		cases = append(cases, genCase(r))
+	}
+	for idx, input := range cases {
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1080-1089/1081/verifierH.go
+++ b/1000-1999/1000-1099/1080-1089/1081/verifierH.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func naiveCount(a, b string) int {
+	palsA := make(map[string]struct{})
+	for i := 0; i < len(a); i++ {
+		for j := i + 1; j <= len(a); j++ {
+			s := a[i:j]
+			if isPalindrome(s) {
+				palsA[s] = struct{}{}
+			}
+		}
+	}
+	palsB := make(map[string]struct{})
+	for i := 0; i < len(b); i++ {
+		for j := i + 1; j <= len(b); j++ {
+			s := b[i:j]
+			if isPalindrome(s) {
+				palsB[s] = struct{}{}
+			}
+		}
+	}
+	seen := make(map[string]struct{})
+	for sa := range palsA {
+		for sb := range palsB {
+			seen[sa+sb] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func isPalindrome(s string) bool {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		if s[i] != s[j] {
+			return false
+		}
+	}
+	return true
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 1
+	m := r.Intn(5) + 1
+	letters := "abc"
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(letters[r.Intn(len(letters))])
+	}
+	a := sb.String()
+	sb.Reset()
+	for i := 0; i < m; i++ {
+		sb.WriteByte(letters[r.Intn(len(letters))])
+	}
+	b := sb.String()
+	return fmt.Sprintf("%s\n%s\n", a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	r := rand.New(rand.NewSource(1))
+	cases := []string{
+		"a\na\n",
+		"ab\naba\n",
+		"abc\nabc\n",
+	}
+	for i := 0; i < 97; i++ {
+		cases = append(cases, genCase(r))
+	}
+	for idx, input := range cases {
+		scanner := bufio.NewScanner(strings.NewReader(input))
+		scanner.Scan()
+		A := scanner.Text()
+		scanner.Scan()
+		B := scanner.Text()
+		want := fmt.Sprintf("%d", naiveCount(A, B))
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", idx+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- implement verifiers for problems A–H of contest 1081
- each verifier builds the official solution as an oracle and runs at least 100 tests
- problem F is interactive so a stub message is provided
- verifierH implements a naive oracle directly in Go

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`

------
https://chatgpt.com/codex/tasks/task_e_688473bb41208324be383e2cf0b21881