### PR TITLE
Add Go verifiers for contest 1242

### DIFF
--- a/1000-1999/1200-1299/1240-1249/1242/verifierA.go
+++ b/1000-1999/1200-1299/1240-1249/1242/verifierA.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(n int64) int64 {
+	if n == 1 {
+		return 1
+	}
+	orig := n
+	var p int64 = -1
+	for i := int64(2); i*i <= n; i++ {
+		if n%i == 0 {
+			p = i
+			break
+		}
+	}
+	if p == -1 {
+		return n
+	}
+	for orig%p == 0 {
+		orig /= p
+	}
+	if orig == 1 {
+		return p
+	}
+	return 1
+}
+
+func genCase(rng *rand.Rand) int64 {
+	return rng.Int63n(1_000_000_000_000) + 1
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	cases := []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 16, 17, 25, 27, 30, 36, 49, 60, 97}
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, n := range cases {
+		in := fmt.Sprintf("%d\n", n)
+		exp := fmt.Sprintf("%d", solve(n))
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1240-1249/1242/verifierB.go
+++ b/1000-1999/1200-1299/1240-1249/1242/verifierB.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type edge struct{ a, b int }
+
+func solve(n int, edges []edge) int {
+	adj := make([]map[int]struct{}, n+1)
+	for _, e := range edges {
+		if adj[e.a] == nil {
+			adj[e.a] = make(map[int]struct{})
+		}
+		if adj[e.b] == nil {
+			adj[e.b] = make(map[int]struct{})
+		}
+		adj[e.a][e.b] = struct{}{}
+		adj[e.b][e.a] = struct{}{}
+	}
+	unvis := make(map[int]struct{}, n)
+	for i := 1; i <= n; i++ {
+		unvis[i] = struct{}{}
+	}
+	components := 0
+	queue := make([]int, 0)
+	for len(unvis) > 0 {
+		var start int
+		for k := range unvis {
+			start = k
+			break
+		}
+		queue = append(queue, start)
+		delete(unvis, start)
+		for len(queue) > 0 {
+			v := queue[0]
+			queue = queue[1:]
+			for u := range unvis {
+				if _, ok := adj[v][u]; !ok {
+					queue = append(queue, u)
+					delete(unvis, u)
+				}
+			}
+		}
+		components++
+	}
+	return components - 1
+}
+
+func genCase(rng *rand.Rand) (int, []edge) {
+	n := rng.Intn(20) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	edges := make([]edge, 0, m)
+	used := make(map[[2]int]struct{})
+	for len(edges) < m {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		if a == b {
+			continue
+		}
+		if a > b {
+			a, b = b, a
+		}
+		key := [2]int{a, b}
+		if _, ok := used[key]; ok {
+			continue
+		}
+		used[key] = struct{}{}
+		edges = append(edges, edge{a, b})
+	}
+	return n, edges
+}
+
+func formatInput(n int, edges []edge) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.a, e.b))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []struct {
+		n  int
+		es []edge
+	}
+	// simple base cases
+	cases = append(cases, struct {
+		n  int
+		es []edge
+	}{1, nil})
+	cases = append(cases, struct {
+		n  int
+		es []edge
+	}{2, []edge{{1, 2}}})
+	cases = append(cases, struct {
+		n  int
+		es []edge
+	}{3, []edge{}})
+	for len(cases) < 100 {
+		n, es := genCase(rng)
+		cases = append(cases, struct {
+			n  int
+			es []edge
+		}{n, es})
+	}
+
+	for i, tc := range cases {
+		in := formatInput(tc.n, tc.es)
+		exp := fmt.Sprintf("%d", solve(tc.n, tc.es))
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1240-1249/1242/verifierC.go
+++ b/1000-1999/1200-1299/1240-1249/1242/verifierC.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+// Implementation of the reference solution from 1242C.go
+
+type cycle struct {
+	mask  int
+	nodes []int64
+}
+
+type move struct {
+	num  int64
+	dest int
+}
+
+func solveC(k int, boxes [][]int64) (string, []move) {
+	boxsum := make([]int64, k)
+	whichbox := make(map[int64]int)
+	var total int64
+	var nodes []int64
+	for i := 0; i < k; i++ {
+		for _, v := range boxes[i] {
+			whichbox[v] = i
+			nodes = append(nodes, v)
+			total += v
+			boxsum[i] += v
+		}
+	}
+	if total%int64(k) != 0 {
+		return "NO", nil
+	}
+	target := total / int64(k)
+	nxt := make(map[int64]int64, len(nodes))
+	for i := 0; i < k; i++ {
+		for _, v := range boxes[i] {
+			needed := target - boxsum[i] + v
+			if _, ok := whichbox[needed]; ok {
+				nxt[v] = needed
+			} else {
+				nxt[v] = -1
+			}
+		}
+	}
+	processed := make(map[int64]bool)
+	var validcycles []cycle
+	for _, start := range nodes {
+		if processed[start] {
+			continue
+		}
+		position := make(map[int64]int)
+		var path []int64
+		cur := start
+		found := false
+		for cur != -1 {
+			if _, seen := position[cur]; seen {
+				found = true
+				break
+			}
+			position[cur] = len(path)
+			path = append(path, cur)
+			cur = nxt[cur]
+		}
+		if found {
+			pos := position[cur]
+			var mask int
+			var cyc []int64
+			ok := true
+			for _, v := range path[pos:] {
+				b := whichbox[v]
+				if mask&(1<<b) != 0 {
+					ok = false
+					break
+				}
+				mask |= 1 << b
+				cyc = append(cyc, v)
+			}
+			if ok {
+				validcycles = append(validcycles, cycle{mask: mask, nodes: cyc})
+			}
+		}
+		for _, v := range path {
+			processed[v] = true
+		}
+	}
+	fullMask := (1 << k) - 1
+	cyclesByMask := make([][]int, fullMask+1)
+	for i, c := range validcycles {
+		cyclesByMask[c.mask] = append(cyclesByMask[c.mask], i)
+	}
+	dp := make([]bool, fullMask+1)
+	parent := make([]int, fullMask+1)
+	used := make([]int, fullMask+1)
+	f := make([]bool, fullMask+1)
+	dp[0] = true
+	for _, c := range validcycles {
+		f[c.mask] = true
+	}
+	for mask := 0; mask <= fullMask; mask++ {
+		if !dp[mask] {
+			continue
+		}
+		remain := fullMask ^ mask
+		for s := remain; s > 0; s = (s - 1) & remain {
+			if !f[s] {
+				continue
+			}
+			newMask := mask | s
+			if !dp[newMask] {
+				dp[newMask] = true
+				parent[newMask] = mask
+				used[newMask] = s
+			}
+		}
+	}
+	if !dp[fullMask] {
+		return "NO", nil
+	}
+	var chain []int
+	for m := fullMask; m != 0; m = parent[m] {
+		chain = append(chain, used[m])
+	}
+	for i, j := 0, len(chain)-1; i < j; i, j = i+1, j-1 {
+		chain[i], chain[j] = chain[j], chain[i]
+	}
+	var ans []move
+	for _, sm := range chain {
+		ci := cyclesByMask[sm][0]
+		cyc := validcycles[ci].nodes
+		for i, j := 0, len(cyc)-1; i < j; i, j = i+1, j-1 {
+			cyc[i], cyc[j] = cyc[j], cyc[i]
+		}
+		t := len(cyc)
+		for i := 0; i < t; i++ {
+			num := cyc[i]
+			destBox := whichbox[cyc[(i+1)%t]] + 1
+			ans = append(ans, move{num: num, dest: destBox})
+		}
+	}
+	sort.Slice(ans, func(i, j int) bool {
+		bi := whichbox[ans[i].num]
+		bj := whichbox[ans[j].num]
+		return bi < bj
+	})
+	return "YES", ans
+}
+
+func formatInput(k int, boxes [][]int64) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", k))
+	for _, box := range boxes {
+		sb.WriteString(fmt.Sprintf("%d ", len(box)))
+		for i, v := range box {
+			if i+1 == len(box) {
+				sb.WriteString(fmt.Sprintf("%d\n", v))
+			} else {
+				sb.WriteString(fmt.Sprintf("%d ", v))
+			}
+		}
+	}
+	return sb.String()
+}
+
+func formatOutput(status string, moves []move) string {
+	if status == "NO" {
+		return "NO"
+	}
+	var sb strings.Builder
+	sb.WriteString("YES\n")
+	for _, mv := range moves {
+		sb.WriteString(fmt.Sprintf("%d %d\n", mv.num, mv.dest))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genCase(rng *rand.Rand) (int, [][]int64) {
+	k := rng.Intn(3) + 1
+	boxes := make([][]int64, k)
+	used := make(map[int64]bool)
+	for i := 0; i < k; i++ {
+		n := rng.Intn(3) + 1
+		boxes[i] = make([]int64, n)
+		for j := 0; j < n; j++ {
+			var v int64
+			for {
+				v = int64(rng.Intn(20) - 10)
+				if !used[v] {
+					break
+				}
+			}
+			used[v] = true
+			boxes[i][j] = v
+		}
+	}
+	return k, boxes
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases []struct {
+		k     int
+		boxes [][]int64
+	}
+	k1 := 1
+	boxes1 := [][]int64{{5}}
+	cases = append(cases, struct {
+		k     int
+		boxes [][]int64
+	}{k1, boxes1})
+	for len(cases) < 100 {
+		k, b := genCase(rng)
+		cases = append(cases, struct {
+			k     int
+			boxes [][]int64
+		}{k, b})
+	}
+
+	for i, tc := range cases {
+		in := formatInput(tc.k, tc.boxes)
+		status, moves := solveC(tc.k, tc.boxes)
+		exp := formatOutput(status, moves)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\n got:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1240-1249/1242/verifierD.go
+++ b/1000-1999/1200-1299/1240-1249/1242/verifierD.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func indexInSequence(n int64, k int) int64 {
+	used := make(map[int64]bool)
+	var p int64 = 1
+	var idx int64
+	for {
+		nums := make([]int64, 0, k)
+		for len(nums) < k {
+			if !used[p] {
+				nums = append(nums, p)
+				used[p] = true
+			}
+			p++
+		}
+		for _, v := range nums {
+			idx++
+			if v == n {
+				return idx
+			}
+		}
+		var sum int64
+		for _, v := range nums {
+			sum += v
+		}
+		idx++
+		if sum == n {
+			return idx
+		}
+		used[sum] = true
+		if idx > n*2 {
+			break
+		}
+	}
+	return -1
+}
+
+func genCase(rng *rand.Rand) (int64, int) {
+	n := int64(rng.Intn(200) + 1)
+	k := rng.Intn(4) + 1
+	return n, k
+}
+
+func formatInput(cases [][2]int64) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(cases)))
+	for _, c := range cases {
+		sb.WriteString(fmt.Sprintf("%d %d\n", c[0], c[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases [][2]int64
+	cases = append(cases, [2]int64{1, 1})
+	for len(cases) < 100 {
+		n, k := genCase(rng)
+		cases = append(cases, [2]int64{n, int64(k)})
+	}
+
+	input := formatInput(cases)
+	var expOut strings.Builder
+	for _, c := range cases {
+		expOut.WriteString(fmt.Sprintf("%d\n", indexInSequence(c[0], int(c[1]))))
+	}
+	expected := strings.TrimSpace(expOut.String())
+
+	out, err := run(bin, input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "verification failed: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != expected {
+		fmt.Fprintf(os.Stderr, "verification failed: expected:\n%s\n got:\n%s\n", expected, out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1240-1249/1242/verifierE.go
+++ b/1000-1999/1200-1299/1240-1249/1242/verifierE.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveE(t []int) string {
+	n := len(t)
+	pocz := make([]int, n)
+	total := 0
+	for i := 0; i < n; i++ {
+		pocz[i] = total
+		total += t[i]
+	}
+	f := make([]int, total)
+	for i := 0; i < total; i++ {
+		f[i] = i
+	}
+	comp := total
+	res := make([]int, total)
+	p := make([]int, n)
+	for i := 0; i < n; i++ {
+		p[i] = i
+	}
+	sort.Slice(p, func(i, j int) bool { return t[p[i]] > t[p[j]] })
+	var find func(int) int
+	find = func(a int) int {
+		if f[a] != a {
+			f[a] = find(f[a])
+		}
+		return f[a]
+	}
+	uni := func(a, b int) {
+		a = find(a)
+		b = find(b)
+		if a != b {
+			f[a] = b
+			comp--
+		}
+	}
+	daj := func(x int) []int {
+		arr := make([]int, t[x])
+		for i := 0; i < t[x]; i++ {
+			arr[i] = pocz[x] + i
+		}
+		return arr
+	}
+	ak := list.New()
+	for _, v := range daj(p[0]) {
+		ak.PushBack(v)
+	}
+	for idx := 1; idx < n; idx++ {
+		i := p[idx]
+		nextSize := 3
+		if idx < n-1 {
+			nextSize = t[p[idx+1]]
+		}
+		pom := daj(i)
+		back := ak.Back().Value.(int)
+		uni(pom[len(pom)-1], ak.Back().Value.(int))
+		ak.Remove(ak.Back())
+		pom = pom[:len(pom)-1]
+		uni(pom[len(pom)-1], ak.Back().Value.(int))
+		ak.Remove(ak.Back())
+		for len(pom) > 1 && len(pom)+ak.Len()-2 >= nextSize {
+			pom = pom[:len(pom)-1]
+			ak.Remove(ak.Back())
+			uni(pom[len(pom)-1], ak.Back().Value.(int))
+		}
+		pom = pom[:len(pom)-1]
+		for j := len(pom) - 1; j >= 0; j-- {
+			ak.PushBack(pom[j])
+		}
+		ak.PushFront(back)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", comp))
+	ver := 1
+	for i := 0; i < n; i++ {
+		var line strings.Builder
+		for j := 0; j < t[i]; j++ {
+			idx := pocz[i] + j
+			root := find(idx)
+			if res[root] == 0 {
+				res[root] = ver
+				ver++
+			}
+			line.WriteString(fmt.Sprintf("%d ", res[root]))
+		}
+		sb.WriteString(strings.TrimSpace(line.String()))
+		sb.WriteString("\n")
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func genCase(rng *rand.Rand) []int {
+	n := rng.Intn(3) + 1
+	t := make([]int, n)
+	for i := 0; i < n; i++ {
+		t[i] = rng.Intn(3) + 1
+	}
+	return t
+}
+
+func formatInput(t []int) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t)))
+	for i, v := range t {
+		if i+1 == len(t) {
+			sb.WriteString(fmt.Sprintf("%d\n", v))
+		} else {
+			sb.WriteString(fmt.Sprintf("%d ", v))
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var cases [][]int
+	cases = append(cases, []int{1})
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, t := range cases {
+		in := formatInput(t)
+		exp := solveE(t)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\n got:\n%s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1242 problems A–E
- each verifier generates at least 100 randomized test cases
- verifiers run an arbitrary binary (or Go source) and check outputs

## Testing
- `go build 1000-1999/1200-1299/1240-1249/1242/verifierA.go`
- `go build 1000-1999/1200-1299/1240-1249/1242/verifierB.go`
- `go build 1000-1999/1200-1299/1240-1249/1242/verifierC.go`
- `go build 1000-1999/1200-1299/1240-1249/1242/verifierD.go`
- `go build 1000-1999/1200-1299/1240-1249/1242/verifierE.go`

------
https://chatgpt.com/codex/tasks/task_e_6884cbd494948324b6eca28c67167f6c