### PR TITLE
Add Go verifiers for contest 1220

### DIFF
--- a/1000-1999/1200-1299/1220-1229/1220/verifierA.go
+++ b/1000-1999/1200-1299/1220-1229/1220/verifierA.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testA struct {
+	s string
+}
+
+func genTestsA() []testA {
+	rand.Seed(122001)
+	tests := make([]testA, 100)
+	for i := range tests {
+		ones := rand.Intn(5)
+		zeros := rand.Intn(5)
+		for ones == 0 && zeros == 0 {
+			ones = rand.Intn(5)
+			zeros = rand.Intn(5)
+		}
+		b := make([]byte, 0, ones*3+zeros*4)
+		for j := 0; j < ones; j++ {
+			b = append(b, 'o', 'n', 'e')
+		}
+		for j := 0; j < zeros; j++ {
+			b = append(b, 'z', 'e', 'r', 'o')
+		}
+		rand.Shuffle(len(b), func(i, j int) { b[i], b[j] = b[j], b[i] })
+		tests[i] = testA{s: string(b)}
+	}
+	return tests
+}
+
+func solveA(tc testA) []int {
+	ones := 0
+	zeros := 0
+	for _, ch := range tc.s {
+		if ch == 'n' {
+			ones++
+		} else if ch == 'z' {
+			zeros++
+		}
+	}
+	res := make([]int, 0, ones+zeros)
+	for i := 0; i < ones; i++ {
+		res = append(res, 1)
+	}
+	for i := 0; i < zeros; i++ {
+		res = append(res, 0)
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d\n%s\n", len(tc.s), tc.s)
+	}
+
+	expected := make([][]int, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveA(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		for j := range exp {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			val, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if val != exp[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1200-1299/1220-1229/1220/verifierB.go
+++ b/1000-1999/1200-1299/1220-1229/1220/verifierB.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testB struct {
+	n int
+	a []int64
+	M [][]int64
+}
+
+func genTestsB() []testB {
+	rand.Seed(122002)
+	tests := make([]testB, 100)
+	for i := range tests {
+		n := rand.Intn(4) + 3 // 3..6
+		a := make([]int64, n)
+		for j := range a {
+			a[j] = int64(rand.Intn(9) + 1)
+		}
+		M := make([][]int64, n)
+		for j := 0; j < n; j++ {
+			M[j] = make([]int64, n)
+			for k := 0; k < n; k++ {
+				if j == k {
+					M[j][k] = 0
+				} else {
+					M[j][k] = a[j] * a[k]
+				}
+			}
+		}
+		tests[i] = testB{n: n, a: a, M: M}
+	}
+	return tests
+}
+
+func solveB(tc testB) []int64 {
+	return tc.a
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.n)
+		for j := 0; j < tc.n; j++ {
+			for k := 0; k < tc.n; k++ {
+				if k > 0 {
+					input.WriteByte(' ')
+				}
+				fmt.Fprint(&input, tc.M[j][k])
+			}
+			input.WriteByte('\n')
+		}
+	}
+
+	expected := make([][]int64, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveB(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		for j := 0; j < len(exp); j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			val, err := strconv.ParseInt(scanner.Text(), 10, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if val != exp[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1200-1299/1220-1229/1220/verifierC.go
+++ b/1000-1999/1200-1299/1220-1229/1220/verifierC.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+)
+
+type testC struct {
+	s string
+}
+
+func genTestsC() []testC {
+	rand.Seed(122003)
+	tests := make([]testC, 100)
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	for i := range tests {
+		n := rand.Intn(20) + 1
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = letters[rand.Intn(len(letters))]
+		}
+		tests[i] = testC{s: string(b)}
+	}
+	return tests
+}
+
+func solveC(tc testC) []string {
+	res := make([]string, len(tc.s))
+	minChar := tc.s[0]
+	res[0] = "Mike"
+	for i := 1; i < len(tc.s); i++ {
+		if tc.s[i] > minChar {
+			res[i] = "Ann"
+		} else {
+			res[i] = "Mike"
+		}
+		if tc.s[i] < minChar {
+			minChar = tc.s[i]
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.s)
+	}
+
+	expected := make([][]string, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveC(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		for j := range exp {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if scanner.Text() != exp[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1200-1299/1220-1229/1220/verifierD.go
+++ b/1000-1999/1200-1299/1220-1229/1220/verifierD.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testD struct {
+	arr []uint64
+}
+
+func genTestsD() []testD {
+	rand.Seed(122004)
+	tests := make([]testD, 100)
+	for i := range tests {
+		n := rand.Intn(10) + 1
+		arr := make([]uint64, n)
+		for j := range arr {
+			arr[j] = uint64(rand.Int63n(1<<30) + 1)
+		}
+		tests[i] = testD{arr: arr}
+	}
+	return tests
+}
+
+func solveD(tc testD) []uint64 {
+	cnt := make([]int, 64)
+	for _, v := range tc.arr {
+		tz := bits.TrailingZeros64(v)
+		if tz < len(cnt) {
+			cnt[tz]++
+		}
+	}
+	maxCnt := 0
+	tu := 0
+	for i, c := range cnt {
+		if c > maxCnt {
+			maxCnt = c
+			tu = i
+		}
+	}
+	res := []uint64{}
+	for _, v := range tc.arr {
+		if bits.TrailingZeros64(v) != tu {
+			res = append(res, v)
+		}
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, len(tc.arr))
+		for i, v := range tc.arr {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expected := make([][]uint64, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveD(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		k, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if k != len(exp) {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d: expected length %d got %d\n", i+1, len(exp), k)
+			os.Exit(1)
+		}
+		for j := 0; j < k; j++ {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+				os.Exit(1)
+			}
+			val, err := strconv.ParseUint(scanner.Text(), 10, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+				os.Exit(1)
+			}
+			if val != exp[j] {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+				os.Exit(1)
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1200-1299/1220-1229/1220/verifierE.go
+++ b/1000-1999/1200-1299/1220-1229/1220/verifierE.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type edgeE struct {
+	to int
+	id int
+}
+
+type testE struct {
+	n     int
+	m     int
+	w     []int64
+	edges [][2]int
+	s     int
+}
+
+func genTestsE() []testE {
+	rand.Seed(122005)
+	tests := make([]testE, 100)
+	for i := range tests {
+		n := rand.Intn(5) + 1
+		maxEdges := n * (n - 1) / 2
+		m := rand.Intn(maxEdges-n+1) + n - 1 // at least tree
+		w := make([]int64, n)
+		for j := range w {
+			w[j] = int64(rand.Intn(10) + 1)
+		}
+		edges := make([][2]int, 0, m)
+		// generate tree first
+		for v := 2; v <= n; v++ {
+			u := rand.Intn(v-1) + 1
+			edges = append(edges, [2]int{u, v})
+		}
+		exist := map[[2]int]bool{}
+		for _, e := range edges {
+			a, b := e[0], e[1]
+			if a > b {
+				a, b = b, a
+			}
+			exist[[2]int{a, b}] = true
+		}
+		for len(edges) < m {
+			u := rand.Intn(n) + 1
+			v := rand.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			a, b := u, v
+			if a > b {
+				a, b = b, a
+			}
+			if exist[[2]int{a, b}] {
+				continue
+			}
+			exist[[2]int{a, b}] = true
+			edges = append(edges, [2]int{u, v})
+		}
+		s := rand.Intn(n) + 1
+		tests[i] = testE{n: n, m: m, w: w, edges: edges, s: s}
+	}
+	return tests
+}
+
+func solveE(tc testE) int64 {
+	n, m := tc.n, tc.m
+	w := make([]int64, n+1)
+	copy(w[1:], tc.w)
+	g := make([][]edgeE, n+1)
+	for idx, e := range tc.edges {
+		u, v := e[0], e[1]
+		g[u] = append(g[u], edgeE{v, idx})
+		g[v] = append(g[v], edgeE{u, idx})
+	}
+
+	disc := make([]int, n+1)
+	low := make([]int, n+1)
+	isBridge := make([]bool, m)
+	timer := 0
+	var dfsBridge func(int, int)
+	dfsBridge = func(u, pe int) {
+		timer++
+		disc[u] = timer
+		low[u] = timer
+		for _, e := range g[u] {
+			v := e.to
+			if e.id == pe {
+				continue
+			}
+			if disc[v] == 0 {
+				dfsBridge(v, e.id)
+				if low[v] < low[u] {
+					low[u] = low[v]
+				}
+				if low[v] > disc[u] {
+					isBridge[e.id] = true
+				}
+			} else if disc[v] < low[u] {
+				low[u] = disc[v]
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if disc[i] == 0 {
+			dfsBridge(i, -1)
+		}
+	}
+
+	comp := make([]int, n+1)
+	compWeight := make([]int64, n+1)
+	compSize := make([]int, n+1)
+	comps := 0
+	var dfsComp func(int)
+	dfsComp = func(u int) {
+		comp[u] = comps
+		compWeight[comps] += w[u]
+		compSize[comps]++
+		for _, e := range g[u] {
+			if isBridge[e.id] {
+				continue
+			}
+			if comp[e.to] == 0 {
+				dfsComp(e.to)
+			}
+		}
+	}
+	for i := 1; i <= n; i++ {
+		if comp[i] == 0 {
+			comps++
+			dfsComp(i)
+		}
+	}
+
+	compWeight = compWeight[:comps+1]
+	compSize = compSize[:comps+1]
+	good := make([]bool, comps+1)
+	for i := 1; i <= comps; i++ {
+		if compSize[i] > 1 {
+			good[i] = true
+		}
+	}
+
+	tree := make([][]int, comps+1)
+	for i, e := range tc.edges {
+		_ = i
+		u, v := e[0], e[1]
+		cu, cv := comp[u], comp[v]
+		if cu != cv {
+			tree[cu] = append(tree[cu], cv)
+			tree[cv] = append(tree[cv], cu)
+		}
+	}
+
+	dpRet := make([]int64, comps+1)
+	dpBest := make([]int64, comps+1)
+	cycleSub := make([]bool, comps+1)
+	var dfs1 func(int, int)
+	dfs1 = func(u, p int) {
+		dpRet[u] = compWeight[u]
+		cycleSub[u] = good[u]
+		for _, v := range tree[u] {
+			if v == p {
+				continue
+			}
+			dfs1(v, u)
+			if cycleSub[v] {
+				dpRet[u] += dpRet[v]
+				cycleSub[u] = true
+			}
+		}
+	}
+	var dfs2 func(int, int)
+	dfs2 = func(u, p int) {
+		dpBest[u] = dpRet[u]
+		for _, v := range tree[u] {
+			if v == p {
+				continue
+			}
+			dfs2(v, u)
+			var cand int64
+			if cycleSub[v] {
+				cand = dpRet[u] - dpRet[v] + dpBest[v]
+			} else {
+				cand = dpRet[u] + dpBest[v]
+			}
+			if cand > dpBest[u] {
+				dpBest[u] = cand
+			}
+		}
+	}
+
+	root := comp[tc.s]
+	dfs1(root, 0)
+	dfs2(root, 0)
+	return dpBest[root]
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.m)
+		for i := 0; i < tc.n; i++ {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, tc.w[i])
+		}
+		input.WriteByte('\n')
+		for _, e := range tc.edges {
+			fmt.Fprintf(&input, "%d %d\n", e[0], e[1])
+		}
+		fmt.Fprintln(&input, tc.s)
+	}
+
+	expected := make([]int64, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveE(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expected {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.ParseInt(scanner.Text(), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1200-1299/1220-1229/1220/verifierF.go
+++ b/1000-1999/1200-1299/1220-1229/1220/verifierF.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+type testF struct {
+	a []int
+}
+
+func genTestsF() []testF {
+	rand.Seed(122006)
+	tests := make([]testF, 100)
+	for i := range tests {
+		n := rand.Intn(8) + 2
+		a := make([]int, n)
+		pos := rand.Intn(n)
+		for j := range a {
+			if j == pos {
+				a[j] = 1
+			} else {
+				a[j] = rand.Intn(9) + 2
+			}
+		}
+		tests[i] = testF{a: a}
+	}
+	return tests
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func solveF(tc testF) (int, int) {
+	n := len(tc.a)
+	a := tc.a
+	root := 0
+	for i, v := range a {
+		if v == 1 {
+			root = i
+			break
+		}
+	}
+	b := make([][]int, 2)
+	b[0] = make([]int, n)
+	b[1] = make([]int, n)
+	for i := 0; i < n; i++ {
+		b[0][i] = a[(root+i)%n]
+		b[1][i] = a[(root+n-i)%n]
+	}
+	dpl := make([][]int, 2)
+	dpr := make([][]int, 2)
+	ans := make([][]int, 2)
+	for t := 0; t < 2; t++ {
+		dpl[t] = make([]int, n)
+		dpr[t] = make([]int, n)
+		ans[t] = make([]int, n)
+	}
+	for t := 0; t < 2; t++ {
+		stack := make([]int, 0, n)
+		dpl[t][0] = 1
+		ans[t][0] = 1
+		stack = append(stack, 0)
+		for i := 1; i < n; i++ {
+			nex := -1
+			for len(stack) > 0 && b[t][stack[len(stack)-1]] > b[t][i] {
+				j := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				if nex == -1 {
+					dpr[t][j] = dpl[t][j]
+					nex = j
+				} else {
+					dpr[t][j] = max(dpr[t][nex]+1, dpl[t][j])
+					nex = j
+				}
+			}
+			if nex == -1 {
+				dpl[t][i] = 1
+			} else {
+				dpl[t][i] = dpr[t][nex] + 1
+			}
+			stack = append(stack, i)
+			cur := len(stack) + dpl[t][i] - 1
+			ans[t][i] = max(cur, ans[t][i-1])
+		}
+	}
+	ret := n + n
+	k := 0
+	for i := 0; i < n; i++ {
+		val := max(ans[0][i], ans[1][n-1-i])
+		if val < ret {
+			ret = val
+			k = (root + 1 + i) % n
+		}
+	}
+	return ret, k
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsF()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, len(tc.a))
+		for i, v := range tc.a {
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprint(&input, v)
+		}
+		input.WriteByte('\n')
+	}
+
+	expectedRet := make([]int, len(tests))
+	expectedK := make([]int, len(tests))
+	for i, tc := range tests {
+		r, k := solveF(tc)
+		expectedRet[i] = r
+		expectedK[i] = k
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i := range tests {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		r, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		k, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if r != expectedRet[i] || k != expectedK[i] {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1200-1299/1220-1229/1220/verifierG.go
+++ b/1000-1999/1200-1299/1220-1229/1220/verifierG.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+)
+
+type Point struct {
+	x, y int64
+}
+
+type testG struct {
+	ants    []Point
+	queries [][]int64
+}
+
+func genTestsG() []testG {
+	rand.Seed(122007)
+	tests := make([]testG, 100)
+	for i := range tests {
+		n := rand.Intn(3) + 2
+		ants := make([]Point, n)
+		for j := range ants {
+			ants[j] = Point{int64(rand.Intn(11) - 5), int64(rand.Intn(11) - 5)}
+		}
+		m := rand.Intn(3) + 1
+		queries := make([][]int64, m)
+		for q := 0; q < m; q++ {
+			arr := make([]int64, n)
+			for j := range arr {
+				val := rand.Intn(25)
+				arr[j] = int64(val)
+			}
+			sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+			queries[q] = arr
+		}
+		tests[i] = testG{ants: ants, queries: queries}
+	}
+	return tests
+}
+
+func int64sqrt(x int64) float64 { return math.Sqrt(float64(x)) }
+
+func circleIntersections(p1 Point, r1 float64, p2 Point, r2 float64) []Point {
+	dx := float64(p2.x - p1.x)
+	dy := float64(p2.y - p1.y)
+	d := math.Hypot(dx, dy)
+	if d > r1+r2+1e-6 || d < math.Abs(r1-r2)-1e-6 || d == 0 {
+		return nil
+	}
+	a := (r1*r1 - r2*r2 + d*d) / (2 * d)
+	h2 := r1*r1 - a*a
+	if h2 < -1e-6 {
+		return nil
+	}
+	if h2 < 0 {
+		h2 = 0
+	}
+	h := math.Sqrt(h2)
+	xm := float64(p1.x) + a*dx/d
+	ym := float64(p1.y) + a*dy/d
+	rx := -dy * (h / d)
+	ry := dx * (h / d)
+	points := []Point{}
+	x1 := math.Round(xm + rx)
+	y1 := math.Round(ym + ry)
+	if math.Abs((xm+rx)-x1) < 1e-6 && math.Abs((ym+ry)-y1) < 1e-6 {
+		points = append(points, Point{int64(x1), int64(y1)})
+	}
+	x2 := math.Round(xm - rx)
+	y2 := math.Round(ym - ry)
+	if math.Abs((xm-rx)-x2) < 1e-6 && math.Abs((ym-ry)-y2) < 1e-6 {
+		p := Point{int64(x2), int64(y2)}
+		if len(points) == 0 || points[0] != p {
+			points = append(points, p)
+		}
+	}
+	return points
+}
+
+func checkPoint(p Point, ants []Point, d []int64) bool {
+	n := len(ants)
+	arr := make([]int64, n)
+	for i, a := range ants {
+		dx := p.x - a.x
+		dy := p.y - a.y
+		arr[i] = dx*dx + dy*dy
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	for i := 0; i < n; i++ {
+		if arr[i] != d[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func solveQuery(ants []Point, d []int64) []Point {
+	n := len(ants)
+	dmin := d[0]
+	dmax := d[n-1]
+	var ans []Point
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if i == j {
+				continue
+			}
+			pts := circleIntersections(ants[i], int64sqrt(dmin), ants[j], int64sqrt(dmax))
+			for _, p := range pts {
+				if checkPoint(p, ants, d) {
+					ans = append(ans, p)
+				}
+			}
+		}
+	}
+	if len(ans) > 1 {
+		sort.Slice(ans, func(i, j int) bool {
+			if ans[i].x == ans[j].x {
+				return ans[i].y < ans[j].y
+			}
+			return ans[i].x < ans[j].x
+		})
+		uniq := ans[:1]
+		for k := 1; k < len(ans); k++ {
+			if ans[k] != ans[k-1] {
+				uniq = append(uniq, ans[k])
+			}
+		}
+		ans = uniq
+	}
+	return ans
+}
+
+func solveG(tc testG) [][]Point {
+	res := make([][]Point, len(tc.queries))
+	for i, q := range tc.queries {
+		res[i] = solveQuery(tc.ants, q)
+	}
+	return res
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsG()
+
+	var input bytes.Buffer
+	fmt.Fprintln(&input, len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, len(tc.ants))
+		for _, p := range tc.ants {
+			fmt.Fprintf(&input, "%d %d\n", p.x, p.y)
+		}
+		fmt.Fprintln(&input, len(tc.queries))
+		for _, q := range tc.queries {
+			for i, v := range q {
+				if i > 0 {
+					input.WriteByte(' ')
+				}
+				fmt.Fprint(&input, v)
+			}
+			input.WriteByte('\n')
+		}
+	}
+
+	expected := make([][][]Point, len(tests))
+	for i, tc := range tests {
+		expected[i] = solveG(tc)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = bytes.NewReader(input.Bytes())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\noutput:\n%s\n", err, out.String())
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out.Bytes()))
+	scanner.Split(bufio.ScanWords)
+	for i, queries := range expected {
+		for j, exp := range queries {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "wrong output format on test %d query %d\n", i+1, j+1)
+				os.Exit(1)
+			}
+			cnt, err := strconv.Atoi(scanner.Text())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "non-integer output on test %d query %d\n", i+1, j+1)
+				os.Exit(1)
+			}
+			if cnt != len(exp) {
+				fmt.Fprintf(os.Stderr, "wrong answer on test %d query %d\n", i+1, j+1)
+				os.Exit(1)
+			}
+			for k := 0; k < cnt; k++ {
+				if !scanner.Scan() {
+					fmt.Fprintf(os.Stderr, "wrong output format on test %d query %d\n", i+1, j+1)
+					os.Exit(1)
+				}
+				x, err := strconv.ParseInt(scanner.Text(), 10, 64)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "non-integer output on test %d query %d\n", i+1, j+1)
+					os.Exit(1)
+				}
+				if !scanner.Scan() {
+					fmt.Fprintf(os.Stderr, "wrong output format on test %d query %d\n", i+1, j+1)
+					os.Exit(1)
+				}
+				y, err := strconv.ParseInt(scanner.Text(), 10, 64)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "non-integer output on test %d query %d\n", i+1, j+1)
+					os.Exit(1)
+				}
+				if x != exp[k].x || y != exp[k].y {
+					fmt.Fprintf(os.Stderr, "wrong answer on test %d query %d\n", i+1, j+1)
+					os.Exit(1)
+				}
+			}
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to check submissions for problem A
- add verifierB.go for problem B
- add verifierC.go for problem C
- add verifierD.go for problem D
- add verifierE.go for problem E
- add verifierF.go for problem F
- add verifierG.go for problem G

## Testing
- `go build 1000-1999/1200-1299/1220-1229/1220/verifierA.go`
- `go build 1000-1999/1200-1299/1220-1229/1220/verifierB.go`
- `go build 1000-1999/1200-1299/1220-1229/1220/verifierC.go`
- `go build 1000-1999/1200-1299/1220-1229/1220/verifierD.go`
- `go build 1000-1999/1200-1299/1220-1229/1220/verifierE.go`
- `go build 1000-1999/1200-1299/1220-1229/1220/verifierF.go`
- `go build 1000-1999/1200-1299/1220-1229/1220/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6884bfcabf9483249274f77c7ededd6e