### PR TITLE
Add Go solution for 1849A

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1849/1849A.go
+++ b/1000-1999/1800-1899/1840-1849/1849/1849A.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var b, c, h int
+		fmt.Fscan(in, &b, &c, &h)
+		f := c + h
+		x := b
+		if f+1 < b {
+			x = f + 1
+		}
+		fmt.Fprintln(out, 2*x-1)
+	}
+}


### PR DESCRIPTION
## Summary
- implement 1849A solution in Go

## Testing
- `go build 1000-1999/1800-1899/1840-1849/1849/1849A.go`


------
https://chatgpt.com/codex/tasks/task_e_6884d82470e483248ba59a72c4a070c1