### PR TITLE
Add verifiers for contest 1205

### DIFF
--- a/1000-1999/1200-1299/1200-1209/1205/verifierA.go
+++ b/1000-1999/1200-1299/1200-1209/1205/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1205A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(1000) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1205/verifierB.go
+++ b/1000-1999/1200-1299/1200-1209/1205/verifierB.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1205B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(150) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		val := rng.Int63()
+		sb.WriteString(fmt.Sprintf("%d", val))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1205/verifierC.go
+++ b/1000-1999/1200-1299/1200-1209/1205/verifierC.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Board [][]int
+
+func genBoard(rng *rand.Rand) Board {
+	n := rng.Intn(3)*2 + 3 // 3,5,7
+	b := make(Board, n)
+	for i := range b {
+		b[i] = make([]int, n)
+		for j := range b[i] {
+			if i == 0 && j == 0 {
+				b[i][j] = 1
+			} else if i == n-1 && j == n-1 {
+				b[i][j] = 0
+			} else {
+				b[i][j] = rng.Intn(2)
+			}
+		}
+	}
+	return b
+}
+
+func computeDP(board Board) [][][][]bool {
+	n := len(board)
+	dp := make([][][][]bool, n)
+	for i := range dp {
+		dp[i] = make([][][]bool, n)
+		for j := range dp[i] {
+			dp[i][j] = make([][]bool, n)
+			for a := range dp[i][j] {
+				dp[i][j][a] = make([]bool, n)
+			}
+		}
+	}
+	for d := 0; d < 2*n-1; d++ {
+		for x1 := 0; x1 < n; x1++ {
+			for y1 := 0; y1 < n; y1++ {
+				s := x1 + y1 + d
+				if s >= 2*n-1 {
+					continue
+				}
+				for x2 := 0; x2 < n; x2++ {
+					y2 := s - x2
+					if y2 < 0 || y2 >= n {
+						continue
+					}
+					if x2 < x1 || y2 < y1 {
+						continue
+					}
+					if board[x1][y1] != board[x2][y2] {
+						dp[x1][y1][x2][y2] = false
+						continue
+					}
+					if d <= 1 {
+						dp[x1][y1][x2][y2] = true
+						continue
+					}
+					v := false
+					if x1+1 < n && x2-1 >= 0 && dp[x1+1][y1][x2-1][y2] {
+						v = true
+					}
+					if x1+1 < n && y2-1 >= 0 && dp[x1+1][y1][x2][y2-1] {
+						v = true
+					}
+					if y1+1 < n && x2-1 >= 0 && dp[x1][y1+1][x2-1][y2] {
+						v = true
+					}
+					if y1+1 < n && y2-1 >= 0 && dp[x1][y1+1][x2][y2-1] {
+						v = true
+					}
+					dp[x1][y1][x2][y2] = v
+				}
+			}
+		}
+	}
+	return dp
+}
+
+func runCase(bin string, board Board) error {
+	n := len(board)
+	dp := computeDP(board)
+	cmd := exec.Command(bin)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	writer := bufio.NewWriter(stdin)
+	reader := bufio.NewReader(stdout)
+
+	fmt.Fprintf(writer, "%d\n", n)
+	writer.Flush()
+
+	queries := 0
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			cmd.Process.Kill()
+			return fmt.Errorf("failed to read from program: %v", err)
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "?") {
+			parts := strings.Fields(line)
+			if len(parts) != 5 {
+				cmd.Process.Kill()
+				return fmt.Errorf("bad query format: %s", line)
+			}
+			var x1, y1, x2, y2 int
+			fmt.Sscan(parts[1], &x1)
+			fmt.Sscan(parts[2], &y1)
+			fmt.Sscan(parts[3], &x2)
+			fmt.Sscan(parts[4], &y2)
+			if x1 < 1 || x1 > n || y1 < 1 || y1 > n || x2 < 1 || x2 > n || y2 < 1 || y2 > n || x1 > x2 || y1 > y2 || x1+y1+2 > x2+y2 {
+				cmd.Process.Kill()
+				return fmt.Errorf("invalid query coordinates: %s", line)
+			}
+			ans := 0
+			if dp[x1-1][y1-1][x2-1][y2-1] {
+				ans = 1
+			}
+			fmt.Fprintf(writer, "%d\n", ans)
+			writer.Flush()
+			queries++
+			if queries > n*n {
+				cmd.Process.Kill()
+				return fmt.Errorf("too many queries")
+			}
+		} else if strings.HasPrefix(line, "!") {
+			final := make(Board, n)
+			for i := 0; i < n; i++ {
+				row, err := reader.ReadString('\n')
+				if err != nil {
+					cmd.Process.Kill()
+					return fmt.Errorf("failed to read row: %v", err)
+				}
+				row = strings.TrimSpace(row)
+				parts := strings.Fields(row)
+				if len(parts) != n {
+					cmd.Process.Kill()
+					return fmt.Errorf("bad row output: %s", row)
+				}
+				final[i] = make([]int, n)
+				for j, p := range parts {
+					var v int
+					fmt.Sscan(p, &v)
+					final[i][j] = v
+				}
+			}
+			cmd.Wait()
+			for i := 0; i < n; i++ {
+				for j := 0; j < n; j++ {
+					if final[i][j] != board[i][j] {
+						return fmt.Errorf("wrong board")
+					}
+				}
+			}
+			return nil
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 1; i <= 100; i++ {
+		board := genBoard(rng)
+		if err := runCase(bin, board); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1205/verifierD.go
+++ b/1000-1999/1200-1299/1200-1209/1205/verifierD.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1205D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genTree(rng *rand.Rand) (string, int) {
+	n := rng.Intn(20) + 2
+	edges := make([][2]int, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i) + 1
+		edges[i-1] = [2]int{p, i + 1}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String(), n
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input, _ := genTree(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1205/verifierE.go
+++ b/1000-1999/1200-1299/1200-1209/1205/verifierE.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1205E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(1000) + 1
+	k := rng.Int63n(1000000000) + 1
+	return fmt.Sprintf("%d %d\n", n, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i, expect, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1205/verifierF.go
+++ b/1000-1999/1200-1299/1200-1209/1205/verifierF.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1205F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin string, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		n := rng.Intn(100) + 1
+		k := rng.Intn(n*(n+1)/2) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 1; i <= 100; i++ {
+		input := genCase(rng)
+		expect, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i, err, input)
+			os.Exit(1)
+		}
+		if got != expect {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s", i, expect, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for all problems of contest 1205
- each verifier builds a reference solution and checks candidate binaries on 100 randomized test cases
- include an interactive judge for problem C

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884b795b49c8324aa76f2bc1df071ac