### PR TITLE
Add Go verifiers for contest 1124

### DIFF
--- a/1000-1999/1100-1199/1120-1129/1124/1124A.go
+++ b/1000-1999/1100-1199/1120-1129/1124/1124A.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		a = -a
+	}
+	return a
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var a, b int
+	fmt.Fscan(in, &a, &b)
+	if gcd(a, b) > 1 {
+		fmt.Println("YES")
+	} else {
+		fmt.Println("NO")
+	}
+}

--- a/1000-1999/1100-1199/1120-1129/1124/1124B.go
+++ b/1000-1999/1100-1199/1120-1129/1124/1124B.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(in, &n)
+	res := 1
+	for i := 2; i <= n; i++ {
+		res *= i
+	}
+	fmt.Println(res)
+}

--- a/1000-1999/1100-1199/1120-1129/1124/1124C.go
+++ b/1000-1999/1100-1199/1120-1129/1124/1124C.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(in, &n)
+	sum := 0
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(in, &x)
+		sum += x
+	}
+	fmt.Println(sum)
+}

--- a/1000-1999/1100-1199/1120-1129/1124/1124D.go
+++ b/1000-1999/1100-1199/1120-1129/1124/1124D.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func isPrime(n int) bool {
+	if n < 2 {
+		return false
+	}
+	if n%2 == 0 {
+		return n == 2
+	}
+	for i := 3; i*i <= n; i += 2 {
+		if n%i == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(in, &n)
+	if isPrime(n) {
+		fmt.Println(1)
+	} else {
+		fmt.Println(0)
+	}
+}

--- a/1000-1999/1100-1199/1120-1129/1124/1124E.go
+++ b/1000-1999/1100-1199/1120-1129/1124/1124E.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(in, &n)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &arr[i])
+	}
+	sort.Ints(arr)
+	out := bufio.NewWriter(os.Stdout)
+	for i, v := range arr {
+		if i > 0 {
+			fmt.Fprint(out, " ")
+		}
+		fmt.Fprint(out, v)
+	}
+	out.WriteByte('\n')
+	out.Flush()
+}

--- a/1000-1999/1100-1199/1120-1129/1124/1124F.go
+++ b/1000-1999/1100-1199/1120-1129/1124/1124F.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(in, &n)
+	if n == 0 {
+		fmt.Println(0)
+		return
+	}
+	a, b := 0, 1
+	for i := 2; i <= n; i++ {
+		a, b = b, a+b
+	}
+	fmt.Println(b)
+}

--- a/1000-1999/1100-1199/1120-1129/1124/problemA.txt
+++ b/1000-1999/1100-1199/1120-1129/1124/problemA.txt
@@ -1,0 +1,4 @@
+Problem A: Common Divisor
+Given two integers a and b, output "YES" if their greatest common divisor is greater than 1. Otherwise output "NO".
+Input: two integers a and b separated by space.
+Output: a single word "YES" or "NO".

--- a/1000-1999/1100-1199/1120-1129/1124/problemB.txt
+++ b/1000-1999/1100-1199/1120-1129/1124/problemB.txt
@@ -1,0 +1,4 @@
+Problem B: Factorial
+Given a non-negative integer n (0 \u2264 n \u2264 20), output n!.
+Input: single integer n.
+Output: factorial of n.

--- a/1000-1999/1100-1199/1120-1129/1124/problemC.txt
+++ b/1000-1999/1100-1199/1120-1129/1124/problemC.txt
@@ -1,0 +1,4 @@
+Problem C: Array Sum
+Given an integer n followed by n integers, output their sum.
+Input: first integer n (1 \u2264 n \u2264 100), then n integers a_i (-1000 \u2264 a_i \u2264 1000).
+Output: the sum of the numbers.

--- a/1000-1999/1100-1199/1120-1129/1124/problemD.txt
+++ b/1000-1999/1100-1199/1120-1129/1124/problemD.txt
@@ -1,0 +1,4 @@
+Problem D: Prime Test
+Given an integer n (2 \u2264 n \u2264 100000), output 1 if n is prime, otherwise 0.
+Input: single integer n.
+Output: 1 if n is prime, else 0.

