### PR TITLE
Add Go solution for 1834C

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1834/1834C.go
+++ b/1000-1999/1800-1899/1830-1839/1834/1834C.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t++ {
+		var n int
+		fmt.Fscan(in, &n)
+		var s, r string
+		fmt.Fscan(in, &s)
+		fmt.Fscan(in, &r)
+		a := 0
+		b := 0
+		for i := 0; i < n; i++ {
+			if s[i] != r[i] {
+				a++
+			}
+			if s[i] != r[n-1-i] {
+				b++
+			}
+		}
+		ans1 := 2*a - a%2
+		ans2 := 2*b - (1 - b%2)
+		if ans2 < 0 {
+			ans2 = 1
+		}
+		fmt.Fprintln(out, min(ans1, ans2))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution `1834C.go`

## Testing
- `go build 1000-1999/1800-1899/1830-1839/1834/1834C.go`
- `go vet 1000-1999/1800-1899/1830-1839/1834/1834C.go`

------
https://chatgpt.com/codex/tasks/task_e_6884ce4b04a48324ba07659d1f23ca44