### PR TITLE
Add verifiers for contest 1158

### DIFF
--- a/1000-1999/1100-1199/1150-1159/1158/verifierA.go
+++ b/1000-1999/1100-1199/1150-1159/1158/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solveA(n, m int, b, g []int64) (int64, bool) {
+	sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
+	sort.Slice(g, func(i, j int) bool { return g[i] < g[j] })
+	bMax := b[n-1]
+	if g[0] < bMax {
+		return -1, false
+	}
+	var sumB int64
+	for i := 0; i < n; i++ {
+		sumB += b[i]
+	}
+	ans := sumB * int64(m)
+	for j := 0; j < m; j++ {
+		ans += g[j] - bMax
+	}
+	if g[0] > bMax {
+		bSec := b[n-2]
+		ans += bMax - bSec
+	}
+	return ans, true
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(5) + 2
+		m := rng.Intn(5) + 2
+		b := make([]int64, n)
+		g := make([]int64, m)
+		for i := 0; i < n; i++ {
+			b[i] = rand.Int63n(20)
+		}
+		for j := 0; j < m; j++ {
+			g[j] = rand.Int63n(20)
+		}
+		// ensure g contains at least one >= max(b)
+		maxB := b[0]
+		for _, v := range b {
+			if v > maxB {
+				maxB = v
+			}
+		}
+		g[0] = maxB + int64(rng.Intn(3)) // ensure feasible sometimes
+		input := fmt.Sprintf("%d %d\n", n, m)
+		for i, v := range b {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprint(v)
+		}
+		input += "\n"
+		for j, v := range g {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprint(v)
+		}
+		input += "\n"
+		expVal, ok := solveA(n, m, append([]int64(nil), b...), append([]int64(nil), g...))
+		var expected string
+		if ok {
+			expected = fmt.Sprint(expVal)
+		} else {
+			expected = "-1"
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", t+1, expected, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1158/verifierB.go
+++ b/1000-1999/1100-1199/1150-1159/1158/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func minUniqueLength(s string) int {
+	n := len(s)
+	for L := 1; L <= n; L++ {
+		occ := make(map[string]int)
+		for i := 0; i+L <= n; i++ {
+			sub := s[i : i+L]
+			occ[sub]++
+		}
+		for _, c := range occ {
+			if c == 1 {
+				return L
+			}
+		}
+	}
+	return n
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(10) + 1
+		k := rng.Intn(n) + 1
+		if n%2 != k%2 {
+			if k%2 == 0 {
+				n++
+			} else {
+				k++
+			}
+		}
+		input := fmt.Sprintf("%d %d\n", n, k)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		s := strings.TrimSpace(out)
+		if len(s) != n {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected length %d got %d\ninput:%s", t+1, n, len(s), input)
+			os.Exit(1)
+		}
+		for i := 0; i < n; i++ {
+			if s[i] != '0' && s[i] != '1' {
+				fmt.Fprintf(os.Stderr, "case %d failed: invalid character\ninput:%s", t+1, input)
+				os.Exit(1)
+			}
+		}
+		mu := minUniqueLength(s)
+		if mu != k {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected minimal unique length %d got %d\ninput:%s output:%s", t+1, k, mu, input, s)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1158/verifierC.go
+++ b/1000-1999/1100-1199/1150-1159/1158/verifierC.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func nextFromPerm(p []int) []int {
+	n := len(p)
+	res := make([]int, n)
+	for i := 0; i < n; i++ {
+		nxt := n + 1
+		for j := i + 1; j < n; j++ {
+			if p[j] > p[i] {
+				nxt = j + 1
+				break
+			}
+		}
+		res[i] = nxt
+	}
+	return res
+}
+
+func check(n int, given []int, out string) bool {
+	if strings.TrimSpace(out) == "-1" {
+		return false
+	}
+	parts := strings.Fields(out)
+	if len(parts) != n {
+		return false
+	}
+	perm := make([]int, n)
+	used := make([]bool, n+1)
+	for i, s := range parts {
+		v, err := strconv.Atoi(s)
+		if err != nil || v < 1 || v > n || used[v] {
+			return false
+		}
+		used[v] = true
+		perm[i] = v
+	}
+	calc := nextFromPerm(perm)
+	for i := 0; i < n; i++ {
+		if given[i] != -1 && given[i] != calc[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for tcase := 0; tcase < 100; tcase++ {
+		n := rng.Intn(6) + 1
+		perm := rand.Perm(n)
+		for i := range perm {
+			perm[i]++
+		}
+		next := nextFromPerm(perm)
+		given := make([]int, n)
+		for i := 0; i < n; i++ {
+			if rng.Intn(3) == 0 {
+				given[i] = -1
+			} else {
+				given[i] = next[i]
+			}
+		}
+		input := fmt.Sprintf("1\n%d\n", n)
+		for i, v := range given {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprint(v)
+		}
+		input += "\n"
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", tcase+1, err, input)
+			os.Exit(1)
+		}
+		if !check(n, given, got) {
+			fmt.Fprintf(os.Stderr, "case %d failed: wrong output\ninput:%s output:%s", tcase+1, input, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1158/verifierD.go
+++ b/1000-1999/1100-1199/1150-1159/1158/verifierD.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Vec struct {
+	x, y int64
+	id   int
+}
+
+func solveD(points []Vec, s string) []int {
+	n := len(points)
+	used := make([]bool, n)
+	ans := make([]int, n)
+	start := 0
+	for i := 1; i < n; i++ {
+		if points[i].x < points[start].x || (points[i].x == points[start].x && points[i].y < points[start].y) {
+			start = i
+		}
+	}
+	used[start] = true
+	ans[0] = points[start].id
+	curr := points[start]
+	prev := Vec{x: 1, y: 0}
+	for k := 0; k < len(s); k++ {
+		best := -1
+		var bestVec Vec
+		for i := 0; i < n; i++ {
+			if used[i] {
+				continue
+			}
+			v := Vec{x: points[i].x - curr.x, y: points[i].y - curr.y, id: points[i].id}
+			if best == -1 {
+				best = i
+				bestVec = v
+				continue
+			}
+			u := bestVec
+			cdu := prev.x*u.y - prev.y*u.x
+			cdv := prev.x*v.y - prev.y*v.x
+			if s[k] == 'L' {
+				useV := false
+				if (cdu >= 0) != (cdv >= 0) {
+					if cdv >= 0 {
+						useV = true
+					}
+				} else if v.x*u.y-v.y*u.x > 0 {
+					useV = true
+				}
+				if useV {
+					best = i
+					bestVec = v
+				}
+			} else {
+				useV := false
+				if (cdu >= 0) != (cdv >= 0) {
+					if cdv < 0 {
+						useV = true
+					}
+				} else if u.x*v.y-u.y*v.x > 0 {
+					useV = true
+				}
+				if useV {
+					best = i
+					bestVec = v
+				}
+			}
+		}
+		used[best] = true
+		ans[k+1] = points[best].id
+		curr = points[best]
+		prev = bestVec
+	}
+	for i := 0; i < n; i++ {
+		if !used[i] {
+			ans[n-1] = points[i].id
+			break
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(5) + 3
+		pts := make([]Vec, 0, n)
+		for len(pts) < n {
+			x := int64(rng.Intn(21) - 10)
+			y := int64(rng.Intn(21) - 10)
+			dup := false
+			for _, p := range pts {
+				if p.x == x && p.y == y {
+					dup = true
+					break
+				}
+			}
+			if dup {
+				continue
+			}
+			pts = append(pts, Vec{x: x, y: y, id: len(pts) + 1})
+		}
+		// ensure no three collinear by regeneration
+		ok := false
+		for !ok {
+			ok = true
+			for i := 0; i < n && ok; i++ {
+				for j := i + 1; j < n && ok; j++ {
+					for k := j + 1; k < n; k++ {
+						if (pts[j].x-pts[i].x)*(pts[k].y-pts[i].y)-(pts[j].y-pts[i].y)*(pts[k].x-pts[i].x) == 0 {
+							// regenerate one point
+							pts[k].x = int64(rng.Intn(21) - 10)
+							pts[k].y = int64(rng.Intn(21) - 10)
+							k = -1
+							ok = false
+							break
+						}
+					}
+				}
+			}
+		}
+		sLen := n - 2
+		var sb strings.Builder
+		for i := 0; i < sLen; i++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('L')
+			} else {
+				sb.WriteByte('R')
+			}
+		}
+		str := sb.String()
+		input := fmt.Sprintf("%d\n", n)
+		for _, p := range pts {
+			input += fmt.Sprintf("%d %d\n", p.x, p.y)
+		}
+		input += str + "\n"
+		exp := solveD(pts, str)
+		expStr := strings.TrimSpace(strings.Join(func() []string {
+			tmp := make([]string, len(exp))
+			for i, v := range exp {
+				tmp[i] = strconv.Itoa(v)
+			}
+			return tmp
+		}(), " "))
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expStr {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", t+1, expStr, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1150-1159/1158/verifierE.go
+++ b/1000-1999/1100-1199/1150-1159/1158/verifierE.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem E is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1100-1199/1150-1159/1158/verifierF.go
+++ b/1000-1999/1100-1199/1150-1159/1158/verifierF.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const MOD = 998244353
+
+func solveF(n, c int, a []int) []int {
+	maxR := n/c + 2
+	dp := make([][]int, maxR)
+	for j := range dp {
+		dp[j] = make([]int, c+2)
+	}
+	dp[0][1] = 1
+	for _, x := range a {
+		newdp := make([][]int, maxR)
+		for j := range newdp {
+			newdp[j] = make([]int, c+2)
+		}
+		for j := 0; j < maxR; j++ {
+			for t := 1; t <= c; t++ {
+				v := dp[j][t]
+				if v == 0 {
+					continue
+				}
+				newdp[j][t] = (newdp[j][t] + v) % MOD
+				if x == t {
+					if t < c {
+						newdp[j][t+1] = (newdp[j][t+1] + v) % MOD
+					} else if j+1 < maxR {
+						newdp[j+1][1] = (newdp[j+1][1] + v) % MOD
+					}
+				} else {
+					newdp[j][t] = (newdp[j][t] + v) % MOD
+				}
+			}
+		}
+		dp = newdp
+	}
+	res := make([]int, n+1)
+	for j := 0; j < maxR; j++ {
+		for t := 1; t <= c; t++ {
+			v := dp[j][t]
+			if v != 0 && j <= n {
+				res[j] = (res[j] + v) % MOD
+			}
+		}
+	}
+	res[0] = (res[0] - 1 + MOD) % MOD
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		n := rng.Intn(5) + 1
+		c := rng.Intn(3) + 1
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(c) + 1
+		}
+		input := fmt.Sprintf("%d %d\n", n, c)
+		for i, v := range a {
+			if i > 0 {
+				input += " "
+			}
+			input += strconv.Itoa(v)
+		}
+		input += "\n"
+		exp := solveF(n, c, a)
+		var expStr strings.Builder
+		for i, v := range exp {
+			if i > 0 {
+				expStr.WriteByte(' ')
+			}
+			expStr.WriteString(strconv.Itoa(v))
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", t+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expStr.String() {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", t+1, expStr.String(), got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier for problem A comparing to reference solver
- add verifier for problem B validating minimal unique substring
- add permutation verifier for problem C
- add verifier for problem D using greedy solver
- note interactive nature of problem E
- add solver-based verifier for problem F

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_68849dddf88c83248d05c76877e58d94