### PR TITLE
Add verifiers for Codeforces 1112

### DIFF
--- a/1000-1999/1100-1199/1110-1119/1112/1112D.go
+++ b/1000-1999/1100-1199/1110-1119/1112/1112D.go
@@ -1,102 +1,103 @@
 package main
 
 import (
-   "bufio"
-   "fmt"
-   "os"
+	"bufio"
+	"fmt"
+	"os"
 )
 
 // Suffix Automaton for lowercase letters
 type state struct {
-   next map[byte]int
-   link int
-   len  int
+	next map[byte]int
+	link int
+	len  int
 }
 
 type suffixAutomaton struct {
-   st   []state
-   last int
+	st   []state
+	last int
 }
 
 func newSuffixAutomaton(n int) *suffixAutomaton {
-   sa := &suffixAutomaton{
-       st:   make([]state, 0, 2*n),
-       last: 0,
-   }
-   sa.st = append(sa.st, state{next: make(map[byte]int), link: -1, len: 0})
-   return sa
+	sa := &suffixAutomaton{
+		st:   make([]state, 0, 2*n),
+		last: 0,
+	}
+	sa.st = append(sa.st, state{next: make(map[byte]int), link: -1, len: 0})
+	return sa
 }
 
 func (sa *suffixAutomaton) extend(c byte) {
-   p := sa.last
-   cur := len(sa.st)
-   sa.st = append(sa.st, state{next: make(map[byte]int), len: sa.st[p].len + 1})
-   for p != -1 && sa.st[p].next[c] == 0 {
-       sa.st[p].next[c] = cur
-       p = sa.st[p].link
-   }
-   if p == -1 {
-       sa.st[cur].link = 0
-   } else {
-       q := sa.st[p].next[c]
-       if sa.st[p].len+1 == sa.st[q].len {
-           sa.st[cur].link = q
-       } else {
-           // clone
-           clone := len(sa.st)
-           // copy q
-           mp := make(map[byte]int)
-           for k, v := range sa.st[q].next {
-               mp[k] = v
-           }
-           sa.st = append(sa.st, state{next: mp, len: sa.st[p].len + 1, link: sa.st[q].link})
-           for p != -1 && sa.st[p].next[c] == q {
-               sa.st[p].next[c] = clone
-               p = sa.st[p].link
-           }
-           sa.st[q].link = sa.st[cur].link = clone
-       }
-   }
-   sa.last = cur
+	p := sa.last
+	cur := len(sa.st)
+	sa.st = append(sa.st, state{next: make(map[byte]int), len: sa.st[p].len + 1})
+	for p != -1 && sa.st[p].next[c] == 0 {
+		sa.st[p].next[c] = cur
+		p = sa.st[p].link
+	}
+	if p == -1 {
+		sa.st[cur].link = 0
+	} else {
+		q := sa.st[p].next[c]
+		if sa.st[p].len+1 == sa.st[q].len {
+			sa.st[cur].link = q
+		} else {
+			// clone
+			clone := len(sa.st)
+			// copy q
+			mp := make(map[byte]int)
+			for k, v := range sa.st[q].next {
+				mp[k] = v
+			}
+			sa.st = append(sa.st, state{next: mp, len: sa.st[p].len + 1, link: sa.st[q].link})
+			for p != -1 && sa.st[p].next[c] == q {
+				sa.st[p].next[c] = clone
+				p = sa.st[p].link
+			}
+			sa.st[q].link = clone
+			sa.st[cur].link = clone
+		}
+	}
+	sa.last = cur
 }
 
 func main() {
-   reader := bufio.NewReader(os.Stdin)
-   var n, a, b int
-   fmt.Fscan(reader, &n, &a, &b)
-   var s string
-   fmt.Fscan(reader, &s)
+	reader := bufio.NewReader(os.Stdin)
+	var n, a, b int
+	fmt.Fscan(reader, &n, &a, &b)
+	var s string
+	fmt.Fscan(reader, &s)
 
-   dp := make([]int, n+1)
-   const inf = 1e18
-   for i := 1; i <= n; i++ {
-       dp[i] = int(1e18)
-   }
+	dp := make([]int, n+1)
+	const inf = 1e18
+	for i := 1; i <= n; i++ {
+		dp[i] = int(1e18)
+	}
 
-   sa := newSuffixAutomaton(n)
-   // process positions
-   for i := 0; i < n; i++ {
-       // cost of single char
-       if dp[i]+a < dp[i+1] {
-           dp[i+1] = dp[i] + a
-       }
-       // longest substring from i in prefix
-       u, length := 0, 0
-       for j := i; j < n; j++ {
-           c := s[j]
-           nxt, ok := sa.st[u].next[c]
-           if !ok {
-               break
-           }
-           u = nxt
-           length++
-           // can encode s[i:j+1] with cost b
-           if dp[i]+b < dp[j+1] {
-               dp[j+1] = dp[i] + b
-           }
-       }
-       // extend automaton with s[i]
-       sa.extend(s[i])
-   }
-   fmt.Println(dp[n])
+	sa := newSuffixAutomaton(n)
+	// process positions
+	for i := 0; i < n; i++ {
+		// cost of single char
+		if dp[i]+a < dp[i+1] {
+			dp[i+1] = dp[i] + a
+		}
+		// longest substring from i in prefix
+		u, length := 0, 0
+		for j := i; j < n; j++ {
+			c := s[j]
+			nxt, ok := sa.st[u].next[c]
+			if !ok {
+				break
+			}
+			u = nxt
+			length++
+			// can encode s[i:j+1] with cost b
+			if dp[i]+b < dp[j+1] {
+				dp[j+1] = dp[i] + b
+			}
+		}
+		// extend automaton with s[i]
+		sa.extend(s[i])
+	}
+	fmt.Println(dp[n])
 }

