### PR TITLE
Add verifiers for contest 1181

### DIFF
--- a/1000-1999/1100-1199/1180-1189/1181/verifierA.go
+++ b/1000-1999/1100-1199/1180-1189/1181/verifierA.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(x, y, z int64) (int64, int64) {
+	a := x / z
+	b := y / z
+	total := (x + y) / z
+	var transfer int64
+	if total == a+b {
+		transfer = 0
+	} else {
+		r1 := z - x%z
+		r2 := z - y%z
+		if r1 < r2 {
+			transfer = r1
+		} else {
+			transfer = r2
+		}
+	}
+	return total, transfer
+}
+
+func runCase(bin string, x, y, z int64) error {
+	input := fmt.Sprintf("%d %d %d\n", x, y, z)
+	exp1, exp2 := solve(x, y, z)
+	expect := fmt.Sprintf("%d %d", exp1, exp2)
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewBufferString(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		x := rng.Int63n(1e12)
+		y := rng.Int63n(1e12)
+		z := rng.Int63n(1e12) + 1
+		if err := runCase(bin, x, y, z); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1180-1189/1181/verifierB.go
+++ b/1000-1999/1100-1199/1180-1189/1181/verifierB.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func bigAdd(a, b string) string {
+	i := len(a) - 1
+	j := len(b) - 1
+	carry := 0
+	var res []byte
+	for i >= 0 || j >= 0 || carry > 0 {
+		sum := carry
+		if i >= 0 {
+			sum += int(a[i] - '0')
+			i--
+		}
+		if j >= 0 {
+			sum += int(b[j] - '0')
+			j--
+		}
+		res = append(res, byte('0'+sum%10))
+		carry = sum / 10
+	}
+	for l, r := 0, len(res)-1; l < r; l, r = l+1, r-1 {
+		res[l], res[r] = res[r], res[l]
+	}
+	return string(res)
+}
+
+func lessNum(a, b string) bool {
+	if len(a) != len(b) {
+		return len(a) < len(b)
+	}
+	return a < b
+}
+
+func solve(l int, s string) string {
+	mid := l / 2
+	left := -1
+	for i := mid; i >= 1; i-- {
+		if s[i] != '0' {
+			left = i
+			break
+		}
+	}
+	right := -1
+	for i := mid + 1; i < l; i++ {
+		if s[i] != '0' {
+			right = i
+			break
+		}
+	}
+	var best string
+	if left != -1 {
+		best = bigAdd(s[:left], s[left:])
+	}
+	if right != -1 {
+		cand := bigAdd(s[:right], s[right:])
+		if best == "" || lessNum(cand, best) {
+			best = cand
+		}
+	}
+	return best
+}
+
+func runCase(bin string, l int, s string) error {
+	input := fmt.Sprintf("%d\n%s\n", l, s)
+	expect := solve(l, s)
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		l := rng.Intn(20) + 2
+		b := make([]byte, l)
+		b[0] = byte('1' + rng.Intn(9))
+		for j := 1; j < l; j++ {
+			b[j] = byte('0' + rng.Intn(10))
+		}
+		s := string(b)
+		if err := runCase(bin, l, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1180-1189/1181/verifierC.go
+++ b/1000-1999/1100-1199/1180-1189/1181/verifierC.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n, m int, grid [][]byte) int64 {
+	up := make([][]int, n)
+	down := make([][]int, n)
+	right := make([][]int, n)
+	for i := 0; i < n; i++ {
+		up[i] = make([]int, m)
+		down[i] = make([]int, m)
+		right[i] = make([]int, m)
+	}
+	for j := 0; j < m; j++ {
+		for i := 0; i < n; i++ {
+			if i > 0 && grid[i][j] == grid[i-1][j] {
+				up[i][j] = up[i-1][j] + 1
+			} else {
+				up[i][j] = 1
+			}
+		}
+	}
+	for j := 0; j < m; j++ {
+		for i := n - 1; i >= 0; i-- {
+			if i+1 < n && grid[i][j] == grid[i+1][j] {
+				down[i][j] = down[i+1][j] + 1
+			} else {
+				down[i][j] = 1
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := m - 1; j >= 0; j-- {
+			if j+1 < m && grid[i][j] == grid[i][j+1] {
+				right[i][j] = right[i][j+1] + 1
+			} else {
+				right[i][j] = 1
+			}
+		}
+	}
+	var ans int64
+	for j := 0; j < m; j++ {
+		for i := 0; i < n; i++ {
+			h2 := up[i][j]
+			midEnd := i
+			topEnd := midEnd - h2
+			if topEnd < 0 {
+				continue
+			}
+			botStart := midEnd + 1
+			if botStart >= n {
+				continue
+			}
+			h1 := up[topEnd][j]
+			h3 := down[botStart][j]
+			c2 := grid[midEnd][j]
+			c1 := grid[topEnd][j]
+			c3 := grid[botStart][j]
+			if c1 == c2 || c2 == c3 {
+				continue
+			}
+			h := h2
+			if h1 < h {
+				h = h1
+			}
+			if h3 < h {
+				h = h3
+			}
+			minW := m
+			for u := 0; u < h; u++ {
+				rTop := topEnd - u
+				if right[rTop][j] < minW {
+					minW = right[rTop][j]
+				}
+				rMid := midEnd - u
+				if right[rMid][j] < minW {
+					minW = right[rMid][j]
+				}
+				rBot := botStart + u
+				if right[rBot][j] < minW {
+					minW = right[rBot][j]
+				}
+			}
+			ans += int64(minW)
+		}
+	}
+	return ans
+}
+
+func runCase(bin string, n, m int, grid [][]byte) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		sb.WriteString(string(grid[i]))
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	expect := fmt.Sprintf("%d", solve(n, m, grid))
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		grid := make([][]byte, n)
+		for r := 0; r < n; r++ {
+			row := make([]byte, m)
+			for c := 0; c < m; c++ {
+				row[c] = byte('a' + rng.Intn(3))
+			}
+			grid[r] = row
+		}
+		if err := runCase(bin, n, m, grid); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1180-1189/1181/verifierD.go
+++ b/1000-1999/1100-1199/1180-1189/1181/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n, m int, a []int, qs []uint64) []int {
+	maxK := uint64(0)
+	for _, k := range qs {
+		if k > maxK {
+			maxK = k
+		}
+	}
+	schedule := make([]int, maxK+1)
+	counts := make([]int, m+1)
+	for i := 0; i < n; i++ {
+		schedule[i+1] = a[i]
+		counts[a[i]]++
+	}
+	for year := n + 1; uint64(year) <= maxK; year++ {
+		best := 1
+		for c := 1; c <= m; c++ {
+			if counts[c] < counts[best] || (counts[c] == counts[best] && c < best) {
+				best = c
+			}
+		}
+		schedule[year] = best
+		counts[best]++
+	}
+	ans := make([]int, len(qs))
+	for i, k := range qs {
+		ans[i] = schedule[k]
+	}
+	return ans
+}
+
+func runCase(bin string, n, m, q int, a []int, ks []uint64) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		sb.WriteString(fmt.Sprintf("%d\n", ks[i]))
+	}
+	input := sb.String()
+	expectAns := solve(n, m, a, ks)
+	var expect strings.Builder
+	for i, v := range expectAns {
+		if i > 0 {
+			expect.WriteByte('\n')
+		}
+		expect.WriteString(fmt.Sprintf("%d", v))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expect.String() {
+		return fmt.Errorf("expected %q got %q", expect.String(), got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(3) + 1
+		m := rng.Intn(4) + 1
+		q := rng.Intn(3) + 1
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			a[j] = rng.Intn(m) + 1
+		}
+		ks := make([]uint64, q)
+		for j := 0; j < q; j++ {
+			ks[j] = uint64(rng.Intn(30) + n + 1)
+		}
+		if err := runCase(bin, n, m, q, a, ks); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1180-1189/1181/verifierE1.go
+++ b/1000-1999/1100-1199/1180-1189/1181/verifierE1.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Rect struct {
+	a, b, c, d int64
+}
+
+func solve(rs []Rect) bool {
+	n := len(rs)
+	if n <= 1 {
+		return true
+	}
+	vs := make([]Rect, n)
+	copy(vs, rs)
+	sort.Slice(vs, func(i, j int) bool { return vs[i].a < vs[j].a })
+	prefixMax := make([]int64, n)
+	prefixMax[0] = vs[0].c
+	for i := 1; i < n; i++ {
+		if vs[i].c > prefixMax[i-1] {
+			prefixMax[i] = vs[i].c
+		} else {
+			prefixMax[i] = prefixMax[i-1]
+		}
+	}
+	suffixMin := make([]int64, n)
+	suffixMin[n-1] = vs[n-1].a
+	for i := n - 2; i >= 0; i-- {
+		if vs[i].a < suffixMin[i+1] {
+			suffixMin[i] = vs[i].a
+		} else {
+			suffixMin[i] = suffixMin[i+1]
+		}
+	}
+	for i := 0; i < n-1; i++ {
+		if prefixMax[i] <= suffixMin[i+1] {
+			if solve(vs[:i+1]) && solve(vs[i+1:]) {
+				return true
+			}
+		}
+	}
+	hs := make([]Rect, n)
+	copy(hs, rs)
+	sort.Slice(hs, func(i, j int) bool { return hs[i].b < hs[j].b })
+	prefixMax = make([]int64, n)
+	prefixMax[0] = hs[0].d
+	for i := 1; i < n; i++ {
+		if hs[i].d > prefixMax[i-1] {
+			prefixMax[i] = hs[i].d
+		} else {
+			prefixMax[i] = prefixMax[i-1]
+		}
+	}
+	suffixMin = make([]int64, n)
+	suffixMin[n-1] = hs[n-1].b
+	for i := n - 2; i >= 0; i-- {
+		if hs[i].b < suffixMin[i+1] {
+			suffixMin[i] = hs[i].b
+		} else {
+			suffixMin[i] = suffixMin[i+1]
+		}
+	}
+	for i := 0; i < n-1; i++ {
+		if prefixMax[i] <= suffixMin[i+1] {
+			if solve(hs[:i+1]) && solve(hs[i+1:]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func runCase(bin string, rects []Rect) error {
+	var sb strings.Builder
+	n := len(rects)
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, r := range rects {
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", r.a, r.b, r.c, r.d))
+	}
+	input := sb.String()
+	expect := "NO"
+	if solve(rects) {
+		expect = "YES"
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.ToUpper(got) != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 1
+		rects := make([]Rect, n)
+		for j := 0; j < n; j++ {
+			x1 := int64(rng.Intn(10))
+			y1 := int64(rng.Intn(10))
+			w := int64(rng.Intn(3) + 1)
+			h := int64(rng.Intn(3) + 1)
+			rects[j] = Rect{x1, y1, x1 + w, y1 + h}
+		}
+		if err := runCase(bin, rects); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1180-1189/1181/verifierE2.go
+++ b/1000-1999/1100-1199/1180-1189/1181/verifierE2.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Rect struct {
+	a, b, c, d int
+}
+
+func solve(rects []Rect) bool {
+	ids0 := make([]int, len(rects))
+	for i := range rects {
+		ids0[i] = i
+	}
+	stack := [][]int{ids0}
+	for len(stack) > 0 {
+		ids := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		m := len(ids)
+		if m <= 1 {
+			continue
+		}
+		idsA := make([]int, m)
+		copy(idsA, ids)
+		sort.Slice(idsA, func(i, j int) bool { return rects[idsA[i]].a < rects[idsA[j]].a })
+		maxC := rects[idsA[0]].c
+		split := -1
+		for i := 0; i < m-1; i++ {
+			if rects[idsA[i]].c > maxC {
+				maxC = rects[idsA[i]].c
+			}
+			if maxC <= rects[idsA[i+1]].a {
+				split = i
+				break
+			}
+		}
+		if split >= 0 {
+			left := make([]int, split+1)
+			right := make([]int, m-split-1)
+			copy(left, idsA[:split+1])
+			copy(right, idsA[split+1:])
+			stack = append(stack, left, right)
+			continue
+		}
+		idsB := make([]int, m)
+		copy(idsB, ids)
+		sort.Slice(idsB, func(i, j int) bool { return rects[idsB[i]].b < rects[idsB[j]].b })
+		maxD := rects[idsB[0]].d
+		split = -1
+		for i := 0; i < m-1; i++ {
+			if rects[idsB[i]].d > maxD {
+				maxD = rects[idsB[i]].d
+			}
+			if maxD <= rects[idsB[i+1]].b {
+				split = i
+				break
+			}
+		}
+		if split >= 0 {
+			left := make([]int, split+1)
+			right := make([]int, m-split-1)
+			copy(left, idsB[:split+1])
+			copy(right, idsB[split+1:])
+			stack = append(stack, left, right)
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func runCase(bin string, rects []Rect) error {
+	var sb strings.Builder
+	n := len(rects)
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, r := range rects {
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", r.a, r.b, r.c, r.d))
+	}
+	input := sb.String()
+	expect := "NO"
+	if solve(rects) {
+		expect = "YES"
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if strings.ToUpper(got) != expect {
+		return fmt.Errorf("expected %q got %q", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 1
+		rects := make([]Rect, n)
+		for j := 0; j < n; j++ {
+			x1 := rng.Intn(10)
+			y1 := rng.Intn(10)
+			w := rng.Intn(3) + 1
+			h := rng.Intn(3) + 1
+			rects[j] = Rect{x1, y1, x1 + w, y1 + h}
+		}
+		if err := runCase(bin, rects); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1181 problems A–E2
- each verifier generates 100 random tests and checks output

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE1.go`
- `go build verifierE2.go`


------
https://chatgpt.com/codex/tasks/task_e_6884aa743210832486b0cbeef70fa986