### PR TITLE
Add Go solution for Codeforces 1831A

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1831/1831A.go
+++ b/1000-1999/1800-1899/1830-1839/1831/1831A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		if _, err := fmt.Fscan(in, &n); err != nil {
+			return
+		}
+		a := make([]int, n)
+		for i := range a {
+			fmt.Fscan(in, &a[i])
+		}
+		for i, v := range a {
+			if i > 0 {
+				fmt.Fprint(out, " ")
+			}
+			fmt.Fprint(out, n+1-v)
+		}
+		fmt.Fprintln(out)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for 1831A

## Testing
- `go build 1000-1999/1800-1899/1830-1839/1831/1831A.go`


------
https://chatgpt.com/codex/tasks/task_e_6884c7b9efcc83248f1abb6b22951946