### PR TITLE
Add Go verifiers for contest 1118

### DIFF
--- a/1000-1999/1100-1199/1110-1119/1118/verifierA.go
+++ b/1000-1999/1100-1199/1110-1119/1118/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= 100; t++ {
+		q := rand.Intn(5) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", q))
+		exp := make([]string, q)
+		for i := 0; i < q; i++ {
+			n := rand.Int63n(1000) + 1
+			a := rand.Int63n(1000) + 1
+			b := rand.Int63n(1000) + 1
+			sb.WriteString(fmt.Sprintf("%d %d %d\n", n, a, b))
+			cost1 := n * a
+			cost2 := (n/2)*b + (n%2)*a
+			if cost1 < cost2 {
+				exp[i] = fmt.Sprintf("%d", cost1)
+			} else {
+				exp[i] = fmt.Sprintf("%d", cost2)
+			}
+		}
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			fmt.Println(string(out))
+			return
+		}
+		scanner := bufio.NewScanner(strings.NewReader(out))
+		got := []string{}
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line != "" {
+				got = append(got, line)
+			}
+		}
+		if len(got) != q {
+			fmt.Printf("test %d wrong number of lines: got %d expected %d\ninput:\n%soutput:\n%s", t, len(got), q, sb.String(), out)
+			return
+		}
+		for i := 0; i < q; i++ {
+			if got[i] != exp[i] {
+				fmt.Printf("test %d case %d failed\ninput:\n%sexpected %s got %s\n", t, i+1, sb.String(), exp[i], got[i])
+				return
+			}
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1118/verifierB.go
+++ b/1000-1999/1100-1199/1110-1119/1118/verifierB.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func solve(n int, a []int) int {
+	prefixOdd := make([]int, n+1)
+	prefixEven := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		prefixOdd[i] = prefixOdd[i-1]
+		prefixEven[i] = prefixEven[i-1]
+		if i%2 == 0 {
+			prefixEven[i] += a[i-1]
+		} else {
+			prefixOdd[i] += a[i-1]
+		}
+	}
+	ans := 0
+	for i := 1; i <= n; i++ {
+		odd := prefixOdd[i-1] + (prefixEven[n] - prefixEven[i])
+		even := prefixEven[i-1] + (prefixOdd[n] - prefixOdd[i])
+		if odd == even {
+			ans++
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(2)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(10) + 1
+		a := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			a[i] = rand.Intn(50)
+			sb.WriteString(fmt.Sprintf("%d ", a[i]))
+		}
+		sb.WriteString("\n")
+		expected := solve(n, a)
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			fmt.Println(string(out))
+			return
+		}
+		var got int
+		fmt.Fscan(strings.NewReader(out), &got)
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected %d got %d\n", t, sb.String(), expected, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1118/verifierC.go
+++ b/1000-1999/1100-1199/1110-1119/1118/verifierC.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func checkMatrix(n int, nums []int, mat [][]int) bool {
+	cnt := make(map[int]int)
+	for _, v := range nums {
+		cnt[v]++
+	}
+	for i := 0; i < n; i++ {
+		if len(mat[i]) != n {
+			return false
+		}
+		for j := 0; j < n; j++ {
+			cnt[mat[i][j]]--
+		}
+	}
+	for _, v := range cnt {
+		if v != 0 {
+			return false
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if mat[i][j] != mat[n-1-i][j] || mat[i][j] != mat[i][n-1-j] || mat[i][j] != mat[n-1-i][n-1-j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func possible(n int, nums []int) bool {
+	cnt := make(map[int]int)
+	for _, v := range nums {
+		cnt[v]++
+	}
+	k := n / 2
+	quads := 0
+	pairs := 0
+	singles := 0
+	for _, c := range cnt {
+		quads += c / 4
+		c %= 4
+		pairs += c / 2
+		c %= 2
+		singles += c
+	}
+	if n%2 == 0 {
+		return singles == 0 && pairs == 0 && quads >= k*k
+	}
+	return singles == 1 && pairs >= 2*k && quads >= k*k
+}
+
+func parseMatrix(lines []string, n int) ([][]int, bool) {
+	mat := make([][]int, n)
+	for i := 0; i < n; i++ {
+		fields := strings.Fields(lines[i])
+		if len(fields) != n {
+			return nil, false
+		}
+		row := make([]int, n)
+		for j := 0; j < n; j++ {
+			var val int
+			if _, err := fmt.Sscan(fields[j], &val); err != nil {
+				return nil, false
+			}
+			row[j] = val
+		}
+		mat[i] = row
+	}
+	return mat, true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(5) + 1
+		total := n * n
+		nums := make([]int, total)
+		for i := 0; i < total; i++ {
+			nums[i] = rand.Intn(3)
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range nums {
+			if i%20 == 0 && i > 0 {
+				sb.WriteString("\n")
+			}
+			sb.WriteString(fmt.Sprintf("%d ", v))
+		}
+		sb.WriteString("\n")
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			fmt.Println(out)
+			return
+		}
+		out = strings.TrimSpace(out)
+		lines := strings.Split(out, "\n")
+		if strings.EqualFold(lines[0], "NO") {
+			if possible(n, nums) {
+				fmt.Printf("test %d failed: expected YES but got NO\ninput:\n%s\n", t, sb.String())
+				return
+			}
+			continue
+		}
+		if !strings.EqualFold(lines[0], "YES") {
+			fmt.Printf("test %d invalid output\n", t)
+			return
+		}
+		if !possible(n, nums) {
+			fmt.Printf("test %d failed: expected NO but got YES\ninput:\n%s\n", t, sb.String())
+			return
+		}
+		if len(lines)-1 != n {
+			fmt.Printf("test %d failed: expected %d rows got %d\n", t, n, len(lines)-1)
+			return
+		}
+		mat, ok := parseMatrix(lines[1:], n)
+		if !ok {
+			fmt.Printf("test %d failed: cannot parse matrix\n", t)
+			return
+		}
+		if !checkMatrix(n, nums, mat) {
+			fmt.Printf("test %d failed: matrix invalid\n", t)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1118/verifierD1.go
+++ b/1000-1999/1100-1199/1110-1119/1118/verifierD1.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func solve(n int, m int64, a []int64) int {
+	sum := int64(0)
+	for _, v := range a {
+		sum += v
+	}
+	if sum < m {
+		return -1
+	}
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	for day := int64(1); day <= int64(n); day++ {
+		var tot int64
+		var cnt int64
+		var t int64
+		for i := n - 1; i >= 0; i-- {
+			if a[i] < cnt {
+				break
+			}
+			tot += a[i] - cnt
+			t++
+			if t == day {
+				cnt++
+				t = 0
+			}
+			if tot >= m {
+				break
+			}
+		}
+		if tot >= m {
+			return int(day)
+		}
+	}
+	return -1
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(4)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(8) + 1
+		m := rand.Int63n(50) + 1
+		a := make([]int64, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			a[i] = rand.Int63n(20) + 1
+			sb.WriteString(fmt.Sprintf("%d ", a[i]))
+		}
+		sb.WriteString("\n")
+		expected := solve(n, m, a)
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			fmt.Println(out)
+			return
+		}
+		var got int
+		fmt.Fscan(strings.NewReader(out), &got)
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected %d got %d\n", t, sb.String(), expected, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1118/verifierD2.go
+++ b/1000-1999/1100-1199/1110-1119/1118/verifierD2.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func solve(n int, m int64, a []int64) int {
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	check := func(x int) bool {
+		var tmp int64
+		cnt := 0
+		cur := int64(0)
+		for i := n - 1; i >= 0; i-- {
+			if a[i] > cur {
+				tmp += a[i] - cur
+			}
+			cnt++
+			if cnt == x {
+				cur++
+				cnt = 0
+			}
+		}
+		return tmp >= m
+	}
+	l, r := 1, n
+	ans := -1
+	for l <= r {
+		mid := (l + r) / 2
+		if check(mid) {
+			ans = mid
+			r = mid - 1
+		} else {
+			l = mid + 1
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD2.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(8) + 1
+		m := rand.Int63n(100) + 1
+		a := make([]int64, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			a[i] = rand.Int63n(50) + 1
+			sb.WriteString(fmt.Sprintf("%d ", a[i]))
+		}
+		sb.WriteString("\n")
+		expected := solve(n, m, a)
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			fmt.Println(out)
+			return
+		}
+		var got int
+		fmt.Fscan(strings.NewReader(out), &got)
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected %d got %d\n", t, sb.String(), expected, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1118/verifierE.go
+++ b/1000-1999/1100-1199/1110-1119/1118/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func solve(n, k int64) (bool, [][2]int64) {
+	if n > k*(k-1) {
+		return false, nil
+	}
+	cnt := int64(0)
+	add := int64(0)
+	fi := int64(0)
+	se := int64(0)
+	res := make([][2]int64, 0, n)
+	for cnt < n {
+		if cnt%k == 0 {
+			add++
+		}
+		cnt++
+		fi = fi%k + 1
+		se = (fi+add-1)%k + 1
+		res = append(res, [2]int64{fi, se})
+	}
+	return true, res
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(6)
+	for t := 1; t <= 100; t++ {
+		k := rand.Int63n(5) + 2
+		n := rand.Int63n(k*(k-1) + 5)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		expectedOK, _ := solve(n, k)
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			fmt.Println(out)
+			return
+		}
+		out = strings.TrimSpace(out)
+		lines := strings.Split(out, "\n")
+		if strings.EqualFold(lines[0], "NO") {
+			if expectedOK {
+				fmt.Printf("test %d expected YES but got NO\ninput:\n%s\n", t, sb.String())
+				return
+			}
+			continue
+		}
+		if !strings.EqualFold(lines[0], "YES") {
+			fmt.Printf("test %d invalid output\n", t)
+			return
+		}
+		if !expectedOK {
+			fmt.Printf("test %d expected NO but got YES\ninput:\n%s\n", t, sb.String())
+			return
+		}
+		if int64(len(lines)-1) != n {
+			fmt.Printf("test %d wrong number of lines\n", t)
+			return
+		}
+		for i := int64(0); i < n; i++ {
+			var x, y int64
+			if _, err := fmt.Sscan(lines[i+1], &x, &y); err != nil {
+				fmt.Printf("test %d cannot parse line\n", t)
+				return
+			}
+			if x < 1 || x > k || y < 1 || y > k || x == y {
+				fmt.Printf("test %d invalid pair\n", t)
+				return
+			}
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1118/verifierF1.go
+++ b/1000-1999/1100-1199/1110-1119/1118/verifierF1.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runBinary(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func solve(n int, colors []int, edges [][2]int) int {
+	totalRed := 0
+	totalBlue := 0
+	for _, c := range colors {
+		if c == 1 {
+			totalRed++
+		} else if c == 2 {
+			totalBlue++
+		}
+	}
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	parent := make([]int, n)
+	parent[0] = -1
+	stack := []int{0}
+	order := make([]int, 0, n)
+	for len(stack) > 0 {
+		u := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, u)
+		for _, v := range adj[u] {
+			if v == parent[u] {
+				continue
+			}
+			parent[v] = u
+			stack = append(stack, v)
+		}
+	}
+	redCnt := make([]int, n)
+	blueCnt := make([]int, n)
+	ans := 0
+	for i := len(order) - 1; i >= 0; i-- {
+		u := order[i]
+		for _, v := range adj[u] {
+			if parent[v] == u {
+				redCnt[u] += redCnt[v]
+				blueCnt[u] += blueCnt[v]
+			}
+		}
+		if colors[u] == 1 {
+			redCnt[u]++
+		} else if colors[u] == 2 {
+			blueCnt[u]++
+		}
+		if u != 0 {
+			if redCnt[u] == 0 && blueCnt[u] == totalBlue {
+				ans++
+			} else if blueCnt[u] == 0 && redCnt[u] == totalRed {
+				ans++
+			}
+		}
+	}
+	return ans
+}
+
+func randomTree(n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 1; i < n; i++ {
+		p := rand.Intn(i)
+		edges = append(edges, [2]int{i, p})
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF1.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rand.Seed(7)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(8) + 2
+		colors := make([]int, n)
+		hasR := false
+		hasB := false
+		for i := 0; i < n; i++ {
+			colors[i] = rand.Intn(3)
+			if colors[i] == 1 {
+				hasR = true
+			} else if colors[i] == 2 {
+				hasB = true
+			}
+		}
+		if !hasR {
+			colors[0] = 1
+			hasR = true
+		}
+		if !hasB {
+			colors[1%n] = 2
+			hasB = true
+		}
+		edges := randomTree(n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d ", colors[i]))
+		}
+		sb.WriteString("\n")
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+		}
+		expected := solve(n, colors, edges)
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			fmt.Println(out)
+			return
+		}
+		var got int
+		fmt.Fscan(strings.NewReader(out), &got)
+		if got != expected {
+			fmt.Printf("test %d failed\ninput:\n%sexpected %d got %d\n", t, sb.String(), expected, got)
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1100-1199/1110-1119/1118/verifierF2.go
+++ b/1000-1999/1100-1199/1110-1119/1118/verifierF2.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refF2.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1118F2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("compile ref: %v %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runBinary(bin string, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func randomTree(n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges = append(edges, [2]int{i, p})
+	}
+	return edges
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF2.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer os.Remove(ref)
+	rand.Seed(8)
+	for t := 1; t <= 100; t++ {
+		n := rand.Intn(8) + 2
+		k := rand.Intn(n-1) + 2
+		colors := make([]int, n)
+		for i := 0; i < k; i++ {
+			colors[i] = i + 1
+		}
+		for i := k; i < n; i++ {
+			colors[i] = rand.Intn(k + 1)
+		}
+		edges := randomTree(n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n; i++ {
+			sb.WriteString(fmt.Sprintf("%d ", colors[i]))
+		}
+		sb.WriteString("\n")
+		for _, e := range edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+		}
+		expOut, err := runBinary(ref, sb.String())
+		if err != nil {
+			fmt.Printf("test %d reference runtime error: %v\n", t, err)
+			fmt.Println(expOut)
+			return
+		}
+		out, err := runBinary(bin, sb.String())
+		if err != nil {
+			fmt.Printf("test %d runtime error: %v\n", t, err)
+			fmt.Println(out)
+			return
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expOut) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected %s got %s\n", t, sb.String(), strings.TrimSpace(expOut), strings.TrimSpace(out))
+			return
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD1.go and verifierD2.go for problems D1/D2
- add verifierE.go for problem E
- add verifierF1.go and verifierF2.go for problems F1/F2

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD1.go`
- `go build verifierD2.go`
- `go build verifierE.go`
- `go build verifierF1.go`
- `go build verifierF2.go`


------
https://chatgpt.com/codex/tasks/task_e_688487fa92fc8324aad5617bed15c417