### PR TITLE
Add Go solution for 1836A

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1836/1836A.go
+++ b/1000-1999/1800-1899/1830-1839/1836/1836A.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+func solve(r *bufio.Reader, w *bufio.Writer) {
+    var n int
+    fmt.Fscan(r, &n)
+    freq := make([]int, 101)
+    maxVal := 0
+    for i := 0; i < n; i++ {
+        var x int
+        fmt.Fscan(r, &x)
+        if x > maxVal {
+            maxVal = x
+        }
+        if x >= len(freq) {
+            tmp := make([]int, x+1)
+            copy(tmp, freq)
+            freq = tmp
+        }
+        freq[x]++
+    }
+    ok := true
+    for i := 1; i <= maxVal; i++ {
+        if freq[i] > freq[i-1] {
+            ok = false
+            break
+        }
+    }
+    if ok {
+        fmt.Fprintln(w, "YES")
+    } else {
+        fmt.Fprintln(w, "NO")
+    }
+}
+
+func main() {
+    reader := bufio.NewReader(os.Stdin)
+    writer := bufio.NewWriter(os.Stdout)
+    defer writer.Flush()
+
+    var t int
+    if _, err := fmt.Fscan(reader, &t); err != nil {
+        return
+    }
+    for ; t > 0; t-- {
+        solve(reader, writer)
+    }
+}


### PR DESCRIPTION
## Summary
- implement solution for problem A of contest 1836 in Go

## Testing
- `go build 1000-1999/1800-1899/1830-1839/1836/1836A.go`
- `go run 1000-1999/1800-1899/1830-1839/1836/1836A.go < /tmp/test_input.txt`

------
https://chatgpt.com/codex/tasks/task_e_6884c8d21b8483248ec0be899c06fd47