### PR TITLE
Add Go verifiers for Codeforces contest 1228

### DIFF
--- a/1000-1999/1200-1299/1220-1229/1228/verifierA.go
+++ b/1000-1999/1200-1299/1220-1229/1228/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]string, 0, 100)
+	tests = append(tests, "1 1\n")       // unique digit exists
+	tests = append(tests, "11 11\n")     // no unique digits
+	tests = append(tests, "98 102\n")    // span multiple digits
+	tests = append(tests, "1000 1000\n") // all same digits
+	tests = append(tests, "1234 1234\n") // already unique
+	for len(tests) < 100 {
+		l := r.Intn(100000) + 1
+		rVal := l + r.Intn(100000-l+1)
+		tests = append(tests, fmt.Sprintf("%d %d\n", l, rVal))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialA"
+	if err := exec.Command("go", "build", "-o", official, "1228A.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1228/verifierB.go
+++ b/1000-1999/1200-1299/1220-1229/1228/verifierB.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(2))
+	tests := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		h := r.Intn(5) + 1
+		w := r.Intn(5) + 1
+		row := make([]int, h)
+		for j := 0; j < h; j++ {
+			row[j] = r.Intn(w + 1)
+		}
+		col := make([]int, w)
+		for j := 0; j < w; j++ {
+			col[j] = r.Intn(h + 1)
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", h, w)
+		for j, v := range row {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		for j, v := range col {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, sb.String())
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialB"
+	if err := exec.Command("go", "build", "-o", official, "1228B.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1228/verifierC.go
+++ b/1000-1999/1200-1299/1220-1229/1228/verifierC.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(3))
+	tests := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		x := r.Intn(1000000-2) + 2
+		n := r.Int63n(1_000_000_000_000) + 1
+		tests = append(tests, fmt.Sprintf("%d %d\n", x, n))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialC"
+	if err := exec.Command("go", "build", "-o", official, "1228C.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1228/verifierD.go
+++ b/1000-1999/1200-1299/1220-1229/1228/verifierD.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func completeTripartite(a, b, c int, r *rand.Rand) string {
+	n := a + b + c
+	groups := []int{}
+	for i := 0; i < a; i++ {
+		groups = append(groups, 1)
+	}
+	for i := 0; i < b; i++ {
+		groups = append(groups, 2)
+	}
+	for i := 0; i < c; i++ {
+		groups = append(groups, 3)
+	}
+	// shuffle vertices
+	r.Shuffle(len(groups), func(i, j int) { groups[i], groups[j] = groups[j], groups[i] })
+	idx := make([]int, n)
+	for i := range idx {
+		idx[i] = i + 1
+	}
+	r.Shuffle(len(idx), func(i, j int) { idx[i], idx[j] = idx[j], idx[i] })
+	edges := make([][2]int, 0, a*b+b*c+c*a)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if groups[i] != groups[j] {
+				edges = append(edges, [2]int{idx[i], idx[j]})
+			}
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, len(edges))
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	return sb.String()
+}
+
+func randomGraph(r *rand.Rand) string {
+	n := r.Intn(6) + 3
+	maxEdges := n * (n - 1) / 2
+	m := r.Intn(maxEdges + 1)
+	edges := make(map[[2]int]struct{})
+	for len(edges) < m {
+		a := r.Intn(n) + 1
+		b := r.Intn(n) + 1
+		if a == b {
+			continue
+		}
+		if a > b {
+			a, b = b, a
+		}
+		edges[[2]int{a, b}] = struct{}{}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, len(edges))
+	for e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	return sb.String()
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(4))
+	tests := make([]string, 0, 100)
+	// first 10 tests complete tripartite
+	for i := 0; i < 10; i++ {
+		a := r.Intn(3) + 1
+		b := r.Intn(3) + 1
+		c := r.Intn(3) + 1
+		tests = append(tests, completeTripartite(a, b, c, r))
+	}
+	for len(tests) < 100 {
+		tests = append(tests, randomGraph(r))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialD"
+	if err := exec.Command("go", "build", "-o", official, "1228D.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1228/verifierE.go
+++ b/1000-1999/1200-1299/1220-1229/1228/verifierE.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(5))
+	tests := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(20) + 1
+		k := r.Int63n(1_000_000_000) + 1
+		tests = append(tests, fmt.Sprintf("%d %d\n", n, k))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialE"
+	if err := exec.Command("go", "build", "-o", official, "1228E.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1220-1229/1228/verifierF.go
+++ b/1000-1999/1200-1299/1220-1229/1228/verifierF.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomTree(n int, r *rand.Rand) string {
+	N := (1 << n) - 2
+	edges := make([][2]int, 0, N-1)
+	for i := 2; i <= N; i++ {
+		p := r.Intn(i-1) + 1
+		edges = append(edges, [2]int{p, i})
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	return sb.String()
+}
+
+func generateTests() []string {
+	r := rand.New(rand.NewSource(6))
+	tests := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(4) + 2 // keep size small
+		tests = append(tests, randomTree(n, r))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	cand := os.Args[1]
+	official := "./officialF"
+	if err := exec.Command("go", "build", "-o", official, "1228F.go").Run(); err != nil {
+		fmt.Println("failed to build official solution:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(official)
+	tests := generateTests()
+	for i, tc := range tests {
+		exp, eerr := runBinary(official, tc)
+		got, gerr := runBinary(cand, tc)
+		if eerr != nil {
+			fmt.Printf("official solution failed on test %d: %v\n", i+1, eerr)
+			os.Exit(1)
+		}
+		if gerr != nil {
+			fmt.Printf("candidate failed on test %d: %v\n", i+1, gerr)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("wrong answer on test %d\ninput:\n%sexpected: %s\ngot: %s\n", i+1, tc, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go–verifierF.go for contest 1228
- each verifier builds the official solution and runs 100 deterministic tests
- random tests cover a range of valid and invalid cases for each problem

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6884c42bd1808324be0d8c21e997361a