### PR TITLE
Add solution verifiers for contest 1211

### DIFF
--- a/1000-1999/1200-1299/1210-1219/1211/verifierA.go
+++ b/1000-1999/1200-1299/1210-1219/1211/verifierA.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func hasTriple(r []int) bool {
+	n := len(r)
+	sufMaxIdx := make([]int, n)
+	maxIdx := n - 1
+	sufMaxIdx[n-1] = maxIdx
+	for i := n - 2; i >= 0; i-- {
+		if r[i] >= r[maxIdx] {
+			maxIdx = i
+		}
+		sufMaxIdx[i] = maxIdx
+	}
+	minIdx := 0
+	for j := 1; j < n-1; j++ {
+		if r[minIdx] < r[j] && r[j] < r[sufMaxIdx[j+1]] {
+			return true
+		}
+		if r[j] < r[minIdx] {
+			minIdx = j
+		}
+	}
+	return false
+}
+
+func checkOutput(out string, r []int) bool {
+	parts := strings.Fields(out)
+	if len(parts) != 3 {
+		return false
+	}
+	a := make([]int, 3)
+	for i := 0; i < 3; i++ {
+		var v int
+		_, err := fmt.Sscan(parts[i], &v)
+		if err != nil {
+			return false
+		}
+		a[i] = v
+	}
+	if a[0] == -1 && a[1] == -1 && a[2] == -1 {
+		return !hasTriple(r)
+	}
+	n := len(r)
+	if a[0] < 1 || a[0] > n || a[1] < 1 || a[1] > n || a[2] < 1 || a[2] > n {
+		return false
+	}
+	if !(a[0] != a[1] && a[1] != a[2] && a[0] != a[2]) {
+		return false
+	}
+	if !(r[a[0]-1] < r[a[1]-1] && r[a[1]-1] < r[a[2]-1]) {
+		return false
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(18) + 3
+		rVals := make([]int, n)
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			rVals[i] = rand.Intn(100) + 1
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(fmt.Sprintf("%d", rVals[i]))
+		}
+		input.WriteByte('\n')
+		inBytes := []byte(input.String())
+		out, err := runProgram(bin, inBytes)
+		if err != nil || !checkOutput(out, rVals) {
+			fmt.Println("Test", t+1, "failed")
+			fmt.Println("Input:\n", input.String())
+			fmt.Println("Output:\n", out)
+			if err != nil {
+				fmt.Println("Error:", err)
+			}
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1211/verifierB.go
+++ b/1000-1999/1200-1299/1210-1219/1211/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expectedB(a []int64) int64 {
+	n := int64(len(a))
+	var ans int64
+	for i, v := range a {
+		if v == 0 {
+			continue
+		}
+		candidate := int64(i+1) + n*(v-1)
+		if candidate > ans {
+			ans = candidate
+		}
+	}
+	return ans
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 1
+		aVals := make([]int64, n)
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", n))
+		allZero := true
+		for i := 0; i < n; i++ {
+			v := int64(rand.Intn(10))
+			aVals[i] = v
+			if v > 0 {
+				allZero = false
+			}
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(fmt.Sprintf("%d", v))
+		}
+		if allZero {
+			aVals[0] = 1
+			input.Reset()
+			input.WriteString(fmt.Sprintf("%d\n", n))
+			for i := 0; i < n; i++ {
+				if i > 0 {
+					input.WriteByte(' ')
+				}
+				input.WriteString(fmt.Sprintf("%d", aVals[i]))
+			}
+		}
+		input.WriteByte('\n')
+		inBytes := []byte(input.String())
+		expected := fmt.Sprintf("%d", expectedB(aVals))
+		out, err := runProgram(bin, inBytes)
+		if err != nil || strings.TrimSpace(out) != expected {
+			fmt.Println("Test", t+1, "failed")
+			fmt.Println("Input:\n", input.String())
+			fmt.Println("Expected:", expected)
+			fmt.Println("Output:", out)
+			if err != nil {
+				fmt.Println("Error:", err)
+			}
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1211/verifierC.go
+++ b/1000-1999/1200-1299/1210-1219/1211/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type day struct {
+	a int64
+	b int64
+	c int64
+}
+
+func runProgram(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expectedC(days []day, k int64) string {
+	var minNeed, maxPossible int64
+	for _, d := range days {
+		minNeed += d.a
+		maxPossible += d.b
+	}
+	if k < minNeed || k > maxPossible {
+		return "-1"
+	}
+	totalCost := int64(0)
+	for i := range days {
+		totalCost += days[i].a * days[i].c
+		days[i].b -= days[i].a
+	}
+	remaining := k - minNeed
+	sort.Slice(days, func(i, j int) bool { return days[i].c < days[j].c })
+	for _, d := range days {
+		if remaining == 0 {
+			break
+		}
+		take := d.b
+		if take > remaining {
+			take = remaining
+		}
+		totalCost += take * d.c
+		remaining -= take
+	}
+	return fmt.Sprintf("%d", totalCost)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(5) + 1
+		days := make([]day, n)
+		var input strings.Builder
+		var minNeed, maxPossible int64
+		for i := 0; i < n; i++ {
+			a := int64(rand.Intn(5))
+			b := a + int64(rand.Intn(5))
+			c := int64(rand.Intn(5) + 1)
+			days[i] = day{a, b, c}
+			minNeed += a
+			maxPossible += b
+		}
+		k := minNeed
+		if maxPossible > minNeed {
+			k += int64(rand.Intn(int(maxPossible - minNeed + 1)))
+		}
+		input.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				input.WriteByte('\n')
+			}
+			d := days[i]
+			input.WriteString(fmt.Sprintf("%d %d %d", d.a, d.b, d.c))
+		}
+		input.WriteByte('\n')
+		inBytes := []byte(input.String())
+		expected := expectedC(append([]day(nil), days...), k)
+		out, err := runProgram(bin, inBytes)
+		if err != nil || strings.TrimSpace(out) != expected {
+			fmt.Println("Test", t+1, "failed")
+			fmt.Println("Input:\n", input.String())
+			fmt.Println("Expected:", expected)
+			fmt.Println("Output:", out)
+			if err != nil {
+				fmt.Println("Error:", err)
+			}
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1211/verifierD.go
+++ b/1000-1999/1200-1299/1210-1219/1211/verifierD.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expectedD(n, a, b, k int, arr []int) string {
+	freq := make(map[int]int, n)
+	for _, r := range arr {
+		freq[r]++
+	}
+	unique := make([]int, 0, len(freq))
+	for v := range freq {
+		unique = append(unique, v)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(unique)))
+
+	ans := 0
+	for _, r := range unique {
+		if r%k != 0 {
+			continue
+		}
+		s := r / k
+		cntR := freq[r]
+		cntS, ok := freq[s]
+		if !ok || cntR == 0 || cntS == 0 {
+			continue
+		}
+		t := cntR / b
+		if v := cntS / a; v < t {
+			t = v
+		}
+		if t > 0 {
+			freq[r] -= t * b
+			freq[s] -= t * a
+			ans += t
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(10) + 1
+		a := rand.Intn(5) + 1
+		b := rand.Intn(5) + 1
+		k := rand.Intn(5) + 2
+		arr := make([]int, n)
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d %d %d %d\n", n, a, b, k))
+		for i := 0; i < n; i++ {
+			arr[i] = rand.Intn(50) + 1
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		input.WriteByte('\n')
+		expected := expectedD(n, a, b, k, append([]int(nil), arr...))
+		out, err := runProgram(bin, []byte(input.String()))
+		if err != nil || strings.TrimSpace(out) != expected {
+			fmt.Println("Test", t+1, "failed")
+			fmt.Println("Input:\n", input.String())
+			fmt.Println("Expected:", expected)
+			fmt.Println("Output:", out)
+			if err != nil {
+				fmt.Println("Error:", err)
+			}
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1211/verifierE.go
+++ b/1000-1999/1200-1299/1210-1219/1211/verifierE.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expectedE(arr []int) string {
+	const limit = 200000
+	first := make([]int, limit+1)
+	second := make([]int, limit+1)
+	count := make([]int, limit+1)
+	for i, v := range arr {
+		count[v]++
+		if count[v] == 1 {
+			first[v] = i + 1
+		} else if count[v] == 2 {
+			second[v] = i + 1
+		}
+	}
+	k0 := 0
+	for v := 1; v <= limit; v++ {
+		if count[v] == 2 {
+			k0 = v
+		} else {
+			break
+		}
+	}
+	type pair struct{ f, s, val int }
+	pairs := make([]pair, 0, k0)
+	for v := 1; v <= k0; v++ {
+		pairs = append(pairs, pair{first[v], second[v], v})
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].f < pairs[j].f })
+
+	curSecond := 0
+	seen := 0
+	maxValSeen := 0
+	k := 0
+	ok := true
+	for _, p := range pairs {
+		if p.s <= curSecond {
+			ok = false
+		}
+		curSecond = p.s
+		seen++
+		if p.val > maxValSeen {
+			maxValSeen = p.val
+		}
+		if ok && seen == maxValSeen {
+			k = maxValSeen
+		}
+	}
+	ans := make([]byte, len(arr))
+	for i := range ans {
+		ans[i] = 'B'
+	}
+	for v := 1; v <= k; v++ {
+		ans[first[v]-1] = 'R'
+		ans[second[v]-1] = 'G'
+	}
+	return string(ans)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(30) + 1
+		arr := make([]int, n)
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			arr[i] = rand.Intn(20) + 1
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		input.WriteByte('\n')
+		expected := expectedE(append([]int(nil), arr...))
+		out, err := runProgram(bin, []byte(input.String()))
+		if err != nil || strings.TrimSpace(out) != expected {
+			fmt.Println("Test", t+1, "failed")
+			fmt.Println("Input:\n", input.String())
+			fmt.Println("Expected:", expected)
+			fmt.Println("Output:", out)
+			if err != nil {
+				fmt.Println("Error:", err)
+			}
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1211/verifierF.go
+++ b/1000-1999/1200-1299/1210-1219/1211/verifierF.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+var word = "kotlin"
+
+func generatePieces() ([]string, []int) {
+	times := rand.Intn(4) + 1
+	full := strings.Repeat(word, times)
+	n := rand.Intn(len(full)) + 1
+	cuts := make([]int, 0, n-1)
+	for len(cuts) < n-1 {
+		pos := rand.Intn(len(full)-1) + 1
+		found := false
+		for _, c := range cuts {
+			if c == pos {
+				found = true
+				break
+			}
+		}
+		if !found {
+			cuts = append(cuts, pos)
+		}
+	}
+	sortInts(cuts)
+	pieces := make([]string, 0, n)
+	last := 0
+	for _, c := range cuts {
+		pieces = append(pieces, full[last:c])
+		last = c
+	}
+	pieces = append(pieces, full[last:])
+	idx := rand.Perm(n)
+	shuffled := make([]string, n)
+	for i, p := range pieces {
+		shuffled[idx[i]] = p
+	}
+	return shuffled, idx
+}
+
+func sortInts(a []int) { // simple insertion sort for small slices
+	for i := 1; i < len(a); i++ {
+		v := a[i]
+		j := i - 1
+		for j >= 0 && a[j] > v {
+			a[j+1] = a[j]
+			j--
+		}
+		a[j+1] = v
+	}
+}
+
+func checkOutput(out string, pieces []string) bool {
+	fields := strings.Fields(out)
+	if len(fields) != len(pieces) {
+		return false
+	}
+	seen := make([]bool, len(pieces))
+	var sb strings.Builder
+	for _, f := range fields {
+		var idx int
+		if _, err := fmt.Sscan(f, &idx); err != nil {
+			return false
+		}
+		if idx < 1 || idx > len(pieces) || seen[idx-1] {
+			return false
+		}
+		seen[idx-1] = true
+		sb.WriteString(pieces[idx-1])
+	}
+	s := sb.String()
+	if len(s)%len(word) != 0 || len(s) == 0 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] != word[i%6] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+
+	for t := 0; t < 100; t++ {
+		pieces, idx := generatePieces()
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", len(pieces)))
+		for i := 0; i < len(pieces); i++ {
+			if i > 0 {
+				input.WriteByte('\n')
+			}
+			input.WriteString(pieces[i])
+		}
+		input.WriteByte('\n')
+		out, err := runProgram(bin, []byte(input.String()))
+		if err != nil || !checkOutput(out, pieces) {
+			fmt.Println("Test", t+1, "failed")
+			fmt.Println("Input:\n", input.String())
+			fmt.Println("Output:", out)
+			if err != nil {
+				fmt.Println("Error:", err)
+			}
+			fmt.Println("Expected order (one possible):", idx)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1211/verifierG.go
+++ b/1000-1999/1200-1299/1210-1219/1211/verifierG.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genInput() string {
+	n := rand.Intn(5) + 2
+	c := make([]int, n)
+	d := make([]int, n)
+	for i := 0; i < n; i++ {
+		c[i] = rand.Intn(3) + 1
+		d[i] = rand.Intn(3) + 1
+	}
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range c {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for i, v := range d {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+
+	ref := "refG_bin"
+	if err := exec.Command("go", "build", "-o", ref, "1211G.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	for t := 0; t < 100; t++ {
+		input := genInput()
+		expected, err1 := runProgram(ref, []byte(input))
+		out, err2 := runProgram(bin, []byte(input))
+		if err1 != nil || err2 != nil || strings.TrimSpace(out) != strings.TrimSpace(expected) {
+			fmt.Println("Test", t+1, "failed")
+			fmt.Println("Input:\n", input)
+			fmt.Println("Expected:\n", expected)
+			fmt.Println("Output:\n", out)
+			if err2 != nil {
+				fmt.Println("Error:", err2)
+			}
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1211/verifierH.go
+++ b/1000-1999/1200-1299/1210-1219/1211/verifierH.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genInput() string {
+	n := rand.Intn(5) + 2
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rand.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+
+	ref := "refH_bin"
+	if err := exec.Command("go", "build", "-o", ref, "1211H.go").Run(); err != nil {
+		fmt.Println("failed to build reference solution:", err)
+		return
+	}
+	defer os.Remove(ref)
+
+	for t := 0; t < 100; t++ {
+		input := genInput()
+		expected, _ := runProgram(ref, []byte(input))
+		out, err := runProgram(bin, []byte(input))
+		if err != nil || strings.TrimSpace(out) != strings.TrimSpace(expected) {
+			fmt.Println("Test", t+1, "failed")
+			fmt.Println("Input:\n", input)
+			fmt.Println("Expected:\n", expected)
+			fmt.Println("Output:\n", out)
+			if err != nil {
+				fmt.Println("Error:", err)
+			}
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1211/verifierI.go
+++ b/1000-1999/1200-1299/1210-1219/1211/verifierI.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input []byte) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genInput() (string, []int, [][2]int) {
+	n := rand.Intn(10) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rand.Intn(16)
+	}
+	edges := make([][2]int, 0)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if bits.OnesCount(uint(arr[i]^arr[j])) == 1 {
+				edges = append(edges, [2]int{i + 1, j + 1})
+			}
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String(), arr, edges
+}
+
+func checkOutput(out string, n int, edges [][2]int) bool {
+	fields := strings.Fields(out)
+	if len(fields) != n {
+		return false
+	}
+	val := make([]int, n)
+	for i, f := range fields {
+		var v int
+		if _, err := fmt.Sscan(f, &v); err != nil {
+			return false
+		}
+		if v < 0 || v > 15 {
+			return false
+		}
+		val[i] = v
+	}
+	adj := make(map[[2]int]bool)
+	for _, e := range edges {
+		if e[0] > e[1] {
+			e[0], e[1] = e[1], e[0]
+		}
+		adj[e] = true
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			diff := bits.OnesCount(uint(val[i]^val[j])) == 1
+			_, has := adj[[2]int{i + 1, j + 1}]
+			if diff != has {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+
+	for t := 0; t < 100; t++ {
+		input, arr, edges := genInput()
+		out, err := runProgram(bin, []byte(input))
+		if err != nil || !checkOutput(out, len(arr), edges) {
+			fmt.Println("Test", t+1, "failed")
+			fmt.Println("Input:\n", input)
+			fmt.Println("Output:\n", out)
+			if err != nil {
+				fmt.Println("Error:", err)
+			}
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based verifiers `verifierA.go`-`verifierI.go`
- each verifier runs 100 random tests against a submitted binary
- verifiers check output or compare with a reference solution when needed

## Testing
- `go vet` *(fails: no main module)*


------
https://chatgpt.com/codex/tasks/task_e_6884bade23bc8324a3c17a4901e8dbeb