### PR TITLE
Add Go verifiers for contest 1129

### DIFF
--- a/1000-1999/1100-1199/1120-1129/1129/verifierA.go
+++ b/1000-1999/1100-1199/1120-1129/1129/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1129A2.go")
+	bin := filepath.Join(os.TempDir(), "ref1129A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(2*n + 1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		a := rand.Intn(n) + 1
+		b := rand.Intn(n) + 1
+		for b == a {
+			b = rand.Intn(n) + 1
+		}
+		fmt.Fprintf(&sb, "%d %d\n", a, b)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierA.go <path-to-binary>")
+		return
+	}
+	userBin := os.Args[1]
+	rand.Seed(1)
+	refBin, err := buildReference()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		return
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		want, err1 := runBinary(refBin, input)
+		if err1 != nil {
+			fmt.Println("reference solution failed:", err1)
+			return
+		}
+		got, err2 := runBinary(userBin, input)
+		if err2 != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err2)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1120-1129/1129/verifierB.go
+++ b/1000-1999/1100-1199/1120-1129/1129/verifierB.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1129B.go")
+	bin := filepath.Join(os.TempDir(), "ref1129B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	k := rand.Int63n(1e12)
+	return fmt.Sprintf("%d\n", k)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierB.go <path-to-binary>")
+		return
+	}
+	userBin := os.Args[1]
+	rand.Seed(1)
+	refBin, err := buildReference()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		return
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		want, err1 := runBinary(refBin, input)
+		if err1 != nil {
+			fmt.Println("reference solution failed:", err1)
+			return
+		}
+		got, err2 := runBinary(userBin, input)
+		if err2 != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err2)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1120-1129/1129/verifierC.go
+++ b/1000-1999/1100-1199/1120-1129/1129/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1129C.go")
+	bin := filepath.Join(os.TempDir(), "ref1129C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		if rand.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierC.go <path-to-binary>")
+		return
+	}
+	userBin := os.Args[1]
+	rand.Seed(1)
+	refBin, err := buildReference()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		return
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		want, err1 := runBinary(refBin, input)
+		if err1 != nil {
+			fmt.Println("reference solution failed:", err1)
+			return
+		}
+		got, err2 := runBinary(userBin, input)
+		if err2 != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err2)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1120-1129/1129/verifierD.go
+++ b/1000-1999/1100-1199/1120-1129/1129/verifierD.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1129D.go")
+	bin := filepath.Join(os.TempDir(), "ref1129D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(10) + 1
+	k := rand.Intn(n) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rand.Intn(5)
+		fmt.Fprintf(&sb, "%d", val)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierD.go <path-to-binary>")
+		return
+	}
+	userBin := os.Args[1]
+	rand.Seed(1)
+	refBin, err := buildReference()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		return
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		want, err1 := runBinary(refBin, input)
+		if err1 != nil {
+			fmt.Println("reference solution failed:", err1)
+			return
+		}
+		got, err2 := runBinary(userBin, input)
+		if err2 != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err2)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1120-1129/1129/verifierE.go
+++ b/1000-1999/1100-1199/1120-1129/1129/verifierE.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildReference() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1129E.go")
+	bin := filepath.Join(os.TempDir(), "ref1129E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return bin, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase() string {
+	n := rand.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		fmt.Fprintf(&sb, "%d %d\n", p, i)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: verifierE.go <path-to-binary>")
+		return
+	}
+	userBin := os.Args[1]
+	rand.Seed(1)
+	refBin, err := buildReference()
+	if err != nil {
+		fmt.Println("failed to build reference:", err)
+		return
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		want, err1 := runBinary(refBin, input)
+		if err1 != nil {
+			fmt.Println("reference solution failed:", err1)
+			return
+		}
+		got, err2 := runBinary(userBin, input)
+		if err2 != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err2)
+			fmt.Println("input:\n" + input)
+			return
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("test %d failed\ninput:\n%sexpected:\n%s\nactual:\n%s\n", i+1, input, want, got)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1129 problems A–E

## Testing
- `go build 1000-1999/1100-1199/1120-1129/1129/verifierA.go`
- `go build 1000-1999/1100-1199/1120-1129/1129/verifierB.go`
- `go build 1000-1999/1100-1199/1120-1129/1129/verifierC.go`
- `go build 1000-1999/1100-1199/1120-1129/1129/verifierD.go`
- `go build 1000-1999/1100-1199/1120-1129/1129/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_68848dff8a9c8324b914ac4bda64ffb0