### PR TITLE
Add Go verifiers for contest 1144

### DIFF
--- a/1000-1999/1100-1199/1140-1149/1144/verifierA.go
+++ b/1000-1999/1100-1199/1140-1149/1144/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	n := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		l := rand.Intn(20) + 1
+		for j := 0; j < l; j++ {
+			sb.WriteByte(byte('a' + rand.Intn(26)))
+		}
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refA.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1144A.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1144/verifierB.go
+++ b/1000-1999/1100-1199/1140-1149/1144/verifierB.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	n := rand.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := rand.Intn(1000000)
+		sb.WriteString(fmt.Sprintf("%d ", x))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refB.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1144B.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1144/verifierC.go
+++ b/1000-1999/1100-1199/1140-1149/1144/verifierC.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	n := rand.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := rand.Intn(200000)
+		sb.WriteString(fmt.Sprintf("%d ", x))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refC.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1144C.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1144/verifierD.go
+++ b/1000-1999/1100-1199/1140-1149/1144/verifierD.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	n := rand.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := rand.Intn(200000)
+		sb.WriteString(fmt.Sprintf("%d ", x))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refD.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1144D.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1144/verifierE.go
+++ b/1000-1999/1100-1199/1140-1149/1144/verifierE.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func toStr(val int64, k int) string {
+	b := make([]byte, k)
+	for i := k - 1; i >= 0; i-- {
+		b[i] = byte(val%26) + 'a'
+		val /= 26
+	}
+	return string(b)
+}
+
+func genTest() []byte {
+	k := rand.Intn(10) + 1
+	max := int64(1)
+	for i := 0; i < k; i++ {
+		max *= 26
+	}
+	if max < 3 {
+		max = 3
+	}
+	a := rand.Int63n(max - 2)
+	diff := rand.Int63n(max - a - 1)
+	if diff%2 == 1 {
+		diff++
+	}
+	if a+diff >= max {
+		a = max - diff - 1
+	}
+	b := a + diff
+	s := toStr(a, k)
+	t := toStr(b, k)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n%s\n%s\n", k, s, t))
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refE.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1144E.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1144/verifierF.go
+++ b/1000-1999/1100-1199/1140-1149/1144/verifierF.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	n := rand.Intn(6) + 2
+	edges := make([]edge, 0)
+	for i := 2; i <= n; i++ {
+		u := rand.Intn(i-1) + 1
+		edges = append(edges, edge{u, i})
+	}
+	maxExtra := n
+	for len(edges) < n-1+rand.Intn(maxExtra+1) {
+		u := rand.Intn(n) + 1
+		v := rand.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		dup := false
+		for _, e := range edges {
+			if (e.u == u && e.v == v) || (e.u == v && e.v == u) {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+		edges = append(edges, edge{u, v})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refF.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1144F.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1144/verifierG.go
+++ b/1000-1999/1100-1199/1140-1149/1144/verifierG.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() []byte {
+	n := rand.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := rand.Intn(200000)
+		sb.WriteString(fmt.Sprintf("%d ", x))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go <binary>")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "./refG.bin"
+	if err := exec.Command("go", "build", "-o", ref, "1144G.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			fmt.Println("input:\n", string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\n", i+1)
+			fmt.Println("input:\n", string(input))
+			fmt.Println("expected:\n", want)
+			fmt.Println("got:\n", got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- provide verification programs for all problems in contest 1144
- each verifier builds the reference solution, generates 100 random tests and checks a candidate binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68849634c83083249094ef7b33666442