### PR TITLE
Add verifiers for contest 1203

### DIFF
--- a/1000-1999/1200-1299/1200-1209/1203/verifierA.go
+++ b/1000-1999/1200-1299/1200-1209/1203/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(arr []int) string {
+	n := len(arr)
+	idx := -1
+	for i, v := range arr {
+		if v == 1 {
+			idx = i
+			break
+		}
+	}
+	ok1 := true
+	for i := 0; i < n; i++ {
+		if arr[(idx+i)%n] != i+1 {
+			ok1 = false
+			break
+		}
+	}
+	ok2 := true
+	for i := 0; i < n; i++ {
+		if arr[(idx-i+n)%n] != i+1 {
+			ok2 = false
+			break
+		}
+	}
+	if ok1 || ok2 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	perm := rng.Perm(n)
+	for i := range perm {
+		perm[i]++
+	}
+	arr := make([]string, n)
+	for i, v := range perm {
+		arr[i] = fmt.Sprintf("%d", v)
+	}
+	input := fmt.Sprintf("1\n%d\n%s\n", n, strings.Join(arr, " "))
+	expected := solve(perm)
+	return input, expected
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	gotLines := strings.Split(got, "\n")
+	if len(gotLines) > 0 {
+		got = strings.TrimSpace(gotLines[0])
+	}
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(bin, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1203/verifierB.go
+++ b/1000-1999/1200-1299/1200-1209/1203/verifierB.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solve(sticks []int) string {
+	sort.Ints(sticks)
+	n := len(sticks) / 4
+	area := sticks[0] * sticks[len(sticks)-1]
+	for i := 0; i < n; i++ {
+		if sticks[2*i] != sticks[2*i+1] || sticks[len(sticks)-2*i-2] != sticks[len(sticks)-2*i-1] || sticks[2*i]*sticks[len(sticks)-2*i-1] != area {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func genValid(rng *rand.Rand) ([]int, string) {
+	n := rng.Intn(10) + 1
+	area := rng.Intn(20) + 1
+	sticks := make([]int, 0, 4*n)
+	for i := 0; i < n; i++ {
+		a := rng.Intn(area) + 1
+		b := area / a
+		// ensure area divides
+		for a*b != area {
+			a = rng.Intn(area) + 1
+			if area%a == 0 {
+				b = area / a
+			}
+		}
+		sticks = append(sticks, a, a, b, b)
+	}
+	rng.Shuffle(len(sticks), func(i, j int) { sticks[i], sticks[j] = sticks[j], sticks[i] })
+	return sticks, "YES"
+}
+
+func genRandom(rng *rand.Rand) ([]int, string) {
+	n := rng.Intn(10) + 1
+	sticks := make([]int, 4*n)
+	for i := range sticks {
+		sticks[i] = rng.Intn(20) + 1
+	}
+	return sticks, solve(sticks)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	if rng.Intn(2) == 0 {
+		sticks, exp := genValid(rng)
+		nums := make([]string, len(sticks))
+		for i, v := range sticks {
+			nums[i] = fmt.Sprintf("%d", v)
+		}
+		input := fmt.Sprintf("1\n%d\n%s\n", len(sticks)/4, strings.Join(nums, " "))
+		return input, exp
+	}
+	sticks, exp := genRandom(rng)
+	nums := make([]string, len(sticks))
+	for i, v := range sticks {
+		nums[i] = fmt.Sprintf("%d", v)
+	}
+	input := fmt.Sprintf("1\n%d\n%s\n", len(sticks)/4, strings.Join(nums, " "))
+	return input, exp
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(strings.Split(out.String(), "\n")[0])
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(bin, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1203/verifierC.go
+++ b/1000-1999/1200-1299/1200-1209/1203/verifierC.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func solve(nums []int64) string {
+	g := nums[0]
+	for _, x := range nums[1:] {
+		g = gcd(g, x)
+	}
+	ans := int64(1)
+	for p := int64(2); p*p <= g; p++ {
+		if g%p == 0 {
+			cnt := int64(0)
+			for g%p == 0 {
+				g /= p
+				cnt++
+			}
+			ans *= cnt + 1
+		}
+	}
+	if g > 1 {
+		ans *= 2
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	nums := make([]int64, n)
+	for i := range nums {
+		nums[i] = int64(rng.Intn(100000) + 1)
+	}
+	parts := make([]string, n)
+	for i, v := range nums {
+		parts[i] = fmt.Sprintf("%d", v)
+	}
+	input := fmt.Sprintf("%d\n%s\n", n, strings.Join(parts, " "))
+	expect := solve(nums)
+	return input, expect
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(strings.Split(out.String(), "\n")[0])
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(bin, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1203/verifierD1.go
+++ b/1000-1999/1200-1299/1200-1209/1203/verifierD1.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solve(s, t string) string {
+	n := len(s)
+	m := len(t)
+	pre := make([]int, m)
+	idx := 0
+	for i := 0; i < m; i++ {
+		for idx < n && s[idx] != t[i] {
+			idx++
+		}
+		if idx == n {
+			pre[i] = n
+		} else {
+			pre[i] = idx
+			idx++
+		}
+	}
+
+	suf := make([]int, m)
+	idx = n - 1
+	for i := m - 1; i >= 0; i-- {
+		for idx >= 0 && s[idx] != t[i] {
+			idx--
+		}
+		if idx < 0 {
+			suf[i] = -1
+		} else {
+			suf[i] = idx
+			idx--
+		}
+	}
+
+	maxDel := 0
+	for i := 0; i <= m; i++ {
+		var l, r int
+		if i == 0 {
+			l = 0
+		} else {
+			l = pre[i-1] + 1
+		}
+		if i == m {
+			r = n - 1
+		} else {
+			r = suf[i] - 1
+		}
+		if r >= l && r-l+1 > maxDel {
+			maxDel = r - l + 1
+		}
+	}
+	return fmt.Sprintf("%d", maxDel)
+}
+
+func randomString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(n) + 1
+	s := randomString(rng, n)
+	// ensure t is subsequence: pick indices in order
+	idxs := rng.Perm(n)[:m]
+	sort.Ints(idxs)
+	tbytes := make([]byte, m)
+	for i, idx := range idxs {
+		tbytes[i] = s[idx]
+	}
+	t := string(tbytes)
+	input := fmt.Sprintf("%s\n%s\n", s, t)
+	expect := solve(s, t)
+	return input, expect
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(strings.Split(out.String(), "\n")[0])
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(bin, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1203/verifierD2.go
+++ b/1000-1999/1200-1299/1200-1209/1203/verifierD2.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solve(s, t string) string {
+	n := len(s)
+	m := len(t)
+	pre := make([]int, m)
+	idx := 0
+	for i := 0; i < n && idx < m; i++ {
+		if s[i] == t[idx] {
+			pre[idx] = i
+			idx++
+		}
+	}
+	suf := make([]int, m)
+	idx = m - 1
+	for i := n - 1; i >= 0 && idx >= 0; i-- {
+		if s[i] == t[idx] {
+			suf[idx] = i
+			idx--
+		}
+	}
+	ans := max(suf[0], n-1-pre[m-1])
+	for i := 0; i < m-1; i++ {
+		if gap := suf[i+1] - pre[i] - 1; gap > ans {
+			ans = gap
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func randomString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(n) + 1
+	s := randomString(rng, n)
+	idxs := rng.Perm(n)[:m]
+	sort.Ints(idxs)
+	tb := make([]byte, m)
+	for i, idx := range idxs {
+		tb[i] = s[idx]
+	}
+	t := string(tb)
+	input := fmt.Sprintf("%s\n%s\n", s, t)
+	expect := solve(s, t)
+	return input, expect
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(strings.Split(out.String(), "\n")[0])
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(bin, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1203/verifierE.go
+++ b/1000-1999/1200-1299/1200-1209/1203/verifierE.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func solve(weights []int) string {
+	sort.Ints(weights)
+	const maxW = 150001
+	used := make(map[int]bool)
+	ans := 0
+	for _, w := range weights {
+		if w-1 > 0 && !used[w-1] {
+			used[w-1] = true
+			ans++
+		} else if !used[w] {
+			used[w] = true
+			ans++
+		} else if !used[w+1] {
+			used[w+1] = true
+			ans++
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	w := make([]int, n)
+	for i := range w {
+		w[i] = rng.Intn(100) + 1
+	}
+	parts := make([]string, n)
+	for i, v := range w {
+		parts[i] = fmt.Sprintf("%d", v)
+	}
+	input := fmt.Sprintf("%d\n%s\n", n, strings.Join(parts, " "))
+	expect := solve(w)
+	return input, expect
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(strings.Split(out.String(), "\n")[0])
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(bin, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1203/verifierF1.go
+++ b/1000-1999/1200-1299/1200-1209/1203/verifierF1.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type project struct {
+	a int
+	b int
+}
+
+func solve(n, r int, projects []project) string {
+	pos := make([]project, 0)
+	neg := make([]project, 0)
+	for _, p := range projects {
+		if p.b >= 0 {
+			pos = append(pos, p)
+		} else {
+			neg = append(neg, p)
+		}
+	}
+	sort.Slice(pos, func(i, j int) bool { return pos[i].a < pos[j].a })
+	for _, p := range pos {
+		if r < p.a {
+			return "NO"
+		}
+		r += p.b
+	}
+	sort.Slice(neg, func(i, j int) bool { return neg[i].a+neg[i].b > neg[j].a+neg[j].b })
+	m := len(neg)
+	dp := make([]int, m+1)
+	const negInf = -1 << 30
+	for i := range dp {
+		dp[i] = negInf
+	}
+	dp[0] = r
+	for i, p := range neg {
+		for j := i + 1; j >= 1; j-- {
+			if dp[j-1] >= p.a && dp[j-1]+p.b >= 0 {
+				cand := dp[j-1] + p.b
+				if cand > dp[j] {
+					dp[j] = cand
+				}
+			}
+		}
+	}
+	if dp[m] >= 0 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	r := rng.Intn(100) + 1
+	pr := make([]project, n)
+	for i := 0; i < n; i++ {
+		a := rng.Intn(100) + 1
+		b := rng.Intn(601) - 300
+		pr[i] = project{a, b}
+	}
+	parts := make([]string, 0, 2*n+2)
+	parts = append(parts, fmt.Sprintf("%d %d", n, r))
+	for _, p := range pr {
+		parts = append(parts, fmt.Sprintf("%d %d", p.a, p.b))
+	}
+	input := strings.Join(parts, "\n") + "\n"
+	expect := solve(n, r, pr)
+	return input, expect
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(strings.Split(out.String(), "\n")[0])
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(bin, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1203/verifierF2.go
+++ b/1000-1999/1200-1299/1200-1209/1203/verifierF2.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type project struct {
+	a int
+	b int
+}
+
+func solve(n, r int, pr []project) string {
+	pos := make([]project, 0)
+	neg := make([]project, 0)
+	for _, p := range pr {
+		if p.b >= 0 {
+			pos = append(pos, p)
+		} else {
+			neg = append(neg, p)
+		}
+	}
+	sort.Slice(pos, func(i, j int) bool {
+		if pos[i].a == pos[j].a {
+			return pos[i].b > pos[j].b
+		}
+		return pos[i].a < pos[j].a
+	})
+	count := 0
+	curr := r
+	for _, p := range pos {
+		if curr >= p.a {
+			curr += p.b
+			count++
+		}
+	}
+	sort.Slice(neg, func(i, j int) bool {
+		left := neg[i].a + neg[i].b
+		right := neg[j].a + neg[j].b
+		if left == right {
+			return neg[i].a > neg[j].a
+		}
+		return left > right
+	})
+	maxR := curr
+	const negInf = -1000000000
+	dp := make([]int, maxR+1)
+	for i := range dp {
+		dp[i] = negInf
+	}
+	dp[curr] = 0
+	for _, p := range neg {
+		for rating := maxR; rating >= p.a; rating-- {
+			if dp[rating] == negInf {
+				continue
+			}
+			newR := rating + p.b
+			if newR < 0 {
+				continue
+			}
+			if dp[rating]+1 > dp[newR] {
+				dp[newR] = dp[rating] + 1
+			}
+		}
+	}
+	best := 0
+	for _, v := range dp {
+		if v > best {
+			best = v
+		}
+	}
+	return fmt.Sprintf("%d", best+count)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	r := rng.Intn(100) + 1
+	pr := make([]project, n)
+	for i := 0; i < n; i++ {
+		a := rng.Intn(100) + 1
+		b := rng.Intn(601) - 300
+		pr[i] = project{a, b}
+	}
+	parts := make([]string, 0, 2*n+2)
+	parts = append(parts, fmt.Sprintf("%d %d", n, r))
+	for _, p := range pr {
+		parts = append(parts, fmt.Sprintf("%d %d", p.a, p.b))
+	}
+	input := strings.Join(parts, "\n") + "\n"
+	expect := solve(n, r, pr)
+	return input, expect
+}
+
+func runCase(bin, input, expect string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(strings.Split(out.String(), "\n")[0])
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(bin, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems in contest 1203
- each verifier generates 100 random test cases and checks a candidate binary

## Testing
- `go build verifierA.go && go build verifierB.go && go build verifierC.go && go build verifierD1.go && go build verifierD2.go && go build verifierE.go && go build verifierF1.go && go build verifierF2.go`

------
https://chatgpt.com/codex/tasks/task_e_6884b67d78e483249b33dabf47cf5345