--- a/1000-1999/1100-1199/1110-1119/1112/verifierA.go
+++ b/1000-1999/1100-1199/1110-1119/1112/verifierA.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1112A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(10) + 1
+	m := r.Intn(n) + 1
+	k := r.Intn(n) + 1
+	p := make([]int, n)
+	s := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = r.Intn(20) + 1
+		s[i] = r.Intn(m) + 1
+	}
+	chosen := rand.Perm(n)[:k]
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i, v := range p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range s {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	for i, idx := range chosen {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(idx + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1112/verifierB.go
+++ b/1000-1999/1100-1199/1110-1119/1112/verifierB.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1112B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(10) + 1
+	k := r.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(r.Intn(150) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1112/verifierC.go
+++ b/1000-1999/1100-1199/1110-1119/1112/verifierC.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1112C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	k := r.Intn(4) + 1
+	nBlocks := r.Intn(4) + 1
+	m := nBlocks*k + r.Intn(4)
+	s := r.Intn(k) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", m, k, nBlocks, s))
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(r.Intn(5) + 1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < s; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(r.Intn(5) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1112/verifierD.go
+++ b/1000-1999/1100-1199/1110-1119/1112/verifierD.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1112D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(8) + 1
+	a := r.Intn(5) + 1
+	b := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, a, b))
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('a' + r.Intn(3)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1112/verifierE.go
+++ b/1000-1999/1100-1199/1110-1119/1112/verifierE.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1112E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	a := make([]byte, n)
+	b := make([]byte, n)
+	a[0] = byte('1' + r.Intn(9))
+	b[0] = byte('1' + r.Intn(9))
+	for i := 1; i < n; i++ {
+		a[i] = byte('0' + r.Intn(10))
+		b[i] = byte('0' + r.Intn(10))
+	}
+	sb.Write(a)
+	sb.WriteByte('\n')
+	sb.Write(b)
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1112/verifierF.go
+++ b/1000-1999/1100-1199/1110-1119/1112/verifierF.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1112F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(r.Intn(10) + 1))
+	}
+	sb.WriteByte('\n')
+	for i := 2; i <= n; i++ {
+		v := r.Intn(i-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", v, i))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1112/verifierG.go
+++ b/1000-1999/1100-1199/1110-1119/1112/verifierG.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleG")
+	cmd := exec.Command("go", "build", "-o", oracle, "1112G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	a := r.Intn(999) + 2
+	return fmt.Sprintf("%d\n", a)
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1112/verifierH.go
+++ b/1000-1999/1100-1199/1110-1119/1112/verifierH.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleH")
+	cmd := exec.Command("go", "build", "-o", oracle, "1112H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 1
+	c := r.Intn(5) + 1
+	d := r.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, c, d))
+	t := 0
+	for i := 0; i < n; i++ {
+		t += r.Intn(5) + 1
+		p := 'W'
+		if r.Intn(2) == 0 {
+			p = 'P'
+		}
+		sb.WriteString(fmt.Sprintf("%d %c\n", t, p))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", t+r.Intn(5)+1))
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}


### PR DESCRIPTION
## Summary
- fix compile issue in 1112D
- add Go verifiers for problems A–H of contest 1112
- format files

## Testing
- `go build 1000-1999/1100-1199/1110-1119/1112/verifierA.go`
- `go build 1000-1999/1100-1199/1110-1119/1112/verifierB.go`
- `go build 1000-1999/1100-1199/1110-1119/1112/verifierC.go`
- `go build 1000-1999/1100-1199/1110-1119/1112/verifierD.go`
- `go build 1000-1999/1100-1199/1110-1119/1112/verifierE.go`
- `go build 1000-1999/1100-1199/1110-1119/1112/verifierF.go`
- `go build 1000-1999/1100-1199/1110-1119/1112/verifierG.go`
- `go build 1000-1999/1100-1199/1110-1119/1112/verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_688484b247608324ad70a03ec77169e0