### PR TITLE
Add verifiers for CF 1157

### DIFF
--- a/1000-1999/1100-1199/1150-1159/1157/verifierA.go
+++ b/1000-1999/1100-1199/1150-1159/1157/verifierA.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const numTestsA = 100
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: verifierA.go <binary>")
+		os.Exit(1)
+	}
+	binPath, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		os.Exit(1)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	r := rand.New(rand.NewSource(1))
+	for t := 1; t <= numTestsA; t++ {
+		n := r.Intn(1_000_000_000) + 1
+		input := fmt.Sprintf("%d\n", n)
+		expected := solveA(n)
+		out, err := run(binPath, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed: n=%d expected %s got %s\n", t, n, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verify_binA")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, string(out))
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func solveA(n int) string {
+	seen := make(map[int]struct{})
+	count := 0
+	for {
+		if _, ok := seen[n]; ok {
+			break
+		}
+		seen[n] = struct{}{}
+		count++
+		n = f(n)
+	}
+	return strconv.Itoa(count)
+}
+
+func f(x int) int {
+	x++
+	for x%10 == 0 {
+		x /= 10
+	}
+	return x
+}

--- a/1000-1999/1100-1199/1150-1159/1157/verifierB.go
+++ b/1000-1999/1100-1199/1150-1159/1157/verifierB.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const numTestsB = 100
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: verifierB.go <binary>")
+		os.Exit(1)
+	}
+	binPath, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		os.Exit(1)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	r := rand.New(rand.NewSource(1))
+	for t := 1; t <= numTestsB; t++ {
+		n := r.Intn(20) + 1
+		digits := make([]byte, n)
+		for i := range digits {
+			digits[i] = byte('1' + r.Intn(9))
+		}
+		f := make([]int, 10)
+		for i := 1; i <= 9; i++ {
+			f[i] = r.Intn(9) + 1
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		sb.WriteString(fmt.Sprintf("%s\n", string(digits)))
+		for i := 1; i <= 9; i++ {
+			if i > 1 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(f[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveB(n, string(digits), f)
+		out, err := run(binPath, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s got:%s\n", t, input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verify_binB")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, string(out))
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func solveB(n int, s string, f []int) string {
+	b := []byte(s)
+	started := false
+	for i := 0; i < n; i++ {
+		d := int(b[i] - '0')
+		if !started {
+			if f[d] > d {
+				started = true
+				b[i] = byte('0' + f[d])
+			}
+		} else {
+			if f[d] >= d {
+				b[i] = byte('0' + f[d])
+			} else {
+				break
+			}
+		}
+	}
+	return string(b)
+}

--- a/1000-1999/1100-1199/1150-1159/1157/verifierC1.go
+++ b/1000-1999/1100-1199/1150-1159/1157/verifierC1.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsC1 = 100
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: verifierC1.go <binary>")
+		os.Exit(1)
+	}
+	binPath, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		os.Exit(1)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	r := rand.New(rand.NewSource(1))
+	for t := 1; t <= numTestsC1; t++ {
+		n := r.Intn(20) + 1
+		a := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			a[i] = r.Intn(100) + 1
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveC1(a)
+		out, err := run(binPath, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s got:%s\n", t, input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verify_binC1")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, string(out))
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func solveC1(a []int) string {
+	l, r := 0, len(a)-1
+	now := 0
+	res := make([]byte, 0, len(a))
+	for l <= r {
+		if a[l] <= now && a[r] <= now {
+			break
+		}
+		if a[l] < a[r] {
+			if now < a[l] {
+				res = append(res, 'L')
+				now = a[l]
+				l++
+			} else {
+				res = append(res, 'R')
+				now = a[r]
+				r--
+			}
+		} else {
+			if now < a[r] {
+				res = append(res, 'R')
+				now = a[r]
+				r--
+			} else {
+				res = append(res, 'L')
+				now = a[l]
+				l++
+			}
+		}
+	}
+	return fmt.Sprintf("%d\n%s", len(res), string(res))
+}

--- a/1000-1999/1100-1199/1150-1159/1157/verifierC2.go
+++ b/1000-1999/1100-1199/1150-1159/1157/verifierC2.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsC2 = 100
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: verifierC2.go <binary>")
+		os.Exit(1)
+	}
+	binPath, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		os.Exit(1)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	r := rand.New(rand.NewSource(1))
+	for t := 1; t <= numTestsC2; t++ {
+		n := r.Intn(20) + 1
+		a := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			a[i] = r.Intn(100) + 1
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveC2(a)
+		out, err := run(binPath, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s got:%s\n", t, input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verify_binC2")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, string(out))
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func solveC2(a []int) string {
+	n := len(a)
+	g := make([]int, n)
+	g[0] = 1
+	for i := 1; i < n; i++ {
+		if a[i-1] > a[i] {
+			g[i] = g[i-1] + 1
+		} else {
+			g[i] = 1
+		}
+	}
+	f := make([]int, n)
+	f[n-1] = 1
+	for i := n - 2; i >= 0; i-- {
+		if a[i+1] > a[i] {
+			f[i] = f[i+1] + 1
+		} else {
+			f[i] = 1
+		}
+	}
+	l, r := 0, n-1
+	now, ans := 0, 0
+	var sb strings.Builder
+	for l <= r && (a[l] > now || a[r] > now) {
+		j := -1
+		if a[l] > now && a[r] > now {
+			if a[l] == a[r] {
+				if f[l] > g[r] {
+					j = l
+				} else {
+					j = r
+				}
+			} else if a[l] < a[r] {
+				j = l
+			} else {
+				j = r
+			}
+		} else if a[l] > now {
+			j = l
+		} else {
+			j = r
+		}
+		now = a[j]
+		ans++
+		if j == l {
+			sb.WriteByte('L')
+			l++
+		} else {
+			sb.WriteByte('R')
+			r--
+		}
+	}
+	return fmt.Sprintf("%d\n%s", ans, sb.String())
+}

--- a/1000-1999/1100-1199/1150-1159/1157/verifierD.go
+++ b/1000-1999/1100-1199/1150-1159/1157/verifierD.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsD = 100
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: verifierD.go <binary>")
+		os.Exit(1)
+	}
+	binPath, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		os.Exit(1)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	r := rand.New(rand.NewSource(1))
+	for t := 1; t <= numTestsD; t++ {
+		k := int64(r.Intn(10) + 1)
+		min := k * (k + 1) / 2
+		n := min + int64(r.Intn(100))
+		input := fmt.Sprintf("%d %d\n", n, k)
+		expected := solveD(n, k)
+		out, err := run(binPath, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s got:%s\n", t, input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verify_binD")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, string(out))
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func solveD(n, k int64) string {
+	sig := k * (k + 1) / 2
+	if k == 1 {
+		return fmt.Sprintf("YES\n%d", n)
+	}
+	if n < sig {
+		return "NO"
+	}
+	n -= sig
+	q := n / k
+	r := n % k
+	if q > 0 || (q == 0 && r != k-1) {
+		var sb strings.Builder
+		sb.WriteString("YES\n")
+		for i := int64(1); i < k; i++ {
+			sb.WriteString(fmt.Sprintf("%d ", i+q))
+		}
+		sb.WriteString(fmt.Sprintf("%d", k+q+r))
+		return sb.String()
+	}
+	if k >= 4 {
+		var sb strings.Builder
+		sb.WriteString("YES\n")
+		for i := int64(1); i <= k-2; i++ {
+			sb.WriteString(fmt.Sprintf("%d ", i+q))
+		}
+		sb.WriteString(fmt.Sprintf("%d %d", k+q, k+q+r-1))
+		return sb.String()
+	}
+	return "NO"
+}

--- a/1000-1999/1100-1199/1150-1159/1157/verifierE.go
+++ b/1000-1999/1100-1199/1150-1159/1157/verifierE.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsE = 100
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: verifierE.go <binary>")
+		os.Exit(1)
+	}
+	binPath, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		os.Exit(1)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	r := rand.New(rand.NewSource(1))
+	for t := 1; t <= numTestsE; t++ {
+		n := r.Intn(10) + 1
+		a := make([]int, n)
+		b := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			a[i] = r.Intn(n)
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteByte('\n')
+		for i := 0; i < n; i++ {
+			b[i] = r.Intn(n)
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", b[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveE(a, b)
+		out, err := run(binPath, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s got:%s\n", t, input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verify_binE")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, string(out))
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+type Fenwick struct {
+	n    int
+	tree []int
+}
+
+func NewFenwick(n int) *Fenwick {
+	return &Fenwick{n: n, tree: make([]int, n+1)}
+}
+
+func (f *Fenwick) Add(i, delta int) {
+	for j := i + 1; j <= f.n; j += j & -j {
+		f.tree[j] += delta
+	}
+}
+
+func (f *Fenwick) Sum(i int) int {
+	if i < 0 {
+		return 0
+	}
+	res := 0
+	for j := i + 1; j > 0; j -= j & -j {
+		res += f.tree[j]
+	}
+	return res
+}
+
+func (f *Fenwick) FindKth(k int) int {
+	idx := 0
+	bit := 1
+	for bit<<1 <= f.n {
+		bit <<= 1
+	}
+	for ; bit > 0; bit >>= 1 {
+		nxt := idx + bit
+		if nxt <= f.n && f.tree[nxt] < k {
+			idx = nxt
+			k -= f.tree[nxt]
+		}
+	}
+	return idx
+}
+
+func solveE(a, b []int) string {
+	n := len(a)
+	fenw := NewFenwick(n)
+	for _, x := range b {
+		fenw.Add(x, 1)
+	}
+	c := make([]int, n)
+	for i := 0; i < n; i++ {
+		want := (n - a[i]) % n
+		s := fenw.Sum(want - 1)
+		total := fenw.Sum(n - 1)
+		var k int
+		if total-s > 0 {
+			k = s + 1
+		} else {
+			k = 1
+		}
+		idx := fenw.FindKth(k)
+		c[i] = (a[i] + idx) % n
+		fenw.Add(idx, -1)
+	}
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c[i]))
+	}
+	return sb.String()
+}

