### PR TITLE
Add verifiers for contest 1105

### DIFF
--- a/1000-1999/1100-1199/1100-1109/1105/verifierA.go
+++ b/1000-1999/1100-1199/1100-1109/1105/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1105A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	r := rand.New(rand.NewSource(0))
+	tests := make([]Test, 0, 105)
+	// random tests
+	for i := 0; i < 100; i++ {
+		n := r.Intn(20) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", r.Intn(100)+1)
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	// edge cases
+	tests = append(tests,
+		Test{"1\n1\n"},
+		Test{"1\n100\n"},
+		Test{"3\n1 1 1\n"},
+		Test{"4\n10 20 30 40\n"},
+		Test{"5\n100 99 98 97 96\n"},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1105/verifierB.go
+++ b/1000-1999/1100-1199/1100-1109/1105/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1105B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]Test, 0, 105)
+	// random tests
+	for i := 0; i < 100; i++ {
+		n := r.Intn(30) + 1
+		k := r.Intn(n) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for j := 0; j < n; j++ {
+			sb.WriteByte(byte('a' + r.Intn(26)))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	// edge cases
+	tests = append(tests,
+		Test{"1 1\na\n"},
+		Test{"2 1\nab\n"},
+		Test{"5 3\nabcde\n"},
+		Test{"6 2\naaaaaa\n"},
+		Test{"10 5\nzzzzzzzzzz\n"},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1105/verifierC.go
+++ b/1000-1999/1100-1199/1100-1109/1105/verifierC.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1105C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	r := rand.New(rand.NewSource(2))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(10) + 1
+		l := int64(r.Intn(100) + 1)
+		rnum := l + int64(r.Intn(100))
+		tests = append(tests, Test{fmt.Sprintf("%d %d %d\n", n, l, rnum)})
+	}
+	tests = append(tests,
+		Test{"1 1 3\n"},
+		Test{"2 1 2\n"},
+		Test{"3 10 20\n"},
+		Test{"5 1 1\n"},
+		Test{"10 100 200\n"},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1105/verifierD.go
+++ b/1000-1999/1100-1199/1100-1109/1105/verifierD.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1105D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genBoard(r *rand.Rand, n, m, p int) []string {
+	board := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if r.Intn(5) == 0 {
+				row[j] = '#'
+			} else {
+				row[j] = '.'
+			}
+		}
+		board[i] = row
+	}
+	// place at least one castle for each player
+	for pid := 0; pid < p; pid++ {
+		for {
+			x := r.Intn(n)
+			y := r.Intn(m)
+			if board[x][y] == '.' {
+				board[x][y] = byte('1' + pid)
+				break
+			}
+		}
+	}
+	lines := make([]string, n)
+	for i := 0; i < n; i++ {
+		lines[i] = string(board[i])
+	}
+	return lines
+}
+
+func genTests() []Test {
+	r := rand.New(rand.NewSource(3))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(5) + 1
+		m := r.Intn(5) + 1
+		p := r.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", n, m, p)
+		for j := 1; j <= p; j++ {
+			if j > 1 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", r.Intn(3)+1)
+		}
+		sb.WriteByte('\n')
+		lines := genBoard(r, n, m, p)
+		for _, line := range lines {
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	// some fixed simple cases
+	tests = append(tests,
+		Test{"1 1 1\n1\n1\n"},
+		Test{"2 2 2\n1 1\n1.\n.2\n"},
+		Test{"3 3 1\n2\n...\n.#.\n..1\n"},
+		Test{"2 3 2\n1 1\n1#2\n...\n"},
+		Test{"3 3 2\n3 3\n1..\n.#.\n..2\n"},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1100-1199/1100-1109/1105/verifierE.go
+++ b/1000-1999/1100-1199/1100-1109/1105/verifierE.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1105E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func randName(r *rand.Rand, idx int) string {
+	return fmt.Sprintf("f%d", idx)
+}
+
+func genTests() []Test {
+	r := rand.New(rand.NewSource(4))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		m := r.Intn(5) + 1
+		n := r.Intn(20) + 1
+		names := make([]string, m)
+		for j := 0; j < m; j++ {
+			names[j] = randName(r, j)
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		sb.WriteString("1\n")
+		visited := make([]bool, m)
+		for j := 1; j < n; j++ {
+			if r.Intn(2) == 0 {
+				sb.WriteString("1\n")
+			} else {
+				idx := r.Intn(m)
+				visited[idx] = true
+				sb.WriteString("2 " + names[idx] + "\n")
+			}
+		}
+		for idx, v := range visited {
+			if !v {
+				sb.WriteString("2 " + names[idx] + "\n")
+			}
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	// fixed tests
+	tests = append(tests,
+		Test{"1 1\n1\n"},
+		Test{"3 2\n1\n2 a\n2 b\n"},
+		Test{"4 1\n1\n2 x\n1\n2 x\n"},
+		Test{"5 2\n1\n2 a\n2 b\n1\n2 a\n"},
+		Test{"6 3\n1\n2 a\n2 b\n2 c\n1\n2 b\n"},
+	)
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–E in contest 1105
- each verifier compiles a reference solution and checks at least 100 random tests

## Testing
- `go run verifierA.go /tmp/1105A.bin`
- `go run verifierB.go /tmp/1105B.bin`
- `go run verifierC.go /tmp/1105C.bin`
- `go build -o verifE verifierE.go && ./verifE /tmp/1105E.bin`


------
https://chatgpt.com/codex/tasks/task_e_688480ddd1cc8324b859ec90c9873bb4