### PR TITLE
Add Go solution for 1697B

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1697/1697B.go
+++ b/1000-1999/1600-1699/1690-1699/1697/1697B.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+// This program solves the problem described in problemB.txt for contest 1697.
+// We sort item prices in descending order and build prefix sums. For each
+// query (x, y) the customer chooses the x most expensive items and receives the
+// y cheapest among them for free, which are exactly the last y items among those
+// x. Their total value is prefix[x] - prefix[x-y].
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, q int
+	fmt.Fscan(reader, &n, &q)
+	prices := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &prices[i])
+	}
+	sort.Slice(prices, func(i, j int) bool { return prices[i] > prices[j] })
+
+	prefix := make([]int64, n+1)
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i] + int64(prices[i])
+	}
+
+	for ; q > 0; q-- {
+		var x, y int
+		fmt.Fscan(reader, &x, &y)
+		ans := prefix[x] - prefix[x-y]
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problemB in contest 1697
- sort prices descending, prefix sums, answer queries with prefix differences

## Testing
- `go build 1000-1999/1600-1699/1690-1699/1697/1697B.go`

------
https://chatgpt.com/codex/tasks/task_e_688477d5eef08324993f8541e1511ac0