### PR TITLE
Add Go solution for 1669A

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1669/1669A.go
+++ b/1000-1999/1600-1699/1660-1669/1669/1669A.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var rating int
+		fmt.Fscan(in, &rating)
+		switch {
+		case rating >= 1900:
+			fmt.Fprintln(out, "Division 1")
+		case rating >= 1600:
+			fmt.Fprintln(out, "Division 2")
+		case rating >= 1400:
+			fmt.Fprintln(out, "Division 3")
+		default:
+			fmt.Fprintln(out, "Division 4")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement division detection for contest 1669A in Go

## Testing
- `go build 1000-1999/1600-1699/1660-1669/1669/1669A.go`

------
https://chatgpt.com/codex/tasks/task_e_6884981efea88324a275aa5c4bdc4f4c