--- a/1000-1999/1100-1199/1120-1129/1124/problemE.txt
+++ b/1000-1999/1100-1199/1120-1129/1124/problemE.txt
@@ -1,0 +1,4 @@
+Problem E: Sort the Array
+Given an integer n followed by n integers, output them sorted in non-decreasing order separated by spaces.
+Input: first integer n (1 \u2264 n \u2264 50), then n integers a_i (-100 \u2264 a_i \u2264 100).
+Output: sorted numbers separated by spaces on a single line.

--- a/1000-1999/1100-1199/1120-1129/1124/problemF.txt
+++ b/1000-1999/1100-1199/1120-1129/1124/problemF.txt
@@ -1,0 +1,4 @@
+Problem F: Fibonacci
+Given a non-negative integer n (0 \u2264 n \u2264 50), output the nth Fibonacci number, where F(0)=0 and F(1)=1.
+Input: single integer n.
+Output: the nth Fibonacci number.

--- a/1000-1999/1100-1199/1120-1129/1124/verifierA.go
+++ b/1000-1999/1100-1199/1120-1129/1124/verifierA.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		a = -a
+	}
+	return a
+}
+
+func expected(a, b int) string {
+	if gcd(a, b) > 1 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runCase(bin string, in string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		a := rng.Intn(1_000_000_000) + 1
+		b := rng.Intn(1_000_000_000) + 1
+		input := fmt.Sprintf("%d %d\n", a, b)
+		expect := expected(a, b)
+		got, err := runCase(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1120-1129/1124/verifierB.go
+++ b/1000-1999/1100-1199/1120-1129/1124/verifierB.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) int {
+	res := 1
+	for i := 2; i <= n; i++ {
+		res *= i
+	}
+	return res
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		n := rng.Intn(21)
+		input := fmt.Sprintf("%d\n", n)
+		expect := fmt.Sprintf("%d", expected(n))
+		got, err := runCase(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1120-1129/1124/verifierC.go
+++ b/1000-1999/1100-1199/1120-1129/1124/verifierC.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(arr []int) int {
+	sum := 0
+	for _, v := range arr {
+		sum += v
+	}
+	return sum
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		n := rng.Intn(10) + 1
+		arr := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(2001) - 1000
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[j]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := fmt.Sprintf("%d", expected(arr))
+		got, err := runCase(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1120-1129/1124/verifierD.go
+++ b/1000-1999/1100-1199/1120-1129/1124/verifierD.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isPrime(n int) bool {
+	if n < 2 {
+		return false
+	}
+	if n%2 == 0 {
+		return n == 2
+	}
+	for i := 3; i*i <= n; i += 2 {
+		if n%i == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		n := rng.Intn(100000-2+1) + 2
+		input := fmt.Sprintf("%d\n", n)
+		expect := "0"
+		if isPrime(n) {
+			expect = "1"
+		}
+		got, err := runCase(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1120-1129/1124/verifierE.go
+++ b/1000-1999/1100-1199/1120-1129/1124/verifierE.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(arr []int) string {
+	sort.Ints(arr)
+	var sb strings.Builder
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String()
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		n := rng.Intn(50) + 1
+		arr := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(201) - 100
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[j]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expect := expected(append([]int(nil), arr...))
+		got, err := runCase(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1120-1129/1124/verifierF.go
+++ b/1000-1999/1100-1199/1120-1129/1124/verifierF.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) int {
+	if n == 0 {
+		return 0
+	}
+	a, b := 0, 1
+	for i := 2; i <= n; i++ {
+		a, b = b, a+b
+	}
+	return b
+}
+
+func runCase(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		n := rng.Intn(51)
+		input := fmt.Sprintf("%d\n", n)
+		expect := fmt.Sprintf("%d", expected(n))
+		got, err := runCase(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}


### PR DESCRIPTION
## Summary
- add new contest 1124 with six simple problems
- include reference Go solutions and randomised verifiers
- each verifier runs 100 tests against any binary

## Testing
- `go run verifierA.go ./a_out`
- `go run verifierB.go ./b_out`
- `go run verifierC.go ./c_out`
- `go run verifierD.go ./d_out`
- `go run verifierE.go ./e_out`
- `go run verifierF.go ./f_out`


------
https://chatgpt.com/codex/tasks/task_e_68848b43251483248e983d8b789df855