### PR TITLE
Add Go solution for 1660F2

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1660/1660F2.go
+++ b/1000-1999/1600-1699/1660-1669/1660/1660F2.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type BIT struct {
+	n    int
+	tree []int
+}
+
+func NewBIT(n int) *BIT {
+	b := &BIT{n: n + 2, tree: make([]int, n+3)}
+	return b
+}
+
+func (b *BIT) Add(idx, val int) {
+	idx++
+	for idx <= b.n {
+		b.tree[idx] += val
+		idx += idx & -idx
+	}
+}
+
+func (b *BIT) Sum(idx int) int {
+	if idx < 0 {
+		return 0
+	}
+	if idx >= b.n {
+		idx = b.n - 1
+	}
+	idx++
+	res := 0
+	for idx > 0 {
+		res += b.tree[idx]
+		idx -= idx & -idx
+	}
+	return res
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var s string
+		fmt.Fscan(reader, &s)
+		size := 2*n + 5
+		bits := []*BIT{NewBIT(size), NewBIT(size), NewBIT(size)}
+		offset := n + 2
+		sum := 0
+		bits[sum%3].Add(sum+offset, 1)
+		var ans int64
+		for i := 0; i < n; i++ {
+			if s[i] == '+' {
+				sum--
+			} else {
+				sum++
+			}
+			mod := ((sum % 3) + 3) % 3
+			idx := sum + offset
+			ans += int64(bits[mod].Sum(idx))
+			bits[mod].Add(idx, 1)
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem F2 (Promising String hard version)
- use BIT per modulo class to count substrings

## Testing
- `go vet 1000-1999/1600-1699/1660-1669/1660/1660F2.go`
- `go run 1000-1999/1600-1699/1660-1669/1660/1660F2.go < /tmp/input.txt`

------
https://chatgpt.com/codex/tasks/task_e_688498ab97bc83249ebcc1a8b68378cc