### PR TITLE
Add Go verifiers for CF 1097

### DIFF
--- a/1000-1999/1000-1099/1090-1099/1097/verifierA.go
+++ b/1000-1999/1000-1099/1090-1099/1097/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1097A_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1097A.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+var suits = []string{"S", "H", "D", "C"}
+var ranks = []string{"2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K", "A"}
+
+func card() string {
+	return ranks[rand.Intn(len(ranks))] + suits[rand.Intn(len(suits))]
+}
+
+func genTest() string {
+	table := card()
+	hand := make([]string, 5)
+	for i := range hand {
+		hand[i] = card()
+	}
+	return table + "\n" + strings.Join(hand, " ") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1097/verifierB.go
+++ b/1000-1999/1000-1099/1090-1099/1097/verifierB.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1097B_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1097B.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() string {
+	n := rand.Intn(15) + 1
+	lines := []string{fmt.Sprintf("%d", n)}
+	for i := 0; i < n; i++ {
+		lines = append(lines, fmt.Sprintf("%d", rand.Intn(180)+1))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1097/verifierC.go
+++ b/1000-1999/1000-1099/1090-1099/1097/verifierC.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1097C_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1097C.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() string {
+	n := rand.Intn(20) + 1
+	lines := []string{fmt.Sprintf("%d", n)}
+	for i := 0; i < n; i++ {
+		l := rand.Intn(10) + 1
+		b := make([]byte, l)
+		for j := range b {
+			if rand.Intn(2) == 0 {
+				b[j] = '('
+			} else {
+				b[j] = ')'
+			}
+		}
+		lines = append(lines, string(b))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1097/verifierD.go
+++ b/1000-1999/1000-1099/1090-1099/1097/verifierD.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1097D_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1097D.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+var primes = []int64{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37}
+
+func randomN() int64 {
+	cnt := rand.Intn(4) + 1
+	n := int64(1)
+	for i := 0; i < cnt; i++ {
+		n *= primes[rand.Intn(len(primes))]
+	}
+	return n
+}
+
+func genTest() string {
+	n := randomN()
+	k := rand.Intn(10) + 1
+	return fmt.Sprintf("%d %d\n", n, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1097/verifierE.go
+++ b/1000-1999/1000-1099/1090-1099/1097/verifierE.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1097E_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1097E.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func perm(n int) []int {
+	a := make([]int, n)
+	for i := range a {
+		a[i] = i + 1
+	}
+	for i := n - 1; i > 0; i-- {
+		j := rand.Intn(i + 1)
+		a[i], a[j] = a[j], a[i]
+	}
+	return a
+}
+
+func genTest() string {
+	q := rand.Intn(3) + 1
+	lines := []string{fmt.Sprintf("%d", q)}
+	for i := 0; i < q; i++ {
+		n := rand.Intn(10) + 1
+		a := perm(n)
+		line := fmt.Sprintf("%d\n", n)
+		parts := make([]string, n)
+		for j, v := range a {
+			parts[j] = fmt.Sprintf("%d", v)
+		}
+		line += strings.Join(parts, " ")
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1097/verifierF.go
+++ b/1000-1999/1000-1099/1090-1099/1097/verifierF.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1097F_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1097F.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	q := rand.Intn(30) + 1
+	lines := []string{fmt.Sprintf("%d %d", n, q)}
+	queryCount := 0
+	for i := 0; i < q; i++ {
+		typ := rand.Intn(4) + 1
+		if i == q-1 && queryCount == 0 {
+			typ = 4
+		}
+		switch typ {
+		case 1:
+			x := rand.Intn(n) + 1
+			v := rand.Intn(50) + 1
+			lines = append(lines, fmt.Sprintf("1 %d %d", x, v))
+		case 2:
+			x := rand.Intn(n) + 1
+			y := rand.Intn(n) + 1
+			z := rand.Intn(n) + 1
+			lines = append(lines, fmt.Sprintf("2 %d %d %d", x, y, z))
+		case 3:
+			x := rand.Intn(n) + 1
+			y := rand.Intn(n) + 1
+			z := rand.Intn(n) + 1
+			lines = append(lines, fmt.Sprintf("3 %d %d %d", x, y, z))
+		case 4:
+			x := rand.Intn(n) + 1
+			v := rand.Intn(50) + 1
+			lines = append(lines, fmt.Sprintf("4 %d %d", x, v))
+			queryCount++
+		}
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1097/verifierG.go
+++ b/1000-1999/1000-1099/1090-1099/1097/verifierG.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1097G_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1097G.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTree(n int) [][2]int {
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	return edges
+}
+
+func genTest() string {
+	n := rand.Intn(6) + 2
+	k := rand.Intn(n) + 1
+	edges := genTree(n)
+	lines := []string{fmt.Sprintf("%d %d", n, k)}
+	for _, e := range edges {
+		lines = append(lines, fmt.Sprintf("%d %d", e[0], e[1]))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1097/verifierH.go
+++ b/1000-1999/1000-1099/1090-1099/1097/verifierH.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1097H_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1097H.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() string {
+	d := rand.Intn(5) + 2
+	m := rand.Intn(20) + 2
+	gen := make([]string, d)
+	gen[0] = "0"
+	for i := 1; i < d; i++ {
+		gen[i] = fmt.Sprintf("%d", rand.Intn(m))
+	}
+	n := rand.Intn(5) + 1
+	B := make([]string, n)
+	for i := range B {
+		B[i] = fmt.Sprintf("%d", rand.Intn(m))
+	}
+	l := rand.Int63n(1000) + 1
+	r := l + int64(n) + rand.Int63n(100)
+	lines := []string{fmt.Sprintf("%d %d", d, m), strings.Join(gen, " "), fmt.Sprintf("%d", n), strings.Join(B, " "), fmt.Sprintf("%d %d", l, r)}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1097 (problems A–H)
- each verifier compiles the official Go solution, generates 100 random tests, and checks a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_68847c7d819c832497f250c30d50073a