### PR TITLE
Add Go verifiers for Codeforces 1132

### DIFF
--- a/1000-1999/1100-1199/1130-1139/1132/verifierA.go
+++ b/1000-1999/1100-1199/1130-1139/1132/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseA struct {
+	n1, n2, n3, n4 int
+}
+
+func genTestsA() []testCaseA {
+	rand.Seed(113201)
+	tests := make([]testCaseA, 100)
+	for i := range tests {
+		tests[i] = testCaseA{
+			n1: rand.Intn(6),
+			n2: rand.Intn(6),
+			n3: rand.Intn(6),
+			n4: rand.Intn(6),
+		}
+	}
+	return tests
+}
+
+func solveA(tc testCaseA) int {
+	if tc.n1 != tc.n4 {
+		return 0
+	}
+	if tc.n1 == 0 {
+		if tc.n3 != 0 {
+			return 0
+		}
+		return 1
+	}
+	return 1
+}
+
+func run(bin string, in []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+	for idx, tc := range tests {
+		input := fmt.Sprintf("%d %d %d %d\n", tc.n1, tc.n2, tc.n3, tc.n4)
+		out, err := run(bin, []byte(input))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", idx+1, err, string(out))
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		scanner.Split(bufio.ScanWords)
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "no output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		expected := solveA(tc)
+		if val != expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", idx+1, expected, val)
+			os.Exit(1)
+		}
+		if scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "extra output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1100-1199/1130-1139/1132/verifierB.go
+++ b/1000-1999/1100-1199/1130-1139/1132/verifierB.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+)
+
+type testCaseB struct {
+	a       []int64
+	queries []int
+}
+
+func genTestsB() []testCaseB {
+	rand.Seed(113202)
+	tests := make([]testCaseB, 100)
+	for i := range tests {
+		n := rand.Intn(5) + 1
+		a := make([]int64, n)
+		for j := range a {
+			a[j] = int64(rand.Intn(20)) + 1
+		}
+		m := rand.Intn(n) + 1
+		q := make([]int, m)
+		for j := range q {
+			q[j] = rand.Intn(n) + 1
+		}
+		tests[i] = testCaseB{a: a, queries: q}
+	}
+	return tests
+}
+
+func solveB(tc testCaseB) []int64 {
+	n := len(tc.a)
+	arr := make([]int64, n)
+	copy(arr, tc.a)
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	sum := int64(0)
+	for _, v := range arr {
+		sum += v
+	}
+	res := make([]int64, len(tc.queries))
+	for i, t := range tc.queries {
+		idx := n - t
+		res[i] = sum - arr[idx]
+	}
+	return res
+}
+
+func run(bin string, in []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+	for idx, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintln(&input, len(tc.a))
+		for i, v := range tc.a {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		fmt.Fprintln(&input, len(tc.queries))
+		for _, q := range tc.queries {
+			fmt.Fprintln(&input, q)
+		}
+		out, err := run(bin, input.Bytes())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", idx+1, err, string(out))
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		scanner.Split(bufio.ScanWords)
+		expected := solveB(tc)
+		for _, exp := range expected {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", idx+1)
+				os.Exit(1)
+			}
+			val, err := strconv.ParseInt(scanner.Text(), 10, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", idx+1)
+				os.Exit(1)
+			}
+			if val != exp {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", idx+1, exp, val)
+				os.Exit(1)
+			}
+		}
+		if scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "extra output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1100-1199/1130-1139/1132/verifierC.go
+++ b/1000-1999/1100-1199/1130-1139/1132/verifierC.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type interval struct{ l, r int }
+
+type testCaseC struct {
+	n   int
+	seg []interval
+}
+
+func genTestsC() []testCaseC {
+	rand.Seed(113203)
+	tests := make([]testCaseC, 100)
+	for i := range tests {
+		n := rand.Intn(8) + 2
+		q := rand.Intn(4) + 2
+		seg := make([]interval, q)
+		for j := range seg {
+			l := rand.Intn(n) + 1
+			r := rand.Intn(n-l+1) + l
+			seg[j] = interval{l, r}
+		}
+		tests[i] = testCaseC{n: n, seg: seg}
+	}
+	return tests
+}
+
+func solveC(tc testCaseC) int {
+	n := tc.n
+	q := len(tc.seg)
+	cov := make([]int, n+1)
+	for _, iv := range tc.seg {
+		for x := iv.l; x <= iv.r; x++ {
+			cov[x]++
+		}
+	}
+	ans := 0
+	for i := 0; i < q; i++ {
+		for j := i + 1; j < q; j++ {
+			cnt := 0
+			for x := 1; x <= n; x++ {
+				c := cov[x]
+				if x >= tc.seg[i].l && x <= tc.seg[i].r {
+					c--
+				}
+				if x >= tc.seg[j].l && x <= tc.seg[j].r {
+					c--
+				}
+				if c > 0 {
+					cnt++
+				}
+			}
+			if cnt > ans {
+				ans = cnt
+			}
+		}
+	}
+	return ans
+}
+
+func run(bin string, in []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+	for idx, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", tc.n, len(tc.seg))
+		for _, iv := range tc.seg {
+			fmt.Fprintf(&input, "%d %d\n", iv.l, iv.r)
+		}
+		out, err := run(bin, input.Bytes())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", idx+1, err, string(out))
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		scanner.Split(bufio.ScanWords)
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "no output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		expected := solveC(tc)
+		if val != expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", idx+1, expected, val)
+			os.Exit(1)
+		}
+		if scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "extra output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1100-1199/1130-1139/1132/verifierD.go
+++ b/1000-1999/1100-1199/1130-1139/1132/verifierD.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseD struct {
+	n int
+	k int
+	a []int64
+	b []int64
+}
+
+func genTestsD() []testCaseD {
+	rand.Seed(113204)
+	tests := make([]testCaseD, 100)
+	for i := range tests {
+		n := rand.Intn(3) + 1
+		k := rand.Intn(4) + 1
+		a := make([]int64, n)
+		b := make([]int64, n)
+		for j := 0; j < n; j++ {
+			a[j] = int64(rand.Intn(20) + 1)
+			b[j] = int64(rand.Intn(10) + 1)
+		}
+		tests[i] = testCaseD{n: n, k: k, a: a, b: b}
+	}
+	return tests
+}
+
+func solveD(tc testCaseD) int64 {
+	N := tc.n
+	K := tc.k - 1
+	A := make([]int64, N)
+	B := make([]int64, N)
+	copy(A, tc.a)
+	copy(B, tc.b)
+	cand := make([]int, K+1)
+	var hoge func(v int64) bool
+	hoge = func(v int64) bool {
+		var num int64
+		for i := 0; i < N; i++ {
+			x := A[i] - int64(K)*B[i]
+			if x < 0 {
+				if v == 0 {
+					return false
+				}
+				x = -x
+				num += (x + v - 1) / v
+				if num > int64(K) {
+					return false
+				}
+			}
+		}
+		for i := 0; i <= K; i++ {
+			cand[i] = 0
+		}
+		for i := 0; i < N; i++ {
+			cur := A[i]
+			for cur-B[i]*int64(K) < 0 {
+				ng := int(cur/B[i] + 1)
+				if ng > K {
+					break
+				}
+				cand[ng]++
+				cur += v
+			}
+		}
+		sum := 0
+		for i := 1; i <= K; i++ {
+			sum += cand[i]
+			if sum > i {
+				return false
+			}
+		}
+		return true
+	}
+	ret := int64((1 << 20))
+	if !hoge(ret) {
+		return -1
+	}
+	for d := ret; d > 0; d >>= 1 {
+		for ret-d >= 0 && hoge(ret-d) {
+			ret -= d
+		}
+	}
+	return ret
+}
+
+func run(bin string, in []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+	for idx, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		for i, v := range tc.a {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		for i, v := range tc.b {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		out, err := run(bin, input.Bytes())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", idx+1, err, string(out))
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		scanner.Split(bufio.ScanWords)
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "no output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(scanner.Text(), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		expected := solveD(tc)
+		if val != expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", idx+1, expected, val)
+			os.Exit(1)
+		}
+		if scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "extra output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1100-1199/1130-1139/1132/verifierE.go
+++ b/1000-1999/1100-1199/1130-1139/1132/verifierE.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseE struct {
+	W   int64
+	cnt [9]int64
+}
+
+func genTestsE() []testCaseE {
+	rand.Seed(113205)
+	tests := make([]testCaseE, 100)
+	for i := range tests {
+		W := int64(rand.Intn(50) + 1)
+		var cnt [9]int64
+		for j := 1; j <= 8; j++ {
+			cnt[j] = int64(rand.Intn(5))
+		}
+		tests[i] = testCaseE{W: W, cnt: cnt}
+	}
+	return tests
+}
+
+func solveE(tc testCaseE) int64 {
+	targetW := tc.W
+	cnt := tc.cnt
+	var sum int64
+	for i := 1; i <= 8; i++ {
+		sum += cnt[i] * int64(i)
+	}
+	if sum <= targetW {
+		return sum
+	}
+	var now int64
+	var cnt2 [9]int64
+	for i := 1; i <= 8; i++ {
+		w := int64(i)
+		if now+w*cnt[i] <= targetW {
+			now += w * cnt[i]
+			cnt2[i] = cnt[i]
+			cnt[i] = 0
+		} else {
+			v := (targetW - now) / w
+			if v < 0 {
+				v = 0
+			}
+			now += w * v
+			cnt[i] -= v
+			cnt2[i] += v
+		}
+	}
+	const AA = 1000
+	var dp [2001]bool
+	dp[AA] = true
+	for v := 1; v <= 8; v++ {
+		times := cnt[v]
+		if times > 100 {
+			times = 100
+		}
+		for j := int64(0); j < times; j++ {
+			for k := 900; k >= -900; k-- {
+				if dp[k+AA] {
+					dp[k+v+AA] = true
+				}
+			}
+		}
+		times2 := cnt2[v]
+		if times2 > 100 {
+			times2 = 100
+		}
+		for j := int64(0); j < times2; j++ {
+			for k := -900; k <= 900; k++ {
+				if dp[k+AA] {
+					dp[k-int(v)+AA] = true
+				}
+			}
+		}
+	}
+	var ans int64
+	maxR := targetW - now
+	if maxR < 0 {
+		maxR = 0
+	}
+	if maxR > 2000 {
+		maxR = 2000
+	}
+	for i := int64(0); i <= maxR; i++ {
+		if dp[int(i)+AA] {
+			ans = now + i
+		}
+	}
+	return ans
+}
+
+func run(bin string, in []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+	for idx, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintln(&input, tc.W)
+		for i := 1; i <= 8; i++ {
+			if i > 1 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, tc.cnt[i])
+		}
+		input.WriteByte('\n')
+		out, err := run(bin, input.Bytes())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", idx+1, err, string(out))
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		scanner.Split(bufio.ScanWords)
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "no output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(scanner.Text(), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		expected := solveE(tc)
+		if val != expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", idx+1, expected, val)
+			os.Exit(1)
+		}
+		if scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "extra output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1100-1199/1130-1139/1132/verifierF.go
+++ b/1000-1999/1100-1199/1130-1139/1132/verifierF.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseF struct {
+	s string
+}
+
+func genTestsF() []testCaseF {
+	rand.Seed(113206)
+	tests := make([]testCaseF, 100)
+	letters := []byte{'a', 'b', 'c'}
+	for i := range tests {
+		n := rand.Intn(8) + 1
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = letters[rand.Intn(len(letters))]
+		}
+		tests[i] = testCaseF{s: string(b)}
+	}
+	return tests
+}
+
+func solveF(tc testCaseF) int {
+	s := []byte(tc.s)
+	seq := []byte{}
+	for i := 0; i < len(s); i++ {
+		if len(seq) == 0 || seq[len(seq)-1] != s[i] {
+			seq = append(seq, s[i])
+		}
+	}
+	s = seq
+	n := len(s)
+	if n == 0 {
+		return 0
+	}
+	const inf = int(1e9)
+	dp := make([][]int, n)
+	for i := range dp {
+		dp[i] = make([]int, n)
+		for j := range dp[i] {
+			dp[i][j] = inf
+		}
+		dp[i][i] = 1
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := i + 1; j < n; j++ {
+			dp[i][j] = dp[i+1][j] + 1
+			for k := i + 1; k <= j; k++ {
+				if s[i] == s[k] {
+					cost := dp[k][j]
+					if k > i+1 {
+						cost += dp[i+1][k-1]
+					}
+					if cost < dp[i][j] {
+						dp[i][j] = cost
+					}
+				}
+			}
+		}
+	}
+	return dp[0][n-1]
+}
+
+func run(bin string, in []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsF()
+	for idx, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintln(&input, len(tc.s))
+		fmt.Fprintln(&input, tc.s)
+		out, err := run(bin, input.Bytes())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", idx+1, err, string(out))
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		scanner.Split(bufio.ScanWords)
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "no output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+		expected := solveF(tc)
+		if val != expected {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected %d got %d\n", idx+1, expected, val)
+			os.Exit(1)
+		}
+		if scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "extra output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1100-1199/1130-1139/1132/verifierG.go
+++ b/1000-1999/1100-1199/1130-1139/1132/verifierG.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testCaseG struct {
+	n int
+	k int
+	a []int
+}
+
+func genTestsG() []testCaseG {
+	rand.Seed(113207)
+	tests := make([]testCaseG, 100)
+	for i := range tests {
+		n := rand.Intn(8) + 2
+		k := rand.Intn(n) + 1
+		a := make([]int, n)
+		for j := range a {
+			a[j] = rand.Intn(n) + 1
+		}
+		tests[i] = testCaseG{n: n, k: k, a: a}
+	}
+	return tests
+}
+
+type DSU struct {
+	p  []int
+	ld []int
+	lb []int
+}
+
+func (d *DSU) init(n int) {
+	d.p = make([]int, n)
+	d.ld = make([]int, n)
+	d.lb = make([]int, n)
+	for i := 0; i < n; i++ {
+		d.p[i] = i
+		d.lb[i] = i
+	}
+}
+
+func (d *DSU) find(x int) int {
+	for d.p[x] != x {
+		d.p[x] = d.p[d.p[x]]
+		x = d.p[x]
+	}
+	return x
+}
+
+func (d *DSU) join(x, y int) {
+	x = d.find(x)
+	y = d.find(y)
+	if x == y {
+		return
+	}
+	d.p[x] = y
+	d.lb[y] = d.lb[x]
+	d.ld[y] += d.ld[x]
+}
+
+func (d *DSU) upd(i, j int) {
+	n := len(d.ld)
+	i = d.find(i)
+	d.ld[i]++
+	if j < n {
+		d.ld[j]--
+	}
+	for {
+		root := d.find(i)
+		if d.ld[root] < 0 || d.lb[root] == 0 {
+			break
+		}
+		left := d.lb[root] - 1
+		d.join(left, root)
+	}
+}
+
+func (d *DSU) upd2(i, k int) {
+	if i < k {
+		return
+	}
+	j := d.find(i - k + 1)
+	for d.lb[j] > i-k {
+		left := d.lb[j] - 1
+		d.join(left, j)
+	}
+}
+
+func (d *DSU) qry() int {
+	return d.ld[d.find(0)]
+}
+
+func solveG(tc testCaseG) []int {
+	n, k := tc.n, tc.k
+	a := tc.a
+	var d DSU
+	d.init(n)
+	l := make([]int, n)
+	res := make([]int, n-k+1)
+	for i := 0; i < n; i++ {
+		d.upd2(i, k)
+		if i == 0 {
+			l[i] = -1
+		} else {
+			l[i] = i - 1
+			for l[i] >= 0 && a[l[i]] < a[i] {
+				l[i] = l[l[i]]
+			}
+		}
+		d.upd(l[i]+1, i+1)
+		if i >= k-1 {
+			res[i-k+1] = d.qry()
+		}
+	}
+	return res
+}
+
+func run(bin string, in []byte) ([]byte, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.Bytes(), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsG()
+	for idx, tc := range tests {
+		var input bytes.Buffer
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		for i, v := range tc.a {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+		out, err := run(bin, input.Bytes())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\noutput:\n%s\n", idx+1, err, string(out))
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		scanner.Split(bufio.ScanWords)
+		expected := solveG(tc)
+		for _, exp := range expected {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", idx+1)
+				os.Exit(1)
+			}
+			val, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", idx+1)
+				os.Exit(1)
+			}
+			if val != exp {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", idx+1)
+				os.Exit(1)
+			}
+		}
+		if scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "extra output on test %d\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1132 problems A–G
- each verifier generates 100 random tests and checks a candidate binary

## Testing
- `go build 1000-1999/1100-1199/1130-1139/1132/verifierA.go`
- `go build 1000-1999/1100-1199/1130-1139/1132/verifierB.go`
- `go build 1000-1999/1100-1199/1130-1139/1132/verifierC.go`
- `go build 1000-1999/1100-1199/1130-1139/1132/verifierD.go`
- `go build 1000-1999/1100-1199/1130-1139/1132/verifierE.go`
- `go build 1000-1999/1100-1199/1130-1139/1132/verifierF.go`
- `go build 1000-1999/1100-1199/1130-1139/1132/verifierG.go`

------
https://chatgpt.com/codex/tasks/task_e_68848fa3e7b883248e542171fbbd6844