### PR TITLE
Fix contest 100 success message

### DIFF
--- a/0-999/100-199/100-109/100/verifierA.go
+++ b/0-999/100-199/100-109/100/verifierA.go
@@ -62,6 +62,6 @@ func main() {
             os.Exit(1)
         }
     }
-    fmt.Printf("ok %d tests\n", len(tests))
+    fmt.Println("All tests passed")
 }
 

--- a/0-999/100-199/100-109/100/verifierB.go
+++ b/0-999/100-199/100-109/100/verifierB.go
@@ -86,6 +86,6 @@ func main() {
             os.Exit(1)
         }
     }
-    fmt.Printf("ok %d tests\n", len(tests))
+    fmt.Println("All tests passed")
 }
 

--- a/0-999/100-199/100-109/100/verifierC.go
+++ b/0-999/100-199/100-109/100/verifierC.go
@@ -77,6 +77,6 @@ func main() {
             os.Exit(1)
         }
     }
-    fmt.Printf("ok %d tests\n", len(tests))
+    fmt.Println("All tests passed")
 }
 

--- a/0-999/100-199/100-109/100/verifierD.go
+++ b/0-999/100-199/100-109/100/verifierD.go
@@ -84,6 +84,6 @@ func main() {
             os.Exit(1)
         }
     }
-    fmt.Printf("ok %d tests\n", len(tests))
+    fmt.Println("All tests passed")
 }
 

--- a/0-999/100-199/100-109/100/verifierE.go
+++ b/0-999/100-199/100-109/100/verifierE.go
@@ -120,6 +120,6 @@ func main() {
             os.Exit(1)
         }
     }
-    fmt.Printf("ok %d tests\n", len(tests))
+    fmt.Println("All tests passed")
 }
 

--- a/0-999/100-199/100-109/100/verifierF.go
+++ b/0-999/100-199/100-109/100/verifierF.go
@@ -122,6 +122,6 @@ func main() {
             os.Exit(1)
         }
     }
-    fmt.Printf("ok %d tests\n", len(tests))
+    fmt.Println("All tests passed")
 }
 

--- a/0-999/100-199/100-109/100/verifierG.go
+++ b/0-999/100-199/100-109/100/verifierG.go
@@ -119,6 +119,6 @@ func main() {
             os.Exit(1)
         }
     }
-    fmt.Printf("ok %d tests\n", len(tests))
+    fmt.Println("All tests passed")
 }
 

--- a/0-999/100-199/100-109/100/verifierH.go
+++ b/0-999/100-199/100-109/100/verifierH.go
@@ -181,6 +181,6 @@ func main() {
             os.Exit(1)
         }
     }
-    fmt.Printf("ok %d tests\n", len(tests))
+    fmt.Println("All tests passed")
 }
 

--- a/0-999/100-199/100-109/100/verifierI.go
+++ b/0-999/100-199/100-109/100/verifierI.go
@@ -67,6 +67,6 @@ func main() {
             os.Exit(1)
         }
     }
-    fmt.Printf("ok %d tests\n", len(tests))
+    fmt.Println("All tests passed")
 }
 

--- a/0-999/100-199/100-109/100/verifierJ.go
+++ b/0-999/100-199/100-109/100/verifierJ.go
@@ -145,6 +145,6 @@ func main() {
             os.Exit(1)
         }
     }
-    fmt.Printf("ok %d tests\n", len(tests))
+    fmt.Println("All tests passed")
 }
 


### PR DESCRIPTION
## Summary
- update contest 100 verifiers to print `All tests passed` instead of `ok N tests`

## Testing
- `go build verifierA.go`

------
https://chatgpt.com/codex/tasks/task_e_688493b0c5fc832489c0ae34f4a8399f