### PR TITLE
Add Go verifiers for contest 1177

### DIFF
--- a/1000-1999/1100-1199/1170-1179/1177/verifierA.go
+++ b/1000-1999/1100-1199/1170-1179/1177/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1177A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []string {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]string, 0, 107)
+	for i := 0; i < 100; i++ {
+		k := r.Intn(10000) + 1
+		tests = append(tests, fmt.Sprintf("%d\n", k))
+	}
+	edges := []int{1, 9, 10, 11, 189, 190, 191, 9999, 10000}
+	for _, e := range edges {
+		tests = append(tests, fmt.Sprintf("%d\n", e))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runExe(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if exp != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1100-1199/1170-1179/1177/verifierB.go
+++ b/1000-1999/1100-1199/1170-1179/1177/verifierB.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1177B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []string {
+	r := rand.New(rand.NewSource(2))
+	tests := make([]string, 0, 112)
+	for i := 0; i < 100; i++ {
+		k := r.Int63n(1000000000000) + 1
+		tests = append(tests, fmt.Sprintf("%d\n", k))
+	}
+	edges := []int64{1, 9, 10, 11, 189, 190, 191, 2889, 2890, 2891, 999999999999, 1000000000000}
+	for _, e := range edges {
+		tests = append(tests, fmt.Sprintf("%d\n", e))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(time.Now().UnixNano())
+	tests := genTests()
+	for i, in := range tests {
+		exp, err := runExe(ref, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if exp != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, in, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` and `verifierB.go` for contest 1177
- each verifier builds a reference solution and runs over 100 tests
- edges and random cases cover the entire range for both problems

## Testing
- `go build 1000-1999/1100-1199/1170-1179/1177/verifierA.go`
- `go build 1000-1999/1100-1199/1170-1179/1177/verifierB.go`

------
https://chatgpt.com/codex/tasks/task_e_6884a8434eac83249336698af47dec4c