### PR TITLE
Add Go verifiers for Codeforces contest 1096

### DIFF
--- a/1000-1999/1000-1099/1090-1099/1096/verifierA.go
+++ b/1000-1999/1000-1099/1090-1099/1096/verifierA.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	t := rng.Intn(5) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		l := rng.Int63n(100000) + 1
+		r := l*2 + rng.Int63n(100)
+		in.WriteString(fmt.Sprintf("%d %d\n", l, r))
+		out.WriteString(fmt.Sprintf("%d %d\n", l, l*2))
+	}
+	return testCase{input: in.String(), expected: out.String()}
+}
+
+func runCase(bin string, tc testCase) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCase{{input: "1\n1 2\n", expected: "1 2\n"}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCase(rng))
+	}
+	for i, tc := range cases {
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1096/verifierB.go
+++ b/1000-1999/1000-1099/1090-1099/1096/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modB = 998244353
+
+type testCaseB struct {
+	input    string
+	expected int
+}
+
+func solveB(s string) int {
+	n := len(s)
+	l := 1
+	for i := 1; i < n; i++ {
+		if s[i] == s[0] {
+			l++
+		} else {
+			break
+		}
+	}
+	r := 1
+	for i := n - 2; i >= 0; i-- {
+		if s[i] == s[n-1] {
+			r++
+		} else {
+			break
+		}
+	}
+	if s[0] == s[n-1] {
+		return int(int64(l) * int64(r) % modB)
+	}
+	return int(int64(l+r-1) % modB)
+}
+
+func generateCaseB(rng *rand.Rand) testCaseB {
+	n := rng.Intn(20) + 2
+	bytesStr := make([]byte, n)
+	for {
+		for i := 0; i < n; i++ {
+			bytesStr[i] = byte('a' + rng.Intn(26))
+		}
+		diff := false
+		for i := 1; i < n; i++ {
+			if bytesStr[i] != bytesStr[0] {
+				diff = true
+				break
+			}
+		}
+		if diff {
+			break
+		}
+	}
+	s := string(bytesStr)
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	return testCaseB{input: input, expected: solveB(s)}
+}
+
+func runCaseB(bin string, tc testCaseB) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCaseB{{input: "2\nab\n", expected: 2}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseB(rng))
+	}
+	for i, tc := range cases {
+		if err := runCaseB(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1096/verifierC.go
+++ b/1000-1999/1000-1099/1090-1099/1096/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseC struct {
+	input    string
+	expected string
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solveAngle(angle int) int {
+	pgcd := gcd(360, angle*2)
+	if pgcd == 1 {
+		return 1
+	}
+	r := 360 / pgcd
+	if angle < 90 {
+		return r
+	}
+	m := 2 * angle
+	if 360-angle*2 < m {
+		m = 360 - angle*2
+	}
+	if m == 360/r {
+		r *= 2
+	}
+	return r
+}
+
+func generateCaseC(rng *rand.Rand) testCaseC {
+	t := rng.Intn(5) + 1
+	var in strings.Builder
+	var out strings.Builder
+	in.WriteString(fmt.Sprintf("%d\n", t))
+	for i := 0; i < t; i++ {
+		ang := rng.Intn(179) + 1
+		in.WriteString(fmt.Sprintf("%d\n", ang))
+		out.WriteString(fmt.Sprintf("%d\n", solveAngle(ang)))
+	}
+	return testCaseC{input: in.String(), expected: out.String()}
+}
+
+func runCaseC(bin string, tc testCaseC) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	exp := strings.TrimSpace(tc.expected)
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCaseC{{input: "1\n1\n", expected: fmt.Sprintf("%d\n", solveAngle(1))}}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseC(rng))
+	}
+	for i, tc := range cases {
+		if err := runCaseC(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1096/verifierD.go
+++ b/1000-1999/1000-1099/1090-1099/1096/verifierD.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseD struct {
+	input    string
+	expected int64
+}
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func solveD(s string, costs []int64) int64 {
+	target := "hard"
+	inf := int64(1) << 60
+	f := make([]int64, 5)
+	for i := 1; i <= 4; i++ {
+		f[i] = inf
+	}
+	for i := 0; i < len(s); i++ {
+		a := costs[i]
+		for j := 3; j >= 0; j-- {
+			if s[i] == target[j] {
+				if f[j] < f[j+1] {
+					f[j+1] = f[j]
+				}
+				f[j] += a
+			}
+		}
+	}
+	res := f[0]
+	for j := 1; j <= 3; j++ {
+		if f[j] < res {
+			res = f[j]
+		}
+	}
+	return res
+}
+
+func generateCaseD(rng *rand.Rand) testCaseD {
+	n := rng.Intn(10) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	s := string(b)
+	costs := make([]int64, n)
+	for i := 0; i < n; i++ {
+		costs[i] = int64(rng.Intn(10) + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", costs[i]))
+	}
+	sb.WriteByte('\n')
+	return testCaseD{input: sb.String(), expected: solveD(s, costs)}
+}
+
+func runCaseD(bin string, tc testCaseD) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCaseD{generateCaseD(rng)}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseD(rng))
+	}
+	for i, tc := range cases {
+		if err := runCaseD(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1096/verifierE.go
+++ b/1000-1999/1000-1099/1090-1099/1096/verifierE.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modE = 998244353
+const M = 5220
+const N = 120
+
+var comb [M][N]int
+
+func initComb() {
+	for i := 0; i < M; i++ {
+		comb[i][0] = 1
+		for j := 1; j < N && j <= i; j++ {
+			comb[i][j] = comb[i-1][j] + comb[i-1][j-1]
+			if comb[i][j] >= modE {
+				comb[i][j] -= modE
+			}
+		}
+	}
+}
+
+func modPowE(a, b int) int {
+	res := 1
+	for b > 0 {
+		if b&1 == 1 {
+			res = int((int64(res) * int64(a)) % modE)
+		}
+		a = int((int64(a) * int64(a)) % modE)
+		b >>= 1
+	}
+	return res
+}
+
+func solveE(p, sum, lower int) int {
+	if lower == 0 {
+		return modPowE(p, modE-2)
+	}
+	totalWays := comb[sum-lower+p-1][p-1]
+	invTotal := modPowE(totalWays, modE-2)
+	ans := 0
+	for ties := 1; ties <= p; ties++ {
+		save := modPowE(ties, modE-2)
+		for top := lower; ties*top <= sum; top++ {
+			rem := sum - ties*top
+			t := p - ties
+			if t == 0 {
+				if rem == 0 {
+					ans += save
+					if ans >= modE {
+						ans -= modE
+					}
+				}
+				continue
+			}
+			res := 0
+			for bad := 0; bad <= t && bad*top <= rem; bad++ {
+				nsum := rem - bad*top
+				add := int((int64(comb[nsum+t-1][t-1]) * int64(comb[t][bad])) % modE)
+				if bad&1 == 1 {
+					res = (res - add + modE) % modE
+				} else {
+					res = (res + add) % modE
+				}
+			}
+			res = int((int64(res) * int64(comb[p-1][ties-1])) % modE)
+			ans = int((int64(ans) + int64(res)*int64(save)) % modE)
+		}
+	}
+	ans = int((int64(ans) * int64(invTotal)) % modE)
+	return ans
+}
+
+type testCaseE struct {
+	input    string
+	expected int
+}
+
+func generateCaseE(rng *rand.Rand) testCaseE {
+	p := rng.Intn(5) + 1
+	lower := rng.Intn(5)
+	sum := lower + rng.Intn(10)
+	input := fmt.Sprintf("%d %d %d\n", p, sum, lower)
+	return testCaseE{input: input, expected: solveE(p, sum, lower)}
+}
+
+func runCaseE(bin string, tc testCaseE) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	initComb()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCaseE{generateCaseE(rng)}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseE(rng))
+	}
+	for i, tc := range cases {
+		if err := runCaseE(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1096/verifierF.go
+++ b/1000-1999/1000-1099/1090-1099/1096/verifierF.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modF = 998244353
+
+type Fenwick struct {
+	n    int
+	tree []int
+}
+
+func NewFenwick(n int) *Fenwick {
+	return &Fenwick{n: n, tree: make([]int, n+1)}
+}
+
+func (f *Fenwick) Add(i, v int) {
+	for ; i <= f.n; i += i & -i {
+		f.tree[i] += v
+	}
+}
+
+func (f *Fenwick) Sum(i int) int {
+	s := 0
+	for ; i > 0; i -= i & -i {
+		s += f.tree[i]
+	}
+	return s
+}
+
+func fpowF(a, b int) int {
+	res := 1
+	for b > 1 {
+		if b&1 == 1 {
+			res = res * a % modF
+		}
+		b >>= 1
+		a = a * a % modF
+	}
+	return a * res % modF
+}
+
+func solveF(a []int) int {
+	n := len(a) - 1
+	vis := make([]bool, n+1)
+	tot := 0
+	for i := 1; i <= n; i++ {
+		if a[i] == -1 {
+			tot++
+		} else if a[i] >= 1 && a[i] <= n {
+			vis[a[i]] = true
+		}
+	}
+	ans := tot * (tot - 1) % modF * fpowF(4, modF-2) % modF
+	cnt := tot
+	fenw := NewFenwick(n)
+	for i := n; i >= 1; i-- {
+		if a[i] != -1 {
+			ans = (ans + fenw.Sum(a[i]-1)) % modF
+			fenw.Add(a[i], 1)
+		}
+	}
+	sum := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		sum[i] = sum[i-1]
+		if !vis[i] {
+			sum[i]++
+		}
+	}
+	invTot := 0
+	if tot > 0 {
+		invTot = fpowF(tot, modF-2)
+	}
+	for i := 1; i <= n; i++ {
+		if a[i] == -1 {
+			cnt--
+		} else {
+			leftMiss := sum[a[i]]
+			rightMiss := tot - leftMiss
+			add := (leftMiss*cnt%modF + rightMiss*(tot-cnt)%modF) % modF
+			ans = (ans + add*invTot%modF) % modF
+		}
+	}
+	if ans < 0 {
+		ans += modF
+	}
+	return ans
+}
+
+type testCaseF struct {
+	input    string
+	expected int
+}
+
+func generateCaseF(rng *rand.Rand) testCaseF {
+	n := rng.Intn(6) + 1
+	arr := make([]int, n+1)
+	used := make([]bool, n+1)
+	for i := 1; i <= n; i++ {
+		if rng.Intn(2) == 0 {
+			arr[i] = -1
+		} else {
+			v := rng.Intn(n) + 1
+			for used[v] {
+				v = rng.Intn(n) + 1
+			}
+			used[v] = true
+			arr[i] = v
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	return testCaseF{input: sb.String(), expected: solveF(arr)}
+}
+
+func runCaseF(bin string, tc testCaseF) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCaseF{generateCaseF(rng)}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseF(rng))
+	}
+	for i, tc := range cases {
+		if err := runCaseF(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1096/verifierG.go
+++ b/1000-1999/1000-1099/1090-1099/1096/verifierG.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const modG = 998244353
+
+func modAdd(a, b int) int {
+	a += b
+	if a >= modG {
+		a -= modG
+	}
+	return a
+}
+func modSub(a, b int) int {
+	a -= b
+	if a < 0 {
+		a += modG
+	}
+	return a
+}
+func modMul(a, b int) int { return int((int64(a) * int64(b)) % modG) }
+
+func modPow(a, e int) int {
+	res := 1
+	x := a % modG
+	for e > 0 {
+		if e&1 != 0 {
+			res = modMul(res, x)
+		}
+		x = modMul(x, x)
+		e >>= 1
+	}
+	return res
+}
+
+func modInv(a int) int { return modPow(a, modG-2) }
+
+func ntt(a []int, invert bool) {
+	n := len(a)
+	for i, j := 1, 0; i < n; i++ {
+		bit := n >> 1
+		for j&bit != 0 {
+			j ^= bit
+			bit >>= 1
+		}
+		j |= bit
+		if i < j {
+			a[i], a[j] = a[j], a[i]
+		}
+	}
+	for length := 2; length <= n; length <<= 1 {
+		wlen := modPow(3, (modG-1)/length)
+		if invert {
+			wlen = modInv(wlen)
+		}
+		for i := 0; i < n; i += length {
+			w := 1
+			half := length >> 1
+			for j := 0; j < half; j++ {
+				u := a[i+j]
+				v := modMul(a[i+j+half], w)
+				a[i+j] = modAdd(u, v)
+				a[i+j+half] = modSub(u, v)
+				w = modMul(w, wlen)
+			}
+		}
+	}
+	if invert {
+		invN := modInv(n)
+		for i := range a {
+			a[i] = modMul(a[i], invN)
+		}
+	}
+}
+
+func multiply(a, b []int) []int {
+	need := len(a) + len(b) - 1
+	n := 1
+	for n < need {
+		n <<= 1
+	}
+	fa := make([]int, n)
+	fb := make([]int, n)
+	copy(fa, a)
+	copy(fb, b)
+	ntt(fa, false)
+	ntt(fb, false)
+	for i := 0; i < n; i++ {
+		fa[i] = modMul(fa[i], fb[i])
+	}
+	ntt(fa, true)
+	return fa[:need]
+}
+
+func square(a []int) []int { return multiply(a, a) }
+
+func solveG(n int, digits []int) int {
+	allowed := [10]bool{}
+	for _, d := range digits {
+		allowed[d] = true
+	}
+	var ans func(int) []int
+	ans = func(k int) []int {
+		if k == 0 {
+			return []int{1}
+		}
+		if k%2 == 0 {
+			ret := ans(k / 2)
+			return square(ret)
+		}
+		ret := ans(k - 1)
+		res := make([]int, len(ret)+10)
+		for i, v := range ret {
+			if v == 0 {
+				continue
+			}
+			for d := 0; d < 10; d++ {
+				if allowed[d] {
+					res[i+d] = modAdd(res[i+d], v)
+				}
+			}
+		}
+		return res
+	}
+	f := ans(n / 2)
+	out := 0
+	for _, v := range f {
+		out = modAdd(out, modMul(v, v))
+	}
+	return out
+}
+
+type testCaseG struct {
+	input    string
+	expected int
+}
+
+func generateCaseG(rng *rand.Rand) testCaseG {
+	n := 2 * (rng.Intn(4) + 1)
+	k := rng.Intn(5) + 1
+	digits := rng.Perm(10)[:k]
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, d := range digits {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", d))
+	}
+	sb.WriteByte('\n')
+	return testCaseG{input: sb.String(), expected: solveG(n, digits)}
+}
+
+func runCaseG(bin string, tc testCaseG) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != tc.expected {
+		return fmt.Errorf("expected %d got %d", tc.expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	cases := []testCaseG{generateCaseG(rng)}
+	for i := 0; i < 100; i++ {
+		cases = append(cases, generateCaseG(rng))
+	}
+	for i, tc := range cases {
+		if err := runCaseG(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for contest 1096 problems A–G
- each verifier runs 100+ randomized tests against an arbitrary binary

## Testing
- `gofmt -w 1000-1999/1000-1099/1090-1099/1096/verifier*.go`

------
https://chatgpt.com/codex/tasks/task_e_68847bf09064832490ca3afcaf0eecca