### PR TITLE
Add verifiers for contest 1172

### DIFF
--- a/1000-1999/1100-1199/1170-1179/1172/verifierA.go
+++ b/1000-1999/1100-1199/1170-1179/1172/verifierA.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(n int, a, b []int) int {
+	const INF = int(1e9)
+	avail := make([]int, n+1)
+	for i := range avail {
+		avail[i] = INF
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != 0 {
+			avail[a[i]] = 0
+		}
+	}
+	for i := 0; i < n; i++ {
+		if b[i] != 0 && avail[b[i]] > i+1 {
+			avail[b[i]] = i + 1
+		}
+	}
+	tail := b[n-1]
+	if tail != 0 {
+		ok := true
+		if tail <= n {
+			for i := 0; i < tail; i++ {
+				if b[n-tail+i] != i+1 {
+					ok = false
+					break
+				}
+			}
+		} else {
+			ok = false
+		}
+		if ok {
+			valid := true
+			for v := tail + 1; v <= n; v++ {
+				if avail[v] > v-tail-1 {
+					valid = false
+					break
+				}
+			}
+			if valid {
+				return n - tail
+			}
+		}
+	}
+	maxDiff := 0
+	for v := 1; v <= n; v++ {
+		diff := avail[v] - v + 1
+		if diff > maxDiff {
+			maxDiff = diff
+		}
+	}
+	if maxDiff < 0 {
+		maxDiff = 0
+	}
+	return maxDiff + n
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	idxA := rng.Perm(n)
+	idxB := rng.Perm(n)
+	pa, pb := 0, 0
+	for v := 1; v <= n; v++ {
+		if rng.Intn(2) == 0 {
+			if pa < n {
+				a[idxA[pa]] = v
+				pa++
+			} else {
+				b[idxB[pb]] = v
+				pb++
+			}
+		} else {
+			if pb < n {
+				b[idxB[pb]] = v
+				pb++
+			} else {
+				a[idxA[pa]] = v
+				pa++
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	ans := solveA(n, a, b)
+	return input, fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1172/verifierB.go
+++ b/1000-1999/1100-1199/1170-1179/1172/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(n int, edges [][2]int) int64 {
+	deg := make([]int, n+1)
+	for _, e := range edges {
+		deg[e[0]]++
+		deg[e[1]]++
+	}
+	fact := make([]int64, n+1)
+	fact[0] = 1
+	for i := 1; i <= n; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	ans := int64(n) % mod
+	for i := 1; i <= n; i++ {
+		ans = ans * fact[deg[i]] % mod
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	edges := make([][2]int, 0, n-1)
+	for v := 2; v <= n; v++ {
+		u := rng.Intn(v-1) + 1
+		edges = append(edges, [2]int{u, v})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	ans := solveB(n, edges)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1172/verifierC1.go
+++ b/1000-1999/1100-1199/1170-1179/1172/verifierC1.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleC1"
+	cmd := exec.Command("go", "build", "-o", exe, "1172C1.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(2)
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		w := rng.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d", w))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expect, err := runProg(filepath.Join("./", oracle), input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle runtime error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected: %s\n got: %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1172/verifierC2.go
+++ b/1000-1999/1100-1199/1170-1179/1172/verifierC2.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleC2"
+	cmd := exec.Command("go", "build", "-o", exe, "1172C2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(2)
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		w := rng.Intn(5) + 1
+		sb.WriteString(fmt.Sprintf("%d", w))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expect, err := runProg(filepath.Join("./", oracle), input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle runtime error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected: %s\n got: %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1172/verifierD.go
+++ b/1000-1999/1100-1199/1170-1179/1172/verifierD.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleD"
+	cmd := exec.Command("go", "build", "-o", exe, "1172D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	a := rng.Perm(n)
+	b := rng.Perm(n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range a {
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	for i, v := range b {
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expect, err := runProg(filepath.Join("./", oracle), input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle runtime error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected: %s\n got: %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1172/verifierE.go
+++ b/1000-1999/1100-1199/1170-1179/1172/verifierE.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func getPath(u, v int, adj [][]int) []int {
+	if u == v {
+		return []int{u}
+	}
+	n := len(adj) - 1
+	parent := make([]int, n+1)
+	for i := range parent {
+		parent[i] = -1
+	}
+	q := []int{u}
+	parent[u] = 0
+	for len(q) > 0 {
+		x := q[0]
+		q = q[1:]
+		if x == v {
+			break
+		}
+		for _, nb := range adj[x] {
+			if parent[nb] == -1 {
+				parent[nb] = x
+				q = append(q, nb)
+			}
+		}
+	}
+	path := []int{}
+	cur := v
+	for cur != u {
+		path = append(path, cur)
+		cur = parent[cur]
+	}
+	path = append(path, u)
+	return path
+}
+
+func sumDistinct(n int, adj [][]int, color []int) int64 {
+	total := int64(0)
+	for i := 1; i <= n; i++ {
+		for j := i; j <= n; j++ {
+			p := getPath(i, j, adj)
+			seen := make(map[int]bool)
+			for _, node := range p {
+				seen[color[node]] = true
+			}
+			total += int64(len(seen))
+		}
+	}
+	return total
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 2
+	m := rng.Intn(4) + 1
+	adj := make([][]int, n+1)
+	edges := make([][2]int, 0, n-1)
+	for v := 2; v <= n; v++ {
+		u := rng.Intn(v-1) + 1
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+		edges = append(edges, [2]int{u, v})
+	}
+	color := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		color[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", color[i]))
+	}
+	sb.WriteByte('\n')
+	res := make([]int64, 0, m+1)
+	res = append(res, sumDistinct(n, adj, color))
+	for k := 0; k < m; k++ {
+		u := rng.Intn(n) + 1
+		x := rng.Intn(n) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", u, x))
+		color[u] = x
+		res = append(res, sumDistinct(n, adj, color))
+	}
+	var out strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		out.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1172/verifierF.go
+++ b/1000-1999/1100-1199/1170-1179/1172/verifierF.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	exe := "oracleF"
+	cmd := exec.Command("go", "build", "-o", exe, "1172F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runProg(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	p := int64(rng.Intn(10) + 1)
+	arr := make([]int64, n)
+	for i := range arr {
+		arr[i] = int64(rng.Intn(10) + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, p))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		l := rng.Intn(n) + 1
+		r := rng.Intn(n-l+1) + l
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		expect, err := runProg(filepath.Join("./", oracle), input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle runtime error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", i+1, err, got)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected: %s\n got: %s\ninput:\n%s", i+1, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1172 problems A–F
- each verifier runs 100 randomized test cases
- oracles are built from the official solutions when available

## Testing
- `go run verifierA.go ./candidateA`


------
https://chatgpt.com/codex/tasks/task_e_6884a586f6788324a453f4bf43ee02d9