### PR TITLE
Add Go verifiers for contest 1167

### DIFF
--- a/1000-1999/1100-1199/1160-1169/1167/verifierA.go
+++ b/1000-1999/1100-1199/1160-1169/1167/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1167A.go")
+	refBin := filepath.Join(os.TempDir(), "1167A_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(20) + 1
+	s := make([]byte, n)
+	for i := 0; i < n; i++ {
+		s[i] = byte('0' + rand.Intn(10))
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n%s\n", n, string(s)))
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1160-1169/1167/verifierB.go
+++ b/1000-1999/1100-1199/1160-1169/1167/verifierB.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem B is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1100-1199/1160-1169/1167/verifierC.go
+++ b/1000-1999/1100-1199/1160-1169/1167/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1167C.go")
+	refBin := filepath.Join(os.TempDir(), "1167C_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(10) + 1
+	m := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < m; i++ {
+		k := rand.Intn(n + 1)
+		sb.WriteString(fmt.Sprintf("%d", k))
+		if k > 0 {
+			perm := rand.Perm(n)
+			perm = perm[:k]
+			sort.Ints(perm)
+			for _, v := range perm {
+				sb.WriteString(fmt.Sprintf(" %d", v+1))
+			}
+		}
+		sb.WriteString("\n")
+	}
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1160-1169/1167/verifierD.go
+++ b/1000-1999/1100-1199/1160-1169/1167/verifierD.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1167D.go")
+	refBin := filepath.Join(os.TempDir(), "1167D_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func isValidRBS(s []byte) bool {
+	bal := 0
+	for _, ch := range s {
+		if ch == '(' {
+			bal++
+		} else {
+			bal--
+			if bal < 0 {
+				return false
+			}
+		}
+	}
+	return bal == 0
+}
+
+func randomRBS(n int) string {
+	for {
+		arr := make([]byte, n)
+		for i := 0; i < n/2; i++ {
+			arr[i] = '('
+		}
+		for i := n / 2; i < n; i++ {
+			arr[i] = ')'
+		}
+		rand.Shuffle(n, func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+		if isValidRBS(arr) {
+			return string(arr)
+		}
+	}
+}
+
+func genTest() []byte {
+	n := (rand.Intn(10) + 1) * 2
+	s := randomRBS(n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n%s\n", n, s))
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1160-1169/1167/verifierE.go
+++ b/1000-1999/1100-1199/1160-1169/1167/verifierE.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1167E.go")
+	refBin := filepath.Join(os.TempDir(), "1167E_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(10) + 1
+	x := rand.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(x)+1))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1160-1169/1167/verifierF.go
+++ b/1000-1999/1100-1199/1160-1169/1167/verifierF.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1167F.go")
+	refBin := filepath.Join(os.TempDir(), "1167F_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(8) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rand.Intn(1000)))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1160-1169/1167/verifierG.go
+++ b/1000-1999/1100-1199/1160-1169/1167/verifierG.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runBinary(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildRef() (string, error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1167G.go")
+	refBin := filepath.Join(os.TempDir(), "1167G_ref.bin")
+	cmd := exec.Command("go", "build", "-o", refBin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, string(out))
+	}
+	return refBin, nil
+}
+
+func genTest() []byte {
+	n := rand.Intn(5) + 1
+	d := rand.Intn(5) + 1
+	a := make([]int, n)
+	a[0] = 0
+	for i := 1; i < n; i++ {
+		a[i] = a[i-1] + rand.Intn(d+1) + 1
+	}
+	upper := a[n-1] + 1
+	m := rand.Intn(5) + 1
+	if m > upper+1 {
+		m = upper + 1
+	}
+	perm := rand.Perm(upper + 1)[:m]
+	sort.Ints(perm)
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, d))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(fmt.Sprintf("%d\n", m))
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", perm[i]))
+	}
+	sb.WriteByte('\n')
+	return []byte(sb.String())
+}
+
+func main() {
+	rand.Seed(time.Now().UnixNano())
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	for i := 1; i <= 100; i++ {
+		in := genTest()
+		expected, err := runBinary(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, in)
+		if err != nil {
+			fmt.Printf("runtime error on test %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(expected) != strings.TrimSpace(got) {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected:%s\ngot:%s\n", i, string(in), expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifier scripts for Codeforces contest 1167
- problem B is interactive and prints a message

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6884a2cab10483248a521e018e27b6ae