### PR TITLE
Add Go verifiers for contest 1216

### DIFF
--- a/1000-1999/1200-1299/1210-1219/1216/verifierA.go
+++ b/1000-1999/1200-1299/1210-1219/1216/verifierA.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func minimalOps(s string) int {
+	cnt := 0
+	for i := 0; i < len(s); i += 2 {
+		if s[i] == s[i+1] {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+func checkCase(orig string, outStr string) error {
+	var cnt int
+	var modified string
+	reader := strings.NewReader(outStr)
+	if _, err := fmt.Fscan(reader, &cnt, &modified); err != nil {
+		return fmt.Errorf("cannot parse output: %v", err)
+	}
+	var extra string
+	if _, err := fmt.Fscan(reader, &extra); err != io.EOF {
+		return fmt.Errorf("extra output detected")
+	}
+	if len(modified) != len(orig) {
+		return fmt.Errorf("expected string length %d got %d", len(orig), len(modified))
+	}
+	// validate characters and pairs
+	for i := 0; i < len(modified); i++ {
+		if modified[i] != 'a' && modified[i] != 'b' {
+			return fmt.Errorf("invalid character %c", modified[i])
+		}
+	}
+	for i := 0; i < len(modified); i += 2 {
+		if modified[i] == modified[i+1] {
+			return fmt.Errorf("pair %d still equal", i/2)
+		}
+	}
+	diff := 0
+	for i := 0; i < len(modified); i++ {
+		if modified[i] != orig[i] {
+			diff++
+		}
+	}
+	if diff != cnt {
+		return fmt.Errorf("reported %d changes but changed %d", cnt, diff)
+	}
+	need := minimalOps(orig)
+	if cnt != need {
+		return fmt.Errorf("expected %d operations got %d", need, cnt)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50)*2 + 2 // even length between 2 and 100
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = 'a'
+		} else {
+			b[i] = 'b'
+		}
+	}
+	s := string(b)
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	return input, s
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, s := genCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := checkCase(s, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\noutput:\n%s\n", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1216/verifierB.go
+++ b/1000-1999/1200-1299/1210-1219/1216/verifierB.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expectedCost(a []int) int64 {
+	vals := append([]int(nil), a...)
+	sort.Slice(vals, func(i, j int) bool { return vals[i] > vals[j] })
+	var res int64
+	for i, v := range vals {
+		res += int64(i*v + 1)
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) (string, []int) {
+	n := rng.Intn(10) + 1
+	vals := make([]int, n)
+	for i := 0; i < n; i++ {
+		vals[i] = rng.Intn(20) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(vals[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), vals
+}
+
+func parseOutput(out string, n int) (int64, []int, error) {
+	reader := strings.NewReader(out)
+	var cost int64
+	if _, err := fmt.Fscan(reader, &cost); err != nil {
+		return 0, nil, fmt.Errorf("parse cost: %v", err)
+	}
+	perm := make([]int, n)
+	for i := 0; i < n; i++ {
+		if _, err := fmt.Fscan(reader, &perm[i]); err != nil {
+			return 0, nil, fmt.Errorf("parse perm: %v", err)
+		}
+	}
+	var extra string
+	if _, err := fmt.Fscan(reader, &extra); err != io.EOF {
+		return 0, nil, fmt.Errorf("extra output")
+	}
+	return cost, perm, nil
+}
+
+func checkCase(vals []int, out string) error {
+	n := len(vals)
+	cost, perm, err := parseOutput(out, n)
+	if err != nil {
+		return err
+	}
+	used := make([]bool, n)
+	var candCost int64
+	for i, v := range perm {
+		if v < 1 || v > n || used[v-1] {
+			return fmt.Errorf("invalid permutation")
+		}
+		used[v-1] = true
+		candCost += int64(i*vals[v-1] + 1)
+	}
+	if cost != candCost {
+		return fmt.Errorf("reported cost %d but computed %d", cost, candCost)
+	}
+	exp := expectedCost(vals)
+	if candCost != exp {
+		return fmt.Errorf("expected cost %d got %d", exp, candCost)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, vals := genCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := checkCase(vals, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s\noutput:\n%s\n", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1216/verifierC.go
+++ b/1000-1999/1200-1299/1210-1219/1216/verifierC.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Rect struct {
+	x1, y1, x2, y2 int
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func area(r Rect) int {
+	if r.x2 <= r.x1 || r.y2 <= r.y1 {
+		return 0
+	}
+	return (r.x2 - r.x1) * (r.y2 - r.y1)
+}
+
+func intersect(a, b Rect) Rect {
+	x1 := max(a.x1, b.x1)
+	y1 := max(a.y1, b.y1)
+	x2 := min(a.x2, b.x2)
+	y2 := min(a.y2, b.y2)
+	if x1 >= x2 || y1 >= y2 {
+		return Rect{x1, y1, x1, y1}
+	}
+	return Rect{x1, y1, x2, y2}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func expected(w, b1, b2 Rect) string {
+	wArea := area(w)
+	cov1 := area(intersect(w, b1))
+	cov2 := area(intersect(w, b2))
+	covBoth := area(intersect(intersect(w, b1), b2))
+	covered := cov1 + cov2 - covBoth
+	if covered < wArea {
+		return "YES"
+	}
+	return "NO"
+}
+
+func genCase(rng *rand.Rand) (string, Rect, Rect, Rect) {
+	x1 := rng.Intn(10)
+	y1 := rng.Intn(10)
+	x2 := x1 + rng.Intn(10) + 1
+	y2 := y1 + rng.Intn(10) + 1
+	w := Rect{x1, y1, x2, y2}
+
+	x3 := rng.Intn(20)
+	y3 := rng.Intn(20)
+	x4 := x3 + rng.Intn(10) + 1
+	y4 := y3 + rng.Intn(10) + 1
+	b1 := Rect{x3, y3, x4, y4}
+
+	x5 := rng.Intn(20)
+	y5 := rng.Intn(20)
+	x6 := x5 + rng.Intn(10) + 1
+	y6 := y5 + rng.Intn(10) + 1
+	b2 := Rect{x5, y5, x6, y6}
+
+	input := fmt.Sprintf("%d %d %d %d\n%d %d %d %d\n%d %d %d %d\n",
+		w.x1, w.y1, w.x2, w.y2,
+		b1.x1, b1.y1, b1.x2, b1.y2,
+		b2.x1, b2.y1, b2.x2, b2.y2)
+	return input, w, b1, b2
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, w, b1, b2 := genCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		exp := expected(w, b1, b2)
+		out = strings.ToUpper(strings.TrimSpace(out))
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1216/verifierD.go
+++ b/1000-1999/1200-1299/1210-1219/1216/verifierD.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func expected(arr []int64) (int64, int64) {
+	maxA := arr[0]
+	for _, v := range arr {
+		if v > maxA {
+			maxA = v
+		}
+	}
+	g := int64(0)
+	for _, v := range arr {
+		g = gcd(g, maxA-v)
+	}
+	var y int64
+	for _, v := range arr {
+		y += (maxA - v) / g
+	}
+	return y, g
+}
+
+func genCase(rng *rand.Rand) (string, []int64) {
+	n := rng.Intn(10) + 1
+	arr := make([]int64, n)
+	for i := 0; i < n; i++ {
+		arr[i] = int64(rng.Intn(100) + 1)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	return sb.String(), arr
+}
+
+func parseOutput(out string) (int64, int64, error) {
+	reader := strings.NewReader(out)
+	var y, g int64
+	if _, err := fmt.Fscan(reader, &y, &g); err != nil {
+		return 0, 0, fmt.Errorf("parse output: %v", err)
+	}
+	var extra string
+	if _, err := fmt.Fscan(reader, &extra); err != io.EOF {
+		return 0, 0, fmt.Errorf("extra output")
+	}
+	return y, g, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, arr := genCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		y, g, err := parseOutput(out)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d bad output: %v\ninput:\n%s\noutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+		expY, expG := expected(arr)
+		if y != expY || g != expG {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d %d got %d %d\ninput:\n%s", i+1, expY, expG, y, g, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1216/verifierE1.go
+++ b/1000-1999/1200-1299/1210-1219/1216/verifierE1.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+// Precompute prefix sums up to exceed 1e9 digits
+var digitsPrefix []int
+var blocksPrefix []int
+
+func initPrefix() {
+	const limit = 1000000000
+	digitsPrefix = []int{0}
+	blocksPrefix = []int{0}
+	sumDigits := 0
+	sumBlocks := 0
+	for i := 1; sumBlocks < limit; i++ {
+		l := 0
+		for x := i; x > 0; x /= 10 {
+			l++
+		}
+		sumDigits += l
+		sumBlocks += sumDigits
+		digitsPrefix = append(digitsPrefix, sumDigits)
+		blocksPrefix = append(blocksPrefix, sumBlocks)
+	}
+}
+
+func digitInBlock(n, idx int) byte {
+	for d := 1; ; d++ {
+		start := 1
+		for i := 1; i < d; i++ {
+			start *= 10
+		}
+		end := start*10 - 1
+		if end > n {
+			end = n
+		}
+		if end < start {
+			continue
+		}
+		cnt := end - start + 1
+		total := cnt * d
+		if idx <= total {
+			number := start + (idx-1)/d
+			digitIdx := (idx - 1) % d
+			digits := make([]byte, d)
+			for i := d - 1; i >= 0; i-- {
+				digits[i] = byte('0' + number%10)
+				number /= 10
+			}
+			return digits[digitIdx]
+		}
+		idx -= total
+	}
+}
+
+func query(k int) byte {
+	l, r := 1, len(blocksPrefix)-1
+	for l < r {
+		m := (l + r) / 2
+		if blocksPrefix[m] < k {
+			l = m + 1
+		} else {
+			r = m
+		}
+	}
+	block := l
+	prev := blocksPrefix[block-1]
+	idx := k - prev
+	return digitInBlock(block, idx)
+}
+
+func genCase(rng *rand.Rand) (string, []int) {
+	q := rng.Intn(5) + 1
+	ks := make([]int, q)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		ks[i] = rng.Intn(1000000000) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", ks[i]))
+	}
+	return sb.String(), ks
+}
+
+func expected(ks []int) string {
+	var sb strings.Builder
+	for _, k := range ks {
+		b := query(k)
+		sb.WriteByte(b)
+		sb.WriteByte('\n')
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE1.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	initPrefix()
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, ks := genCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		exp := expected(ks)
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1216/verifierE2.go
+++ b/1000-1999/1200-1299/1210-1219/1216/verifierE2.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func sumLen(n int64) int64 {
+	var res int64
+	pow10 := int64(1)
+	d := int64(1)
+	for pow10 <= n {
+		nxt := pow10*10 - 1
+		if nxt > n {
+			nxt = n
+		}
+		res += (nxt - pow10 + 1) * d
+		pow10 *= 10
+		d++
+	}
+	return res
+}
+
+func sumXLen(n int64) int64 {
+	var res int64
+	pow10 := int64(1)
+	d := int64(1)
+	for pow10 <= n {
+		nxt := pow10*10 - 1
+		if nxt > n {
+			nxt = n
+		}
+		cnt := nxt - pow10 + 1
+		res += d * (pow10 + nxt) * cnt / 2
+		pow10 *= 10
+		d++
+	}
+	return res
+}
+
+func prefix(n int64) int64 {
+	if n <= 0 {
+		return 0
+	}
+	return (n+1)*sumLen(n) - sumXLen(n)
+}
+
+func digitInRange(n, k int64) int {
+	pow10 := int64(1)
+	d := int64(1)
+	for {
+		nxt := pow10*10 - 1
+		if nxt > n {
+			nxt = n
+		}
+		cnt := nxt - pow10 + 1
+		total := cnt * d
+		if k > total {
+			k -= total
+		} else {
+			idx := (k - 1) / d
+			num := pow10 + idx
+			pos := (k - 1) % d
+			str := fmt.Sprintf("%d", num)
+			return int(str[pos] - '0')
+		}
+		if nxt == n {
+			break
+		}
+		pow10 *= 10
+		d++
+	}
+	return 0
+}
+
+func query(k int64) int {
+	l, r := int64(1), int64(1e9)
+	for l < r {
+		m := (l + r) / 2
+		if prefix(m) >= k {
+			r = m
+		} else {
+			l = m + 1
+		}
+	}
+	n := l
+	k -= prefix(n - 1)
+	return digitInRange(n, k)
+}
+
+func genCase(rng *rand.Rand) (string, []int64) {
+	q := rng.Intn(5) + 1
+	ks := make([]int64, q)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		ks[i] = rng.Int63n(1_000_000_000_000) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", ks[i]))
+	}
+	return sb.String(), ks
+}
+
+func expected(ks []int64) string {
+	var sb strings.Builder
+	for _, k := range ks {
+		sb.WriteString(fmt.Sprintf("%d\n", query(k)))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE2.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, ks := genCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		exp := expected(ks)
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1216/verifierF.go
+++ b/1000-1999/1200-1299/1210-1219/1216/verifierF.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type interval struct {
+	r   int
+	val int64
+}
+
+type pq []interval
+
+func (h pq) Len() int { return len(h) }
+func (h pq) Less(i, j int) bool {
+	if h[i].val == h[j].val {
+		return h[i].r < h[j].r
+	}
+	return h[i].val < h[j].val
+}
+func (h pq) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *pq) Push(x interface{}) { *h = append(*h, x.(interval)) }
+func (h *pq) Pop() interface{} {
+	old := *h
+	x := old[len(old)-1]
+	*h = old[:len(old)-1]
+	return x
+}
+
+func solve(n, k int, s string) int64 {
+	starts := make([][]int, n+2)
+	for i := 1; i <= n; i++ {
+		if s[i-1] == '1' {
+			L := i - k
+			if L < 1 {
+				L = 1
+			}
+			starts[L] = append(starts[L], i)
+		}
+	}
+	dp := make([]int64, n+1)
+	active := &pq{}
+	heap.Init(active)
+	for i := 1; i <= n; i++ {
+		for _, j := range starts[i] {
+			r := j + k
+			if r > n {
+				r = n
+			}
+			val := dp[i-1] + int64(j)
+			heap.Push(active, interval{r, val})
+		}
+		for active.Len() > 0 && (*active)[0].r < i {
+			heap.Pop(active)
+		}
+		best := int64(1 << 60)
+		if active.Len() > 0 {
+			best = (*active)[0].val
+		}
+		direct := dp[i-1] + int64(i)
+		if direct < best {
+			dp[i] = direct
+		} else {
+			dp[i] = best
+		}
+	}
+	return dp[n]
+}
+
+func genCase(rng *rand.Rand) (string, int, int, string) {
+	n := rng.Intn(30) + 1
+	k := rng.Intn(n) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(3) == 0 {
+			b[i] = '1'
+		} else {
+			b[i] = '0'
+		}
+	}
+	s := string(b)
+	input := fmt.Sprintf("%d %d\n%s\n", n, k, s)
+	return input, n, k, s
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, n, k, s := genCase(rng)
+		out, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		var ans int64
+		if _, err := fmt.Sscan(out, &ans); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d bad output: %v\ninput:\n%s\noutput:\n%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+		exp := solve(n, k, s)
+		if ans != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:\n%s", i+1, exp, ans, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement `verifierA.go`–`verifierF.go` for contest 1216
- each verifier runs the candidate binary or Go source on 100 randomized tests and checks the output
- verification logic includes custom checking for multiple valid answers (A and B) and reference implementations of the required algorithms

## Testing
- `go build` on each verifier

------
https://chatgpt.com/codex/tasks/task_e_6884bd9a7df883248d8b85e51f6e6159