### PR TITLE
Add Go verifiers for contest 1093

### DIFF
--- a/1000-1999/1000-1099/1090-1099/1093/verifierA.go
+++ b/1000-1999/1000-1099/1090-1099/1093/verifierA.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, x int) error {
+	input := fmt.Sprintf("1\n%d\n", x)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	tokens := strings.Fields(out)
+	if len(tokens) != 1 {
+		return fmt.Errorf("expected one number, got %d", len(tokens))
+	}
+	n, err := strconv.Atoi(tokens[0])
+	if err != nil {
+		return fmt.Errorf("invalid integer %q", tokens[0])
+	}
+	if n <= 0 || 2*n > x || 7*n < x {
+		return fmt.Errorf("invalid number of rolls %d for x=%d", n, x)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		x := rng.Intn(99) + 2 // 2..100
+		if err := runCase(bin, x); err != nil {
+			fmt.Printf("case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1093/verifierB.go
+++ b/1000-1999/1000-1099/1090-1099/1093/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1093B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genString(r *rand.Rand) string {
+	n := r.Intn(30) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + r.Intn(26))
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := genString(rng)
+		input := fmt.Sprintf("1\n%s\n", s)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\n got:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1093/verifierC.go
+++ b/1000-1999/1000-1099/1090-1099/1093/verifierC.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1093C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+type caseC struct {
+	n int
+	b []int64
+}
+
+func genCase(r *rand.Rand) caseC {
+	half := r.Intn(5) + 1 // 1..5 => n up to 10
+	n := half * 2
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		if i == 0 {
+			a[i] = int64(r.Intn(5))
+		} else {
+			a[i] = a[i-1] + int64(r.Intn(5))
+		}
+	}
+	b := make([]int64, half)
+	for i := 0; i < half; i++ {
+		b[i] = a[i] + a[n-1-i]
+	}
+	return caseC{n: n, b: b}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("1\n%d\n", tc.n))
+		for j, v := range tc.b {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\n got:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1093/verifierD.go
+++ b/1000-1999/1000-1099/1090-1099/1093/verifierD.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1093D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+type edge struct{ u, v int }
+
+type caseD struct {
+	n, m  int
+	edges []edge
+}
+
+func genCase(r *rand.Rand) caseD {
+	n := r.Intn(6) + 1 // 1..6
+	maxM := n * (n - 1) / 2
+	m := r.Intn(min(maxM, 6) + 1) // up to 6 edges
+	used := make(map[[2]int]bool)
+	edges := make([]edge, 0, m)
+	for len(edges) < m {
+		u := r.Intn(n) + 1
+		v := r.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		key := [2]int{u, v}
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		edges = append(edges, edge{u, v})
+	}
+	return caseD{n: n, m: m, edges: edges}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("1\n%d %d\n", tc.n, tc.m))
+		for _, e := range tc.edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+		}
+		input := sb.String()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\n got:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1093/verifierE.go
+++ b/1000-1999/1000-1099/1090-1099/1093/verifierE.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1093E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+type query struct {
+	t  int
+	a1 int
+	a2 int
+	a3 int
+	a4 int
+}
+
+type caseE struct {
+	n, m int
+	a    []int
+	b    []int
+	q    []query
+}
+
+func genCase(r *rand.Rand) caseE {
+	n := r.Intn(5) + 2 // 2..6
+	m := r.Intn(5) + 1 // 1..5
+	a := r.Perm(n)
+	for i := range a {
+		a[i]++
+	}
+	b := r.Perm(n)
+	for i := range b {
+		b[i]++
+	}
+	qs := make([]query, m)
+	for i := 0; i < m; i++ {
+		if r.Intn(2) == 0 {
+			la := r.Intn(n) + 1
+			ra := r.Intn(n-la+1) + la
+			lb := r.Intn(n) + 1
+			rb := r.Intn(n-lb+1) + lb
+			qs[i] = query{1, la, ra, lb, rb}
+		} else {
+			x := r.Intn(n) + 1
+			y := r.Intn(n) + 1
+			for y == x {
+				y = r.Intn(n) + 1
+			}
+			qs[i] = query{2, x, y, 0, 0}
+		}
+	}
+	return caseE{n: n, m: m, a: a, b: b, q: qs}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+		for j, v := range tc.a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for j, v := range tc.b {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for _, q := range tc.q {
+			if q.t == 1 {
+				sb.WriteString(fmt.Sprintf("1 %d %d %d %d\n", q.a1, q.a2, q.a3, q.a4))
+			} else {
+				sb.WriteString(fmt.Sprintf("2 %d %d\n", q.a1, q.a2))
+			}
+		}
+		input := sb.String()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\n got:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1093/verifierF.go
+++ b/1000-1999/1000-1099/1090-1099/1093/verifierF.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1093F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+type caseF struct {
+	n, k, m int
+	arr     []int
+}
+
+func genCase(r *rand.Rand) caseF {
+	n := r.Intn(6) + 1
+	k := r.Intn(4) + 2
+	m := r.Intn(n) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		if r.Intn(3) == 0 {
+			arr[i] = -1
+		} else {
+			arr[i] = r.Intn(k) + 1
+		}
+	}
+	return caseF{n: n, k: k, m: m, arr: arr}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", tc.n, tc.k, tc.m))
+		for j, v := range tc.arr {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\n got:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1093/verifierG.go
+++ b/1000-1999/1000-1099/1090-1099/1093/verifierG.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func buildRef() (string, error) {
+	ref := "refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1093G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+type query struct {
+	t    int
+	a1   int
+	a2   int
+	vals []int
+}
+
+type caseG struct {
+	n, k   int
+	points [][]int
+	q      int
+	qs     []query
+}
+
+func genCase(r *rand.Rand) caseG {
+	n := r.Intn(4) + 1
+	k := r.Intn(3) + 1
+	points := make([][]int, n)
+	for i := 0; i < n; i++ {
+		p := make([]int, k)
+		for j := 0; j < k; j++ {
+			p[j] = r.Intn(21) - 10
+		}
+		points[i] = p
+	}
+	q := r.Intn(5) + 1
+	qs := make([]query, q)
+	for i := 0; i < q; i++ {
+		if r.Intn(2) == 0 {
+			l := r.Intn(n) + 1
+			r2 := r.Intn(n-l+1) + l
+			qs[i] = query{2, l, r2, nil}
+		} else {
+			idx := r.Intn(n) + 1
+			vals := make([]int, k)
+			for j := 0; j < k; j++ {
+				vals[j] = r.Intn(21) - 10
+			}
+			qs[i] = query{1, idx, 0, vals}
+		}
+	}
+	return caseG{n: n, k: k, points: points, q: q, qs: qs}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.k))
+		for _, p := range tc.points {
+			for j, v := range p {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", v))
+			}
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", tc.q))
+		for _, q := range tc.qs {
+			if q.t == 1 {
+				sb.WriteString("1 ")
+				sb.WriteString(fmt.Sprintf("%d", q.a1))
+				for _, v := range q.vals {
+					sb.WriteByte(' ')
+					sb.WriteString(fmt.Sprintf("%d", v))
+				}
+				sb.WriteByte('\n')
+			} else {
+				sb.WriteString(fmt.Sprintf("2 %d %d\n", q.a1, q.a2))
+			}
+		}
+		input := sb.String()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\n got:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement new Go verifiers for problems A–G of contest 1093
- each verifier runs 100 randomized tests and checks output using reference solutions

## Testing
- `gofmt -w 1000-1999/1000-1099/1090-1099/1093/verifier*.go`

------
https://chatgpt.com/codex/tasks/task_e_68847a4c51ec8324a731d4e981952904