### PR TITLE
Add verifiers for Codeforces 1208

### DIFF
--- a/1000-1999/1200-1299/1200-1209/1208/verifierA.go
+++ b/1000-1999/1200-1299/1200-1209/1208/verifierA.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(a, b int64, n int64) int64 {
+	switch n % 3 {
+	case 0:
+		return a
+	case 1:
+		return b
+	default:
+		return a ^ b
+	}
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	a := rng.Int63n(1_000_000_000)
+	b := rng.Int63n(1_000_000_000)
+	n := rng.Int63n(1_000_000_000)
+	input := fmt.Sprintf("1\n%d %d %d\n", a, b, n)
+	expect := fmt.Sprintf("%d", solveCase(a, b, n))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1208/verifierB.go
+++ b/1000-1999/1200-1299/1200-1209/1208/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(arr []int) int {
+	n := len(arr)
+	best := n
+	for l := 0; l <= n; l++ {
+		for r := l; r <= n; r++ {
+			seen := map[int]bool{}
+			valid := true
+			for i := 0; i < l; i++ {
+				if seen[arr[i]] {
+					valid = false
+					break
+				}
+				seen[arr[i]] = true
+			}
+			for i := r; i < n && valid; i++ {
+				if seen[arr[i]] {
+					valid = false
+					break
+				}
+				seen[arr[i]] = true
+			}
+			if valid && r-l < best {
+				best = r - l
+			}
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(7) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(10)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	expect := fmt.Sprintf("%d", solveCase(arr))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1208/verifierC.go
+++ b/1000-1999/1200-1299/1200-1209/1208/verifierC.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func checkGrid(n int, out string) error {
+	rows := strings.Split(strings.TrimSpace(out), "\n")
+	if len(rows) != n {
+		return fmt.Errorf("expected %d rows got %d", n, len(rows))
+	}
+	seen := make([]bool, n*n)
+	var target int
+	for i, row := range rows {
+		fields := strings.Fields(row)
+		if len(fields) != n {
+			return fmt.Errorf("row %d: expected %d numbers got %d", i+1, n, len(fields))
+		}
+		xor := 0
+		for _, f := range fields {
+			v, err := strconv.Atoi(f)
+			if err != nil {
+				return fmt.Errorf("invalid integer %q", f)
+			}
+			if v < 0 || v >= n*n {
+				return fmt.Errorf("value out of range")
+			}
+			if seen[v] {
+				return fmt.Errorf("value %d repeated", v)
+			}
+			seen[v] = true
+			xor ^= v
+		}
+		if i == 0 {
+			target = xor
+		} else if xor != target {
+			return fmt.Errorf("row %d XOR mismatch", i+1)
+		}
+	}
+	for j := 0; j < n; j++ {
+		xor := 0
+		for i := 0; i < n; i++ {
+			fields := strings.Fields(rows[i])
+			v, _ := strconv.Atoi(fields[j])
+			xor ^= v
+		}
+		if xor != target {
+			return fmt.Errorf("column %d XOR mismatch", j+1)
+		}
+	}
+	for _, ok := range seen {
+		if !ok {
+			return fmt.Errorf("missing numbers")
+		}
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, int) {
+	opts := []int{4, 8, 12, 16}
+	n := opts[rng.Intn(len(opts))]
+	return fmt.Sprintf("%d\n", n), n
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, n := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if err := checkGrid(n, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1208/verifierD.go
+++ b/1000-1999/1200-1299/1200-1209/1208/verifierD.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type BIT struct {
+	n    int
+	tree []int64
+}
+
+func NewBIT(n int) *BIT {
+	return &BIT{n: n, tree: make([]int64, n+1)}
+}
+
+func (b *BIT) Add(i int, v int64) {
+	for i <= b.n {
+		b.tree[i] += v
+		i += i & -i
+	}
+}
+
+func (b *BIT) Sum(i int) int64 {
+	var s int64
+	for i > 0 {
+		s += b.tree[i]
+		i -= i & -i
+	}
+	return s
+}
+
+func (b *BIT) LowerBound(target int64) int {
+	idx := 0
+	bitMask := 1 << (bits.Len(uint(b.n)) - 1)
+	for bitMask > 0 {
+		next := idx + bitMask
+		if next <= b.n && b.tree[next] <= target {
+			target -= b.tree[next]
+			idx = next
+		}
+		bitMask >>= 1
+	}
+	return idx + 1
+}
+
+func solveCase(s []int64) []int {
+	n := len(s)
+	bit := NewBIT(n)
+	for i := 1; i <= n; i++ {
+		bit.Add(i, int64(i))
+	}
+	p := make([]int, n)
+	for i := n - 1; i >= 0; i-- {
+		idx := bit.LowerBound(s[i])
+		p[i] = idx
+		bit.Add(idx, -int64(idx))
+	}
+	return p
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	bit := NewBIT(n)
+	for i := 1; i <= n; i++ {
+		bit.Add(i, int64(i))
+	}
+	s := make([]int64, n)
+	for i := n - 1; i >= 0; i-- {
+		val := rng.Int63n(bit.Sum(n))
+		idx := bit.LowerBound(val)
+		s[i] = val
+		bit.Add(idx, -int64(idx))
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range s {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	p := solveCase(s)
+	var exp strings.Builder
+	for i, v := range p {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(strconv.Itoa(v))
+	}
+	return sb.String(), exp.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1208/verifierE.go
+++ b/1000-1999/1200-1299/1200-1209/1208/verifierE.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(arrs [][]int64, w int) []int64 {
+	ans := make([]int64, w)
+	for col := 0; col < w; col++ {
+		var sum int64
+		for _, arr := range arrs {
+			l := len(arr)
+			best := int64(0)
+			for shift := 0; shift <= w-l; shift++ {
+				idx := col - shift
+				var v int64
+				if idx >= 0 && idx < l {
+					v = arr[idx]
+				} else {
+					v = 0
+				}
+				if v > best {
+					best = v
+				}
+			}
+			sum += best
+		}
+		ans[col] = sum
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	w := rng.Intn(5) + 1
+	arrs := make([][]int64, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, w))
+	for i := 0; i < n; i++ {
+		l := rng.Intn(w) + 1
+		arr := make([]int64, l)
+		for j := 0; j < l; j++ {
+			arr[j] = int64(rng.Intn(11) - 5)
+		}
+		arrs[i] = arr
+		sb.WriteString(fmt.Sprintf("%d", l))
+		for j := 0; j < l; j++ {
+			sb.WriteString(fmt.Sprintf(" %d", arr[j]))
+		}
+		sb.WriteByte('\n')
+	}
+	res := solveCase(arrs, w)
+	var exp strings.Builder
+	for i, v := range res {
+		if i > 0 {
+			exp.WriteByte(' ')
+		}
+		exp.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String(), exp.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1208/verifierF.go
+++ b/1000-1999/1200-1299/1200-1209/1208/verifierF.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(arr []int) int {
+	n := len(arr)
+	best := 0
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			for k := j + 1; k < n; k++ {
+				val := arr[i] | (arr[j] & arr[k])
+				if val > best {
+					best = val
+				}
+			}
+		}
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 3
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(21)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+	expect := fmt.Sprintf("%d", solveCase(arr))
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1208/verifierG.go
+++ b/1000-1999/1200-1299/1200-1209/1208/verifierG.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func unionSize(nums []int) int {
+	m := len(nums)
+	ans := 0
+	for mask := 1; mask < 1<<m; mask++ {
+		g := 0
+		bits := 0
+		for i := 0; i < m; i++ {
+			if mask>>i&1 == 1 {
+				if g == 0 {
+					g = nums[i]
+				} else {
+					g = gcd(g, nums[i])
+				}
+				bits++
+			}
+		}
+		if bits%2 == 1 {
+			ans += g
+		} else {
+			ans -= g
+		}
+	}
+	return ans
+}
+
+func bruteForce(n, k int) int {
+	values := make([]int, n-2)
+	for i := range values {
+		values[i] = i + 3
+	}
+	choose := make([]int, k)
+	best := math.MaxInt32
+	var dfs func(start, idx int)
+	dfs = func(start, idx int) {
+		if idx == k {
+			val := unionSize(choose)
+			if val < best {
+				best = val
+			}
+			return
+		}
+		for i := start; i <= len(values)-(k-idx); i++ {
+			choose[idx] = values[i]
+			dfs(i+1, idx+1)
+		}
+	}
+	dfs(0, 0)
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(8) + 4
+	k := rng.Intn(min(n-2, 4)) + 1
+	input := fmt.Sprintf("%d %d\n", n, k)
+	expect := fmt.Sprintf("%d", bruteForce(n, k))
+	return input, expect
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1200-1209/1208/verifierH.go
+++ b/1000-1999/1200-1299/1200-1209/1208/verifierH.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func computeColors(n, k int, adj [][]int, leafColor []int) []int {
+	parent := make([]int, n+1)
+	order := make([]int, 0, n)
+	stack := []int{1}
+	parent[1] = 0
+	for len(stack) > 0 {
+		v := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		order = append(order, v)
+		for _, u := range adj[v] {
+			if u != parent[v] {
+				parent[u] = v
+				stack = append(stack, u)
+			}
+		}
+	}
+	color := make([]int, n+1)
+	for i := len(order) - 1; i >= 0; i-- {
+		v := order[i]
+		if v != 1 && len(adj[v]) == 1 {
+			color[v] = leafColor[v]
+		} else {
+			blue, red := 0, 0
+			for _, u := range adj[v] {
+				if u == parent[v] {
+					continue
+				}
+				if color[u] == 1 {
+					blue++
+				} else {
+					red++
+				}
+			}
+			if blue-red >= k {
+				color[v] = 1
+			} else {
+				color[v] = 0
+			}
+		}
+	}
+	return color
+}
+
+func solveCase(n, k int, edges [][2]int, s []int, queries [][]int) []int {
+	adj := make([][]int, n+1)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	leafColor := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		if s[i] == -1 {
+			leafColor[i] = 0
+		} else {
+			leafColor[i] = s[i]
+		}
+	}
+	curK := k
+	color := computeColors(n, curK, adj, leafColor)
+	var res []int
+	for _, q := range queries {
+		switch q[0] {
+		case 1:
+			v := q[1]
+			color = computeColors(n, curK, adj, leafColor)
+			res = append(res, color[v])
+		case 2:
+			v := q[1]
+			c := q[2]
+			leafColor[v] = c
+			color = computeColors(n, curK, adj, leafColor)
+		case 3:
+			curK = q[1]
+			color = computeColors(n, curK, adj, leafColor)
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	k := rng.Intn(2*n+1) - n
+	edges := make([][2]int, n-1)
+	for i := 0; i < n-1; i++ {
+		u := i + 2
+		v := rng.Intn(i+1) + 1
+		edges[i] = [2]int{u, v}
+	}
+	s := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		if rng.Intn(2) == 0 {
+			s[i] = -1
+		} else {
+			s[i] = rng.Intn(2)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", s[i]))
+	}
+	sb.WriteByte('\n')
+	q := rng.Intn(5) + 1
+	queries := make([][]int, q)
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	leaves := []int{}
+	for i := 2; i <= n; i++ {
+		if s[i] != -1 {
+			leaves = append(leaves, i)
+		}
+	}
+	if len(leaves) == 0 {
+		leaves = append(leaves, 2)
+	}
+	for i := 0; i < q; i++ {
+		t := rng.Intn(3) + 1
+		if t == 1 {
+			v := rng.Intn(n) + 1
+			queries[i] = []int{1, v}
+			sb.WriteString(fmt.Sprintf("1 %d\n", v))
+		} else if t == 2 {
+			v := leaves[rng.Intn(len(leaves))]
+			c := rng.Intn(2)
+			queries[i] = []int{2, v, c}
+			sb.WriteString(fmt.Sprintf("2 %d %d\n", v, c))
+		} else {
+			h := rng.Intn(2*n+1) - n
+			queries[i] = []int{3, h}
+			sb.WriteString(fmt.Sprintf("3 %d\n", h))
+		}
+	}
+	answers := solveCase(n, k, edges, s, queries)
+	var exp strings.Builder
+	for i, v := range answers {
+		if i > 0 {
+			exp.WriteByte('\n')
+		}
+		exp.WriteString(fmt.Sprintf("%d", v))
+	}
+	return sb.String(), exp.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for contest 1208 problems A–H
- each verifier generates 100 randomized test cases
- verifiers execute a candidate binary (or Go file) and check outputs

## Testing
- `go vet verifierA.go`
- `go vet verifierB.go`
- `go vet verifierC.go`
- `go vet verifierD.go`
- `go vet verifierE.go`
- `go vet verifierF.go`
- `go vet verifierG.go`
- `go vet verifierH.go`


------
https://chatgpt.com/codex/tasks/task_e_6884b939dddc8324907f461ace08a692