### PR TITLE
Add Go verifiers for CF contest 1256

### DIFF
--- a/1000-1999/1200-1299/1250-1259/1256/verifierA.go
+++ b/1000-1999/1200-1299/1250-1259/1256/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveCase(a, b, n, s int64) string {
+	use := s / n
+	if use > a {
+		use = a
+	}
+	if s-use*n <= b {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generate() (string, string) {
+	const T = 100
+	rand.Seed(1)
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", T)
+	for i := 0; i < T; i++ {
+		a := rand.Int63n(1e9) + 1
+		b := rand.Int63n(1e9) + 1
+		n := rand.Int63n(1e9) + 1
+		s := rand.Int63n(1e9) + 1
+		fmt.Fprintf(&in, "%d %d %d %d\n", a, b, n, s)
+		fmt.Fprintln(&out, solveCase(a, b, n, s))
+	}
+	return in.String(), out.String()
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	in, exp := generate()
+	out, err := runCandidate(bin, in)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		fmt.Fprintln(os.Stderr, "wrong answer")
+		fmt.Fprintln(os.Stderr, "expected:\n"+exp)
+		fmt.Fprintln(os.Stderr, "got:\n"+out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1256/verifierB.go
+++ b/1000-1999/1200-1299/1250-1259/1256/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solvePerm(a []int) []int {
+	n := len(a)
+	used := make([]bool, n-1)
+	for x := 1; x <= n; x++ {
+		pos := 0
+		for pos < n && a[pos] != x {
+			pos++
+		}
+		for pos > 0 && !used[pos-1] && a[pos-1] > a[pos] {
+			a[pos], a[pos-1] = a[pos-1], a[pos]
+			used[pos-1] = true
+			pos--
+		}
+	}
+	return a
+}
+
+func generate() (string, string) {
+	const T = 100
+	rand.Seed(2)
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(10) + 2
+		p := rand.Perm(n)
+		for j := 0; j < n; j++ {
+			p[j]++
+		}
+		tmp := append([]int(nil), p...)
+		res := solvePerm(tmp)
+		fmt.Fprintf(&in, "%d\n", n)
+		for j := 0; j < n; j++ {
+			if j+1 == n {
+				fmt.Fprintf(&in, "%d\n", p[j])
+			} else {
+				fmt.Fprintf(&in, "%d ", p[j])
+			}
+		}
+		for j := 0; j < n; j++ {
+			if j+1 == n {
+				fmt.Fprintf(&out, "%d\n", res[j])
+			} else {
+				fmt.Fprintf(&out, "%d ", res[j])
+			}
+		}
+	}
+	return in.String(), out.String()
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	in, exp := generate()
+	out, err := runCandidate(bin, in)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		fmt.Fprintln(os.Stderr, "wrong answer")
+		fmt.Fprintln(os.Stderr, "expected:\n"+exp)
+		fmt.Fprintln(os.Stderr, "got:\n"+out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1256/verifierC.go
+++ b/1000-1999/1200-1299/1250-1259/1256/verifierC.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveCase(n, m, d int, c []int) (bool, []int) {
+	sum := 0
+	for _, v := range c {
+		sum += v
+	}
+	rem := n - sum
+	if rem > (m+1)*d {
+		return false, nil
+	}
+	gaps := make([]int, m+1)
+	for i := 0; i <= m; i++ {
+		if rem > d {
+			gaps[i] = d
+			rem -= d
+		} else {
+			gaps[i] = rem
+			rem = 0
+		}
+	}
+	ans := make([]int, 0, n)
+	for i := 0; i <= m; i++ {
+		for j := 0; j < gaps[i]; j++ {
+			ans = append(ans, 0)
+		}
+		if i < m {
+			for j := 0; j < c[i]; j++ {
+				ans = append(ans, i+1)
+			}
+		}
+	}
+	return true, ans
+}
+
+func generateCase() (string, string) {
+	m := rand.Intn(5) + 1
+	c := make([]int, m)
+	sum := 0
+	for i := 0; i < m; i++ {
+		c[i] = rand.Intn(3) + 1
+		sum += c[i]
+	}
+	d := rand.Intn(3) + 1
+	var n int
+	if rand.Intn(2) == 0 {
+		n = sum + rand.Intn(d*(m+1)+1)
+	} else {
+		n = sum + (m+1)*d + rand.Intn(5) + 1
+	}
+	ok, ans := solveCase(n, m, d, c)
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d %d %d\n", n, m, d)
+	for i := 0; i < m; i++ {
+		if i+1 == m {
+			fmt.Fprintf(&in, "%d\n", c[i])
+		} else {
+			fmt.Fprintf(&in, "%d ", c[i])
+		}
+	}
+	if !ok {
+		return in.String(), "NO\n"
+	}
+	var out strings.Builder
+	fmt.Fprintln(&out, "YES")
+	for i := 0; i < len(ans); i++ {
+		if i+1 == len(ans) {
+			fmt.Fprintf(&out, "%d\n", ans[i])
+		} else {
+			fmt.Fprintf(&out, "%d ", ans[i])
+		}
+	}
+	return in.String(), out.String()
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(3)
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase()
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\ngot:\n%s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1256/verifierD.go
+++ b/1000-1999/1200-1299/1250-1259/1256/verifierD.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveCase(n int, k int64, s string) string {
+	zeroPos := []int{}
+	for i := 0; i < n; i++ {
+		if s[i] == '0' {
+			zeroPos = append(zeroPos, i)
+		}
+	}
+	res := make([]byte, n)
+	for i := range res {
+		res[i] = '1'
+	}
+	pos := 0
+	for _, idx := range zeroPos {
+		dist := idx - pos
+		shift := int64(dist)
+		if shift > k {
+			shift = k
+		}
+		final := idx - int(shift)
+		res[final] = '0'
+		k -= shift
+		pos++
+	}
+	return string(res)
+}
+
+func generate() (string, string) {
+	const T = 100
+	rand.Seed(4)
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", T)
+	for i := 0; i < T; i++ {
+		n := rand.Intn(20) + 1
+		maxK := int64(n*(n-1)/2 + 1)
+		k := rand.Int63n(maxK)
+		bytes := make([]byte, n)
+		for j := 0; j < n; j++ {
+			if rand.Intn(2) == 0 {
+				bytes[j] = '0'
+			} else {
+				bytes[j] = '1'
+			}
+		}
+		s := string(bytes)
+		fmt.Fprintf(&in, "%d %d\n", n, k)
+		fmt.Fprintf(&in, "%s\n", s)
+		fmt.Fprintln(&out, solveCase(n, k, s))
+	}
+	return in.String(), out.String()
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	in, exp := generate()
+	out, err := runCandidate(bin, in)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		fmt.Fprintln(os.Stderr, "wrong answer")
+		fmt.Fprintln(os.Stderr, "expected:\n"+exp)
+		fmt.Fprintln(os.Stderr, "got:\n"+out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1256/verifierE.go
+++ b/1000-1999/1200-1299/1250-1259/1256/verifierE.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type pair struct {
+	val int
+	idx int
+}
+
+func solveCase(a []int) (int64, int, []int) {
+	n := len(a)
+	pairs := make([]pair, n)
+	for i := 0; i < n; i++ {
+		pairs[i] = pair{val: a[i], idx: i}
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].val < pairs[j].val })
+	const INF int64 = 1<<63 - 1
+	dp := make([]int64, n+1)
+	prev := make([]int, n+1)
+	for i := range dp {
+		dp[i] = INF
+	}
+	dp[0] = 0
+	for i := 3; i <= n; i++ {
+		for s := 3; s <= 5; s++ {
+			if i-s < 0 {
+				continue
+			}
+			diff := pairs[i-1].val - pairs[i-s].val
+			cost := dp[i-s] + int64(diff)
+			if cost < dp[i] {
+				dp[i] = cost
+				prev[i] = s
+			}
+		}
+	}
+	teams := make([]int, n)
+	teamCount := 0
+	for i := n; i > 0; {
+		s := prev[i]
+		teamCount++
+		for j := i - s; j < i; j++ {
+			teams[pairs[j].idx] = teamCount
+		}
+		i -= s
+	}
+	return dp[n], teamCount, teams
+}
+
+func generateCase() (string, string) {
+	n := rand.Intn(10) + 3
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rand.Intn(2000) + 1
+	}
+	cost, teamCount, teams := solveCase(arr)
+	var in strings.Builder
+	fmt.Fprintf(&in, "%d\n", n)
+	for i := 0; i < n; i++ {
+		if i+1 == n {
+			fmt.Fprintf(&in, "%d\n", arr[i])
+		} else {
+			fmt.Fprintf(&in, "%d ", arr[i])
+		}
+	}
+	var out strings.Builder
+	fmt.Fprintf(&out, "%d %d\n", cost, teamCount)
+	for i := 0; i < n; i++ {
+		if i+1 == n {
+			fmt.Fprintf(&out, "%d\n", teams[i])
+		} else {
+			fmt.Fprintf(&out, "%d ", teams[i])
+		}
+	}
+	return in.String(), out.String()
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rand.Seed(5)
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase()
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed\nexpected:\n%s\ngot:\n%s\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1256/verifierF.go
+++ b/1000-1999/1200-1299/1250-1259/1256/verifierF.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func solveCase(s, t string) string {
+	n := len(s)
+	cntS := [26]int{}
+	cntT := [26]int{}
+	for i := 0; i < n; i++ {
+		cntS[s[i]-'a']++
+		cntT[t[i]-'a']++
+	}
+	equal := true
+	dup := false
+	for i := 0; i < 26; i++ {
+		if cntS[i] != cntT[i] {
+			equal = false
+			break
+		}
+		if cntS[i] >= 2 {
+			dup = true
+		}
+	}
+	if !equal {
+		return "NO"
+	}
+	if dup {
+		return "YES"
+	}
+	pos := make([]int, 26)
+	for i := 0; i < n; i++ {
+		pos[t[i]-'a'] = i
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = pos[s[i]-'a']
+	}
+	invParity := 0
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if arr[i] > arr[j] {
+				invParity ^= 1
+			}
+		}
+	}
+	if invParity == 0 {
+		return "YES"
+	}
+	return "NO"
+}
+
+func generate() (string, string) {
+	const T = 100
+	rand.Seed(6)
+	var in strings.Builder
+	var out strings.Builder
+	fmt.Fprintf(&in, "%d\n", T)
+	letters := []rune("abcdef")
+	for i := 0; i < T; i++ {
+		n := rand.Intn(10) + 1
+		sb1 := make([]rune, n)
+		sb2 := make([]rune, n)
+		for j := 0; j < n; j++ {
+			sb1[j] = letters[rand.Intn(len(letters))]
+			sb2[j] = letters[rand.Intn(len(letters))]
+		}
+		s := string(sb1)
+		t := string(sb2)
+		fmt.Fprintf(&in, "%d\n%s\n%s\n", n, s, t)
+		fmt.Fprintln(&out, solveCase(s, t))
+	}
+	return in.String(), out.String()
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	in, exp := generate()
+	out, err := runCandidate(bin, in)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+		fmt.Fprintln(os.Stderr, "wrong answer")
+		fmt.Fprintln(os.Stderr, "expected:\n"+exp)
+		fmt.Fprintln(os.Stderr, "got:\n"+out)
+		os.Exit(1)
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier scripts for contest 1256 problems A–F
- each verifier generates 100 deterministic test cases and checks a candidate binary

## Testing
- `go run verifierA.go ./A_bin`
- `go run verifierB.go ./B_bin`
- `go run verifierC.go ./C_bin`
- `go run verifierD.go ./D_bin`
- `go run verifierF.go ./F_bin`

------
https://chatgpt.com/codex/tasks/task_e_6884d37dc938832495cf057d222aa32f