### PR TITLE
Add Go verifiers for Codeforces contest 1262

### DIFF
--- a/1000-1999/1200-1299/1260-1269/1262/1262A.go
+++ b/1000-1999/1200-1299/1260-1269/1262/1262A.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func main() {
+	var n int
+	fmt.Scan(&n)
+	a := make([]int, n)
+	for i := 0; i <= n; i++ { // deliberate out-of-bounds for runtime error
+		fmt.Scan(&a[i])
+	}
+	fmt.Println("0")
+}

--- a/1000-1999/1200-1299/1260-1269/1262/verifierA.go
+++ b/1000-1999/1200-1299/1260-1269/1262/verifierA.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solve(n int, seg [][2]int) int {
+	lmax := seg[0][0]
+	rmin := seg[0][1]
+	for i := 1; i < n; i++ {
+		if seg[i][0] > lmax {
+			lmax = seg[i][0]
+		}
+		if seg[i][1] < rmin {
+			rmin = seg[i][1]
+		}
+	}
+	if lmax <= rmin {
+		return 0
+	}
+	return lmax - rmin
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, seg [][2]int) error {
+	n := len(seg)
+	input := fmt.Sprintf("1\n%d\n", n)
+	for _, p := range seg {
+		input += fmt.Sprintf("%d %d\n", p[0], p[1])
+	}
+	expect := solve(n, seg)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	var got int
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := [][][2]int{
+		{{4, 5}, {5, 9}, {7, 7}},
+		{{11, 19}, {4, 17}, {16, 16}, {3, 12}, {14, 17}},
+		{{1, 10}},
+		{{1, 1}},
+	}
+	for idx, seg := range cases {
+		if err := runCase(bin, seg); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	for i := len(cases); i < 100; i++ {
+		n := rng.Intn(10) + 1
+		seg := make([][2]int, n)
+		for j := 0; j < n; j++ {
+			a := rng.Intn(20)
+			b := rng.Intn(20)
+			if a > b {
+				a, b = b, a
+			}
+			seg[j] = [2]int{a, b}
+		}
+		if err := runCase(bin, seg); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1262/verifierB.go
+++ b/1000-1999/1200-1299/1260-1269/1262/verifierB.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func construct(q []int) ([]int, bool) {
+	n := len(q)
+	used := make([]bool, n+1)
+	res := make([]int, n)
+	next := 1
+	for i := 0; i < n; i++ {
+		if i == 0 || q[i] > q[i-1] {
+			if q[i] < 1 || q[i] > n || used[q[i]] {
+				return nil, false
+			}
+			res[i] = q[i]
+			used[q[i]] = true
+		} else {
+			for next <= n && (used[next] || next >= q[i]) {
+				next++
+			}
+			if next >= q[i] || next > n {
+				return nil, false
+			}
+			res[i] = next
+			used[next] = true
+		}
+		for next <= n && used[next] {
+			next++
+		}
+	}
+	return res, true
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func parseOutput(out string, n int) ([]int, bool, error) {
+	fields := strings.Fields(out)
+	if len(fields) == 1 && fields[0] == "-1" {
+		return nil, false, nil
+	}
+	if len(fields) != n {
+		return nil, false, fmt.Errorf("expected %d numbers, got %d", n, len(fields))
+	}
+	res := make([]int, n)
+	used := make(map[int]bool)
+	for i, f := range fields {
+		var v int
+		if _, err := fmt.Sscan(f, &v); err != nil {
+			return nil, false, fmt.Errorf("bad number %q", f)
+		}
+		if v < 1 || v > n || used[v] {
+			return nil, false, fmt.Errorf("invalid permutation value %d", v)
+		}
+		used[v] = true
+		res[i] = v
+	}
+	return res, true, nil
+}
+
+func runCase(bin string, q []int) error {
+	n := len(q)
+	input := fmt.Sprintf("1\n%d\n", n)
+	for i, v := range q {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	_, ok := construct(q)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	got, valid, err := parseOutput(out, n)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		if valid {
+			return fmt.Errorf("expected -1 but got permutation")
+		}
+		return nil
+	}
+	if !valid {
+		return fmt.Errorf("expected permutation but got -1")
+	}
+	// verify got matches q
+	pm := 0
+	for i := 0; i < n; i++ {
+		if got[i] > pm {
+			pm = got[i]
+		}
+		if pm != q[i] {
+			return fmt.Errorf("prefix max mismatch at %d", i)
+		}
+	}
+	return nil
+}
+
+func genValidCase(rng *rand.Rand, n int) []int {
+	p := rng.Perm(n)
+	for i := range p {
+		p[i]++
+	}
+	q := make([]int, n)
+	mx := 0
+	for i := 0; i < n; i++ {
+		if p[i] > mx {
+			mx = p[i]
+		}
+		q[i] = mx
+	}
+	return q
+}
+
+func genInvalidCase(rng *rand.Rand, n int) []int {
+	q := make([]int, n)
+	mx := 0
+	for i := 0; i < n; i++ {
+		inc := rng.Intn(2)
+		if inc == 1 {
+			mx += rng.Intn(2)
+		}
+		q[i] = mx + 1
+	}
+	return q
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// some edge cases from problem
+	cases := [][]int{
+		{1, 3, 4, 5, 5},
+		{1, 1, 3, 4},
+		{2, 2},
+		{1},
+	}
+	for idx, q := range cases {
+		if err := runCase(bin, q); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	for i := len(cases); i < 100; i++ {
+		n := rng.Intn(8) + 1
+		var q []int
+		if rng.Intn(2) == 0 {
+			q = genValidCase(rng, n)
+		} else {
+			q = genInvalidCase(rng, n)
+		}
+		if err := runCase(bin, q); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1262/verifierC.go
+++ b/1000-1999/1200-1299/1260-1269/1262/verifierC.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type op struct{ l, r int }
+
+func targetString(n, k int) string {
+	var b strings.Builder
+	for i := 0; i < k-1; i++ {
+		b.WriteString("()")
+	}
+	rem := n - 2*(k-1)
+	b.WriteString(strings.Repeat("(", rem/2))
+	b.WriteString(strings.Repeat(")", rem/2))
+	return b.String()
+}
+
+func applyOps(s []byte, ops []op) []byte {
+	for _, o := range ops {
+		l, r := o.l-1, o.r-1
+		for l < r {
+			s[l], s[r] = s[r], s[l]
+			l++
+			r--
+		}
+	}
+	return s
+}
+
+func parseOutput(out string) ([]op, error) {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	if !scanner.Scan() {
+		return nil, fmt.Errorf("empty output")
+	}
+	var m int
+	if _, err := fmt.Sscan(scanner.Text(), &m); err != nil {
+		return nil, fmt.Errorf("bad m: %v", err)
+	}
+	var ops []op
+	for i := 0; i < m; i++ {
+		if !scanner.Scan() {
+			return nil, fmt.Errorf("missing op line %d", i+1)
+		}
+		var l, r int
+		if _, err := fmt.Sscan(scanner.Text(), &l, &r); err != nil {
+			return nil, fmt.Errorf("bad op %d: %v", i+1, err)
+		}
+		ops = append(ops, op{l, r})
+	}
+	return ops, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func runCase(bin string, n, k int, s string) error {
+	input := fmt.Sprintf("1\n%d %d\n%s\n", n, k, s)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	ops, err := parseOutput(out)
+	if err != nil {
+		return err
+	}
+	if len(ops) > n {
+		return fmt.Errorf("too many operations")
+	}
+	b := []byte(s)
+	for _, o := range ops {
+		if o.l < 1 || o.r > n || o.l > o.r {
+			return fmt.Errorf("invalid op")
+		}
+	}
+	b = applyOps(b, ops)
+	if string(b) != targetString(n, k) {
+		return fmt.Errorf("wrong final string")
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (int, int, string) {
+	n := (rng.Intn(10) + 1) * 2
+	k := rng.Intn(n/2) + 1
+	open := n / 2
+	close := n / 2
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if open > 0 && close > 0 {
+			if rng.Intn(2) == 0 {
+				b[i] = '('
+				open--
+			} else {
+				b[i] = ')'
+				close--
+			}
+		} else if open > 0 {
+			b[i] = '('
+			open--
+		} else {
+			b[i] = ')'
+			close--
+		}
+	}
+	return n, k, string(b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := []struct {
+		n, k int
+		s    string
+	}{
+		{8, 2, "(()())()"},
+	}
+	for idx, c := range cases {
+		if err := runCase(bin, c.n, c.k, c.s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+	}
+	for i := len(cases); i < 100; i++ {
+		n, k, s := genCase(rng)
+		if err := runCase(bin, n, k, s); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1262/verifierD1.go
+++ b/1000-1999/1200-1299/1260-1269/1262/verifierD1.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type query struct{ k, pos int }
+
+func solve(a []int, qs []query) []int {
+	res := make([]int, len(qs))
+	for qi, q := range qs {
+		n := len(a)
+		pairs := make([]struct{ v, idx int }, n)
+		for i, v := range a {
+			pairs[i] = struct{ v, idx int }{v, i}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			if pairs[i].v == pairs[j].v {
+				return pairs[i].idx < pairs[j].idx
+			}
+			return pairs[i].v > pairs[j].v
+		})
+		sel := pairs[:q.k]
+		sort.Slice(sel, func(i, j int) bool { return sel[i].idx < sel[j].idx })
+		res[qi] = a[sel[q.pos-1].idx]
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, a []int, qs []query) error {
+	input := fmt.Sprintf("%d\n", len(a))
+	for i, v := range a {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n" + fmt.Sprintf("%d\n", len(qs))
+	for _, q := range qs {
+		input += fmt.Sprintf("%d %d\n", q.k, q.pos)
+	}
+	expect := solve(a, qs)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(out)
+	if len(fields) != len(qs) {
+		return fmt.Errorf("expected %d numbers got %d", len(qs), len(fields))
+	}
+	for i, f := range fields {
+		var v int
+		if _, err := fmt.Sscan(f, &v); err != nil {
+			return fmt.Errorf("bad int %q", f)
+		}
+		if v != expect[i] {
+			return fmt.Errorf("ans %d expected %d got %d", i+1, expect[i], v)
+		}
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) ([]int, []query) {
+	n := rng.Intn(8) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(50)
+	}
+	m := rng.Intn(5) + 1
+	qs := make([]query, m)
+	for i := range qs {
+		k := rng.Intn(n) + 1
+		pos := rng.Intn(k) + 1
+		qs[i] = query{k, pos}
+	}
+	return a, qs
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	a := []int{10, 20, 30, 20}
+	qs := []query{{2, 1}, {2, 2}}
+	if err := runCase(bin, a, qs); err != nil {
+		fmt.Fprintf(os.Stderr, "case 1 failed: %v\n", err)
+		os.Exit(1)
+	}
+	for i := 1; i < 100; i++ {
+		a, qs := genCase(rng)
+		if err := runCase(bin, a, qs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1262/verifierD2.go
+++ b/1000-1999/1200-1299/1260-1269/1262/verifierD2.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type query struct{ k, pos int }
+
+func solve(a []int, qs []query) []int {
+	res := make([]int, len(qs))
+	for qi, q := range qs {
+		n := len(a)
+		pairs := make([]struct{ v, idx int }, n)
+		for i, v := range a {
+			pairs[i] = struct{ v, idx int }{v, i}
+		}
+		sort.Slice(pairs, func(i, j int) bool {
+			if pairs[i].v == pairs[j].v {
+				return pairs[i].idx < pairs[j].idx
+			}
+			return pairs[i].v > pairs[j].v
+		})
+		sel := pairs[:q.k]
+		sort.Slice(sel, func(i, j int) bool { return sel[i].idx < sel[j].idx })
+		res[qi] = a[sel[q.pos-1].idx]
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, a []int, qs []query) error {
+	input := fmt.Sprintf("%d\n", len(a))
+	for i, v := range a {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n" + fmt.Sprintf("%d\n", len(qs))
+	for _, q := range qs {
+		input += fmt.Sprintf("%d %d\n", q.k, q.pos)
+	}
+	expect := solve(a, qs)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(out)
+	if len(fields) != len(qs) {
+		return fmt.Errorf("expected %d numbers got %d", len(qs), len(fields))
+	}
+	for i, f := range fields {
+		var v int
+		if _, err := fmt.Sscan(f, &v); err != nil {
+			return fmt.Errorf("bad int %q", f)
+		}
+		if v != expect[i] {
+			return fmt.Errorf("ans %d expected %d got %d", i+1, expect[i], v)
+		}
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) ([]int, []query) {
+	n := rng.Intn(10) + 1
+	a := make([]int, n)
+	for i := range a {
+		a[i] = rng.Intn(1000)
+	}
+	m := rng.Intn(10) + 1
+	qs := make([]query, m)
+	for i := range qs {
+		k := rng.Intn(n) + 1
+		pos := rng.Intn(k) + 1
+		qs[i] = query{k, pos}
+	}
+	return a, qs
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	a := []int{5, 1, 2, 3}
+	qs := []query{{3, 2}}
+	if err := runCase(bin, a, qs); err != nil {
+		fmt.Fprintf(os.Stderr, "case 1 failed: %v\n", err)
+		os.Exit(1)
+	}
+	for i := 1; i < 100; i++ {
+		a, qs := genCase(rng)
+		if err := runCase(bin, a, qs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1262/verifierE.go
+++ b/1000-1999/1200-1299/1260-1269/1262/verifierE.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type cell struct{ x, y int }
+
+var dirs = []cell{{1, 0}, {-1, 0}, {0, 1}, {0, -1}, {1, 1}, {1, -1}, {-1, 1}, {-1, -1}}
+
+func maxT(grid []string) (int, []string) {
+	n := len(grid)
+	m := len(grid[0])
+	dist := make([][]int, n)
+	for i := range dist {
+		dist[i] = make([]int, m)
+		for j := range dist[i] {
+			dist[i][j] = -1
+		}
+	}
+	q := []cell{}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == '.' {
+				dist[i][j] = 0
+				q = append(q, cell{i, j})
+			} else if i == 0 || i == n-1 || j == 0 || j == m-1 {
+				dist[i][j] = 1
+				q = append(q, cell{i, j})
+			}
+		}
+	}
+	for h := 0; h < len(q); h++ {
+		c := q[h]
+		for _, d := range dirs {
+			ni := c.x + d.x
+			nj := c.y + d.y
+			if ni < 0 || nj < 0 || ni >= n || nj >= m {
+				continue
+			}
+			if dist[ni][nj] == -1 {
+				dist[ni][nj] = dist[c.x][c.y] + 1
+				q = append(q, cell{ni, nj})
+			}
+		}
+	}
+	T := 1 << 30
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if grid[i][j] == 'X' {
+				if dist[i][j] < T {
+					T = dist[i][j]
+				}
+			}
+		}
+	}
+	if T == 1<<30 {
+		T = 0
+	} else {
+		T--
+	}
+	seeds := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if dist[i][j] > T {
+				b[j] = 'X'
+			} else {
+				b[j] = '.'
+			}
+		}
+		seeds[i] = string(b)
+	}
+	return T, seeds
+}
+
+func simulate(seeds []string, T int) []string {
+	n := len(seeds)
+	m := len(seeds[0])
+	burn := make([][]int, n)
+	for i := range burn {
+		burn[i] = make([]int, m)
+	}
+	q := []cell{}
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if seeds[i][j] == 'X' {
+				burn[i][j] = 0
+				q = append(q, cell{i, j})
+			} else {
+				burn[i][j] = -1
+			}
+		}
+	}
+	for h := 0; h < len(q); h++ {
+		c := q[h]
+		if burn[c.x][c.y] == T {
+			continue
+		}
+		for _, d := range dirs {
+			ni := c.x + d.x
+			nj := c.y + d.y
+			if ni < 0 || nj < 0 || ni >= n || nj >= m {
+				continue
+			}
+			if burn[ni][nj] == -1 {
+				burn[ni][nj] = burn[c.x][c.y] + 1
+				q = append(q, cell{ni, nj})
+			}
+		}
+	}
+	res := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if burn[i][j] >= 0 {
+				b[j] = 'X'
+			} else {
+				b[j] = '.'
+			}
+		}
+		res[i] = string(b)
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return out.String(), nil
+}
+
+func runCase(bin string, grid []string) error {
+	n := len(grid)
+	m := len(grid[0])
+	input := fmt.Sprintf("%d %d\n", n, m)
+	for _, row := range grid {
+		input += row + "\n"
+	}
+	T, _ := maxT(grid)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != n+1 {
+		return fmt.Errorf("expected %d lines got %d", n+1, len(lines))
+	}
+	var gotT int
+	if _, err := fmt.Sscan(lines[0], &gotT); err != nil {
+		return fmt.Errorf("bad T: %v", err)
+	}
+	if gotT != T {
+		return fmt.Errorf("expected T=%d got %d", T, gotT)
+	}
+	for i := 0; i < n; i++ {
+		if len(lines[i+1]) != m {
+			return fmt.Errorf("bad row length")
+		}
+	}
+	sim := simulate(lines[1:], gotT)
+	for i := 0; i < n; i++ {
+		if sim[i] != grid[i] {
+			return fmt.Errorf("simulation mismatch")
+		}
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) []string {
+	n := rng.Intn(3) + 2
+	m := rng.Intn(3) + 2
+	grid := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, m)
+		for j := 0; j < m; j++ {
+			if rng.Intn(2) == 0 {
+				b[j] = 'X'
+			} else {
+				b[j] = '.'
+			}
+		}
+		grid[i] = string(b)
+	}
+	// ensure at least one X
+	xFound := false
+	for i := 0; i < n; i++ {
+		if strings.Contains(grid[i], "X") {
+			xFound = true
+			break
+		}
+	}
+	if !xFound {
+		grid[0] = "X" + grid[0][1:]
+	}
+	return grid
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	grid := []string{"XXXXXX", "XXXXXX", "XXXXXX"}
+	if err := runCase(bin, grid); err != nil {
+		fmt.Fprintf(os.Stderr, "case 1 failed: %v\n", err)
+		os.Exit(1)
+	}
+	for i := 1; i < 100; i++ {
+		g := genCase(rng)
+		if err := runCase(bin, g); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1262/verifierF1.go
+++ b/1000-1999/1200-1299/1260-1269/1262/verifierF1.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+func solve(k int, h []int) int {
+	n := len(h)
+	size := 2*n + 5
+	dp := make([]int, size)
+	off := n + 2
+	dp[off] = 1
+	for i := 0; i < n; i++ {
+		next := make([]int, size)
+		if h[i] == h[(i+1)%n] {
+			for d := 0; d < size; d++ {
+				if dp[d] != 0 {
+					next[d] = (next[d] + dp[d]*k) % mod
+				}
+			}
+		} else {
+			for d := 0; d < size; d++ {
+				val := dp[d]
+				if val == 0 {
+					continue
+				}
+				next[d] = (next[d] + val*(k-2)) % mod
+				if d+1 < size {
+					next[d+1] = (next[d+1] + val) % mod
+				}
+				if d-1 >= 0 {
+					next[d-1] = (next[d-1] + val) % mod
+				}
+			}
+		}
+		dp = next
+	}
+	ans := 0
+	for d := off + 1; d < size; d++ {
+		ans = (ans + dp[d]) % mod
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, n, k int, h []int) error {
+	input := fmt.Sprintf("%d %d\n", n, k)
+	for i, v := range h {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	expect := solve(k, h)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	var got int
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (int, int, []int) {
+	n := rng.Intn(8) + 1
+	k := rng.Intn(5) + 1
+	h := make([]int, n)
+	for i := range h {
+		h[i] = rng.Intn(k) + 1
+	}
+	return n, k, h
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	n, k, h := 5, 3, []int{5, 2, 2, 3, 4}
+	if err := runCase(bin, n, k, h); err != nil {
+		fmt.Fprintf(os.Stderr, "case 1 failed: %v\n", err)
+		os.Exit(1)
+	}
+	for i := 1; i < 100; i++ {
+		n, k, h := genCase(rng)
+		if err := runCase(bin, n, k, h); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1260-1269/1262/verifierF2.go
+++ b/1000-1999/1200-1299/1260-1269/1262/verifierF2.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const mod = 998244353
+
+func solve(k int, h []int) int {
+	n := len(h)
+	size := 2*n + 5
+	dp := make([]int, size)
+	off := n + 2
+	dp[off] = 1
+	for i := 0; i < n; i++ {
+		next := make([]int, size)
+		if h[i] == h[(i+1)%n] {
+			for d := 0; d < size; d++ {
+				if dp[d] != 0 {
+					next[d] = (next[d] + dp[d]*k) % mod
+				}
+			}
+		} else {
+			for d := 0; d < size; d++ {
+				val := dp[d]
+				if val == 0 {
+					continue
+				}
+				next[d] = (next[d] + val*(k-2)) % mod
+				if d+1 < size {
+					next[d+1] = (next[d+1] + val) % mod
+				}
+				if d-1 >= 0 {
+					next[d-1] = (next[d-1] + val) % mod
+				}
+			}
+		}
+		dp = next
+	}
+	ans := 0
+	for d := off + 1; d < size; d++ {
+		ans = (ans + dp[d]) % mod
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func runCase(bin string, n, k int, h []int) error {
+	input := fmt.Sprintf("%d %d\n", n, k)
+	for i, v := range h {
+		if i > 0 {
+			input += " "
+		}
+		input += fmt.Sprintf("%d", v)
+	}
+	input += "\n"
+	expect := solve(k, h)
+	out, err := run(bin, input)
+	if err != nil {
+		return err
+	}
+	var got int
+	if _, err := fmt.Sscan(out, &got); err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expect {
+		return fmt.Errorf("expected %d got %d", expect, got)
+	}
+	return nil
+}
+
+func genCase(rng *rand.Rand) (int, int, []int) {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(6) + 1
+	h := make([]int, n)
+	for i := range h {
+		h[i] = rng.Intn(k) + 1
+	}
+	return n, k, h
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	n, k, h := 3, 3, []int{1, 2, 3}
+	if err := runCase(bin, n, k, h); err != nil {
+		fmt.Fprintf(os.Stderr, "case 1 failed: %v\n", err)
+		os.Exit(1)
+	}
+	for i := 1; i < 100; i++ {
+		n, k, h := genCase(rng)
+		if err := runCase(bin, n, k, h); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add directory for contest 1262
- add runtime-error sample `1262A.go`
- implement `verifierA.go`–`verifierF2.go` with 100 randomized tests each

## Testing
- `go build 1000-1999/1200-1299/1260-1269/1262/verifierA.go`
- `go build 1000-1999/1200-1299/1260-1269/1262/verifierB.go`
- `go build 1000-1999/1200-1299/1260-1269/1262/verifierC.go`
- `go build 1000-1999/1200-1299/1260-1269/1262/verifierD1.go`
- `go build 1000-1999/1200-1299/1260-1269/1262/verifierD2.go`
- `go build 1000-1999/1200-1299/1260-1269/1262/verifierE.go`
- `go build 1000-1999/1200-1299/1260-1269/1262/verifierF1.go`
- `go build 1000-1999/1200-1299/1260-1269/1262/verifierF2.go`


------
https://chatgpt.com/codex/tasks/task_e_6884d6c645508324bca2d94c678f1b43