### PR TITLE
Add Go solution for 1662D

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1662/1662D.go
+++ b/1000-1999/1600-1699/1660-1669/1662/1662D.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func canonical(s string) (int, string) {
+	b := 0
+	stack := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if ch == 'B' {
+			b ^= 1
+		} else {
+			if len(stack) > 0 && stack[len(stack)-1] == ch {
+				stack = stack[:len(stack)-1]
+			} else {
+				stack = append(stack, ch)
+			}
+		}
+	}
+	return b, string(stack)
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var u, v string
+		fmt.Fscan(reader, &u)
+		fmt.Fscan(reader, &v)
+		bu, su := canonical(u)
+		bv, sv := canonical(v)
+		if bu == bv && su == sv {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solver for problem D in contest 1662

## Testing
- `go build 1000-1999/1600-1699/1660-1669/1662/1662D.go`
- `go run 1000-1999/1600-1699/1660-1669/1662/1662D.go <<'EOF'
1
ABAB

EOF`

------
https://chatgpt.com/codex/tasks/task_e_688487b47e508324bccf64a6a30462ce