### PR TITLE
Add Go verifiers for Codeforces contest 1110

### DIFF
--- a/1000-1999/1100-1199/1110-1119/1110/verifierA.go
+++ b/1000-1999/1100-1199/1110-1119/1110/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1110A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(1)
+	var tests []Test
+	// simple fixed cases
+	tests = append(tests, Test{"2 1\n0\n"})
+	tests = append(tests, Test{"2 1\n1\n"})
+	tests = append(tests, Test{"10 3\n1 2 3\n"})
+	for len(tests) < 100 {
+		b := rand.Intn(99) + 2
+		k := rand.Intn(10) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", b, k))
+		for i := 0; i < k; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(rand.Intn(b)))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1110/verifierB.go
+++ b/1000-1999/1100-1199/1110-1119/1110/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1110B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(2)
+	var tests []Test
+	tests = append(tests, Test{"1 1 1\n1\n"})
+	for len(tests) < 100 {
+		n := rand.Intn(20) + 1
+		m := rand.Intn(200) + n
+		k := rand.Intn(n) + 1
+		pos := rand.Perm(m)[:n]
+		for i := range pos {
+			pos[i]++
+		}
+		sort.Ints(pos)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+		for i, p := range pos {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(p))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1110/verifierC.go
+++ b/1000-1999/1100-1199/1110-1119/1110/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1110C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(3)
+	var tests []Test
+	tests = append(tests, Test{"1\n2\n"})
+	for len(tests) < 100 {
+		q := rand.Intn(10) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", q))
+		for i := 0; i < q; i++ {
+			a := rand.Intn((1<<25)-2) + 2
+			sb.WriteString(strconv.Itoa(a))
+			sb.WriteByte('\n')
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1110/verifierD.go
+++ b/1000-1999/1100-1199/1110-1119/1110/verifierD.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1110D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(4)
+	var tests []Test
+	tests = append(tests, Test{"1 1\n1\n"})
+	for len(tests) < 100 {
+		n := rand.Intn(50) + 1
+		m := rand.Intn(50) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(rand.Intn(m) + 1))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1110/verifierE.go
+++ b/1000-1999/1100-1199/1110-1119/1110/verifierE.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1110E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(5)
+	var tests []Test
+	tests = append(tests, Test{"2\n0 0\n0 0\n"})
+	for len(tests) < 100 {
+		n := rand.Intn(10) + 2
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			sb.WriteString(strconv.Itoa(rand.Intn(1000)))
+			if i+1 < n {
+				sb.WriteByte(' ')
+			} else {
+				sb.WriteByte('\n')
+			}
+		}
+		for i := 0; i < n; i++ {
+			sb.WriteString(strconv.Itoa(rand.Intn(1000)))
+			if i+1 < n {
+				sb.WriteByte(' ')
+			} else {
+				sb.WriteByte('\n')
+			}
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1110/verifierF.go
+++ b/1000-1999/1100-1199/1110-1119/1110/verifierF.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1110F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(6)
+	var tests []Test
+	for len(tests) < 100 {
+		n := rand.Intn(13) + 3
+		q := rand.Intn(5) + 1
+		parent := make([]int, n+1)
+		weight := make([]int, n+1)
+		for i := 2; i <= n; i++ {
+			parent[i] = rand.Intn(i-1) + 1
+			weight[i] = rand.Intn(20) + 1
+		}
+		leaves := make([]bool, n+1)
+		for i := 1; i <= n; i++ {
+			leaves[i] = true
+		}
+		for i := 2; i <= n; i++ {
+			leaves[parent[i]] = false
+		}
+		var leafIdx []int
+		for i := 1; i <= n; i++ {
+			if leaves[i] {
+				leafIdx = append(leafIdx, i)
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+		for i := 2; i <= n; i++ {
+			sb.WriteString(fmt.Sprintf("%d %d\n", parent[i], weight[i]))
+		}
+		for i := 0; i < q; i++ {
+			v := rand.Intn(n) + 1
+			lf := leafIdx[rand.Intn(len(leafIdx))]
+			l := rand.Intn(lf) + 1
+			r := lf + rand.Intn(n-lf+1)
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", v, l, r))
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1110/verifierG.go
+++ b/1000-1999/1100-1199/1110-1119/1110/verifierG.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1110G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTree(n int) string {
+	var sb strings.Builder
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", p, i))
+	}
+	return sb.String()
+}
+
+func genTests() []Test {
+	rand.Seed(7)
+	var tests []Test
+	for len(tests) < 100 {
+		t := rand.Intn(3) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", t))
+		for i := 0; i < t; i++ {
+			n := rand.Intn(8) + 2
+			sb.WriteString(fmt.Sprintf("%d\n", n))
+			sb.WriteString(genTree(n))
+			str := make([]byte, n)
+			hasN := false
+			for j := 0; j < n; j++ {
+				if rand.Intn(2) == 0 {
+					str[j] = 'W'
+				} else {
+					str[j] = 'N'
+					hasN = true
+				}
+			}
+			if !hasN {
+				str[rand.Intn(n)] = 'N'
+			}
+			sb.WriteString(string(str))
+			sb.WriteByte('\n')
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1110/verifierH.go
+++ b/1000-1999/1100-1199/1110-1119/1110/verifierH.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refH.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1110H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func randNum(max int) string {
+	v := rand.Intn(max) + 1
+	return strconv.Itoa(v)
+}
+
+func genTests() []Test {
+	rand.Seed(8)
+	var tests []Test
+	for len(tests) < 100 {
+		l := randNum(1000)
+		li, _ := strconv.Atoi(l)
+		r := strconv.Itoa(li + rand.Intn(50))
+		n := rand.Intn(5) + 1
+		tests = append(tests, Test{fmt.Sprintf("%s\n%s\n%d\n", l, r, n)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–H of contest 1110
- verifiers build the reference solution and compare it to a candidate
- generate at least 100 random test cases per problem
- fix unused import in `verifierF.go`

## Testing
- `go build 1000-1999/1100-1199/1110-1119/1110/verifierA.go`
- `go build 1000-1999/1100-1199/1110-1119/1110/verifierB.go`
- `go build 1000-1999/1100-1199/1110-1119/1110/verifierC.go`
- `go build 1000-1999/1100-1199/1110-1119/1110/verifierD.go`
- `go build 1000-1999/1100-1199/1110-1119/1110/verifierE.go`
- `go build 1000-1999/1100-1199/1110-1119/1110/verifierF.go`
- `go build 1000-1999/1100-1199/1110-1119/1110/verifierG.go`
- `go build 1000-1999/1100-1199/1110-1119/1110/verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_6884839a52dc832480061dca35d8867c