### PR TITLE
Add verifiers for Codeforces 1269

### DIFF
--- a/1000-1999/1200-1299/1260-1269/1269/verifierA.go
+++ b/1000-1999/1200-1299/1260-1269/1269/verifierA.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func isComposite(x int) bool {
+	if x < 4 {
+		return false
+	}
+	for i := 2; i*i <= x; i++ {
+		if x%i == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+type testCase int
+
+func generateTests(rng *rand.Rand) []testCase {
+	tests := []testCase{1, 2, 3, 4, 5, 10, 17, 37, 9999999, 10000000}
+	for len(tests) < 100 {
+		tests = append(tests, testCase(rng.Intn(10000000)+1))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := generateTests(rng)
+
+	for i, n := range tests {
+		input := fmt.Sprintf("%d\n", n)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != 2 {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected two numbers got %q\ninput:\n%s", i+1, out, input)
+			os.Exit(1)
+		}
+		var a, b int
+		if _, err := fmt.Sscan(fields[0], &a); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad number %q\ninput:\n%s", i+1, fields[0], input)
+			os.Exit(1)
+		}
+		if _, err := fmt.Sscan(fields[1], &b); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: bad number %q\ninput:\n%s", i+1, fields[1], input)
+			os.Exit(1)
+		}
+		if a-b != int(n) {
+			fmt.Fprintf(os.Stderr, "case %d failed: a-b != n (%d-%d=%d)\ninput:\n%s", i+1, a, b, a-b, input)
+			os.Exit(1)
+		}
+		if a < 2 || a > 1000000000 || b < 2 || b > 1000000000 {
+			fmt.Fprintf(os.Stderr, "case %d failed: values out of range a=%d b=%d\ninput:\n%s", i+1, a, b, input)
+			os.Exit(1)
+		}
+		if !isComposite(a) || !isComposite(b) {
+			fmt.Fprintf(os.Stderr, "case %d failed: numbers must be composite a=%d b=%d\ninput:\n%s", i+1, a, b, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1269/verifierB.go
+++ b/1000-1999/1200-1299/1260-1269/1269/verifierB.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m int
+	a, b []int
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveCase(tc testCase) int {
+	a := append([]int(nil), tc.a...)
+	b := append([]int(nil), tc.b...)
+	sort.Ints(a)
+	sort.Ints(b)
+	best := tc.m
+	for i := 0; i < tc.n; i++ {
+		x := (b[i] - a[0]) % tc.m
+		if x < 0 {
+			x += tc.m
+		}
+		tmp := make([]int, tc.n)
+		for j := 0; j < tc.n; j++ {
+			val := (a[j] + x) % tc.m
+			if val < 0 {
+				val += tc.m
+			}
+			tmp[j] = val
+		}
+		sort.Ints(tmp)
+		equal := true
+		for j := 0; j < tc.n; j++ {
+			if tmp[j] != b[j] {
+				equal = false
+				break
+			}
+		}
+		if equal && x < best {
+			best = x
+		}
+	}
+	return best
+}
+
+func permute(rng *rand.Rand, arr []int) []int {
+	perm := rng.Perm(len(arr))
+	res := make([]int, len(arr))
+	for i, p := range perm {
+		res[i] = arr[p]
+	}
+	return res
+}
+
+func genRandomCase(rng *rand.Rand) testCase {
+	n := rng.Intn(50) + 1
+	if rng.Intn(10) == 0 {
+		n = 2000
+	}
+	m := rng.Intn(1000000000) + 1
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		a[i] = rng.Intn(m)
+	}
+	x := rng.Intn(m)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		b[i] = (a[i] + x) % m
+	}
+	b = permute(rng, b)
+	return testCase{n: n, m: m, a: a, b: b}
+}
+
+func generateTests(rng *rand.Rand) []testCase {
+	tests := make([]testCase, 0, 100)
+	tests = append(tests, testCase{n: 1, m: 2, a: []int{1}, b: []int{0}})
+	tests = append(tests, testCase{n: 3, m: 5, a: []int{1, 2, 3}, b: []int{1, 2, 3}})
+	tests = append(tests, testCase{n: 4, m: 3, a: []int{0, 0, 2, 1}, b: []int{2, 0, 1, 1}})
+	tests = append(tests, testCase{n: 2, m: 5, a: []int{0, 0}, b: []int{3, 3}})
+	tests = append(tests, testCase{n: 3, m: 1, a: []int{0, 0, 0}, b: []int{0, 0, 0}})
+	tests = append(tests, testCase{n: 2, m: 1000000000, a: []int{999999999, 12345678}, b: []int{(999999999 + 500000000) % 1000000000, (12345678 + 500000000) % 1000000000}})
+
+	for len(tests) < 100 {
+		tests = append(tests, genRandomCase(rng))
+	}
+	return tests
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := generateTests(rng)
+
+	for i, tc := range tests {
+		input := fmt.Sprintf("%d %d\n", tc.n, tc.m)
+		for j, val := range tc.a {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", val)
+		}
+		input += "\n"
+		for j, val := range tc.b {
+			if j > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", val)
+		}
+		input += "\n"
+		expected := fmt.Sprintf("%d", solveCase(tc))
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, expected, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifier with 100+ random tests for problem A
- add Go verifier with 100+ random tests for problem B

## Testing
- `go run 1000-1999/1200-1299/1260-1269/1269/verifierA.go -- 1000-1999/1200-1299/1260-1269/1269/1269A.go`
- `go run 1000-1999/1200-1299/1260-1269/1269/verifierB.go -- 1000-1999/1200-1299/1260-1269/1269/1269B.go`

------
https://chatgpt.com/codex/tasks/task_e_6884da9ad71083249853865136a530f5