### PR TITLE
Fix 1921D verifier random generator

### DIFF
--- a/1000-1999/1900-1999/1920-1929/1921/verifierD.go
+++ b/1000-1999/1900-1999/1920-1929/1921/verifierD.go
@@ -33,7 +33,7 @@ func buildRef() (string, error) {
 
 func genTest() []byte {
 	n := rand.Intn(6) + 1
-	m := rand.Intn(6) + 1
+	m := n + rand.Intn(6)
 	a := make([]int, n)
 	b := make([]int, m)
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
## Summary
- ensure `verifierD.go` never generates invalid tests where `n > m`
- run `gofmt` on the file

## Testing
- `go run verifierD.go ./dsol`

------
https://chatgpt.com/codex/tasks/task_e_68848df1131c8324944122e6ef937a0e