### PR TITLE
Add verifiers for contest 1263

### DIFF
--- a/1000-1999/1200-1299/1260-1269/1263/verifierA.go
+++ b/1000-1999/1200-1299/1260-1269/1263/verifierA.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(r, g, b int64) int64 {
+	sum := r + g + b
+	max := r
+	if g > max {
+		max = g
+	}
+	if b > max {
+		max = b
+	}
+	ans := sum - max
+	if sum/2 < ans {
+		ans = sum / 2
+	}
+	return ans
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	r := rng.Int63n(1_000_000) + 1
+	g := rng.Int63n(1_000_000) + 1
+	b := rng.Int63n(1_000_000) + 1
+	input := fmt.Sprintf("1\n%d %d %d\n", r, g, b)
+	expect := fmt.Sprintf("%d", solve(r, g, b))
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1263/verifierB.go
+++ b/1000-1999/1200-1299/1260-1269/1263/verifierB.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type resultB struct {
+	cnt   int
+	codes []string
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(codes []string) resultB {
+	mp := make(map[string]int)
+	n := len(codes)
+	for _, s := range codes {
+		mp[s]++
+	}
+	res := make([]string, n)
+	copy(res, codes)
+	cnt := 0
+	for i := 0; i < n; i++ {
+		if mp[res[i]] > 1 {
+			cnt++
+			orig := res[i]
+			tmp := []byte(orig)
+			ok := false
+			for j := byte('0'); j <= '9'; j++ {
+				tmp[3] = j
+				s := string(tmp)
+				if mp[s] == 0 {
+					ok = true
+					res[i] = s
+					break
+				}
+			}
+			if !ok {
+				tmp = []byte(orig)
+				for j := byte('0'); j <= '9'; j++ {
+					tmp[2] = j
+					s := string(tmp)
+					if mp[s] == 0 {
+						ok = true
+						res[i] = s
+						break
+					}
+				}
+			}
+			mp[orig]--
+			mp[res[i]]++
+		}
+	}
+	return resultB{cnt, res}
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(9) + 2
+	codes := make([]string, n)
+	for i := 0; i < n; i++ {
+		var b [4]byte
+		for j := 0; j < 4; j++ {
+			b[j] = byte('0' + rng.Intn(10))
+		}
+		codes[i] = string(b[:])
+	}
+	inputBuilder := strings.Builder{}
+	inputBuilder.WriteString("1\n")
+	inputBuilder.WriteString(fmt.Sprintf("%d\n", n))
+	for _, s := range codes {
+		inputBuilder.WriteString(s)
+		inputBuilder.WriteByte('\n')
+	}
+	res := solveB(codes)
+	outBuilder := strings.Builder{}
+	outBuilder.WriteString(fmt.Sprintf("%d\n", res.cnt))
+	for i, s := range res.codes {
+		outBuilder.WriteString(s)
+		if i+1 < len(res.codes) {
+			outBuilder.WriteByte('\n')
+		}
+	}
+	return inputBuilder.String(), strings.TrimSpace(outBuilder.String())
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\n", i+1, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1263/verifierC.go
+++ b/1000-1999/1200-1299/1260-1269/1263/verifierC.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(n int) string {
+	vals := map[int]struct{}{0: {}}
+	for i := 1; i*i <= n; i++ {
+		vals[i] = struct{}{}
+		vals[n/i] = struct{}{}
+	}
+	arr := make([]int, 0, len(vals))
+	for v := range vals {
+		arr = append(arr, v)
+	}
+	sort.Ints(arr)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(1_000_000) + 1
+	input := fmt.Sprintf("1\n%d\n", n)
+	return input, solveC(n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\n", i+1, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1263/verifierD.go
+++ b/1000-1999/1200-1299/1260-1269/1263/verifierD.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	parent []int
+}
+
+func newDSU(n int) *DSU {
+	d := &DSU{parent: make([]int, n)}
+	for i := range d.parent {
+		d.parent[i] = i
+	}
+	return d
+}
+
+func (d *DSU) find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) union(a, b int) {
+	pa := d.find(a)
+	pb := d.find(b)
+	if pa != pb {
+		d.parent[pa] = pb
+	}
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveD(words []string) int {
+	dsu := newDSU(26)
+	used := make([]bool, 26)
+	for _, s := range words {
+		first := -1
+		for _, ch := range s {
+			idx := int(ch - 'a')
+			used[idx] = true
+			if first == -1 {
+				first = idx
+			} else {
+				dsu.union(first, idx)
+			}
+		}
+	}
+	comps := make(map[int]bool)
+	for i := 0; i < 26; i++ {
+		if used[i] {
+			root := dsu.find(i)
+			comps[root] = true
+		}
+	}
+	return len(comps)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	words := make([]string, n)
+	for i := 0; i < n; i++ {
+		l := rng.Intn(6) + 1
+		b := make([]byte, l)
+		for j := 0; j < l; j++ {
+			b[j] = byte('a' + rng.Intn(5))
+		}
+		words[i] = string(b)
+	}
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	for _, w := range words {
+		input.WriteString(w)
+		input.WriteByte('\n')
+	}
+	expect := fmt.Sprintf("%d", solveD(words))
+	return input.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1263/verifierE.go
+++ b/1000-1999/1200-1299/1260-1269/1263/verifierE.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveE(n int, s string) string {
+	arr := make([]int, n+5)
+	pos := 1
+	maxPos := 1
+	results := make([]int, n)
+	for i := 0; i < n; i++ {
+		c := s[i]
+		switch c {
+		case 'L':
+			if pos > 1 {
+				pos--
+			}
+		case 'R':
+			pos++
+			if pos > maxPos {
+				maxPos = pos
+			}
+		case '(':
+			arr[pos] = 1
+			if pos > maxPos {
+				maxPos = pos
+			}
+		case ')':
+			arr[pos] = -1
+			if pos > maxPos {
+				maxPos = pos
+			}
+		default:
+			arr[pos] = 0
+			if pos > maxPos {
+				maxPos = pos
+			}
+		}
+		sum := 0
+		minV := 0
+		maxV := 0
+		for j := 1; j <= maxPos; j++ {
+			sum += arr[j]
+			if sum < minV {
+				minV = sum
+			}
+			if sum > maxV {
+				maxV = sum
+			}
+		}
+		if sum != 0 || minV < 0 {
+			results[i] = -1
+		} else {
+			results[i] = maxV
+		}
+	}
+	var sb strings.Builder
+	for i, v := range results {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	return sb.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(50) + 1
+	cmds := make([]byte, n)
+	alphabet := []byte{'L', 'R', '(', ')', 'a'}
+	for i := 0; i < n; i++ {
+		cmds[i] = alphabet[rng.Intn(len(alphabet))]
+	}
+	s := string(cmds)
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	return input, solveE(n, s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected\n%s\ngot\n%s\n", i+1, exp, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1263/verifierF.go
+++ b/1000-1999/1200-1299/1260-1269/1263/verifierF.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type edge struct {
+	l, r int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveF(n int, parA []int, x []int, parB []int, y []int) int {
+	a := len(parA) - 1
+	b := len(parB) - 1
+	chA := make([][]int, a+1)
+	for i := 2; i <= a; i++ {
+		p := parA[i]
+		chA[p] = append(chA[p], i)
+	}
+	chB := make([][]int, b+1)
+	for i := 2; i <= b; i++ {
+		p := parB[i]
+		chB[p] = append(chB[p], i)
+	}
+	leafIdxA := make([]int, a+1)
+	leafIdxB := make([]int, b+1)
+	for i := 1; i <= n; i++ {
+		leafIdxA[x[i]] = i
+		leafIdxB[y[i]] = i
+	}
+	lA := make([]int, a+1)
+	rA := make([]int, a+1)
+	var dfsA func(int)
+	dfsA = func(u int) {
+		if len(chA[u]) == 0 {
+			idx := leafIdxA[u]
+			lA[u], rA[u] = idx, idx
+			return
+		}
+		l, r := n+1, 0
+		for _, v := range chA[u] {
+			dfsA(v)
+			if lA[v] < l {
+				l = lA[v]
+			}
+			if rA[v] > r {
+				r = rA[v]
+			}
+		}
+		lA[u], rA[u] = l, r
+	}
+	dfsA(1)
+	lB := make([]int, b+1)
+	rB := make([]int, b+1)
+	var dfsB func(int)
+	dfsB = func(u int) {
+		if len(chB[u]) == 0 {
+			idx := leafIdxB[u]
+			lB[u], rB[u] = idx, idx
+			return
+		}
+		l, r := n+1, 0
+		for _, v := range chB[u] {
+			dfsB(v)
+			if lB[v] < l {
+				l = lB[v]
+			}
+			if rB[v] > r {
+				r = rB[v]
+			}
+		}
+		lB[u], rB[u] = l, r
+	}
+	dfsB(1)
+	edgesA := make([]edge, 0, a-1)
+	for i := 2; i <= a; i++ {
+		edgesA = append(edgesA, edge{lA[i], rA[i]})
+	}
+	edgesB := make([]edge, 0, b-1)
+	for i := 2; i <= b; i++ {
+		edgesB = append(edgesB, edge{lB[i], rB[i]})
+	}
+	n1 := len(edgesA)
+	n2 := len(edgesB)
+	adj := make([][]int, n1)
+	for i := 0; i < n1; i++ {
+		e1 := edgesA[i]
+		for j := 0; j < n2; j++ {
+			e2 := edgesB[j]
+			if e1.l <= e2.r && e2.l <= e1.r {
+				adj[i] = append(adj[i], j)
+			}
+		}
+	}
+	pairU := make([]int, n1)
+	for i := range pairU {
+		pairU[i] = -1
+	}
+	pairV := make([]int, n2)
+	for i := range pairV {
+		pairV[i] = -1
+	}
+	dist := make([]int, n1)
+	INF := int(1e9)
+	bfs := func() bool {
+		q := []int{}
+		for i := 0; i < n1; i++ {
+			if pairU[i] == -1 {
+				dist[i] = 0
+				q = append(q, i)
+			} else {
+				dist[i] = INF
+			}
+		}
+		found := false
+		for head := 0; head < len(q); head++ {
+			u := q[head]
+			for _, v := range adj[u] {
+				pu := pairV[v]
+				if pu != -1 && dist[pu] == INF {
+					dist[pu] = dist[u] + 1
+					q = append(q, pu)
+				}
+				if pu == -1 {
+					found = true
+				}
+			}
+		}
+		return found
+	}
+	var dfs func(int) bool
+	dfs = func(u int) bool {
+		for _, v := range adj[u] {
+			pu := pairV[v]
+			if pu == -1 || (dist[pu] == dist[u]+1 && dfs(pu)) {
+				pairU[u] = v
+				pairV[v] = u
+				return true
+			}
+		}
+		dist[u] = INF
+		return false
+	}
+	matching := 0
+	for bfs() {
+		for i := 0; i < n1; i++ {
+			if pairU[i] == -1 {
+				if dfs(i) {
+					matching++
+				}
+			}
+		}
+	}
+	totalEdges := (a - 1) + (b - 1)
+	return totalEdges - matching
+}
+
+func generateTree(nLeaves int, rng *rand.Rand) (int, []int) {
+	m := rng.Intn(2)
+	a := 1 + m + nLeaves
+	par := make([]int, a+1)
+	for i := 2; i <= 1+m; i++ {
+		par[i] = 1
+	}
+	for i := 0; i < nLeaves; i++ {
+		id := m + 2 + i
+		var parent int
+		if i < 1+m {
+			parent = 1 + i
+			if parent > 1+m {
+				parent = 1
+			}
+		} else {
+			parent = rng.Intn(1+m) + 1
+		}
+		par[id] = parent
+	}
+	return a, par
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	a, parA := generateTree(n, rng)
+	x := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		x[i] = len(parA) - n - 1 + i
+	}
+	b, parB := generateTree(n, rng)
+	y := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		y[i] = len(parB) - n - 1 + i
+	}
+	rng.Shuffle(n, func(i, j int) { y[i+1], y[j+1] = y[j+1], y[i+1] })
+	var input strings.Builder
+	input.WriteString(fmt.Sprintf("%d\n", n))
+	input.WriteString(fmt.Sprintf("%d\n", a))
+	for i := 2; i <= a; i++ {
+		input.WriteString(fmt.Sprintf("%d ", parA[i]))
+	}
+	input.WriteByte('\n')
+	for i := 1; i <= n; i++ {
+		input.WriteString(fmt.Sprintf("%d ", x[i]))
+	}
+	input.WriteByte('\n')
+	input.WriteString(fmt.Sprintf("%d\n", b))
+	for i := 2; i <= b; i++ {
+		input.WriteString(fmt.Sprintf("%d ", parB[i]))
+	}
+	input.WriteByte('\n')
+	for i := 1; i <= n; i++ {
+		input.WriteString(fmt.Sprintf("%d ", y[i]))
+	}
+	input.WriteByte('\n')
+	expect := fmt.Sprintf("%d", solveF(n, parA, x, parB, y))
+	return input.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := run(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for all problems in contest 1263
- each verifier generates 100 random test cases and checks a binary solution

## Testing
- `go run verifierA.go ./1263A.go`
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`

------
https://chatgpt.com/codex/tasks/task_e_6884d75264b8832483ab02444133f633