### PR TITLE
Add Go solution for 1832A

### DIFF
--- a/1000-1999/1800-1899/1830-1839/1832/1832A.go
+++ b/1000-1999/1800-1899/1830-1839/1832/1832A.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(in, &s)
+		freq := make(map[rune]int)
+		for _, c := range s {
+			freq[c]++
+		}
+		if len(freq) == 1 {
+			fmt.Fprintln(out, "NO")
+			continue
+		}
+		if len(freq) == 2 {
+			ones := 0
+			for _, c := range freq {
+				if c == 1 {
+					ones++
+				}
+			}
+			if ones == 1 {
+				fmt.Fprintln(out, "NO")
+				continue
+			}
+		}
+		fmt.Fprintln(out, "YES")
+	}
+}


### PR DESCRIPTION
## Summary
- implement problem A solution for contest 1832 in Go

## Testing
- `go build 1000-1999/1800-1899/1830-1839/1832/1832A.go`
- `go vet 1000-1999/1800-1899/1830-1839/1832/1832A.go`

------
https://chatgpt.com/codex/tasks/task_e_6884d44feb308324b4d25684f00f9a20