### PR TITLE
Add verifiers for contest 1136

### DIFF
--- a/1000-1999/1100-1199/1130-1139/1136/verifierA.go
+++ b/1000-1999/1100-1199/1130-1139/1136/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type chapter struct{ l, r int }
+
+func expected(n int, seg []chapter, k int) string {
+	cnt := 0
+	for _, c := range seg {
+		if c.r >= k {
+			cnt++
+		}
+	}
+	return fmt.Sprintf("%d", cnt)
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(want) != got {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct {
+		n   int
+		seg []chapter
+		k   int
+	}
+	tests := []test{
+		{n: 3, seg: []chapter{{1, 3}, {4, 7}, {8, 11}}, k: 2},
+		{n: 3, seg: []chapter{{1, 3}, {4, 7}, {8, 11}}, k: 5},
+		{n: 1, seg: []chapter{{1, 5}}, k: 3},
+	}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(100) + 1
+		seg := make([]chapter, n)
+		l := 1
+		for j := 0; j < n; j++ {
+			len := rng.Intn(100) + 1
+			seg[j] = chapter{l, l + len - 1}
+			l += len
+		}
+		k := rng.Intn(l-1) + 1
+		tests = append(tests, test{n: n, seg: seg, k: k})
+	}
+	for idx, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for i, c := range tc.seg {
+			sb.WriteString(fmt.Sprintf("%d %d", c.l, c.r))
+			if i+1 < len(tc.seg) {
+				sb.WriteByte('\n')
+			}
+		}
+		sb.WriteString(fmt.Sprintf("\n%d\n", tc.k))
+		want := expected(tc.n, tc.seg, tc.k)
+		if err := runCase(bin, sb.String(), want); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1136/verifierB.go
+++ b/1000-1999/1100-1199/1130-1139/1136/verifierB.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, k int) string {
+	if k-1 < n-k {
+		return fmt.Sprintf("%d", 3*n+k-1)
+	}
+	return fmt.Sprintf("%d", 3*n+n-k)
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(want) != got {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct{ n, k int }
+	tests := []test{
+		{n: 2, k: 2},
+		{n: 5, k: 3},
+	}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5000-2+1) + 2
+		k := rng.Intn(n) + 1
+		tests = append(tests, test{n: n, k: k})
+	}
+	for idx, tc := range tests {
+		input := fmt.Sprintf("%d %d\n", tc.n, tc.k)
+		want := expected(tc.n, tc.k)
+		if err := runCase(bin, input, want); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1136/verifierC.go
+++ b/1000-1999/1100-1199/1130-1139/1136/verifierC.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(n, m int, A, B [][]int) string {
+	for sum := 0; sum <= n+m-2; sum++ {
+		var da, db []int
+		for i := 0; i < n; i++ {
+			j := sum - i
+			if j >= 0 && j < m {
+				da = append(da, A[i][j])
+				db = append(db, B[i][j])
+			}
+		}
+		sort.Ints(da)
+		sort.Ints(db)
+		if len(da) != len(db) {
+			return "NO"
+		}
+		for i := range da {
+			if da[i] != db[i] {
+				return "NO"
+			}
+		}
+	}
+	return "YES"
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(want) != got {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct {
+		n, m int
+		A, B [][]int
+	}
+	tests := []test{
+		{n: 1, m: 1, A: [][]int{{5}}, B: [][]int{{5}}},
+		{n: 2, m: 2, A: [][]int{{1, 2}, {3, 4}}, B: [][]int{{1, 3}, {2, 4}}},
+		{n: 2, m: 2, A: [][]int{{1, 2}, {3, 4}}, B: [][]int{{1, 2}, {4, 3}}},
+	}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		m := rng.Intn(10) + 1
+		A := make([][]int, n)
+		B := make([][]int, n)
+		for r := 0; r < n; r++ {
+			A[r] = make([]int, m)
+			B[r] = make([]int, m)
+			for c := 0; c < m; c++ {
+				A[r][c] = rng.Intn(1000)
+				B[r][c] = rng.Intn(1000)
+			}
+		}
+		if i%2 == 0 {
+			// make B reachable by shuffling diagonals
+			for sum := 0; sum <= n+m-2; sum++ {
+				var idxs []int
+				for r := 0; r < n; r++ {
+					c := sum - r
+					if c >= 0 && c < m {
+						idxs = append(idxs, r)
+					}
+				}
+				vals := make([]int, len(idxs))
+				for j, r := range idxs {
+					c := sum - r
+					vals[j] = A[r][c]
+				}
+				rng.Shuffle(len(vals), func(a, b int) { vals[a], vals[b] = vals[b], vals[a] })
+				for j, r := range idxs {
+					c := sum - r
+					B[r][c] = vals[j]
+				}
+			}
+		}
+		tests = append(tests, test{n: n, m: m, A: A, B: B})
+	}
+
+	for idx, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, tc.m))
+		for i := 0; i < tc.n; i++ {
+			for j := 0; j < tc.m; j++ {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", tc.A[i][j]))
+			}
+			sb.WriteByte('\n')
+		}
+		for i := 0; i < tc.n; i++ {
+			for j := 0; j < tc.m; j++ {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", tc.B[i][j]))
+			}
+			sb.WriteByte('\n')
+		}
+		want := expected(tc.n, tc.m, tc.A, tc.B)
+		if err := runCase(bin, sb.String(), want); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1136/verifierD.go
+++ b/1000-1999/1100-1199/1130-1139/1136/verifierD.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func expected(n int, p []int, edges []edge) string {
+	adj := make(map[int]map[int]bool)
+	for _, e := range edges {
+		if adj[e.u] == nil {
+			adj[e.u] = make(map[int]bool)
+		}
+		adj[e.u][e.v] = true
+	}
+	bj := make(map[int]bool)
+	last := p[n-1]
+	for _, e := range edges {
+		if e.v == last {
+			bj[e.u] = true
+		}
+	}
+	var a []int
+	ans := 0
+	for i := n - 2; i >= 0; i-- {
+		pi := p[i]
+		if bj[pi] {
+			ans++
+			ok := true
+			for _, idx := range a {
+				if !adj[pi][p[idx]] {
+					ok = false
+					break
+				}
+			}
+			if !ok {
+				ans--
+				a = append(a, i)
+			}
+		} else {
+			a = append(a, i)
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(want) != got {
+		return fmt.Errorf("expected %s got %s", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	type test struct {
+		n     int
+		p     []int
+		edges []edge
+	}
+	tests := []test{
+		{n: 2, p: []int{1, 2}, edges: []edge{{1, 2}}},
+		{n: 3, p: []int{1, 2, 3}, edges: []edge{{2, 3}}},
+	}
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		perm := rand.Perm(n)
+		for i := range perm {
+			perm[i]++
+		}
+		m := rng.Intn(n*n + 1)
+		es := make([]edge, m)
+		for j := 0; j < m; j++ {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				if u < n {
+					v = u + 1
+				} else {
+					v = u - 1
+				}
+			}
+			es[j] = edge{u, v}
+		}
+		tests = append(tests, test{n: n, p: perm, edges: es})
+	}
+
+	for idx, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", tc.n, len(tc.edges)))
+		for i, v := range tc.p {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for _, e := range tc.edges {
+			sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+		}
+		want := expected(tc.n, tc.p, tc.edges)
+		if err := runCase(bin, sb.String(), want); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1130-1139/1136/verifierE.go
+++ b/1000-1999/1100-1199/1130-1139/1136/verifierE.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type query struct {
+	typ    byte
+	x1, x2 int
+}
+
+type test struct {
+	n  int
+	a  []int
+	k  []int
+	qs []query
+}
+
+func expected(t test) string {
+	arr := make([]int, t.n)
+	copy(arr, t.a)
+	kk := make([]int, t.n-1)
+	copy(kk, t.k)
+	var out []string
+	for _, q := range t.qs {
+		if q.typ == '+' {
+			idx := q.x1 - 1
+			add := q.x2
+			arr[idx] += add
+			for i := idx; i < t.n-1; i++ {
+				need := arr[i] + kk[i]
+				if arr[i+1] < need {
+					arr[i+1] = need
+				} else {
+					break
+				}
+			}
+		} else {
+			l := q.x1 - 1
+			r := q.x2 - 1
+			sum := 0
+			for i := l; i <= r; i++ {
+				sum += arr[i]
+			}
+			out = append(out, fmt.Sprintf("%d", sum))
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+func runCase(bin, input, want string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.TrimSpace(want) != got {
+		return fmt.Errorf("expected %q got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	tests := []test{
+		{n: 3, a: []int{1, 2, 3}, k: []int{1, 1}, qs: []query{{typ: '+', x1: 1, x2: 2}, {typ: 's', x1: 1, x2: 3}}},
+	}
+
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 2
+		a := make([]int, n)
+		k := make([]int, n-1)
+		a[0] = rng.Intn(21) - 10
+		for j := 0; j < n-1; j++ {
+			k[j] = rng.Intn(7) - 3
+			base := a[j] + k[j]
+			a[j+1] = base + rng.Intn(5)
+		}
+		qn := rng.Intn(15) + 1
+		qs := make([]query, qn)
+		for j := 0; j < qn; j++ {
+			if rng.Intn(2) == 0 {
+				idx := rng.Intn(n) + 1
+				x := rng.Intn(4)
+				qs[j] = query{typ: '+', x1: idx, x2: x}
+			} else {
+				l := rng.Intn(n) + 1
+				r := rng.Intn(n-l+1) + l
+				qs[j] = query{typ: 's', x1: l, x2: r}
+			}
+		}
+		tests = append(tests, test{n: n, a: a, k: k, qs: qs})
+	}
+
+	for idx, tc := range tests {
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+		for i, v := range tc.a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		for i, v := range tc.k {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		sb.WriteByte('\n')
+		sb.WriteString(fmt.Sprintf("%d\n", len(tc.qs)))
+		for _, q := range tc.qs {
+			if q.typ == '+' {
+				sb.WriteString(fmt.Sprintf("+ %d %d\n", q.x1, q.x2))
+			} else {
+				sb.WriteString(fmt.Sprintf("s %d %d\n", q.x1, q.x2))
+			}
+		}
+		want := expected(tc)
+		if err := runCase(bin, sb.String(), want); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", idx+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go, verifierB.go, verifierC.go, verifierD.go and verifierE.go for contest 1136
- each verifier generates at least 100 test cases and checks a solution binary

## Testing
- `go run verifierA.go ./candA`
- `go run verifierB.go ./candB`
- `go run verifierC.go ./candC`
- `go run verifierD.go ./candD`
- `go run verifierE.go ./candE` *(fails: expected output not produced by provided solution)*

------
https://chatgpt.com/codex/tasks/task_e_688491d473b48324a62e63c269d4925b