### PR TITLE
Add solution verifiers for Codeforces contest 1200

### DIFF
--- a/1000-1999/1200-1299/1200-1209/1200/verifierA.go
+++ b/1000-1999/1200-1299/1200-1209/1200/verifierA.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1200A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(0))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		rooms := make([]bool, 10)
+		for j := 0; j < n; j++ {
+			ops := make([]byte, 0, 12)
+			free := 0
+			for _, v := range rooms {
+				if !v {
+					free++
+				}
+			}
+			if free > 0 {
+				ops = append(ops, 'L', 'R')
+			}
+			for k := 0; k < 10; k++ {
+				if rooms[k] {
+					ops = append(ops, byte('0'+k))
+				}
+			}
+			ch := ops[rng.Intn(len(ops))]
+			sb.WriteByte(ch)
+			switch ch {
+			case 'L':
+				for idx := 0; idx < 10; idx++ {
+					if !rooms[idx] {
+						rooms[idx] = true
+						break
+					}
+				}
+			case 'R':
+				for idx := 9; idx >= 0; idx-- {
+					if !rooms[idx] {
+						rooms[idx] = true
+						break
+					}
+				}
+			default:
+				rooms[int(ch-'0')] = false
+			}
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	tests = append(tests, Test{"1\nL\n"})
+	tests = append(tests, Test{"2\nLR\n"})
+	tests = append(tests, Test{"3\nLR0\n"})
+	tests = append(tests, Test{"10\nLLLLLLLLLL\n"})
+	tests = append(tests, Test{"10\nRRRRRRRRRR\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1200/verifierB.go
+++ b/1000-1999/1200-1299/1200-1209/1200/verifierB.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1200B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randCase(rng *rand.Rand) Test {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(30)
+	k := rng.Intn(20)
+	h := make([]int, n)
+	for i := range h {
+		h[i] = rng.Intn(30)
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i, v := range h {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	return Test{sb.String()}
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		tests = append(tests, randCase(rng))
+	}
+	tests = append(tests, Test{"1\n1 0 0\n0\n"})
+	tests = append(tests, Test{"1\n2 0 0\n0 0\n"})
+	tests = append(tests, Test{"1\n3 1 1\n1 2 3\n"})
+	tests = append(tests, Test{"1\n1 5 0\n10\n"})
+	tests = append(tests, Test{"1\n5 0 10\n0 0 0 0 0\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1200/verifierC.go
+++ b/1000-1999/1200-1299/1200-1209/1200/verifierC.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1200C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randCase(rng *rand.Rand) Test {
+	n := int64(rng.Intn(50) + 1)
+	m := int64(rng.Intn(50) + 1)
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, q))
+	for i := 0; i < q; i++ {
+		sx := rng.Intn(2) + 1
+		var sy int64
+		if sx == 1 {
+			sy = int64(rng.Intn(int(n)) + 1)
+		} else {
+			sy = int64(rng.Intn(int(m)) + 1)
+		}
+		ex := rng.Intn(2) + 1
+		var ey int64
+		if ex == 1 {
+			ey = int64(rng.Intn(int(n)) + 1)
+		} else {
+			ey = int64(rng.Intn(int(m)) + 1)
+		}
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", sx, sy, ex, ey))
+	}
+	return Test{sb.String()}
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(2))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		tests = append(tests, randCase(rng))
+	}
+	tests = append(tests, Test{"1 1 1\n1 1 1 1\n"})
+	tests = append(tests, Test{"2 3 2\n1 1 2 2\n2 3 2 1\n"})
+	tests = append(tests, Test{"5 5 1\n1 5 2 1\n"})
+	tests = append(tests, Test{"10 1 1\n2 1 2 1\n"})
+	tests = append(tests, Test{"7 9 3\n1 1 1 7\n2 9 1 1\n2 3 2 8\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1200/verifierD.go
+++ b/1000-1999/1200-1299/1200-1209/1200/verifierD.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1200D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randCase(rng *rand.Rand) Test {
+	n := rng.Intn(6) + 1
+	k := rng.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('B')
+			} else {
+				sb.WriteByte('W')
+			}
+		}
+		sb.WriteByte('\n')
+	}
+	return Test{sb.String()}
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(3))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		tests = append(tests, randCase(rng))
+	}
+	tests = append(tests, Test{"1 1\nB\n"})
+	tests = append(tests, Test{"1 1\nW\n"})
+	tests = append(tests, Test{"2 1\nBW\nWB\n"})
+	tests = append(tests, Test{"2 2\nBB\nBB\n"})
+	tests = append(tests, Test{"3 1\nWWW\nWWW\nWWW\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1200/verifierE.go
+++ b/1000-1999/1200-1299/1200-1209/1200/verifierE.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1200E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+const letters = "abcdefghijklmnopqrstuvwxyz"
+
+func randCase(rng *rand.Rand) Test {
+	n := rng.Intn(6) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		l := rng.Intn(6) + 1
+		for j := 0; j < l; j++ {
+			sb.WriteByte(letters[rng.Intn(len(letters))])
+		}
+	}
+	sb.WriteByte('\n')
+	return Test{sb.String()}
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(4))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		tests = append(tests, randCase(rng))
+	}
+	tests = append(tests, Test{"1\na\n"})
+	tests = append(tests, Test{"2\na b\n"})
+	tests = append(tests, Test{"3\nabc abc abc\n"})
+	tests = append(tests, Test{"4\ncode forces rocks go\n"})
+	tests = append(tests, Test{"5\na bb ccc dddd eeeee\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1200/verifierF.go
+++ b/1000-1999/1200-1299/1200-1209/1200/verifierF.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type Test struct {
+	input string
+}
+
+func buildRef() (string, error) {
+	ref := "refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1200F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randCase(rng *rand.Rand) Test {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(rng.Intn(11) - 5))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		m := rng.Intn(3) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", m))
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(strconv.Itoa(rng.Intn(n) + 1))
+		}
+		sb.WriteByte('\n')
+	}
+	q := rng.Intn(5) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(11) - 5
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	return Test{sb.String()}
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(5))
+	tests := make([]Test, 0, 105)
+	for i := 0; i < 100; i++ {
+		tests = append(tests, randCase(rng))
+	}
+	tests = append(tests, Test{"1\n0\n1\n1\n1\n0\n"})
+	tests = append(tests, Test{"2\n1 1\n1\n1\n1\n2\n1\n1 0\n"})
+	tests = append(tests, Test{"3\n0 0 0\n1\n1\n1\n2\n1 2\n3\n1 0\n2 -1\n3 2\n"})
+	tests = append(tests, Test{"1\n5\n1\n1\n2\n1\n1 1\n"})
+	tests = append(tests, Test{"2\n-1 2\n1\n2\n1 2\n1\n1 0\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–F of contest 1200
- each verifier builds the reference solution, generates 100+ tests and runs a provided binary
- ensure binaries in the current directory run correctly

## Testing
- `go build 1000-1999/1200-1299/1200-1209/1200/verifierA.go`
- `go build 1000-1999/1200-1299/1200-1209/1200/verifierB.go`
- `go build 1000-1999/1200-1299/1200-1209/1200/verifierC.go`
- `go build 1000-1999/1200-1299/1200-1209/1200/verifierD.go`
- `go build 1000-1999/1200-1299/1200-1209/1200/verifierE.go`
- `go build 1000-1999/1200-1299/1200-1209/1200/verifierF.go`
- `go run verifierA.go ./candA.bin`

------
https://chatgpt.com/codex/tasks/task_e_6884b4d93fe08324b645fcd055fcf243