### PR TITLE
Add Go solver for 1665D

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1665/1665D.go
+++ b/1000-1999/1600-1699/1660-1669/1665/1665D.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+
+	ask := func(a, b int) int {
+		fmt.Fprintf(out, "? %d %d\n", a, b)
+		out.Flush()
+		var g int
+		if _, err := fmt.Fscan(in, &g); err != nil {
+			os.Exit(0)
+		}
+		return g
+	}
+
+	for ; t > 0; t-- {
+		ans := 0
+		for i := 0; i < 30; i++ {
+			a := (1 << i) - ans
+			b := 3*(1<<i) - ans
+			g := ask(a, b)
+			if g%(1<<(i+1)) == 0 {
+				ans |= 1 << i
+			}
+		}
+		fmt.Fprintf(out, "! %d\n", ans)
+		out.Flush()
+	}
+}


### PR DESCRIPTION
## Summary
- add interactive solver for problem 1665D

## Testing
- `gofmt -w 1000-1999/1600-1699/1660-1669/1665/1665D.go`


------
https://chatgpt.com/codex/tasks/task_e_68848afd1ad88324b1f3f986994506b4