### PR TITLE
Add runtime verifiers for Codeforces 1109

### DIFF
--- a/1000-1999/1100-1199/1100-1109/1109/1109F.go
+++ b/1000-1999/1100-1199/1100-1109/1109/1109F.go
@@ -66,8 +66,9 @@ func rotate(x *Node) {
    } else {
        x.f = p.f
    }
-   p.setChild(x.s[!d], d)
-   x.setChild(p, !d)
+   // toggle child based on direction
+   p.setChild(x.s[1-d], d)
+   x.setChild(p, 1-d)
    p.update()
 }
 

--- a/1000-1999/1100-1199/1100-1109/1109/verifierA.go
+++ b/1000-1999/1100-1199/1100-1109/1109/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := "refA.bin"
+	cmd := exec.Command("go", "build", "-o", out, "1109A.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return "./" + out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(18) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(1 << 20)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := runBin(ref, in)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBin(bin, in)
+		if err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1109/verifierB.go
+++ b/1000-1999/1100-1199/1100-1109/1109/verifierB.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", out, "1109B.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return "./" + out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := 0; i < (n+1)/2; i++ {
+		ch := byte('a' + rng.Intn(26))
+		b[i] = ch
+		b[n-1-i] = ch
+	}
+	return fmt.Sprintf("%s\n", string(b))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := runBin(ref, in)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBin(bin, in)
+		if err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1109/verifierC.go
+++ b/1000-1999/1100-1199/1100-1109/1109/verifierC.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", out, "1109C.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return "./" + out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	events := make(map[int]bool)
+	used := make(map[int]bool)
+	for i := 0; i < q; i++ {
+		op := rng.Intn(3) + 1
+		if op == 1 || len(events) == 0 {
+			op = 1
+		}
+		if op == 1 {
+			t := rng.Intn(20)
+			for used[t] {
+				t = rng.Intn(20)
+			}
+			used[t] = true
+			events[t] = true
+			s := rng.Intn(11) - 5
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", t, s))
+		} else if op == 2 {
+			var keys []int
+			for k := range events {
+				keys = append(keys, k)
+			}
+			t := keys[rng.Intn(len(keys))]
+			delete(events, t)
+			sb.WriteString(fmt.Sprintf("2 %d\n", t))
+		} else {
+			l := rng.Intn(20)
+			r := rng.Intn(20)
+			if l > r {
+				l, r = r, l
+			}
+			v := rng.Intn(11) - 5
+			sb.WriteString(fmt.Sprintf("3 %d %d %d\n", l, r, v))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := runBin(ref, in)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBin(bin, in)
+		if err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1109/verifierD.go
+++ b/1000-1999/1100-1199/1100-1109/1109/verifierD.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", out, "1109D.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return "./" + out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 2
+	m := rng.Intn(6) + 1
+	a := rng.Intn(n) + 1
+	b := rng.Intn(n-1) + 1
+	if b >= a {
+		b++
+	}
+	return fmt.Sprintf("%d %d %d %d\n", n, m, a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := runBin(ref, in)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBin(bin, in)
+		if err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1109/verifierE.go
+++ b/1000-1999/1100-1199/1100-1109/1109/verifierE.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", out, "1109E.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return "./" + out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	mod := rng.Intn(50) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, mod))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rng.Intn(20) + 1))
+	}
+	sb.WriteByte('\n')
+	q := rng.Intn(5) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		op := rng.Intn(3) + 1
+		if op == 1 {
+			l := rng.Intn(n)
+			r := rng.Intn(n-l) + l
+			x := rng.Intn(20) + 1
+			sb.WriteString(fmt.Sprintf("1 %d %d %d\n", l+1, r+1, x))
+		} else if op == 2 {
+			u := rng.Intn(n)
+			x := rng.Intn(20) + 1
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", u+1, x))
+		} else {
+			l := rng.Intn(n)
+			r := rng.Intn(n-l) + l
+			sb.WriteString(fmt.Sprintf("3 %d %d\n", l+1, r+1))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := runBin(ref, in)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBin(bin, in)
+		if err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1109/verifierF.go
+++ b/1000-1999/1100-1199/1100-1109/1109/verifierF.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := "refF.bin"
+	cmd := exec.Command("go", "build", "-o", out, "1109F.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return "./" + out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	r := rng.Intn(3) + 1
+	c := rng.Intn(3) + 1
+	n := r * c
+	perm := rng.Perm(n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", r, c))
+	for i := 0; i < r; i++ {
+		for j := 0; j < c; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprint(perm[i*c+j] + 1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := genCase(rng)
+		exp, err := runBin(ref, in)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		out, err := runBin(bin, in)
+		if err != nil {
+			fmt.Printf("test %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Printf("test %d failed\nInput:\n%sExpected: %s\nGot: %s\n", i+1, in, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- fix compilation issue in `1109F.go`
- add Go verifiers for problems A–F of contest 1109

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884830df4c08324baa8e883e30eabd5