### PR TITLE
Add Go verifiers for contest 1130

### DIFF
--- a/1000-1999/1100-1199/1130-1139/1130/verifierA.go
+++ b/1000-1999/1100-1199/1130-1139/1130/verifierA.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+type test struct {
+    input string
+}
+
+func parseInput(input string) (n int, arr []int) {
+    fields := strings.Fields(strings.TrimSpace(input))
+    if len(fields) == 0 {
+        return 0, nil
+    }
+    n, _ = strconv.Atoi(fields[0])
+    arr = make([]int, n)
+    for i := 0; i < n; i++ {
+        arr[i], _ = strconv.Atoi(fields[i+1])
+    }
+    return
+}
+
+func isValidAnswer(arr []int, out string) bool {
+    d, err := strconv.Atoi(strings.TrimSpace(out))
+    if err != nil {
+        return false
+    }
+    if d < -1000 || d > 1000 {
+        return false
+    }
+    n := len(arr)
+    posCount, negCount := 0, 0
+    for _, v := range arr {
+        if v > 0 {
+            posCount++
+        } else if v < 0 {
+            negCount++
+        }
+    }
+    half := (n + 1) / 2
+    if posCount < half && negCount < half {
+        return d == 0
+    }
+    if d == 0 {
+        return false
+    }
+    if d > 0 {
+        return posCount >= half
+    }
+    return negCount >= half
+}
+
+func generateTests() []test {
+    rand.Seed(1130)
+    var tests []test
+    fixed := [][]int{
+        {1, 1},
+        {1, -1},
+        {3, 1, -2, 3},
+        {5, -1, -2, -3, 0, 0},
+        {4, 0, 0, 0, 0},
+    }
+    for _, arr := range fixed {
+        n := arr[0]
+        data := arr[1:]
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprint(n))
+        sb.WriteByte('\n')
+        for i, v := range data {
+            if i > 0 {
+                sb.WriteByte(' ')
+            }
+            sb.WriteString(fmt.Sprint(v))
+        }
+        sb.WriteByte('\n')
+        inp := sb.String()
+        tests = append(tests, test{inp})
+    }
+    for len(tests) < 100 {
+        n := rand.Intn(20) + 1
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprint(n))
+        sb.WriteByte('\n')
+        for i := 0; i < n; i++ {
+            if i > 0 {
+                sb.WriteByte(' ')
+            }
+            val := rand.Intn(2001) - 1000
+            sb.WriteString(fmt.Sprint(val))
+        }
+        sb.WriteByte('\n')
+        tests = append(tests, test{sb.String()})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        n, arr := parseInput(t.input)
+        _ = n
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if !isValidAnswer(arr, got) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sOutput: %s\n", i+1, t.input, got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1100-1199/1130-1139/1130/verifierB.go
+++ b/1000-1999/1100-1199/1130-1139/1130/verifierB.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+func abs(x int) int {
+    if x < 0 {
+        return -x
+    }
+    return x
+}
+
+func min(a, b int) int {
+    if a < b {
+        return a
+    }
+    return b
+}
+
+type test struct {
+    input    string
+    expected string
+}
+
+func solve(input string) string {
+    fields := strings.Fields(strings.TrimSpace(input))
+    if len(fields) == 0 {
+        return ""
+    }
+    idx := 0
+    n, _ := strconv.Atoi(fields[idx])
+    idx++
+    m := 2 * n
+    arr := make([]int, m)
+    for i := 0; i < m; i++ {
+        arr[i], _ = strconv.Atoi(fields[idx+i])
+    }
+    pos := make([][2]int, n+1)
+    pos[0][0], pos[0][1] = 1, 1
+    for i := 0; i < m; i++ {
+        x := arr[i]
+        if pos[x][0] == 0 {
+            pos[x][0] = i + 1
+        } else {
+            pos[x][1] = i + 1
+        }
+    }
+    var ans int64
+    for i := 1; i <= n; i++ {
+        p0, p1 := pos[i][0], pos[i][1]
+        q0, q1 := pos[i-1][0], pos[i-1][1]
+        cost1 := abs(p1-q1) + abs(p0-q0)
+        cost2 := abs(p0-q1) + abs(p1-q0)
+        if cost1 < cost2 {
+            ans += int64(cost1)
+        } else {
+            ans += int64(cost2)
+        }
+    }
+    return fmt.Sprint(ans)
+}
+
+func generateTests() []test {
+    rand.Seed(1130)
+    var tests []test
+    fixed := []int{1, 2, 3, 4, 5}
+    for _, n := range fixed {
+        arr := make([]int, 2*n)
+        for i := 0; i < n; i++ {
+            arr[i] = i + 1
+            arr[i+n] = i + 1
+        }
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprint(n))
+        sb.WriteByte('\n')
+        for i, v := range arr {
+            if i > 0 {
+                sb.WriteByte(' ')
+            }
+            sb.WriteString(fmt.Sprint(v))
+        }
+        sb.WriteByte('\n')
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    for len(tests) < 100 {
+        n := rand.Intn(10) + 1
+        arr := make([]int, 2*n)
+        for i := 0; i < n; i++ {
+            arr[i] = i + 1
+            arr[i+n] = i + 1
+        }
+        rand.Shuffle(2*n, func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+        var sb strings.Builder
+        sb.WriteString(fmt.Sprint(n))
+        sb.WriteByte('\n')
+        for i, v := range arr {
+            if i > 0 {
+                sb.WriteByte(' ')
+            }
+            sb.WriteString(fmt.Sprint(v))
+        }
+        sb.WriteByte('\n')
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected: %s\nGot: %s\n", i+1, t.input, strings.TrimSpace(t.expected), got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+

--- a/1000-1999/1100-1199/1130-1139/1130/verifierC.go
+++ b/1000-1999/1100-1199/1130-1139/1130/verifierC.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+    "bytes"
+    "container/list"
+    "fmt"
+    "math/rand"
+    "os"
+    "os/exec"
+    "strconv"
+    "strings"
+)
+
+func bfs(start [2]int, grid [][]byte) ([][2]int, map[[2]int]bool) {
+    n := len(grid)
+    visited := make(map[[2]int]bool)
+    q := list.New()
+    q.PushBack(start)
+    visited[start] = true
+    var comp [][2]int
+    dirs := [][2]int{{1,0},{-1,0},{0,1},{0,-1}}
+    for q.Len() > 0 {
+        e := q.Front()
+        q.Remove(e)
+        p := e.Value.([2]int)
+        comp = append(comp, p)
+        for _, d := range dirs {
+            nx, ny := p[0]+d[0], p[1]+d[1]
+            if nx<0 || nx>=n || ny<0 || ny>=n {continue}
+            if visited[[2]int{nx,ny}] {continue}
+            if grid[nx][ny] == '1' {continue}
+            visited[[2]int{nx,ny}] = true
+            q.PushBack([2]int{nx,ny})
+        }
+    }
+    return comp, visited
+}
+
+func solve(input string) string {
+    reader := strings.NewReader(strings.TrimSpace(input))
+    var n int
+    fmt.Fscan(reader, &n)
+    var sx, sy, ex, ey int
+    fmt.Fscan(reader, &sx, &sy)
+    fmt.Fscan(reader, &ex, &ey)
+    sx--; sy--; ex--; ey--
+    grid := make([][]byte, n)
+    for i := 0; i < n; i++ {
+        var row string
+        fmt.Fscan(reader, &row)
+        grid[i] = []byte(row)
+    }
+    comp1, vis1 := bfs([2]int{sx, sy}, grid)
+    if vis1[[2]int{ex, ey}] {
+        return "0"
+    }
+    comp2, _ := bfs([2]int{ex, ey}, grid)
+    ans := 1<<60
+    for _, a := range comp1 {
+        for _, b := range comp2 {
+            dx := a[0]-b[0]
+            dy := a[1]-b[1]
+            d := dx*dx + dy*dy
+            if d < ans {
+                ans = d
+            }
+        }
+    }
+    return strconv.Itoa(ans)
+}
+
+type test struct{ input, expected string }
+
+func randGrid(n int) (grid []string, sx, sy, ex, ey int) {
+    for {
+        grid = make([]string, n)
+        for i := 0; i < n; i++ {
+            var sb strings.Builder
+            for j := 0; j < n; j++ {
+                if rand.Intn(4) == 0 {
+                    sb.WriteByte('1')
+                } else {
+                    sb.WriteByte('0')
+                }
+            }
+            grid[i] = sb.String()
+        }
+        sx, sy = rand.Intn(n), rand.Intn(n)
+        ex, ey = rand.Intn(n), rand.Intn(n)
+        if grid[sx][sy]=='0' && grid[ex][ey]=='0' {
+            break
+        }
+    }
+    return
+}
+
+func generateTests() []test {
+    rand.Seed(1130)
+    var tests []test
+    for len(tests) < 5 {
+        n := len(tests) + 1
+        grid, sx, sy, ex, ey := randGrid(n)
+        var sb strings.Builder
+        fmt.Fprintf(&sb, "%d\n%d %d\n%d %d\n", n, sx+1, sy+1, ex+1, ey+1)
+        for _, row := range grid {
+            fmt.Fprintln(&sb, row)
+        }
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    for len(tests) < 100 {
+        n := rand.Intn(6) + 1
+        grid, sx, sy, ex, ey := randGrid(n)
+        var sb strings.Builder
+        fmt.Fprintf(&sb, "%d\n%d %d\n%d %d\n", n, sx+1, sy+1, ex+1, ey+1)
+        for _, row := range grid {
+            fmt.Fprintln(&sb, row)
+        }
+        inp := sb.String()
+        tests = append(tests, test{inp, solve(inp)})
+    }
+    return tests
+}
+
+func runBinary(bin, input string) (string, error) {
+    cmd := exec.Command(bin)
+    cmd.Stdin = strings.NewReader(input)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &out
+    err := cmd.Run()
+    return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+    if len(os.Args) != 2 {
+        fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+        os.Exit(1)
+    }
+    bin := os.Args[1]
+    tests := generateTests()
+    for i, t := range tests {
+        got, err := runBinary(bin, t.input)
+        if err != nil {
+            fmt.Printf("Runtime error on test %d: %v\n", i+1, err)
+            os.Exit(1)
+        }
+        if got != strings.TrimSpace(t.expected) {
+            fmt.Printf("Wrong answer on test %d\nInput:\n%sExpected: %s\nGot: %s\n", i+1, t.input, strings.TrimSpace(t.expected), got)
+            os.Exit(1)
+        }
+    }
+    fmt.Printf("All %d tests passed.\n", len(tests))
+}
+


### PR DESCRIPTION
## Summary
- implement solution verifiers for contest 1130 problems A–C
- generate 100 deterministic tests for each verifier
- validate problem A answers allowing any correct `d`

## Testing
- `go run 1000-1999/1100-1199/1130-1139/1130/verifierA.go 1000-1999/1100-1199/1130-1139/1130/1130A.bin`
- `go run 1000-1999/1100-1199/1130-1139/1130/verifierB.go 1000-1999/1100-1199/1130-1139/1130/1130B.bin`
- `go run 1000-1999/1100-1199/1130-1139/1130/verifierC.go 1000-1999/1100-1199/1130-1139/1130/1130C.bin`


------
https://chatgpt.com/codex/tasks/task_e_68848e8bab548324acfe52f30260719a