### PR TITLE
Add Go verifiers for contest 1259

### DIFF
--- a/1000-1999/1200-1299/1250-1259/1259/verifierA.go
+++ b/1000-1999/1200-1299/1250-1259/1259/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	nums []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.nums)))
+	for _, v := range t.nums {
+		sb.WriteString(fmt.Sprintf("%d\n", v))
+	}
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "refA.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1259A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		t := rng.Intn(10) + 1
+		nums := make([]int, t)
+		for j := 0; j < t; j++ {
+			nums[j] = rng.Intn(1_000_000_000) + 1
+		}
+		tests = append(tests, Test{nums})
+	}
+	tests = append(tests, Test{[]int{1}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1259/verifierB.go
+++ b/1000-1999/1200-1299/1250-1259/1259/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	arr []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d\n", len(t.arr)))
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "refB.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1259B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := rng.Intn(8) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			// generate random up to 1e9 with powers of two included
+			arr[j] = rng.Intn(1000) + 1
+			if rng.Intn(3) == 0 {
+				arr[j] <<= uint(rng.Intn(5))
+			}
+		}
+		tests = append(tests, Test{arr})
+	}
+	tests = append(tests, Test{[]int{1}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1259/verifierC.go
+++ b/1000-1999/1200-1299/1250-1259/1259/verifierC.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	s string
+}
+
+func (t Test) Input() string {
+	return fmt.Sprintf("1\n%s\n", t.s)
+}
+
+func buildRef() (string, error) {
+	ref := "refC.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1259C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randString(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + r.Intn(26))
+	}
+	return string(b)
+}
+
+func genTests() []Test {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(20) + 1
+		s := randString(r, n)
+		if r.Intn(4) == 0 {
+			// insert substring "one" or "two"
+			pos := r.Intn(n - 2)
+			if r.Intn(2) == 0 {
+				s = s[:pos] + "one" + s[pos+3:]
+			} else {
+				s = s[:pos] + "two" + s[pos+3:]
+			}
+		}
+		tests = append(tests, Test{s})
+	}
+	tests = append(tests, Test{"one"})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1259/verifierD.go
+++ b/1000-1999/1200-1299/1250-1259/1259/verifierD.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	words []string
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("1\n%d\n", len(t.words)))
+	for i, w := range t.words {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(w)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "refD.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1259D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func randWord(r *rand.Rand) string {
+	n := r.Intn(6) + 1
+	b := make([]byte, n)
+	for i := range b {
+		if r.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	return string(b)
+}
+
+func genTests() []Test {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(6) + 1
+		words := make([]string, 0, n)
+		m := make(map[string]bool)
+		for len(words) < n {
+			w := randWord(r)
+			if !m[w] {
+				m[w] = true
+				words = append(words, w)
+			}
+		}
+		tests = append(tests, Test{words})
+	}
+	tests = append(tests, Test{[]string{"0"}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1259/verifierE.go
+++ b/1000-1999/1200-1299/1250-1259/1259/verifierE.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct{ u, v int }
+
+type Test struct {
+	n, m  int
+	a, b  int
+	edges []Edge
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d %d %d\n", t.n, t.m, t.a, t.b))
+	for _, e := range t.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "refE.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1259E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genGraph(r *rand.Rand, n int) []Edge {
+	edgesMap := make(map[[2]int]bool)
+	res := make([]Edge, 0)
+	for len(res) < n-1 {
+		u := r.Intn(n) + 1
+		v := r.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		a, b := u, v
+		if a > b {
+			a, b = b, a
+		}
+		if edgesMap[[2]int{a, b}] {
+			continue
+		}
+		edgesMap[[2]int{a, b}] = true
+		res = append(res, Edge{u, v})
+	}
+	m := n - 1 + r.Intn(n)
+	for len(res) < m {
+		u := r.Intn(n) + 1
+		v := r.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		a, b := u, v
+		if a > b {
+			a, b = b, a
+		}
+		if edgesMap[[2]int{a, b}] {
+			continue
+		}
+		edgesMap[[2]int{a, b}] = true
+		res = append(res, Edge{u, v})
+	}
+	return res
+}
+
+func genTests() []Test {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(6) + 4
+		edges := genGraph(r, n)
+		a := r.Intn(n) + 1
+		b := r.Intn(n) + 1
+		for a == b {
+			b = r.Intn(n) + 1
+		}
+		tests = append(tests, Test{n, len(edges), a, b, edges})
+	}
+	// simple fixed case
+	tests = append(tests, Test{4, 3, 1, 2, []Edge{{1, 3}, {2, 3}, {3, 4}}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1259/verifierF.go
+++ b/1000-1999/1200-1299/1250-1259/1259/verifierF.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Test struct {
+	arr []int
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(t.arr)))
+	for i, v := range t.arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "refF.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1259F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTests() []Test {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(10) + 1
+		arr := make([]int, n)
+		for j := 0; j < n; j++ {
+			arr[j] = r.Intn(20) + 1
+		}
+		tests = append(tests, Test{arr})
+	}
+	tests = append(tests, Test{[]int{1}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}

--- a/1000-1999/1200-1299/1250-1259/1259/verifierG.go
+++ b/1000-1999/1200-1299/1250-1259/1259/verifierG.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct{ u, v int }
+
+type Test struct {
+	n     int
+	edges []Edge
+}
+
+func (t Test) Input() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", t.n))
+	for _, e := range t.edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e.u, e.v))
+	}
+	return sb.String()
+}
+
+func buildRef() (string, error) {
+	ref := "refG.bin"
+	cmd := exec.Command("go", "build", "-o", ref, "1259G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build reference failed: %v: %s", err, string(out))
+	}
+	return ref, nil
+}
+
+func runExe(path, input string) (string, error) {
+	if !strings.Contains(path, "/") {
+		path = "./" + path
+	}
+	cmd := exec.Command(path)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
+}
+
+func genTree(r *rand.Rand, n int) []Edge {
+	edges := make([]Edge, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := r.Intn(i-1) + 1
+		edges = append(edges, Edge{i, p})
+	}
+	return edges
+}
+
+func genTests() []Test {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]Test, 0, 101)
+	for i := 0; i < 100; i++ {
+		n := r.Intn(8) + 2
+		edges := genTree(r, n)
+		tests = append(tests, Test{n, edges})
+	}
+	tests = append(tests, Test{2, []Edge{{1, 2}}})
+	return tests
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	bin := os.Args[1]
+	ref, err := buildRef()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(ref)
+
+	tests := genTests()
+	for i, tc := range tests {
+		input := tc.Input()
+		exp, err := runExe(ref, input)
+		if err != nil {
+			fmt.Printf("reference runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runExe(bin, input)
+		if err != nil {
+			fmt.Printf("candidate runtime error on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if exp != got {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%s\nGot:\n%s\n", i+1, input, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("all tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–G of contest 1259
- generate over 100 random test cases per verifier
- compile reference solutions and compare outputs
- fix path handling for spawned binaries

## Testing
- `go run verifierA.go ./candA`
- `go run verifierB.go ./candB`


------
https://chatgpt.com/codex/tasks/task_e_6884d5220d6c8324966d13fd081fc0df