### PR TITLE
Add Go solution for 1697A

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1697/1697A.go
+++ b/1000-1999/1600-1699/1690-1699/1697/1697A.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(reader, &n, &m)
+		sum := 0
+		for i := 0; i < n; i++ {
+			var a int
+			fmt.Fscan(reader, &a)
+			sum += a
+		}
+		need := sum - m
+		if need < 0 {
+			need = 0
+		}
+		fmt.Fprintln(writer, need)
+	}
+}


### PR DESCRIPTION
## Summary
- implement 1697A solution in Go

## Testing
- `go build 1000-1999/1600-1699/1690-1699/1697/1697A.go`


------
https://chatgpt.com/codex/tasks/task_e_688478620d6c8324a22580632c413ae0