### PR TITLE
Add verifiers for contest 1131

### DIFF
--- a/1000-1999/1100-1199/1130-1139/1131/verifierA.go
+++ b/1000-1999/1100-1199/1130-1139/1131/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	w1, h1, w2, h2 int
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1131A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{1, 1, 1, 1}}
+	for len(cases) < 100 {
+		w1 := rng.Intn(100) + 1
+		w2 := rng.Intn(w1) + 1
+		h1 := rng.Intn(100) + 1
+		h2 := rng.Intn(100) + 1
+		cases = append(cases, testCase{w1, h1, w2, h2})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	input := fmt.Sprintf("%d %d %d %d\n", tc.w1, tc.h1, tc.w2, tc.h2)
+	expect, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1131/verifierB.go
+++ b/1000-1999/1100-1199/1130-1139/1131/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type pair struct{ a, b int64 }
+type testCase struct {
+	pairs []pair
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1131B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 100)
+	// simple case
+	cases = append(cases, testCase{pairs: []pair{{0, 0}}})
+	for len(cases) < 100 {
+		n := rng.Intn(10) + 1
+		p := make([]pair, n)
+		var a, b int64
+		for i := 0; i < n; i++ {
+			a += int64(rng.Intn(3))
+			b += int64(rng.Intn(3))
+			p[i] = pair{a, b}
+		}
+		cases = append(cases, testCase{pairs: p})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(tc.pairs))
+	for _, pr := range tc.pairs {
+		fmt.Fprintf(&sb, "%d %d\n", pr.a, pr.b)
+	}
+	input := sb.String()
+	expect, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1131/verifierC.go
+++ b/1000-1999/1100-1199/1130-1139/1131/verifierC.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	vals []int
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1131C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{vals: []int{1, 2}}}
+	for len(cases) < 100 {
+		n := rng.Intn(10) + 2
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			arr[i] = rng.Intn(100) + 1
+		}
+		cases = append(cases, testCase{vals: arr})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(tc.vals))
+	for i, v := range tc.vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expect, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1131/verifierD.go
+++ b/1000-1999/1100-1199/1130-1139/1131/verifierD.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m int
+	rows []string
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1131D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 100)
+	cases = append(cases, testCase{n: 1, m: 1, rows: []string{"="}})
+	for len(cases) < 100 {
+		n := rng.Intn(4) + 1
+		m := rng.Intn(4) + 1
+		rows := make([]string, n)
+		for i := 0; i < n; i++ {
+			var sb strings.Builder
+			for j := 0; j < m; j++ {
+				v := rng.Intn(3)
+				switch v {
+				case 0:
+					sb.WriteByte('>')
+				case 1:
+					sb.WriteByte('<')
+				default:
+					sb.WriteByte('=')
+				}
+			}
+			rows[i] = sb.String()
+		}
+		cases = append(cases, testCase{n: n, m: m, rows: rows})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", tc.n, tc.m)
+	for _, r := range tc.rows {
+		sb.WriteString(r)
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	expect, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1131/verifierE.go
+++ b/1000-1999/1100-1199/1130-1139/1131/verifierE.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	strs []string
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1131E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{strs: []string{"a"}}}
+	for len(cases) < 100 {
+		n := rng.Intn(5) + 1
+		arr := make([]string, n)
+		for i := 0; i < n; i++ {
+			l := rng.Intn(6) + 1
+			var sb strings.Builder
+			for j := 0; j < l; j++ {
+				sb.WriteByte(byte('a' + rng.Intn(3)))
+			}
+			arr[i] = sb.String()
+		}
+		cases = append(cases, testCase{strs: arr})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", len(tc.strs))
+	for _, s := range tc.strs {
+		sb.WriteString(s)
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	expect, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1131/verifierF.go
+++ b/1000-1999/1100-1199/1130-1139/1131/verifierF.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+type testCase struct {
+	n     int
+	edges []edge
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1131F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []testCase{{n: 1}}
+	for len(cases) < 100 {
+		n := rng.Intn(10) + 1
+		var edges []edge
+		for i := 2; i <= n; i++ {
+			p := rng.Intn(i-1) + 1
+			edges = append(edges, edge{p, i})
+		}
+		cases = append(cases, testCase{n: n, edges: edges})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", tc.n)
+	for _, e := range tc.edges {
+		fmt.Fprintf(&sb, "%d %d\n", e.u, e.v)
+	}
+	input := sb.String()
+	expect, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1131/verifierG.go
+++ b/1000-1999/1100-1199/1130-1139/1131/verifierG.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type block struct {
+	hs []int
+	cs []int64
+}
+type query struct{ id, mul int }
+type testCase struct {
+	blocks  []block
+	queries []query
+}
+
+func buildRef() (string, error) {
+	ref := "./refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1131G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCases() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := make([]testCase, 0, 100)
+	// simple single block single query
+	cases = append(cases, testCase{blocks: []block{{hs: []int{1}, cs: []int64{1}}}, queries: []query{{id: 1, mul: 1}}})
+	for len(cases) < 100 {
+		B := rng.Intn(3) + 1
+		blocks := make([]block, B)
+		for i := 0; i < B; i++ {
+			L := rng.Intn(3) + 1
+			hs := make([]int, L)
+			cs := make([]int64, L)
+			for j := 0; j < L; j++ {
+				hs[j] = rng.Intn(3) + 1
+			}
+			for j := 0; j < L; j++ {
+				cs[j] = int64(rng.Intn(5) + 1)
+			}
+			blocks[i] = block{hs: hs, cs: cs}
+		}
+		q := rng.Intn(3) + 1
+		queries := make([]query, q)
+		for i := 0; i < q; i++ {
+			id := rng.Intn(B) + 1
+			mul := rng.Intn(3) + 1
+			queries[i] = query{id: id, mul: mul}
+		}
+		cases = append(cases, testCase{blocks: blocks, queries: queries})
+	}
+	return cases
+}
+
+func runCase(bin, ref string, tc testCase) error {
+	// compute n as total lengths
+	n := 0
+	for _, q := range tc.queries {
+		b := tc.blocks[q.id-1]
+		n += len(b.hs)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", len(tc.blocks), n)
+	for _, b := range tc.blocks {
+		fmt.Fprintf(&sb, "%d\n", len(b.hs))
+		for i, v := range b.hs {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		for i, v := range b.cs {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+	}
+	fmt.Fprintf(&sb, "%d\n", len(tc.queries))
+	for _, q := range tc.queries {
+		fmt.Fprintf(&sb, "%d %d\n", q.id, q.mul)
+	}
+	input := sb.String()
+	expect, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	cases := genCases()
+	for i, tc := range cases {
+		if err := runCase(bin, ref, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for contest 1131 problems A–G
- verifiers compile a reference solution and compare outputs on 100+ randomized test cases

## Testing
- `go run verifierA.go /tmp/binA`

------
https://chatgpt.com/codex/tasks/task_e_68848f17bc8883248b4e0cb9ef175f56