### PR TITLE
Add Go solution for 1833E

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1833/1833E.go
+++ b/1000-1999/1800-1899/1830-1839/1833/1833E.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+
+		adj := make([][]int, n+1)
+		for i := 1; i <= n; i++ {
+			j := a[i]
+			exists := false
+			for _, v := range adj[i] {
+				if v == j {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				adj[i] = append(adj[i], j)
+			}
+			exists = false
+			for _, v := range adj[j] {
+				if v == i {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				adj[j] = append(adj[j], i)
+			}
+		}
+
+		visited := make([]bool, n+1)
+		components := 0
+		cycleComp := 0
+
+		for i := 1; i <= n; i++ {
+			if visited[i] {
+				continue
+			}
+			components++
+			queue := []int{i}
+			visited[i] = true
+			isCycle := true
+			for len(queue) > 0 {
+				v := queue[0]
+				queue = queue[1:]
+				if len(adj[v]) != 2 {
+					isCycle = false
+				}
+				for _, to := range adj[v] {
+					if !visited[to] {
+						visited[to] = true
+						queue = append(queue, to)
+					}
+				}
+			}
+			if isCycle {
+				cycleComp++
+			}
+		}
+
+		pathComp := components - cycleComp
+		maxCycles := components
+		minCycles := cycleComp
+		if pathComp > 0 {
+			minCycles++
+		}
+		fmt.Fprintf(out, "%d %d\n", minCycles, maxCycles)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation solving problem E from 1833

## Testing
- `go vet 1000-1999/1800-1899/1830-1839/1833/1833E.go`
- `go build 1000-1999/1800-1899/1830-1839/1833/1833E.go`
- `echo '1
6
2 1 4 3 6 5
' | go run 1000-1999/1800-1899/1830-1839/1833/1833E.go`
- `echo -e '3
4
2 1 1 2
8
2 1 1 2 6 5 5 6
5
2 3 1 5 4
' | go run 1000-1999/1800-1899/1830-1839/1833/1833E.go`

------
https://chatgpt.com/codex/tasks/task_e_6884c95e2ec8832484d2c5611ef4f147