### PR TITLE
Add verifiers for contest 1117

### DIFF
--- a/1000-1999/1100-1199/1110-1119/1117/verifierA.go
+++ b/1000-1999/1100-1199/1110-1119/1117/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedA(arr []int64) int {
+	n := len(arr)
+	maxAvg := math.Inf(-1)
+	bestLen := 0
+	for l := 0; l < n; l++ {
+		sum := int64(0)
+		for r := l; r < n; r++ {
+			sum += arr[r]
+			avg := float64(sum) / float64(r-l+1)
+			if avg > maxAvg+1e-9 {
+				maxAvg = avg
+				bestLen = r - l + 1
+			} else if math.Abs(avg-maxAvg) <= 1e-9 && r-l+1 > bestLen {
+				bestLen = r - l + 1
+			}
+		}
+	}
+	return bestLen
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10) + 1
+	arr := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(50))
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expectedA(arr)
+}
+
+func runCase(bin, input string, exp int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1117/verifierB.go
+++ b/1000-1999/1100-1199/1110-1119/1117/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedB(n, m, k int64, arr []int64) int64 {
+	var max1, max2 int64
+	for _, v := range arr {
+		if v > max1 {
+			max2 = max1
+			max1 = v
+		} else if v > max2 {
+			max2 = v
+		}
+	}
+	cnt := m / (k + 1)
+	return max1*(m-cnt) + max2*cnt
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := int64(rng.Intn(8) + 2)
+	m := int64(rng.Intn(30) + 1)
+	k := int64(rng.Intn(5) + 1)
+	arr := make([]int64, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := range arr {
+		arr[i] = int64(rng.Intn(50))
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), expectedB(n, m, k, arr)
+}
+
+func runCase(bin, input string, exp int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1117/verifierC.go
+++ b/1000-1999/1100-1199/1110-1119/1117/verifierC.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedC(x1, y1, x2, y2 int, s string) int {
+	dx := x2 - x1
+	dy := y2 - y1
+	for t := 0; t <= 2000; t++ {
+		if dx == 0 && dy == 0 {
+			return t
+		}
+		c := s[t%len(s)]
+		switch c {
+		case 'U':
+			dy--
+		case 'D':
+			dy++
+		case 'L':
+			dx++
+		case 'R':
+			dx--
+		}
+	}
+	return -1
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	x1 := rng.Intn(21) - 10
+	y1 := rng.Intn(21) - 10
+	x2 := rng.Intn(21) - 10
+	y2 := rng.Intn(21) - 10
+	n := rng.Intn(10) + 1
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %d %d %d %d\n", x1, y1, x2, y2, n)
+	var s strings.Builder
+	moves := []byte{'U', 'D', 'L', 'R'}
+	for i := 0; i < n; i++ {
+		s.WriteByte(moves[rng.Intn(4)])
+	}
+	b.WriteString(s.String())
+	b.WriteByte('\n')
+	return b.String(), expectedC(x1, y1, x2, y2, s.String())
+}
+
+func runCase(bin, input string, exp int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1117/verifierD.go
+++ b/1000-1999/1100-1199/1110-1119/1117/verifierD.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD int64 = 1000000007
+
+func expectedD(N, M int) int64 {
+	dp := make([]int64, N+1)
+	dp[0] = 1
+	for i := 1; i <= N; i++ {
+		dp[i] = dp[i-1]
+		if i >= M {
+			dp[i] = (dp[i] + dp[i-M]) % MOD
+		}
+	}
+	return dp[N]
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	N := rng.Intn(40) + 1
+	M := rng.Intn(8) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", N, M)
+	return sb.String(), expectedD(N, M)
+}
+
+func runCase(bin, input string, exp int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	var got int64
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1117/verifierE.go
+++ b/1000-1999/1100-1199/1110-1119/1117/verifierE.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// applyOps applies swap operations to string s
+func applyOps(s string, ops [][2]int) string {
+	b := []byte(s)
+	for _, op := range ops {
+		i := op[0] - 1
+		j := op[1] - 1
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}
+
+type caseE struct {
+	s   string
+	ops [][2]int
+}
+
+func generateCase(rng *rand.Rand) caseE {
+	n := rng.Intn(6) + 1
+	letters := []byte{'a', 'b', 'c', 'd', 'e'}
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	k := rng.Intn(n + 1)
+	ops := make([][2]int, k)
+	for i := 0; i < k; i++ {
+		a := rng.Intn(n) + 1
+		b2 := rng.Intn(n) + 1
+		ops[i] = [2]int{a, b2}
+	}
+	return caseE{string(b), ops}
+}
+
+func runCase(bin string, c caseE) error {
+	t := applyOps(c.s, c.ops)
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	inWriter := bufio.NewWriter(stdin)
+	outReader := bufio.NewReader(stdout)
+	fmt.Fprintln(inWriter, t)
+	inWriter.Flush()
+	for i := 0; i < 3; i++ {
+		line, err := outReader.ReadString('\n')
+		if err != nil {
+			cmd.Process.Kill()
+			return fmt.Errorf("expected query %d: %v", i+1, err)
+		}
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "? ") {
+			cmd.Process.Kill()
+			return fmt.Errorf("expected '? query', got %q", line)
+		}
+		q := line[2:]
+		if len(q) != len(c.s) {
+			cmd.Process.Kill()
+			return fmt.Errorf("query length mismatch")
+		}
+		resp := applyOps(q, c.ops)
+		fmt.Fprintln(inWriter, resp)
+		inWriter.Flush()
+	}
+	ansLine, err := outReader.ReadString('\n')
+	if err != nil {
+		cmd.Process.Kill()
+		return fmt.Errorf("failed to read answer: %v", err)
+	}
+	ansLine = strings.TrimSpace(ansLine)
+	if !strings.HasPrefix(ansLine, "! ") {
+		cmd.Process.Kill()
+		return fmt.Errorf("expected final answer, got %q", ansLine)
+	}
+	ans := ansLine[2:]
+	if ans != c.s {
+		cmd.Process.Kill()
+		return fmt.Errorf("expected %s got %s", c.s, ans)
+	}
+	cmd.Wait()
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		c := generateCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1117/verifierF.go
+++ b/1000-1999/1100-1199/1110-1119/1117/verifierF.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isCrisp(s []byte, A [][]int) bool {
+	for i := 0; i < len(s)-1; i++ {
+		if A[int(s[i]-'a')][int(s[i+1]-'a')] == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func removeAll(s string, ch byte) string {
+	var b []byte
+	for i := 0; i < len(s); i++ {
+		if s[i] != ch {
+			b = append(b, s[i])
+		}
+	}
+	return string(b)
+}
+
+func dfs(s string, A [][]int, memo map[string]int) int {
+	if v, ok := memo[s]; ok {
+		return v
+	}
+	best := len(s)
+	used := make(map[byte]bool)
+	for i := 0; i < len(s); i++ {
+		used[s[i]] = true
+	}
+	for ch := range used {
+		t := removeAll(s, ch)
+		if isCrisp([]byte(t), A) {
+			l := dfs(t, A, memo)
+			if l < best {
+				best = l
+			}
+		}
+	}
+	memo[s] = best
+	return best
+}
+
+func expectedF(n, p int, str string, A [][]int) int {
+	memo := make(map[string]int)
+	memo[str] = len(str)
+	return dfs(str, A, memo)
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	p := rng.Intn(3) + 2
+	n := rng.Intn(6) + 1
+	A := make([][]int, p)
+	for i := 0; i < p; i++ {
+		A[i] = make([]int, p)
+		for j := 0; j <= i; j++ {
+			val := rng.Intn(2)
+			A[i][j] = val
+			A[j][i] = val
+		}
+		A[i][i] = 1
+	}
+	letters := make([]byte, p)
+	for i := 0; i < p; i++ {
+		letters[i] = byte('a' + i)
+	}
+	var str string
+	for {
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			b[i] = letters[rng.Intn(p)]
+		}
+		if isCrisp(b, A) {
+			str = string(b)
+			break
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n%s\n", n, p, str)
+	for i := 0; i < p; i++ {
+		for j := 0; j < p; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", A[i][j]))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), expectedF(n, p, str, A)
+}
+
+func runCase(bin, input string, exp int) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	var got int
+	if _, err := fmt.Fscan(strings.NewReader(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != exp {
+		return fmt.Errorf("expected %d got %d", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1117/verifierG.go
+++ b/1000-1999/1100-1199/1110-1119/1117/verifierG.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func maxPos(arr []int, l, r int) int {
+	idx := l
+	for i := l + 1; i <= r; i++ {
+		if arr[i] > arr[idx] {
+			idx = i
+		}
+	}
+	return idx
+}
+
+func solve(arr []int, l, r int) int64 {
+	if l > r {
+		return 0
+	}
+	m := maxPos(arr, l, r)
+	return int64(r-l+1) + solve(arr, l, m-1) + solve(arr, m+1, r)
+}
+
+func expectedG(arr []int, l, r int) int64 {
+	return solve(arr, l, r)
+}
+
+func generateCase(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(7) + 1
+	q := rng.Intn(5) + 1
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	l := make([]int, q)
+	r := make([]int, q)
+	for i := 0; i < q; i++ {
+		a := rng.Intn(n)
+		b := rng.Intn(n)
+		if a > b {
+			a, b = b, a
+		}
+		l[i] = a + 1
+		r[i] = b + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range l {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range r {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	answers := make([]int64, q)
+	for i := 0; i < q; i++ {
+		answers[i] = expectedG(perm, l[i]-1, r[i]-1)
+	}
+	return sb.String(), answers
+}
+
+func runCase(bin, input string, exp []int64) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	gotFields := strings.Fields(out.String())
+	if len(gotFields) != len(exp) {
+		return fmt.Errorf("expected %d numbers got %d", len(exp), len(gotFields))
+	}
+	for i, gf := range gotFields {
+		var g int64
+		fmt.Sscan(gf, &g)
+		if g != exp[i] {
+			return fmt.Errorf("at %d expected %d got %d", i+1, exp[i], g)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	bin := os.Args[1]
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest 1117 problems A–G
- each verifier generates 100 random tests and checks a given binary
- verifiers include an interactive judge for problem E

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6884876e77508324b02f849990d0cf4b