### PR TITLE
Add verifiers for contest 1156

### DIFF
--- a/1000-1999/1100-1199/1150-1159/1156/verifierA.go
+++ b/1000-1999/1100-1199/1150-1159/1156/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1156A.go")
+	bin := filepath.Join(os.TempDir(), "oracle1156A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(99-2+1) + 2 // 2..99
+	arr := make([]int, n)
+	arr[0] = r.Intn(3) + 1
+	for i := 1; i < n; i++ {
+		for {
+			x := r.Intn(3) + 1
+			if x != arr[i-1] {
+				arr[i] = x
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1100-1199/1150-1159/1156/verifierB.go
+++ b/1000-1999/1100-1199/1150-1159/1156/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1156B.go")
+	bin := filepath.Join(os.TempDir(), "oracle1156B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + r.Intn(26))
+	}
+	return string(b)
+}
+
+func genCase(r *rand.Rand) string {
+	t := r.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := r.Intn(10) + 1
+		sb.WriteString(randString(r, n))
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1100-1199/1150-1159/1156/verifierC.go
+++ b/1000-1999/1100-1199/1150-1159/1156/verifierC.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1156C.go")
+	bin := filepath.Join(os.TempDir(), "oracle1156C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(50) + 2
+	z := r.Intn(20) + 1
+	xs := make([]int, n)
+	for i := 0; i < n; i++ {
+		xs[i] = r.Intn(100)
+	}
+	sort.Ints(xs)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, z)
+	for i, v := range xs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1100-1199/1150-1159/1156/verifierD.go
+++ b/1000-1999/1100-1199/1150-1159/1156/verifierD.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1156D.go")
+	bin := filepath.Join(os.TempDir(), "oracle1156D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(20) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 2; i <= n; i++ {
+		parent := r.Intn(i-1) + 1
+		c := r.Intn(2)
+		fmt.Fprintf(&sb, "%d %d %d\n", parent, i, c)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1100-1199/1150-1159/1156/verifierE.go
+++ b/1000-1999/1100-1199/1150-1159/1156/verifierE.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1156E.go")
+	bin := filepath.Join(os.TempDir(), "oracle1156E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(30) + 3
+	perm := r.Perm(n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1100-1199/1150-1159/1156/verifierF.go
+++ b/1000-1999/1100-1199/1150-1159/1156/verifierF.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1156F.go")
+	bin := filepath.Join(os.TempDir(), "oracle1156F.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(20) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", r.Intn(n)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1100-1199/1150-1159/1156/verifierG.go
+++ b/1000-1999/1100-1199/1150-1159/1156/verifierG.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1156G.go")
+	bin := filepath.Join(os.TempDir(), "oracle1156G.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+var names = []string{"a", "b", "c", "d", "e", "f", "g", "h", "res"}
+var ops = []byte{'$', '^', '#', '&'}
+
+func randName(r *rand.Rand) string { return names[r.Intn(len(names))] }
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		l := randName(r)
+		if r.Intn(2) == 0 {
+			r1 := randName(r)
+			fmt.Fprintf(&sb, "%s=%s\n", l, r1)
+		} else {
+			r1 := randName(r)
+			r2 := randName(r)
+			op := ops[r.Intn(len(ops))]
+			fmt.Fprintf(&sb, "%s=%s%c%s\n", l, r1, op, r2)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 100; i++ {
+		input := genCase(r)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(userBin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if want != got {
+			fmt.Printf("test %d failed\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for problems A–G of contest 1156
- each verifier builds the official solution as an oracle
- 100 random tests are generated for each problem
- verifiers can be run via `go run verifierX.go /path/to/binary`

## Testing
- `go build 1000-1999/1100-1199/1150-1159/1156/verifierA.go`
- `go build 1000-1999/1100-1199/1150-1159/1156/verifierB.go`
- `go build 1000-1999/1100-1199/1150-1159/1156/verifierC.go`
- `go build 1000-1999/1100-1199/1150-1159/1156/verifierD.go`
- `go build 1000-1999/1100-1199/1150-1159/1156/verifierE.go`
- `go build 1000-1999/1100-1199/1150-1159/1156/verifierF.go`
- `go build 1000-1999/1100-1199/1150-1159/1156/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_68849cc593e48324bb62387442b27f12