### PR TITLE
Add Go verifiers for contest 1103

### DIFF
--- a/1000-1999/1100-1199/1100-1109/1103/verifierA.go
+++ b/1000-1999/1100-1199/1100-1109/1103/verifierA.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyCase(s, out string) error {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != len(s) {
+		return fmt.Errorf("expected %d lines, got %d", len(s), len(lines))
+	}
+	grid := [4][4]int{}
+	for idx, ch := range s {
+		var r, c int
+		if _, err := fmt.Sscanf(lines[idx], "%d %d", &r, &c); err != nil {
+			return fmt.Errorf("line %d parse error: %v", idx+1, err)
+		}
+		if r < 1 || r > 4 || c < 1 || c > 4 {
+			return fmt.Errorf("line %d out of bounds", idx+1)
+		}
+		r--
+		c--
+		if ch == '0' {
+			if r+1 >= 4 {
+				return fmt.Errorf("tile %d out of bounds", idx+1)
+			}
+			if grid[r][c] != 0 || grid[r+1][c] != 0 {
+				return fmt.Errorf("tile %d overlaps", idx+1)
+			}
+			grid[r][c] = 1
+			grid[r+1][c] = 1
+		} else {
+			if c+1 >= 4 {
+				return fmt.Errorf("tile %d out of bounds", idx+1)
+			}
+			if grid[r][c] != 0 || grid[r][c+1] != 0 {
+				return fmt.Errorf("tile %d overlaps", idx+1)
+			}
+			grid[r][c] = 1
+			grid[r][c+1] = 1
+		}
+		// clear full rows
+		for i := 0; i < 4; i++ {
+			full := true
+			for j := 0; j < 4; j++ {
+				if grid[i][j] == 0 {
+					full = false
+					break
+				}
+			}
+			if full {
+				for j := 0; j < 4; j++ {
+					grid[i][j] = 0
+				}
+			}
+		}
+		// clear full cols
+		for j := 0; j < 4; j++ {
+			full := true
+			for i := 0; i < 4; i++ {
+				if grid[i][j] == 0 {
+					full = false
+					break
+				}
+			}
+			if full {
+				for i := 0; i < 4; i++ {
+					grid[i][j] = 0
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(1000) + 1
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if r.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []string{"0", "1"}
+	cases = append(cases, strings.Repeat("0", 1000))
+	cases = append(cases, strings.Repeat("1", 1000))
+	for i := len(cases); i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for idx, s := range cases {
+		out, err := runCandidate(bin, s+"\n")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		if err := verifyCase(s, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput: %s\noutput:\n%s\n", idx+1, err, s, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1100-1199/1100-1109/1103/verifierB.go
+++ b/1000-1999/1100-1199/1100-1109/1103/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runGame(bin string, secret int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	r := bufio.NewReader(stdout)
+	w := bufio.NewWriter(stdin)
+	queries := 0
+	for {
+		var token string
+		if _, err := fmt.Fscan(r, &token); err != nil {
+			cmd.Process.Kill()
+			return fmt.Errorf("read error: %v", err)
+		}
+		if token == "?" {
+			var x, y int64
+			if _, err := fmt.Fscan(r, &x, &y); err != nil {
+				cmd.Process.Kill()
+				return fmt.Errorf("bad query: %v", err)
+			}
+			queries++
+			if queries > 60 {
+				cmd.Process.Kill()
+				return fmt.Errorf("too many queries")
+			}
+			resp := "y"
+			if x%secret >= y%secret {
+				resp = "x"
+			}
+			fmt.Fprintln(w, resp)
+			w.Flush()
+		} else if token == "!" {
+			var ans int64
+			if _, err := fmt.Fscan(r, &ans); err != nil {
+				cmd.Process.Kill()
+				return fmt.Errorf("bad answer: %v", err)
+			}
+			if ans != secret {
+				cmd.Process.Kill()
+				return fmt.Errorf("wrong answer: got %d expected %d", ans, secret)
+			}
+			stdin.Close()
+			err := cmd.Wait()
+			return err
+		} else {
+			cmd.Process.Kill()
+			return fmt.Errorf("unexpected token %s", token)
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []int64{1, 2, 3}
+	for len(tests) < 100 {
+		tests = append(tests, rng.Int63n(1_000_000_000)+1)
+	}
+	for i, secret := range tests {
+		if err := runGame(bin, secret); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1100-1199/1100-1109/1103/verifierC.go
+++ b/1000-1999/1100-1199/1100-1109/1103/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, _ := os.Getwd()
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1103C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 4 // 4..8
+	k := r.Intn(n) + 1
+	m := n * (n - 1) / 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 1; i <= n; i++ {
+		for j := i + 1; j <= n; j++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", i, j))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []string
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		expect, err := run(oracle, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1100-1199/1100-1109/1103/verifierD.go
+++ b/1000-1999/1100-1199/1100-1109/1103/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, _ := os.Getwd()
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1103D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 1
+	k := r.Int63n(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", r.Int63n(50)+1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d ", r.Int63n(50)+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []string
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		expect, err := run(oracle, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1100-1199/1100-1109/1103/verifierE.go
+++ b/1000-1999/1100-1199/1100-1109/1103/verifierE.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, _ := os.Getwd()
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1103E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", r.Intn(100)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var cases []string
+	for i := 0; i < 100; i++ {
+		cases = append(cases, genCase(rng))
+	}
+	for i, tc := range cases {
+		expect, err := run(oracle, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expect) != strings.TrimSpace(got) {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:\n%s\ngot:\n%s\n", i+1, tc, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add solution verification programs for contest 1103 problems A–E
- each verifier runs 100 randomized testcases and reports success or failure
- verifierB provides an interactive judge for problem B

## Testing
- `go build 1000-1999/1100-1199/1100-1109/1103/verifierA.go`
- `go build 1000-1999/1100-1199/1100-1109/1103/verifierB.go`
- `go build 1000-1999/1100-1199/1100-1109/1103/verifierC.go`
- `go build 1000-1999/1100-1199/1100-1109/1103/verifierD.go`
- `go build 1000-1999/1100-1199/1100-1109/1103/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68847fc567488324be1a17a092ca82d7