### PR TITLE
Add Go solution for 1663D

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1663/1663D.go
+++ b/1000-1999/1600-1699/1660-1669/1663/1663D.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var s string
+	var x int
+	fmt.Fscan(in, &s)
+	fmt.Fscan(in, &x)
+
+	if (s == "ABC" && x < 2000) || (s == "ARC" && x < 2800) || (s == "AGC" && x >= 1200) {
+		fmt.Println("Yes")
+	} else {
+		fmt.Println("No")
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem D in contest 1663

## Testing
- `gofmt -w 1000-1999/1600-1699/1660-1669/1663/1663D.go`

------
https://chatgpt.com/codex/tasks/task_e_68848db98670832486350ca8bdedcefc