### PR TITLE
Add Go verifiers for Codeforces contest 1111

### DIFF
--- a/1000-1999/1100-1199/1110-1119/1111/verifierA.go
+++ b/1000-1999/1100-1199/1110-1119/1111/verifierA.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type test struct {
+	s string
+	t string
+}
+
+func isVowel(c byte) bool {
+	switch c {
+	case 'a', 'e', 'i', 'o', 'u':
+		return true
+	default:
+		return false
+	}
+}
+
+func solve(s, t string) string {
+	if len(s) != len(t) {
+		return "No"
+	}
+	for i := 0; i < len(s); i++ {
+		if isVowel(s[i]) != isVowel(t[i]) {
+			return "No"
+		}
+	}
+	return "Yes"
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(42))
+	vowels := "aeiou"
+	cons := "bcdfghjklmnpqrstvwxyz"
+	tests := make([]test, 0, 100)
+	for i := 0; i < 50; i++ {
+		n := rng.Intn(8) + 1
+		sb := make([]byte, n)
+		tb := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				sb[j] = vowels[rng.Intn(len(vowels))]
+			} else {
+				sb[j] = cons[rng.Intn(len(cons))]
+			}
+			if rng.Intn(2) == 0 {
+				if isVowel(sb[j]) {
+					tb[j] = vowels[rng.Intn(len(vowels))]
+				} else {
+					tb[j] = cons[rng.Intn(len(cons))]
+				}
+			} else {
+				if isVowel(sb[j]) {
+					tb[j] = cons[rng.Intn(len(cons))]
+				} else {
+					tb[j] = vowels[rng.Intn(len(vowels))]
+				}
+			}
+		}
+		tests = append(tests, test{string(sb), string(tb)})
+	}
+	for i := 0; i < 50; i++ {
+		n := rng.Intn(8) + 1
+		m := rng.Intn(8) + 1
+		if m == n {
+			m = (m % 8) + 1
+		}
+		sb := make([]byte, n)
+		tb := make([]byte, m)
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				sb[j] = vowels[rng.Intn(len(vowels))]
+			} else {
+				sb[j] = cons[rng.Intn(len(cons))]
+			}
+		}
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				tb[j] = vowels[rng.Intn(len(vowels))]
+			} else {
+				tb[j] = cons[rng.Intn(len(cons))]
+			}
+		}
+		tests = append(tests, test{string(sb), string(tb)})
+	}
+	return tests
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("%s\n%s\n", tc.s, tc.t)
+		want := solve(tc.s, tc.t)
+		got, err := run(binary, input)
+		if err != nil {
+			fmt.Printf("Test %d: error running binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got = strings.TrimSpace(strings.ToLower(got))
+		want = strings.TrimSpace(strings.ToLower(want))
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1100-1199/1110-1119/1111/verifierB.go
+++ b/1000-1999/1100-1199/1110-1119/1111/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type test struct {
+	n int
+	k int64
+	m int64
+	a []int64
+}
+
+func solve(n int, k, m int64, a []int64) string {
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	var sum int64
+	for _, v := range a {
+		sum += v
+	}
+	ans := float64(sum) / float64(n)
+	var suffix int64
+	for i := n - 1; i >= 0; i-- {
+		suffix += a[i]
+		s := int64(n - i)
+		ops := m - int64(i)
+		if ops < 0 {
+			continue
+		}
+		add := k * s
+		if add > ops {
+			add = ops
+		}
+		cand := float64(suffix+add) / float64(s)
+		if cand > ans {
+			ans = cand
+		}
+	}
+	return fmt.Sprintf("%.10f", ans)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(43))
+	tests := make([]test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		k := int64(rng.Intn(5) + 1)
+		m := int64(rng.Intn(10) + 1)
+		a := make([]int64, n)
+		for j := 0; j < n; j++ {
+			a[j] = int64(rng.Intn(10) + 1)
+		}
+		tests = append(tests, test{n, k, m, a})
+	}
+	return tests
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", tc.n, tc.k, tc.m)
+		for j, v := range tc.a {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want := solve(tc.n, tc.k, tc.m, append([]int64(nil), tc.a...))
+		got, err := run(binary, input)
+		if err != nil {
+			fmt.Printf("Test %d: error running binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1100-1199/1110-1119/1111/verifierC.go
+++ b/1000-1999/1100-1199/1110-1119/1111/verifierC.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type test struct {
+	n   int
+	k   int
+	A   int64
+	B   int64
+	pos []int64
+}
+
+func work(l, beg, end int, st int64, A, B int64, p []int64) int64 {
+	if beg > end {
+		return A
+	}
+	if l == 0 {
+		return int64(end-beg+1) * B
+	}
+	half := int64(1) << (l - 1)
+	m := st + half
+	cnt := end - beg + 1
+	idx := sort.Search(cnt, func(i int) bool { return p[beg+i] >= m })
+	mid := beg + idx
+	total := int64(cnt)
+	costAll := total * (int64(1) << l) * B
+	costSplit := work(l-1, beg, mid-1, st, A, B, p) + work(l-1, mid, end, m, A, B, p)
+	if costAll < costSplit {
+		return costAll
+	}
+	return costSplit
+}
+
+func solve(tc test) string {
+	p := append([]int64(nil), tc.pos...)
+	sort.Slice(p, func(i, j int) bool { return p[i] < p[j] })
+	res := work(tc.n, 0, tc.k-1, 1, tc.A, tc.B, p)
+	return fmt.Sprintf("%d", res)
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(44))
+	tests := make([]test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(3) + 1
+		maxPos := 1 << uint(n)
+		k := rng.Intn(maxPos)
+		A := int64(rng.Intn(5) + 1)
+		B := int64(rng.Intn(5) + 1)
+		pos := make([]int64, k)
+		for j := 0; j < k; j++ {
+			pos[j] = int64(rng.Intn(maxPos) + 1)
+		}
+		tests = append(tests, test{n, k, A, B, pos})
+	}
+	return tests
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d\n", tc.n, tc.k, tc.A, tc.B)
+		for j, v := range tc.pos {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		if tc.k > 0 {
+			sb.WriteByte('\n')
+		} else {
+			sb.WriteString("\n")
+		}
+		input := sb.String()
+		want := solve(tc)
+		got, err := run(binary, input)
+		if err != nil {
+			fmt.Printf("Test %d: error running binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1100-1199/1110-1119/1111/verifierD.go
+++ b/1000-1999/1100-1199/1110-1119/1111/verifierD.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod = int64(1e9 + 7)
+
+type test struct {
+	s       string
+	q       int
+	queries [][2]int
+}
+
+func modExp(x, y int64) int64 {
+	res := int64(1)
+	for y > 0 {
+		if y&1 == 1 {
+			res = res * x % mod
+		}
+		x = x * x % mod
+		y >>= 1
+	}
+	return res
+}
+
+func pd(c byte) int {
+	if c >= 'A' && c <= 'Z' {
+		return int(c-'A') + 1
+	}
+	return int(c-'a') + 27
+}
+
+func solve(tc test) string {
+	s := tc.s
+	n := len(s)
+	cnt := make([]int, 53)
+	for i := 0; i < n; i++ {
+		cnt[pd(s[i])]++
+	}
+	jc := make([]int64, n+1)
+	inv := make([]int64, n+1)
+	jc[0] = 1
+	for i := 1; i <= n; i++ {
+		jc[i] = jc[i-1] * int64(i) % mod
+	}
+	inv[n] = modExp(jc[n], mod-2)
+	for i := n; i > 0; i-- {
+		inv[i-1] = inv[i] * int64(i) % mod
+	}
+	half := n / 2
+	g := jc[half] * jc[half] % mod
+	for i := 1; i <= 52; i++ {
+		if cnt[i] > 0 {
+			g = g * inv[cnt[i]] % mod
+		}
+	}
+	p := make([]int64, n+1)
+	p[0] = 1
+	for i := 1; i <= 52; i++ {
+		c := cnt[i]
+		if c == 0 {
+			continue
+		}
+		for j := n; j >= c; j-- {
+			p[j] = (p[j] + p[j-c]) % mod
+		}
+	}
+	var sres [53][53]int64
+	p2 := make([]int64, n+1)
+	for i := 1; i <= 52; i++ {
+		ci := cnt[i]
+		if ci == 0 || ci > half {
+			continue
+		}
+		copy(p2, p)
+		for j := ci; j <= n; j++ {
+			p2[j] = (p2[j] - p2[j-ci] + mod) % mod
+		}
+		idx := half - ci
+		if idx >= 0 {
+			sres[i][i] = p2[idx] * g % mod * 2 % mod
+		}
+		for j := i + 1; j <= 52; j++ {
+			cj := cnt[j]
+			if cj == 0 || ci+cj > half {
+				continue
+			}
+			w := half - ci - cj
+			var ct int64
+			sign := int64(1)
+			for ww := w; ww >= 0; ww -= cj {
+				ct = (ct + p2[ww]*sign) % mod
+				sign = -sign
+			}
+			sres[i][j] = (ct%mod + mod) % mod * g % mod * 2 % mod
+		}
+	}
+	var out strings.Builder
+	for _, q := range tc.queries {
+		x := pd(s[q[0]-1])
+		y := pd(s[q[1]-1])
+		if x > y {
+			x, y = y, x
+		}
+		out.WriteString(fmt.Sprintln(sres[x][y]))
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(45))
+	tests := make([]test, 0, 100)
+	letters := []rune("abAB")
+	for i := 0; i < 100; i++ {
+		n := 2 * (rng.Intn(2) + 1)
+		b := make([]rune, n)
+		for j := range b {
+			b[j] = letters[rng.Intn(len(letters))]
+		}
+		q := rng.Intn(3) + 1
+		qs := make([][2]int, q)
+		for j := 0; j < q; j++ {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(n) + 1
+			for y == x {
+				y = rng.Intn(n) + 1
+			}
+			qs[j] = [2]int{x, y}
+		}
+		tests = append(tests, test{string(b), q, qs})
+	}
+	return tests
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%s\n%d\n", tc.s, tc.q)
+		for _, pq := range tc.queries {
+			fmt.Fprintf(&sb, "%d %d\n", pq[0], pq[1])
+		}
+		input := sb.String()
+		want := solve(tc)
+		got, err := run(binary, input)
+		if err != nil {
+			fmt.Printf("Test %d: error running binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1100-1199/1110-1119/1111/verifierE.go
+++ b/1000-1999/1100-1199/1110-1119/1111/verifierE.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type edge struct{ u, v int }
+
+type query struct {
+	k     int
+	m     int
+	r     int
+	nodes []int
+}
+
+type test struct {
+	n       int
+	edges   []edge
+	queries []query
+}
+
+func buildReference() (string, error) {
+	exe := filepath.Join(os.TempDir(), "refE_bin")
+	cmd := exec.Command("go", "build", "-o", exe, "1111E.go")
+	cmd.Dir = "."
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return exe, nil
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func generateTests() []test {
+	rng := rand.New(rand.NewSource(46))
+	tests := make([]test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 2
+		edges := make([]edge, n-1)
+		for j := 1; j < n; j++ {
+			u := rng.Intn(j) + 1
+			edges[j-1] = edge{u, j + 1}
+		}
+		qn := rng.Intn(2) + 1
+		queries := make([]query, qn)
+		for j := 0; j < qn; j++ {
+			k := rng.Intn(n) + 1
+			m := rng.Intn(k) + 1
+			r := rng.Intn(n) + 1
+			nodes := make([]int, k)
+			used := map[int]bool{}
+			for x := 0; x < k; x++ {
+				v := rng.Intn(n) + 1
+				for used[v] {
+					v = rng.Intn(n) + 1
+				}
+				used[v] = true
+				nodes[x] = v
+			}
+			queries[j] = query{k, m, r, nodes}
+		}
+		tests = append(tests, test{n, edges, queries})
+	}
+	return tests
+}
+
+func formatInput(t test) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", t.n, len(t.queries))
+	for _, e := range t.edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+	}
+	for _, q := range t.queries {
+		fmt.Fprintf(&sb, "%d %d %d", q.k, q.m, q.r)
+		for _, v := range q.nodes {
+			fmt.Fprintf(&sb, " %d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	ref, err := buildReference()
+	if err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	tests := generateTests()
+	for i, t := range tests {
+		input := formatInput(t)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(binary, input)
+		if err != nil {
+			fmt.Printf("Test %d: error running binary: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("Test %d failed.\nInput:\n%sExpected: %s\nGot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go`..`verifierE.go` to validate solutions for contest 1111
- each verifier runs 100 random tests
- `verifierE.go` builds the official solution to use as reference output

## Testing
- `go build verifierA.go`
- `go run verifierA.go ./a_bin`
- `go build verifierB.go`
- `go run verifierB.go ./b_bin`
- `go build verifierC.go`
- `go run verifierC.go ./c_bin`
- `go build verifierD.go`
- `go run verifierD.go ./d_bin`
- `go build verifierE.go`
- `go run verifierE.go ./e_bin`


------
https://chatgpt.com/codex/tasks/task_e_6884842629c48324a2bc18265187c86f