### PR TITLE
Fix verifierD build and execution

### DIFF
--- a/1000-1999/1000-1099/1090-1099/1093/verifierD.go
+++ b/1000-1999/1000-1099/1090-1099/1093/verifierD.go
@@ -6,12 +6,14 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"time"
 )
 
 func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
 	cmd := exec.Command(path)
 	if strings.HasSuffix(path, ".go") {
 		cmd = exec.Command("go", "run", path)


### PR DESCRIPTION
## Summary
- remove unused `strconv` import
- ensure local binaries are executed correctly by prefixing `./`

## Testing
- `go run verifierD.go ./candidate`

------
https://chatgpt.com/codex/tasks/task_e_68848f8f36d083249a3951bbf7674501