### PR TITLE
Add Go verifiers for contest 1155

### DIFF
--- a/1000-1999/1100-1199/1150-1159/1155/verifierA.go
+++ b/1000-1999/1100-1199/1150-1159/1155/verifierA.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+// findPair returns whether there exists l<r so that reversing makes string smaller
+func findPair(s string) (bool, int, int) {
+	n := len(s)
+	minChar := make([]byte, n)
+	pos := make([]int, n)
+	minChar[n-1] = s[n-1]
+	pos[n-1] = n - 1
+	for i := n - 2; i >= 0; i-- {
+		if s[i+1] < minChar[i+1] {
+			minChar[i] = s[i+1]
+			pos[i] = i + 1
+		} else {
+			minChar[i] = minChar[i+1]
+			pos[i] = pos[i+1]
+		}
+	}
+	for i := 0; i < n-1; i++ {
+		if minChar[i] < s[i] {
+			return true, i + 1, pos[i] + 1
+		}
+	}
+	return false, 0, 0
+}
+
+func checkCase(bin string, n int, s string) error {
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(out)
+	has, _, _ := findPair(s)
+	if !has {
+		if len(fields) != 1 || strings.ToUpper(fields[0]) != "NO" {
+			return fmt.Errorf("expected NO, got %s", out)
+		}
+		return nil
+	}
+	if len(fields) < 3 || strings.ToUpper(fields[0]) != "YES" {
+		return fmt.Errorf("expected YES l r, got %s", out)
+	}
+	l, err1 := strconv.Atoi(fields[1])
+	r, err2 := strconv.Atoi(fields[2])
+	if err1 != nil || err2 != nil {
+		return fmt.Errorf("invalid indices in output: %s", out)
+	}
+	if l < 1 || l >= r || r > n {
+		return fmt.Errorf("indices out of range: %s", out)
+	}
+	b := []byte(s)
+	for i, j := l-1, r-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	if !(string(b) < s) {
+		return fmt.Errorf("reversing [%d,%d] does not make string smaller", l, r)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []string{"ab", "aa", "abc", "cba", "abacaba"}
+	for len(tests) < 100 {
+		n := rng.Intn(8) + 2
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteByte(byte('a' + rng.Intn(26)))
+		}
+		tests = append(tests, sb.String())
+	}
+	for i, s := range tests {
+		if err := checkCase(bin, len(s), s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1155/verifierB.go
+++ b/1000-1999/1100-1199/1150-1159/1155/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(s string) string {
+	n := len(s)
+	moves := (n - 11) / 2
+	count8 := 0
+	limit := n - 10
+	for i := 0; i < limit && i < len(s); i++ {
+		if s[i] == '8' {
+			count8++
+		}
+	}
+	if count8 > moves {
+		return "YES"
+	}
+	return "NO"
+}
+
+func checkCase(bin string, s string) error {
+	input := fmt.Sprintf("%d\n%s\n", len(s), s)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(out) != expected(s) {
+		return fmt.Errorf("expected %s got %s", expected(s), out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := []string{"8", "12345678901", "88888888888"}
+	for len(tests) < 100 {
+		n := rng.Intn(9)*2 + 11 // odd length >=11
+		var sb strings.Builder
+		for i := 0; i < n; i++ {
+			sb.WriteByte(byte('0' + rng.Intn(10)))
+		}
+		tests = append(tests, sb.String())
+	}
+	for i, s := range tests {
+		if err := checkCase(bin, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1155/verifierC.go
+++ b/1000-1999/1100-1199/1150-1159/1155/verifierC.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func expectedIndices(xs []int64, ps []int64) map[int]bool {
+	if len(xs) < 2 {
+		return map[int]bool{}
+	}
+	d := xs[1] - xs[0]
+	for i := 2; i < len(xs); i++ {
+		d = gcd(d, xs[i]-xs[0])
+	}
+	res := make(map[int]bool)
+	for i, p := range ps {
+		if d%p == 0 {
+			res[i+1] = true
+		}
+	}
+	return res
+}
+
+func checkCase(bin string, xs []int64, ps []int64) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", len(xs), len(ps))
+	for i, v := range xs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	for i, v := range ps {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(out)
+	valid := expectedIndices(xs, ps)
+	if len(valid) == 0 {
+		if len(fields) != 1 || strings.ToUpper(fields[0]) != "NO" {
+			return fmt.Errorf("expected NO, got %s", out)
+		}
+		return nil
+	}
+	if len(fields) < 3 || strings.ToUpper(fields[0]) != "YES" {
+		return fmt.Errorf("expected YES y j, got %s", out)
+	}
+	y, err1 := strconv.ParseInt(fields[1], 10, 64)
+	j, err2 := strconv.Atoi(fields[2])
+	if err1 != nil || err2 != nil {
+		return fmt.Errorf("invalid output numbers: %s", out)
+	}
+	if !valid[j] {
+		return fmt.Errorf("index %d does not divide gcd", j)
+	}
+	pj := ps[j-1]
+	if (xs[0]-y)%pj != 0 {
+		return fmt.Errorf("y does not satisfy congruence")
+	}
+	if y < 1 {
+		return fmt.Errorf("y must be >=1")
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	type pair struct {
+		xs []int64
+		ps []int64
+	}
+	tests := []pair{
+		{xs: []int64{1, 3}, ps: []int64{2, 3}},
+		{xs: []int64{5, 10, 15}, ps: []int64{5}},
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(4) + 2
+		m := rng.Intn(4) + 1
+		xs := make([]int64, n)
+		start := int64(rng.Intn(20) + 1)
+		xs[0] = start
+		step := int64(rng.Intn(5) + 1)
+		for i := 1; i < n; i++ {
+			xs[i] = xs[i-1] + step + int64(rng.Intn(3))
+		}
+		ps := make([]int64, m)
+		for i := 0; i < m; i++ {
+			ps[i] = int64(rng.Intn(10) + 1)
+		}
+		tests = append(tests, pair{xs: xs, ps: ps})
+	}
+	for i, tc := range tests {
+		if err := checkCase(bin, tc.xs, tc.ps); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1155/verifierD.go
+++ b/1000-1999/1100-1199/1150-1159/1155/verifierD.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func expected(n int, x int64, arr []int64) int64 {
+	const inf = int64(4e18)
+	var dp0, dp1, dp2, ans int64
+	dp1 = -inf
+	dp2 = -inf
+	for i := 0; i < n; i++ {
+		a := arr[i]
+		noPrev := dp0
+		mulPrev := dp1
+		aftPrev := dp2
+		dp0 = maxInt64(noPrev+a, 0)
+		dp1 = maxInt64(mulPrev+a*x, noPrev+a*x)
+		dp2 = maxInt64(aftPrev+a, mulPrev+a)
+		ans = maxInt64(ans, dp0)
+		ans = maxInt64(ans, dp1)
+		ans = maxInt64(ans, dp2)
+	}
+	return ans
+}
+
+func checkCase(bin string, n int, x int64, arr []int64) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, x)
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	want := fmt.Sprintf("%d", expected(n, x, arr))
+	if strings.TrimSpace(out) != want {
+		return fmt.Errorf("expected %s got %s", want, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	type caseD struct {
+		n   int
+		x   int64
+		arr []int64
+	}
+	tests := []caseD{
+		{n: 1, x: 1, arr: []int64{5}},
+		{n: 3, x: -1, arr: []int64{1, 2, 3}},
+	}
+	for len(tests) < 100 {
+		n := rng.Intn(7) + 1
+		x := int64(rng.Intn(7) - 3)
+		arr := make([]int64, n)
+		for i := 0; i < n; i++ {
+			arr[i] = int64(rng.Intn(11) - 5)
+		}
+		tests = append(tests, caseD{n: n, x: x, arr: arr})
+	}
+	for i, tc := range tests {
+		if err := checkCase(bin, tc.n, tc.x, tc.arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1155/verifierE.go
+++ b/1000-1999/1100-1199/1150-1159/1155/verifierE.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem E is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1100-1199/1150-1159/1155/verifierF.go
+++ b/1000-1999/1100-1199/1150-1159/1155/verifierF.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runExe(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1155F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+type test struct {
+	input string
+}
+
+func genTests() []test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var tests []test
+	for len(tests) < 100 {
+		n := rng.Intn(4) + 2
+		m := rng.Intn(4) + n - 1
+		edges := make(map[[2]int]bool)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for len(edges) < m {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			if u > v {
+				u, v = v, u
+			}
+			key := [2]int{u, v}
+			if edges[key] {
+				continue
+			}
+			edges[key] = true
+			fmt.Fprintf(&sb, "%d %d\n", u, v)
+		}
+		tests = append(tests, test{input: sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifier programs for contest 1155 problems A–F
- generate at least 100 random tests for each verifier
- handle interactive problem E with a simple message
- use the solution `1155F.go` as a reference implementation for problem F

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_68849c39bfc08324ba128b2920ee2ccb