### PR TITLE
Add verifiers for contest 1166

### DIFF
--- a/1000-1999/1100-1199/1160-1169/1166/verifierA.go
+++ b/1000-1999/1100-1199/1160-1169/1166/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(names []string) string {
+	counts := make([]int, 26)
+	for _, name := range names {
+		if len(name) > 0 {
+			c := name[0] - 'a'
+			if c < 26 {
+				counts[c]++
+			}
+		}
+	}
+	result := 0
+	for _, c := range counts {
+		a := c / 2
+		b := c - a
+		result += a*(a-1)/2 + b*(b-1)/2
+	}
+	return fmt.Sprintf("%d", result)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(100) + 1
+	names := make([]string, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		l := rng.Intn(10) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('a' + rng.Intn(26))
+		}
+		names[i] = string(b)
+		sb.WriteString(names[i])
+		sb.WriteByte('\n')
+	}
+	exp := expected(names)
+	return sb.String(), exp
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1160-1169/1166/verifierB.go
+++ b/1000-1999/1100-1199/1160-1169/1166/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n int) string {
+	if n < 25 {
+		return "-1"
+	}
+	y := 0
+	for i := 5; i*i <= n; i++ {
+		if n%i == 0 {
+			y = i
+			break
+		}
+	}
+	if y == 0 {
+		return "-1"
+	}
+	other := n / y
+	if other < 5 {
+		return "-1"
+	}
+	if y == 5 {
+		patterns := []string{"aeiou", "eioua", "iouae", "ouaei", "uaeio"}
+		var b strings.Builder
+		for i := 0; i < other; i++ {
+			b.WriteString(patterns[i%5])
+		}
+		return b.String()
+	}
+	vowels := []byte{'a', 'e', 'i', 'o', 'u'}
+	var b strings.Builder
+	x := 0
+	for j := 0; j < other; j++ {
+		for i := 0; i < y; i++ {
+			b.WriteByte(vowels[x%5])
+			x++
+		}
+	}
+	return b.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(200) + 1
+	return fmt.Sprintf("%d\n", n), expected(n)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1160-1169/1166/verifierC.go
+++ b/1000-1999/1100-1199/1160-1169/1166/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expected(nums []int64) string {
+	sort.Slice(nums, func(i, j int) bool { return nums[i] < nums[j] })
+	n := len(nums)
+	ans := int64(0)
+	j := 0
+	for i := 0; i < n; i++ {
+		if j < i {
+			j = i
+		}
+		for j+1 < n && nums[j+1] <= 2*nums[i] {
+			j++
+		}
+		ans += int64(j - i)
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	nums := make([]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		val := int64(rng.Intn(2000) - 1000)
+		nums[i] = abs(val)
+		sb.WriteString(fmt.Sprintf("%d", val))
+		if i+1 < n {
+			sb.WriteByte(' ')
+		}
+	}
+	sb.WriteByte('\n')
+	exp := expected(nums)
+	return sb.String(), exp
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1160-1169/1166/verifierD.go
+++ b/1000-1999/1100-1199/1160-1169/1166/verifierD.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func tryMake(a, b, m int64, k int, p []int64) ([]int64, bool) {
+	b2 := b - p[k]*a
+	if b2 < p[k] || (b2+p[k]-1)/p[k] > m {
+		return nil, false
+	}
+	r := make([]int64, k+1)
+	for i := 1; i < k; i++ {
+		r[i] = 1
+		b2 -= p[i]
+	}
+	for i := 1; i < k; i++ {
+		if b2 <= 0 {
+			break
+		}
+		pi := p[k-i]
+		maxAdd := b2 / pi
+		if maxAdd > m-1 {
+			maxAdd = m - 1
+		}
+		r[i] += maxAdd
+		b2 -= pi * maxAdd
+	}
+	if b2 != 0 {
+		return nil, false
+	}
+	return r, true
+}
+
+func expectedSingle(a, b, m int64) string {
+	if a == b {
+		return fmt.Sprintf("1 %d", a)
+	}
+	const K = 51
+	p := make([]int64, K)
+	p[1], p[2] = 1, 1
+	for i := 3; i < K; i++ {
+		p[i] = p[i-1] * 2
+	}
+	for k := 2; k < K; k++ {
+		if p[k]*a > b {
+			break
+		}
+		r, ok := tryMake(a, b, m, k, p)
+		if !ok {
+			continue
+		}
+		seq := make([]int64, k)
+		x := a
+		var sum int64
+		for i := 0; i < k; i++ {
+			seq[i] = x
+			sum += x
+			x = sum + r[i+1]
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d ", k))
+		for i, v := range seq {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", v))
+		}
+		return sb.String()
+	}
+	return "-1"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	var expLines []string
+	for i := 0; i < t; i++ {
+		a := int64(rng.Intn(20) + 1)
+		b := a + int64(rng.Intn(50)+1)
+		m := int64(rng.Intn(10) + 1)
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", a, b, m))
+		expLines = append(expLines, expectedSingle(a, b, m))
+	}
+	return sb.String(), strings.Join(expLines, "\n")
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1160-1169/1166/verifierE.go
+++ b/1000-1999/1100-1199/1160-1169/1166/verifierE.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func disjoint(a, b []int) bool {
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		if a[i] == b[j] {
+			return false
+		}
+		if a[i] < b[j] {
+			i++
+		} else {
+			j++
+		}
+	}
+	return true
+}
+
+func expected(days [][]int) string {
+	m := len(days)
+	adj := make([][]int, m)
+	for i := 0; i < m; i++ {
+		for j := 0; j < m; j++ {
+			if i == j {
+				continue
+			}
+			if disjoint(days[i], days[j]) {
+				adj[i] = append(adj[i], j)
+			}
+		}
+	}
+	vis := make([]int, m)
+	var dfs func(int) bool
+	dfs = func(u int) bool {
+		vis[u] = 1
+		for _, v := range adj[u] {
+			if vis[v] == 1 {
+				return true
+			}
+			if vis[v] == 0 {
+				if dfs(v) {
+					return true
+				}
+			}
+		}
+		vis[u] = 2
+		return false
+	}
+	for i := 0; i < m; i++ {
+		if vis[i] == 0 {
+			if dfs(i) {
+				return "impossible"
+			}
+		}
+	}
+	return "possible"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	m := rng.Intn(5) + 1
+	n := rng.Intn(8) + m + 1 // ensure n > max s_i
+	days := make([][]int, m)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", m, n))
+	for i := 0; i < m; i++ {
+		s := rng.Intn(n-1) + 1
+		perm := rng.Perm(n)
+		lst := perm[:s]
+		sort.Ints(lst)
+		days[i] = lst
+		sb.WriteString(fmt.Sprintf("%d", s))
+		for _, v := range lst {
+			sb.WriteString(fmt.Sprintf(" %d", v+1))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String(), expected(days)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1160-1169/1166/verifierF.go
+++ b/1000-1999/1100-1199/1160-1169/1166/verifierF.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	parent []int
+	size   []int
+}
+
+func NewDSU(n int) *DSU {
+	parent := make([]int, n+1)
+	size := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		parent[i] = i
+		size[i] = 1
+	}
+	return &DSU{parent: parent, size: size}
+}
+
+func (d *DSU) Find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.Find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) Union(a, b int) {
+	ra := d.Find(a)
+	rb := d.Find(b)
+	if ra == rb {
+		return
+	}
+	if d.size[ra] < d.size[rb] {
+		ra, rb = rb, ra
+	}
+	d.parent[rb] = ra
+	d.size[ra] += d.size[rb]
+}
+
+func expected(n, m, c int, initEdges [][3]int, events []string) string {
+	dsu := NewDSU(n)
+	adj := make([]map[int][]int, n+1)
+	for i := 1; i <= n; i++ {
+		adj[i] = make(map[int][]int)
+	}
+	addEdge := func(x, y, z int) {
+		if lst, ok := adj[x][z]; ok {
+			for _, v := range lst {
+				dsu.Union(v, y)
+			}
+		}
+		if lst, ok := adj[y][z]; ok {
+			for _, u := range lst {
+				dsu.Union(u, x)
+			}
+		}
+		adj[x][z] = append(adj[x][z], y)
+		adj[y][z] = append(adj[y][z], x)
+	}
+	for _, e := range initEdges {
+		addEdge(e[0], e[1], e[2])
+	}
+	var out strings.Builder
+	for _, line := range events {
+		parts := strings.Fields(line)
+		if parts[0] == "+" {
+			x := atoi(parts[1])
+			y := atoi(parts[2])
+			z := atoi(parts[3])
+			addEdge(x, y, z)
+		} else {
+			x := atoi(parts[1])
+			y := atoi(parts[2])
+			if dsu.Find(x) == dsu.Find(y) {
+				out.WriteString("Yes\n")
+			} else {
+				out.WriteString("No\n")
+			}
+		}
+	}
+	res := out.String()
+	if len(res) > 0 && res[len(res)-1] == '\n' {
+		res = res[:len(res)-1]
+	}
+	return res
+}
+
+func atoi(s string) int {
+	var n int
+	fmt.Sscanf(s, "%d", &n)
+	return n
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	c := rng.Intn(3) + 1
+	m := rng.Intn(3)
+	q := rng.Intn(5) + 1
+	used := make(map[[2]int]bool)
+	var initEdges [][3]int
+	for len(initEdges) < m {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(n) + 1
+		if x == y {
+			continue
+		}
+		if x > y {
+			x, y = y, x
+		}
+		if used[[2]int{x, y}] {
+			continue
+		}
+		used[[2]int{x, y}] = true
+		z := rng.Intn(c) + 1
+		initEdges = append(initEdges, [3]int{x, y, z})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, c, q))
+	for _, e := range initEdges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e[0], e[1], e[2]))
+	}
+	events := make([]string, q)
+	hasQuery := false
+	for i := 0; i < q; i++ {
+		if rng.Intn(2) == 0 {
+			// add edge
+			x := rng.Intn(n) + 1
+			y := rng.Intn(n) + 1
+			for x == y {
+				y = rng.Intn(n) + 1
+			}
+			z := rng.Intn(c) + 1
+			events[i] = fmt.Sprintf("+ %d %d %d", x, y, z)
+		} else {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(n) + 1
+			for x == y {
+				y = rng.Intn(n) + 1
+			}
+			events[i] = fmt.Sprintf("? %d %d", x, y)
+			hasQuery = true
+		}
+	}
+	if !hasQuery {
+		// ensure at least one query
+		events[q-1] = fmt.Sprintf("? %d %d", 1, n)
+		hasQuery = true
+	}
+	for _, line := range events {
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+	return sb.String(), expected(n, m, c, initEdges, events)
+}
+
+func runCase(bin, input, expected string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1166
- each verifier generates 100 random tests and checks a binary's output using the reference solution logic

## Testing
- `go build 1000-1999/1100-1199/1160-1169/1166/verifierA.go`
- `go build 1000-1999/1100-1199/1160-1169/1166/verifierB.go`
- `go build 1000-1999/1100-1199/1160-1169/1166/verifierC.go`
- `go build 1000-1999/1100-1199/1160-1169/1166/verifierD.go`
- `go build 1000-1999/1100-1199/1160-1169/1166/verifierE.go`
- `go build 1000-1999/1100-1199/1160-1169/1166/verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6884a23e6b988324ba4cebff245606ed