### PR TITLE
Add Go solution for 1837C

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1837/1837C.go
+++ b/1000-1999/1800-1899/1830-1839/1837/1837C.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func solve(s string) string {
+	b := []byte(s)
+	n := len(b)
+	// propagate known characters to the right
+	for i := 1; i < n; i++ {
+		if b[i] == '?' && b[i-1] != '?' {
+			b[i] = b[i-1]
+		}
+	}
+	// fill remaining '?' from right to left
+	for i := n - 1; i >= 0; i-- {
+		if b[i] == '?' {
+			if i+1 < n {
+				b[i] = b[i+1]
+			} else {
+				b[i] = '0'
+			}
+		}
+	}
+	return string(b)
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		fmt.Fprintln(writer, solve(s))
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem C in contest 1837

## Testing
- `go build 1000-1999/1800-1899/1830-1839/1837/1837C.go`
- `go vet 1000-1999/1800-1899/1830-1839/1837/1837C.go`
- `go run 1000-1999/1800-1899/1830-1839/1837/1837C.go <<EOF
4
??01?
10100
1??10?
0?1?10?10
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6884bef8b5d48324a615f62e03f94d22