### PR TITLE
Add Go solution for 1692B

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1692/1692B.go
+++ b/1000-1999/1600-1699/1690-1699/1692/1692B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// Solution to problemB.txt for 1692B (All Distinct).
+// We remove elements in pairs to maximize the length of the
+// resulting array with all unique values. The final size is the
+// count of unique elements minus one if the number of duplicates is odd.
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		uniq := make(map[int]struct{})
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(in, &x)
+			uniq[x] = struct{}{}
+		}
+		duplicates := n - len(uniq)
+		if duplicates%2 == 1 {
+			fmt.Fprintln(out, len(uniq)-1)
+		} else {
+			fmt.Fprintln(out, len(uniq))
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1692B.go` for contest 1692 problem B

## Testing
- `go build 1000-1999/1600-1699/1690-1699/1692/1692B.go`

------
https://chatgpt.com/codex/tasks/task_e_68847baa95f08324b661688c412d2355