### PR TITLE
Add verifiers for Codeforces contest 1083

### DIFF
--- a/1000-1999/1000-1099/1080-1089/1083/verifierA.go
+++ b/1000-1999/1000-1099/1080-1089/1083/verifierA.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveA(input string) string {
+	rdr := bufio.NewReader(strings.NewReader(input))
+	readInt := func() int {
+		var x int
+		var sign int = 1
+		c, _ := rdr.ReadByte()
+		for (c < '0' || c > '9') && c != '-' {
+			c, _ = rdr.ReadByte()
+		}
+		if c == '-' {
+			sign = -1
+			c, _ = rdr.ReadByte()
+		}
+		for c >= '0' && c <= '9' {
+			x = x*10 + int(c-'0')
+			c, _ = rdr.ReadByte()
+		}
+		return x * sign
+	}
+	n := readInt()
+	val := make([]int, n+1)
+	f := make([]int64, n+1)
+	g := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		val[i] = readInt()
+		f[i] = int64(val[i])
+		g[i] = int64(val[i])
+	}
+	type Edge struct{ to, w int }
+	adj := make([][]Edge, n+1)
+	for i := 2; i <= n; i++ {
+		u := readInt()
+		v := readInt()
+		w := readInt()
+		adj[u] = append(adj[u], Edge{v, w})
+		adj[v] = append(adj[v], Edge{u, w})
+	}
+	type Frame struct{ u, parent, idx, wUp int }
+	stack := make([]Frame, 0, n)
+	stack = append(stack, Frame{1, 0, 0, 0})
+	for len(stack) > 0 {
+		top := &stack[len(stack)-1]
+		u := top.u
+		if top.idx < len(adj[u]) {
+			e := adj[u][top.idx]
+			top.idx++
+			v := e.to
+			w := e.w
+			if v == top.parent {
+				continue
+			}
+			if g[u] >= int64(w) {
+				cand := g[u] - int64(w) + int64(val[v])
+				if cand > g[v] {
+					g[v] = cand
+				}
+			}
+			stack = append(stack, Frame{v, u, 0, w})
+		} else {
+			cur := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if cur.parent != 0 {
+				if f[cur.u] >= int64(cur.wUp) {
+					cand := f[cur.u] - int64(cur.wUp) + int64(val[cur.parent])
+					if cand > f[cur.parent] {
+						f[cur.parent] = cand
+					}
+				}
+				if f[cur.parent] > g[cur.parent] {
+					g[cur.parent] = f[cur.parent]
+				}
+			}
+		}
+	}
+	var ans int64
+	for i := 1; i <= n; i++ {
+		if g[i] > ans {
+			ans = g[i]
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(42))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(6) + 1
+		vals := make([]int, n)
+		for i := 0; i < n; i++ {
+			vals[i] = rng.Intn(10)
+		}
+		edges := make([][3]int, n-1)
+		for i := 1; i < n; i++ {
+			u := rng.Intn(i) + 1
+			v := i + 1
+			w := rng.Intn(10)
+			edges[i-1] = [3]int{u, v, w}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", vals[i]))
+		}
+		sb.WriteByte('\n')
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+		}
+		input := sb.String()
+		expected := solveA(input)
+		tests = append(tests, test{input, expected})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1000-1099/1080-1089/1083/verifierB.go
+++ b/1000-1999/1000-1099/1080-1089/1083/verifierB.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveB(input string) string {
+	fields := strings.Fields(input)
+	idx := 0
+	n := 0
+	fmt.Sscan(fields[idx], &n)
+	idx++
+	var k int64
+	fmt.Sscan(fields[idx], &k)
+	idx++
+	s1 := fields[idx]
+	idx++
+	s2 := fields[idx]
+	cnt := int64(0)
+	cur := int64(1)
+	ans := int64(0)
+	for i := 0; i < n; i++ {
+		cur <<= 1
+		if s1[i] == 'b' {
+			cur--
+		}
+		if s2[i] == 'a' {
+			cur--
+		}
+		if cur > k {
+			ans = cnt + k*int64(n-i)
+			return fmt.Sprintf("%d", ans)
+		}
+		cnt += cur
+		ans = cnt + cur*int64(n-1-i)
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(43))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(8) + 1
+		k := rng.Int63n(10) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		b1 := make([]byte, n)
+		b2 := make([]byte, n)
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 0 {
+				b1[i] = 'a'
+			} else {
+				b1[i] = 'b'
+			}
+			if rng.Intn(2) == 0 {
+				b2[i] = 'a'
+			} else {
+				b2[i] = 'b'
+			}
+		}
+		s1 := string(b1)
+		s2 := string(b2)
+		if s1 > s2 {
+			s1, s2 = s2, s1
+		}
+		sb.WriteString(fmt.Sprintf("%s\n%s\n", s1, s2))
+		input := sb.String()
+		expected := solveB(strings.TrimSpace(fmt.Sprintf("%d %d %s %s", n, k, s1, s2)))
+		tests = append(tests, test{input, expected})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1000-1099/1080-1089/1083/verifierC.go
+++ b/1000-1999/1000-1099/1080-1089/1083/verifierC.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+const MAXLOG = 19
+
+type Node struct {
+	a, b, g int
+}
+
+func (nd *Node) bad() bool { return nd.a == -1 }
+func (nd *Node) beBad()    { nd.a, nd.b, nd.g = -1, -1, -1 }
+
+func solveC(input string) string {
+	r := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(r, &n)
+	a := make([]int, n)
+	where := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(r, &a[i])
+		where[a[i]] = i
+	}
+	v := make([][]int, n)
+	for i := 0; i < n-1; i++ {
+		var x int
+		fmt.Fscan(r, &x)
+		v[x-1] = append(v[x-1], i+1)
+	}
+	tin := make([]int, n)
+	tout := make([]int, n)
+	gl := make([]int, n)
+	par := make([][]int, n)
+	for i := range par {
+		par[i] = make([]int, MAXLOG)
+	}
+	curT := 0
+	var dfs func(int, int)
+	dfs = func(cur, p int) {
+		curT++
+		tin[cur] = curT
+		par[cur][0] = p
+		for i := 1; i < MAXLOG; i++ {
+			par[cur][i] = par[par[cur][i-1]][i-1]
+		}
+		for _, to := range v[cur] {
+			gl[to] = gl[cur] + 1
+			dfs(to, cur)
+		}
+		tout[cur] = curT
+	}
+	dfs(0, 0)
+	isAncestor := func(x, y int) bool { return tin[x] <= tin[y] && tin[y] <= tout[x] }
+	onTheWay := func(x, y, z int) bool { return isAncestor(x, y) && isAncestor(y, z) }
+	var lca func(int, int) int
+	lca = func(x, y int) int {
+		if isAncestor(x, y) {
+			return x
+		}
+		if isAncestor(y, x) {
+			return y
+		}
+		for i := MAXLOG - 1; i >= 0; i-- {
+			p := par[x][i]
+			if !isAncestor(p, y) {
+				x = p
+			}
+		}
+		return par[x][0]
+	}
+	add := func(nd *Node, x int) {
+		if nd.bad() {
+			return
+		}
+		if nd.a == nd.b {
+			nd.b = x
+			nd.g = lca(nd.a, nd.b)
+			if nd.a == nd.g {
+				nd.a, nd.b = nd.b, nd.a
+			}
+		} else {
+			if isAncestor(nd.a, x) {
+				nd.a = x
+				return
+			}
+			if nd.b == nd.g {
+				if onTheWay(nd.b, x, nd.a) {
+					return
+				}
+				if onTheWay(x, nd.b, nd.a) {
+					nd.b = x
+					nd.g = x
+					return
+				}
+				ng := lca(nd.a, x)
+				if isAncestor(ng, nd.b) {
+					nd.b = x
+					nd.g = ng
+					return
+				}
+				nd.beBad()
+				return
+			}
+			if isAncestor(nd.b, x) {
+				nd.b = x
+				return
+			}
+			if onTheWay(nd.g, x, nd.a) || onTheWay(nd.g, x, nd.b) {
+				return
+			}
+			nd.beBad()
+		}
+	}
+	merge := func(s, t Node) Node {
+		if s.bad() || t.bad() {
+			return Node{-1, -1, -1}
+		}
+		res := s
+		add(&res, t.a)
+		add(&res, t.b)
+		return res
+	}
+	tree := make([]Node, 4*n)
+	var build func(int, int, int)
+	build = func(cur, l, r int) {
+		if l == r {
+			tree[cur] = Node{where[l], where[l], where[l]}
+		} else {
+			m := (l + r) >> 1
+			lc := cur << 1
+			build(lc, l, m)
+			build(lc|1, m+1, r)
+			tree[cur] = merge(tree[lc], tree[lc|1])
+		}
+	}
+	build(1, 0, n-1)
+	var update func(int, int, int, int)
+	update = func(cur, l, r, pos int) {
+		if l == r {
+			tree[cur] = Node{where[l], where[l], where[l]}
+		} else {
+			m := (l + r) >> 1
+			lc := cur << 1
+			if pos <= m {
+				update(lc, l, m, pos)
+			} else {
+				update(lc|1, m+1, r, pos)
+			}
+			tree[cur] = merge(tree[lc], tree[lc|1])
+		}
+	}
+	ans := Node{where[0], where[0], where[0]}
+	mex := 0
+	var getAns func(int, int, int)
+	getAns = func(cur, l, r int) {
+		res := merge(ans, tree[cur])
+		if !res.bad() {
+			mex = r
+			ans = res
+		} else if l < r {
+			m := (l + r) >> 1
+			lc := cur << 1
+			getAns(lc, l, m)
+			if mex == m {
+				getAns(lc|1, m+1, r)
+			}
+		}
+	}
+	var q int
+	fmt.Fscan(r, &q)
+	var sb strings.Builder
+	for q > 0 {
+		q--
+		var t int
+		fmt.Fscan(r, &t)
+		if t == 1 {
+			var x, y int
+			fmt.Fscan(r, &x, &y)
+			x--
+			y--
+			a[x], a[y] = a[y], a[x]
+			where[a[x]] = x
+			where[a[y]] = y
+			update(1, 0, n-1, a[x])
+			update(1, 0, n-1, a[y])
+		} else {
+			ans = Node{where[0], where[0], where[0]}
+			mex = 0
+			getAns(1, 0, n-1)
+			fmt.Fprintf(&sb, "%d\n", mex+1)
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(44))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 2
+		perm := rand.Perm(n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", perm[i])
+		}
+		sb.WriteByte('\n')
+		for i := 1; i < n; i++ {
+			p := rng.Intn(i) + 1
+			fmt.Fprintf(&sb, "%d ", p)
+		}
+		sb.WriteByte('\n')
+		q := rng.Intn(5) + 1
+		fmt.Fprintf(&sb, "%d\n", q)
+		for i := 0; i < q; i++ {
+			if rng.Intn(2) == 0 {
+				x := rng.Intn(n) + 1
+				y := rng.Intn(n) + 1
+				fmt.Fprintf(&sb, "1 %d %d\n", x, y)
+			} else {
+				fmt.Fprintf(&sb, "2\n")
+			}
+		}
+		input := sb.String()
+		expected := solveC(input)
+		tests = append(tests, test{input, expected})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1000-1099/1080-1089/1083/verifierD.go
+++ b/1000-1999/1000-1099/1080-1089/1083/verifierD.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func bruteForce(a []int) int {
+	n := len(a)
+	mod := 1000000007
+	count := 0
+	for l1 := 0; l1 < n; l1++ {
+		for r1 := l1; r1 < n; r1++ {
+			for l2 := 0; l2 < n; l2++ {
+				for r2 := l2; r2 < n; r2++ {
+					if (l1 <= l2 && r2 <= r1) || (l2 <= l1 && r1 <= r2) {
+						continue
+					}
+					L := l1
+					if l2 > L {
+						L = l2
+					}
+					R := r1
+					if r2 < R {
+						R = r2
+					}
+					if L > R {
+						continue
+					}
+					ok := true
+					for i := L; i <= R && ok; i++ {
+						val := a[i]
+						cnt1 := 0
+						for j := l1; j <= r1; j++ {
+							if a[j] == val {
+								cnt1++
+							}
+						}
+						cnt2 := 0
+						for j := l2; j <= r2; j++ {
+							if a[j] == val {
+								cnt2++
+							}
+						}
+						if cnt1 != 1 || cnt2 != 1 {
+							ok = false
+						}
+					}
+					if ok {
+						count++
+					}
+				}
+			}
+		}
+	}
+	return count % mod
+}
+
+func solveD(input string) string {
+	fields := strings.Fields(input)
+	idx := 0
+	n := 0
+	fmt.Sscan(fields[idx], &n)
+	idx++
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Sscan(fields[idx+i], &a[i])
+	}
+	ans := bruteForce(a)
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(45))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(5)
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", a[i])
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveD(strings.TrimSpace(fmt.Sprintf("%d %s", n, strings.TrimSpace(strings.Join(strings.Fields(sb.String())[1:], " ")))))
+		expected = solveD(input)
+		tests = append(tests, test{input, expected})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1000-1099/1080-1089/1083/verifierE.go
+++ b/1000-1999/1000-1099/1080-1089/1083/verifierE.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type square struct{ x, y, w int64 }
+
+func solveE(input string) string {
+	rdr := bufio.NewReader(strings.NewReader(input))
+	var n int
+	fmt.Fscan(rdr, &n)
+	s := make([]square, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(rdr, &s[i].x, &s[i].y, &s[i].w)
+	}
+	sort.Slice(s, func(i, j int) bool { return s[i].y > s[j].y })
+	f := make([]int64, n)
+	q := make([]int, 0, n)
+	var ans int64
+	eps := 1e-12
+	getSlope := func(u, v int) float64 {
+		dx := float64(s[v].x - s[u].x)
+		if math.Abs(dx) < eps {
+			return math.Inf(1)
+		}
+		return float64(f[v]-f[u]) / dx
+	}
+	l := 0
+	for i := 0; i < n; i++ {
+		for len(q)-l >= 2 && getSlope(q[l], q[l+1]) >= float64(s[i].y) {
+			l++
+		}
+		fi := s[i].x*s[i].y - s[i].w
+		if len(q)-l > 0 {
+			j := q[l]
+			val := f[j] + (s[i].x-s[j].x)*s[i].y - s[i].w
+			if val > fi {
+				fi = val
+			}
+		}
+		f[i] = fi
+		if fi > ans {
+			ans = fi
+		}
+		for len(q)-l >= 2 && getSlope(q[len(q)-2], q[len(q)-1]) <= getSlope(q[len(q)-1], i) {
+			q = q[:len(q)-1]
+		}
+		q = append(q, i)
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(46))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(6) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		squares := make([]square, n)
+		for i := 0; i < n; i++ {
+			squares[i].x = int64(rng.Intn(10))
+			squares[i].y = int64(rng.Intn(10))
+			squares[i].w = int64(rng.Intn(10))
+			fmt.Fprintf(&sb, "%d %d %d\n", squares[i].x, squares[i].y, squares[i].w)
+		}
+		input := sb.String()
+		expected := solveE(input)
+		tests = append(tests, test{input, expected})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1000-1099/1080-1089/1083/verifierF.go
+++ b/1000-1999/1000-1099/1080-1089/1083/verifierF.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	input    string
+	expected string
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+const B = 500
+
+func solveF(input string) string {
+	reader := bufio.NewReader(strings.NewReader(input))
+	writer := bufio.NewWriter(&bytes.Buffer{})
+	var n, k, q int
+	fmt.Fscan(reader, &n, &k, &q)
+	a := make([]int, n+2)
+	b := make([]int, n+2)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(reader, &b[i])
+	}
+	d := make([]int, n+2)
+	nch := make([][]int, k)
+	for i := 0; i < k; i++ {
+		nch[i] = make([]int, 0)
+	}
+	for i := 0; i <= n; i++ {
+		d[i] = (a[i] ^ a[i+1]) ^ (b[i] ^ b[i+1])
+		rem := i % k
+		nch[rem] = append(nch[rem], i)
+	}
+	pos := make([]int, n+2)
+	epos := make([]int, n+2)
+	spos := make([]int, n+2)
+	m := 0
+	zch := 0
+	for i := 0; i < k; i++ {
+		s := 0
+		for _, u := range nch[i] {
+			s ^= d[u]
+			spos[m] = s
+			pos[u] = m
+			m++
+		}
+		if m > 0 && spos[m-1] == 0 {
+			zch++
+		}
+		for _, u := range nch[i] {
+			epos[u] = m
+		}
+	}
+	blocks := (m + B - 1) / B
+	off := make([]int, blocks)
+	cnt := make([]map[int]int, blocks)
+	for i := 0; i < blocks; i++ {
+		cnt[i] = make(map[int]int)
+	}
+	for i := 0; i < m; i++ {
+		blk := i / B
+		cnt[blk][spos[i]]++
+	}
+	modify := func(p, v int) {
+		if p < 0 || p > n {
+			return
+		}
+		l := pos[p]
+		r := epos[p]
+		if r > 0 {
+			br := (r - 1) / B
+			if spos[r-1]^off[br] == 0 {
+				zch--
+			}
+		}
+		idl := l / B
+		idr := r / B
+		if idl == idr {
+			for i := l; i < r; i++ {
+				blk := idl
+				cnt[blk][spos[i]]--
+				spos[i] ^= v
+				cnt[blk][spos[i]]++
+			}
+		} else {
+			endL := (idl + 1) * B
+			for i := l; i < endL; i++ {
+				blk := idl
+				cnt[blk][spos[i]]--
+				spos[i] ^= v
+				cnt[blk][spos[i]]++
+			}
+			for blk := idl + 1; blk < idr; blk++ {
+				off[blk] ^= v
+			}
+			startR := idr * B
+			for i := startR; i < r; i++ {
+				blk := idr
+				cnt[blk][spos[i]]--
+				spos[i] ^= v
+				cnt[blk][spos[i]]++
+			}
+		}
+		if r > 0 {
+			br := (r - 1) / B
+			if spos[r-1]^off[br] == 0 {
+				zch++
+			}
+		}
+	}
+	output := func(w *bufio.Writer) string {
+		if zch != k {
+			return "-1"
+		}
+		sumZero := 0
+		for blk := range off {
+			sumZero += cnt[blk][off[blk]]
+		}
+		res := m - sumZero
+		return fmt.Sprintf("%d", res)
+	}
+	resBuilder := strings.Builder{}
+	resBuilder.WriteString(output(writer))
+	resBuilder.WriteByte('\n')
+	for qi := 0; qi < q; qi++ {
+		var op string
+		var p, v int
+		fmt.Fscan(reader, &op, &p, &v)
+		if op[0] == 'a' {
+			a[p] ^= v
+			v, a[p] = a[p], v
+		} else {
+			b[p] ^= v
+			v, b[p] = b[p], v
+		}
+		modify(p, v)
+		modify(p-1, v)
+		resBuilder.WriteString(output(writer))
+		resBuilder.WriteByte('\n')
+	}
+	return strings.TrimSpace(resBuilder.String())
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(47))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 1
+		k := rng.Intn(3) + 1
+		q := rng.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, k, q)
+		a := make([]int, n+1)
+		b := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			a[i] = rng.Intn(8)
+			fmt.Fprintf(&sb, "%d ", a[i])
+		}
+		sb.WriteByte('\n')
+		for i := 1; i <= n; i++ {
+			b[i] = rng.Intn(8)
+			fmt.Fprintf(&sb, "%d ", b[i])
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < q; i++ {
+			if rng.Intn(2) == 0 {
+				p := rng.Intn(n + 1)
+				v := rng.Intn(4)
+				fmt.Fprintf(&sb, "a %d %d\n", p, v)
+			} else {
+				p := rng.Intn(n + 1)
+				v := rng.Intn(4)
+				fmt.Fprintf(&sb, "b %d %d\n", p, v)
+			}
+		}
+		input := sb.String()
+		expected := solveF(input)
+		tests = append(tests, test{input, expected})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		out, err := runBinary(bin, t.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(t.expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, t.input, t.expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F in contest 1083
- each verifier generates 100 random tests and checks a target binary

## Testing
- `go build 1000-1999/1000-1099/1080-1089/1083/verifierA.go`
- `go build 1000-1999/1000-1099/1080-1089/1083/verifierB.go`
- `go build 1000-1999/1000-1099/1080-1089/1083/verifierC.go`
- `go build 1000-1999/1000-1099/1080-1089/1083/verifierD.go`
- `go build 1000-1999/1000-1099/1080-1089/1083/verifierE.go`
- `go build 1000-1999/1000-1099/1080-1089/1083/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_688474d35d2083249fedc73233e51626