### PR TITLE
Add verifiers for Codeforces 1152

### DIFF
--- a/1000-1999/1100-1199/1150-1159/1152/verifierA.go
+++ b/1000-1999/1100-1199/1150-1159/1152/verifierA.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expected(n, m int, a, b []int) int {
+	oddA, evenA := 0, 0
+	for _, v := range a {
+		if v%2 == 1 {
+			oddA++
+		} else {
+			evenA++
+		}
+	}
+	oddB, evenB := 0, 0
+	for _, v := range b {
+		if v%2 == 1 {
+			oddB++
+		} else {
+			evenB++
+		}
+	}
+	min := func(x, y int) int {
+		if x < y {
+			return x
+		}
+		return y
+	}
+	return min(oddA, evenB) + min(evenA, oddB)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	m := rng.Intn(100) + 1
+	a := make([]int, n)
+	b := make([]int, m)
+	for i := range a {
+		a[i] = rng.Intn(1000) + 1
+	}
+	for i := range b {
+		b[i] = rng.Intn(1000) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	exp := strconv.Itoa(expected(n, m, a, b))
+	return sb.String(), exp
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// include some deterministic edge cases
+	fixed := []struct {
+		n, m int
+		a, b []int
+	}{
+		{1, 1, []int{1}, []int{2}},
+		{2, 2, []int{1, 2}, []int{3, 4}},
+		{3, 1, []int{2, 4, 6}, []int{3}},
+		{4, 3, []int{1, 3, 5, 7}, []int{2, 4, 6}},
+	}
+	idx := 0
+	for ; idx < len(fixed); idx++ {
+		f := fixed[idx]
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", f.n, f.m))
+		for i, v := range f.a {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		for i, v := range f.b {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expectedOut := strconv.Itoa(expected(f.n, f.m, f.a, f.b))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedOut {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", idx+1, expectedOut, got, input)
+			os.Exit(1)
+		}
+	}
+	for ; idx < 100; idx++ {
+		input, expectedOut := generateCase(rng)
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, input)
+			os.Exit(1)
+		}
+		if got != expectedOut {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", idx+1, expectedOut, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}

--- a/1000-1999/1100-1199/1150-1159/1152/verifierB.go
+++ b/1000-1999/1100-1199/1150-1159/1152/verifierB.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func verifyOutput(x int64, out string) error {
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return fmt.Errorf("no output")
+	}
+	t, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid t: %v", err)
+	}
+	if t < 0 || t > 40 {
+		return fmt.Errorf("t out of range")
+	}
+	opsNeeded := (t + 1) / 2
+	if len(fields)-1 < opsNeeded {
+		return fmt.Errorf("not enough operations provided")
+	}
+	idx := 1
+	for i := 0; i < t; i++ {
+		if i%2 == 0 {
+			n, err := strconv.Atoi(fields[idx])
+			if err != nil {
+				return fmt.Errorf("invalid op: %v", err)
+			}
+			idx++
+			if n < 0 || n > 30 {
+				return fmt.Errorf("n out of range")
+			}
+			mask := int64((1 << uint(n)) - 1)
+			x ^= mask
+		} else {
+			x++
+		}
+	}
+	if idx != 1+opsNeeded {
+		return fmt.Errorf("too many numbers in output")
+	}
+	if bits.OnesCount64(uint64(x+1)) != 1 {
+		return fmt.Errorf("result not 2^m-1")
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	x := rng.Int63n(1_000_000) + 1
+	return fmt.Sprintf("%d\n", x), x
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	fixed := []int64{1, 2, 3, 39, 1000000}
+	idx := 0
+	for ; idx < len(fixed); idx++ {
+		inp := fmt.Sprintf("%d\n", fixed[idx])
+		out, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, inp)
+			os.Exit(1)
+		}
+		if err := verifyOutput(fixed[idx], out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%soutput:%s\n", idx+1, err, inp, out)
+			os.Exit(1)
+		}
+	}
+	for ; idx < 100; idx++ {
+		inp, val := generateCase(rng)
+		out, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, inp)
+			os.Exit(1)
+		}
+		if err := verifyOutput(val, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%soutput:%s\n", idx+1, err, inp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}

--- a/1000-1999/1100-1199/1150-1159/1152/verifierC.go
+++ b/1000-1999/1100-1199/1150-1159/1152/verifierC.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func lcm(a, b int64) uint64 {
+	g := gcd(a, b)
+	return uint64(a/g) * uint64(b)
+}
+
+func expected(a, b int64) int64 {
+	if a == b {
+		return 0
+	}
+	diff := a - b
+	if diff < 0 {
+		diff = -diff
+	}
+	bestK := int64(0)
+	bestLCM := ^uint64(0)
+	for d := int64(1); d*d <= diff; d++ {
+		if diff%d != 0 {
+			continue
+		}
+		for _, div := range []int64{d, diff / d} {
+			if div == 0 {
+				continue
+			}
+			k := (div - a%div) % div
+			A := a + k
+			B := b + k
+			l := lcm(A, B)
+			if l < bestLCM || (l == bestLCM && k < bestK) {
+				bestLCM = l
+				bestK = k
+			}
+		}
+	}
+	return bestK
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	a := rng.Int63n(1_000_000) + 1
+	b := rng.Int63n(1_000_000) + 1
+	inp := fmt.Sprintf("%d %d\n", a, b)
+	return inp, expected(a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	fixed := [][2]int64{
+		{6, 10},
+		{4, 4},
+		{1, 9},
+		{100000, 99999},
+	}
+	idx := 0
+	for ; idx < len(fixed); idx++ {
+		a := fixed[idx][0]
+		b := fixed[idx][1]
+		inp := fmt.Sprintf("%d %d\n", a, b)
+		exp := strconv.FormatInt(expected(a, b), 10)
+		out, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, inp)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", idx+1, exp, out, inp)
+			os.Exit(1)
+		}
+	}
+	for ; idx < 100; idx++ {
+		inp, expVal := generateCase(rng)
+		out, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, inp)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strconv.FormatInt(expVal, 10) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", idx+1, expVal, out, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}

--- a/1000-1999/1100-1199/1150-1159/1152/verifierD.go
+++ b/1000-1999/1100-1199/1150-1159/1152/verifierD.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expected(n int) int {
+	N := 2 * n
+	prev0 := make([]int, n+2)
+	prev1 := make([]int, n+2)
+	for pos := N - 1; pos >= 0; pos-- {
+		maxb := min(pos, N-pos)
+		cur0 := make([]int, n+2)
+		cur1 := make([]int, n+2)
+		for b := 0; b <= maxb; b++ {
+			sumAll := 0
+			bestVal := 0
+			if b+1 <= N-pos-1 {
+				p0 := prev0[b+1]
+				p1 := prev1[b+1]
+				mx := p0
+				if p1 > mx {
+					mx = p1
+				}
+				sumAll += mx
+				val := 1 + p1 - mx
+				if val > bestVal {
+					bestVal = val
+				}
+			}
+			if b > 0 {
+				p0 := prev0[b-1]
+				p1 := prev1[b-1]
+				mx := p0
+				if p1 > mx {
+					mx = p1
+				}
+				sumAll += mx
+				val := 1 + p1 - mx
+				if val > bestVal {
+					bestVal = val
+				}
+			}
+			cur1[b] = sumAll
+			if bestVal > 0 {
+				cur0[b] = sumAll + bestVal
+			} else {
+				cur0[b] = sumAll
+			}
+		}
+		prev0 = cur0
+		prev1 = cur1
+	}
+	res := prev0[0] % MOD
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(10) + 1
+	inp := fmt.Sprintf("%d\n", n)
+	return inp, expected(n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	fixed := []int{1, 2, 3, 10}
+	idx := 0
+	for ; idx < len(fixed); idx++ {
+		n := fixed[idx]
+		inp := fmt.Sprintf("%d\n", n)
+		exp := strconv.Itoa(expected(n))
+		out, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, inp)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", idx+1, exp, out, inp)
+			os.Exit(1)
+		}
+	}
+	for ; idx < 100; idx++ {
+		inp, expVal := generateCase(rng)
+		out, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, inp)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strconv.Itoa(expVal) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", idx+1, expVal, out, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}

--- a/1000-1999/1100-1199/1150-1159/1152/verifierE.go
+++ b/1000-1999/1100-1199/1150-1159/1152/verifierE.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func checkAnswer(ans []int, b, c []int) bool {
+	if len(ans) != len(b)+1 {
+		return false
+	}
+	n := len(ans)
+	pairs1 := make([][2]int, n-1)
+	for i := 0; i < n-1; i++ {
+		x, y := ans[i], ans[i+1]
+		if x <= 0 || y <= 0 || x > 1_000_000_000 || y > 1_000_000_000 {
+			return false
+		}
+		if x > y {
+			x, y = y, x
+		}
+		pairs1[i] = [2]int{x, y}
+	}
+	pairs2 := make([][2]int, n-1)
+	for i := 0; i < n-1; i++ {
+		x, y := b[i], c[i]
+		if x > y {
+			x, y = y, x
+		}
+		pairs2[i] = [2]int{x, y}
+	}
+	sort.Slice(pairs1, func(i, j int) bool {
+		if pairs1[i][0] == pairs1[j][0] {
+			return pairs1[i][1] < pairs1[j][1]
+		}
+		return pairs1[i][0] < pairs1[j][0]
+	})
+	sort.Slice(pairs2, func(i, j int) bool {
+		if pairs2[i][0] == pairs2[j][0] {
+			return pairs2[i][1] < pairs2[j][1]
+		}
+		return pairs2[i][0] < pairs2[j][0]
+	})
+	for i := 0; i < n-1; i++ {
+		if pairs1[i] != pairs2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func generateCase(rng *rand.Rand) (string, []int, []int) {
+	n := rng.Intn(8) + 2
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(1000) + 1
+	}
+	b := make([]int, n-1)
+	c := make([]int, n-1)
+	for i := 0; i < n-1; i++ {
+		if a[i] < a[i+1] {
+			b[i] = a[i]
+			c[i] = a[i+1]
+		} else {
+			b[i] = a[i+1]
+			c[i] = a[i]
+		}
+	}
+	perm := rng.Perm(n - 1)
+	b2 := make([]int, n-1)
+	c2 := make([]int, n-1)
+	for i, p := range perm {
+		b2[i] = b[p]
+		c2[i] = c[p]
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range b2 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range c2 {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), b2, c2
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// deterministic cases
+	fixed := []struct {
+		b []int
+		c []int
+	}{
+		{[]int{3}, []int{4}},
+		{[]int{2, 3}, []int{5, 4}},
+	}
+	idx := 0
+	for ; idx < len(fixed); idx++ {
+		n := len(fixed[idx].b) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i, v := range fixed[idx].b {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		for i, v := range fixed[idx].c {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(v))
+		}
+		sb.WriteByte('\n')
+		inp := sb.String()
+		out, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, inp)
+			os.Exit(1)
+		}
+		toks := strings.Fields(out)
+		if len(toks) != n {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\n", idx+1, n, len(toks))
+			os.Exit(1)
+		}
+		ans := make([]int, n)
+		for i := 0; i < n; i++ {
+			val, err := strconv.Atoi(toks[i])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: invalid number %v\n", idx+1, err)
+				os.Exit(1)
+			}
+			ans[i] = val
+		}
+		if !checkAnswer(ans, fixed[idx].b, fixed[idx].c) {
+			fmt.Fprintf(os.Stderr, "case %d failed: invalid answer\n", idx+1)
+			os.Exit(1)
+		}
+	}
+	for ; idx < 100; idx++ {
+		inp, b, c := generateCase(rng)
+		out, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, inp)
+			os.Exit(1)
+		}
+		toks := strings.Fields(out)
+		n := len(b) + 1
+		if len(toks) != n {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d numbers got %d\n", idx+1, n, len(toks))
+			os.Exit(1)
+		}
+		ans := make([]int, n)
+		for i := 0; i < n; i++ {
+			v, err := strconv.Atoi(toks[i])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "case %d failed: invalid number %v\n", idx+1, err)
+				os.Exit(1)
+			}
+			ans[i] = v
+		}
+		if !checkAnswer(ans, b, c) {
+			fmt.Fprintf(os.Stderr, "case %d failed: wrong answer\ninput:%soutput:%s\n", idx+1, inp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}

--- a/1000-1999/1100-1199/1150-1159/1152/verifierF1.go
+++ b/1000-1999/1100-1199/1150-1159/1152/verifierF1.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, k, m int) int64 {
+	dp := make([]int64, n+2)
+	dp2 := make([]int64, n+2)
+	for M := 1; M <= n; M++ {
+		dp[M] = 1
+	}
+	for i := 1; i < k; i++ {
+		for idx := 1; idx <= n; idx++ {
+			dp2[idx] = 0
+		}
+		for M := i; M <= n; M++ {
+			v := dp[M]
+			if v == 0 {
+				continue
+			}
+			stay := int64(M - i)
+			if stay > 0 {
+				dp2[M] = (dp2[M] + v*stay) % MOD
+			}
+			end := M + m
+			if end > n {
+				end = n
+			}
+			for y := M + 1; y <= end; y++ {
+				dp2[y] = (dp2[y] + v) % MOD
+			}
+		}
+		dp, dp2 = dp2, dp
+	}
+	var ans int64
+	for M := k; M <= n; M++ {
+		ans = (ans + dp[M]) % MOD
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	if k > 12 {
+		k = 12
+	}
+	m := rng.Intn(4) + 1
+	input := fmt.Sprintf("%d %d %d\n", n, k, m)
+	return input, expected(n, k, m)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	fixed := [][3]int{
+		{3, 3, 1},
+		{4, 2, 2},
+	}
+	idx := 0
+	for ; idx < len(fixed); idx++ {
+		n := fixed[idx][0]
+		k := fixed[idx][1]
+		m := fixed[idx][2]
+		inp := fmt.Sprintf("%d %d %d\n", n, k, m)
+		exp := strconv.FormatInt(expected(n, k, m), 10)
+		out, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, inp)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", idx+1, exp, out, inp)
+			os.Exit(1)
+		}
+	}
+	for ; idx < 100; idx++ {
+		inp, expVal := generateCase(rng)
+		out, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, inp)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strconv.FormatInt(expVal, 10) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", idx+1, expVal, out, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}

