### PR TITLE
Add Go verifiers for contest 1217

### DIFF
--- a/1000-1999/1200-1299/1210-1219/1217/verifierA.go
+++ b/1000-1999/1200-1299/1210-1219/1217/verifierA.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsA = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binA")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleA")
+	cmd := exec.Command("go", "build", "-o", tmp, "1217A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	str := rng.Intn(1e8) + 1
+	intellect := rng.Intn(1e8) + 1
+	exp := rng.Intn(1e8 + 1)
+	return fmt.Sprintf("1\n%d %d %d\n", str, intellect, exp)
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < numTestsA; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1217/verifierB.go
+++ b/1000-1999/1200-1299/1210-1219/1217/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsB = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binB")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleB")
+	cmd := exec.Command("go", "build", "-o", tmp, "1217B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 1
+	x := rng.Int63n(1e9) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, x)
+	for i := 0; i < n; i++ {
+		d := rng.Int63n(1e9) + 1
+		h := rng.Int63n(1e9) + 1
+		fmt.Fprintf(&sb, "%d %d\n", d, h)
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(2))
+	for i := 0; i < numTestsB; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1217/verifierC.go
+++ b/1000-1999/1200-1299/1210-1219/1217/verifierC.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsC = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binC")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleC")
+	cmd := exec.Command("go", "build", "-o", tmp, "1217C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func randomString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		if rng.Intn(2) == 1 {
+			b[i] = '1'
+		} else {
+			b[i] = '0'
+		}
+	}
+	return string(b)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(30) + 1
+	s := randomString(rng, n)
+	return fmt.Sprintf("1\n%s\n", s)
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(3))
+	for i := 0; i < numTestsC; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1217/verifierD.go
+++ b/1000-1999/1200-1299/1210-1219/1217/verifierD.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsD = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binD")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleD")
+	cmd := exec.Command("go", "build", "-o", tmp, "1217D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2 // at least 2
+	maxEdges := n * (n - 1)
+	m := rng.Intn(min(maxEdges, 15)) + 1
+	edges := make(map[[2]int]bool)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		key := [2]int{u, v}
+		if edges[key] {
+			continue
+		}
+		edges[key] = true
+		fmt.Fprintf(&sb, "%d %d\n", u, v)
+	}
+	return sb.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(4))
+	for i := 0; i < numTestsD; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1217/verifierE.go
+++ b/1000-1999/1200-1299/1210-1219/1217/verifierE.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsE = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binE")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleE")
+	cmd := exec.Command("go", "build", "-o", tmp, "1217E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	m := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		val := rng.Int63n(1e9-1) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", val)
+	}
+	sb.WriteByte('\n')
+	type2 := false
+	for i := 0; i < m; i++ {
+		if rng.Intn(2) == 0 {
+			idx := rng.Intn(n) + 1
+			val := rng.Int63n(1e9-1) + 1
+			fmt.Fprintf(&sb, "1 %d %d\n", idx, val)
+		} else {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			fmt.Fprintf(&sb, "2 %d %d\n", l, r)
+			type2 = true
+		}
+	}
+	if !type2 {
+		// ensure at least one type2 query
+		l := 1
+		r := n
+		fmt.Fprintf(&sb, "2 %d %d\n", l, r)
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(5))
+	for i := 0; i < numTestsE; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1217/verifierF.go
+++ b/1000-1999/1200-1299/1210-1219/1217/verifierF.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const numTestsF = 100
+
+func prepareBinary(path string) (string, func(), error) {
+	if strings.HasSuffix(path, ".go") {
+		tmp := filepath.Join(os.TempDir(), "binF")
+		cmd := exec.Command("go", "build", "-o", tmp, path)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return "", nil, fmt.Errorf("go build failed: %v: %s", err, out)
+		}
+		return tmp, func() { os.Remove(tmp) }, nil
+	}
+	return path, nil, nil
+}
+
+func prepareOracle() (string, func(), error) {
+	tmp := filepath.Join(os.TempDir(), "oracleF")
+	cmd := exec.Command("go", "build", "-o", tmp, "1217F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("go build oracle failed: %v: %s", err, out)
+	}
+	return tmp, func() { os.Remove(tmp) }, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return strings.TrimSpace(buf.String()), err
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 2
+	m := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	type2 := false
+	for i := 0; i < m; i++ {
+		t := rng.Intn(2) + 1
+		x := rng.Intn(n) + 1
+		y := rng.Intn(n-1) + 1
+		if y >= x {
+			y++
+		}
+		fmt.Fprintf(&sb, "%d %d %d\n", t, x, y)
+		if t == 2 {
+			type2 = true
+		}
+	}
+	if !type2 {
+		x := 1
+		y := 2
+		fmt.Fprintf(&sb, "2 %d %d\n", x, y)
+	}
+	return sb.String()
+}
+
+func runCase(bin, oracle, input string) error {
+	expected, err := run(oracle, input)
+	if err != nil {
+		return fmt.Errorf("oracle error: %v", err)
+	}
+	got, err := run(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 && !(len(os.Args) == 3 && os.Args[1] == "--") {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	path := os.Args[len(os.Args)-1]
+	bin, cleanup, err := prepareBinary(path)
+	if err != nil {
+		fmt.Println("compile error:", err)
+		return
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	oracle, cleanOracle, err := prepareOracle()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer cleanOracle()
+	rng := rand.New(rand.NewSource(6))
+	for i := 0; i < numTestsF; i++ {
+		input := generateCase(rng)
+		if err := runCase(bin, oracle, input); err != nil {
+			fmt.Printf("case %d failed: %v\ninput:%s", i+1, err, input)
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F of contest 1217
- each verifier compiles the target solution and a reference oracle
- deterministic random tests (100 per problem)
- handle `go run` argument style with optional `--`

## Testing
- `go run verifierA.go -- 1217A.go`
- `go run verifierB.go -- 1217B.go`
- `go run verifierC.go -- 1217C.go`
- `go run verifierD.go -- 1217D.go`
- `go run verifierE.go -- 1217E.go`
- `go run verifierF.go -- 1217F.go`


------
https://chatgpt.com/codex/tasks/task_e_6884be26908083248c9a557ea2b1e5f1