### PR TITLE
Add Go verifiers for CF1159

### DIFF
--- a/1000-1999/1100-1199/1150-1159/1159/verifierA.go
+++ b/1000-1999/1100-1199/1150-1159/1159/verifierA.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(s string) int {
+	cur := 0
+	minCur := 0
+	for _, ch := range s {
+		if ch == '+' {
+			cur++
+		} else {
+			cur--
+		}
+		if cur < minCur {
+			minCur = cur
+		}
+	}
+	return cur - minCur
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '-'
+		} else {
+			b[i] = '+'
+		}
+	}
+	s := string(b)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n%s\n", n, s)
+	exp := fmt.Sprintf("%d", expected(s))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1159/verifierB.go
+++ b/1000-1999/1100-1199/1150-1159/1159/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(a []int) int {
+	n := len(a)
+	const INF int64 = 1 << 60
+	ans := INF
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			diff := int64(j - i)
+			m := int64(a[i])
+			if a[j] < a[i] {
+				m = int64(a[j])
+			}
+			v := m / diff
+			if v < ans {
+				ans = v
+				if ans == 0 {
+					return 0
+				}
+			}
+		}
+	}
+	if ans == INF {
+		return 0
+	}
+	return int(ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 2
+	a := make([]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(1000)
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", a[i])
+	}
+	sb.WriteString("\n")
+	exp := fmt.Sprintf("%d", expected(a))
+	return sb.String(), exp
+}
+
+func runCase(bin, input, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != exp {
+		return fmt.Errorf("expected %s got %s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add automated verifiers for contest 1159 problems A and B
- generate random tests and compare with expected results

## Testing
- `go run verifierA.go ./1159A.bin`
- `go run verifierB.go ./1159B.bin`

------
https://chatgpt.com/codex/tasks/task_e_68849e69dfdc83248b5acc6987ff1bc7