### PR TITLE
Add Go solution for 1662M

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1662/1662M.go
+++ b/1000-1999/1600-1699/1660-1669/1662/1662M.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var n, m int
+		fmt.Fscan(in, &n, &m)
+		maxR, maxW := 0, 0
+		pairs := make([][2]int, m)
+		for i := 0; i < m; i++ {
+			fmt.Fscan(in, &pairs[i][0], &pairs[i][1])
+			if pairs[i][0] > maxR {
+				maxR = pairs[i][0]
+			}
+			if pairs[i][1] > maxW {
+				maxW = pairs[i][1]
+			}
+		}
+
+		if maxR+maxW > n {
+			fmt.Fprintln(out, "IMPOSSIBLE")
+			continue
+		}
+		res := make([]byte, n)
+		for i := 0; i < maxR; i++ {
+			res[i] = 'R'
+		}
+		for i := maxR; i < n; i++ {
+			res[i] = 'W'
+		}
+		fmt.Fprintln(out, string(res))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem M in contest 1662

## Testing
- `go build 1000-1999/1600-1699/1660-1669/1662/1662M.go`
- `cat /tmp/in.txt | go run 1000-1999/1600-1699/1660-1669/1662/1662M.go`

------
https://chatgpt.com/codex/tasks/task_e_688483e017dc832486735a158f36bf05