### PR TITLE
Add verifiers for contest 1204

### DIFF
--- a/1000-1999/1200-1299/1200-1209/1204/verifierA.go
+++ b/1000-1999/1200-1299/1200-1209/1204/verifierA.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	s string
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveA(s string) string {
+	n := new(big.Int)
+	n.SetString(s, 2)
+	pow := big.NewInt(1)
+	cnt := 0
+	for pow.Cmp(n) < 0 {
+		cnt++
+		pow.Lsh(pow, 2)
+	}
+	return fmt.Sprintf("%d", cnt)
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 0, 100)
+	fixed := []string{"0", "1", "10", "11", "101", "1111", "100000", "101010", "11111111", "100000000"}
+	for _, f := range fixed {
+		tests = append(tests, testCase{s: f})
+	}
+	for len(tests) < 100 {
+		length := rng.Intn(100) + 1
+		if length == 1 {
+			if rng.Intn(2) == 0 {
+				tests = append(tests, testCase{s: "0"})
+				continue
+			}
+		}
+		sb := make([]byte, length)
+		for i := 0; i < length; i++ {
+			b := byte('0' + rng.Intn(2))
+			if i == 0 && b == '0' && length > 1 {
+				b = '1'
+			}
+			sb[i] = b
+		}
+		tests = append(tests, testCase{s: string(sb)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%s\n", t.s)
+		expect := solveA(t.s)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, expect, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1204/verifierB.go
+++ b/1000-1999/1200-1299/1200-1209/1204/verifierB.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	n int
+	l int
+	r int
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveB(n, l, r int) string {
+	minSum := int64(n - l)
+	minSum += int64(1<<uint(l)) - 1
+	maxSum := int64(1<<uint(r)) - 1
+	maxSum += int64(n-r) * int64(1<<uint(r-1))
+	return fmt.Sprintf("%d %d", minSum, maxSum)
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(2))
+	tests := make([]testCase, 0, 100)
+	fixed := []testCase{{n: 1, l: 1, r: 1}, {n: 5, l: 2, r: 3}, {n: 10, l: 1, r: 1}, {n: 20, l: 5, r: 5}}
+	tests = append(tests, fixed...)
+	for len(tests) < 100 {
+		n := rng.Intn(1000) + 1
+		maxLR := n
+		if maxLR > 20 {
+			maxLR = 20
+		}
+		l := rng.Intn(maxLR) + 1
+		r := l + rng.Intn(maxLR-l+1)
+		if r > maxLR {
+			r = maxLR
+		}
+		tests = append(tests, testCase{n: n, l: l, r: r})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d %d\n", t.n, t.l, t.r)
+		expect := solveB(t.n, t.l, t.r)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, expect, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1204/verifierC.go
+++ b/1000-1999/1200-1299/1200-1209/1204/verifierC.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	n    int
+	adj  [][]int
+	path []int
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveC(tc testCase) string {
+	n := tc.n
+	adj := tc.adj
+	m := len(tc.path)
+	// compute distances via BFS for each node
+	dist := make([][]int, n)
+	for i := 0; i < n; i++ {
+		dist[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			dist[i][j] = -1
+		}
+		queue := []int{i}
+		dist[i][i] = 0
+		for head := 0; head < len(queue); head++ {
+			u := queue[head]
+			for _, v := range adj[u] {
+				if dist[i][v] == -1 {
+					dist[i][v] = dist[i][u] + 1
+					queue = append(queue, v)
+				}
+			}
+		}
+	}
+	ans := []int{tc.path[0]}
+	last := 0
+	for i := 1; i < m-1; i++ {
+		if dist[tc.path[last]][tc.path[i+1]] < i+1-last {
+			ans = append(ans, tc.path[i])
+			last = i
+		}
+	}
+	ans = append(ans, tc.path[m-1])
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("%d\n", len(ans)))
+	for i, v := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+	}
+	return sb.String()
+}
+
+func generateGraph(rng *rand.Rand, n int) [][]int {
+	adj := make([][]int, n)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if i == j {
+				continue
+			}
+			if rng.Intn(2) == 0 {
+				adj[i] = append(adj[i], j)
+			}
+		}
+		if len(adj[i]) == 0 {
+			j := (i + 1) % n
+			adj[i] = append(adj[i], j)
+		}
+	}
+	return adj
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(3))
+	tests := make([]testCase, 0, 100)
+	for len(tests) < 100 {
+		n := rng.Intn(5) + 2
+		adj := generateGraph(rng, n)
+		m := rng.Intn(10) + 2
+		path := make([]int, m)
+		path[0] = rng.Intn(n)
+		for i := 1; i < m; i++ {
+			options := adj[path[i-1]]
+			path[i] = options[rng.Intn(len(options))]
+		}
+		tests = append(tests, testCase{n: n, adj: adj, path: path})
+	}
+	return tests
+}
+
+func formatInput(tc testCase) string {
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("%d\n", tc.n))
+	for i := 0; i < tc.n; i++ {
+		row := make([]byte, tc.n)
+		for j := 0; j < tc.n; j++ {
+			row[j] = '0'
+		}
+		for _, v := range tc.adj[i] {
+			row[v] = '1'
+		}
+		sb.WriteString(fmt.Sprintf("%s\n", string(row)))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", len(tc.path)))
+	for i, v := range tc.path {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := formatInput(t)
+		expect := solveC(t)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(expect) {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, strings.TrimSpace(expect), strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1204/verifierD1.go
+++ b/1000-1999/1200-1299/1200-1209/1204/verifierD1.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	s string
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveD(s string) string {
+	res := []byte(s)
+	stack := make([]int, 0)
+	for i := 0; i < len(s); i++ {
+		if s[i] == '1' {
+			stack = append(stack, i)
+		} else {
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		}
+	}
+	for _, idx := range stack {
+		res[idx] = '0'
+	}
+	return string(res)
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(4))
+	tests := make([]testCase, 0, 100)
+	fixed := []string{"0", "1", "10", "01", "111000", "101010", "1111", "0000"}
+	for _, f := range fixed {
+		tests = append(tests, testCase{s: f})
+	}
+	letters := []byte{'0', '1'}
+	for len(tests) < 100 {
+		n := rng.Intn(50) + 1
+		sb := make([]byte, n)
+		for i := 0; i < n; i++ {
+			sb[i] = letters[rng.Intn(2)]
+		}
+		tests = append(tests, testCase{s: string(sb)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%s\n", t.s)
+		expect := solveD(t.s)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, expect, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1204/verifierD2.go
+++ b/1000-1999/1200-1299/1200-1209/1204/verifierD2.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type testCase struct {
+	s string
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func solveD(s string) string {
+	res := []byte(s)
+	stack := make([]int, 0)
+	for i := 0; i < len(s); i++ {
+		if s[i] == '1' {
+			stack = append(stack, i)
+		} else {
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		}
+	}
+	for _, idx := range stack {
+		res[idx] = '0'
+	}
+	return string(res)
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(5))
+	tests := make([]testCase, 0, 100)
+	fixed := []string{"0", "1", "1010", "0101", "111000", "000111"}
+	for _, f := range fixed {
+		tests = append(tests, testCase{s: f})
+	}
+	letters := []byte{'0', '1'}
+	for len(tests) < 100 {
+		n := rng.Intn(1000) + 1
+		sb := make([]byte, n)
+		for i := 0; i < n; i++ {
+			sb[i] = letters[rng.Intn(2)]
+		}
+		tests = append(tests, testCase{s: string(sb)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%s\n", t.s)
+		expect := solveD(t.s)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, expect, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1204/verifierE.go
+++ b/1000-1999/1200-1299/1200-1209/1204/verifierE.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const mod int64 = 998244853
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+type testCase struct {
+	n int
+	m int
+}
+
+func modPow(a, e int64) int64 {
+	a %= mod
+	res := int64(1)
+	for e > 0 {
+		if e&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		e >>= 1
+	}
+	return res
+}
+
+func solveE(n, m int) string {
+	maxN := n + m
+	fact := make([]int64, maxN+1)
+	invFact := make([]int64, maxN+1)
+	fact[0] = 1
+	for i := 1; i <= maxN; i++ {
+		fact[i] = fact[i-1] * int64(i) % mod
+	}
+	invFact[maxN] = modPow(fact[maxN], mod-2)
+	for i := maxN; i > 0; i-- {
+		invFact[i-1] = invFact[i] * int64(i) % mod
+	}
+	comb := func(n, k int) int64 {
+		if k < 0 || k > n {
+			return 0
+		}
+		return fact[n] * invFact[k] % mod * invFact[n-k] % mod
+	}
+
+	total := comb(n+m, n)
+	r := n - m
+	ans := int64(0)
+	for k := 1; k <= n; k++ {
+		if r > k {
+			ans += total
+		} else {
+			ans += comb(n+m, n-k)
+		}
+		if ans >= mod {
+			ans %= mod
+		}
+	}
+	return fmt.Sprintf("%d", ans%mod)
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(6))
+	tests := make([]testCase, 0, 100)
+	fixed := []testCase{{0, 0}, {1, 1}, {2, 0}, {0, 2}, {3, 3}}
+	tests = append(tests, fixed...)
+	for len(tests) < 100 {
+		n := rng.Intn(20)
+		m := rng.Intn(20)
+		tests = append(tests, testCase{n: n, m: m})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n", t.n, t.m)
+		expect := solveE(t.n, t.m)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: execution failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expect {
+			fmt.Printf("test %d failed: expected %q got %q\n", i+1, expect, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for Codeforces contest 1204
- support running any solution binary with 100+ random tests
- verifiers cover problems A through E

## Testing
- `go build 1000-1999/1200-1299/1200-1209/1204/verifierA.go`
- `go build 1000-1999/1200-1299/1200-1209/1204/verifierB.go`
- `go build 1000-1999/1200-1299/1200-1209/1204/verifierC.go`
- `go build 1000-1999/1200-1299/1200-1209/1204/verifierD1.go`
- `go build 1000-1999/1200-1299/1200-1209/1204/verifierD2.go`
- `go build 1000-1999/1200-1299/1200-1209/1204/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_6884b709ae808324b0166ed304cbe6ea