### PR TITLE
Add Go verifiers for contest 1188

### DIFF
--- a/1000-1999/1100-1199/1180-1189/1188/verifierA.go
+++ b/1000-1999/1100-1199/1180-1189/1188/verifierA.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedA(input string) (string, error) {
+	sc := bufio.NewScanner(strings.NewReader(input))
+	sc.Split(bufio.ScanWords)
+	if !sc.Scan() {
+		return "", fmt.Errorf("invalid input")
+	}
+	var n int
+	fmt.Sscan(sc.Text(), &n)
+	deg := make([]int, n+1)
+	for i := 0; i < n-1; i++ {
+		if !sc.Scan() {
+			return "", fmt.Errorf("invalid edge u")
+		}
+		var u int
+		fmt.Sscan(sc.Text(), &u)
+		if !sc.Scan() {
+			return "", fmt.Errorf("invalid edge v")
+		}
+		var v int
+		fmt.Sscan(sc.Text(), &v)
+		deg[u]++
+		deg[v]++
+	}
+	for i := 1; i <= n; i++ {
+		if deg[i] == 2 {
+			return "NO", nil
+		}
+	}
+	return "YES", nil
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(18) + 2 // 2..19
+	edges := make([][2]int, n-1)
+	if rng.Intn(2) == 0 {
+		// path
+		for i := 2; i <= n; i++ {
+			edges[i-2] = [2]int{i - 1, i}
+		}
+	} else {
+		for i := 2; i <= n; i++ {
+			p := rng.Intn(i-1) + 1
+			edges[i-2] = [2]int{p, i}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	input := sb.String()
+	exp, _ := expectedA(input)
+	return input, exp
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1180-1189/1188/verifierA2.go
+++ b/1000-1999/1100-1199/1180-1189/1188/verifierA2.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA2")
+	cmd := exec.Command("go", "build", "-o", oracle, "1188A2.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2 // 2..9
+	vals := rng.Perm(n - 1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		val := (vals[i-2] + 1) * 2
+		fmt.Fprintf(&sb, "%d %d %d\n", p, i, val)
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	run := func(exe string) (string, error) {
+		var cmd *exec.Cmd
+		if strings.HasSuffix(exe, ".go") {
+			cmd = exec.Command("go", "run", exe)
+		} else {
+			cmd = exec.Command(exe)
+		}
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+		}
+		return strings.TrimSpace(out.String()), nil
+	}
+	exp, err := run(oracle)
+	if err != nil {
+		return fmt.Errorf("oracle: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1180-1189/1188/verifierB.go
+++ b/1000-1999/1100-1199/1180-1189/1188/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var primes = []int64{3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73}
+
+func expectedB(n int, p, k int64, arr []int64) int64 {
+	freq := make(map[int64]int64, n)
+	for _, a := range arr {
+		a %= p
+		a2 := (a * a) % p
+		a4 := (a2 * a2) % p
+		key := (a4 - (k*a)%p + p) % p
+		freq[key]++
+	}
+	var ans int64
+	for _, c := range freq {
+		if c > 1 {
+			ans += c * (c - 1) / 2
+		}
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	p := primes[rng.Intn(len(primes))]
+	n := rng.Intn(int(p)) + 1
+	if n > 10 {
+		n = 10
+	}
+	k := rng.Int63n(p)
+	used := make(map[int64]bool)
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		for {
+			v := rng.Int63n(p)
+			if !used[v] {
+				arr[i] = v
+				used[v] = true
+				break
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, p, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	expect := expectedB(n, p, k, arr)
+	return sb.String(), fmt.Sprintf("%d", expect)
+}
+
+func runCase(bin, input, expected string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1180-1189/1188/verifierC.go
+++ b/1000-1999/1100-1199/1180-1189/1188/verifierC.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1188C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2 // at least 2
+	k := rng.Intn(n-1) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(100)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	run := func(exe string) (string, error) {
+		var cmd *exec.Cmd
+		if strings.HasSuffix(exe, ".go") {
+			cmd = exec.Command("go", "run", exe)
+		} else {
+			cmd = exec.Command(exe)
+		}
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+		}
+		return strings.TrimSpace(out.String()), nil
+	}
+	exp, err := run(oracle)
+	if err != nil {
+		return fmt.Errorf("oracle: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1180-1189/1188/verifierD.go
+++ b/1000-1999/1100-1199/1180-1189/1188/verifierD.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1188D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Int63n(1000)
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	run := func(exe string) (string, error) {
+		var cmd *exec.Cmd
+		if strings.HasSuffix(exe, ".go") {
+			cmd = exec.Command("go", "run", exe)
+		} else {
+			cmd = exec.Command(exe)
+		}
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+		}
+		return strings.TrimSpace(out.String()), nil
+	}
+	exp, err := run(oracle)
+	if err != nil {
+		return fmt.Errorf("oracle: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1180-1189/1188/verifierE.go
+++ b/1000-1999/1100-1199/1180-1189/1188/verifierE.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1188E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	k := rng.Intn(6) + 2
+	arr := make([]int, k)
+	total := 0
+	for i := 0; i < k; i++ {
+		arr[i] = rng.Intn(5)
+		total += arr[i]
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", k)
+	for i := 0; i < k; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", arr[i])
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	run := func(exe string) (string, error) {
+		var cmd *exec.Cmd
+		if strings.HasSuffix(exe, ".go") {
+			cmd = exec.Command("go", "run", exe)
+		} else {
+			cmd = exec.Command(exe)
+		}
+		cmd.Stdin = strings.NewReader(input)
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+		}
+		return strings.TrimSpace(out.String()), nil
+	}
+	exp, err := run(oracle)
+	if err != nil {
+		return fmt.Errorf("oracle: %v", err)
+	}
+	got, err := run(bin)
+	if err != nil {
+		return err
+	}
+	if got != exp {
+		return fmt.Errorf("expected:\n%s\n\ngot:\n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in := generateCase(rng)
+		if err := runCase(bin, oracle, in); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to check problem A1
- add verifierA2.go for problem A2
- add verifierB.go with built‑in expected logic
- add verifierC.go, verifierD.go, and verifierE.go using oracle solutions
- each verifier generates 100 random tests and compares results

## Testing
- `go build verifierA.go`
- `go build verifierA2.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`


------
https://chatgpt.com/codex/tasks/task_e_6884ae48ba7883249bbeae7c263e1ba7