### PR TITLE
Add Go verifiers for contest 1212

### DIFF
--- a/1000-1999/1200-1299/1210-1219/1212/verifierA.go
+++ b/1000-1999/1200-1299/1210-1219/1212/verifierA.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Int63n(1_000_000_000) + 1
+	k := rand.Intn(20) + 1
+	return fmt.Sprintf("%d %d\n", n, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refA"
+	if err := exec.Command("go", "build", "-o", ref, "1212A.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1212/verifierB.go
+++ b/1000-1999/1200-1299/1210-1219/1212/verifierB.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(99) + 2
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('A' + rand.Intn(26)))
+	}
+	return fmt.Sprintf("%d\n%s\n", n, sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refB"
+	if err := exec.Command("go", "build", "-o", ref, "1212B.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1212/verifierC.go
+++ b/1000-1999/1200-1299/1210-1219/1212/verifierC.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(20) + 1
+	k := rand.Intn(n + 1)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rand.Intn(100) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refC"
+	if err := exec.Command("go", "build", "-o", ref, "1212C.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1212/verifierD.go
+++ b/1000-1999/1200-1299/1210-1219/1212/verifierD.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(6) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(rand.Intn(50) + 1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refD"
+	if err := exec.Command("go", "build", "-o", ref, "1212D.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1212/verifierE.go
+++ b/1000-1999/1200-1299/1210-1219/1212/verifierE.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(4) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", rand.Intn(5)+1, rand.Intn(20)+1))
+	}
+	k := rand.Intn(4) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", k))
+	for i := 0; i < k; i++ {
+		sb.WriteString(fmt.Sprintf("%d\n", rand.Intn(5)+1))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refE"
+	if err := exec.Command("go", "build", "-o", ref, "1212E.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1212/verifierF.go
+++ b/1000-1999/1200-1299/1210-1219/1212/verifierF.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Int63n(1_000_000_000) + 1
+	return fmt.Sprintf("%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refF"
+	if err := exec.Command("go", "build", "-o", ref, "1212F.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1212/verifierG.go
+++ b/1000-1999/1200-1299/1210-1219/1212/verifierG.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(4) + 2
+	l := rand.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, l))
+	pos := 0
+	for i := 0; i < n; i++ {
+		pos += rand.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", pos, rand.Intn(10)+1))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refG"
+	if err := exec.Command("go", "build", "-o", ref, "1212G.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1212/verifierH.go
+++ b/1000-1999/1200-1299/1210-1219/1212/verifierH.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	if !strings.Contains(bin, "/") {
+		bin = "./" + bin
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func genTest() string {
+	n := rand.Intn(7) + 1
+	k := rand.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	parents := make([]int, n+1)
+	for i := 2; i <= n; i++ {
+		parent := rand.Intn(i-1) + 1
+		parents[i] = parent
+		sb.WriteString(fmt.Sprintf("%d %d\n", i, parent))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s /path/to/binary\n", os.Args[0])
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	ref := "refH"
+	if err := exec.Command("go", "build", "-o", ref, "1212H.go").Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "failed to build reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rand.Seed(1)
+	for i := 0; i < 100; i++ {
+		input := genTest()
+		exp, err := runBinary(ref, input)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "reference failed:", err)
+			os.Exit(1)
+		}
+		got, err := runBinary(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d failed to run: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Fprintf(os.Stderr, "test %d failed:\ninput:\n%sexpected: %s\ngot: %s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers in Go for contest 1212 problems A–H
- each verifier builds the reference solution and checks 100 random tests
- use reference implementations from repository to validate any binary

## Testing
- `go run verifierA.go ./candidateA`
- `go run verifierB.go ./candidateB`

------
https://chatgpt.com/codex/tasks/task_e_6884bb6a313c83249c27b16dfa89d79f