--- a/1000-1999/1100-1199/1150-1159/1152/verifierF2.go
+++ b/1000-1999/1100-1199/1150-1159/1152/verifierF2.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n, k, m int) int64 {
+	dp := make([]int64, n+2)
+	dp2 := make([]int64, n+2)
+	for M := 1; M <= n; M++ {
+		dp[M] = 1
+	}
+	for i := 1; i < k; i++ {
+		for idx := 1; idx <= n; idx++ {
+			dp2[idx] = 0
+		}
+		for M := i; M <= n; M++ {
+			v := dp[M]
+			if v == 0 {
+				continue
+			}
+			stay := int64(M - i)
+			if stay > 0 {
+				dp2[M] = (dp2[M] + v*stay) % MOD
+			}
+			end := M + m
+			if end > n {
+				end = n
+			}
+			for y := M + 1; y <= end; y++ {
+				dp2[y] = (dp2[y] + v) % MOD
+			}
+		}
+		dp, dp2 = dp2, dp
+	}
+	var ans int64
+	for M := k; M <= n; M++ {
+		ans = (ans + dp[M]) % MOD
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, int64) {
+	n := rng.Intn(30) + 1
+	k := rng.Intn(12) + 1
+	if k > n {
+		k = n
+	}
+	m := rng.Intn(4) + 1
+	input := fmt.Sprintf("%d %d %d\n", n, k, m)
+	return input, expected(n, k, m)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	fixed := [][3]int{
+		{3, 3, 1},
+		{5, 2, 3},
+	}
+	idx := 0
+	for ; idx < len(fixed); idx++ {
+		n := fixed[idx][0]
+		k := fixed[idx][1]
+		m := fixed[idx][2]
+		inp := fmt.Sprintf("%d %d %d\n", n, k, m)
+		exp := strconv.FormatInt(expected(n, k, m), 10)
+		out, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, inp)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", idx+1, exp, out, inp)
+			os.Exit(1)
+		}
+	}
+	for ; idx < 100; idx++ {
+		inp, expVal := generateCase(rng)
+		out, err := run(bin, inp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", idx+1, err, inp)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strconv.FormatInt(expVal, 10) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", idx+1, expVal, out, inp)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", idx)
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers for contest 1152 problems A through F2
- verifiers generate 100 random tests plus fixed edge cases and can run any binary

## Testing
- `go run verifierA.go -- 1152A.go` *(produced `All 100 tests passed`)*

------
https://chatgpt.com/codex/tasks/task_e_68849a955d7c8324ad1451dcc2ca2044