### PR TITLE
Add solution verifiers for Codeforces 1170

### DIFF
--- a/1000-1999/1100-1199/1170-1179/1170/verifierA.go
+++ b/1000-1999/1100-1199/1170-1179/1170/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1170A_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1170A.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() string {
+	q := rand.Intn(10) + 1
+	lines := []string{fmt.Sprintf("%d", q)}
+	for i := 0; i < q; i++ {
+		x := rand.Intn(1000) + 2
+		y := rand.Intn(1000) + 2
+		lines = append(lines, fmt.Sprintf("%d %d", x, y))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1170/verifierB.go
+++ b/1000-1999/1100-1199/1170-1179/1170/verifierB.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1170B_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1170B.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() string {
+	n := rand.Intn(50) + 1
+	nums := make([]string, n)
+	for i := 0; i < n; i++ {
+		nums[i] = fmt.Sprintf("%d", rand.Intn(200)+1)
+	}
+	return fmt.Sprintf("%d\n%s\n", n, strings.Join(nums, " "))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1170/verifierC.go
+++ b/1000-1999/1100-1199/1170-1179/1170/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1170C_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1170C.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func randSigns(n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rand.Intn(2) == 0 {
+			b[i] = '+'
+		} else {
+			b[i] = '-'
+		}
+	}
+	return string(b)
+}
+
+func genTest() string {
+	k := rand.Intn(5) + 1
+	lines := []string{fmt.Sprintf("%d", k)}
+	for i := 0; i < k; i++ {
+		s := randSigns(rand.Intn(10) + 1)
+		t := randSigns(rand.Intn(10) + 1)
+		lines = append(lines, s)
+		lines = append(lines, t)
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1170/verifierD.go
+++ b/1000-1999/1100-1199/1170-1179/1170/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1170D_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1170D.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func encode(seqs [][]int) []int {
+	// append -1 to each sequence and interleave by rounds
+	for i := range seqs {
+		seqs[i] = append(seqs[i], -1)
+	}
+	var res []int
+	for idx := 0; ; idx++ {
+		added := false
+		for i := range seqs {
+			if idx < len(seqs[i]) {
+				res = append(res, seqs[i][idx])
+				added = true
+			}
+		}
+		if !added {
+			break
+		}
+	}
+	return res
+}
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	seqs := make([][]int, n)
+	for i := 0; i < n; i++ {
+		l := rand.Intn(5)
+		seq := make([]int, l)
+		for j := 0; j < l; j++ {
+			seq[j] = rand.Intn(20)
+		}
+		seqs[i] = seq
+	}
+	enc := encode(seqs)
+	nums := make([]string, len(enc))
+	for i, v := range enc {
+		nums[i] = fmt.Sprintf("%d", v)
+	}
+	return fmt.Sprintf("%d\n%s\n", len(enc), strings.Join(nums, " "))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1170/verifierE.go
+++ b/1000-1999/1100-1199/1170-1179/1170/verifierE.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1170E_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1170E.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func randSubset(n, k int) []int {
+	perm := rand.Perm(n)
+	res := make([]int, k)
+	for i := 0; i < k; i++ {
+		res[i] = perm[i] + 1
+	}
+	sort.Ints(res)
+	return res
+}
+
+func genTest() string {
+	n := rand.Intn(3) + 1
+	m := rand.Intn(10) + n
+	widths := make([]int, n)
+	rem := m
+	for i := 0; i < n; i++ {
+		maxW := rem - (n - i - 1)
+		w := rand.Intn(maxW) + 1
+		widths[i] = w
+		rem -= w
+	}
+	q := rand.Intn(5) + 1
+	lines := []string{fmt.Sprintf("%d %d", n, m)}
+	wstr := make([]string, n)
+	for i, v := range widths {
+		wstr[i] = fmt.Sprintf("%d", v)
+	}
+	lines = append(lines, strings.Join(wstr, " "))
+	lines = append(lines, fmt.Sprintf("%d", q))
+	for i := 0; i < q; i++ {
+		c := rand.Intn(m) + 1
+		subset := randSubset(m, c)
+		s := make([]string, c)
+		for j, v := range subset {
+			s[j] = fmt.Sprintf("%d", v)
+		}
+		lines = append(lines, fmt.Sprintf("%d %s", c, strings.Join(s, " ")))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1170/verifierF.go
+++ b/1000-1999/1100-1199/1170-1179/1170/verifierF.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1170F_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1170F.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() string {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(n) + 1
+	k := rand.Intn(100)
+	arr := make([]string, n)
+	for i := 0; i < n; i++ {
+		arr[i] = fmt.Sprintf("%d", rand.Intn(100))
+	}
+	lines := []string{fmt.Sprintf("%d %d %d", n, m, k), strings.Join(arr, " ")}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1170/verifierG.go
+++ b/1000-1999/1100-1199/1170-1179/1170/verifierG.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1170G_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1170G.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	maxEdges := n*(n-1)/2 + n // allow loops
+	m := rand.Intn(maxEdges + 1)
+	lines := []string{fmt.Sprintf("%d %d", n, m)}
+	for i := 0; i < m; i++ {
+		u := rand.Intn(n) + 1
+		v := rand.Intn(n) + 1
+		lines = append(lines, fmt.Sprintf("%d %d", u, v))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1170/verifierH.go
+++ b/1000-1999/1100-1199/1170-1179/1170/verifierH.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1170H_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1170H.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() string {
+	t := rand.Intn(5) + 1
+	lines := []string{fmt.Sprintf("%d", t)}
+	for i := 0; i < t; i++ {
+		n := rand.Intn(10) + 1
+		arr := make([]string, n)
+		for j := 0; j < n; j++ {
+			arr[j] = fmt.Sprintf("%d", rand.Intn(20))
+		}
+		lines = append(lines, fmt.Sprintf("%d", n))
+		lines = append(lines, strings.Join(arr, " "))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1170-1179/1170/verifierI.go
+++ b/1000-1999/1100-1199/1170-1179/1170/verifierI.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	out := filepath.Join(os.TempDir(), "1170I_ref")
+	cmd := exec.Command("go", "build", "-o", out, "1170I.go")
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func runBin(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func genTest() string {
+	n := rand.Intn(5) + 1
+	lines := []string{fmt.Sprintf("%d", n)}
+	for i := 0; i < n; i++ {
+		l := rand.Intn(100) + 1
+		r := l + rand.Intn(100)
+		lines = append(lines, fmt.Sprintf("%d %d", l, r))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for t := 0; t < 100; t++ {
+		test := genTest()
+		exp, err := runBin(ref, test)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference run failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBin(cand, test)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate run failed on test %d: %v\n", t+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("mismatch on test %d\ninput:\n%sexpected:%s got:%s\n", t+1, test, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems in contest 1170
- each verifier compiles the reference solution, generates 100 random tests and checks a candidate binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build verifierI.go`


------
https://chatgpt.com/codex/tasks/task_e_6884a46eca888324bb71ea81aa5c4381