### PR TITLE
Add Go solution for 1660A

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1660/1660A.go
+++ b/1000-1999/1600-1699/1660-1669/1660/1660A.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a, b int
+		fmt.Fscan(in, &a, &b)
+		if a == 0 {
+			fmt.Fprintln(out, 1)
+		} else {
+			fmt.Fprintln(out, a+2*b+1)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem 1660A

## Testing
- `go build 1000-1999/1600-1699/1660-1669/1660/1660A.go`


------
https://chatgpt.com/codex/tasks/task_e_68849b676d388324b9a5a851436c4835