### PR TITLE
Add Go solution for 1669E

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1669/1669E.go
+++ b/1000-1999/1600-1699/1660-1669/1669/1669E.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		cnt := make(map[string]int)
+		var ans int64
+		for i := 0; i < n; i++ {
+			var s string
+			fmt.Fscan(reader, &s)
+			// Count pairs differing in one position with previously seen strings
+			// iterate over both positions and try changing the letter to others
+			for pos := 0; pos < 2; pos++ {
+				b := []byte(s)
+				orig := b[pos]
+				for ch := byte('a'); ch <= byte('k'); ch++ {
+					if ch == orig {
+						continue
+					}
+					b[pos] = ch
+					ans += int64(cnt[string(b)])
+				}
+				b[pos] = orig
+			}
+			cnt[s]++
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem E in contest 1669

## Testing
- `go build 1000-1999/1600-1699/1660-1669/1669/1669E.go`


------
https://chatgpt.com/codex/tasks/task_e_68849562ad5c83249b90e74e057d7fce