### PR TITLE
Add Go verifiers for Codeforces 1245

### DIFF
--- a/1000-1999/1200-1299/1240-1249/1245/verifierA.go
+++ b/1000-1999/1200-1299/1240-1249/1245/verifierA.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1245A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	a := rng.Intn(10000) + 1
+	b := rng.Intn(10000) + 1
+	return fmt.Sprintf("1\n%d %d\n", a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		want, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(strings.ToLower(got)) != strings.TrimSpace(strings.ToLower(want)) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1240-1249/1245/verifierB.go
+++ b/1000-1999/1200-1299/1240-1249/1245/verifierB.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCaseB struct {
+	n int
+	a int
+	b int
+	c int
+	s string
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func computeWin(tc testCaseB) (bool, string) {
+	ans := make([]byte, tc.n)
+	wins := 0
+	a, b, c := tc.a, tc.b, tc.c
+	for i, ch := range tc.s {
+		switch ch {
+		case 'R':
+			if b > 0 {
+				ans[i] = 'P'
+				b--
+				wins++
+			}
+		case 'P':
+			if c > 0 {
+				ans[i] = 'S'
+				c--
+				wins++
+			}
+		case 'S':
+			if a > 0 {
+				ans[i] = 'R'
+				a--
+				wins++
+			}
+		}
+	}
+	if wins < (tc.n+1)/2 {
+		return false, ""
+	}
+	for i := 0; i < tc.n; i++ {
+		if ans[i] == 0 {
+			if a > 0 {
+				ans[i] = 'R'
+				a--
+			} else if b > 0 {
+				ans[i] = 'P'
+				b--
+			} else {
+				ans[i] = 'S'
+				c--
+			}
+		}
+	}
+	return true, string(ans)
+}
+
+func validateOutput(tc testCaseB, out string) error {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	var lines []string
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" || len(lines) < 2 {
+			lines = append(lines, line)
+		}
+	}
+	if len(lines) == 0 {
+		return fmt.Errorf("no output")
+	}
+	first := strings.ToUpper(lines[0])
+	canWin, _ := computeWin(tc)
+	if first == "NO" {
+		if canWin {
+			return fmt.Errorf("should be YES")
+		}
+		if len(lines) > 1 && strings.TrimSpace(lines[1]) != "" {
+			return fmt.Errorf("extra output after NO")
+		}
+		return nil
+	}
+	if first != "YES" {
+		return fmt.Errorf("first line must be YES or NO")
+	}
+	if !canWin {
+		return fmt.Errorf("should be NO")
+	}
+	if len(lines) < 2 {
+		return fmt.Errorf("missing answer string")
+	}
+	ans := lines[1]
+	if len(ans) != tc.n {
+		return fmt.Errorf("answer length %d expected %d", len(ans), tc.n)
+	}
+	rc, pc, sc := 0, 0, 0
+	wins := 0
+	for i := 0; i < tc.n; i++ {
+		ch := ans[i]
+		switch ch {
+		case 'R':
+			rc++
+			if tc.s[i] == 'S' {
+				wins++
+			}
+		case 'P':
+			pc++
+			if tc.s[i] == 'R' {
+				wins++
+			}
+		case 'S':
+			sc++
+			if tc.s[i] == 'P' {
+				wins++
+			}
+		default:
+			return fmt.Errorf("invalid char %c", ch)
+		}
+	}
+	if rc != tc.a || pc != tc.b || sc != tc.c {
+		return fmt.Errorf("counts mismatch")
+	}
+	if wins < (tc.n+1)/2 {
+		return fmt.Errorf("not enough wins")
+	}
+	if len(lines) > 2 && strings.TrimSpace(lines[2]) != "" {
+		return fmt.Errorf("extra output lines")
+	}
+	return nil
+}
+
+func generateCase(rng *rand.Rand) (string, testCaseB) {
+	n := rng.Intn(100) + 1
+	a := rng.Intn(n + 1)
+	b := rng.Intn(n - a + 1)
+	c := n - a - b
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", a, b, c))
+	moves := []byte{'R', 'P', 'S'}
+	sbytes := make([]byte, n)
+	for i := 0; i < n; i++ {
+		sbytes[i] = moves[rng.Intn(3)]
+	}
+	s := string(sbytes)
+	sb.WriteString(s)
+	sb.WriteByte('\n')
+	return sb.String(), testCaseB{n: n, a: a, b: b, c: c, s: s}
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, tc := generateCase(rng)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if err := validateOutput(tc, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%soutput:%s", i+1, err, input, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1240-1249/1245/verifierC.go
+++ b/1000-1999/1200-1299/1240-1249/1245/verifierC.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod int64 = 1000000007
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func fib(n int) []int64 {
+	f := make([]int64, n+2)
+	f[0] = 1
+	f[1] = 1
+	for i := 2; i <= n; i++ {
+		f[i] = (f[i-1] + f[i-2]) % mod
+	}
+	return f
+}
+
+func solve(s string) int64 {
+	for _, c := range s {
+		if c == 'w' || c == 'm' {
+			return 0
+		}
+	}
+	n := len(s)
+	f := fib(n)
+	res := int64(1)
+	i := 0
+	for i < n {
+		if s[i] == 'u' || s[i] == 'n' {
+			j := i
+			for j < n && s[j] == s[i] {
+				j++
+			}
+			length := j - i
+			res = (res * f[length]) % mod
+			i = j
+		} else {
+			i++
+		}
+	}
+	return res
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		s := generateCase(rng)
+		input := s + "\n"
+		want := solve(s)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output: %v\noutput:%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if got%mod != want%mod {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1240-1249/1245/verifierD.go
+++ b/1000-1999/1200-1299/1240-1249/1245/verifierD.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1245D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		x := rng.Intn(20)
+		y := rng.Intn(20)
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+	}
+	for i := 0; i < n; i++ {
+		c := rng.Intn(100) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		k := rng.Intn(10) + 1
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", k))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func parseCost(out string) (int64, error) {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	if !scanner.Scan() {
+		return 0, fmt.Errorf("no output")
+	}
+	line := strings.Fields(scanner.Text())
+	if len(line) == 0 {
+		return 0, fmt.Errorf("empty output")
+	}
+	return strconv.ParseInt(line[0], 10, 64)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		wantOut, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		want, err := parseCost(wantOut)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle parse error on case %d: %v\noutput:%s", i+1, err, wantOut)
+			os.Exit(1)
+		}
+		gotOut, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := parseCost(gotOut)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output: %v\noutput:%s", i+1, err, gotOut)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected cost %d got %d\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1240-1249/1245/verifierE.go
+++ b/1000-1999/1200-1299/1240-1249/1245/verifierE.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1245E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	var sb strings.Builder
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 10; j++ {
+			val := 0
+			if i > 0 {
+				val = rng.Intn(i)
+			}
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", val))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func parseFloat(out string) (float64, error) {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	if !scanner.Scan() {
+		return 0, fmt.Errorf("no output")
+	}
+	return strconv.ParseFloat(strings.Fields(scanner.Text())[0], 64)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		wantOut, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		want, err := parseFloat(wantOut)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle parse error on case %d: %v\noutput:%s", i+1, err, wantOut)
+			os.Exit(1)
+		}
+		gotOut, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := parseFloat(gotOut)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output: %v\noutput:%s", i+1, err, gotOut)
+			os.Exit(1)
+		}
+		diff := got - want
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > 1e-6 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %f got %f\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1240-1249/1245/verifierF.go
+++ b/1000-1999/1200-1299/1240-1249/1245/verifierF.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1245F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	l := rng.Int63n(1_000_000_000)
+	r := l + rng.Int63n(1_000_000_000-l)
+	return fmt.Sprintf("1\n%d %d\n", l, r)
+}
+
+func parseInt(out string) (int64, error) {
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return 0, fmt.Errorf("no output")
+	}
+	return strconv.ParseInt(fields[0], 10, 64)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		wantOut, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		want, err := parseInt(wantOut)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle parse error on case %d: %v\noutput:%s", i+1, err, wantOut)
+			os.Exit(1)
+		}
+		gotOut, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := parseInt(gotOut)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: cannot parse output: %v\noutput:%s", i+1, err, gotOut)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %d\ninput:%s", i+1, want, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement verifierA.go that uses the official solution as an oracle
- add verifierB.go which validates arbitrary winning strategies
- implement verifierC.go using DP to check outputs
- add oracle based verifiers for problems D, E and F

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884cd79552c832481c1ed423c7b972a