### PR TITLE
Add Go verifiers for contest 1227

### DIFF
--- a/1000-1999/1200-1299/1220-1229/1227/verifierA.go
+++ b/1000-1999/1200-1299/1220-1229/1227/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	var b bytes.Buffer
+	fmt.Fprintln(&b, 1)
+	fmt.Fprintln(&b, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(20) + 1
+		r := l + rng.Intn(20)
+		fmt.Fprintf(&b, "%d %d\n", l, r)
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierA.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refA")
+	if out, err := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1227A.go")).CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1227/verifierB.go
+++ b/1000-1999/1200-1299/1220-1229/1227/verifierB.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	perm := rng.Perm(n)
+	var q []int
+	max := 0
+	for i := 0; i < n; i++ {
+		val := perm[i] + 1
+		if val > max {
+			max = val
+		}
+		q = append(q, max)
+	}
+	var b bytes.Buffer
+	fmt.Fprintln(&b, 1)
+	fmt.Fprintln(&b, n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, q[i])
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierB.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refB")
+	if out, err := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1227B.go")).CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1227/verifierC.go
+++ b/1000-1999/1200-1299/1220-1229/1227/verifierC.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := 2 * (rng.Intn(4) + 2) // length 4..10 even
+	k := rng.Intn(n/2) + 1
+	arr := make([]byte, n)
+	for i := 0; i < n/2; i++ {
+		arr[i] = '('
+	}
+	for i := n / 2; i < n; i++ {
+		arr[i] = ')'
+	}
+	rng.Shuffle(n, func(i, j int) { arr[i], arr[j] = arr[j], arr[i] })
+	s := string(arr)
+	var b bytes.Buffer
+	fmt.Fprintln(&b, 1)
+	fmt.Fprintf(&b, "%d %d\n", n, k)
+	fmt.Fprintln(&b, s)
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierC.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refC")
+	if out, err := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1227C.go")).CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1227/verifierD1.go
+++ b/1000-1999/1200-1299/1220-1229/1227/verifierD1.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	var b bytes.Buffer
+	fmt.Fprintln(&b, n)
+	for i := 0; i < n; i++ {
+		v := rng.Intn(50) + 1
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, v)
+	}
+	b.WriteByte('\n')
+	m := rng.Intn(6) + 1
+	fmt.Fprintln(&b, m)
+	for i := 0; i < m; i++ {
+		k := rng.Intn(n) + 1
+		pos := rng.Intn(k) + 1
+		fmt.Fprintf(&b, "%d %d\n", k, pos)
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierD1.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refD1")
+	if out, err := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1227D1.go")).CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1227/verifierD2.go
+++ b/1000-1999/1200-1299/1220-1229/1227/verifierD2.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	var b bytes.Buffer
+	fmt.Fprintln(&b, n)
+	for i := 0; i < n; i++ {
+		v := rng.Intn(100) + 1
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, v)
+	}
+	b.WriteByte('\n')
+	m := rng.Intn(6) + 1
+	fmt.Fprintln(&b, m)
+	for i := 0; i < m; i++ {
+		k := rng.Intn(n) + 1
+		pos := rng.Intn(k) + 1
+		fmt.Fprintf(&b, "%d %d\n", k, pos)
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierD2.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refD2")
+	if out, err := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1227D2.go")).CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1227/verifierE.go
+++ b/1000-1999/1200-1299/1220-1229/1227/verifierE.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		row := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				row[j] = '.'
+			} else {
+				row[j] = 'X'
+			}
+		}
+		fmt.Fprintln(&b, string(row))
+	}
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierE.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refE")
+	if out, err := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1227E.go")).CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1227/verifierF1.go
+++ b/1000-1999/1200-1299/1220-1229/1227/verifierF1.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	k := rng.Intn(5) + 1
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, rng.Intn(4)+1)
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierF1.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refF1")
+	if out, err := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1227F1.go")).CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1227/verifierF2.go
+++ b/1000-1999/1200-1299/1220-1229/1227/verifierF2.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	k := rng.Int63n(5) + 1
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, rng.Intn(4)+1)
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierF2.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refF2")
+	if out, err := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1227F2.go")).CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1227/verifierG.go
+++ b/1000-1999/1200-1299/1220-1229/1227/verifierG.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	var b bytes.Buffer
+	fmt.Fprintln(&b, n)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprint(&b, rng.Intn(n)+1)
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: go run verifierG.go /path/to/binary\n")
+		os.Exit(1)
+	}
+	candidate := os.Args[1]
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	ref := filepath.Join(dir, "refG")
+	if out, err := exec.Command("go", "build", "-o", ref, filepath.Join(dir, "1227G.go")).CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build reference solution: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 0; t < 100; t++ {
+		input := genCase(rng)
+		candOut, cErr := runBinary(candidate, input)
+		refOut, rErr := runBinary(ref, input)
+		if cErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: candidate error: %v\ninput:\n%s", t+1, cErr, input)
+			os.Exit(1)
+		}
+		if rErr != nil {
+			fmt.Fprintf(os.Stderr, "case %d: reference error: %v\ninput:\n%s", t+1, rErr, input)
+			os.Exit(1)
+		}
+		if candOut != refOut {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%s\nexpected:%s\nactual:%s\n", t+1, input, refOut, candOut)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for contest 1227 problems A-G
- each verifier builds the reference solution and compares 100 random tests

## Testing
- `go vet` *(not run: no instructions)*

------
https://chatgpt.com/codex/tasks/task_e_6884c39f8900832489dd4391af5af1b8