### PR TITLE
Add Go verifiers for contest 1085

### DIFF
--- a/1000-1999/1000-1099/1080-1089/1085/verifierA.go
+++ b/1000-1999/1000-1099/1080-1089/1085/verifierA.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1085A.go")
+	bin := filepath.Join(os.TempDir(), "ref1085A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct {
+	t string
+}
+
+func genCases() []Case {
+	r := rand.New(rand.NewSource(1085))
+	cases := make([]Case, 100)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	for i := range cases {
+		n := r.Intn(50) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteRune(letters[r.Intn(len(letters))])
+		}
+		cases[i] = Case{sb.String()}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	cases := genCases()
+	for i, c := range cases {
+		input := c.t + "\n"
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput: %s\nexpected: %s\ngot: %s\n", i+1, c.t, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1080-1089/1085/verifierB.go
+++ b/1000-1999/1000-1099/1080-1089/1085/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1085B.go")
+	bin := filepath.Join(os.TempDir(), "ref1085B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ n, k int64 }
+
+func genCases() []Case {
+	r := rand.New(rand.NewSource(1085))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := r.Int63n(1e6) + 1
+		k := r.Int63n(1000) + 2
+		cases[i] = Case{n, k}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	cases := genCases()
+	for i, c := range cases {
+		input := fmt.Sprintf("%d %d\n", c.n, c.k)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput: %d %d\nexpected: %s\ngot: %s\n", i+1, c.n, c.k, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1080-1089/1085/verifierC.go
+++ b/1000-1999/1000-1099/1080-1089/1085/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type Case struct {
+	ax, ay, bx, by, cx, cy int
+}
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1085C.go")
+	bin := filepath.Join(os.TempDir(), "ref1085C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []Case {
+	r := rand.New(rand.NewSource(1085))
+	cases := make([]Case, 100)
+	for i := range cases {
+		ax := r.Intn(11)
+		ay := r.Intn(11)
+		bx := r.Intn(11)
+		by := r.Intn(11)
+		cx := r.Intn(11)
+		cy := r.Intn(11)
+		// ensure distinct
+		for ax == bx && ay == by {
+			bx = r.Intn(11)
+			by = r.Intn(11)
+		}
+		for (cx == ax && cy == ay) || (cx == bx && cy == by) {
+			cx = r.Intn(11)
+			cy = r.Intn(11)
+		}
+		cases[i] = Case{ax, ay, bx, by, cx, cy}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	cases := genCases()
+	for i, c := range cases {
+		input := fmt.Sprintf("%d %d\n%d %d\n%d %d\n", c.ax, c.ay, c.bx, c.by, c.cx, c.cy)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1080-1089/1085/verifierD.go
+++ b/1000-1999/1000-1099/1080-1089/1085/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1085D.go")
+	bin := filepath.Join(os.TempDir(), "ref1085D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct {
+	n     int
+	s     int
+	edges [][2]int
+}
+
+func genCases() []Case {
+	r := rand.New(rand.NewSource(1085))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := r.Intn(9) + 2
+		s := r.Intn(100) + 1
+		edges := make([][2]int, n-1)
+		for j := 2; j <= n; j++ {
+			p := r.Intn(j-1) + 1
+			edges[j-2] = [2]int{p, j}
+		}
+		cases[i] = Case{n, s, edges}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	cases := genCases()
+	for i, c := range cases {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", c.n, c.s)
+		for _, e := range c.edges {
+			fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+		}
+		input := sb.String()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1080-1089/1085/verifierE.go
+++ b/1000-1999/1000-1099/1080-1089/1085/verifierE.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1085E.go")
+	bin := filepath.Join(os.TempDir(), "ref1085E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct {
+	k int
+	s string
+	a string
+	b string
+}
+
+func genCases() []Case {
+	r := rand.New(rand.NewSource(1085))
+	cases := make([]Case, 100)
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	for i := range cases {
+		k := r.Intn(5) + 1
+		n := r.Intn(5) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteByte(letters[r.Intn(k)])
+		}
+		s := sb.String()
+		sb.Reset()
+		for j := 0; j < n; j++ {
+			sb.WriteByte(letters[r.Intn(k)])
+		}
+		a := sb.String()
+		sb.Reset()
+		for j := 0; j < n; j++ {
+			sb.WriteByte(letters[r.Intn(k)])
+		}
+		b := sb.String()
+		if a > b {
+			a, b = b, a
+		}
+		cases[i] = Case{k, s, a, b}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	cases := genCases()
+	for i, c := range cases {
+		input := fmt.Sprintf("1\n%d\n%s\n%s\n%s\n", c.k, c.s, c.a, c.b)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1080-1089/1085/verifierF.go
+++ b/1000-1999/1000-1099/1080-1089/1085/verifierF.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1085F.go")
+	bin := filepath.Join(os.TempDir(), "ref1085F.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct {
+	n   int
+	q   int
+	s   string
+	ops [][2]interface{}
+}
+
+func genCases() []Case {
+	r := rand.New(rand.NewSource(1085))
+	letters := [3]byte{'R', 'P', 'S'}
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := r.Intn(8) + 2
+		q := r.Intn(8) + 1
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteByte(letters[r.Intn(3)])
+		}
+		s := sb.String()
+		ops := make([][2]interface{}, q)
+		for j := 0; j < q; j++ {
+			pos := r.Intn(n) + 1
+			ch := letters[r.Intn(3)]
+			ops[j] = [2]interface{}{pos, ch}
+		}
+		cases[i] = Case{n, q, s, ops}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	cases := genCases()
+	for i, c := range cases {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n%s\n", c.n, c.q, c.s)
+		for _, op := range c.ops {
+			fmt.Fprintf(&sb, "%d %c\n", op[0], op[1])
+		}
+		input := sb.String()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1000-1099/1080-1089/1085/verifierG.go
+++ b/1000-1999/1000-1099/1080-1089/1085/verifierG.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1085G.go")
+	bin := filepath.Join(os.TempDir(), "ref1085G.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct {
+	n    int
+	grid [][]int
+}
+
+func genCases() []Case {
+	r := rand.New(rand.NewSource(1085))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := r.Intn(4) + 2
+		grid := make([][]int, n)
+		for j := 0; j < n; j++ {
+			row := make([]int, n)
+			for k := 0; k < n; k++ {
+				row[k] = r.Intn(5)
+			}
+			grid[j] = row
+		}
+		cases[i] = Case{n, grid}
+	}
+	return cases
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rand.Seed(time.Now().UnixNano())
+	cases := genCases()
+	for i, c := range cases {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", c.n)
+		for _, row := range c.grid {
+			for j, x := range row {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				fmt.Fprintf(&sb, "%d", x)
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add Go verification programs for contest 1085 problems A–G
- each verifier builds the reference solution and checks 100 random test cases

## Testing
- `go build 1000-1999/1000-1099/1080-1089/1085/verifierA.go`
- `go build 1000-1999/1000-1099/1080-1089/1085/verifierB.go`
- `go build 1000-1999/1000-1099/1080-1089/1085/verifierC.go`
- `go build 1000-1999/1000-1099/1080-1089/1085/verifierD.go`
- `go build 1000-1999/1000-1099/1080-1089/1085/verifierE.go`
- `go build 1000-1999/1000-1099/1080-1089/1085/verifierF.go`
- `go build 1000-1999/1000-1099/1080-1089/1085/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_688475eb95d88324bd782f20489dada2