### PR TITLE
Add verifiers for contest 1150

### DIFF
--- a/1000-1999/1100-1199/1150-1159/1150/verifierA.go
+++ b/1000-1999/1100-1199/1150-1159/1150/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type TestCase struct {
+	input  string
+	output string
+}
+
+func compute(n, m, r int, buy, sell []int) int {
+	minBuy := buy[0]
+	for _, v := range buy {
+		if v < minBuy {
+			minBuy = v
+		}
+	}
+	maxSell := sell[0]
+	for _, v := range sell {
+		if v > maxSell {
+			maxSell = v
+		}
+	}
+	if maxSell > minBuy {
+		shares := r / minBuy
+		leftover := r % minBuy
+		return leftover + shares*maxSell
+	}
+	return r
+}
+
+func generateTests() []TestCase {
+	var tests []TestCase
+	for i := 1; i <= 120; i++ {
+		n := i%5 + 1
+		m := i%4 + 1
+		r := (i*7)%1000 + 1
+		buy := make([]int, n)
+		sell := make([]int, m)
+		for j := 0; j < n; j++ {
+			buy[j] = (i+j*3)%10 + 1
+		}
+		for j := 0; j < m; j++ {
+			sell[j] = (i+j*5)%10 + 1
+		}
+		expect := compute(n, m, r, buy, sell)
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d %d %d\n", n, m, r)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&b, "%d", buy[j])
+			if j+1 < n {
+				b.WriteByte(' ')
+			}
+		}
+		b.WriteByte('\n')
+		for j := 0; j < m; j++ {
+			fmt.Fprintf(&b, "%d", sell[j])
+			if j+1 < m {
+				b.WriteByte(' ')
+			}
+		}
+		b.WriteByte('\n')
+		tests = append(tests, TestCase{input: b.String(), output: fmt.Sprintf("%d\n", expect)})
+	}
+	return tests
+}
+
+func runTest(binary string, tc TestCase) error {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("execution failed: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(tc.output)
+	if got != want {
+		return fmt.Errorf("expected %q, got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierA <binary>")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		if err := runTest(binary, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1150/verifierB.go
+++ b/1000-1999/1100-1199/1150-1159/1150/verifierB.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type TestCase struct {
+	input  string
+	output string
+}
+
+func computeAnswer(n int, grid []string) string {
+	board := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		board[i] = []byte(grid[i])
+	}
+	for i := 1; i < n-1; i++ {
+		for j := 1; j < n-1; j++ {
+			if board[i][j] == '.' && board[i-1][j] == '.' && board[i+1][j] == '.' && board[i][j-1] == '.' && board[i][j+1] == '.' {
+				board[i][j] = '#'
+				board[i-1][j] = '#'
+				board[i+1][j] = '#'
+				board[i][j-1] = '#'
+				board[i][j+1] = '#'
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if board[i][j] == '.' {
+				return "NO"
+			}
+		}
+	}
+	return "YES"
+}
+
+func generateTests() []TestCase {
+	var tests []TestCase
+	for i := 1; i <= 120; i++ {
+		n := (i % 4) + 3 // sizes 3..6
+		grid := make([]string, n)
+		for r := 0; r < n; r++ {
+			row := make([]byte, n)
+			for c := 0; c < n; c++ {
+				if (i+r+c)%3 == 0 {
+					row[c] = '#'
+				} else {
+					row[c] = '.'
+				}
+			}
+			// ensure at least one dot
+			if !bytes.Contains(row, []byte{'.'}) {
+				row[0] = '.'
+			}
+			grid[r] = string(row)
+		}
+		expect := computeAnswer(n, grid)
+		input := fmt.Sprintf("%d\n%s\n", n, strings.Join(grid, "\n"))
+		tests = append(tests, TestCase{input: input, output: expect + "\n"})
+	}
+	return tests
+}
+
+func runTest(binary string, tc TestCase) error {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(tc.input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("execution failed: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
+	want := strings.TrimSpace(tc.output)
+	if got != want {
+		return fmt.Errorf("expected %q, got %q", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: verifierB <binary>")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		if err := runTest(binary, tc); err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for contest 1150
- each verifier generates 120 deterministic tests and checks a provided binary

## Testing
- `go run 1000-1999/1100-1199/1150-1159/1150/verifierA.go ./1150A_bin`
- `go run 1000-1999/1100-1199/1150-1159/1150/verifierB.go ./1150B_bin`


------
https://chatgpt.com/codex/tasks/task_e_6884997d25a48324aafb3564b2f3207a