### PR TITLE
Add Go verifiers for Codeforces contest 1253

### DIFF
--- a/1000-1999/1200-1299/1250-1259/1253/verifierA.go
+++ b/1000-1999/1200-1299/1250-1259/1253/verifierA.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expectedA(a, b []int) string {
+	n := len(a)
+	diff := make([]int, n)
+	for i := 0; i < n; i++ {
+		diff[i] = b[i] - a[i]
+		if diff[i] < 0 {
+			return "NO"
+		}
+	}
+	i := 0
+	for i < n && diff[i] == 0 {
+		i++
+	}
+	if i == n {
+		return "YES"
+	}
+	k := diff[i]
+	if k <= 0 {
+		return "NO"
+	}
+	for i < n && diff[i] == k {
+		i++
+	}
+	for i < n {
+		if diff[i] != 0 {
+			return "NO"
+		}
+		i++
+	}
+	return "YES"
+}
+
+func generateCaseA(rng *rand.Rand) ([]int, []int) {
+	n := rng.Intn(6) + 1
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(11)
+		b[i] = rng.Intn(11)
+	}
+	return a, b
+}
+
+func runCaseA(bin string, a, b []int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(a)))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	for i, v := range b {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	got = strings.ToUpper(got)
+	expect := expectedA(a, b)
+	if got != expect {
+		return fmt.Errorf("expected %s got %s", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		a, b := generateCaseA(rng)
+		if err := runCaseA(bin, a, b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1253/verifierB.go
+++ b/1000-1999/1200-1299/1250-1259/1253/verifierB.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveB(events []int) ([]int, bool) {
+	inside := map[int]bool{}
+	seen := map[int]bool{}
+	res := []int{}
+	last := 0
+	for i, x := range events {
+		if x > 0 {
+			if seen[x] {
+				return nil, false
+			}
+			seen[x] = true
+			inside[x] = true
+		} else {
+			id := -x
+			if !inside[id] {
+				return nil, false
+			}
+			delete(inside, id)
+		}
+		if len(inside) == 0 {
+			res = append(res, i-last+1)
+			last = i + 1
+			seen = map[int]bool{}
+		}
+	}
+	if len(inside) != 0 || last != len(events) {
+		return nil, false
+	}
+	return res, true
+}
+
+func generateCaseB(rng *rand.Rand) []int {
+	n := rng.Intn(10) + 1
+	events := make([]int, n)
+	for i := 0; i < n; i++ {
+		id := rng.Intn(5) + 1
+		if rng.Intn(2) == 0 {
+			events[i] = id
+		} else {
+			events[i] = -id
+		}
+	}
+	return events
+}
+
+func checkOutputB(events []int, output string, possible bool) error {
+	out := strings.TrimSpace(output)
+	if !possible {
+		if out != "-1" {
+			return fmt.Errorf("expected -1 got %q", out)
+		}
+		return nil
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) != 2 {
+		return fmt.Errorf("expected 2 lines got %d", len(lines))
+	}
+	var d int
+	if _, err := fmt.Sscan(lines[0], &d); err != nil {
+		return fmt.Errorf("failed to parse d: %v", err)
+	}
+	fields := strings.Fields(lines[1])
+	if len(fields) != d {
+		return fmt.Errorf("expected %d segment lengths got %d", d, len(fields))
+	}
+	seg := make([]int, d)
+	for i := 0; i < d; i++ {
+		if _, err := fmt.Sscan(fields[i], &seg[i]); err != nil {
+			return fmt.Errorf("failed to parse segment length: %v", err)
+		}
+	}
+	sum := 0
+	idx := 0
+	for _, c := range seg {
+		sum += c
+		inside := map[int]bool{}
+		seen := map[int]bool{}
+		for j := 0; j < c; j++ {
+			x := events[idx]
+			if x > 0 {
+				if seen[x] {
+					return fmt.Errorf("employee %d enters twice in a day", x)
+				}
+				seen[x] = true
+				inside[x] = true
+			} else {
+				id := -x
+				if !inside[id] {
+					return fmt.Errorf("employee %d leaves before entering", id)
+				}
+				delete(inside, id)
+			}
+			idx++
+		}
+		if len(inside) != 0 {
+			return fmt.Errorf("day not empty at end")
+		}
+	}
+	if sum != len(events) {
+		return fmt.Errorf("segments sum %d != %d", sum, len(events))
+	}
+	return nil
+}
+
+func runCaseB(bin string, events []int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(events)))
+	for i, v := range events {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	seg, ok := solveB(events)
+	possible := ok && seg != nil
+	if err := checkOutputB(events, out.String(), possible); err != nil {
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		events := generateCaseB(rng)
+		if err := runCaseB(bin, events); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1253/verifierC.go
+++ b/1000-1999/1200-1299/1250-1259/1253/verifierC.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expectedC(n, m int, a []int64) []int64 {
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	prefix := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		prefix[i] = prefix[i-1] + a[i-1]
+	}
+	dp := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		if i <= m {
+			dp[i] = prefix[i]
+		} else {
+			dp[i] = prefix[i] + dp[i-m]
+		}
+	}
+	return dp[1:]
+}
+
+func generateCaseC(rng *rand.Rand) (int, int, []int64) {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(n) + 1
+	a := make([]int64, n)
+	for i := 0; i < n; i++ {
+		a[i] = int64(rng.Intn(11))
+	}
+	return n, m, a
+}
+
+func runCaseC(bin string, n, m int, a []int64) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprint(v))
+	}
+	sb.WriteString("\n")
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	fields := strings.Fields(strings.TrimSpace(out.String()))
+	if len(fields) != n {
+		return fmt.Errorf("expected %d values got %d", n, len(fields))
+	}
+	expect := expectedC(n, m, append([]int64(nil), a...))
+	for i := 0; i < n; i++ {
+		var val int64
+		if _, err := fmt.Sscan(fields[i], &val); err != nil {
+			return fmt.Errorf("failed to parse output: %v", err)
+		}
+		if val != expect[i] {
+			return fmt.Errorf("index %d expected %d got %d", i, expect[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, a := generateCaseC(rng)
+		if err := runCaseC(bin, n, m, a); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1253/verifierD.go
+++ b/1000-1999/1200-1299/1250-1259/1253/verifierD.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type dsu struct {
+	parent []int
+	right  []int
+}
+
+func newDSU(n int) *dsu {
+	p := make([]int, n+1)
+	r := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		p[i] = i
+		r[i] = i
+	}
+	return &dsu{p, r}
+}
+
+func (d *dsu) find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *dsu) union(a, b int) {
+	ra := d.find(a)
+	rb := d.find(b)
+	if ra == rb {
+		return
+	}
+	if d.right[ra] < d.right[rb] {
+		ra, rb = rb, ra
+	}
+	d.parent[rb] = ra
+	if d.right[rb] > d.right[ra] {
+		d.right[ra] = d.right[rb]
+	}
+}
+
+func expectedD(n int, edges [][2]int) int {
+	dsu := newDSU(n)
+	for _, e := range edges {
+		dsu.union(e[0], e[1])
+	}
+	ans := 0
+	i := 1
+	for i <= n {
+		r := dsu.right[dsu.find(i)]
+		j := i + 1
+		for j <= r {
+			if dsu.find(j) != dsu.find(i) {
+				dsu.union(i, j)
+				ans++
+			}
+			if dsu.right[dsu.find(i)] > r {
+				r = dsu.right[dsu.find(i)]
+			}
+			j++
+		}
+		i = r + 1
+	}
+	return ans
+}
+
+func generateCaseD(rng *rand.Rand) (int, [][2]int) {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(n*(n-1)/2 + 1)
+	edges := make([][2]int, 0, m)
+	used := make(map[[2]int]bool)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		key := [2]int{u, v}
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		edges = append(edges, key)
+	}
+	return n, edges
+}
+
+func runCaseD(bin string, n int, edges [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, len(edges)))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expect := expectedD(n, edges)
+	var got int
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, edges := generateCaseD(rng)
+		if err := runCaseD(bin, n, edges); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1253/verifierE.go
+++ b/1000-1999/1200-1299/1250-1259/1253/verifierE.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func expectedE(n, m int, ants [][2]int) int {
+	type Ant struct{ x, s int }
+	arr := make([]Ant, n)
+	for i, v := range ants {
+		arr[i] = Ant{v[0], v[1]}
+	}
+	sort.Slice(arr, func(i, j int) bool { return arr[i].x < arr[j].x })
+	const INF = int(1e9)
+	dp := make([]int, m+1)
+	for i := 1; i <= m; i++ {
+		dp[i] = INF
+	}
+	for _, a := range arr {
+		newdp := make([]int, m+1)
+		copy(newdp, dp)
+		best := make([]int, m+1)
+		for i := 0; i <= m; i++ {
+			best[i] = INF
+		}
+		for pos := 0; pos < m; pos++ {
+			if dp[pos] == INF {
+				continue
+			}
+			need := pos + 1
+			d := 0
+			if need < a.x-a.s {
+				d = a.x - a.s - need
+			}
+			r0 := a.x + a.s + d
+			if r0 > m {
+				r0 = m
+			}
+			val := dp[pos] + d - r0
+			if val < best[r0] {
+				best[r0] = val
+			}
+		}
+		pref := INF
+		for r := 0; r <= m; r++ {
+			if best[r] < pref {
+				pref = best[r]
+			}
+			if pref == INF {
+				continue
+			}
+			if cand := pref + r; cand < newdp[r] {
+				newdp[r] = cand
+			}
+		}
+		dp = newdp
+	}
+	return dp[m]
+}
+
+func generateCaseE(rng *rand.Rand) (int, int, [][2]int) {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(10) + 1
+	ants := make([][2]int, n)
+	for i := 0; i < n; i++ {
+		ants[i][0] = rng.Intn(m) + 1
+		ants[i][1] = rng.Intn(5)
+	}
+	return n, m, ants
+}
+
+func runCaseE(bin string, n, m int, ants [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, v := range ants {
+		sb.WriteString(fmt.Sprintf("%d %d\n", v[0], v[1]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expect := expectedE(n, m, ants)
+	var got int
+	if _, err := fmt.Sscan(strings.TrimSpace(out.String()), &got); err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, ants := generateCaseE(rng)
+		if err := runCaseE(bin, n, m, ants); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1253/verifierF.go
+++ b/1000-1999/1200-1299/1250-1259/1253/verifierF.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	u, v int
+	w    int64
+}
+type item struct {
+	node int
+	dist int64
+}
+type priorityQueue []item
+
+func (pq priorityQueue) Len() int            { return len(pq) }
+func (pq priorityQueue) Less(i, j int) bool  { return pq[i].dist < pq[j].dist }
+func (pq priorityQueue) Swap(i, j int)       { pq[i], pq[j] = pq[j], pq[i] }
+func (pq *priorityQueue) Push(x interface{}) { *pq = append(*pq, x.(item)) }
+func (pq *priorityQueue) Pop() interface{} {
+	old := *pq
+	v := old[len(old)-1]
+	*pq = old[:len(old)-1]
+	return v
+}
+
+func expectedF(n, m, k, q int, edges []edge, queries [][2]int) []int64 {
+	g := make([][]edge, n+1)
+	for _, e := range edges {
+		g[e.u] = append(g[e.u], edge{e.v, e.u, e.w})
+		g[e.v] = append(g[e.v], edge{e.u, e.v, e.w})
+	}
+	const INF int64 = 1 << 60
+	dist := make([]int64, n+1)
+	belong := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = INF
+	}
+	pqq := &priorityQueue{}
+	heap.Init(pqq)
+	for i := 1; i <= k; i++ {
+		dist[i] = 0
+		belong[i] = i
+		heap.Push(pqq, item{i, 0})
+	}
+	for pqq.Len() > 0 {
+		it := heap.Pop(pqq).(item)
+		if it.dist != dist[it.node] {
+			continue
+		}
+		u := it.node
+		for _, e := range g[u] {
+			nd := dist[u] + e.w
+			if nd < dist[e.u] {
+				dist[e.u] = nd
+				belong[e.u] = belong[u]
+				heap.Push(pqq, item{e.u, nd})
+			}
+		}
+	}
+	type e2 struct {
+		u, v int
+		w    int64
+	}
+	edges2 := make([]e2, 0)
+	for _, e := range edges {
+		bu := belong[e.u]
+		bv := belong[e.v]
+		if bu != bv {
+			cost := dist[e.u] + dist[e.v] + e.w
+			edges2 = append(edges2, e2{bu, bv, cost})
+		}
+	}
+	sort.Slice(edges2, func(i, j int) bool { return edges2[i].w < edges2[j].w })
+	parent := make([]int, k+1)
+	for i := 1; i <= k; i++ {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	unite := func(a, b int) bool {
+		fa := find(a)
+		fb := find(b)
+		if fa == fb {
+			return false
+		}
+		parent[fb] = fa
+		return true
+	}
+	adj := make([][]edge, k+1)
+	for _, e := range edges2 {
+		if unite(e.u, e.v) {
+			adj[e.u] = append(adj[e.u], edge{e.u, e.v, e.w})
+			adj[e.v] = append(adj[e.v], edge{e.v, e.u, e.w})
+		}
+	}
+	res := make([]int64, len(queries))
+	for idx, qu := range queries {
+		a := qu[0]
+		b := qu[1]
+		// BFS on MST
+		type node struct {
+			id int
+			mx int64
+		}
+		visited := make([]bool, k+1)
+		queue := []node{{a, 0}}
+		visited[a] = true
+		ans := int64(0)
+		for len(queue) > 0 {
+			cur := queue[0]
+			queue = queue[1:]
+			if cur.id == b {
+				ans = cur.mx
+				break
+			}
+			for _, e := range adj[cur.id] {
+				if !visited[e.v] {
+					visited[e.v] = true
+					mx := cur.mx
+					if e.w > mx {
+						mx = e.w
+					}
+					queue = append(queue, node{e.v, mx})
+				}
+			}
+		}
+		res[idx] = ans
+	}
+	return res
+}
+
+func generateCaseF(rng *rand.Rand) (int, int, int, int, []edge, [][2]int) {
+	n := rng.Intn(6) + 1
+	k := rng.Intn(n) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges) + 1
+	edges := make([]edge, 0, m)
+	used := make(map[[2]int]bool)
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if u > v {
+			u, v = v, u
+		}
+		key := [2]int{u, v}
+		if used[key] {
+			continue
+		}
+		used[key] = true
+		w := int64(rng.Intn(10) + 1)
+		edges = append(edges, edge{u, v, w})
+	}
+	q := rng.Intn(5) + 1
+	queries := make([][2]int, q)
+	for i := 0; i < q; i++ {
+		queries[i][0] = rng.Intn(k) + 1
+		queries[i][1] = rng.Intn(k) + 1
+	}
+	return n, m, k, q, edges, queries
+}
+
+func runCaseF(bin string, n, m, k, q int, edges []edge, queries [][2]int) error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, m, k, q))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", e.u, e.v, e.w))
+	}
+	for _, qu := range queries {
+		sb.WriteString(fmt.Sprintf("%d %d\n", qu[0], qu[1]))
+	}
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(sb.String())
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	expected := expectedF(n, m, k, q, edges, queries)
+	outLines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(outLines) != q {
+		return fmt.Errorf("expected %d lines got %d", q, len(outLines))
+	}
+	for i := 0; i < q; i++ {
+		var val int64
+		if _, err := fmt.Sscan(strings.TrimSpace(outLines[i]), &val); err != nil {
+			return fmt.Errorf("failed to parse line %d: %v", i+1, err)
+		}
+		if val != expected[i] {
+			return fmt.Errorf("query %d expected %d got %d", i+1, expected[i], val)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n, m, k, q, edges, queries := generateCaseF(rng)
+		if err := runCaseF(bin, n, m, k, q, edges, queries); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go-based solution verifiers for contest 1253 problems A–F
- each verifier generates 100 random test cases and checks the output of a provided binary

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build 1253A.go`
- `go run verifierA.go ./1253A`

------
https://chatgpt.com/codex/tasks/task_e_6884d1d98cb0832484fcc54cd348fdd3