### PR TITLE
Add Go solution for problem 1834B

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1834/1834B.go
+++ b/1000-1999/1800-1899/1830-1839/1834/1834B.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var L, R string
+		fmt.Fscan(reader, &L, &R)
+		// Pad with leading zeros to equal length
+		if len(L) < len(R) {
+			for len(L) < len(R) {
+				L = "0" + L
+			}
+		} else if len(R) < len(L) {
+			for len(R) < len(L) {
+				R = "0" + R
+			}
+		}
+		n := len(L)
+		ans := 0
+		for i := 0; i < n; i++ {
+			if L[i] != R[i] {
+				diff := int(L[i]) - int(R[i])
+				if diff < 0 {
+					diff = -diff
+				}
+				ans = diff + 9*(n-i-1)
+				break
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1834B.go` with digit difference logic

## Testing
- `go build 1000-1999/1800-1899/1830-1839/1834/1834B.go`


------
https://chatgpt.com/codex/tasks/task_e_6884ced78a6883248240b1e384c7d5de