### PR TITLE
Add Go solution for 1692C

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1692/1692C.go
+++ b/1000-1999/1600-1699/1690-1699/1692/1692C.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		board := make([]string, 8)
+		for i := 0; i < 8; i++ {
+			fmt.Fscan(reader, &board[i])
+		}
+		found := false
+		for i := 1; i < 7 && !found; i++ {
+			for j := 1; j < 7 && !found; j++ {
+				if board[i][j] == '#' &&
+					board[i-1][j-1] == '#' &&
+					board[i-1][j+1] == '#' &&
+					board[i+1][j-1] == '#' &&
+					board[i+1][j+1] == '#' {
+					fmt.Fprintln(writer, i+1, j+1)
+					found = true
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problemC.txt (1692C)

## Testing
- `go vet 1000-1999/1600-1699/1690-1699/1692/1692C.go`
- `go run 1000-1999/1600-1699/1690-1699/1692/1692C.go < /tmp/sample2.txt`


------
https://chatgpt.com/codex/tasks/task_e_68847b1e9a08832489fb54bbad035aa9