### PR TITLE
Add Go verifiers for CF 1098

### DIFF
--- a/1000-1999/1000-1099/1090-1099/1098/verifierA.go
+++ b/1000-1999/1000-1099/1090-1099/1098/verifierA.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() string {
+	exe := "refA_bin"
+	if _, err := os.Stat(exe); err == nil {
+		return "./" + exe
+	}
+	cmd := exec.Command("g++", "-std=c++17", "solA.cpp", "-O2", "-o", exe)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	return "./" + exe
+}
+
+func run(path string, input []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return out, err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := buildRef()
+	rand.Seed(1)
+
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(8) + 2
+		parent := make([]int, n+1)
+		for i := 2; i <= n; i++ {
+			parent[i] = rand.Intn(i-1) + 1
+		}
+		s := make([]int64, n+1)
+		for i := 1; i <= n; i++ {
+			if i == 1 || rand.Intn(3) > 0 {
+				s[i] = int64(rand.Intn(20))
+			} else {
+				s[i] = -1
+			}
+		}
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "%d\n", n)
+		for i := 2; i <= n; i++ {
+			if i > 2 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprintf(&buf, "%d", parent[i])
+		}
+		buf.WriteByte('\n')
+		for i := 1; i <= n; i++ {
+			if i > 1 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprintf(&buf, "%d", s[i])
+		}
+		buf.WriteByte('\n')
+		input := buf.Bytes()
+
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference run error:", err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(exp)) != strings.TrimSpace(string(out)) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:\n%sGot:\n%s", t, string(input), string(exp), string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1000-1099/1090-1099/1098/verifierB.go
+++ b/1000-1999/1000-1099/1090-1099/1098/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() string {
+	exe := "refB_bin"
+	if _, err := os.Stat(exe); err == nil {
+		return "./" + exe
+	}
+	cmd := exec.Command("go", "build", "-o", exe, "1098B.go")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	return "./" + exe
+}
+
+func run(path string, input []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return out, err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := buildRef()
+	rand.Seed(2)
+
+	letters := []byte{'A', 'G', 'C', 'T'}
+
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(4) + 2
+		m := rand.Intn(4) + 2
+		grid := make([][]byte, n)
+		for i := 0; i < n; i++ {
+			row := make([]byte, m)
+			for j := 0; j < m; j++ {
+				row[j] = letters[rand.Intn(4)]
+			}
+			grid[i] = row
+		}
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "%d %d\n", n, m)
+		for i := 0; i < n; i++ {
+			buf.Write(grid[i])
+			buf.WriteByte('\n')
+		}
+		input := buf.Bytes()
+
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference run error:", err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(exp)) != strings.TrimSpace(string(out)) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:\n%sGot:\n%s", t, string(input), string(exp), string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1000-1099/1090-1099/1098/verifierC.go
+++ b/1000-1999/1000-1099/1090-1099/1098/verifierC.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() string {
+	exe := "refC_bin"
+	if _, err := os.Stat(exe); err == nil {
+		return "./" + exe
+	}
+	cmd := exec.Command("go", "build", "-o", exe, "1098C.go")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	return "./" + exe
+}
+
+func run(path string, input []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return out, err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := buildRef()
+	rand.Seed(3)
+
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(8) + 2
+		maxSum := n * (n + 1) / 2
+		s := rand.Intn(maxSum-n+1) + n
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "%d %d\n", n, s)
+		input := buf.Bytes()
+
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference run error:", err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(exp)) != strings.TrimSpace(string(out)) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:\n%sGot:\n%s", t, string(input), string(exp), string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1000-1099/1090-1099/1098/verifierD.go
+++ b/1000-1999/1000-1099/1090-1099/1098/verifierD.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() string {
+	exe := "refD_bin"
+	if _, err := os.Stat(exe); err == nil {
+		return "./" + exe
+	}
+	cmd := exec.Command("g++", "-std=c++17", "solD.cpp", "-O2", "-o", exe)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	return "./" + exe
+}
+
+func run(path string, input []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return out, err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := buildRef()
+	rand.Seed(4)
+
+	for t := 1; t <= 100; t++ {
+		q := rand.Intn(20) + 1
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "%d\n", q)
+		weights := []int{}
+		for i := 0; i < q; i++ {
+			if len(weights) == 0 || rand.Intn(3) > 0 {
+				// add
+				x := rand.Intn(20) + 1
+				weights = append(weights, x)
+				fmt.Fprintf(&buf, "+ %d\n", x)
+			} else {
+				idx := rand.Intn(len(weights))
+				x := weights[idx]
+				weights = append(weights[:idx], weights[idx+1:]...)
+				fmt.Fprintf(&buf, "- %d\n", x)
+			}
+		}
+		input := buf.Bytes()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference run error:", err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(exp)) != strings.TrimSpace(string(out)) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:\n%sGot:\n%s", t, string(input), string(exp), string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1000-1099/1090-1099/1098/verifierE.go
+++ b/1000-1999/1000-1099/1090-1099/1098/verifierE.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() string {
+	exe := "refE_bin"
+	if _, err := os.Stat(exe); err == nil {
+		return "./" + exe
+	}
+	cmd := exec.Command("go", "build", "-o", exe, "1098E.go")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	return "./" + exe
+}
+
+func run(path string, input []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return out, err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := buildRef()
+	rand.Seed(5)
+
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(10) + 1
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "%d\n", n)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprintf(&buf, "%d", rand.Intn(10)+1)
+		}
+		buf.WriteByte('\n')
+		input := buf.Bytes()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference run error:", err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(exp)) != strings.TrimSpace(string(out)) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:\n%sGot:\n%s", t, string(input), string(exp), string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1000-1099/1090-1099/1098/verifierF.go
+++ b/1000-1999/1000-1099/1090-1099/1098/verifierF.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() string {
+	exe := "refF_bin"
+	if _, err := os.Stat(exe); err == nil {
+		return "./" + exe
+	}
+	cmd := exec.Command("go", "build", "-o", exe, "1098F.go")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Println("failed to build reference:", err)
+		os.Exit(1)
+	}
+	return "./" + exe
+}
+
+func run(path string, input []byte) ([]byte, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return out, err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref := buildRef()
+	rand.Seed(6)
+
+	letters := []byte("abcde")
+
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(10) + 1
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			b[i] = letters[rand.Intn(len(letters))]
+		}
+		q := rand.Intn(10) + 1
+		var buf bytes.Buffer
+		buf.Write(b)
+		buf.WriteByte('\n')
+		fmt.Fprintf(&buf, "%d\n", q)
+		for i := 0; i < q; i++ {
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			fmt.Fprintf(&buf, "%d %d\n", l, r)
+		}
+		input := buf.Bytes()
+		exp, err := run(ref, input)
+		if err != nil {
+			fmt.Println("reference run error:", err)
+			os.Exit(1)
+		}
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Printf("Runtime error on test %d: %v\n", t, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(string(exp)) != strings.TrimSpace(string(out)) {
+			fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected:\n%sGot:\n%s", t, string(input), string(exp), string(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for problems A–F of contest 1098
- verifiers compile the provided reference solutions and run 100 random tests

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_68847d08db3c8324a1372b61783806ab