### PR TITLE
Add Go solution for 1847A

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1847/1847A.go
+++ b/1000-1999/1800-1899/1840-1849/1847/1847A.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		if n == 1 {
+			fmt.Fprintln(writer, 0)
+			continue
+		}
+		diffs := make([]int, n-1)
+		total := 0
+		for i := 0; i < n-1; i++ {
+			d := a[i+1] - a[i]
+			if d < 0 {
+				d = -d
+			}
+			diffs[i] = d
+			total += d
+		}
+		sort.Slice(diffs, func(i, j int) bool { return diffs[i] > diffs[j] })
+		remove := 0
+		for i := 0; i < k-1 && i < len(diffs); i++ {
+			remove += diffs[i]
+		}
+		fmt.Fprintln(writer, total-remove)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem A in contest 1847

## Testing
- `go run 1000-1999/1800-1899/1840-1849/1847/1847A.go <<EOF
2
4 2
1 3 5 2
6 3
1 9 12 4 7 2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6884db6cf5a48324954ed8284e3ada41