### PR TITLE
Add Go solution for 1611B

### DIFF
--- a/1000-1999/1600-1699/1610-1619/1611/1611B.go
+++ b/1000-1999/1600-1699/1610-1619/1611/1611B.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+func main() {
+    reader := bufio.NewReader(os.Stdin)
+    writer := bufio.NewWriter(os.Stdout)
+    defer writer.Flush()
+
+    var T int
+    fmt.Fscan(reader, &T)
+    for ; T > 0; T-- {
+        var a, b int
+        fmt.Fscan(reader, &a, &b)
+        if a > b {
+            a, b = b, a
+        }
+        total := (a + b) / 4
+        ans := a
+        if b < ans {
+            ans = b
+        }
+        if total < ans {
+            ans = total
+        }
+        fmt.Fprintln(writer, ans)
+    }
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem B in contest 1611

## Testing
- `go build 1000-1999/1600-1699/1610-1619/1611/1611B.go`
- `echo -e "5\n2 1\n1 5\n5 5\n3 6\n14 10" | go run 1000-1999/1600-1699/1610-1619/1611/1611B.go`

------
https://chatgpt.com/codex/tasks/task_e_6884b14c5cd08324955b972741d2fe5e