### PR TITLE
Add verifiers for contest 1153

### DIFF
--- a/1000-1999/1100-1199/1150-1159/1153/verifierA.go
+++ b/1000-1999/1100-1199/1150-1159/1153/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input    string
+	expected string
+}
+
+func generateTests() []Test {
+	rng := rand.New(rand.NewSource(42))
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(100) + 1
+		t := rng.Intn(100000) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, t))
+		starts := make([]int, n)
+		d := make([]int, n)
+		for j := 0; j < n; j++ {
+			starts[j] = rng.Intn(100000) + 1
+			d[j] = rng.Intn(100000) + 1
+			sb.WriteString(fmt.Sprintf("%d %d\n", starts[j], d[j]))
+		}
+		input := sb.String()
+		bestTime := int64(1 << 62)
+		bestIndex := 1
+		for j := 0; j < n; j++ {
+			arrival := int64(starts[j])
+			if arrival < int64(t) {
+				delta := int64(t) - arrival
+				k := (delta + int64(d[j]) - 1) / int64(d[j])
+				arrival += k * int64(d[j])
+			}
+			if arrival < bestTime {
+				bestTime = arrival
+				bestIndex = j + 1
+			}
+		}
+		tests = append(tests, Test{input: input, expected: strconv.Itoa(bestIndex)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expected {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.input, tc.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1153/verifierB.go
+++ b/1000-1999/1100-1199/1150-1159/1153/verifierB.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input    string
+	expected string
+}
+
+func generateTests() []Test {
+	rng := rand.New(rand.NewSource(43))
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		h := rng.Intn(10) + 1
+		a := make([]int, m)
+		b := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, h))
+		for j := 0; j < m; j++ {
+			a[j] = rng.Intn(h + 1)
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(a[j]))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			b[j] = rng.Intn(h + 1)
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(b[j]))
+		}
+		sb.WriteByte('\n')
+		t := make([][]int, n)
+		for i2 := 0; i2 < n; i2++ {
+			t[i2] = make([]int, m)
+			for j := 0; j < m; j++ {
+				t[i2][j] = rng.Intn(2)
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(strconv.Itoa(t[i2][j]))
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		var out strings.Builder
+		for i2 := 0; i2 < n; i2++ {
+			for j := 0; j < m; j++ {
+				val := 0
+				if t[i2][j] == 1 {
+					if a[j] < b[i2] {
+						val = a[j]
+					} else {
+						val = b[i2]
+					}
+				}
+				if j > 0 {
+					out.WriteByte(' ')
+				}
+				out.WriteString(strconv.Itoa(val))
+			}
+			if i2 < n-1 {
+				out.WriteByte('\n')
+			}
+		}
+		tests = append(tests, Test{input: input, expected: out.String()})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expected {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, tc.input, tc.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1153/verifierC.go
+++ b/1000-1999/1100-1199/1150-1159/1153/verifierC.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input    string
+	n        int
+	original string
+}
+
+func generateTests() []Test {
+	rng := rand.New(rand.NewSource(44))
+	tests := make([]Test, 0, 100)
+	for len(tests) < 100 {
+		n := (rng.Intn(20) + 2) / 2 * 2 // even between 2 and 20
+		var sb strings.Builder
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			r := rng.Intn(3)
+			if r == 0 {
+				b[i] = '('
+			} else if r == 1 {
+				b[i] = ')'
+			} else {
+				b[i] = '?'
+			}
+		}
+		if b[0] == ')' {
+			b[0] = '?'
+		}
+		if b[n-1] == '(' {
+			b[n-1] = '?'
+		}
+		s := string(b)
+		sb.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+		// ensure there is a solution using algorithm from 1153C
+		res := solveC(n, s)
+		if res == ":(" {
+			continue
+		}
+		tests = append(tests, Test{input: sb.String(), n: n, original: s})
+	}
+	return tests
+}
+
+func solveC(n int, s string) string {
+	if n%2 == 1 {
+		return ":("
+	}
+	if s[0] == ')' || s[n-1] == '(' {
+		return ":("
+	}
+	b := []byte(s)
+	b[0] = '('
+	b[n-1] = ')'
+	open := 0
+	close := 0
+	for i := 0; i < n; i++ {
+		if b[i] == '(' {
+			open++
+		} else if b[i] == ')' {
+			close++
+		}
+	}
+	need := n / 2
+	remOpen := need - open
+	remClose := need - close
+	if remOpen < 0 || remClose < 0 {
+		return ":("
+	}
+	for i := 1; i < n-1; i++ {
+		if b[i] == '?' {
+			if remOpen > 0 {
+				b[i] = '('
+				remOpen--
+			} else {
+				b[i] = ')'
+				remClose--
+			}
+		}
+	}
+	bal := 0
+	for i := 0; i < n; i++ {
+		if b[i] == '(' {
+			bal++
+		} else {
+			bal--
+		}
+		if i < n-1 && bal <= 0 {
+			return ":("
+		}
+	}
+	if bal != 0 {
+		return ":("
+	}
+	return string(b)
+}
+
+func validate(n int, orig, out string) bool {
+	if len(out) != n {
+		return false
+	}
+	for i := 0; i < n; i++ {
+		if orig[i] != '?' && orig[i] != out[i] {
+			return false
+		}
+		if out[i] != '(' && out[i] != ')' {
+			return false
+		}
+	}
+	bal := 0
+	for i := 0; i < n; i++ {
+		if out[i] == '(' {
+			bal++
+		} else {
+			bal--
+		}
+		if bal < 0 {
+			return false
+		}
+		if i < n-1 && bal == 0 {
+			return false
+		}
+	}
+	return bal == 0
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if !validate(tc.n, tc.original, got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected valid output\ngot: %s\n", i+1, tc.input, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1153/verifierD.go
+++ b/1000-1999/1100-1199/1150-1159/1153/verifierD.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input    string
+	expected string
+}
+
+func generateTests() []Test {
+	rng := rand.New(rand.NewSource(45))
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		op := make([]int, n+1)
+		parent := make([]int, n+1)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for v := 1; v <= n; v++ {
+			op[v] = rng.Intn(2)
+			if v > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(op[v]))
+		}
+		sb.WriteByte('\n')
+		for v := 2; v <= n; v++ {
+			p := rng.Intn(v-1) + 1
+			parent[v] = p
+			if v > 2 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(p))
+		}
+		if n > 1 {
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		children := make([][]int, n+1)
+		for v := 2; v <= n; v++ {
+			children[parent[v]] = append(children[parent[v]], v)
+		}
+		f := make([]int, n+1)
+		leafCount := 0
+		for v := n; v >= 1; v-- {
+			if len(children[v]) == 0 {
+				f[v] = 1
+				leafCount++
+			} else if op[v] == 0 {
+				sum := 0
+				for _, c := range children[v] {
+					sum += f[c]
+				}
+				f[v] = sum
+			} else {
+				mn := f[children[v][0]]
+				for _, c := range children[v] {
+					if f[c] < mn {
+						mn = f[c]
+					}
+				}
+				f[v] = mn
+			}
+		}
+		res := leafCount - f[1] + 1
+		tests = append(tests, Test{input: input, expected: strconv.Itoa(res)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expected {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc.input, tc.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1153/verifierE.go
+++ b/1000-1999/1100-1199/1150-1159/1153/verifierE.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type cell struct{ r, c int }
+
+type Test struct {
+	n    int
+	path []cell
+}
+
+func generatePath(n int, rng *rand.Rand) []cell {
+	length := 1 // at least 1 step
+	visited := make(map[cell]bool)
+	dirs := []struct{ dr, dc int }{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	x := rng.Intn(n) + 1
+	y := rng.Intn(n) + 1
+	path := []cell{{x, y}}
+	visited[cell{x, y}] = true
+	for len(path)-1 < length {
+		cur := path[len(path)-1]
+		candidates := make([]cell, 0, 4)
+		for _, d := range dirs {
+			nx, ny := cur.r+d.dr, cur.c+d.dc
+			if nx >= 1 && nx <= n && ny >= 1 && ny <= n {
+				c := cell{nx, ny}
+				if !visited[c] {
+					candidates = append(candidates, c)
+				}
+			}
+		}
+		if len(candidates) == 0 {
+			break
+		}
+		next := candidates[rng.Intn(len(candidates))]
+		path = append(path, next)
+		visited[next] = true
+	}
+	if len(path) == 1 {
+		// pick random adjacent cell
+		d := dirs[rng.Intn(4)]
+		nx, ny := x+d.dr, y+d.dc
+		if nx < 1 || nx > n || ny < 1 || ny > n {
+			nx, ny = x-d.dr, y-d.dc
+		}
+		path = append(path, cell{nx, ny})
+	}
+	return path
+}
+
+func generateTests() []Test {
+	rng := rand.New(rand.NewSource(46))
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 3 // n in [3,6]
+		path := generatePath(n, rng)
+		tests = append(tests, Test{n: n, path: path})
+	}
+	return tests
+}
+
+func inside(c cell, x1, y1, x2, y2 int) bool {
+	return c.r >= x1 && c.r <= x2 && c.c >= y1 && c.c <= y2
+}
+
+func queryAnswer(path []cell, x1, y1, x2, y2 int) int {
+	cnt := 0
+	for i := 0; i < len(path)-1; i++ {
+		a := inside(path[i], x1, y1, x2, y2)
+		b := inside(path[i+1], x1, y1, x2, y2)
+		if a != b {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func runCase(bin string, t Test) error {
+	var cmd *exec.Cmd
+	cmd = exec.Command(bin)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	inw := bufio.NewWriter(stdin)
+	outr := bufio.NewReader(stdout)
+	fmt.Fprintln(inw, t.n)
+	inw.Flush()
+	queries := 0
+	for {
+		line, err := outr.ReadString('\n')
+		if err != nil {
+			cmd.Process.Kill()
+			return fmt.Errorf("failed read: %v", err)
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "?") {
+			queries++
+			if queries > 2019 {
+				cmd.Process.Kill()
+				return fmt.Errorf("too many queries")
+			}
+			var x1, y1, x2, y2 int
+			fmt.Sscanf(line, "? %d %d %d %d", &x1, &y1, &x2, &y2)
+			if x1 > x2 {
+				x1, x2 = x2, x1
+			}
+			if y1 > y2 {
+				y1, y2 = y2, y1
+			}
+			ans := queryAnswer(t.path, x1, y1, x2, y2)
+			fmt.Fprintln(inw, ans)
+			inw.Flush()
+		} else if strings.HasPrefix(line, "!") {
+			var x1, y1, x2, y2 int
+			fmt.Sscanf(line, "! %d %d %d %d", &x1, &y1, &x2, &y2)
+			head := t.path[0]
+			tail := t.path[len(t.path)-1]
+			ok := (x1 == head.r && y1 == head.c && x2 == tail.r && y2 == tail.c) ||
+				(x2 == head.r && y2 == head.c && x1 == tail.r && y1 == tail.c)
+			if !ok {
+				cmd.Process.Kill()
+				return fmt.Errorf("wrong answer")
+			}
+			cmd.Wait()
+			return nil
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		if err := runCase(bin, t); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1153/verifierF.go
+++ b/1000-1999/1100-1199/1150-1159/1153/verifierF.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const mod = 998244353
+
+type Test struct {
+	input    string
+	expected string
+}
+
+func add(a, b int) int {
+	a += b
+	if a >= mod {
+		a -= mod
+	}
+	return a
+}
+func sub(a, b int) int {
+	a -= b
+	if a < 0 {
+		a += mod
+	}
+	return a
+}
+func mul(a, b int) int { return int((int64(a) * int64(b)) % mod) }
+func powmod(a, e int) int {
+	res := 1
+	x := a
+	for e > 0 {
+		if e&1 == 1 {
+			res = mul(res, x)
+		}
+		x = mul(x, x)
+		e >>= 1
+	}
+	return res
+}
+
+func solve(n, k int, l int64) int {
+	maxN := 2*n + 1
+	fact := make([]int, maxN+1)
+	invf := make([]int, maxN+1)
+	fact[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fact[i] = mul(fact[i-1], i)
+	}
+	invf[maxN] = powmod(fact[maxN], mod-2)
+	for i := maxN; i > 0; i-- {
+		invf[i-1] = mul(invf[i], i)
+	}
+	pow2 := make([]int, n+1)
+	pow2[0] = 1
+	for i := 1; i <= n; i++ {
+		pow2[i] = add(pow2[i-1], pow2[i-1])
+	}
+	cnr := make([]int, n+1)
+	for r := 0; r <= n; r++ {
+		cnr[r] = mul(fact[n], mul(invf[r], invf[n-r]))
+	}
+	Fr := make([]int, n+1)
+	for r := 0; r <= n; r++ {
+		Fr[r] = mul(pow2[r], mul(fact[r], mul(fact[r], invf[2*r+1])))
+	}
+	sumS := 0
+	for i := 0; i < k; i++ {
+		for r := i; r <= n; r++ {
+			coef := mul(cnr[r], mul(fact[r], mul(invf[i], invf[r-i])))
+			term := mul(coef, Fr[r])
+			if (r-i)&1 == 1 {
+				term = sub(0, term)
+			}
+			sumS = add(sumS, term)
+		}
+	}
+	res := int((l % int64(mod)) * int64(sub(1, sumS)) % int64(mod))
+	if res < 0 {
+		res += mod
+	}
+	return res
+}
+
+func generateTests() []Test {
+	rng := rand.New(rand.NewSource(47))
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		k := rng.Intn(n) + 1
+		l := rng.Int63n(1000000) + 1
+		input := fmt.Sprintf("%d %d %d\n", n, k, l)
+		expected := solve(n, k, l)
+		tests = append(tests, Test{input: input, expected: strconv.Itoa(expected)})
+	}
+	return tests
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		got, err := run(bin, tc.input)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != tc.expected {
+			fmt.Printf("wrong answer on test %d\ninput:%sexpected:%s\ngot:%s\n", i+1, tc.input, tc.expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifier programs for contest 1153 problems A–F
- each verifier generates 100 random tests
- verifiers run an arbitrary binary and compare its output
- interactive verifier added for problem E

## Testing
- `go run verifierA.go ./1153A`
- `go run verifierB.go ./bbin`
- `go run verifierC.go ./cbin`
- `go run verifierD.go ./dbin`
- `go run verifierE.go ./ebin` *(fails: wrong answer)*
- `go run verifierF.go ./fbin`


------
https://chatgpt.com/codex/tasks/task_e_68849b21523c83248b2bb599c7008bf7