### PR TITLE
Add solution verifiers for CF contest 1238

### DIFF
--- a/1000-1999/1200-1299/1230-1239/1238/verifierA.go
+++ b/1000-1999/1200-1299/1230-1239/1238/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	x int64
+	y int64
+}
+
+func expected(x, y int64) string {
+	if x-y == 1 {
+		return "NO"
+	}
+	return "YES"
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 0, 100)
+	// edge cases around x-y==1
+	for i := int64(1); i <= 50; i++ {
+		tests = append(tests, testCase{x: i + 1, y: i}) // difference 1 -> NO
+	}
+	for i := int64(1); i <= 50; i++ {
+		x := rng.Int63n(1e6) + 2
+		y := rng.Int63n(x - 1)
+		if x-y == 1 {
+			x++ // ensure difference not 1
+		}
+		tests = append(tests, testCase{x: x, y: y})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("1\n%d %d\n", t.x, t.y)
+		want := expected(t.x, t.y)
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: x=%d y=%d expected %s got %s\n", i+1, t.x, t.y, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1200-1299/1230-1239/1238/verifierB.go
+++ b/1000-1999/1200-1299/1230-1239/1238/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	r int
+	x []int
+}
+
+func expected(n, r int, x []int) string {
+	sort.Slice(x, func(i, j int) bool { return x[i] > x[j] })
+	uniq := []int{x[0]}
+	for i := 1; i < n; i++ {
+		if x[i] != x[i-1] {
+			uniq = append(uniq, x[i])
+		}
+	}
+	shots := 0
+	shift := 0
+	for _, pos := range uniq {
+		if pos-shift <= 0 {
+			break
+		}
+		shots++
+		shift += r
+	}
+	return fmt.Sprintf("%d", shots)
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		r := rng.Intn(10) + 1
+		x := make([]int, n)
+		for j := 0; j < n; j++ {
+			x[j] = rng.Intn(50) + 1
+		}
+		tests = append(tests, testCase{n: n, r: r, x: x})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("1\n%d %d\n", t.n, t.r)
+		for _, v := range t.x {
+			input += fmt.Sprintf("%d ", v)
+		}
+		input = strings.TrimSpace(input) + "\n"
+		want := expected(t.n, t.r, append([]int(nil), t.x...))
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1200-1299/1230-1239/1238/verifierC.go
+++ b/1000-1999/1200-1299/1230-1239/1238/verifierC.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	h int
+	p []int
+}
+
+func minCrystals(h int, p []int) int {
+	p = append(append([]int(nil), p...), 0)
+	idx := 1
+	cur := h
+	ans := 0
+	for cur > 2 {
+		for idx < len(p) && p[idx] >= cur {
+			idx++
+		}
+		if idx >= len(p) {
+			break
+		}
+		if p[idx] == cur-1 {
+			next := 0
+			if idx+1 < len(p) {
+				next = p[idx+1]
+			}
+			if cur-next > 2 {
+				ans++
+				cur -= 2
+				for idx < len(p) && p[idx] >= cur {
+					idx++
+				}
+			} else {
+				cur = next
+				idx += 2
+			}
+		} else {
+			cur--
+		}
+	}
+	return ans
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		h := rng.Intn(50) + 3
+		n := rng.Intn(10) + 1
+		p := make([]int, n)
+		cur := h - 1
+		for j := 0; j < n; j++ {
+			if cur <= 0 {
+				cur = 0
+			} else {
+				cur -= rng.Intn(3) + 1
+				if cur < 0 {
+					cur = 0
+				}
+			}
+			p[j] = cur
+		}
+		sort.Sort(sort.Reverse(sort.IntSlice(p)))
+		tests = append(tests, testCase{h: h, p: p})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("1\n%d %d\n", t.h, len(t.p))
+		for _, v := range t.p {
+			input += fmt.Sprintf("%d ", v)
+		}
+		input = strings.TrimSpace(input) + "\n"
+		want := fmt.Sprintf("%d", minCrystals(t.h, append([]int(nil), t.p...)))
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1200-1299/1230-1239/1238/verifierD.go
+++ b/1000-1999/1200-1299/1230-1239/1238/verifierD.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Fenwick struct {
+	n   int
+	bit []int
+}
+
+func NewFenwick(n int) *Fenwick { return &Fenwick{n, make([]int, n+2)} }
+func (f *Fenwick) Add(idx, val int) {
+	for idx <= f.n {
+		f.bit[idx] += val
+		idx += idx & -idx
+	}
+}
+func (f *Fenwick) Sum(idx int) int {
+	res := 0
+	for idx > 0 {
+		res += f.bit[idx]
+		idx -= idx & -idx
+	}
+	return res
+}
+
+func countGood(s string) int64 {
+	n := len(s)
+	next := make([]int, n)
+	prev := make([]int, n)
+	last := map[byte]int{'A': -1, 'B': -1}
+	for i := 0; i < n; i++ {
+		prev[i] = last[s[i]]
+		last[s[i]] = i
+	}
+	last['A'] = n
+	last['B'] = n
+	for i := n - 1; i >= 0; i-- {
+		next[i] = last[s[i]]
+		last[s[i]] = i
+	}
+	buckets := make([][]int, n+1)
+	for l := 0; l < n; l++ {
+		if next[l] < n {
+			buckets[next[l]] = append(buckets[next[l]], l+1)
+		}
+	}
+	ft := NewFenwick(n)
+	var ans int64
+	for r := 0; r < n; r++ {
+		for _, idx := range buckets[r] {
+			ft.Add(idx, 1)
+		}
+		if prev[r] >= 0 {
+			ans += int64(ft.Sum(prev[r] + 1))
+		}
+	}
+	return ans
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []string {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(15) + 1
+		b := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if rng.Intn(2) == 0 {
+				b[j] = 'A'
+			} else {
+				b[j] = 'B'
+			}
+		}
+		tests = append(tests, string(b))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, s := range tests {
+		input := fmt.Sprintf("%d %s\n", len(s), s)
+		want := fmt.Sprintf("%d", countGood(s))
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1200-1299/1230-1239/1238/verifierE.go
+++ b/1000-1999/1200-1299/1230-1239/1238/verifierE.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	m int
+	s string
+}
+
+func solve(n, m int, s string) int {
+	w := make([][]int, m)
+	for i := range w {
+		w[i] = make([]int, m)
+	}
+	for i := 1; i < n; i++ {
+		a := int(s[i-1] - 'a')
+		b := int(s[i] - 'a')
+		if a == b || a >= m || b >= m {
+			continue
+		}
+		w[a][b]++
+		w[b][a]++
+	}
+	total := make([]int, m)
+	for i := 0; i < m; i++ {
+		sum := 0
+		for j := 0; j < m; j++ {
+			sum += w[i][j]
+		}
+		total[i] = sum
+	}
+	maxMask := 1 << m
+	sumW := make([][]int, m)
+	for j := 0; j < m; j++ {
+		arr := make([]int, maxMask)
+		for mask := 1; mask < maxMask; mask++ {
+			lb := mask & -mask
+			k := bits.TrailingZeros(uint(lb))
+			arr[mask] = arr[mask^lb] + w[j][k]
+		}
+		sumW[j] = arr
+	}
+	cross := make([]int, maxMask)
+	for mask := 1; mask < maxMask; mask++ {
+		lb := mask & -mask
+		j := bits.TrailingZeros(uint(lb))
+		prev := mask ^ lb
+		cross[mask] = cross[prev] + total[j] - 2*sumW[j][prev]
+	}
+	const inf int = int(1e18)
+	dp := make([]int, maxMask)
+	for i := 1; i < maxMask; i++ {
+		dp[i] = inf
+	}
+	for mask := 0; mask < maxMask; mask++ {
+		for j := 0; j < m; j++ {
+			if mask&(1<<j) == 0 {
+				next := mask | (1 << j)
+				val := dp[mask] + cross[next]
+				if val < dp[next] {
+					dp[next] = val
+				}
+			}
+		}
+	}
+	return dp[maxMask-1]
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		m := rng.Intn(4) + 1
+		n := rng.Intn(10) + 1
+		b := make([]byte, n)
+		for j := 0; j < n; j++ {
+			b[j] = byte('a' + rng.Intn(m))
+		}
+		tests = append(tests, testCase{n: n, m: m, s: string(b)})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("%d %d\n%s\n", t.n, t.m, t.s)
+		want := fmt.Sprintf("%d", solve(t.n, t.m, t.s))
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1200-1299/1230-1239/1238/verifierF.go
+++ b/1000-1999/1200-1299/1230-1239/1238/verifierF.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n     int
+	edges [][2]int
+}
+
+func solve(n int, edges [][2]int) int {
+	g := make([][]int, n)
+	for _, e := range edges {
+		x, y := e[0], e[1]
+		g[x] = append(g[x], y)
+		g[y] = append(g[y], x)
+	}
+	w := make([]int, n)
+	for i := 0; i < n; i++ {
+		w[i] = len(g[i]) - 1
+	}
+	down := make([]int, n)
+	ans := 0
+	var dfs func(v, p int)
+	dfs = func(v, p int) {
+		max1, max2 := 0, 0
+		for _, u := range g[v] {
+			if u == p {
+				continue
+			}
+			dfs(u, v)
+			val := down[u]
+			if val > max1 {
+				max2 = max1
+				max1 = val
+			} else if val > max2 {
+				max2 = val
+			}
+		}
+		if cur := w[v] + max1 + max2; cur > ans {
+			ans = cur
+		}
+		down[v] = w[v] + max1
+	}
+	dfs(0, -1)
+	return ans + 2
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []testCase {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 2
+		edges := make([][2]int, n-1)
+		for j := 0; j < n-1; j++ {
+			x := rng.Intn(j + 1)
+			y := j + 1
+			edges[j] = [2]int{x, y}
+		}
+		tests = append(tests, testCase{n: n, edges: edges})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("1\n%d\n", t.n)
+		for _, e := range t.edges {
+			input += fmt.Sprintf("%d %d\n", e[0]+1, e[1]+1)
+		}
+		want := fmt.Sprintf("%d", solve(t.n, t.edges))
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1200-1299/1230-1239/1238/verifierG.go
+++ b/1000-1999/1200-1299/1230-1239/1238/verifierG.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Event struct {
+	t int64
+	a int64
+	b int64
+}
+
+type MinHeap []int64
+
+type MaxHeap []int64
+
+func (h MinHeap) Len() int            { return len(h) }
+func (h MinHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h MinHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MinHeap) Push(x interface{}) { *h = append(*h, x.(int64)) }
+func (h *MinHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func (h MaxHeap) Len() int            { return len(h) }
+func (h MaxHeap) Less(i, j int) bool  { return h[i] > h[j] }
+func (h MaxHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *MaxHeap) Push(x interface{}) { *h = append(*h, x.(int64)) }
+func (h *MaxHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func solve(n int, m, c, c0 int64, events []Event) int64 {
+	total := c0
+	for _, e := range events {
+		total += e.a
+	}
+	if total < m {
+		return -1
+	}
+	sort.Slice(events, func(i, j int) bool { return events[i].t < events[j].t })
+	events = append(events, Event{t: m})
+
+	minH := &MinHeap{}
+	maxH := &MaxHeap{}
+	heap.Init(minH)
+	heap.Init(maxH)
+	counts := make(map[int64]int64)
+
+	counts[0] = c0
+	heap.Push(minH, int64(0))
+	heap.Push(maxH, int64(0))
+
+	volume := c0
+	var costSum int64
+	prev := int64(0)
+	possible := true
+
+	consume := func(need int64) bool {
+		for need > 0 {
+			if minH.Len() == 0 {
+				return false
+			}
+			cost := heap.Pop(minH).(int64)
+			cnt := counts[cost]
+			if cnt == 0 {
+				continue
+			}
+			use := need
+			if cnt < use {
+				use = cnt
+			}
+			cnt -= use
+			counts[cost] = cnt
+			need -= use
+			volume -= use
+			costSum += cost * use
+			if cnt > 0 {
+				heap.Push(minH, cost)
+				heap.Push(maxH, cost)
+			}
+		}
+		return true
+	}
+
+	discard := func(rem int64) {
+		for rem > 0 {
+			if maxH.Len() == 0 {
+				break
+			}
+			cost := heap.Pop(maxH).(int64)
+			cnt := counts[cost]
+			if cnt == 0 {
+				continue
+			}
+			use := rem
+			if cnt < use {
+				use = cnt
+			}
+			cnt -= use
+			counts[cost] = cnt
+			rem -= use
+			volume -= use
+			if cnt > 0 {
+				heap.Push(minH, cost)
+				heap.Push(maxH, cost)
+			}
+		}
+	}
+
+	for _, e := range events {
+		delta := e.t - prev
+		if delta > 0 {
+			if volume < delta {
+				possible = false
+				break
+			}
+			if !consume(delta) {
+				possible = false
+				break
+			}
+		}
+		if e.t == m {
+			break
+		}
+		counts[e.b] += e.a
+		heap.Push(minH, e.b)
+		heap.Push(maxH, e.b)
+		volume += e.a
+		if volume > c {
+			discard(volume - c)
+		}
+		prev = e.t
+	}
+
+	if possible {
+		return costSum
+	}
+	return -1
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateTests() []struct {
+	n        int
+	m, c, c0 int64
+	events   []Event
+} {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]struct {
+		n        int
+		m, c, c0 int64
+		events   []Event
+	}, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(4) + 1
+		m := int64(rng.Intn(20) + 5)
+		c := int64(rng.Intn(10) + 5)
+		if c > m {
+			c = m
+		}
+		c0 := int64(rng.Intn(int(c) + 1))
+		events := make([]Event, n)
+		curT := int64(0)
+		for j := 0; j < n; j++ {
+			curT += int64(rng.Intn(5) + 1)
+			a := int64(rng.Intn(5) + 1)
+			b := int64(rng.Intn(5) + 1)
+			events[j] = Event{t: curT, a: a, b: b}
+		}
+		tests = append(tests, struct {
+			n        int
+			m, c, c0 int64
+			events   []Event
+		}{n: n, m: m, c: c, c0: c0, events: events})
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, t := range tests {
+		input := fmt.Sprintf("1\n%d %d %d %d\n", t.n, t.m, t.c, t.c0)
+		for _, e := range t.events {
+			input += fmt.Sprintf("%d %d %d\n", e.t, e.a, e.b)
+		}
+		want := fmt.Sprintf("%d", solve(t.n, t.m, t.c, t.c0, append([]Event(nil), t.events...)))
+		got, err := runCandidate(bin, input)
+		if err != nil {
+			fmt.Printf("case %d runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != want {
+			fmt.Printf("case %d failed: expected %s got %s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–G of contest 1238
- each verifier generates at least 100 randomized test cases
- verifiers run an arbitrary binary (or Go source) and compare outputs with the reference implementation logic

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6884c9a43fa48324a9fcc5630e21b53f