### PR TITLE
Add Go solution for 1832C

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1832/1832C.go
+++ b/1000-1999/1800-1899/1830-1839/1832/1832C.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// This program solves the problem described in problemC.txt.
+// Given an array, we need a non-empty subsequence with the
+// same contrast (sum of absolute differences of consecutive
+// elements) as the whole array but with minimal length.
+//
+// Removing an element a[i] does not change the contrast if
+// it lies between its neighbours in value, i.e. when
+// |prev-a[i]| + |a[i]-next| = |prev-next|. Therefore the
+// minimal subsequence keeps only the endpoints and the points
+// where the direction of monotonicity changes (local maxima
+// and minima). After building this compressed sequence, if it
+// contains exactly two equal numbers we can reduce it to one
+// element since the contrast is zero.
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		if n == 1 {
+			fmt.Fprintln(out, 1)
+			continue
+		}
+		b := make([]int, 0, n)
+		b = append(b, a[0])
+		for i := 1; i < n-1; i++ {
+			prev := b[len(b)-1]
+			curr := a[i]
+			next := a[i+1]
+			if (prev <= curr && curr <= next) || (prev >= curr && curr >= next) {
+				continue
+			}
+			b = append(b, curr)
+		}
+		b = append(b, a[n-1])
+		ans := len(b)
+		if ans == 2 && b[0] == b[1] {
+			ans = 1
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem C (minimum subsequence keeping contrast) in `1832C.go`
- add algorithm description comments

## Testing
- `go run 1000-1999/1800-1899/1830-1839/1832/1832C.go <<<'3
3
1 2 3
5
1 4 5 3 2
3
1 1 1
'`

------
https://chatgpt.com/codex/tasks/task_e_6884d337d7fc832496717557f0f574a4