### PR TITLE
Add Go verifiers for CF1230

### DIFF
--- a/1000-1999/1200-1299/1230-1239/1230/verifierA.go
+++ b/1000-1999/1200-1299/1230-1239/1230/verifierA.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	a [4]int
+}
+
+func generateTests() []testCase {
+	r := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := 0; i < 100; i++ {
+		tests[i] = testCase{a: [4]int{r.Intn(100) + 1, r.Intn(100) + 1, r.Intn(100) + 1, r.Intn(100) + 1}}
+	}
+	return tests
+}
+
+func expected(t testCase) string {
+	a := []int{t.a[0], t.a[1], t.a[2], t.a[3]}
+	sort.Ints(a)
+	if a[0]+a[3] == a[1]+a[2] || a[0]+a[1]+a[2] == a[3] {
+		return "YES"
+	}
+	return "NO"
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("run failed: %v\n%s", err, errb.String())
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d %d %d\n", t.a[0], t.a[1], t.a[2], t.a[3])
+		want := expected(t)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.ToUpper(strings.TrimSpace(got)) != want {
+			fmt.Printf("test %d failed: expected %s got %s\n", i+1, want, strings.TrimSpace(got))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1200-1299/1230-1239/1230/verifierB.go
+++ b/1000-1999/1200-1299/1230-1239/1230/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	k int
+	s string
+}
+
+func generateTests() []testCase {
+	r := rand.New(rand.NewSource(2))
+	tests := make([]testCase, 0, 100)
+	// fixed edge cases
+	tests = append(tests, testCase{n: 1, k: 0, s: "5"})
+	tests = append(tests, testCase{n: 1, k: 1, s: "8"})
+	for len(tests) < 100 {
+		n := r.Intn(10) + 1
+		k := r.Intn(n + 1)
+		b := make([]byte, n)
+		b[0] = byte('1' + r.Intn(9))
+		for i := 1; i < n; i++ {
+			b[i] = byte('0' + r.Intn(10))
+		}
+		tests = append(tests, testCase{n: n, k: k, s: string(b)})
+	}
+	return tests
+}
+
+func expected(t testCase) string {
+	if t.n == 1 {
+		if t.k > 0 {
+			return "0"
+		}
+		return t.s
+	}
+	b := []byte(t.s)
+	k := t.k
+	if k > 0 && b[0] != '1' {
+		b[0] = '1'
+		k--
+	}
+	for i := 1; i < t.n && k > 0; i++ {
+		if b[i] != '0' {
+			b[i] = '0'
+			k--
+		}
+	}
+	return string(b)
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout")
+		}
+		return "", fmt.Errorf("run failed: %v\n%s", err, errb.String())
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n%s\n", t.n, t.k, t.s)
+		want := expected(t)
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("test %d failed:\ninput: %q %d\nexpected %s got %s\n", i+1, t.s, t.k, want, strings.TrimSpace(got))
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add verifierA.go and verifierB.go for contest 1230
- each verifier runs the target binary against 100 randomly-generated tests
- verifierB includes fixed edge cases for single-digit inputs

## Testing
- `go build -o 1230A 1230A.go`
- `go build -o 1230B 1230B.go`
- `go run verifierA.go ./1230A`
- `go run verifierB.go ./1230B`


------
https://chatgpt.com/codex/tasks/task_e_6884c5439a3883248a2cc6944b750e4c