### PR TITLE
Add verifiers for CF contest 1198

### DIFF
--- a/1000-1999/1100-1199/1190-1199/1198/verifierA.go
+++ b/1000-1999/1100-1199/1190-1199/1198/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(n int, I int64, a []int) int {
+	sort.Ints(a)
+	vals := []int{a[0]}
+	cnt := []int{1}
+	for i := 1; i < n; i++ {
+		if a[i] == vals[len(vals)-1] {
+			cnt[len(cnt)-1]++
+		} else {
+			vals = append(vals, a[i])
+			cnt = append(cnt, 1)
+		}
+	}
+	m := len(vals)
+	B := (I * 8) / int64(n)
+	if B >= 31 {
+		return 0
+	}
+	W := 1 << B
+	if W >= m {
+		return 0
+	}
+	pref := make([]int, m+1)
+	for i := 0; i < m; i++ {
+		pref[i+1] = pref[i] + cnt[i]
+	}
+	best := 0
+	for i := 0; i+W <= m; i++ {
+		sum := pref[i+W] - pref[i]
+		if sum > best {
+			best = sum
+		}
+	}
+	return n - best
+}
+
+func generateCase(rng *rand.Rand) ([]byte, int) {
+	n := rng.Intn(20) + 1
+	I := int64(rng.Intn(20) + 1)
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(40)
+	}
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d %d\n", n, I)
+	for i, v := range a {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, v)
+	}
+	b.WriteByte('\n')
+	return b.Bytes(), solveA(n, I, a)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, expect := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, string(input))
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(out)
+		if got != fmt.Sprint(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i, expect, got, string(input))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1198/verifierB.go
+++ b/1000-1999/1100-1199/1190-1199/1198/verifierB.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type query struct {
+	typ int
+	p   int
+	x   int
+}
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(n int, a []int, queries []query) []int {
+	val := make([]int, n+1)
+	copy(val[1:], a)
+	last := make([]int, n+1)
+	payouts := make([]int, len(queries)+1)
+	for i, q := range queries {
+		idx := i + 1
+		if q.typ == 1 {
+			val[q.p] = q.x
+			last[q.p] = idx
+		} else {
+			payouts[idx] = q.x
+		}
+	}
+	suf := make([]int, len(queries)+2)
+	for i := len(queries); i >= 1; i-- {
+		if payouts[i] > suf[i+1] {
+			suf[i] = payouts[i]
+		} else {
+			suf[i] = suf[i+1]
+		}
+	}
+	res := make([]int, n)
+	for i := 1; i <= n; i++ {
+		mx := suf[last[i]+1]
+		if val[i] < mx {
+			val[i] = mx
+		}
+		res[i-1] = val[i]
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) ([]byte, []int) {
+	n := rng.Intn(5) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(30)
+	}
+	qn := rng.Intn(10) + 1
+	queries := make([]query, qn)
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, v)
+	}
+	b.WriteByte('\n')
+	fmt.Fprintf(&b, "%d\n", qn)
+	for i := 0; i < qn; i++ {
+		if rng.Intn(2) == 0 {
+			p := rng.Intn(n) + 1
+			x := rng.Intn(30)
+			queries[i] = query{typ: 1, p: p, x: x}
+			fmt.Fprintf(&b, "1 %d %d\n", p, x)
+		} else {
+			x := rng.Intn(30)
+			queries[i] = query{typ: 2, x: x}
+			fmt.Fprintf(&b, "2 %d\n", x)
+		}
+	}
+	expect := solveB(n, a, queries)
+	return b.Bytes(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, expect := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, string(input))
+			os.Exit(1)
+		}
+		gotFields := strings.Fields(out)
+		if len(gotFields) != len(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %v got %s\ninput:\n%s", i, expect, out, string(input))
+			os.Exit(1)
+		}
+		ok := true
+		for j, f := range gotFields {
+			if fmt.Sprint(expect[j]) != f {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %v got %s\ninput:\n%s", i, expect, out, string(input))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1198/verifierC.go
+++ b/1000-1999/1100-1199/1190-1199/1198/verifierC.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct{ u, v int }
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(n, m int, edges []edge) (string, []int) {
+	used := make([]bool, 3*n+1)
+	matching := make([]int, 0, n)
+	for i := 0; i < m; i++ {
+		u := edges[i].u
+		v := edges[i].v
+		if !used[u] && !used[v] {
+			used[u] = true
+			used[v] = true
+			matching = append(matching, i+1)
+			if len(matching) == n {
+				break
+			}
+		}
+	}
+	if len(matching) >= n {
+		return "Matching", matching[:n]
+	}
+	ind := make([]int, 0, n)
+	for v := 1; v <= 3*n && len(ind) < n; v++ {
+		if !used[v] {
+			ind = append(ind, v)
+		}
+	}
+	return "IndSet", ind
+}
+
+func generateCase(rng *rand.Rand) ([]byte, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3*n) + n
+	edges := make([]edge, m)
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "1\n")
+	fmt.Fprintf(&b, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		u := rng.Intn(3*n) + 1
+		v := rng.Intn(3*n) + 1
+		edges[i] = edge{u, v}
+		fmt.Fprintf(&b, "%d %d\n", u, v)
+	}
+	kind, ans := solveC(n, m, edges)
+	var expect bytes.Buffer
+	fmt.Fprintln(&expect, kind)
+	for i, v := range ans {
+		if i > 0 {
+			expect.WriteByte(' ')
+		}
+		fmt.Fprint(&expect, v)
+	}
+	return b.Bytes(), strings.TrimSpace(expect.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, expect := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, strings.TrimSpace(out), string(input))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1198/verifierD.go
+++ b/1000-1999/1100-1199/1190-1199/1198/verifierD.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveD(grid []string) int {
+	n := len(grid)
+	sum := make([][]int, n+1)
+	for i := range sum {
+		sum[i] = make([]int, n+1)
+	}
+	for i := 1; i <= n; i++ {
+		for j := 1; j <= n; j++ {
+			add := 0
+			if grid[i-1][j-1] == '#' {
+				add = 1
+			}
+			sum[i][j] = sum[i-1][j] + sum[i][j-1] - sum[i-1][j-1] + add
+		}
+	}
+	var dp [51][51][51][51]int
+	for h := 1; h <= n; h++ {
+		for w := 1; w <= n; w++ {
+			for x1 := 1; x1+h-1 <= n; x1++ {
+				x2 := x1 + h - 1
+				for y1 := 1; y1+w-1 <= n; y1++ {
+					y2 := y1 + w - 1
+					cnt := sum[x2][y2] - sum[x1-1][y2] - sum[x2][y1-1] + sum[x1-1][y1-1]
+					if cnt == 0 {
+						dp[x1][x2][y1][y2] = 0
+					} else {
+						best := h
+						if w > best {
+							best = w
+						}
+						for k := x1; k < x2; k++ {
+							cost := dp[x1][k][y1][y2] + dp[k+1][x2][y1][y2]
+							if cost < best {
+								best = cost
+							}
+						}
+						for k := y1; k < y2; k++ {
+							cost := dp[x1][x2][y1][k] + dp[x1][x2][k+1][y2]
+							if cost < best {
+								best = cost
+							}
+						}
+						dp[x1][x2][y1][y2] = best
+					}
+				}
+			}
+		}
+	}
+	return dp[1][n][1][n]
+}
+
+func generateCase(rng *rand.Rand) ([]byte, int) {
+	n := rng.Intn(5) + 1
+	grid := make([]string, n)
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d\n", n)
+	for i := 0; i < n; i++ {
+		row := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = '.'
+			} else {
+				row[j] = '#'
+			}
+		}
+		grid[i] = string(row)
+		fmt.Fprintln(&b, grid[i])
+	}
+	expect := solveD(grid)
+	return b.Bytes(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, expect := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != fmt.Sprint(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i, expect, strings.TrimSpace(out), string(input))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1198/verifierE.go
+++ b/1000-1999/1100-1199/1190-1199/1198/verifierE.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+const INF = int64(4e18)
+
+type Edge struct {
+	to, rev int
+	cap     int64
+}
+
+type Dinic struct {
+	N     int
+	G     [][]Edge
+	level []int
+	ptr   []int
+}
+
+func NewDinic(n int) *Dinic {
+	d := &Dinic{N: n, G: make([][]Edge, n), level: make([]int, n), ptr: make([]int, n)}
+	return d
+}
+
+func (d *Dinic) AddEdge(u, v int, c int64) {
+	d.G[u] = append(d.G[u], Edge{v, len(d.G[v]), c})
+	d.G[v] = append(d.G[v], Edge{u, len(d.G[u]) - 1, 0})
+}
+
+func (d *Dinic) bfs(s, t int) bool {
+	for i := range d.level {
+		d.level[i] = -1
+	}
+	q := make([]int, 0, d.N)
+	d.level[s] = 0
+	q = append(q, s)
+	for i := 0; i < len(q); i++ {
+		u := q[i]
+		for _, e := range d.G[u] {
+			if d.level[e.to] < 0 && e.cap > 0 {
+				d.level[e.to] = d.level[u] + 1
+				q = append(q, e.to)
+			}
+		}
+	}
+	return d.level[t] >= 0
+}
+
+func (d *Dinic) dfs(u, t int, f int64) int64 {
+	if u == t || f == 0 {
+		return f
+	}
+	for ; d.ptr[u] < len(d.G[u]); d.ptr[u]++ {
+		e := &d.G[u][d.ptr[u]]
+		if d.level[e.to] == d.level[u]+1 && e.cap > 0 {
+			pushed := d.dfs(e.to, t, min64(f, e.cap))
+			if pushed > 0 {
+				e.cap -= pushed
+				d.G[e.to][e.rev].cap += pushed
+				return pushed
+			}
+		}
+	}
+	return 0
+}
+
+func (d *Dinic) MaxFlow(s, t int) int64 {
+	flow := int64(0)
+	for d.bfs(s, t) {
+		for i := range d.ptr {
+			d.ptr[i] = 0
+		}
+		for {
+			pushed := d.dfs(s, t, INF)
+			if pushed == 0 {
+				break
+			}
+			flow += pushed
+		}
+	}
+	return flow
+}
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func uniqueInts(a []int) []int {
+	if len(a) == 0 {
+		return a
+	}
+	res := []int{a[0]}
+	for i := 1; i < len(a); i++ {
+		if a[i] != a[i-1] {
+			res = append(res, a[i])
+		}
+	}
+	return res
+}
+
+func solveE(n int, rects [][4]int) int64 {
+	if len(rects) == 0 {
+		return 0
+	}
+	xs := make([]int, 0, 2*len(rects))
+	ys := make([]int, 0, 2*len(rects))
+	for _, r := range rects {
+		xs = append(xs, r[0])
+		xs = append(xs, r[2]+1)
+		ys = append(ys, r[1])
+		ys = append(ys, r[3]+1)
+	}
+	sort.Ints(xs)
+	sort.Ints(ys)
+	xs = uniqueInts(xs)
+	ys = uniqueInts(ys)
+	nx := len(xs) - 1
+	ny := len(ys) - 1
+	rowLen := make([]int64, nx)
+	colLen := make([]int64, ny)
+	for i := 0; i < nx; i++ {
+		rowLen[i] = int64(xs[i+1] - xs[i])
+	}
+	for j := 0; j < ny; j++ {
+		colLen[j] = int64(ys[j+1] - ys[j])
+	}
+	has := make([][]bool, nx)
+	for i := range has {
+		has[i] = make([]bool, ny)
+	}
+	for _, r := range rects {
+		x1 := sort.SearchInts(xs, r[0])
+		x2 := sort.SearchInts(xs, r[2]+1)
+		y1 := sort.SearchInts(ys, r[1])
+		y2 := sort.SearchInts(ys, r[3]+1)
+		for i := x1; i < x2; i++ {
+			for j := y1; j < y2; j++ {
+				has[i][j] = true
+			}
+		}
+	}
+	N := nx + ny + 2
+	src := 0
+	sink := N - 1
+	d := NewDinic(N)
+	for i := 0; i < nx; i++ {
+		if rowLen[i] > 0 {
+			d.AddEdge(src, 1+i, rowLen[i])
+		}
+	}
+	for j := 0; j < ny; j++ {
+		if colLen[j] > 0 {
+			d.AddEdge(1+nx+j, sink, colLen[j])
+		}
+	}
+	for i := 0; i < nx; i++ {
+		for j := 0; j < ny; j++ {
+			if has[i][j] {
+				d.AddEdge(1+i, 1+nx+j, INF)
+			}
+		}
+	}
+	return d.MaxFlow(src, sink)
+}
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) ([]byte, int64) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(4)
+	rects := make([][4]int, m)
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d %d\n", n, m)
+	for i := 0; i < m; i++ {
+		x1 := rng.Intn(n) + 1
+		x2 := rng.Intn(n-x1+1) + x1
+		y1 := rng.Intn(n) + 1
+		y2 := rng.Intn(n-y1+1) + y1
+		rects[i] = [4]int{x1, y1, x2, y2}
+		fmt.Fprintf(&b, "%d %d %d %d\n", x1, y1, x2, y2)
+	}
+	expect := solveE(n, rects)
+	return b.Bytes(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, expect := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, string(input))
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != fmt.Sprint(expect) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", i, expect, strings.TrimSpace(out), string(input))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1100-1199/1190-1199/1198/verifierF.go
+++ b/1000-1999/1100-1199/1190-1199/1198/verifierF.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func expectedF(a []int) (bool, []int) {
+	n := len(a)
+	total := 1 << n
+	for mask := 1; mask < total-1; mask++ {
+		g1, g2 := 0, 0
+		for i := 0; i < n; i++ {
+			if mask&(1<<i) != 0 {
+				g1 = gcd(g1, a[i])
+			} else {
+				g2 = gcd(g2, a[i])
+			}
+		}
+		if g1 == 1 && g2 == 1 {
+			res := make([]int, n)
+			for i := 0; i < n; i++ {
+				if mask&(1<<i) != 0 {
+					res[i] = 1
+				} else {
+					res[i] = 2
+				}
+			}
+			return true, res
+		}
+	}
+	return false, nil
+}
+
+func generateCase(rng *rand.Rand) ([]byte, bool, []int) {
+	n := rng.Intn(6) + 2
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(50) + 1
+	}
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d\n", n)
+	for i, v := range a {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, v)
+	}
+	b.WriteByte('\n')
+	ok, assignment := expectedF(a)
+	return b.Bytes(), ok, assignment
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, ok, assign := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, string(input))
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if !ok {
+			if strings.TrimSpace(lines[0]) != "NO" {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected NO got %s\ninput:\n%s", i, out, string(input))
+				os.Exit(1)
+			}
+			continue
+		}
+		if strings.TrimSpace(lines[0]) != "YES" {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected YES got %s\ninput:\n%s", i, out, string(input))
+			os.Exit(1)
+		}
+		if len(lines) < 2 {
+			fmt.Fprintf(os.Stderr, "case %d failed: incomplete output\ninput:\n%s", i, string(input))
+			os.Exit(1)
+		}
+		fields := strings.Fields(lines[1])
+		if len(fields) != len(assign) {
+			fmt.Fprintf(os.Stderr, "case %d failed: wrong output length\ninput:\n%s", i, string(input))
+			os.Exit(1)
+		}
+		for j, f := range fields {
+			if f != fmt.Sprint(assign[j]) {
+				fmt.Fprintf(os.Stderr, "case %d failed: expected %v got %s\ninput:\n%s", i, assign, out, string(input))
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1198
- each verifier generates 100 random tests and checks any binary

## Testing
- `go run verifierA.go ./a.out`
- `go run verifierB.go ./b.out`

------
https://chatgpt.com/codex/tasks/task_e_6884b3c113d08324bcf5100bd176f992