### PR TITLE
Add Go verifiers for contest 1082

### DIFF
--- a/1000-1999/1000-1099/1080-1089/1082/verifierA.go
+++ b/1000-1999/1000-1099/1080-1089/1082/verifierA.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(name string, args []string, input string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string {
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}
+
+func genTests() string {
+	rand.Seed(1)
+	const t = 100
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(1000) + 1
+		x := rand.Intn(n) + 1
+		y := rand.Intn(n) + 1
+		d := rand.Intn(n) + 1
+		fmt.Fprintf(&sb, "%d %d %d %d\n", n, x, y, d)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	inp := genTests()
+	candOut, err := runCmd(os.Args[1], nil, inp)
+	if err != nil {
+		fmt.Println("candidate error:", err)
+		fmt.Print(candOut)
+		os.Exit(1)
+	}
+	refOut, err := runCmd("go", []string{"run", "1082A.go"}, inp)
+	if err != nil {
+		fmt.Println("reference error:", err)
+		fmt.Print(refOut)
+		os.Exit(1)
+	}
+	if normalize(candOut) != normalize(refOut) {
+		fmt.Println("outputs differ")
+		fmt.Println("candidate:\n", candOut)
+		fmt.Println("expected:\n", refOut)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1000-1099/1080-1089/1082/verifierB.go
+++ b/1000-1999/1000-1099/1080-1089/1082/verifierB.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(name string, args []string, input string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string {
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}
+
+func genTests() string {
+	rand.Seed(1)
+	const t = 100
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(20) + 1
+		var sb2 strings.Builder
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				sb2.WriteByte('G')
+			} else {
+				sb2.WriteByte('S')
+			}
+		}
+		fmt.Fprintf(&sb, "%d %s\n", n, sb2.String())
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	inp := genTests()
+	candOut, err := runCmd(os.Args[1], nil, inp)
+	if err != nil {
+		fmt.Println("candidate error:", err)
+		fmt.Print(candOut)
+		os.Exit(1)
+	}
+	refOut, err := runCmd("go", []string{"run", "1082B.go"}, inp)
+	if err != nil {
+		fmt.Println("reference error:", err)
+		fmt.Print(refOut)
+		os.Exit(1)
+	}
+	if normalize(candOut) != normalize(refOut) {
+		fmt.Println("outputs differ")
+		fmt.Println("candidate:\n", candOut)
+		fmt.Println("expected:\n", refOut)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1000-1099/1080-1089/1082/verifierC.go
+++ b/1000-1999/1000-1099/1080-1089/1082/verifierC.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(name string, args []string, input string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string {
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}
+
+func genTests() string {
+	rand.Seed(1)
+	const t = 100
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(5) + 1
+		m := rand.Intn(3) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for j := 0; j < n; j++ {
+			s := rand.Intn(m) + 1
+			r := rand.Intn(21) - 10
+			fmt.Fprintf(&sb, "%d %d\n", s, r)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	inp := genTests()
+	candOut, err := runCmd(os.Args[1], nil, inp)
+	if err != nil {
+		fmt.Println("candidate error:", err)
+		fmt.Print(candOut)
+		os.Exit(1)
+	}
+	refOut, err := runCmd("go", []string{"run", "1082C.go"}, inp)
+	if err != nil {
+		fmt.Println("reference error:", err)
+		fmt.Print(refOut)
+		os.Exit(1)
+	}
+	if normalize(candOut) != normalize(refOut) {
+		fmt.Println("outputs differ")
+		fmt.Println("candidate:\n", candOut)
+		fmt.Println("expected:\n", refOut)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1000-1099/1080-1089/1082/verifierD.go
+++ b/1000-1999/1000-1099/1080-1089/1082/verifierD.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(name string, args []string, input string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string {
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}
+
+func genTests() string {
+	rand.Seed(1)
+	const t = 100
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(5) + 3
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			val := rand.Intn(n-1) + 1
+			if j+1 == n && val == 0 {
+				val = 1
+			}
+			fmt.Fprintf(&sb, "%d ", val)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	inp := genTests()
+	candOut, err := runCmd(os.Args[1], nil, inp)
+	if err != nil {
+		fmt.Println("candidate error:", err)
+		fmt.Print(candOut)
+		os.Exit(1)
+	}
+	refOut, err := runCmd("go", []string{"run", "1082D.go"}, inp)
+	if err != nil {
+		fmt.Println("reference error:", err)
+		fmt.Print(refOut)
+		os.Exit(1)
+	}
+	if normalize(candOut) != normalize(refOut) {
+		fmt.Println("outputs differ")
+		fmt.Println("candidate:\n", candOut)
+		fmt.Println("expected:\n", refOut)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1000-1099/1080-1089/1082/verifierE.go
+++ b/1000-1999/1000-1099/1080-1089/1082/verifierE.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(name string, args []string, input string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string {
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}
+
+func genTests() string {
+	rand.Seed(1)
+	const t = 100
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(10) + 1
+		c := rand.Intn(5) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, c)
+		for j := 0; j < n; j++ {
+			v := rand.Intn(5) + 1
+			fmt.Fprintf(&sb, "%d ", v)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	inp := genTests()
+	candOut, err := runCmd(os.Args[1], nil, inp)
+	if err != nil {
+		fmt.Println("candidate error:", err)
+		fmt.Print(candOut)
+		os.Exit(1)
+	}
+	refOut, err := runCmd("go", []string{"run", "1082E.go"}, inp)
+	if err != nil {
+		fmt.Println("reference error:", err)
+		fmt.Print(refOut)
+		os.Exit(1)
+	}
+	if normalize(candOut) != normalize(refOut) {
+		fmt.Println("outputs differ")
+		fmt.Println("candidate:\n", candOut)
+		fmt.Println("expected:\n", refOut)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1000-1099/1080-1089/1082/verifierF.go
+++ b/1000-1999/1000-1099/1080-1089/1082/verifierF.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(name string, args []string, input string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string {
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}
+
+func randStr() string {
+	l := rand.Intn(3) + 1
+	b := make([]byte, l)
+	for i := 0; i < l; i++ {
+		b[i] = byte('0' + rand.Intn(10))
+	}
+	return string(b)
+}
+
+func genTests() string {
+	rand.Seed(1)
+	const t = 100
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(6) + 1
+		k := rand.Intn(3)
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%s %d\n", randStr(), rand.Intn(10))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	inp := genTests()
+	candOut, err := runCmd(os.Args[1], nil, inp)
+	if err != nil {
+		fmt.Println("candidate error:", err)
+		fmt.Print(candOut)
+		os.Exit(1)
+	}
+	refOut, err := runCmd("go", []string{"run", "1082F.go"}, inp)
+	if err != nil {
+		fmt.Println("reference error:", err)
+		fmt.Print(refOut)
+		os.Exit(1)
+	}
+	if normalize(candOut) != normalize(refOut) {
+		fmt.Println("outputs differ")
+		fmt.Println("candidate:\n", candOut)
+		fmt.Println("expected:\n", refOut)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1000-1099/1080-1089/1082/verifierG.go
+++ b/1000-1999/1000-1099/1080-1089/1082/verifierG.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCmd(name string, args []string, input string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func normalize(s string) string {
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}
+
+func genTests() string {
+	rand.Seed(1)
+	const t = 100
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rand.Intn(4) + 2
+		m := rand.Intn(5) + 1
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for j := 0; j < n; j++ {
+			w := rand.Intn(5) + 1
+			fmt.Fprintf(&sb, "%d ", w)
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < m; j++ {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			if v == u {
+				v = (v % n) + 1
+			}
+			c := rand.Intn(5) + 1
+			fmt.Fprintf(&sb, "%d %d %d\n", u, v, c)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	inp := genTests()
+	candOut, err := runCmd(os.Args[1], nil, inp)
+	if err != nil {
+		fmt.Println("candidate error:", err)
+		fmt.Print(candOut)
+		os.Exit(1)
+	}
+	refOut, err := runCmd("go", []string{"run", "1082G.go"}, inp)
+	if err != nil {
+		fmt.Println("reference error:", err)
+		fmt.Print(refOut)
+		os.Exit(1)
+	}
+	if normalize(candOut) != normalize(refOut) {
+		fmt.Println("outputs differ")
+		fmt.Println("candidate:\n", candOut)
+		fmt.Println("expected:\n", refOut)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+}


### PR DESCRIPTION
## Summary
- implement Go verifier scripts for each problem in contest 1082
- each verifier generates 100 random tests, runs provided binary and compares against reference solver

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_688474478948832483de6572f6ebda7e