### PR TITLE
Add Go verifiers for CF contest 1102

### DIFF
--- a/1000-1999/1100-1199/1100-1109/1102/verifierA.go
+++ b/1000-1999/1100-1199/1100-1109/1102/verifierA.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n int64) int {
+	r := n % 4
+	if r == 1 || r == 2 {
+		return 1
+	}
+	return 0
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(2000000000) + 1
+	input := fmt.Sprintf("%d\n", n)
+	output := fmt.Sprintf("%d", solve(n))
+	return input, output
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1102/verifierB.go
+++ b/1000-1999/1100-1199/1100-1109/1102/verifierB.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input    string
+	expected string
+	n, k     int
+	arr      []int
+}
+
+func generateCase(rng *rand.Rand) testCase {
+	n := rng.Intn(15) + 1
+	k := rng.Intn(n) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(10) + 1
+	}
+	// build input string
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	expected := feasible(n, k, arr)
+	return testCase{input: sb.String(), expected: expected, n: n, k: k, arr: arr}
+}
+
+func feasible(n, k int, a []int) string {
+	const maxV = 5000
+	if n < k {
+		return "NO"
+	}
+	pos := make([][]int, maxV+1)
+	for i, v := range a {
+		if v >= 1 && v <= maxV {
+			pos[v] = append(pos[v], i)
+			if len(pos[v]) > k {
+				return "NO"
+			}
+		} else {
+			return "NO" // out of range
+		}
+	}
+	ans := make([]int, n)
+	idx := 0
+	for v := 1; v <= maxV; v++ {
+		for _, p := range pos[v] {
+			ans[p] = (idx % k) + 1
+			idx++
+		}
+	}
+	if idx < k {
+		return "NO"
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	for i, c := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin string, t testCase) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(t.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	expStr := strings.TrimSpace(t.expected)
+	if expStr == "NO" {
+		if outStr != "NO" {
+			return fmt.Errorf("expected NO got %q", outStr)
+		}
+		return nil
+	}
+	// expected YES coloring
+	lines := strings.Split(outStr, "\n")
+	if len(lines) != 2 || strings.TrimSpace(lines[0]) != "YES" {
+		return fmt.Errorf("expected YES with coloring, got %q", outStr)
+	}
+	cols := strings.Fields(lines[1])
+	if len(cols) != t.n {
+		return fmt.Errorf("expected %d colors, got %d", t.n, len(cols))
+	}
+	// verify validity
+	k := t.k
+	a := t.arr
+	usedColor := make([]bool, k+1)
+	countsByValue := make(map[int]map[int]bool)
+	for i, colStr := range cols {
+		var c int
+		fmt.Sscanf(colStr, "%d", &c)
+		if c < 1 || c > k {
+			return fmt.Errorf("color out of range")
+		}
+		usedColor[c] = true
+		v := a[i]
+		if countsByValue[v] == nil {
+			countsByValue[v] = make(map[int]bool)
+		}
+		if countsByValue[v][c] {
+			return fmt.Errorf("duplicate color for value")
+		}
+		countsByValue[v][c] = true
+	}
+	for c := 1; c <= k; c++ {
+		if !usedColor[c] {
+			return fmt.Errorf("color %d unused", c)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := generateCase(rng)
+		if err := runCase(bin, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1102/verifierC.go
+++ b/1000-1999/1100-1199/1100-1109/1102/verifierC.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n, x, y int, arr []int) int {
+	if x > y {
+		return n
+	}
+	cnt := 0
+	for _, v := range arr {
+		if v <= x {
+			cnt++
+		}
+	}
+	if cnt%2 == 0 {
+		return cnt / 2
+	}
+	return cnt/2 + 1
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	x := rng.Intn(100) + 1
+	y := rng.Intn(100) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(100) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, x, y))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	ans := solve(n, x, y, arr)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1102/verifierD.go
+++ b/1000-1999/1100-1199/1100-1109/1102/verifierD.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func balance(s []byte) string {
+	n := len(s)
+	target := n / 3
+	a, b, c := 0, 0, 0
+	for _, ch := range s {
+		switch ch {
+		case '0':
+			a++
+		case '1':
+			b++
+		case '2':
+			c++
+		}
+	}
+	// increase zeros
+	for i := 0; i < n && a < target; i++ {
+		if s[i] == '1' && b > target {
+			s[i], a, b = '0', a+1, b-1
+		} else if s[i] == '2' && c > target {
+			s[i], a, c = '0', a+1, c-1
+		}
+	}
+	for i := n - 1; i >= 0 && a > target; i-- {
+		if s[i] == '0' {
+			s[i] = '3'
+			a--
+		}
+	}
+	for i := 0; i < n && b < target; i++ {
+		if s[i] == '3' {
+			s[i] = '1'
+			b++
+		}
+	}
+	for i := 0; i < n && b < target; i++ {
+		if s[i] == '2' {
+			s[i], b, c = '1', b+1, c-1
+		}
+	}
+	for i := n - 1; i >= 0 && b > target; i-- {
+		if s[i] == '1' {
+			s[i] = '3'
+			b--
+		}
+	}
+	for i := 0; i < n; i++ {
+		if s[i] == '3' {
+			s[i] = '2'
+		}
+	}
+	return string(s)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := (rng.Intn(30) + 1) * 3
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('0' + rng.Intn(3))
+	}
+	input := fmt.Sprintf("%d\n%s\n", n, string(b))
+	ans := balance(append([]byte(nil), b...))
+	return input, ans
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1102/verifierE.go
+++ b/1000-1999/1100-1199/1100-1109/1102/verifierE.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+func solve(arr []int) int64 {
+	n := len(arr)
+	type node struct{ id, val int }
+	type node1 struct{ l, r, val int }
+	a := make([]node, n)
+	for i, v := range arr {
+		a[i] = node{i, v}
+	}
+	sort.Slice(a, func(i, j int) bool {
+		if a[i].val != a[j].val {
+			return a[i].val < a[j].val
+		}
+		return a[i].id < a[j].id
+	})
+	b := make([]node1, 0)
+	for i := 1; i < n; i++ {
+		if a[i].val == a[i-1].val {
+			b = append(b, node1{a[i-1].id, a[i].id, a[i].val})
+		}
+	}
+	cnt := len(b)
+	sort.Slice(b, func(i, j int) bool { return b[i].l < b[j].l })
+	ans := make([]int, n)
+	if cnt > 0 {
+		lp, ip, col := b[0].l, 0, 1
+		for lp < n && ip < cnt {
+			for lp > b[ip].r {
+				ip++
+				if ip >= cnt {
+					break
+				}
+				if b[ip].val != b[ip-1].val && lp <= b[ip].l {
+					col++
+				}
+				if lp < b[ip].l {
+					lp = b[ip].l
+				}
+			}
+			if ip >= cnt {
+				break
+			}
+			ans[lp] = col
+			lp++
+		}
+	}
+	var res int64 = 1
+	for i := 1; i < n; i++ {
+		if ans[i] == 0 || ans[i] != ans[i-1] {
+			res = res * 2 % mod
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 2
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(20)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	ans := solve(arr)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1102/verifierF.go
+++ b/1000-1999/1100-1199/1100-1109/1102/verifierF.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func abs(a, b int) int {
+	if a < b {
+		return b - a
+	}
+	return a - b
+}
+
+func solve(matrix [][]int) int {
+	n := len(matrix)
+	m := len(matrix[0])
+	minimum := make([][]int, n)
+	for i := 0; i < n; i++ {
+		minimum[i] = make([]int, n)
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			tmp := int(^uint(0) >> 1)
+			for k := 0; k < m; k++ {
+				d := abs(matrix[i][k], matrix[j][k])
+				if d < tmp {
+					tmp = d
+				}
+			}
+			minimum[i][j] = tmp
+			minimum[j][i] = tmp
+		}
+	}
+	fullMask := (1 << n) - 1
+	dp := make([][][]int, n)
+	for i := 0; i < n; i++ {
+		dp[i] = make([][]int, n)
+		for j := 0; j < n; j++ {
+			dp[i][j] = make([]int, 1<<n)
+			for k := range dp[i][j] {
+				dp[i][j][k] = -1
+			}
+		}
+	}
+	var calc func(fi, pre, mask int) int
+	calc = func(fi, pre, mask int) int {
+		if mask == fullMask {
+			r := int(^uint(0) >> 1)
+			for i := 0; i < m-1; i++ {
+				d := abs(matrix[pre][i], matrix[fi][i+1])
+				if d < r {
+					r = d
+				}
+			}
+			return r
+		}
+		if dp[fi][pre][mask] != -1 {
+			return dp[fi][pre][mask]
+		}
+		best := 0
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) == 0 {
+				c := calc(fi, i, mask|(1<<i))
+				if minimum[pre][i] < c {
+					c = minimum[pre][i]
+				}
+				if c > best {
+					best = c
+				}
+			}
+		}
+		dp[fi][pre][mask] = best
+		return best
+	}
+	res := 0
+	for i := 0; i < n; i++ {
+		v := calc(i, i, 1<<i)
+		if v > res {
+			res = v
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	m := rng.Intn(4) + 2
+	matrix := make([][]int, n)
+	for i := 0; i < n; i++ {
+		matrix[i] = make([]int, m)
+		for j := 0; j < m; j++ {
+			matrix[i][j] = rng.Intn(50)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", matrix[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	ans := solve(matrix)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(expected) {
+		return fmt.Errorf("expected %q got %q", expected, strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go through verifierF.go under contest 1102
- each verifier runs 100 random tests and checks a binary submission
- usage: `go run verifierX.go /path/to/binary`

## Testing
- `go build 1000-1999/1100-1199/1100-1109/1102/verifierA.go`
- `go build 1000-1999/1100-1199/1100-1109/1102/verifierB.go`
- `go build 1000-1999/1100-1199/1100-1109/1102/verifierC.go`
- `go build 1000-1999/1100-1199/1100-1109/1102/verifierD.go`
- `go build 1000-1999/1100-1199/1100-1109/1102/verifierE.go`
- `go build 1000-1999/1100-1199/1100-1109/1102/verifierF.go`
- `go run 1000-1999/1100-1199/1100-1109/1102/verifierA.go /tmp/1102A_bin`
- `go run 1000-1999/1100-1199/1100-1109/1102/verifierB.go /tmp/1102B_bin`
- `go run 1000-1999/1100-1199/1100-1109/1102/verifierC.go /tmp/1102C_bin`
- `go run 1000-1999/1100-1199/1100-1109/1102/verifierD.go /tmp/1102D_bin`
- `go run 1000-1999/1100-1199/1100-1109/1102/verifierE.go /tmp/1102E_bin`
- `go run 1000-1999/1100-1199/1100-1109/1102/verifierF.go /tmp/1102F_bin`


------
https://chatgpt.com/codex/tasks/task_e_68847f393d908324b9e23d761dfd883c