### PR TITLE
Add Go solution for 1617C

### DIFF
--- a/1000-1999/1600-1699/1610-1619/1617/1617C.go
+++ b/1000-1999/1600-1699/1610-1619/1617/1617C.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		used := make([]bool, n+1)
+		extras := make([]int, 0)
+		for _, v := range a {
+			if v >= 1 && v <= n && !used[v] {
+				used[v] = true
+			} else {
+				extras = append(extras, v)
+			}
+		}
+		sort.Ints(extras)
+		missing := make([]int, 0)
+		for i := 1; i <= n; i++ {
+			if !used[i] {
+				missing = append(missing, i)
+			}
+		}
+		if len(extras) != len(missing) {
+			fmt.Fprintln(writer, -1)
+			continue
+		}
+		possible := true
+		for i, m := range missing {
+			if extras[i] <= 2*m {
+				possible = false
+				break
+			}
+		}
+		if possible {
+			fmt.Fprintln(writer, len(extras))
+		} else {
+			fmt.Fprintln(writer, -1)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for Paprika's permutation problem

## Testing
- `go vet 1000-1999/1600-1699/1610-1619/1617/1617C.go`
- `go build 1000-1999/1600-1699/1610-1619/1617/1617C.go`


------
https://chatgpt.com/codex/tasks/task_e_6884b7dbb13483248d878559c096fd08