### PR TITLE
Add Go verifiers for Codeforces contest 1252

### DIFF
--- a/1000-1999/1200-1299/1250-1259/1252/verifierA.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierA.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1252A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type TestCase string
+
+func genTests() []TestCase {
+	rng := rand.New(rand.NewSource(1))
+	tests := make([]TestCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(20) + 2
+		perm := rng.Perm(n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j, v := range perm {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v+1)
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, TestCase(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1252/verifierB.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1252B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type TestCase string
+
+func genTests() []TestCase {
+	rng := rand.New(rand.NewSource(2))
+	tests := make([]TestCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(9) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for v := 2; v <= n; v++ {
+			u := rng.Intn(v-1) + 1
+			fmt.Fprintf(&sb, "%d %d\n", u, v)
+		}
+		tests = append(tests, TestCase(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1252/verifierC.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierC.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1252C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type TestCase string
+
+func genTests() []TestCase {
+	rng := rand.New(rand.NewSource(3))
+	tests := make([]TestCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(10) + 1
+		q := rng.Intn(10) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, q)
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(2))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < n; j++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(2))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < q; j++ {
+			ra := rng.Intn(n) + 1
+			ca := rng.Intn(n) + 1
+			rb := rng.Intn(n) + 1
+			cb := rng.Intn(n) + 1
+			fmt.Fprintf(&sb, "%d %d %d %d\n", ra, ca, rb, cb)
+		}
+		tests = append(tests, TestCase(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1252/verifierD.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierD.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1252D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type TestCase string
+
+func genTests() []TestCase {
+	rng := rand.New(rand.NewSource(4))
+	letters := []byte{'A', 'B', 'C', 'D', 'E'}
+	tests := make([]TestCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		R := rng.Intn(3) + 1
+		C := rng.Intn(3) + 1
+		Q := rng.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", R, C, Q)
+		for r := 0; r < R; r++ {
+			for c := 0; c < C; c++ {
+				sb.WriteByte(letters[rng.Intn(len(letters))])
+			}
+			sb.WriteByte('\n')
+		}
+		for q := 0; q < Q; q++ {
+			l := rng.Intn(3) + 1
+			for j := 0; j < l; j++ {
+				sb.WriteByte(letters[rng.Intn(len(letters))])
+			}
+			sb.WriteByte('\n')
+		}
+		tests = append(tests, TestCase(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1252/verifierE.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierE.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1252E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type TestCase string
+
+func genTests() []TestCase {
+	rng := rand.New(rand.NewSource(5))
+	tests := make([]TestCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		L := rng.Intn(10)
+		R := L + rng.Intn(10)
+		K := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d\n", n, L, R, K)
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(10))
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, TestCase(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1252/verifierF.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierF.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1252F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type TestCase string
+
+func genTests() []TestCase {
+	rng := rand.New(rand.NewSource(6))
+	tests := make([]TestCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(6) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for v := 2; v <= n; v++ {
+			u := rng.Intn(v-1) + 1
+			fmt.Fprintf(&sb, "%d %d\n", u, v)
+		}
+		tests = append(tests, TestCase(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1252/verifierG.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierG.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1252G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type TestCase string
+
+func genTests() []TestCase {
+	rng := rand.New(rand.NewSource(7))
+	tests := make([]TestCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		N := rng.Intn(3) + 1
+		M := rng.Intn(3) + 1
+		Q := rng.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d\n", N, M, Q)
+		for j := 0; j < N; j++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(10))
+		}
+		sb.WriteByte('\n')
+		for j := 0; j < M; j++ {
+			R := rng.Intn(3) + 1
+			fmt.Fprintf(&sb, "%d ", R)
+			for k := 0; k < R; k++ {
+				fmt.Fprintf(&sb, "%d ", rng.Intn(10))
+			}
+			sb.WriteByte('\n')
+		}
+		for j := 0; j < Q; j++ {
+			X := rng.Intn(M) + 1
+			Y := rng.Intn(3)
+			Z := rng.Intn(10)
+			fmt.Fprintf(&sb, "%d %d %d\n", X, Y, Z)
+		}
+		tests = append(tests, TestCase(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1252/verifierH.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierH.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refH.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1252H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type TestCase string
+
+func genTests() []TestCase {
+	rng := rand.New(rand.NewSource(8))
+	tests := make([]TestCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for j := 0; j < n; j++ {
+			l := rng.Intn(10) + 1
+			w := rng.Intn(10) + 1
+			fmt.Fprintf(&sb, "%d %d\n", l, w)
+		}
+		tests = append(tests, TestCase(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1252/verifierI.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierI.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refI.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1252I.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type TestCase string
+
+func genTests() []TestCase {
+	rng := rand.New(rand.NewSource(9))
+	tests := make([]TestCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		N := rng.Intn(3)
+		xL := 0
+		yL := 0
+		xR := rng.Intn(5) + 1
+		yR := rng.Intn(5) + 1
+		xs := rng.Intn(xR-xL+1) + xL
+		ys := rng.Intn(yR-yL+1) + yL
+		xt := rng.Intn(xR-xL+1) + xL
+		yt := rng.Intn(yR-yL+1) + yL
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d %d\n", N, xL, yL, xR, yR)
+		fmt.Fprintf(&sb, "%d %d\n", xs, ys)
+		fmt.Fprintf(&sb, "%d %d\n", xt, yt)
+		for j := 0; j < N; j++ {
+			xi := rng.Intn(xR-xL+1) + xL
+			yi := rng.Intn(yR-yL+1) + yL
+			ri := rng.Intn(3) + 1
+			fmt.Fprintf(&sb, "%d %d %d\n", xi, yi, ri)
+		}
+		tests = append(tests, TestCase(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1252/verifierJ.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierJ.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refJ.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1252J.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type TestCase string
+
+func genTests() []TestCase {
+	rng := rand.New(rand.NewSource(10))
+	tests := make([]TestCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		N := rng.Intn(5) + 1
+		K := rng.Intn(3) + 1
+		G1 := rng.Intn(5) + 1
+		G2 := rng.Intn(5) + 1
+		G3 := rng.Intn(5) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d %d %d %d\n", N, K, G1, G2, G3)
+		for j := 0; j < N; j++ {
+			if rng.Intn(2) == 0 {
+				sb.WriteByte('.')
+			} else {
+				sb.WriteByte('#')
+			}
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, TestCase(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierJ.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1252/verifierK.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierK.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refK.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1252K.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type TestCase string
+
+func randAB(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = 'A'
+		} else {
+			b[i] = 'B'
+		}
+	}
+	return string(b)
+}
+
+func genTests() []TestCase {
+	rng := rand.New(rand.NewSource(11))
+	tests := make([]TestCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(5) + 1
+		q := rng.Intn(5) + 1
+		s := randAB(rng, n)
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", n, q)
+		sb.WriteString(s)
+		sb.WriteByte('\n')
+		for j := 0; j < q; j++ {
+			if rng.Intn(2) == 0 {
+				l := rng.Intn(n) + 1
+				r := rng.Intn(n-l+1) + l
+				fmt.Fprintf(&sb, "1 %d %d\n", l, r)
+			} else {
+				l := rng.Intn(n) + 1
+				r := rng.Intn(n-l+1) + l
+				A := rng.Intn(10)
+				B := rng.Intn(10)
+				fmt.Fprintf(&sb, "2 %d %d %d %d\n", l, r, A, B)
+			}
+		}
+		tests = append(tests, TestCase(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierK.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1252/verifierL.go
+++ b/1000-1999/1200-1299/1250-1259/1252/verifierL.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func buildRef() (string, error) {
+	ref := "refL.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1252L.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v\n%s", err, out)
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+type TestCase string
+
+func genTests() []TestCase {
+	rng := rand.New(rand.NewSource(12))
+	tests := make([]TestCase, 0, 100)
+	for i := 0; i < 100; i++ {
+		N := rng.Intn(4) + 1
+		K := rng.Intn(3) + 1
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d %d\n", N, K)
+		for j := 1; j <= N; j++ {
+			Ai := rng.Intn(N) + 1
+			Mi := rng.Intn(3)
+			fmt.Fprintf(&sb, "%d %d ", Ai, Mi)
+			for t := 0; t < Mi; t++ {
+				fmt.Fprintf(&sb, "%d ", rng.Intn(5)+1)
+			}
+			sb.WriteByte('\n')
+		}
+		for j := 0; j < K; j++ {
+			fmt.Fprintf(&sb, "%d ", rng.Intn(5)+1)
+		}
+		sb.WriteByte('\n')
+		tests = append(tests, TestCase(sb.String()))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierL.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+	tests := genTests()
+	for i, t := range tests {
+		input := string(t)
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(exp) != strings.TrimSpace(got) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:%sGot:%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` through `verifierL.go` under contest `1252`
- each verifier builds the reference solution and runs 100 random tests against a candidate binary
- fixed build warnings in verifiers

## Testing
- `go build 1000-1999/1200-1299/1250-1259/1252/verifierA.go`
- `go build 1000-1999/1200-1299/1250-1259/1252/verifierB.go`
- `go build 1000-1999/1200-1299/1250-1259/1252/verifierC.go`
- `for f in verifier*.go; do go build $f; done`

------
https://chatgpt.com/codex/tasks/task_e_6884d14d77348324aacb7880adfd3ec9