### PR TITLE
Update verifier success message

### DIFF
--- a/0-999/500-599/500-509/504/verifierA.go
+++ b/0-999/500-599/500-509/504/verifierA.go
@@ -123,5 +123,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/500-599/500-509/504/verifierB.go
+++ b/0-999/500-599/500-509/504/verifierB.go
@@ -143,5 +143,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/500-599/500-509/504/verifierC.go
+++ b/0-999/500-599/500-509/504/verifierC.go
@@ -120,5 +120,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/500-599/500-509/504/verifierD.go
+++ b/0-999/500-599/500-509/504/verifierD.go
@@ -126,5 +126,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/500-599/500-509/504/verifierE.go
+++ b/0-999/500-599/500-509/504/verifierE.go
@@ -141,5 +141,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/500-599/560-569/567/verifierA.go
+++ b/0-999/500-599/560-569/567/verifierA.go
@@ -110,5 +110,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/500-599/560-569/567/verifierB.go
+++ b/0-999/500-599/560-569/567/verifierB.go
@@ -138,5 +138,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/500-599/560-569/567/verifierC.go
+++ b/0-999/500-599/560-569/567/verifierC.go
@@ -94,5 +94,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/500-599/560-569/567/verifierD.go
+++ b/0-999/500-599/560-569/567/verifierD.go
@@ -122,5 +122,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/500-599/560-569/567/verifierE.go
+++ b/0-999/500-599/560-569/567/verifierE.go
@@ -226,5 +226,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/500-599/560-569/567/verifierF.go
+++ b/0-999/500-599/560-569/567/verifierF.go
@@ -145,5 +145,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/800-899/870-879/878/verifierA.go
+++ b/0-999/800-899/870-879/878/verifierA.go
@@ -117,5 +117,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/800-899/870-879/878/verifierB.go
+++ b/0-999/800-899/870-879/878/verifierB.go
@@ -99,5 +99,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/800-899/870-879/878/verifierC.go
+++ b/0-999/800-899/870-879/878/verifierC.go
@@ -113,5 +113,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/800-899/870-879/878/verifierD.go
+++ b/0-999/800-899/870-879/878/verifierD.go
@@ -147,5 +147,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/800-899/870-879/878/verifierE.go
+++ b/0-999/800-899/870-879/878/verifierE.go
@@ -125,5 +125,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/900-999/920-929/924/verifierA.go
+++ b/0-999/900-999/920-929/924/verifierA.go
@@ -108,5 +108,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/900-999/920-929/924/verifierB.go
+++ b/0-999/900-999/920-929/924/verifierB.go
@@ -101,5 +101,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/900-999/920-929/924/verifierC.go
+++ b/0-999/900-999/920-929/924/verifierC.go
@@ -104,5 +104,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/900-999/920-929/924/verifierD.go
+++ b/0-999/900-999/920-929/924/verifierD.go
@@ -153,5 +153,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/900-999/920-929/924/verifierE.go
+++ b/0-999/900-999/920-929/924/verifierE.go
@@ -124,5 +124,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }

--- a/0-999/900-999/920-929/924/verifierF.go
+++ b/0-999/900-999/920-929/924/verifierF.go
@@ -131,5 +131,5 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	fmt.Println("ok 100 tests")
+	fmt.Println("All tests passed")
 }


### PR DESCRIPTION
## Summary
- replace `ok 100 tests` output with `All tests passed` in several verifier scripts

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain main module)*
- `go build 0-999/500-599/500-509/504/verifierA.go`
- `for f in $(cat files.txt); do go build "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68848739a7dc8324921aa022dd333431