### PR TITLE
Add Go solution for 1836B

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1836/1836B.go
+++ b/1000-1999/1800-1899/1830-1839/1836/1836B.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k, g int64
+		fmt.Fscan(reader, &n, &k, &g)
+		tVal := (g - 1) / 2
+		maxSave := tVal * n
+		total := k * g
+		if maxSave > total {
+			maxSave = total
+		}
+		ans := (maxSave / g) * g
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `1836B`

## Testing
- `go build 1000-1999/1800-1899/1830-1839/1836/1836B.go`

------
https://chatgpt.com/codex/tasks/task_e_6884c8461b8c8324aa8e4709f9d0f8b4