### PR TITLE
Fix contest 747 verifier output

### DIFF
--- a/0-999/700-799/740-749/747/verifierA.go
+++ b/0-999/700-799/740-749/747/verifierA.go
@@ -51,5 +51,5 @@ func main() {
 			return
 		}
 	}
-	fmt.Println("OK")
+	fmt.Println("All tests passed")
 }

--- a/0-999/700-799/740-749/747/verifierB.go
+++ b/0-999/700-799/740-749/747/verifierB.go
@@ -95,5 +95,5 @@ func main() {
 		}
 		time.Sleep(0) // yield for determinism
 	}
-	fmt.Println("OK")
+	fmt.Println("All tests passed")
 }

--- a/0-999/700-799/740-749/747/verifierC.go
+++ b/0-999/700-799/740-749/747/verifierC.go
@@ -120,5 +120,5 @@ func main() {
 			return
 		}
 	}
-	fmt.Println("OK")
+	fmt.Println("All tests passed")
 }

--- a/0-999/700-799/740-749/747/verifierD.go
+++ b/0-999/700-799/740-749/747/verifierD.go
@@ -119,5 +119,5 @@ func main() {
 			return
 		}
 	}
-	fmt.Println("OK")
+	fmt.Println("All tests passed")
 }

--- a/0-999/700-799/740-749/747/verifierE.go
+++ b/0-999/700-799/740-749/747/verifierE.go
@@ -134,5 +134,5 @@ func main() {
 			return
 		}
 	}
-	fmt.Println("OK")
+	fmt.Println("All tests passed")
 }

--- a/0-999/700-799/740-749/747/verifierF.go
+++ b/0-999/700-799/740-749/747/verifierF.go
@@ -118,5 +118,5 @@ func main() {
 			return
 		}
 	}
-	fmt.Println("OK")
+	fmt.Println("All tests passed")
 }


### PR DESCRIPTION
## Summary
- update all contest 747 verifiers to print `All tests passed` instead of `OK`

## Testing
- `go build 0-999/700-799/740-749/747/verifierA.go`

------
https://chatgpt.com/codex/tasks/task_e_68849054b1b4832496917cb51e3356ac