### PR TITLE
Add Go verifiers for contest 1133

### DIFF
--- a/1000-1999/1100-1199/1130-1139/1133/verifierA.go
+++ b/1000-1999/1100-1199/1130-1139/1133/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(h1, m1, h2, m2 int) string {
+	t1 := h1*60 + m1
+	t2 := h2*60 + m2
+	mid := (t1 + t2) / 2
+	return fmt.Sprintf("%02d:%02d", mid/60, mid%60)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	start := rng.Intn(24*60 - 2)
+	length := rng.Intn(60)*2 + 2
+	if start+length >= 24*60 {
+		length = (24*60 - start - 2) / 2 * 2
+		if length < 2 {
+			length = 2
+		}
+	}
+	end := start + length
+	h1, m1 := start/60, start%60
+	h2, m2 := end/60, end%60
+	input := fmt.Sprintf("%02d:%02d\n%02d:%02d\n", h1, m1, h2, m2)
+	return input, solve(h1, m1, h2, m2)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1133/verifierB.go
+++ b/1000-1999/1100-1199/1130-1139/1133/verifierB.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveB(n, k int, arr []int) int {
+	buckets := make([]int, k)
+	for _, v := range arr {
+		r := v % k
+		if r < 0 {
+			r += k
+		}
+		buckets[r]++
+	}
+	ans := 0
+	for i := 1; i <= k/2; i++ {
+		if i == k-i {
+			ans += (buckets[i] / 2) * 2
+		} else {
+			if buckets[i] < buckets[k-i] {
+				ans += buckets[i] * 2
+			} else {
+				ans += buckets[k-i] * 2
+			}
+		}
+	}
+	ans += (buckets[0] / 2) * 2
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(8) + 2
+	k := rng.Intn(9) + 2
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(1000) - 500
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveB(n, k, arr)
+}
+
+func run(bin, input string) (int, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return 0, fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	val, err := strconv.Atoi(strings.TrimSpace(out.String()))
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer output: %v", err)
+	}
+	return val, nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch: expected %d got %d\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1133/verifierC.go
+++ b/1000-1999/1100-1199/1130-1139/1133/verifierC.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveC(arr []int) int {
+	sort.Ints(arr)
+	left := 0
+	best := 1
+	for i := 1; i < len(arr); i++ {
+		for arr[i]-arr[left] > 5 {
+			left++
+		}
+		if cur := i - left + 1; cur > best {
+			best = cur
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(8) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(30)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveC(arr)
+}
+
+func run(bin, input string) (int, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return 0, fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	val, err := strconv.Atoi(strings.TrimSpace(out.String()))
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer output: %v", err)
+	}
+	return val, nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch: expected %d got %d\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1133/verifierD.go
+++ b/1000-1999/1100-1199/1130-1139/1133/verifierD.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func solveD(a, b []int64) int {
+	counts := make(map[[2]int64]int)
+	alwaysZero := 0
+	for i := range a {
+		ai, bi := a[i], b[i]
+		if ai == 0 {
+			if bi == 0 {
+				alwaysZero++
+			}
+			continue
+		}
+		num := -bi
+		den := ai
+		if den < 0 {
+			den = -den
+			num = -num
+		}
+		if num == 0 {
+			den = 1
+		} else {
+			g := gcd(num, den)
+			num /= g
+			den /= g
+		}
+		key := [2]int64{num, den}
+		counts[key]++
+	}
+	maxCount := 0
+	for _, v := range counts {
+		if v > maxCount {
+			maxCount = v
+		}
+	}
+	return alwaysZero + maxCount
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(7) + 1
+	a := make([]int64, n)
+	b := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(21) - 10)
+		b[i] = int64(rng.Intn(21) - 10)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.FormatInt(v, 10))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveD(a, b)
+}
+
+func run(bin, input string) (int, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return 0, fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	val, err := strconv.Atoi(strings.TrimSpace(out.String()))
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer output: %v", err)
+	}
+	return val, nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch: expected %d got %d\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1133/verifierE.go
+++ b/1000-1999/1100-1199/1130-1139/1133/verifierE.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solveE(n, k int, arr []int) int {
+	sort.Ints(arr)
+	best := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		for j := i; j >= 1; j-- {
+			if arr[i-1]-arr[j-1] > 5 {
+				break
+			}
+			best[i] = j
+		}
+	}
+	dp := make([][]int, n+1)
+	for i := range dp {
+		dp[i] = make([]int, k+1)
+	}
+	for i := 1; i <= n; i++ {
+		copy(dp[i], dp[i-1])
+		l := best[i]
+		sz := i - l + 1
+		if dp[i][1] < sz {
+			dp[i][1] = sz
+		}
+		for j := 2; j <= k; j++ {
+			if dp[l-1][j-1]+sz > dp[i][j] {
+				dp[i][j] = dp[l-1][j-1] + sz
+			}
+		}
+	}
+	ans := 0
+	for j := 1; j <= k; j++ {
+		if dp[n][j] > ans {
+			ans = dp[n][j]
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(n) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(30)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solveE(n, k, arr)
+}
+
+func run(bin, input string) (int, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return 0, fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	val, err := strconv.Atoi(strings.TrimSpace(out.String()))
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer output: %v", err)
+	}
+	return val, nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch: expected %d got %d\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1133/verifierF1.go
+++ b/1000-1999/1100-1199/1130-1139/1133/verifierF1.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	p []int
+}
+
+func NewDSU(n int) *DSU {
+	d := &DSU{p: make([]int, n+1)}
+	for i := 1; i <= n; i++ {
+		d.p[i] = i
+	}
+	return d
+}
+
+func (d *DSU) Find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.Find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *DSU) Union(a, b int) {
+	fa := d.Find(a)
+	fb := d.Find(b)
+	if fa != fb {
+		d.p[fa] = fb
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, int, [][2]int, int) {
+	n := rng.Intn(5) + 2
+	edges := make([][2]int, 0, n*(n-1)/2)
+	used := make(map[[2]int]bool)
+	for i := 2; i <= n; i++ {
+		edges = append(edges, [2]int{i - 1, i})
+		used[[2]int{i - 1, i}] = true
+	}
+	total := n * (n - 1) / 2
+	extras := rng.Intn(total - (n - 1) + 1)
+	for len(edges) < n-1+extras {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		if used[[2]int{u, v}] {
+			continue
+		}
+		used[[2]int{u, v}] = true
+		edges = append(edges, [2]int{u, v})
+	}
+	deg := make([]int, n+1)
+	for _, e := range edges {
+		deg[e[0]]++
+		deg[e[1]]++
+	}
+	maxDeg := 0
+	for i := 1; i <= n; i++ {
+		if deg[i] > maxDeg {
+			maxDeg = deg[i]
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String(), maxDeg, edges, n
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func checkOutput(n int, edgesIn [][2]int, expect int, out string) error {
+	r := bufio.NewReader(strings.NewReader(out))
+	edgesOut := make([][2]int, 0, n-1)
+	for i := 0; i < n-1; i++ {
+		var u, v int
+		_, err := fmt.Fscan(r, &u, &v)
+		if err != nil {
+			return fmt.Errorf("invalid output")
+		}
+		edgesOut = append(edgesOut, [2]int{u, v})
+	}
+	// check no extra integers
+	if _, err := fmt.Fscan(r, new(int)); err == nil {
+		return fmt.Errorf("extra data")
+	}
+	allowed := make(map[[2]int]bool)
+	for _, e := range edgesIn {
+		a, b := e[0], e[1]
+		if a > b {
+			a, b = b, a
+		}
+		allowed[[2]int{a, b}] = true
+	}
+	dsu := NewDSU(n)
+	deg := make([]int, n+1)
+	for _, e := range edgesOut {
+		u, v := e[0], e[1]
+		if u < 1 || u > n || v < 1 || v > n {
+			return fmt.Errorf("vertex out of range")
+		}
+		a, b := u, v
+		if a > b {
+			a, b = b, a
+		}
+		if !allowed[[2]int{a, b}] {
+			return fmt.Errorf("edge not in input")
+		}
+		if dsu.Find(u) == dsu.Find(v) {
+			return fmt.Errorf("not a tree")
+		}
+		dsu.Union(u, v)
+		deg[u]++
+		deg[v]++
+	}
+	root := dsu.Find(1)
+	for i := 2; i <= n; i++ {
+		if dsu.Find(i) != root {
+			return fmt.Errorf("not a tree")
+		}
+	}
+	maxd := 0
+	for i := 1; i <= n; i++ {
+		if deg[i] > maxd {
+			maxd = deg[i]
+		}
+	}
+	if maxd != expect {
+		return fmt.Errorf("max degree %d, expected %d", maxd, expect)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierF1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, expect, edges, n := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if err := checkOutput(n, edges, expect, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1133/verifierF2.go
+++ b/1000-1999/1100-1199/1130-1139/1133/verifierF2.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	p []int
+}
+
+func NewDSU(n int) *DSU {
+	d := &DSU{p: make([]int, n+1)}
+	for i := 1; i <= n; i++ {
+		d.p[i] = i
+	}
+	return d
+}
+
+func (d *DSU) Find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.Find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *DSU) Union(a, b int) {
+	fa := d.Find(a)
+	fb := d.Find(b)
+	if fa != fb {
+		d.p[fa] = fb
+	}
+}
+
+type edge struct{ u, v int }
+
+func solveF2(n, D int, edges []edge) (bool, [][2]int) {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		adj[e.u] = append(adj[e.u], e.v)
+		adj[e.v] = append(adj[e.v], e.u)
+	}
+	if len(adj[1]) < D {
+		return false, nil
+	}
+	comp := make([]int, n+1)
+	compID := 0
+	for i := 2; i <= n; i++ {
+		if comp[i] == 0 {
+			compID++
+			stack := []int{i}
+			comp[i] = compID
+			for len(stack) > 0 {
+				u := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				for _, v := range adj[u] {
+					if v == 1 || comp[v] != 0 {
+						continue
+					}
+					comp[v] = compID
+					stack = append(stack, v)
+				}
+			}
+		}
+	}
+	if compID > D {
+		return false, nil
+	}
+	compEdges := make(map[int][]int)
+	for _, y := range adj[1] {
+		compEdges[comp[y]] = append(compEdges[comp[y]], y)
+	}
+	chosen := make(map[int]bool)
+	initial := make([]int, 0, D)
+	for cid := 1; cid <= compID; cid++ {
+		list := compEdges[cid]
+		if len(list) == 0 {
+			return false, nil
+		}
+		y := list[0]
+		chosen[y] = true
+		initial = append(initial, y)
+	}
+	left := D - compID
+	for _, y := range adj[1] {
+		if left == 0 {
+			break
+		}
+		if chosen[y] {
+			continue
+		}
+		chosen[y] = true
+		initial = append(initial, y)
+		left--
+	}
+	visited := make([]bool, n+1)
+	visited[1] = true
+	edgesOut := make([][2]int, 0, n-1)
+	queue := make([]int, len(initial))
+	for i, v := range initial {
+		edgesOut = append(edgesOut, [2]int{1, v})
+		visited[v] = true
+		queue[i] = v
+	}
+	for qi := 0; qi < len(queue); qi++ {
+		u := queue[qi]
+		for _, v := range adj[u] {
+			if v == 1 || visited[v] {
+				continue
+			}
+			visited[v] = true
+			edgesOut = append(edgesOut, [2]int{u, v})
+			queue = append(queue, v)
+		}
+	}
+	if len(edgesOut) != n-1 {
+		return false, nil
+	}
+	return true, edgesOut
+}
+
+func generateCase(rng *rand.Rand) (string, int, []edge, int) {
+	n := rng.Intn(6) + 2
+	edges := make([]edge, 0, n*(n-1)/2)
+	used := make(map[[2]int]bool)
+	for i := 2; i <= n; i++ {
+		edges = append(edges, edge{i - 1, i})
+		used[[2]int{i - 1, i}] = true
+	}
+	total := n * (n - 1) / 2
+	extras := rng.Intn(total - (n - 1) + 1)
+	for len(edges) < n-1+extras {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		if used[[2]int{u, v}] {
+			continue
+		}
+		used[[2]int{u, v}] = true
+		edges = append(edges, edge{u, v})
+	}
+	D := rng.Intn(n-1) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, len(edges), D))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	return sb.String(), D, edges, n
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func parseOutput(out string, n, D int, edgesIn map[[2]int]bool) error {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	if !scanner.Scan() {
+		return fmt.Errorf("no output")
+	}
+	first := strings.TrimSpace(scanner.Text())
+	if first == "NO" {
+		if scanner.Scan() {
+			return fmt.Errorf("extra data")
+		}
+		return fmt.Errorf("NO")
+	}
+	if first != "YES" {
+		return fmt.Errorf("missing YES/NO")
+	}
+	edgesOut := make([][2]int, 0, n-1)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var u, v int
+		if _, err := fmt.Sscan(line, &u, &v); err != nil {
+			return fmt.Errorf("bad edge")
+		}
+		edgesOut = append(edgesOut, [2]int{u, v})
+	}
+	if len(edgesOut) != n-1 {
+		return fmt.Errorf("wrong edge count")
+	}
+	dsu := NewDSU(n)
+	deg1 := 0
+	for _, e := range edgesOut {
+		a, b := e[0], e[1]
+		if a < 1 || a > n || b < 1 || b > n {
+			return fmt.Errorf("vertex range")
+		}
+		x, y := a, b
+		if x > y {
+			x, y = y, x
+		}
+		if !edgesIn[[2]int{x, y}] {
+			return fmt.Errorf("edge not in input")
+		}
+		if dsu.Find(a) == dsu.Find(b) {
+			return fmt.Errorf("not tree")
+		}
+		dsu.Union(a, b)
+		if a == 1 || b == 1 {
+			deg1++
+		}
+	}
+	root := dsu.Find(1)
+	for i := 2; i <= n; i++ {
+		if dsu.Find(i) != root {
+			return fmt.Errorf("not tree")
+		}
+	}
+	if deg1 != D {
+		return fmt.Errorf("degree not %d", D)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierF2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[len(os.Args)-1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, D, edges, n := generateCase(rng)
+		expectedOk, _ := solveF2(n, D, edges)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		edgeMap := make(map[[2]int]bool)
+		for _, e := range edges {
+			a, b := e.u, e.v
+			if a > b {
+				a, b = b, a
+			}
+			edgeMap[[2]int{a, b}] = true
+		}
+		err = parseOutput(out, n, D, edgeMap)
+		if expectedOk {
+			if err != nil && err.Error() == "NO" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected YES but got NO\ninput:\n%s", i+1, in)
+				os.Exit(1)
+			}
+			if err != nil && err.Error() != "NO" {
+				fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+				os.Exit(1)
+			}
+			if err == nil {
+				continue
+			}
+		} else {
+			if err == nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected NO but output tree\ninput:\n%s", i+1, in)
+				os.Exit(1)
+			}
+			if err.Error() != "NO" {
+				fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add randomized Go verifiers for all 1133 problems
- each verifier runs 100 random tests against a provided binary

## Testing
- `go run verifierA.go -- 1133A.go`
- `go run verifierB.go -- 1133B.go`
- `go run verifierC.go -- 1133C.go`
- `go run verifierD.go -- 1133D.go`
- `go run verifierE.go -- 1133E.go`
- `go run verifierF1.go -- 1133F1.go`
- `go run verifierF2.go -- 1133F2.go`


------
https://chatgpt.com/codex/tasks/task_e_688490303cdc8324ba34696504efb53e