### PR TITLE
Add Go verifiers for Codeforces contest 1165

### DIFF
--- a/1000-1999/1100-1199/1160-1169/1165/verifierA.go
+++ b/1000-1999/1100-1199/1160-1169/1165/verifierA.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const numTestsA = 100
+
+func solveA(n, x, y int, s string) int {
+	ans := 0
+	for i := 0; i < x; i++ {
+		target := byte('0')
+		if i == y {
+			target = '1'
+		}
+		if s[n-1-i] != target {
+			ans++
+		}
+	}
+	return ans
+}
+
+func run(binary string, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(1)
+	for t := 1; t <= numTestsA; t++ {
+		n := rand.Intn(100) + 2 // >=2
+		x := rand.Intn(n-1) + 1
+		y := rand.Intn(x)
+		b := make([]byte, n)
+		b[0] = '1'
+		for i := 1; i < n; i++ {
+			if rand.Intn(2) == 0 {
+				b[i] = '0'
+			} else {
+				b[i] = '1'
+			}
+		}
+		s := string(b)
+		input := fmt.Sprintf("%d %d %d\n%s\n", n, x, y, s)
+		expect := solveA(n, x, y, s)
+		out, err := run(binary, input)
+		if err != nil {
+			fmt.Printf("test %d failed to run: %v\noutput:%s\n", t, err, out)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) == 0 {
+			fmt.Printf("test %d: no output\n", t)
+			os.Exit(1)
+		}
+		var got int
+		fmt.Sscanf(fields[0], "%d", &got)
+		if got != expect {
+			fmt.Printf("test %d failed: expected %d got %d\ninput:%s\n", t, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1100-1199/1160-1169/1165/verifierB.go
+++ b/1000-1999/1100-1199/1160-1169/1165/verifierB.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const numTestsB = 100
+
+func solveB(a []int) int {
+	sort.Ints(a)
+	days := 0
+	for _, v := range a {
+		if v >= days+1 {
+			days++
+		}
+	}
+	return days
+}
+
+func run(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(2)
+	for t := 1; t <= numTestsB; t++ {
+		n := rand.Intn(50) + 1
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rand.Intn(100) + 1
+		}
+		input := fmt.Sprintf("%d\n", n)
+		for i, v := range a {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		expect := solveB(append([]int(nil), a...))
+		out, err := run(binary, input)
+		if err != nil {
+			fmt.Printf("test %d failed to run: %v\noutput:%s\n", t, err, out)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) == 0 {
+			fmt.Printf("test %d: no output\n", t)
+			os.Exit(1)
+		}
+		var got int
+		fmt.Sscanf(fields[0], "%d", &got)
+		if got != expect {
+			fmt.Printf("test %d failed: expected %d got %d\ninput:%s\n", t, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1100-1199/1160-1169/1165/verifierC.go
+++ b/1000-1999/1100-1199/1160-1169/1165/verifierC.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const numTestsC = 100
+
+func solveC(s string) (int, string) {
+	ans := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		if len(ans)%2 == 0 {
+			ans = append(ans, s[i])
+		} else if ans[len(ans)-1] != s[i] {
+			ans = append(ans, s[i])
+		}
+	}
+	if len(ans)%2 == 1 {
+		ans = ans[:len(ans)-1]
+	}
+	deletions := len(s) - len(ans)
+	return deletions, string(ans)
+}
+
+func run(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(3)
+	letters := []byte("abc")
+	for t := 1; t <= numTestsC; t++ {
+		n := rand.Intn(50) + 1
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = letters[rand.Intn(len(letters))]
+		}
+		s := string(b)
+		input := fmt.Sprintf("%d\n%s\n", n, s)
+		del, res := solveC(s)
+		out, err := run(binary, input)
+		if err != nil {
+			fmt.Printf("test %d failed to run: %v\noutput:%s\n", t, err, out)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) == 0 {
+			fmt.Printf("test %d: no output\n", t)
+			os.Exit(1)
+		}
+		var gotDel int
+		fmt.Sscanf(strings.Fields(lines[0])[0], "%d", &gotDel)
+		gotRes := ""
+		if len(lines) > 1 {
+			gotRes = strings.TrimSpace(lines[1])
+		}
+		if gotDel != del || gotRes != res {
+			fmt.Printf("test %d failed\ninput:%sexpected:%d %s\noutput:%s\n", t, input, del, res, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1100-1199/1160-1169/1165/verifierD.go
+++ b/1000-1999/1100-1199/1160-1169/1165/verifierD.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const numTestsD = 100
+
+func countDivisors(x int64) int {
+	cnt := 1
+	n := x
+	for i := int64(2); i*i <= n; i++ {
+		if n%i == 0 {
+			e := 0
+			for n%i == 0 {
+				n /= i
+				e++
+			}
+			cnt *= (e + 1)
+		}
+	}
+	if n > 1 {
+		cnt *= 2
+	}
+	return cnt
+}
+
+func solveQuery(divs []int64) int64 {
+	sort.Slice(divs, func(i, j int) bool { return divs[i] < divs[j] })
+	candidate := divs[0] * divs[len(divs)-1]
+	n := len(divs)
+	for i := 0; i < n; i++ {
+		if divs[i]*divs[n-1-i] != candidate {
+			return -1
+		}
+	}
+	if countDivisors(candidate)-2 != n {
+		return -1
+	}
+	return candidate
+}
+
+func run(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func divisors(x int64) []int64 {
+	var d []int64
+	for i := int64(1); i*i <= x; i++ {
+		if x%i == 0 {
+			d = append(d, i)
+			if i*i != x {
+				d = append(d, x/i)
+			}
+		}
+	}
+	sort.Slice(d, func(i, j int) bool { return d[i] < d[j] })
+	return d
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(4)
+	for tcase := 1; tcase <= numTestsD; tcase++ {
+		t := rand.Intn(3) + 1
+		input := fmt.Sprintf("%d\n", t)
+		var expectedLines []string
+		for q := 0; q < t; q++ {
+			valid := rand.Intn(2) == 0
+			var n int
+			var divs []int64
+			var ans int64
+			if valid {
+				x := int64(rand.Intn(5000) + 2)
+				d := divisors(x)
+				// remove 1 and x
+				var list []int64
+				for _, v := range d {
+					if v != 1 && v != x {
+						list = append(list, v)
+					}
+				}
+				divs = list
+				n = len(divs)
+				ans = solveQuery(append([]int64(nil), divs...))
+			} else {
+				// create invalid set
+				x := int64(rand.Intn(5000) + 2)
+				d := divisors(x)
+				var list []int64
+				for _, v := range d {
+					if v != 1 && v != x {
+						list = append(list, v)
+					}
+				}
+				if len(list) > 0 {
+					list[0]++ // modify to break
+				} else {
+					list = append(list, x+1)
+				}
+				divs = list
+				n = len(divs)
+				ans = -1
+			}
+			// shuffle divs
+			rand.Shuffle(n, func(i, j int) { divs[i], divs[j] = divs[j], divs[i] })
+			input += fmt.Sprintf("%d\n", n)
+			for i, v := range divs {
+				if i > 0 {
+					input += " "
+				}
+				input += fmt.Sprintf("%d", v)
+			}
+			input += "\n"
+			expectedLines = append(expectedLines, fmt.Sprintf("%d", ans))
+		}
+		expect := strings.Join(expectedLines, "\n") + "\n"
+		out, err := run(binary, input)
+		if err != nil {
+			fmt.Printf("case %d failed to run: %v\noutput:%s\n", tcase, err, out)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out)
+		if got != strings.TrimSpace(expect) {
+			fmt.Printf("case %d failed\ninput:%sexpected:%s got:%s\n", tcase, input, expect, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1100-1199/1160-1169/1165/verifierE.go
+++ b/1000-1999/1100-1199/1160-1169/1165/verifierE.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const numTestsE = 100
+const mod = 998244353
+
+func solveE(a, b []uint64) uint64 {
+	n := len(a)
+	c := make([]uint64, n)
+	nn := uint64(n)
+	for i := 0; i < n; i++ {
+		idx := uint64(i + 1)
+		w := idx * (nn - idx + 1)
+		c[i] = w * a[i]
+	}
+	sort.Slice(c, func(i, j int) bool { return c[i] > c[j] })
+	sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
+	var ans uint64
+	for i := 0; i < n; i++ {
+		ci := c[i] % mod
+		bi := b[i] % mod
+		ans = (ans + ci*bi) % mod
+	}
+	return ans
+}
+
+func run(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(5)
+	for t := 1; t <= numTestsE; t++ {
+		n := rand.Intn(30) + 1
+		a := make([]uint64, n)
+		b := make([]uint64, n)
+		for i := 0; i < n; i++ {
+			a[i] = uint64(rand.Intn(1000))
+		}
+		for i := 0; i < n; i++ {
+			b[i] = uint64(rand.Intn(1000))
+		}
+		input := fmt.Sprintf("%d\n", n)
+		for i, v := range a {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		for i, v := range b {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		expect := solveE(append([]uint64(nil), a...), append([]uint64(nil), b...))
+		out, err := run(binary, input)
+		if err != nil {
+			fmt.Printf("test %d failed to run: %v\noutput:%s\n", t, err, out)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) == 0 {
+			fmt.Printf("test %d: no output\n", t)
+			os.Exit(1)
+		}
+		var got uint64
+		fmt.Sscanf(fields[0], "%d", &got)
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:%sexpected:%d got:%d\n", t, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1100-1199/1160-1169/1165/verifierF1.go
+++ b/1000-1999/1100-1199/1160-1169/1165/verifierF1.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const numTestsF1 = 100
+
+func canFinish(D int, k []int, sales [][]int, totalK int) bool {
+	cheap := 0
+	for i, ki := range k {
+		if ki <= 0 {
+			continue
+		}
+		ci := sort.SearchInts(sales[i], D+1)
+		if ci > ki {
+			ci = ki
+		}
+		cheap += ci
+	}
+	expensive := totalK - cheap
+	cost := cheap + expensive*2
+	return cost <= D
+}
+
+func solveF1(k []int, sales [][]int) int {
+	totalK := 0
+	for _, v := range k {
+		totalK += v
+	}
+	lo, hi := 0, 3000
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if canFinish(mid, k, sales, totalK) {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	return lo
+}
+
+func run(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF1.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(6)
+	for t := 1; t <= numTestsF1; t++ {
+		n := rand.Intn(3) + 1
+		m := rand.Intn(5) + 1
+		k := make([]int, n)
+		for i := range k {
+			k[i] = rand.Intn(3) + 1
+		}
+		sales := make([][]int, n)
+		events := make([][2]int, m)
+		for j := 0; j < m; j++ {
+			d := rand.Intn(10) + 1
+			tpe := rand.Intn(n) + 1
+			events[j] = [2]int{d, tpe}
+			sales[tpe-1] = append(sales[tpe-1], d)
+		}
+		for i := 0; i < n; i++ {
+			sort.Ints(sales[i])
+		}
+		input := fmt.Sprintf("%d %d\n", n, m)
+		for i, v := range k {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		for _, e := range events {
+			input += fmt.Sprintf("%d %d\n", e[0], e[1])
+		}
+		expect := solveF1(k, sales)
+		out, err := run(binary, input)
+		if err != nil {
+			fmt.Printf("test %d failed to run: %v\noutput:%s\n", t, err, out)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) == 0 {
+			fmt.Printf("test %d: no output\n", t)
+			os.Exit(1)
+		}
+		var got int
+		fmt.Sscanf(fields[0], "%d", &got)
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:%sexpected:%d got:%d\n", t, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}

--- a/1000-1999/1100-1199/1160-1169/1165/verifierF2.go
+++ b/1000-1999/1100-1199/1160-1169/1165/verifierF2.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const numTestsF2 = 100
+
+func can(D int, k []int, offers [][]int, totalK int) bool {
+	cheap := 0
+	for i := 0; i < len(k); i++ {
+		if k[i] == 0 {
+			continue
+		}
+		c := sort.SearchInts(offers[i], D+1)
+		if c > k[i] {
+			c = k[i]
+		}
+		cheap += c
+	}
+	need := 2*totalK - cheap
+	return need <= D
+}
+
+func solveF2(k []int, offers [][]int) int {
+	totalK := 0
+	for _, v := range k {
+		totalK += v
+	}
+	maxDay := 0
+	for i := 0; i < len(offers); i++ {
+		for _, d := range offers[i] {
+			if d > maxDay {
+				maxDay = d
+			}
+		}
+	}
+	left, right := 0, max(maxDay, 2*totalK)
+	for left+1 < right {
+		mid := (left + right) / 2
+		if can(mid, k, offers, totalK) {
+			right = mid
+		} else {
+			left = mid
+		}
+	}
+	return right
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func run(binary, input string) (string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF2.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	rand.Seed(7)
+	for t := 1; t <= numTestsF2; t++ {
+		n := rand.Intn(3) + 1
+		m := rand.Intn(5) + 1
+		k := make([]int, n)
+		total := 0
+		for i := range k {
+			k[i] = rand.Intn(3) + 1
+			total += k[i]
+		}
+		offers := make([][]int, n)
+		events := make([][2]int, m)
+		for j := 0; j < m; j++ {
+			d := rand.Intn(10) + 1
+			tpe := rand.Intn(n) + 1
+			events[j] = [2]int{d, tpe}
+			offers[tpe-1] = append(offers[tpe-1], d)
+		}
+		for i := 0; i < n; i++ {
+			sort.Ints(offers[i])
+		}
+		input := fmt.Sprintf("%d %d\n", n, m)
+		for i, v := range k {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", v)
+		}
+		input += "\n"
+		for _, e := range events {
+			input += fmt.Sprintf("%d %d\n", e[0], e[1])
+		}
+		expect := solveF2(k, offers)
+		out, err := run(binary, input)
+		if err != nil {
+			fmt.Printf("test %d failed to run: %v\noutput:%s\n", t, err, out)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) == 0 {
+			fmt.Printf("test %d: no output\n", t)
+			os.Exit(1)
+		}
+		var got int
+		fmt.Sscanf(fields[0], "%d", &got)
+		if got != expect {
+			fmt.Printf("test %d failed\ninput:%sexpected:%d got:%d\n", t, input, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("OK")
+}


### PR DESCRIPTION
## Summary
- introduce verifierA.go .. verifierF2.go for contest 1165
- each verifier generates 100 random tests and checks a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go verifierC.go verifierD.go verifierE.go verifierF1.go verifierF2.go`
- `go run verifierB.go ./solB` (after compiling 1165B.go)

------
https://chatgpt.com/codex/tasks/task_e_6884a1b27108832493b106a9a435ea2a