### PR TITLE
Add contest 1194 verifiers

### DIFF
--- a/1000-1999/1100-1199/1190-1199/1194/verifierA.go
+++ b/1000-1999/1100-1199/1190-1199/1194/verifierA.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct {
+	n int64
+	x int64
+}
+
+func expected(x int64) string {
+	return fmt.Sprintf("%d", 2*x)
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1194))
+	cases := make([]Case, 100)
+	for i := range cases {
+		x := rng.Int63n(1_000_000_000-1) + 1 // 1..1e9-1
+		n := x + rng.Int63n(1_000_000_000-x) + 1
+		cases[i] = Case{n, x}
+	}
+	return cases
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	cases := genCases()
+	for i, c := range cases {
+		input := fmt.Sprintf("1\n%d %d\n", c.n, c.x)
+		want := expected(c.x)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1194/verifierB.go
+++ b/1000-1999/1100-1199/1190-1199/1194/verifierB.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct {
+	n    int
+	m    int
+	grid []string
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1194))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(5) + 1
+		m := rng.Intn(5) + 1
+		grid := make([]string, n)
+		for r := 0; r < n; r++ {
+			var sb strings.Builder
+			for c := 0; c < m; c++ {
+				if rng.Intn(2) == 0 {
+					sb.WriteByte('.')
+				} else {
+					sb.WriteByte('*')
+				}
+			}
+			grid[r] = sb.String()
+		}
+		cases[i] = Case{n, m, grid}
+	}
+	return cases
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1194B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, ref string, c Case) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", c.n, c.m)
+	for _, row := range c.grid {
+		sb.WriteString(row)
+		sb.WriteByte('\n')
+	}
+	input := sb.String()
+	expected, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			var sb strings.Builder
+			fmt.Fprintf(&sb, "1\n%d %d\n", c.n, c.m)
+			for _, row := range c.grid {
+				sb.WriteString(row)
+				sb.WriteByte('\n')
+			}
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1194/verifierC.go
+++ b/1000-1999/1100-1199/1190-1199/1194/verifierC.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct {
+	s string
+	t string
+	p string
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1194))
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	cases := make([]Case, 100)
+	for i := range cases {
+		ls := rng.Intn(5) + 1
+		lt := ls + rng.Intn(5)
+		lp := rng.Intn(5) + 1
+		b := make([]rune, ls)
+		for j := range b {
+			b[j] = letters[rng.Intn(len(letters))]
+		}
+		s := string(b)
+		b = make([]rune, lt)
+		for j := range b {
+			b[j] = letters[rng.Intn(len(letters))]
+		}
+		t := string(b)
+		b = make([]rune, lp)
+		for j := range b {
+			b[j] = letters[rng.Intn(len(letters))]
+		}
+		p := string(b)
+		cases[i] = Case{s, t, p}
+	}
+	return cases
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1194C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, ref string, c Case) error {
+	input := fmt.Sprintf("1\n%s\n%s\n%s\n", c.s, c.t, c.p)
+	expected, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			input := fmt.Sprintf("1\n%s\n%s\n%s\n", c.s, c.t, c.p)
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1194/verifierD.go
+++ b/1000-1999/1100-1199/1190-1199/1194/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct {
+	n int64
+	k int64
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1194))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Int63n(1_000_000_000 + 1)
+		k := rng.Int63n(1_000_000_000-2) + 3
+		cases[i] = Case{n, k}
+	}
+	return cases
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1194D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, ref string, c Case) error {
+	input := fmt.Sprintf("1\n%d %d\n", c.n, c.k)
+	expected, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			input := fmt.Sprintf("1\n%d %d\n", c.n, c.k)
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1194/verifierE.go
+++ b/1000-1999/1100-1199/1190-1199/1194/verifierE.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type HSeg struct{ x1, x2, y int }
+type VSeg struct{ x, y1, y2 int }
+
+type Case struct {
+	hs []HSeg
+	vs []VSeg
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1194))
+	cases := make([]Case, 100)
+	for i := range cases {
+		nH := rng.Intn(3) + 2 // at least 2
+		nV := rng.Intn(3) + 2
+		yUsed := make(map[int]bool)
+		xUsed := make(map[int]bool)
+		hs := make([]HSeg, nH)
+		vs := make([]VSeg, nV)
+		for j := 0; j < nH; j++ {
+			y := rng.Intn(11) - 5
+			for yUsed[y] {
+				y = rng.Intn(11) - 5
+			}
+			yUsed[y] = true
+			x1 := rng.Intn(11) - 5
+			x2 := rng.Intn(11) - 5
+			if x1 == x2 {
+				x2++
+			}
+			if x1 > x2 {
+				x1, x2 = x2, x1
+			}
+			hs[j] = HSeg{x1, x2, y}
+		}
+		for j := 0; j < nV; j++ {
+			x := rng.Intn(11) - 5
+			for xUsed[x] {
+				x = rng.Intn(11) - 5
+			}
+			xUsed[x] = true
+			y1 := rng.Intn(11) - 5
+			y2 := rng.Intn(11) - 5
+			if y1 == y2 {
+				y2++
+			}
+			if y1 > y2 {
+				y1, y2 = y2, y1
+			}
+			vs[j] = VSeg{x, y1, y2}
+		}
+		cases[i] = Case{hs, vs}
+	}
+	return cases
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1194E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, ref string, c Case) error {
+	n := len(c.hs) + len(c.vs)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, h := range c.hs {
+		fmt.Fprintf(&sb, "%d %d %d %d\n", h.x1, h.y, h.x2, h.y)
+	}
+	for _, v := range c.vs {
+		fmt.Fprintf(&sb, "%d %d %d %d\n", v.x, v.y1, v.x, v.y2)
+	}
+	input := sb.String()
+	expected, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			n := len(c.hs) + len(c.vs)
+			var sb strings.Builder
+			fmt.Fprintf(&sb, "%d\n", n)
+			for _, h := range c.hs {
+				fmt.Fprintf(&sb, "%d %d %d %d\n", h.x1, h.y, h.x2, h.y)
+			}
+			for _, v := range c.vs {
+				fmt.Fprintf(&sb, "%d %d %d %d\n", v.x, v.y1, v.x, v.y2)
+			}
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1194/verifierF.go
+++ b/1000-1999/1100-1199/1190-1199/1194/verifierF.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Case struct {
+	n     int
+	T     int64
+	times []int64
+}
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1194))
+	cases := make([]Case, 100)
+	for i := range cases {
+		n := rng.Intn(10) + 1
+		times := make([]int64, n)
+		var sum int64
+		for j := 0; j < n; j++ {
+			t := rng.Int63n(20) + 1
+			times[j] = t
+			sum += t
+		}
+		T := sum/2 + rng.Int63n(sum/2+1)
+		cases[i] = Case{n, T, times}
+	}
+	return cases
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1194F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build reference: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runBinary(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin, ref string, c Case) error {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", c.n, c.T)
+	for i, t := range c.times {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", t)
+	}
+	sb.WriteByte('\n')
+	input := sb.String()
+	expected, err := runBinary(ref, input)
+	if err != nil {
+		return fmt.Errorf("reference failed: %v", err)
+	}
+	got, err := runBinary(bin, input)
+	if err != nil {
+		return err
+	}
+	if expected != strings.TrimSpace(got) {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, ref, c); err != nil {
+			var sb strings.Builder
+			fmt.Fprintf(&sb, "%d %d\n", c.n, c.T)
+			for j, t := range c.times {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				fmt.Fprintf(&sb, "%d", t)
+			}
+			sb.WriteByte('\n')
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, sb.String())
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add standalone Go verifiers for contest 1194 problems A–F
- each verifier generates ~100 random test cases and checks a target binary against the reference solution

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884b190cb0083249941916aabdfc18b