### PR TITLE
Add Go verifiers for CF contest 1190

### DIFF
--- a/1000-1999/1100-1199/1190-1199/1190/verifierA.go
+++ b/1000-1999/1100-1199/1190-1199/1190/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n, m, k int64, p []int64) int64 {
+	removed := int64(0)
+	ops := int64(0)
+	i := 0
+	for i < len(p) {
+		curr := (p[i] - removed - 1) / k
+		cnt := 0
+		for i < len(p) && (p[i]-removed-1)/k == curr {
+			cnt++
+			i++
+		}
+		removed += int64(cnt)
+		ops++
+	}
+	return ops
+}
+
+func genTest(rng *rand.Rand) (string, int64) {
+	n := int64(rng.Intn(100) + 1)
+	m := int64(rng.Intn(int(n)) + 1)
+	k := int64(rng.Intn(int(n)) + 1)
+	// generate m distinct indices 1..n
+	set := make(map[int64]struct{})
+	for len(set) < int(m) {
+		v := int64(rng.Intn(int(n)) + 1)
+		set[v] = struct{}{}
+	}
+	p := make([]int64, 0, m)
+	for v := range set {
+		p = append(p, v)
+	}
+	// sort ascending
+	for i := 0; i < len(p); i++ {
+		for j := i + 1; j < len(p); j++ {
+			if p[j] < p[i] {
+				p[i], p[j] = p[j], p[i]
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i, v := range p {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solve(n, m, k, p)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != fmt.Sprint(expected) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1190/verifierB.go
+++ b/1000-1999/1100-1199/1190-1199/1190/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(a []int64) string {
+	n := len(a)
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	dupCount := 0
+	dupIdx := -1
+	for i := 1; i < n; i++ {
+		if a[i] == a[i-1] {
+			dupCount++
+			dupIdx = i
+		}
+	}
+	if dupCount > 1 {
+		return "cslnb"
+	}
+	if dupCount == 1 {
+		v := a[dupIdx]
+		if v == 0 {
+			return "cslnb"
+		}
+		target := v - 1
+		idx := sort.Search(len(a), func(i int) bool { return a[i] >= target })
+		if idx < n && a[idx] == target {
+			return "cslnb"
+		}
+	}
+	var moves int64
+	for i := 0; i < n; i++ {
+		moves += a[i] - int64(i)
+	}
+	if moves%2 == 1 {
+		return "sjfnb"
+	}
+	return "cslnb"
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	n := rng.Intn(4) + 1
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(10))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", a[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), solve(a)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1190/verifierC.go
+++ b/1000-1999/1100-1199/1190-1199/1190/verifierC.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solve(n, k int, s string) string {
+	L0, R0 := n, -1
+	L1, R1 := n, -1
+	for i := 0; i < n; i++ {
+		if s[i] == '0' {
+			L0 = min(L0, i)
+			R0 = max(R0, i)
+		} else {
+			L1 = min(L1, i)
+			R1 = max(R1, i)
+		}
+	}
+	if R0-L0+1 <= k || R1-L1+1 <= k {
+		return "tokitsukaze"
+	}
+	prev0 := make([]int, n)
+	prev1 := make([]int, n)
+	last0, last1 := -1, -1
+	for i := 0; i < n; i++ {
+		if s[i] == '0' {
+			last0 = i
+		} else {
+			last1 = i
+		}
+		prev0[i] = last0
+		prev1[i] = last1
+	}
+	next0 := make([]int, n)
+	next1 := make([]int, n)
+	nxt0, nxt1 := n, n
+	for i := n - 1; i >= 0; i-- {
+		if s[i] == '0' {
+			nxt0 = i
+		} else {
+			nxt1 = i
+		}
+		next0[i] = nxt0
+		next1[i] = nxt1
+	}
+	onceAgain := false
+	for i := 0; i+k <= n; i++ {
+		l, r := i, i+k-1
+		// flip to 0
+		newL0 := min(L0, l)
+		newR0 := max(R0, r)
+		nl1, nr1 := n, -1
+		if l > 0 {
+			p := prev1[l-1]
+			if p >= 0 {
+				nl1 = min(nl1, p)
+				nr1 = max(nr1, p)
+			}
+		}
+		if r+1 < n {
+			p := next1[r+1]
+			if p < n {
+				nl1 = min(nl1, p)
+				nr1 = max(nr1, p)
+			}
+		}
+		if newR0-newL0+1 > k && nr1-nl1+1 > k {
+			onceAgain = true
+			break
+		}
+		// flip to 1
+		newL1 := min(L1, l)
+		newR1 := max(R1, r)
+		nl0, nr0 := n, -1
+		if l > 0 {
+			p := prev0[l-1]
+			if p >= 0 {
+				nl0 = min(nl0, p)
+				nr0 = max(nr0, p)
+			}
+		}
+		if r+1 < n {
+			p := next0[r+1]
+			if p < n {
+				nl0 = min(nl0, p)
+				nr0 = max(nr0, p)
+			}
+		}
+		if newR1-newL1+1 > k && nr0-nl0+1 > k {
+			onceAgain = true
+			break
+		}
+	}
+	if onceAgain {
+		return "once again"
+	}
+	return "quailty"
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 2
+	k := rng.Intn(n) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	s := string(b)
+	input := fmt.Sprintf("%d %d\n%s\n", n, k, s)
+	return input, solve(n, k, s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1190/verifierD.go
+++ b/1000-1999/1100-1199/1190-1199/1190/verifierD.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func unique(a []int64) []int64 {
+	if len(a) == 0 {
+		return a
+	}
+	j := 1
+	for i := 1; i < len(a); i++ {
+		if a[i] != a[i-1] {
+			a[j] = a[i]
+			j++
+		}
+	}
+	return a[:j]
+}
+
+func solve(points [][2]int64) int64 {
+	n := len(points)
+	xs := make([]int64, n)
+	ys := make([]int64, n)
+	for i := 0; i < n; i++ {
+		xs[i] = points[i][0]
+		ys[i] = points[i][1]
+	}
+	ux := make([]int64, n)
+	copy(ux, xs)
+	sort.Slice(ux, func(i, j int) bool { return ux[i] < ux[j] })
+	ux = unique(ux)
+	pts := make([]struct {
+		x int
+		y int64
+	}, n)
+	for i := 0; i < n; i++ {
+		xi := sort.Search(len(ux), func(j int) bool { return ux[j] >= xs[i] })
+		pts[i] = struct {
+			x int
+			y int64
+		}{xi, ys[i]}
+	}
+	sort.Slice(pts, func(i, j int) bool { return pts[i].y > pts[j].y })
+	countX := make([]int, len(ux))
+	active := 0
+	var ans int64
+	for i := 0; i < n; {
+		yv := pts[i].y
+		j := i
+		for j < n && pts[j].y == yv {
+			xi := pts[j].x
+			if countX[xi] == 0 {
+				active++
+			}
+			countX[xi]++
+			j++
+		}
+		ac := int64(active)
+		ans += ac * (ac + 1) / 2
+		i = j
+	}
+	return ans
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	pts := make([][2]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := int64(rng.Intn(10))
+		y := int64(rng.Intn(10))
+		pts[i] = [2]int64{x, y}
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return sb.String(), fmt.Sprint(solve(pts))
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if out != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1190/verifierE.go
+++ b/1000-1999/1100-1199/1190-1199/1190/verifierE.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type pair struct{ x, y float64 }
+type interval struct{ l, r float64 }
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(pts []pair, m int) float64 {
+	n := len(pts)
+	sort.Slice(pts, func(i, j int) bool {
+		if pts[i].x != pts[j].x {
+			return pts[i].x < pts[j].x
+		}
+		return pts[i].y < pts[j].y
+	})
+	uniq := pts[:1]
+	for i := 1; i < n; i++ {
+		if pts[i].x != pts[i-1].x || pts[i].y != pts[i-1].y {
+			uniq = append(uniq, pts[i])
+		}
+	}
+	pts = uniq
+	n = len(pts)
+	dist := make([]float64, n)
+	th := make([]float64, n)
+	rb := math.Inf(1)
+	for i, p := range pts {
+		d := math.Hypot(p.x, p.y)
+		dist[i] = d
+		if d < rb {
+			rb = d
+		}
+		th[i] = math.Atan2(p.y, p.x)
+	}
+	lb := 0.0
+	b := make([]interval, n)
+	var c []interval
+	twoPI := 2 * math.Pi
+	chk := func(r float64) bool {
+		for i := 0; i < n; i++ {
+			ac := math.Acos(r / dist[i])
+			l := th[i] - ac
+			rr := th[i] + ac
+			if l < 0 {
+				l += twoPI
+				rr += twoPI
+			}
+			b[i].l = l
+			b[i].r = rr
+		}
+		sort.Slice(b, func(i, j int) bool { return b[i].l < b[j].l })
+		c = c[:0]
+		for i := 0; i < n; i++ {
+			for len(c) > 0 && c[len(c)-1].r >= b[i].r {
+				c = c[:len(c)-1]
+			}
+			if len(c) == 0 || c[0].r > b[i].r-twoPI {
+				c = append(c, b[i])
+			}
+		}
+		aa := len(c)
+		if aa == 0 {
+			return true
+		}
+		orig := make([]interval, aa)
+		copy(orig, c)
+		for i := 0; i < aa; i++ {
+			c = append(c, interval{orig[i].l + twoPI, orig[i].r + twoPI})
+		}
+		st := make([][17]int, aa)
+		j := 0
+		for i := 0; i < aa; i++ {
+			for j < i+aa && c[j].l <= c[i].r {
+				j++
+			}
+			st[i][0] = j - i
+		}
+		for k := 1; k < 17; k++ {
+			for i := 0; i < aa; i++ {
+				nxt := (i + st[i][k-1]) % aa
+				st[i][k] = st[i][k-1] + st[nxt][k-1]
+			}
+		}
+		for s := 0; s < aa; s++ {
+			used, covered, idx := 0, 0, s
+			for k := 16; k >= 0; k-- {
+				if used+(1<<k) <= m {
+					covered += st[idx][k]
+					idx = (idx + st[idx][k]) % aa
+					used += 1 << k
+				}
+			}
+			if covered >= aa {
+				return true
+			}
+		}
+		return false
+	}
+	for rb-lb > 1e-7 {
+		mb := (lb + rb) / 2
+		if chk(mb) {
+			lb = mb
+		} else {
+			rb = mb
+		}
+	}
+	return (lb + rb) / 2
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(n) + 1
+	pts := make([]pair, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		x := rng.Float64()*5 - 2.5
+		y := rng.Float64()*5 - 2.5
+		pts[i] = pair{x, y}
+		sb.WriteString(fmt.Sprintf("%.3f %.3f\n", x, y))
+	}
+	ans := solve(pts, m)
+	return sb.String(), fmt.Sprintf("%.9f", ans)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		ev, _ := strconv.ParseFloat(expected, 64)
+		ov, err2 := strconv.ParseFloat(out, 64)
+		if err2 != nil || math.Abs(ev-ov) > 1e-3 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1190/verifierF.go
+++ b/1000-1999/1100-1199/1190-1199/1190/verifierF.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func factorPrimePower(m uint64) (uint64, int) {
+	mBig := new(big.Int).SetUint64(m)
+	for t := 60; t >= 2; t-- {
+		r := uint64(math.Round(math.Pow(float64(m), 1.0/float64(t))))
+		for d := int64(r) - 1; d <= int64(r)+1; d++ {
+			if d <= 1 {
+				continue
+			}
+			cand := new(big.Int).SetInt64(d)
+			pow := new(big.Int).Exp(cand, big.NewInt(int64(t)), nil)
+			if pow.Cmp(mBig) == 0 {
+				return uint64(d), t
+			}
+		}
+	}
+	return m, 1
+}
+
+func factorDistinct(x uint64) []uint64 {
+	var fs []uint64
+	if x%2 == 0 {
+		fs = append(fs, 2)
+		for x%2 == 0 {
+			x /= 2
+		}
+	}
+	for i := uint64(3); i*i <= x; i += 2 {
+		if x%i == 0 {
+			fs = append(fs, i)
+			for x%i == 0 {
+				x /= i
+			}
+		}
+	}
+	if x > 1 {
+		fs = append(fs, x)
+	}
+	return fs
+}
+
+func modPow(a, e, m uint64) uint64 {
+	return new(big.Int).Exp(new(big.Int).SetUint64(a), new(big.Int).SetUint64(e), new(big.Int).SetUint64(m)).Uint64()
+}
+
+func solve(n, m, p uint64) []uint64 {
+	q, t := factorPrimePower(m)
+	phi := uint64(1)
+	for i := 0; i < t-1; i++ {
+		phi *= q
+	}
+	phi *= (q - 1)
+	if p%q == 0 {
+		if phi < 1+n {
+			return []uint64{math.MaxUint64}
+		}
+		res := make([]uint64, 0, n)
+		for x := uint64(2); x < m && uint64(len(res)) < n; x++ {
+			if x%q == 0 {
+				continue
+			}
+			res = append(res, x)
+		}
+		return res
+	}
+	var primes []uint64
+	if t > 1 {
+		primes = append(primes, q)
+	}
+	primes = append(primes, factorDistinct(q-1)...)
+	mset := make(map[uint64]bool)
+	for _, v := range primes {
+		mset[v] = true
+	}
+	primes = primes[:0]
+	for v := range mset {
+		primes = append(primes, v)
+	}
+	ord := phi
+	for _, f := range primes {
+		for ord%f == 0 {
+			if modPow(p, ord/f, m) == 1 {
+				ord /= f
+			} else {
+				break
+			}
+		}
+	}
+	if phi < ord+n {
+		return []uint64{math.MaxUint64}
+	}
+	mBig := new(big.Int).SetUint64(m)
+	ordBig := new(big.Int).SetUint64(ord)
+	oneBig := big.NewInt(1)
+	xBig := new(big.Int)
+	res := make([]uint64, 0, n)
+	for x := uint64(1); x < m && uint64(len(res)) < n; x++ {
+		if x%q == 0 {
+			continue
+		}
+		xBig.SetUint64(x)
+		if new(big.Int).Exp(xBig, ordBig, mBig).Cmp(oneBig) == 0 {
+			continue
+		}
+		res = append(res, x)
+	}
+	return res
+}
+
+func genTest(rng *rand.Rand) (string, string) {
+	n := uint64(rng.Intn(3) + 1)
+	m := uint64(rng.Intn(50) + 2)
+	p := uint64(rng.Intn(int(m-1)) + 1)
+	ans := solve(n, m, p)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, p))
+	var out strings.Builder
+	if len(ans) == 1 && ans[0] == math.MaxUint64 {
+		out.WriteString("-1")
+	} else {
+		for i, v := range ans {
+			if i > 0 {
+				out.WriteByte('\n')
+			}
+			out.WriteString(fmt.Sprintf("%d", v))
+		}
+	}
+	return sb.String(), out.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expected := genTest(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verification scripts for each problem in contest 1190
- verifiers generate 100 random tests and compare results with embedded reference solutions
- numeric comparison with tolerance for problem E

## Testing
- `go run verifierA.go ./solA`
- `go run verifierB.go ./solB`
- `go run verifierC.go ./solC`
- `go run verifierD.go ./solD`
- `go run verifierE.go ./solE`
- `go run verifierF.go ./solF`


------
https://chatgpt.com/codex/tasks/task_e_6884af6079f883249fd6f3a9d796cc6a