--- a/1000-1999/1100-1199/1150-1159/1157/verifierF.go
+++ b/1000-1999/1100-1199/1150-1159/1157/verifierF.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsF = 100
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: verifierF.go <binary>")
+		os.Exit(1)
+	}
+	binPath, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		os.Exit(1)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	r := rand.New(rand.NewSource(1))
+	for t := 1; t <= numTestsF; t++ {
+		n := r.Intn(20) + 1
+		a := make([]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			a[i] = r.Intn(30) + 1
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveF(a)
+		out, err := run(binPath, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s got:%s\n", t, input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verify_binF")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, string(out))
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func solveF(a []int) string {
+	const MAX = 200005
+	cnt := make([]int, MAX)
+	for _, x := range a {
+		if x >= 0 && x < MAX {
+			cnt[x]++
+		}
+	}
+	sumcnt := make([]int, MAX)
+	for i := 1; i < MAX; i++ {
+		sumcnt[i] = sumcnt[i-1] + cnt[i]
+	}
+	ans := -1
+	ansL, ansR := 0, 0
+	r := 0
+	for l := 1; l < MAX; l++ {
+		if cnt[l] == 0 {
+			continue
+		}
+		if r < l {
+			r = l
+		}
+		for r+1 < MAX && cnt[r+1] >= 1 && (cnt[r] >= 2 || l == r) {
+			r++
+		}
+		tans := sumcnt[r] - sumcnt[l-1]
+		if tans > ans {
+			ans = tans
+			ansL = l
+			ansR = r
+		}
+	}
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("%d\n", ans))
+	for i := ansL; i <= ansR; i++ {
+		if cnt[i] > 0 {
+			out.WriteString(fmt.Sprintf("%d ", i))
+			cnt[i]--
+		}
+	}
+	for i := ansR; i >= ansL; i-- {
+		for cnt[i] > 0 {
+			out.WriteString(fmt.Sprintf("%d ", i))
+			cnt[i]--
+		}
+	}
+	s := strings.TrimSpace(out.String())
+	return s
+}

