### PR TITLE
Add Go solution for 1694B

### DIFF
--- a/1000-1999/1600-1699/1690-1699/1694/1694B.go
+++ b/1000-1999/1600-1699/1690-1699/1694/1694B.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(reader, &n)
+		fmt.Fscan(reader, &s)
+		var res int64 = 1
+		for i := 1; i < n; i++ {
+			if s[i] != s[i-1] {
+				res += int64(i + 1)
+			} else {
+				res++
+			}
+		}
+		fmt.Fprintln(writer, res)
+	}
+}


### PR DESCRIPTION
## Summary
- add solution 1694B.go for Paranoid String problem

## Testing
- `go build 1000-1999/1600-1699/1690-1699/1694/1694B.go`
- `./1694Bbin <<EOF
4
1
0
3
001
4
0011
4
0110
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68847f7f44f88324bb1206ded6081f79