### PR TITLE
Add Go verifiers for CF 1257

### DIFF
--- a/1000-1999/1200-1299/1250-1259/1257/verifierA.go
+++ b/1000-1999/1200-1299/1250-1259/1257/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, x, a, b int) int {
+	if a > b {
+		a, b = b, a
+	}
+	dist := b - a
+	ans := dist + x
+	if ans > n-1 {
+		ans = n - 1
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	exp := make([]string, t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(100) + 1
+		x := rng.Intn(100)
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", n, x, a, b))
+		exp[i] = fmt.Sprintf("%d", expected(n, x, a, b))
+	}
+	return sb.String(), exp
+}
+
+func runCase(bin, input string, exp []string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, line := range lines {
+		if strings.TrimSpace(line) != exp[i] {
+			return fmt.Errorf("line %d expected %s got %s", i+1, exp[i], strings.TrimSpace(line))
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1257/verifierB.go
+++ b/1000-1999/1200-1299/1250-1259/1257/verifierB.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(x, y int) string {
+	if x >= y {
+		return "YES"
+	}
+	if x == 1 {
+		return "NO"
+	}
+	if x == 2 && y == 3 {
+		return "YES"
+	}
+	if x <= 3 {
+		return "NO"
+	}
+	return "YES"
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	exp := make([]string, t)
+	for i := 0; i < t; i++ {
+		x := rng.Intn(10) + 1
+		y := rng.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", x, y))
+		exp[i] = expected(x, y)
+	}
+	return sb.String(), exp
+}
+
+func runCase(bin, input string, exp []string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != exp[i] {
+			return fmt.Errorf("line %d expected %s got %s", i+1, exp[i], line)
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1257/verifierC.go
+++ b/1000-1999/1200-1299/1250-1259/1257/verifierC.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(arr []int) int {
+	last := make(map[int]int)
+	best := len(arr) + 10
+	for i, v := range arr {
+		if p, ok := last[v]; ok {
+			if i-p+1 < best {
+				best = i - p + 1
+			}
+		}
+		last[v] = i
+	}
+	if best > len(arr) {
+		return -1
+	}
+	return best
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	exp := make([]string, t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(10) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = rng.Intn(5)
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for j := 0; j < n; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", arr[j]))
+		}
+		sb.WriteByte('\n')
+		exp[i] = fmt.Sprintf("%d", expected(arr))
+	}
+	return sb.String(), exp
+}
+
+func runCase(bin, input string, exp []string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, line := range lines {
+		if strings.TrimSpace(line) != exp[i] {
+			return fmt.Errorf("line %d expected %s got %s", i+1, exp[i], strings.TrimSpace(line))
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1257/verifierD.go
+++ b/1000-1999/1200-1299/1250-1259/1257/verifierD.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(monsters []int, heroes [][2]int) int {
+	n := len(monsters)
+	maxPower := make([]int, n+2)
+	for _, h := range heroes {
+		p, s := h[0], h[1]
+		if s <= n && maxPower[s] < p {
+			maxPower[s] = p
+		}
+	}
+	for i := n - 1; i >= 1; i-- {
+		if maxPower[i] < maxPower[i+1] {
+			maxPower[i] = maxPower[i+1]
+		}
+	}
+	for _, m := range monsters {
+		if m > maxPower[1] {
+			return -1
+		}
+	}
+	days := 0
+	i := 0
+	for i < n {
+		days++
+		maxA := 0
+		j := i
+		for j < n {
+			if monsters[j] > maxA {
+				maxA = monsters[j]
+			}
+			length := j - i + 1
+			if maxPower[length] < maxA {
+				break
+			}
+			j++
+		}
+		i = j
+	}
+	return days
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t))
+	exp := make([]string, t)
+	for caseIdx := 0; caseIdx < t; caseIdx++ {
+		n := rng.Intn(5) + 1
+		monsters := make([]int, n)
+		for i := 0; i < n; i++ {
+			monsters[i] = rng.Intn(9) + 1
+		}
+		sb.WriteString(fmt.Sprintf("%d\n", n))
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", monsters[i]))
+		}
+		sb.WriteByte('\n')
+		m := rng.Intn(5) + 1
+		heroes := make([][2]int, m)
+		for i := 0; i < m; i++ {
+			p := rng.Intn(9) + 1
+			s := rng.Intn(n) + 1
+			heroes[i] = [2]int{p, s}
+			sb.WriteString(fmt.Sprintf("%d %d\n", p, s))
+		}
+		exp[caseIdx] = fmt.Sprintf("%d", expected(monsters, heroes))
+	}
+	return sb.String(), exp
+}
+
+func runCase(bin, input string, exp []string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, line := range lines {
+		if strings.TrimSpace(line) != exp[i] {
+			return fmt.Errorf("line %d expected %s got %s", i+1, exp[i], strings.TrimSpace(line))
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1257/verifierE.go
+++ b/1000-1999/1200-1299/1250-1259/1257/verifierE.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(owner []int) int {
+	const inf = int(1e9)
+	dp1, dp2, dp3 := 0, inf, inf
+	for _, o := range owner {
+		cost1, cost2, cost3 := 0, 0, 0
+		if o != 1 {
+			cost1 = 1
+		}
+		if o != 2 {
+			cost2 = 1
+		}
+		if o != 3 {
+			cost3 = 1
+		}
+		newDp1 := dp1 + cost1
+		newDp2 := min(dp1, dp2) + cost2
+		newDp3 := min(dp2, dp3) + cost3
+		dp1, dp2, dp3 = newDp1, newDp2, newDp3
+	}
+	return dp3
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(10) + 1
+	k1 := rng.Intn(n + 1)
+	k2 := rng.Intn(n - k1 + 1)
+	k3 := n - k1 - k2
+	owner := make([]int, n+1)
+	nums := rng.Perm(n)
+	idx := 0
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", k1, k2, k3))
+	for i := 0; i < k1; i++ {
+		owner[nums[idx]+1] = 1
+		sb.WriteString(fmt.Sprintf("%d ", nums[idx]+1))
+		idx++
+	}
+	if k1 > 0 {
+		sb.WriteByte('\n')
+	} else {
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < k2; i++ {
+		owner[nums[idx]+1] = 2
+		sb.WriteString(fmt.Sprintf("%d ", nums[idx]+1))
+		idx++
+	}
+	if k2 > 0 {
+		sb.WriteByte('\n')
+	} else {
+		sb.WriteByte('\n')
+	}
+	for i := 0; i < k3; i++ {
+		owner[nums[idx]+1] = 3
+		sb.WriteString(fmt.Sprintf("%d ", nums[idx]+1))
+		idx++
+	}
+	if k3 > 0 {
+		sb.WriteByte('\n')
+	} else {
+		sb.WriteByte('\n')
+	}
+	// trim trailing spaces and compute expected
+	lines := strings.Split(sb.String(), "\n")
+	for i := range lines {
+		lines[i] = strings.TrimSpace(lines[i])
+	}
+	input := strings.Join(lines, "\n") + "\n"
+	exp := []string{fmt.Sprintf("%d", expected(owner[1:]))}
+	return input, exp
+}
+
+func runCase(bin, input string, exp []string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, line := range lines {
+		if strings.TrimSpace(line) != exp[i] {
+			return fmt.Errorf("line %d expected %s got %s", i+1, exp[i], strings.TrimSpace(line))
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1257/verifierF.go
+++ b/1000-1999/1200-1299/1250-1259/1257/verifierF.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/bits"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func uniqueInts(a []int) []int {
+	if len(a) == 0 {
+		return a
+	}
+	sort.Ints(a)
+	j := 0
+	for i := 1; i < len(a); i++ {
+		if a[i] != a[j] {
+			j++
+			a[j] = a[i]
+		}
+	}
+	return a[:j+1]
+}
+
+func intsToKey(a []int) string {
+	var sb strings.Builder
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	return sb.String()
+}
+
+func expected(arr []int) int {
+	sort.Ints(arr)
+	arr = uniqueInts(arr)
+	n := len(arr)
+	mp := make(map[string]int)
+	for mask := 0; mask < (1 << 15); mask++ {
+		d := make([]int, n)
+		for i := 0; i < n; i++ {
+			d[i] = bits.OnesCount(uint(arr[i]&0x7fff ^ mask))
+		}
+		base := d[0]
+		for i := 0; i < n; i++ {
+			d[i] -= base
+		}
+		mp[intsToKey(d)] = mask
+	}
+	for mask := 0; mask < (1 << 15); mask++ {
+		d := make([]int, n)
+		for i := 0; i < n; i++ {
+			d[i] = 30 - bits.OnesCount(uint(arr[i]>>15^mask))
+		}
+		base := d[0]
+		for i := 0; i < n; i++ {
+			d[i] -= base
+		}
+		key := intsToKey(d)
+		if low, ok := mp[key]; ok {
+			return (mask << 15) ^ low
+		}
+	}
+	return -1
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(4) + 1
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(1 << 20)
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", arr[i]))
+	}
+	sb.WriteByte('\n')
+	exp := []string{fmt.Sprintf("%d", expected(arr))}
+	return sb.String(), exp
+}
+
+func runCase(bin, input string, exp []string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, line := range lines {
+		if strings.TrimSpace(line) != exp[i] {
+			return fmt.Errorf("line %d expected %s got %s", i+1, exp[i], strings.TrimSpace(line))
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1257/verifierG.go
+++ b/1000-1999/1200-1299/1250-1259/1257/verifierG.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+func expected(counts []int) int64 {
+	n := 0
+	for _, c := range counts {
+		n += c
+	}
+	limit := n / 2
+	dp := make([]int64, limit+1)
+	dp[0] = 1
+	for _, c := range counts {
+		if c > limit {
+			c = limit
+		}
+		next := make([]int64, limit+1)
+		for i := 0; i <= limit; i++ {
+			if dp[i] == 0 {
+				continue
+			}
+			for j := 0; j <= c && i+j <= limit; j++ {
+				next[i+j] = (next[i+j] + dp[i]) % mod
+			}
+		}
+		dp = next
+	}
+	return dp[limit] % mod
+}
+
+func generateCase(rng *rand.Rand) (string, []string) {
+	n := rng.Intn(5) + 1
+	counts := make([]int, n)
+	for i := 0; i < n; i++ {
+		counts[i] = rng.Intn(4) + 1
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", counts[i]))
+	}
+	sb.WriteByte('\n')
+	exp := []string{fmt.Sprintf("%d", expected(counts))}
+	return sb.String(), exp
+}
+
+func runCase(bin, input string, exp []string) error {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != len(exp) {
+		return fmt.Errorf("expected %d lines got %d", len(exp), len(lines))
+	}
+	for i, line := range lines {
+		if strings.TrimSpace(line) != exp[i] {
+			return fmt.Errorf("line %d expected %s got %s", i+1, exp[i], strings.TrimSpace(line))
+		}
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add random test verifiers for all problems in contest 1257
- verifiers produce 100 random tests and run user binary

## Testing
- `GO111MODULE=off go build 1000-1999/1200-1299/1250-1259/1257/verifierA.go`
- `GO111MODULE=off go build 1000-1999/1200-1299/1250-1259/1257/verifierB.go`
- `GO111MODULE=off go build 1000-1999/1200-1299/1250-1259/1257/verifierC.go`
- `GO111MODULE=off go build 1000-1999/1200-1299/1250-1259/1257/verifierD.go`
- `GO111MODULE=off go build 1000-1999/1200-1299/1250-1259/1257/verifierE.go`
- `GO111MODULE=off go build 1000-1999/1200-1299/1250-1259/1257/verifierF.go`
- `GO111MODULE=off go build 1000-1999/1200-1299/1250-1259/1257/verifierG.go`


------
https://chatgpt.com/codex/tasks/task_e_6884d409e2f0832495f8a8333e54aa17