### PR TITLE
Add Go verifiers for contest 1210

### DIFF
--- a/1000-1999/1200-1299/1210-1219/1210/verifierA.go
+++ b/1000-1999/1200-1299/1210-1219/1210/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	bin := filepath.Join(os.TempDir(), "1210A_ref")
+	cmd := exec.Command("go", "build", "-o", bin, "1210A.go")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	maxM := n * (n - 1) / 2
+	m := 0
+	if maxM > 0 {
+		m = rng.Intn(maxM + 1)
+	}
+	edges := make(map[[2]int]struct{})
+	for len(edges) < m {
+		a := rng.Intn(n)
+		b := rng.Intn(n)
+		if a == b {
+			continue
+		}
+		if a > b {
+			a, b = b, a
+		}
+		edges[[2]int{a, b}] = struct{}{}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1210/verifierB.go
+++ b/1000-1999/1200-1299/1210-1219/1210/verifierB.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	bin := filepath.Join(os.TempDir(), "1210B_ref")
+	cmd := exec.Command("go", "build", "-o", bin, "1210B.go")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Uint64()%1000))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(200)-100))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1210/verifierC.go
+++ b/1000-1999/1200-1299/1210-1219/1210/verifierC.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	bin := filepath.Join(os.TempDir(), "1210C_ref")
+	cmd := exec.Command("go", "build", "-o", bin, "1210C.go")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(20)+1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n-1; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		for a == b {
+			b = rng.Intn(n) + 1
+		}
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1210/verifierD.go
+++ b/1000-1999/1200-1299/1210-1219/1210/verifierD.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	bin := filepath.Join(os.TempDir(), "1210D_ref")
+	cmd := exec.Command("go", "build", "-o", bin, "1210D.go")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	maxM := n * (n - 1) / 2
+	m := rng.Intn(maxM + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	edges := make(map[[2]int]struct{})
+	for len(edges) < m {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a == b {
+			continue
+		}
+		if a > b {
+			a, b = b, a
+		}
+		if _, ok := edges[[2]int{a, b}]; !ok {
+			edges[[2]int{a, b}] = struct{}{}
+			sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+		}
+	}
+	q := rng.Intn(5) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		sb.WriteString(fmt.Sprintf("%d\n", rng.Intn(n)+1))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1210/verifierE.go
+++ b/1000-1999/1200-1299/1210-1219/1210/verifierE.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef() (string, error) {
+	bin := filepath.Join(os.TempDir(), "1210E_ref")
+	cmd := exec.Command("go", "build", "-o", bin, "1210E.go")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("compile reference: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	k := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		for j := 0; j < k; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(k)))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref, err := compileRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := run(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference failed on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1210/verifierF1.go
+++ b/1000-1999/1200-1299/1210-1219/1210/verifierF1.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func inv(x int64) int64 { return modPow(x, mod-2) }
+
+func hasMatch(adj [][]bool) bool {
+	n := len(adj)
+	match := make([]int, n)
+	for i := range match {
+		match[i] = -1
+	}
+	var dfs func(int, []bool) bool
+	dfs = func(v int, used []bool) bool {
+		for j := 0; j < n; j++ {
+			if adj[v][j] && !used[j] {
+				used[j] = true
+				if match[j] == -1 || dfs(match[j], used) {
+					match[j] = v
+					return true
+				}
+			}
+		}
+		return false
+	}
+	cnt := 0
+	for v := 0; v < n; v++ {
+		used := make([]bool, n)
+		if dfs(v, used) {
+			cnt++
+		}
+	}
+	return cnt == n
+}
+
+func bruteProb(p [][]int) int64 {
+	n := len(p)
+	inv100 := inv(100)
+	q := make([][]int64, n)
+	r := make([][]int64, n)
+	for i := 0; i < n; i++ {
+		q[i] = make([]int64, n)
+		r[i] = make([]int64, n)
+		for j := 0; j < n; j++ {
+			q[i][j] = int64(p[i][j]) * inv100 % mod
+			r[i][j] = (1 - q[i][j] + mod) % mod
+		}
+	}
+	edges := n * n
+	ans := int64(0)
+	adj := make([][]bool, n)
+	for i := range adj {
+		adj[i] = make([]bool, n)
+	}
+	for mask := 0; mask < (1 << edges); mask++ {
+		prob := int64(1)
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				bit := (mask >> (i*n + j)) & 1
+				if bit == 1 {
+					prob = prob * q[i][j] % mod
+					adj[i][j] = true
+				} else {
+					prob = prob * r[i][j] % mod
+					adj[i][j] = false
+				}
+			}
+		}
+		if hasMatch(adj) {
+			ans = (ans + prob) % mod
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	p := make([][]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		p[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			val := rng.Intn(101)
+			p[i][j] = val
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", val))
+		}
+		sb.WriteByte('\n')
+	}
+	ans := bruteProb(p)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF1.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, want := genCase(rng)
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1210/verifierF2.go
+++ b/1000-1999/1200-1299/1210-1219/1210/verifierF2.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 1000000007
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func inv(x int64) int64 { return modPow(x, mod-2) }
+
+func hasMatch(adj [][]bool) bool {
+	n := len(adj)
+	match := make([]int, n)
+	for i := range match {
+		match[i] = -1
+	}
+	var dfs func(int, []bool) bool
+	dfs = func(v int, used []bool) bool {
+		for j := 0; j < n; j++ {
+			if adj[v][j] && !used[j] {
+				used[j] = true
+				if match[j] == -1 || dfs(match[j], used) {
+					match[j] = v
+					return true
+				}
+			}
+		}
+		return false
+	}
+	cnt := 0
+	for i := 0; i < n; i++ {
+		used := make([]bool, n)
+		if dfs(i, used) {
+			cnt++
+		}
+	}
+	return cnt == n
+}
+
+func bruteProb(p [][]int) int64 {
+	n := len(p)
+	inv100 := inv(100)
+	q := make([][]int64, n)
+	r := make([][]int64, n)
+	for i := 0; i < n; i++ {
+		q[i] = make([]int64, n)
+		r[i] = make([]int64, n)
+		for j := 0; j < n; j++ {
+			q[i][j] = int64(p[i][j]) * inv100 % mod
+			r[i][j] = (1 - q[i][j] + mod) % mod
+		}
+	}
+	edges := n * n
+	ans := int64(0)
+	adj := make([][]bool, n)
+	for i := range adj {
+		adj[i] = make([]bool, n)
+	}
+	for mask := 0; mask < (1 << edges); mask++ {
+		prob := int64(1)
+		for i := 0; i < n; i++ {
+			for j := 0; j < n; j++ {
+				if (mask>>(i*n+j))&1 == 1 {
+					prob = prob * q[i][j] % mod
+					adj[i][j] = true
+				} else {
+					prob = prob * r[i][j] % mod
+					adj[i][j] = false
+				}
+			}
+		}
+		if hasMatch(adj) {
+			ans = (ans + prob) % mod
+		}
+	}
+	return ans
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	p := make([][]int, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		p[i] = make([]int, n)
+		for j := 0; j < n; j++ {
+			val := rng.Intn(101)
+			p[i][j] = val
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", val))
+		}
+		sb.WriteByte('\n')
+	}
+	ans := bruteProb(p)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF2.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, want := genCase(rng)
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1210/verifierG.go
+++ b/1000-1999/1200-1299/1210-1219/1210/verifierG.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func minMoves(a, l, r []int) int {
+	n := len(a)
+	type state struct {
+		arr []int
+		d   int
+	}
+	start := make([]int, n)
+	copy(start, a)
+	key := func(x []int) string { return fmt.Sprint(x) }
+	vis := map[string]bool{key(start): true}
+	q := []state{{start, 0}}
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+		ok := true
+		for i := 0; i < n; i++ {
+			if cur.arr[i] < l[i] || cur.arr[i] > r[i] {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return cur.d
+		}
+		for i := 0; i < n; i++ {
+			if cur.arr[i] == 0 {
+				continue
+			}
+			for _, j := range []int{(i + n - 1) % n, (i + 1) % n} {
+				nxt := append([]int(nil), cur.arr...)
+				nxt[i]--
+				nxt[j]++
+				k := key(nxt)
+				if !vis[k] {
+					vis[k] = true
+					q = append(q, state{nxt, cur.d + 1})
+				}
+			}
+		}
+	}
+	return -1
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 3
+	a := make([]int, n)
+	l := make([]int, n)
+	r := make([]int, n)
+	total := 0
+	for i := 0; i < n; i++ {
+		l[i] = rng.Intn(3)
+		r[i] = l[i] + rng.Intn(3)
+		a[i] = l[i] + rng.Intn(r[i]-l[i]+1)
+		total += a[i]
+	}
+	// ensure solvable
+	sumL, sumR := 0, 0
+	for i := 0; i < n; i++ {
+		sumL += l[i]
+		sumR += r[i]
+	}
+	if total < sumL {
+		a[0] += sumL - total
+		total = sumL
+	}
+	if total > sumR {
+		a[0] -= total - sumR
+		total = sumR
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", a[i], l[i], r[i]))
+	}
+	ans := minMoves(a, l, r)
+	return sb.String(), fmt.Sprintf("%d", ans)
+}
+
+func run(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, want := genCase(rng)
+		got, err := run(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for every problem in contest 1210
- verifiers A–E compile reference solutions to check candidates
- verifiers F1/F2/G include small brute-force solvers for random cases

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF1.go`
- `go build verifierF2.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6884ba5210d08324aa64e74eaf8138be