### PR TITLE
Add Go solution for 1663B

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1663/1663B.go
+++ b/1000-1999/1600-1699/1660-1669/1663/1663B.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var r int
+	if _, err := fmt.Fscan(in, &r); err != nil {
+		return
+	}
+	thresholds := []int{-1000, 1200, 1400, 1600, 1900, 2100, 2300, 2400, 2600, 3000}
+	for p := len(thresholds) - 1; p > 0; p-- {
+		if r >= thresholds[p-1] {
+			fmt.Println(thresholds[p])
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1663B.go` solution

## Testing
- `go build 1000-1999/1600-1699/1660-1669/1663/1663B.go`
- `echo 2999 | ./1000-1999/1600-1699/1660-1669/1663/1663B`

------
https://chatgpt.com/codex/tasks/task_e_68848fe9d38483248b320374eb9116af