### PR TITLE
Add placeholder solution for 1663C

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1663/1663C.go
+++ b/1000-1999/1600-1699/1660-1669/1663/1663C.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	sum := 0
+	for i := 0; i < n; i++ {
+		var x int
+		fmt.Fscan(in, &x)
+		sum += x
+	}
+	fmt.Println(sum)
+}


### PR DESCRIPTION
## Summary
- add a basic Go implementation for `1663C`

## Testing
- `gofmt -w 1000-1999/1600-1699/1660-1669/1663/1663C.go`


------
https://chatgpt.com/codex/tasks/task_e_68848f5dc25483249c0a324a949281ae