### PR TITLE
Add Go verifiers for CF contest 1099

### DIFF
--- a/1000-1999/1000-1099/1090-1099/1099/verifierA.go
+++ b/1000-1999/1000-1099/1090-1099/1099/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1099A.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		h := rng.Intn(100) + 1
+		w := rng.Intn(101)
+		h1 := rng.Intn(h) + 1
+		h2 := rng.Intn(h) + 1
+		if h2 == h1 {
+			if h2 == h {
+				h2--
+			} else {
+				h2++
+			}
+		}
+		w1 := rng.Intn(101)
+		w2 := rng.Intn(101)
+		tests[i] = fmt.Sprintf("%d %d\n%d %d\n%d %d\n", w, h, w1, h1, w2, h2)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1099/verifierB.go
+++ b/1000-1999/1000-1099/1090-1099/1099/verifierB.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1099B.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Int63n(1_000_000_000) + 1
+		tests[i] = fmt.Sprintf("%d\n", n)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1099/verifierC.go
+++ b/1000-1999/1000-1099/1090-1099/1099/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1099C.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	for i := 0; i < 100; i++ {
+		l := rng.Intn(15) + 1
+		var sb strings.Builder
+		for j := 0; j < l; j++ {
+			ch := letters[rng.Intn(len(letters))]
+			sb.WriteRune(ch)
+			r := rng.Intn(3)
+			if r == 0 {
+				sb.WriteByte('?')
+			} else if r == 1 {
+				sb.WriteByte('*')
+			}
+		}
+		k := rng.Intn(20) + 1
+		tests[i] = fmt.Sprintf("%s\n%d\n", sb.String(), k)
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1000-1099/1090-1099/1099/verifierF.go
+++ b/1000-1999/1000-1099/1090-1099/1099/verifierF.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refF_bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1099F.go")
+	cmd.Stdout = new(bytes.Buffer)
+	cmd.Stderr = new(bytes.Buffer)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = new(bytes.Buffer)
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(7) + 1
+		T := rng.Int63n(200) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, T)
+		for j := 0; j < n; j++ {
+			x := rng.Intn(10) + 1
+			fmt.Fprintf(&sb, "%d ", x)
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			t := rng.Intn(10) + 1
+			fmt.Fprintf(&sb, "%d ", t)
+		}
+		sb.WriteByte('\n')
+		for v := 2; v <= n; v++ {
+			p := rng.Intn(v-1) + 1
+			l := rng.Intn(10)
+			fmt.Fprintf(&sb, "%d %d\n", p, l)
+		}
+		tests[i] = sb.String()
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for idx, input := range tests {
+		exp, err1 := runBinary(ref, input)
+		out, err2 := runBinary(cand, input)
+		if err1 != nil || err2 != nil {
+			fmt.Printf("runtime error on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(out) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", idx+1, input, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1099 solutions A, B, C and F
- each verifier builds the reference solution and checks 100 random tests
- verifiers run candidate binaries and compare outputs

## Testing
- `go vet ./...` *(fails: directory prefix does not contain module)*

------
https://chatgpt.com/codex/tasks/task_e_68847d9505e48324a8f91135fb62c679