### PR TITLE
Add verifiers for CF contest 1175

### DIFF
--- a/1000-1999/1100-1199/1170-1179/1175/verifierA.go
+++ b/1000-1999/1100-1199/1170-1179/1175/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// compute expected answer for a single query
+func steps(n, k uint64) uint64 {
+	var cnt uint64
+	if k <= 1 {
+		return n
+	}
+	for n > 0 {
+		if n < k {
+			cnt += n
+			break
+		}
+		r := n % k
+		if r != 0 {
+			cnt += r
+			n -= r
+		} else {
+			n /= k
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(5) + 1
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", t)
+	var output strings.Builder
+	for i := 0; i < t; i++ {
+		n := rng.Uint64()%1_000_000_000 + 1
+		k := rng.Uint64()%10 + 2
+		fmt.Fprintf(&input, "%d %d\n", n, k)
+		fmt.Fprintf(&output, "%d\n", steps(n, k))
+	}
+	return input.String(), output.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}
+
+func runCase(bin string, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, out.String())
+	}
+	return nil
+}

--- a/1000-1999/1100-1199/1170-1179/1175/verifierB.go
+++ b/1000-1999/1100-1199/1170-1179/1175/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func solve(commands []string) string {
+	const limit = uint64(1) << 32
+	stack := []uint64{1}
+	var x uint64
+	for _, cmd := range commands {
+		if cmd == "add" {
+			x += stack[len(stack)-1]
+			if x >= limit {
+				return "OVERFLOW!!!"
+			}
+		} else if strings.HasPrefix(cmd, "for") {
+			n, _ := strconv.ParseUint(strings.Fields(cmd)[1], 10, 64)
+			top := stack[len(stack)-1]
+			prod := top * n
+			if top >= limit || prod >= limit {
+				stack = append(stack, limit)
+			} else {
+				stack = append(stack, prod)
+			}
+		} else { // end
+			stack = stack[:len(stack)-1]
+		}
+	}
+	return fmt.Sprint(x)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	l := rng.Intn(10) + 1
+	cmds := make([]string, 0, l)
+	open := 0
+	for len(cmds) < l {
+		choice := rng.Intn(3)
+		if choice == 0 && open < 3 && len(cmds)+1 < l { // open loop
+			n := rng.Intn(5) + 1
+			cmds = append(cmds, fmt.Sprintf("for %d", n))
+			open++
+		} else if choice == 1 && open > 0 { // close loop
+			cmds = append(cmds, "end")
+			open--
+		} else { // add
+			cmds = append(cmds, "add")
+		}
+	}
+	for open > 0 {
+		cmds = append(cmds, "end")
+		open--
+	}
+	input := fmt.Sprintf("%d\n%s\n", len(cmds), strings.Join(cmds, "\n"))
+	expected := solve(cmds)
+	return input, expected + "\n"
+}
+
+func runCase(bin string, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1175/verifierC.go
+++ b/1000-1999/1100-1199/1170-1179/1175/verifierC.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n, k int, a []int64) int64 {
+	bestSpan := int64(1<<62 - 1)
+	bestI := 0
+	for i := 0; i+k < n; i++ {
+		span := a[i+k] - a[i]
+		if span < bestSpan {
+			bestSpan = span
+			bestI = i
+		}
+	}
+	return (a[bestI] + a[bestI+k]) / 2
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(3) + 1
+	var input strings.Builder
+	var output strings.Builder
+	fmt.Fprintf(&input, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(8) + 2
+		k := rng.Intn(n-1) + 1
+		arr := make([]int64, n)
+		val := rng.Int63n(1_000_000)
+		for j := 0; j < n; j++ {
+			val += int64(rng.Intn(10) + 1)
+			arr[j] = val
+		}
+		fmt.Fprintf(&input, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprintf(&input, "%d", arr[j])
+		}
+		input.WriteByte('\n')
+		fmt.Fprintf(&output, "%d\n", solve(n, k, arr))
+	}
+	return input.String(), output.String()
+}
+
+func runCase(bin string, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1175/verifierD.go
+++ b/1000-1999/1100-1199/1170-1179/1175/verifierD.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solve(n, k int, a []int64) int64 {
+	suff := make([]int64, n)
+	var sum int64
+	for i := n - 1; i >= 0; i-- {
+		sum += a[i]
+		suff[i] = sum
+	}
+	ans := suff[0]
+	if k > 1 {
+		vals := make([]int64, n-1)
+		for i := 1; i < n; i++ {
+			vals[i-1] = suff[i]
+		}
+		sort.Slice(vals, func(i, j int) bool { return vals[i] > vals[j] })
+		for i := 0; i < k-1; i++ {
+			ans += vals[i]
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(n) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(100)) - 50
+	}
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprintf(&input, "%d", arr[i])
+	}
+	input.WriteByte('\n')
+	out := fmt.Sprintf("%d\n", solve(n, k, arr))
+	return input.String(), out
+}
+
+func runCase(bin string, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1175/verifierE.go
+++ b/1000-1999/1100-1199/1170-1179/1175/verifierE.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type interval struct{ l, r int }
+
+func solve(n, m int, intervals []interval, queries []interval) []int {
+	res := make([]int, m)
+	for qi, q := range queries {
+		curr := q.l
+		cnt := 0
+		for curr < q.r {
+			bestR := curr
+			for _, in := range intervals {
+				if in.l <= curr && in.r > bestR {
+					bestR = in.r
+				}
+			}
+			if bestR == curr {
+				cnt = -1
+				break
+			}
+			curr = bestR
+			cnt++
+		}
+		res[qi] = cnt
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	ints := make([]interval, n)
+	for i := range ints {
+		l := rng.Intn(20)
+		r := l + rng.Intn(10) + 1
+		ints[i] = interval{l, r}
+	}
+	qs := make([]interval, m)
+	for i := range qs {
+		x := rng.Intn(20)
+		y := x + rng.Intn(10) + 1
+		qs[i] = interval{x, y}
+	}
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d %d\n", n, m)
+	for _, in := range ints {
+		fmt.Fprintf(&input, "%d %d\n", in.l, in.r)
+	}
+	for _, q := range qs {
+		fmt.Fprintf(&input, "%d %d\n", q.l, q.r)
+	}
+	ans := solve(n, m, ints, qs)
+	var output strings.Builder
+	for i, v := range ans {
+		if i > 0 {
+			output.WriteByte(' ')
+		}
+		fmt.Fprintf(&output, "%d", v)
+	}
+	output.WriteByte('\n')
+	return input.String(), output.String()
+}
+
+func runCase(bin string, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1175/verifierF.go
+++ b/1000-1999/1100-1199/1170-1179/1175/verifierF.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func isSubperm(a []int) bool {
+	n := len(a)
+	seen := make([]bool, n+1)
+	for _, v := range a {
+		if v < 1 || v > n || seen[v] {
+			return false
+		}
+		seen[v] = true
+	}
+	return true
+}
+
+func solve(n int, arr []int) int {
+	cnt := 0
+	for l := 0; l < n; l++ {
+		for r := l; r < n; r++ {
+			if isSubperm(arr[l : r+1]) {
+				cnt++
+			}
+		}
+	}
+	return cnt
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(n) + 1
+	}
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", n)
+	for i, v := range arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprintf(&input, "%d", v)
+	}
+	input.WriteByte('\n')
+	out := fmt.Sprintf("%d\n", solve(n, arr))
+	return input.String(), out
+}
+
+func runCase(bin string, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1175/verifierG.go
+++ b/1000-1999/1100-1199/1170-1179/1175/verifierG.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n, k int, a []int) int64 {
+	dp := make([][]int64, k+1)
+	for i := range dp {
+		dp[i] = make([]int64, n+1)
+		for j := range dp[i] {
+			dp[i][j] = math.MaxInt64 / 4
+		}
+	}
+	dp[0][0] = 0
+	for seg := 1; seg <= k; seg++ {
+		for i := seg; i <= n; i++ {
+			maxVal := 0
+			for j := i; j >= seg; j-- {
+				if a[j-1] > maxVal {
+					maxVal = a[j-1]
+				}
+				val := dp[seg-1][j-1]
+				if val != math.MaxInt64/4 {
+					cost := val + int64(maxVal*(i-j+1))
+					if cost < dp[seg][i] {
+						dp[seg][i] = cost
+					}
+				}
+			}
+		}
+	}
+	return dp[k][n]
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(n) + 1
+	arr := make([]int, n)
+	for i := range arr {
+		arr[i] = rng.Intn(20) + 1
+	}
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d %d\n", n, k)
+	for i, v := range arr {
+		if i > 0 {
+			input.WriteByte(' ')
+		}
+		fmt.Fprintf(&input, "%d", v)
+	}
+	input.WriteByte('\n')
+	out := fmt.Sprintf("%d\n", solve(n, k, arr))
+	return input.String(), out
+}
+
+func runCase(bin string, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	if strings.TrimSpace(out.String()) != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s", exp, out.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1175 (problems A–G)
- each verifier runs 100 random tests against an arbitrary binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6884a72b2ef883249fc17a73235e1897