### PR TITLE
Add verifiers for contest 1248

### DIFF
--- a/1000-1999/1200-1299/1240-1249/1248/verifierA.go
+++ b/1000-1999/1200-1299/1240-1249/1248/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expectedA(p, q []int) string {
+	evenP, oddP := 0, 0
+	for _, v := range p {
+		if v%2 == 0 {
+			evenP++
+		} else {
+			oddP++
+		}
+	}
+	evenQ, oddQ := 0, 0
+	for _, v := range q {
+		if v%2 == 0 {
+			evenQ++
+		} else {
+			oddQ++
+		}
+	}
+	ans := int64(evenP*evenQ + oddP*oddQ)
+	return fmt.Sprintf("%d", ans)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+
+	for t := 0; t < 100; t++ {
+		tc := rand.Intn(5) + 1
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", tc))
+		expectedOut := make([]string, tc)
+		for i := 0; i < tc; i++ {
+			n := rand.Intn(10) + 1
+			p := make([]int, n)
+			input.WriteString(fmt.Sprintf("%d\n", n))
+			for j := 0; j < n; j++ {
+				p[j] = rand.Intn(1000)
+				if j > 0 {
+					input.WriteByte(' ')
+				}
+				input.WriteString(fmt.Sprintf("%d", p[j]))
+			}
+			input.WriteByte('\n')
+			m := rand.Intn(10) + 1
+			q := make([]int, m)
+			input.WriteString(fmt.Sprintf("%d\n", m))
+			for j := 0; j < m; j++ {
+				q[j] = rand.Intn(1000)
+				if j > 0 {
+					input.WriteByte(' ')
+				}
+				input.WriteString(fmt.Sprintf("%d", q[j]))
+			}
+			input.WriteByte('\n')
+			expectedOut[i] = expectedA(p, q)
+		}
+		expected := strings.Join(expectedOut, "\n")
+		out, err := runProgram(bin, []byte(input.String()))
+		if err != nil || strings.TrimSpace(out) != expected {
+			fmt.Printf("Test %d failed\n", t+1)
+			fmt.Println("Input:\n", input.String())
+			fmt.Println("Expected:\n", expected)
+			fmt.Println("Output:\n", out)
+			if err != nil {
+				fmt.Println("Error:", err)
+			}
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1240-1249/1248/verifierB.go
+++ b/1000-1999/1200-1299/1240-1249/1248/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expectedB(arr []int64) string {
+	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+	var x, y int64
+	n := len(arr)
+	for i := 0; i < n/2; i++ {
+		x += arr[i]
+	}
+	for i := n / 2; i < n; i++ {
+		y += arr[i]
+	}
+	res := x*x + y*y
+	return fmt.Sprintf("%d", res)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 1
+		arr := make([]int64, n)
+		var input strings.Builder
+		input.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			arr[i] = int64(rand.Intn(1000))
+			if i > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteString(fmt.Sprintf("%d", arr[i]))
+		}
+		input.WriteByte('\n')
+		expected := expectedB(arr)
+		out, err := runProgram(bin, []byte(input.String()))
+		if err != nil || strings.TrimSpace(out) != expected {
+			fmt.Printf("Test %d failed\n", t+1)
+			fmt.Println("Input:\n", input.String())
+			fmt.Println("Expected:\n", expected)
+			fmt.Println("Output:\n", out)
+			if err != nil {
+				fmt.Println("Error:", err)
+			}
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1240-1249/1248/verifierD1.go
+++ b/1000-1999/1200-1299/1240-1249/1248/verifierD1.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProgram(bin string, input []byte) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = bytes.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func expectedD1(s string) string {
+	n := len(s)
+	id, hmin, h, count := 0, 0, 0, 0
+	for i := 0; i < n; i++ {
+		if h < hmin {
+			id = i
+			hmin = h
+			count = 0
+		}
+		if h == hmin {
+			count++
+		}
+		if s[i] == '(' {
+			h++
+		} else {
+			h--
+		}
+	}
+	if h != 0 {
+		return "0\n1 1"
+	}
+	s2 := s[id:] + s[:id]
+	best := count
+	curr1, curr2 := 0, 0
+	a, b := 0, 0
+	a1, a2 := 0, 0
+	h = 0
+	for i := 0; i < n; i++ {
+		if s2[i] == '(' {
+			h++
+		} else {
+			h--
+		}
+		switch {
+		case h == 0:
+			if curr1 > best {
+				best = curr1
+				a = a1
+				b = i
+			}
+			curr1 = 0
+			a1 = i + 1
+		case h == 1:
+			curr1++
+			if curr2+count > best {
+				best = curr2 + count
+				a = a2
+				b = i
+			}
+			curr2 = 0
+			a2 = i + 1
+		case h == 2:
+			curr2++
+		}
+	}
+	start := (a + id) % n
+	end := (b + id) % n
+	return fmt.Sprintf("%d\n%d %d", best, start+1, end+1)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD1.go /path/to/binary")
+		return
+	}
+	rand.Seed(time.Now().UnixNano())
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+
+	for t := 0; t < 100; t++ {
+		n := rand.Intn(20) + 1
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		var s strings.Builder
+		for i := 0; i < n; i++ {
+			if rand.Intn(2) == 0 {
+				s.WriteByte('(')
+			} else {
+				s.WriteByte(')')
+			}
+		}
+		str := s.String()
+		sb.WriteString(str)
+		sb.WriteByte('\n')
+		expected := expectedD1(str)
+		out, err := runProgram(bin, []byte(sb.String()))
+		if err != nil || strings.TrimSpace(out) != expected {
+			fmt.Printf("Test %d failed\n", t+1)
+			fmt.Println("Input:\n", sb.String())
+			fmt.Println("Expected:\n", expected)
+			fmt.Println("Output:\n", out)
+			if err != nil {
+				fmt.Println("Error:", err)
+			}
+			return
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A, B and D1 of contest 1248
- generators create 100 random test cases each
- allow verification of either compiled binaries or Go source solutions

## Testing
- `go run verifierA.go -- 1248A.go`
- `go run verifierB.go -- 1248B.go`
- `go run verifierD1.go -- 1248D1.go`

------
https://chatgpt.com/codex/tasks/task_e_6884cf1d1fe88324bcaf47e1fc002c47