### PR TITLE
Add verifiers for contest 1148

### DIFF
--- a/1000-1999/1100-1199/1140-1149/1148/verifierA.go
+++ b/1000-1999/1100-1199/1140-1149/1148/verifierA.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, in []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1148A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genCase() []byte {
+	a := rand.Int63n(1000) + 1
+	b := rand.Int63n(1000) + 1
+	c := rand.Int63n(1000) + 1
+	return []byte(fmt.Sprintf("%d %d %d\n", a, b, c))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, string(input), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1148/verifierB.go
+++ b/1000-1999/1100-1199/1140-1149/1148/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, in []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1148B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genCase() []byte {
+	n := rand.Intn(5) + 1
+	m := rand.Intn(5) + 1
+	ta := rand.Intn(10) + 1
+	tb := rand.Intn(10) + 1
+	k := rand.Intn(n + m)
+	a := make([]int, n)
+	cur := 0
+	for i := 0; i < n; i++ {
+		cur += rand.Intn(5) + 1
+		a[i] = cur
+	}
+	b := make([]int, m)
+	cur = 0
+	for i := 0; i < m; i++ {
+		cur += rand.Intn(5) + 1
+		b[i] = cur
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d %d %d\n", n, m, ta, tb, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(b[i]))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 100; i++ {
+		input := genCase()
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(want) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s", i+1, string(input), want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1148/verifierC.go
+++ b/1000-1999/1100-1199/1140-1149/1148/verifierC.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, in []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase() (string, []int) {
+	n := (rand.Intn(4) + 1) * 2 // even 2..8
+	perm := rand.Perm(n)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = perm[i] + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(arr[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), arr
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func check(n int, arr []int, out string) error {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) == 0 {
+		return fmt.Errorf("empty output")
+	}
+	m, err := strconv.Atoi(strings.TrimSpace(lines[0]))
+	if err != nil {
+		return fmt.Errorf("invalid first line")
+	}
+	if m < 0 || m > 5*n {
+		return fmt.Errorf("invalid operations count")
+	}
+	if len(lines)-1 != m {
+		return fmt.Errorf("expected %d operation lines", m)
+	}
+	for i := 1; i <= m; i++ {
+		parts := strings.Fields(lines[i])
+		if len(parts) != 2 {
+			return fmt.Errorf("op %d: need two numbers", i)
+		}
+		a, _ := strconv.Atoi(parts[0])
+		b, _ := strconv.Atoi(parts[1])
+		if a < 1 || a > n || b < 1 || b > n {
+			return fmt.Errorf("op %d: index out of range", i)
+		}
+		if 2*abs(a-b) < n {
+			return fmt.Errorf("op %d: distance too small", i)
+		}
+		arr[a-1], arr[b-1] = arr[b-1], arr[a-1]
+	}
+	for i := 0; i < n; i++ {
+		if arr[i] != i+1 {
+			return fmt.Errorf("array not sorted")
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		input, arr := genCase()
+		arrCopy := make([]int, len(arr))
+		copy(arrCopy, arr)
+		out, err := run(bin, []byte(input))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if err := check(len(arr), arrCopy, out); err != nil {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: %v\ninput:\n%soutput:\n%s", t+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1148/verifierD.go
+++ b/1000-1999/1100-1199/1140-1149/1148/verifierD.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, in []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1148D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genCase() (string, [][2]int) {
+	n := rand.Intn(5) + 2 // 2..6
+	vals := rand.Perm(2 * n)
+	pairs := make([][2]int, n)
+	for i := 0; i < n; i++ {
+		a := vals[2*i] + 1
+		b := vals[2*i+1] + 1
+		if rand.Intn(2) == 0 {
+			pairs[i] = [2]int{a, b}
+		} else {
+			pairs[i] = [2]int{b, a}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", pairs[i][0], pairs[i][1]))
+	}
+	return sb.String(), pairs
+}
+
+func parseIndices(out string, n int) ([]int, error) {
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("empty output")
+	}
+	t, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid count")
+	}
+	if len(fields)-1 != t {
+		return nil, fmt.Errorf("expected %d indices", t)
+	}
+	idx := make([]int, t)
+	for i := 0; i < t; i++ {
+		v, err := strconv.Atoi(fields[i+1])
+		if err != nil || v < 1 || v > n {
+			return nil, fmt.Errorf("bad index")
+		}
+		idx[i] = v
+	}
+	return idx, nil
+}
+
+func isGood(seq []int) bool {
+	if len(seq) < 2 {
+		return true
+	}
+	// try pattern < > < > ...
+	ok := true
+	less := seq[0] < seq[1]
+	if seq[0] == seq[1] {
+		ok = false
+	}
+	expectLess := !less
+	for i := 1; i < len(seq)-1 && ok; i++ {
+		if expectLess {
+			if !(seq[i] < seq[i+1]) {
+				ok = false
+			}
+		} else {
+			if !(seq[i] > seq[i+1]) {
+				ok = false
+			}
+		}
+		expectLess = !expectLess
+	}
+	if ok {
+		return true
+	}
+	// try opposite pattern
+	ok = true
+	less = seq[0] > seq[1]
+	if seq[0] == seq[1] {
+		return false
+	}
+	expectLess = !less
+	for i := 1; i < len(seq)-1 && ok; i++ {
+		if expectLess {
+			if !(seq[i] < seq[i+1]) {
+				ok = false
+			}
+		} else {
+			if !(seq[i] > seq[i+1]) {
+				ok = false
+			}
+		}
+		expectLess = !expectLess
+	}
+	return ok
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		input, pairs := genCase()
+		wantOut, err := run(ref, []byte(input))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		refIdx, err := parseIndices(wantOut, len(pairs))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "bad reference output on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		gotOut, err := run(bin, []byte(input))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		candIdx, err := parseIndices(gotOut, len(pairs))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "wrong format on test %d: %v\ninput:\n%soutput:\n%s", t+1, err, input, gotOut)
+			os.Exit(1)
+		}
+		if len(candIdx) != len(refIdx) {
+			fmt.Fprintf(os.Stderr, "wrong subset size on test %d\n", t+1)
+			os.Exit(1)
+		}
+		seq := make([]int, 0, 2*len(candIdx))
+		for _, id := range candIdx {
+			pr := pairs[id-1]
+			seq = append(seq, pr[0], pr[1])
+		}
+		if !isGood(seq) {
+			fmt.Fprintf(os.Stderr, "sequence not good on test %d\ninput:\n%soutput:\n%s", t+1, input, gotOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1148/verifierE.go
+++ b/1000-1999/1100-1199/1140-1149/1148/verifierE.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, in []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1148E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genCase() (string, []int, []int) {
+	n := rand.Intn(5) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(20)
+		b[i] = rand.Intn(20)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(b[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), a, b
+}
+
+func simulate(a []int, ops [][3]int) ([]int, error) {
+	for _, op := range ops {
+		i, j, d := op[0], op[1], op[2]
+		if i < 1 || i > len(a) || j < 1 || j > len(a) {
+			return nil, fmt.Errorf("index out of range")
+		}
+		if a[i-1] > a[j-1] {
+			i, j = j, i
+		}
+		if 2*d < 0 || 2*d > a[j-1]-a[i-1] {
+			return nil, fmt.Errorf("invalid d")
+		}
+		a[i-1] += d
+		a[j-1] -= d
+	}
+	return a, nil
+}
+
+func equalMultiset(x, y []int) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	x2 := append([]int(nil), x...)
+	y2 := append([]int(nil), y...)
+	sort.Ints(x2)
+	sort.Ints(y2)
+	for i := range x2 {
+		if x2[i] != y2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func parseOutput(out string) (bool, [][3]int, error) {
+	out = strings.TrimSpace(out)
+	if strings.HasPrefix(out, "NO") {
+		return false, nil, nil
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) < 2 {
+		return false, nil, fmt.Errorf("bad output")
+	}
+	if strings.TrimSpace(lines[0]) != "YES" {
+		return false, nil, fmt.Errorf("expected YES or NO")
+	}
+	m, err := strconv.Atoi(strings.TrimSpace(lines[1]))
+	if err != nil {
+		return false, nil, fmt.Errorf("bad m")
+	}
+	if m < 0 || m > 5*len(lines) {
+		return false, nil, fmt.Errorf("bad m")
+	}
+	if len(lines)-2 != m {
+		return false, nil, fmt.Errorf("expected %d operations", m)
+	}
+	ops := make([][3]int, m)
+	for i := 0; i < m; i++ {
+		parts := strings.Fields(lines[i+2])
+		if len(parts) != 3 {
+			return false, nil, fmt.Errorf("op %d format", i+1)
+		}
+		a1, _ := strconv.Atoi(parts[0])
+		b1, _ := strconv.Atoi(parts[1])
+		d, _ := strconv.Atoi(parts[2])
+		ops[i] = [3]int{a1, b1, d}
+	}
+	return true, ops, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		input, a, b := genCase()
+		refOut, err := run(ref, []byte(input))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		possible := !strings.HasPrefix(strings.TrimSpace(refOut), "NO")
+		candOut, err := run(bin, []byte(input))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		yes, ops, err := parseOutput(candOut)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "bad output on test %d: %v\ninput:\n%soutput:\n%s", t+1, err, input, candOut)
+			os.Exit(1)
+		}
+		if yes != possible {
+			fmt.Fprintf(os.Stderr, "incorrect YES/NO on test %d\ninput:\n%s", t+1, input)
+			os.Exit(1)
+		}
+		if yes {
+			arr := append([]int(nil), a...)
+			arr2, err := simulate(arr, ops)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "invalid operations on test %d: %v\ninput:\n%soutput:\n%s", t+1, err, input, candOut)
+				os.Exit(1)
+			}
+			if !equalMultiset(arr2, b) {
+				fmt.Fprintf(os.Stderr, "wrong final array on test %d\ninput:\n%soutput:\n%s", t+1, input, candOut)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1148/verifierF.go
+++ b/1000-1999/1100-1199/1140-1149/1148/verifierF.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, in []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase() (string, []int64, []uint64) {
+	n := rand.Intn(6) + 1
+	vals := make([]int64, n)
+	masks := make([]uint64, n)
+	sum := int64(0)
+	for i := 0; i < n; i++ {
+		vals[i] = int64(rand.Intn(41) - 20)
+		masks[i] = uint64(rand.Int63n(1<<10) + 1)
+		sum += vals[i]
+	}
+	if sum == 0 {
+		vals[0]++
+		sum++
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", vals[i], masks[i]))
+	}
+	return sb.String(), vals, masks
+}
+
+func apply(vals []int64, masks []uint64, s uint64) int64 {
+	tot := int64(0)
+	for i := 0; i < len(vals); i++ {
+		v := vals[i]
+		if bits.OnesCount64(s&masks[i])%2 == 1 {
+			v = -v
+		}
+		tot += v
+	}
+	return tot
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		input, vals, masks := genCase()
+		out, err := run(bin, []byte(input))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		s, err := strconv.ParseUint(out, 10, 64)
+		if err != nil || s == 0 {
+			fmt.Fprintf(os.Stderr, "bad output on test %d\n", t+1)
+			os.Exit(1)
+		}
+		initial := int64(0)
+		for _, v := range vals {
+			initial += v
+		}
+		after := apply(vals, masks, s)
+		if initial > 0 && after >= 0 {
+			fmt.Fprintf(os.Stderr, "sum sign not changed on test %d\n", t+1)
+			os.Exit(1)
+		}
+		if initial < 0 && after <= 0 {
+			fmt.Fprintf(os.Stderr, "sum sign not changed on test %d\n", t+1)
+			os.Exit(1)
+		}
+		if after == 0 {
+			fmt.Fprintf(os.Stderr, "sum became zero on test %d\n", t+1)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1148/verifierG.go
+++ b/1000-1999/1100-1199/1140-1149/1148/verifierG.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, in []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func genCase() (string, []int) {
+	k := rand.Intn(3) + 2
+	n := rand.Intn(5) + 2*k
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rand.Intn(50) + 2
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(a[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), a
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func isValid(set []int, vals []int) bool {
+	k := len(set)
+	for i := 0; i < k; i++ {
+		if set[i] < 1 || set[i] > len(vals) {
+			return false
+		}
+		for j := i + 1; j < k; j++ {
+			if set[i] == set[j] {
+				return false
+			}
+		}
+	}
+	allFair := true
+	noneFair := true
+	for i := 0; i < k; i++ {
+		fair := true
+		for j := 0; j < k; j++ {
+			if i == j {
+				continue
+			}
+			if gcd(vals[set[i]-1], vals[set[j]-1]) == 1 {
+				fair = false
+			}
+		}
+		if fair {
+			noneFair = false
+		} else {
+			allFair = false
+		}
+	}
+	return allFair || noneFair
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		input, vals := genCase()
+		out, err := run(bin, []byte(input))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(strings.TrimSpace(out))
+		first := strings.Fields(strings.Split(strings.TrimSpace(input), "\n")[0])
+		k, _ := strconv.Atoi(first[1])
+		if len(fields) != k {
+			fmt.Fprintf(os.Stderr, "wrong number of indices on test %d\n", t+1)
+			os.Exit(1)
+		}
+		set := make([]int, k)
+		for i := 0; i < k; i++ {
+			v, err := strconv.Atoi(fields[i])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "bad output on test %d\n", t+1)
+				os.Exit(1)
+			}
+			set[i] = v
+		}
+		if !isValid(set, vals) {
+			fmt.Fprintf(os.Stderr, "invalid set on test %d\ninput:\n%soutput:\n%s", t+1, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1140-1149/1148/verifierH.go
+++ b/1000-1999/1100-1199/1140-1149/1148/verifierH.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin string, in []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func mex(arr []int) int {
+	used := make(map[int]bool)
+	for _, v := range arr {
+		used[v] = true
+	}
+	for i := 0; ; i++ {
+		if !used[i] {
+			return i
+		}
+	}
+}
+
+func genCase() (string, [][]int) {
+	n := rand.Intn(5) + 1
+	ops := make([][]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		a := rand.Intn(n + 1)
+		l := rand.Intn(n + 1)
+		r := rand.Intn(n + 1)
+		k := rand.Intn(n + 1)
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", a, l, r, k))
+		ops[i] = []int{a, l, r, k}
+	}
+	return sb.String(), ops
+}
+
+func solveNaive(ops [][]int) []int {
+	n := len(ops)
+	arr := make([]int, 0, n)
+	last := 0
+	res := make([]int, n)
+	for i := 0; i < n; i++ {
+		a := (ops[i][0] + last) % (n + 1)
+		l := (ops[i][1]+last)%(i+1) + 1
+		r := (ops[i][2]+last)%(i+1) + 1
+		if l > r {
+			l, r = r, l
+		}
+		k := (ops[i][3] + last) % (n + 1)
+		arr = append(arr, a)
+		ans := 0
+		for x := l - 1; x < r; x++ {
+			for y := x; y < r; y++ {
+				if mex(arr[x:y+1]) == k {
+					ans++
+				}
+			}
+		}
+		res[i] = ans
+		last = ans
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(time.Now().UnixNano())
+	for t := 0; t < 100; t++ {
+		input, ops := genCase()
+		out, err := run(bin, []byte(input))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "runtime error on test %d: %v\ninput:\n%s", t+1, err, input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(strings.TrimSpace(out))
+		if len(fields) != len(ops) {
+			fmt.Fprintf(os.Stderr, "wrong number of answers on test %d\n", t+1)
+			os.Exit(1)
+		}
+		cand := make([]int, len(ops))
+		for i := range fields {
+			v, err := strconv.Atoi(fields[i])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "bad output on test %d\n", t+1)
+				os.Exit(1)
+			}
+			cand[i] = v
+		}
+		exp := solveNaive(ops)
+		for i := range exp {
+			if cand[i] != exp[i] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\ninput:\n%soutput:\n%s", t+1, input, out)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–H of contest 1148
- each verifier generates 100 randomized test cases
- reference solutions compiled where available

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go verifierG.go verifierH.go`

------
https://chatgpt.com/codex/tasks/task_e_688498650320832484bb769ca7c5d339