### PR TITLE
Add Go verifiers for contest 1143

### DIFF
--- a/1000-1999/1100-1199/1140-1149/1143/verifierA.go
+++ b/1000-1999/1100-1199/1140-1149/1143/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1143A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runProg(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Intn(200) + 2 // n from 2..201
+	arr := make([]int, n)
+	zeros, ones := 0, 0
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(2)
+		if arr[i] == 0 {
+			zeros++
+		} else {
+			ones++
+		}
+	}
+	if zeros == 0 {
+		arr[0] = 0
+	}
+	if ones == 0 {
+		arr[len(arr)-1] = 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(input), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1143/verifierB.go
+++ b/1000-1999/1100-1199/1140-1149/1143/verifierB.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1143B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runProg(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Int63n(2000000000) + 1
+	return []byte(fmt.Sprintf("%d\n", n))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(input), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1143/verifierC.go
+++ b/1000-1999/1100-1199/1140-1149/1143/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1143C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runProg(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase(rng *rand.Rand) []byte {
+	n := rng.Intn(50) + 1 // 1..50
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		var parent int
+		if i == 1 {
+			parent = -1
+		} else {
+			parent = rng.Intn(i-1) + 1
+		}
+		c := 0
+		if i != 1 {
+			c = rng.Intn(2)
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", parent, c))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, string(input), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- implement verifierA.go, verifierB.go, and verifierC.go for contest 1143
- each verifier builds reference solutions and checks 100 random cases

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`

------
https://chatgpt.com/codex/tasks/task_e_688495a8abe08324ab357b7adbf74a15