### PR TITLE
Add Go verifiers for contest 1146

### DIFF
--- a/1000-1999/1100-1199/1140-1149/1146/verifierA.go
+++ b/1000-1999/1100-1199/1140-1149/1146/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) int {
+	cnt := 0
+	for _, ch := range s {
+		if ch == 'a' {
+			cnt++
+		}
+	}
+	maxKeep := 2*cnt - 1
+	if maxKeep > len(s) {
+		return len(s)
+	}
+	return maxKeep
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(50) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	b[rng.Intn(n)] = 'a'
+	s := string(b)
+	return s + "\n", expected(s)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != fmt.Sprint(exp) {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1140-1149/1146/verifierC.go
+++ b/1000-1999/1100-1199/1140-1149/1146/verifierC.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ to, w int }
+
+func bfs(start int, adj [][]edge) (node, dist int) {
+	n := len(adj)
+	distArr := make([]int, n)
+	for i := range distArr {
+		distArr[i] = -1
+	}
+	q := []int{start}
+	distArr[start] = 0
+	node = start
+	for idx := 0; idx < len(q); idx++ {
+		u := q[idx]
+		for _, e := range adj[u] {
+			if distArr[e.to] == -1 {
+				distArr[e.to] = distArr[u] + e.w
+				q = append(q, e.to)
+				if distArr[e.to] > distArr[node] {
+					node = e.to
+				}
+			}
+		}
+	}
+	return node, distArr[node]
+}
+
+func expected(n int, edges [][3]int) int {
+	adj := make([][]edge, n+1)
+	for _, e := range edges {
+		u, v, w := e[0], e[1], e[2]
+		adj[u] = append(adj[u], edge{v, w})
+		adj[v] = append(adj[v], edge{u, w})
+	}
+	u, _ := bfs(1, adj)
+	_, d := bfs(u, adj)
+	return d
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10) + 1
+	edges := make([][3]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		w := rng.Intn(10) + 1
+		edges[i-2] = [3]int{p, i, w}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d %d\n", e[0], e[1], e[2])
+	}
+	return sb.String(), expected(n, edges)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != fmt.Sprint(exp) {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1140-1149/1146/verifierD.go
+++ b/1000-1999/1100-1199/1140-1149/1146/verifierD.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func reachable(limit, a, b int) int {
+	vis := make([]bool, limit+1)
+	q := []int{0}
+	vis[0] = true
+	for front := 0; front < len(q); front++ {
+		u := q[front]
+		v := u + a
+		if v <= limit && !vis[v] {
+			vis[v] = true
+			q = append(q, v)
+		}
+		v = u - b
+		if v >= 0 && !vis[v] {
+			vis[v] = true
+			q = append(q, v)
+		}
+	}
+	cnt := 0
+	for _, ok := range vis {
+		if ok {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func expected(m, a, b int) int {
+	sum := 0
+	for i := 0; i <= m; i++ {
+		sum += reachable(i, a, b)
+	}
+	return sum
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	m := rng.Intn(20) + 1
+	a := rng.Intn(5) + 1
+	b := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", m, a, b)
+	return sb.String(), expected(m, a, b)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != fmt.Sprint(exp) {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1140-1149/1146/verifierE.go
+++ b/1000-1999/1100-1199/1140-1149/1146/verifierE.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type query struct {
+	s byte
+	x int
+}
+
+func expected(n, q int, arr []int, ops []query) []int {
+	for _, op := range ops {
+		if op.s == '>' {
+			for i := 0; i < n; i++ {
+				if arr[i] > op.x {
+					arr[i] = -arr[i]
+				}
+			}
+		} else {
+			for i := 0; i < n; i++ {
+				if arr[i] < op.x {
+					arr[i] = -arr[i]
+				}
+			}
+		}
+	}
+	return arr
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	q := rng.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(11) - 5
+	}
+	ops := make([]query, q)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(arr[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			ops[i].s = '>'
+		} else {
+			ops[i].s = '<'
+		}
+		ops[i].x = rng.Intn(11) - 5
+		fmt.Fprintf(&sb, "%c %d\n", ops[i].s, ops[i].x)
+	}
+	expArr := expected(n, q, append([]int(nil), arr...), ops)
+	var sbExp strings.Builder
+	for i, v := range expArr {
+		if i > 0 {
+			sbExp.WriteByte(' ')
+		}
+		sbExp.WriteString(fmt.Sprint(v))
+	}
+	return sb.String(), sbExp.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1140-1149/1146/verifierF.go
+++ b/1000-1999/1100-1199/1140-1149/1146/verifierF.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+func add(a, b int) int {
+	a += b
+	if a >= mod {
+		a -= mod
+	}
+	return a
+}
+func mul(a, b int) int { return int((int64(a) * int64(b)) % mod) }
+
+func solve(n int, parents []int) int {
+	children := make([][]int, n+1)
+	for i := 2; i <= n; i++ {
+		p := parents[i-2]
+		children[p] = append(children[p], i)
+	}
+	leafCount := make([]int, n+1)
+	dp := make([]int, n+1)
+	type fr struct{ u, state int }
+	stack := []fr{{1, 0}}
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		u, state := v.u, v.state
+		if state == 0 {
+			stack = append(stack, fr{u, 1})
+			for _, ch := range children[u] {
+				stack = append(stack, fr{ch, 0})
+			}
+		} else {
+			if len(children[u]) == 0 {
+				leafCount[u] = 1
+				dp[u] = 1
+			} else {
+				tot := 0
+				prod := 1
+				for _, ch := range children[u] {
+					tot += leafCount[ch]
+					prod = mul(prod, dp[ch])
+				}
+				leafCount[u] = tot
+				if tot >= 2 {
+					dp[u] = add(prod, 1)
+				} else {
+					dp[u] = prod
+				}
+			}
+		}
+	}
+	return dp[1]
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 2
+	parents := make([]int, n-1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		parents[i-2] = p
+		fmt.Fprintf(&sb, "%d ", p)
+	}
+	sb.WriteByte('\n')
+	exp := solve(n, parents)
+	return sb.String(), fmt.Sprint(exp)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1140-1149/1146/verifierG.go
+++ b/1000-1999/1100-1199/1140-1149/1146/verifierG.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type restr struct{ l, r, x, c int }
+
+func expected(n, h int, res []restr) int {
+	heights := make([]int, n)
+	best := -1 << 31
+	var dfs func(int)
+	dfs = func(pos int) {
+		if pos == n {
+			profit := 0
+			for i := 0; i < n; i++ {
+				profit += heights[i] * heights[i]
+			}
+			for _, R := range res {
+				mx := 0
+				for i := R.l - 1; i < R.r; i++ {
+					if heights[i] > mx {
+						mx = heights[i]
+					}
+				}
+				if mx > R.x {
+					profit -= R.c
+				}
+			}
+			if profit > best {
+				best = profit
+			}
+			return
+		}
+		for k := 0; k <= h; k++ {
+			heights[pos] = k
+			dfs(pos + 1)
+		}
+	}
+	dfs(0)
+	return best
+}
+
+func genCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(4) + 1
+	h := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	res := make([]restr, m)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, h, m)
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		x := rng.Intn(h + 1)
+		c := rng.Intn(5) + 1
+		res[i] = restr{l, r, x, c}
+		fmt.Fprintf(&sb, "%d %d %d %d\n", l, r, x, c)
+	}
+	exp := expected(n, h, res)
+	return sb.String(), exp
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != fmt.Sprint(exp) {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1140-1149/1146/verifierH.go
+++ b/1000-1999/1100-1199/1140-1149/1146/verifierH.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Point struct{ x, y int64 }
+
+func solve(pts []Point) int64 {
+	n := len(pts)
+	sort.Slice(pts, func(i, j int) bool {
+		if pts[i].y != pts[j].y {
+			return pts[i].y < pts[j].y
+		}
+		return pts[i].x < pts[j].x
+	})
+	var ans int64
+	for s := 0; s < n; s++ {
+		m := n - s - 1
+		if m < 4 {
+			break
+		}
+		O := pts[s]
+		Q := make([]Point, m)
+		copy(Q, pts[s+1:])
+		sort.Slice(Q, func(i, j int) bool {
+			return (Q[i].x-O.x)*(Q[j].y-O.y)-(Q[i].y-O.y)*(Q[j].x-O.x) > 0
+		})
+		dp3 := make([][]int, m)
+		for i := range dp3 {
+			dp3[i] = make([]int, m)
+		}
+		for k := 1; k < m; k++ {
+			for j := k + 1; j < m; j++ {
+				cnt := 0
+				xk, yk := Q[k].x, Q[k].y
+				xj, yj := Q[j].x, Q[j].y
+				for i := 0; i < k; i++ {
+					if (xk-Q[i].x)*(yj-Q[i].y)-(yk-Q[i].y)*(xj-Q[i].x) > 0 {
+						cnt++
+					}
+				}
+				dp3[k][j] = cnt
+			}
+		}
+		dp4 := make([][]int, m)
+		for i := range dp4 {
+			dp4[i] = make([]int, m)
+		}
+		for u := 2; u < m; u++ {
+			xu, yu := Q[u].x, Q[u].y
+			for t := u + 1; t < m; t++ {
+				xt, yt := Q[t].x, Q[t].y
+				cnt := 0
+				for k := 1; k < u; k++ {
+					if (xu-Q[k].x)*(yt-Q[k].y)-(yu-Q[k].y)*(xt-Q[k].x) > 0 {
+						cnt += dp3[k][u]
+					}
+				}
+				dp4[u][t] = cnt
+			}
+		}
+		for u := 2; u < m; u++ {
+			xu, yu := Q[u].x, Q[u].y
+			for t := u + 1; t < m; t++ {
+				if dp4[u][t] > 0 {
+					if (Q[t].x-xu)*(O.y-yu)-(Q[t].y-yu)*(O.x-xu) > 0 {
+						ans += int64(dp4[u][t])
+					}
+				}
+			}
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(4) + 5 // 5..8
+	pts := make([]Point, n)
+	for {
+		ok := true
+		for i := 0; i < n; i++ {
+			pts[i] = Point{int64(rng.Intn(11) - 5), int64(rng.Intn(11) - 5)}
+		}
+		// ensure no duplicates or collinear triple
+		dup := false
+		for i := 0; i < n; i++ {
+			for j := i + 1; j < n; j++ {
+				if pts[i] == pts[j] {
+					dup = true
+				}
+			}
+		}
+		if dup {
+			continue
+		}
+		for i := 0; i < n && ok; i++ {
+			for j := i + 1; j < n && ok; j++ {
+				for k := j + 1; k < n && ok; k++ {
+					if (pts[j].x-pts[i].x)*(pts[k].y-pts[i].y)-(pts[j].y-pts[i].y)*(pts[k].x-pts[i].x) == 0 {
+						ok = false
+					}
+				}
+			}
+		}
+		if ok {
+			break
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, p := range pts {
+		fmt.Fprintf(&sb, "%d %d\n", p.x, p.y)
+	}
+	return sb.String(), solve(pts)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != fmt.Sprint(exp) {
+			fmt.Fprintf(os.Stderr, "case %d: expected %d got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–H of contest 1146

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_6884974ce6b88324931aa231ade3c8a7