### PR TITLE
Add Go solution for 1618B

### DIFF
--- a/1000-1999/1600-1699/1610-1619/1618/1618B.go
+++ b/1000-1999/1600-1699/1610-1619/1618/1618B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		bigrams := make([]string, n-2)
+		for i := 0; i < n-2; i++ {
+			fmt.Fscan(reader, &bigrams[i])
+		}
+
+		res := bigrams[0]
+		for i := 1; i < n-2; i++ {
+			if bigrams[i-1][1] != bigrams[i][0] {
+				res += string(bigrams[i][0])
+			}
+			res += string(bigrams[i][1])
+		}
+		if len(res) < n {
+			res += "a"
+		}
+		fmt.Fprintln(writer, res)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1618B.go` solution in Go for the Missing Bigram problem

## Testing
- `go build 1000-1999/1600-1699/1610-1619/1618/1618B.go`
- `go run 1000-1999/1600-1699/1610-1619/1618/1618B.go < /tmp/test3.txt`

------
https://chatgpt.com/codex/tasks/task_e_6884aab9b6188324b532e821457ab62e