--- a/1000-1999/1100-1199/1150-1159/1157/verifierG.go
+++ b/1000-1999/1100-1199/1150-1159/1157/verifierG.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsG = 100
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: verifierG.go <binary>")
+		os.Exit(1)
+	}
+	binPath, cleanup, err := prepareBinary(os.Args[1])
+	if err != nil {
+		fmt.Println("compile error:", err)
+		os.Exit(1)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	r := rand.New(rand.NewSource(1))
+	for t := 1; t <= numTestsG; t++ {
+		n := r.Intn(4) + 1
+		m := r.Intn(4) + 1
+		a := make([][]int, n)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+		for i := 0; i < n; i++ {
+			a[i] = make([]int, m)
+			for j := 0; j < m; j++ {
+				a[i][j] = r.Intn(2)
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				sb.WriteString(fmt.Sprintf("%d", a[i][j]))
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expected := solveG(a)
+		out, err := run(binPath, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", t, err)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Printf("test %d failed\ninput:%sexpected:%s got:%s\n", t, input, expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "verify_binG")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, string(out))
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func solveG(a [][]int) string {
+	n := len(a)
+	m := len(a[0])
+	F := make([][2][2]bool, m-1)
+	for i := 0; i < n; i++ {
+		for j := 0; j+1 < m; j++ {
+			x := a[i][j]
+			y := a[i][j+1]
+			u := 1 - x
+			v := y
+			F[j][u][v] = true
+		}
+	}
+	dp := make([][2]bool, m)
+	parent := make([][2]int, m)
+	dp[0][0] = true
+	dp[0][1] = true
+	for j := 0; j+1 < m; j++ {
+		for b := 0; b < 2; b++ {
+			if !dp[j][b] {
+				continue
+			}
+			for nb := 0; nb < 2; nb++ {
+				if !F[j][b][nb] {
+					if !dp[j+1][nb] {
+						dp[j+1][nb] = true
+						parent[j+1][nb] = b
+					}
+				}
+			}
+		}
+	}
+	c := make([]int, m)
+	if m > 0 {
+		if dp[m-1][0] {
+			c[m-1] = 0
+		} else if dp[m-1][1] {
+			c[m-1] = 1
+		} else {
+			return "NO"
+		}
+		for j := m - 1; j > 0; j-- {
+			c[j-1] = parent[j][c[j]]
+		}
+	}
+	rarr := make([]int, n)
+	if n > 0 {
+		rarr[0] = 0
+		for i := 0; i+1 < n; i++ {
+			d := a[i][m-1] ^ c[m-1] ^ a[i+1][0] ^ c[0]
+			if d == 0 {
+				rarr[i+1] = rarr[i]
+			} else {
+				rarr[i+1] = 0
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('0' + rarr[i]))
+	}
+	sb.WriteByte('\n')
+	for j := 0; j < m; j++ {
+		sb.WriteByte(byte('0' + c[j]))
+	}
+	return strings.TrimSpace(sb.String())
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for every problem of contest 1157
- verifiers compile the target solution if it is a Go file and run 100 randomized test cases

## Testing
- `go vet verifierA.go ... verifierG.go`
- `for f in 1000-1999/1100-1199/1150-1159/1157/verifier*.go; do go build $f; done`

------
https://chatgpt.com/codex/tasks/task_e_68849d51a70083249c5c1eab1c180d12