### PR TITLE
Add Go solution for 1611D

### DIFF
--- a/1000-1999/1600-1699/1610-1619/1611/1611D.go
+++ b/1000-1999/1600-1699/1610-1619/1611/1611D.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var T int
+	fmt.Fscan(reader, &T)
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		b := make([]int, n+1)
+		root := -1
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(reader, &b[i])
+			if b[i] == i {
+				root = i
+			}
+		}
+		p := make([]int, n)
+		pos := make([]int, n+1)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &p[i])
+			pos[p[i]] = i
+		}
+		if p[0] != root {
+			fmt.Fprintln(writer, -1)
+			continue
+		}
+		ok := true
+		w := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			if i == root {
+				w[i] = 0
+				continue
+			}
+			if pos[i] <= pos[b[i]] {
+				ok = false
+				break
+			}
+			w[i] = pos[i] - pos[b[i]]
+		}
+		if !ok {
+			fmt.Fprintln(writer, -1)
+			continue
+		}
+		for i := 1; i <= n; i++ {
+			if i > 1 {
+				fmt.Fprint(writer, " ")
+			}
+			fmt.Fprint(writer, w[i])
+		}
+		fmt.Fprintln(writer)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem 1611D

## Testing
- `go run 1000-1999/1600-1699/1610-1619/1611/1611D.go <<EOF
1
5
3 1 3 3 1
3 1 2 5 4
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6884afa6a7748324aed79353d47d925f