### PR TITLE
Add Go solution for 1839E

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1839/1839E.go
+++ b/1000-1999/1800-1899/1830-1839/1839/1839E.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	a := make([]int, n)
+	sum := 0
+	maxv := 0
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+		sum += a[i]
+		if a[i] > maxv {
+			maxv = a[i]
+		}
+	}
+
+	if sum%2 == 1 || maxv > sum-maxv {
+		fmt.Fprintln(out, "First")
+	} else {
+		fmt.Fprintln(out, "Second")
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for `problemE.txt` following a common stone game strategy

## Testing
- `gofmt -w 1000-1999/1800-1899/1830-1839/1839/1839E.go`

------
https://chatgpt.com/codex/tasks/task_e_6884c35953cc8324be3a7878fb31ce17