### PR TITLE
Add verifiers for contest 1218

### DIFF
--- a/1000-1999/1200-1299/1210-1219/1218/verifierA.go
+++ b/1000-1999/1200-1299/1210-1219/1218/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1218A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(1)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			fmt.Fprintf(&sb, "%d %d\n", u, v)
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	tests = append(tests, Test{"1\n1 1\n"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1218/verifierB.go
+++ b/1000-1999/1200-1299/1210-1219/1218/verifierB.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1218B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(2)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			c := 4
+			x0 := (j + 1) * 10
+			y0 := (j + 1) * 10
+			w := rand.Intn(3) + 1
+			h := rand.Intn(3) + 1
+			fmt.Fprintf(&sb, "%d\n", c)
+			fmt.Fprintf(&sb, "%d %d\n", x0, y0)
+			fmt.Fprintf(&sb, "%d %d\n", x0+w, y0)
+			fmt.Fprintf(&sb, "%d %d\n", x0+w, y0+h)
+			fmt.Fprintf(&sb, "%d %d\n", x0, y0+h)
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1218/verifierC.go
+++ b/1000-1999/1200-1299/1210-1219/1218/verifierC.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1218C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(3)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		N := rand.Intn(4) + 1
+		M := rand.Intn(4) + 1
+		K := rand.Intn(5)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", N, M, K)
+		for j := 0; j < K; j++ {
+			x := rand.Intn(N)
+			y := rand.Intn(M)
+			maxD := N - 1 - x
+			if y < maxD {
+				if maxD > y {
+					maxD = y
+				}
+			}
+			if M-1-y < maxD {
+				maxD = M - 1 - y
+			}
+			if maxD < 0 {
+				maxD = 0
+			}
+			d := rand.Intn(maxD + 1)
+			t := rand.Intn(10)
+			e := rand.Intn(100)
+			fmt.Fprintf(&sb, "%d %d %d %d %d\n", x, y, d, t, e)
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1218/verifierD.go
+++ b/1000-1999/1200-1299/1210-1219/1218/verifierD.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1218D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(4)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(4) + 2
+		maxEdges := n * (n - 1) / 2
+		m := n - 1 + rand.Intn(maxEdges-(n-1)+1)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		for j := 0; j < m; j++ {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			for u == v {
+				v = rand.Intn(n) + 1
+			}
+			w := rand.Intn(16)
+			fmt.Fprintf(&sb, "%d %d %d\n", u, v, w)
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1218/verifierE.go
+++ b/1000-1999/1200-1299/1210-1219/1218/verifierE.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1218E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(5)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(3) + 1
+		K := rand.Intn(4) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, K)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rand.Intn(10))
+		}
+		sb.WriteByte('\n')
+		q := rand.Intn(3) + 1
+		fmt.Fprintf(&sb, "%d\n", q)
+		for j := 0; j < q; j++ {
+			typ := rand.Intn(2) + 1
+			if typ == 1 {
+				qv := rand.Intn(10)
+				idx := rand.Intn(n) + 1
+				d := rand.Intn(10)
+				fmt.Fprintf(&sb, "1 %d %d %d\n", qv, idx, d)
+			} else {
+				qv := rand.Intn(10)
+				L := rand.Intn(n) + 1
+				R := L + rand.Intn(n-L+1)
+				d := rand.Intn(10)
+				fmt.Fprintf(&sb, "2 %d %d %d %d\n", qv, L, R, d)
+			}
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1218/verifierF.go
+++ b/1000-1999/1200-1299/1210-1219/1218/verifierF.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1218F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(6)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(3) + 1
+		k := rand.Int63n(10)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, k)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rand.Int63n(10))
+		}
+		sb.WriteByte('\n')
+		fmt.Fprintf(&sb, "%d\n", rand.Int63n(5)+1)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rand.Int63n(10))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1218/verifierG.go
+++ b/1000-1999/1200-1299/1210-1219/1218/verifierG.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1218G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(7)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(4) + 1
+		maxEdges := n * (n - 1) / 2
+		if maxEdges == 0 {
+			maxEdges = 1
+		}
+		m := rand.Intn(maxEdges) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, m)
+		chars := []byte{'X', 'Y', 'Z'}
+		for j := 0; j < n; j++ {
+			sb.WriteByte(chars[rand.Intn(3)])
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < m; j++ {
+			u := rand.Intn(n)
+			v := rand.Intn(n)
+			for u == v {
+				v = rand.Intn(n)
+			}
+			fmt.Fprintf(&sb, "%d %d\n", u, v)
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1218/verifierH.go
+++ b/1000-1999/1200-1299/1210-1219/1218/verifierH.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refH.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1218H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(8)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(4) + 2
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rand.Intn(n)+1)
+		}
+		sb.WriteByte('\n')
+		Q := rand.Intn(3) + 1
+		fmt.Fprintf(&sb, "%d\n", Q)
+		for q := 0; q < Q; q++ {
+			m := rand.Intn(10)
+			y := rand.Intn(n) + 1
+			fmt.Fprintf(&sb, "%d %d\n", m, y)
+		}
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1210-1219/1218/verifierI.go
+++ b/1000-1999/1200-1299/1210-1219/1218/verifierI.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Test struct{ input string }
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func buildRef() (string, error) {
+	ref := "./refI.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1218I.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func genTests() []Test {
+	rand.Seed(9)
+	tests := make([]Test, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(3) + 2
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			for k := 0; k < n; k++ {
+				if rand.Intn(2) == 0 {
+					sb.WriteByte('0')
+				} else {
+					sb.WriteByte('1')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		for j := 0; j < n; j++ {
+			for k := 0; k < n; k++ {
+				if rand.Intn(2) == 0 {
+					sb.WriteByte('0')
+				} else {
+					sb.WriteByte('1')
+				}
+			}
+			sb.WriteByte('\n')
+		}
+		c1 := rand.Intn(n)
+		for k := 0; k < n; k++ {
+			if k == c1 {
+				sb.WriteByte('1')
+			} else {
+				sb.WriteByte('0')
+			}
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, Test{sb.String()})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierI.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		exp, err := runExe(ref, tc.input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, tc.input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for every problem of contest 1218
- each verifier builds the reference solution and runs over 100 random tests

## Testing
- `go build 1000-1999/1200-1299/1210-1219/1218/verifierA.go`
- `go build 1000-1999/1200-1299/1210-1219/1218/verifierB.go`
- `go build 1000-1999/1200-1299/1210-1219/1218/verifierC.go`
- `go build 1000-1999/1200-1299/1210-1219/1218/verifierD.go`
- `go build 1000-1999/1200-1299/1210-1219/1218/verifierE.go`
- `go build 1000-1999/1200-1299/1210-1219/1218/verifierF.go`
- `go build 1000-1999/1200-1299/1210-1219/1218/verifierG.go`
- `go build 1000-1999/1200-1299/1210-1219/1218/verifierH.go`
- `go build 1000-1999/1200-1299/1210-1219/1218/verifierI.go`


------
https://chatgpt.com/codex/tasks/task_e_6884beb2afd48324adad74483b8bbcd4