### PR TITLE
Add Go verifiers for Codeforces contest 1179

### DIFF
--- a/1000-1999/1100-1199/1170-1179/1179/verifierA.go
+++ b/1000-1999/1100-1199/1170-1179/1179/verifierA.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1179A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(8) + 2
+	q := r.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, q))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", r.Intn(100)))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		m := r.Int63n(int64(n)*2+20) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1179/verifierB.go
+++ b/1000-1999/1100-1199/1170-1179/1179/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1179B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 1
+	m := r.Intn(5) + 1
+	return fmt.Sprintf("%d %d\n", n, m)
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1179/verifierC.go
+++ b/1000-1999/1100-1199/1170-1179/1179/verifierC.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1179C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(4) + 1
+	m := r.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(r.Intn(6)))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(r.Intn(6)))
+	}
+	sb.WriteByte('\n')
+	q := r.Intn(8) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		tp := r.Intn(2) + 1
+		if tp == 1 {
+			idx := r.Intn(n) + 1
+			x := r.Intn(6)
+			sb.WriteString(fmt.Sprintf("1 %d %d\n", idx, x))
+		} else {
+			idx := r.Intn(m) + 1
+			x := r.Intn(6)
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", idx, x))
+		}
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1179/verifierD.go
+++ b/1000-1999/1100-1199/1170-1179/1179/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1179D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 2
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		v := r.Intn(i-1) + 1
+		edges[i-2] = [2]int{i, v}
+	}
+	// shuffle
+	r.Shuffle(len(edges), func(i, j int) { edges[i], edges[j] = edges[j], edges[i] })
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1179/verifierE.go
+++ b/1000-1999/1100-1199/1170-1179/1179/verifierE.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type caseE struct {
+	n     int
+	L     int64
+	funcs [][]int64
+}
+
+func genFuncs(n int, L int64, rng *rand.Rand) [][]int64 {
+	funcs := make([][]int64, n)
+	for i := 0; i < n; i++ {
+		vals := make([]int64, L+1)
+		remain := L
+		for x := int64(1); x <= L; x++ {
+			stepsLeft := L - (x - 1)
+			inc := int64(rng.Intn(2))
+			if remain == stepsLeft {
+				inc = 1
+			} else if remain == 0 {
+				inc = 0
+			}
+			if inc > remain {
+				inc = remain
+			}
+			vals[x] = vals[x-1] + inc
+			remain -= inc
+		}
+		vals[L] = L
+		funcs[i] = vals
+	}
+	return funcs
+}
+
+func generateCase(rng *rand.Rand) caseE {
+	n := rng.Intn(3) + 2
+	per := rng.Intn(5) + 1
+	L := int64(n * per)
+	funcs := genFuncs(n, int64(L), rng)
+	return caseE{n: n, L: L, funcs: funcs}
+}
+
+func value(f []int64, x int64, L int64) int64 {
+	if x < 0 {
+		return 0
+	}
+	if x >= L {
+		return L
+	}
+	return f[x]
+}
+
+func runCase(bin string, c caseE) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	inw := bufio.NewWriter(stdin)
+	outr := bufio.NewReader(stdout)
+	fmt.Fprintf(inw, "%d %d\n", c.n, c.L)
+	inw.Flush()
+	queries := 0
+	segs := make([][2]int64, c.n)
+	for {
+		line, err := outr.ReadString('\n')
+		if err != nil {
+			cmd.Process.Kill()
+			return fmt.Errorf("read error: %v %s", err, stderr.String())
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "?") {
+			var idx int
+			var x int64
+			fmt.Sscanf(line, "? %d %d", &idx, &x)
+			if idx < 1 || idx > c.n {
+				cmd.Process.Kill()
+				return fmt.Errorf("bad query index")
+			}
+			queries++
+			if queries > 200000 {
+				cmd.Process.Kill()
+				return fmt.Errorf("too many queries")
+			}
+			val := value(c.funcs[idx-1], x, c.L)
+			fmt.Fprintln(inw, val)
+			inw.Flush()
+		} else if line == "!" {
+			for i := 0; i < c.n; i++ {
+				l, _ := outr.ReadString('\n')
+				l = strings.TrimSpace(l)
+				fmt.Sscanf(l, "%d %d", &segs[i][0], &segs[i][1])
+			}
+			inw.Flush()
+			stdin.Close()
+			err := cmd.Wait()
+			if err != nil {
+				return fmt.Errorf("runtime error: %v %s", err, stderr.String())
+			}
+			break
+		} else {
+			cmd.Process.Kill()
+			return fmt.Errorf("unexpected output: %q", line)
+		}
+	}
+	per := c.L / int64(c.n)
+	for i := 0; i < c.n; i++ {
+		l := segs[i][0]
+		r := segs[i][1]
+		if l < 0 || r < l {
+			return fmt.Errorf("bad segment")
+		}
+		if value(c.funcs[i], r, c.L)-value(c.funcs[i], l, c.L) < per {
+			return fmt.Errorf("segment %d too small", i+1)
+		}
+	}
+	for i := 0; i < c.n; i++ {
+		for j := i + 1; j < c.n; j++ {
+			l1, r1 := segs[i][0], segs[i][1]
+			l2, r2 := segs[j][0], segs[j][1]
+			if max64(l1, l2) < min64(r1, r2) {
+				return fmt.Errorf("segments overlap")
+			}
+		}
+	}
+	return nil
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		c := generateCase(rng)
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to check solutions for problem A using 100 generated cases
- add verifierB.go to check solutions for problem B
- add verifierC.go, verifierD.go using oracle build and random tests
- add verifierE.go implementing a mini interactive judge

## Testing
- `go build 1000-1999/1100-1199/1170-1179/1179/verifierA.go`
- `go build 1000-1999/1100-1199/1170-1179/1179/verifierB.go`
- `go build 1000-1999/1100-1199/1170-1179/1179/verifierC.go`
- `go build 1000-1999/1100-1199/1170-1179/1179/verifierD.go`
- `go build 1000-1999/1100-1199/1170-1179/1179/verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6884a95b81708324bbbcc9abf5290c6e