### PR TITLE
Add Go solution for 1837B

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1837/1837B.go
+++ b/1000-1999/1800-1899/1830-1839/1837/1837B.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(reader, &n, &s)
+		maxRun := 1
+		cur := 1
+		for i := 1; i < n; i++ {
+			if s[i] == s[i-1] {
+				cur++
+			} else {
+				if cur > maxRun {
+					maxRun = cur
+				}
+				cur = 1
+			}
+		}
+		if cur > maxRun {
+			maxRun = cur
+		}
+		fmt.Fprintln(writer, maxRun+1)
+	}
+}


### PR DESCRIPTION
## Summary
- implement 1837B in Go with a simple max-run approach

## Testing
- `go build 1000-1999/1800-1899/1830-1839/1837/1837B.go`


------
https://chatgpt.com/codex/tasks/task_e_6884bf84c75c8324b7e5675ef29a168e