### PR TITLE
Add solution verifiers for contest 1272

### DIFF
--- a/1000-1999/1200-1299/1270-1279/1272/verifierA.go
+++ b/1000-1999/1200-1299/1270-1279/1272/verifierA.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testA struct{ a, b, c int }
+
+func genTestsA() []testA {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testA, 100)
+	for i := range tests {
+		tests[i] = testA{
+			a: r.Intn(1_000_000_000) + 1,
+			b: r.Intn(1_000_000_000) + 1,
+			c: r.Intn(1_000_000_000) + 1,
+		}
+	}
+	return tests
+}
+
+func solveA(t testA) int {
+	best := int(^uint(0) >> 1)
+	for da := -1; da <= 1; da++ {
+		for db := -1; db <= 1; db++ {
+			for dc := -1; dc <= 1; dc++ {
+				aa := t.a + da
+				bb := t.b + db
+				cc := t.c + dc
+				dist := abs(aa-bb) + abs(aa-cc) + abs(bb-cc)
+				if dist < best {
+					best = dist
+				}
+			}
+		}
+	}
+	return best
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsA()
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", len(tests))
+	for _, tc := range tests {
+		fmt.Fprintf(&input, "%d %d %d\n", tc.a, tc.b, tc.c)
+	}
+	expect := make([]int, len(tests))
+	for i, tc := range tests {
+		expect[i] = solveA(tc)
+	}
+	output, err := runBinary(bin, input.String())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\n", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Split(bufio.ScanWords)
+	for i, exp := range expect {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		val, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		if val != exp {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1200-1299/1270-1279/1272/verifierB.go
+++ b/1000-1999/1200-1299/1270-1279/1272/verifierB.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testB struct{ s string }
+
+func genTestsB() []testB {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testB, 100)
+	letters := []byte{'L', 'R', 'U', 'D'}
+	for i := range tests {
+		n := r.Intn(50) + 1
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = letters[r.Intn(len(letters))]
+		}
+		tests[i] = testB{s: string(b)}
+	}
+	return tests
+}
+
+func solveB(t testB) (int, string) {
+	cnt := make(map[rune]int)
+	for _, ch := range t.s {
+		cnt[ch]++
+	}
+	horiz := min(cnt['L'], cnt['R'])
+	vert := min(cnt['U'], cnt['D'])
+	if horiz == 0 && vert == 0 {
+		return 0, ""
+	}
+	if horiz == 0 {
+		return 2, "UD"
+	}
+	if vert == 0 {
+		return 2, "LR"
+	}
+	total := (horiz + vert) * 2
+	var sb strings.Builder
+	for i := 0; i < vert; i++ {
+		sb.WriteByte('U')
+	}
+	for i := 0; i < horiz; i++ {
+		sb.WriteByte('R')
+	}
+	for i := 0; i < vert; i++ {
+		sb.WriteByte('D')
+	}
+	for i := 0; i < horiz; i++ {
+		sb.WriteByte('L')
+	}
+	return total, sb.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsB()
+	var input strings.Builder
+	fmt.Fprintf(&input, "%d\n", len(tests))
+	for _, tc := range tests {
+		fmt.Fprintln(&input, tc.s)
+	}
+	outputs := make([]struct {
+		len  int
+		path string
+	}, len(tests))
+	for i, tc := range tests {
+		outputs[i].len, outputs[i].path = solveB(tc)
+	}
+	out, err := runBinary(bin, input.String())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "runtime error: %v\n", err)
+		os.Exit(1)
+	}
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for i, exp := range outputs {
+		if !scanner.Scan() {
+			fmt.Fprintf(os.Stderr, "wrong output format on test %d\n", i+1)
+			os.Exit(1)
+		}
+		length, err := strconv.Atoi(strings.TrimSpace(scanner.Text()))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "non-integer output on test %d\n", i+1)
+			os.Exit(1)
+		}
+		var path string
+		if length > 0 {
+			if !scanner.Scan() {
+				fmt.Fprintf(os.Stderr, "missing path on test %d\n", i+1)
+				os.Exit(1)
+			}
+			path = strings.TrimSpace(scanner.Text())
+		}
+		if length != exp.len || path != exp.path {
+			fmt.Fprintf(os.Stderr, "wrong answer on test %d\n", i+1)
+			os.Exit(1)
+		}
+	}
+	if scanner.Scan() {
+		fmt.Fprintln(os.Stderr, "extra output")
+		os.Exit(1)
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1200-1299/1270-1279/1272/verifierC.go
+++ b/1000-1999/1200-1299/1270-1279/1272/verifierC.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testC struct {
+	n       int
+	k       int
+	s       string
+	allowed []byte
+}
+
+func genTestsC() []testC {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testC, 100)
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	for i := range tests {
+		n := r.Intn(100) + 1
+		b := make([]byte, n)
+		for j := range b {
+			b[j] = letters[r.Intn(26)]
+		}
+		k := r.Intn(26) + 1
+		perm := r.Perm(26)
+		allowed := make([]byte, k)
+		for j := 0; j < k; j++ {
+			allowed[j] = letters[perm[j]]
+		}
+		tests[i] = testC{n: n, k: k, s: string(b), allowed: allowed}
+	}
+	return tests
+}
+
+func solveC(tc testC) int64 {
+	allowed := make(map[byte]bool)
+	for _, ch := range tc.allowed {
+		allowed[ch] = true
+	}
+	var cur int64
+	var ans int64
+	for i := 0; i < tc.n; i++ {
+		if allowed[tc.s[i]] {
+			cur++
+		} else {
+			ans += cur * (cur + 1) / 2
+			cur = 0
+		}
+	}
+	ans += cur * (cur + 1) / 2
+	return ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsC()
+	for i, tc := range tests {
+		var input strings.Builder
+		fmt.Fprintf(&input, "%d %d\n", tc.n, tc.k)
+		fmt.Fprintln(&input, tc.s)
+		for j := 0; j < tc.k; j++ {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			input.WriteByte(tc.allowed[j])
+		}
+		input.WriteByte('\n')
+		expected := fmt.Sprintf("%d", solveC(tc))
+		out, err := runBinary(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input.String(), expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1200-1299/1270-1279/1272/verifierD.go
+++ b/1000-1999/1200-1299/1270-1279/1272/verifierD.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testD struct {
+	a []int
+}
+
+func genTestsD() []testD {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testD, 100)
+	for i := range tests {
+		n := r.Intn(100) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = r.Intn(1_000_000_000) + 1
+		}
+		tests[i] = testD{a: arr}
+	}
+	return tests
+}
+
+func solveD(tc testD) int {
+	n := len(tc.a)
+	if n == 0 {
+		return 0
+	}
+	left := make([]int, n)
+	left[0] = 1
+	for i := 1; i < n; i++ {
+		if tc.a[i] > tc.a[i-1] {
+			left[i] = left[i-1] + 1
+		} else {
+			left[i] = 1
+		}
+	}
+	right := make([]int, n)
+	right[n-1] = 1
+	for i := n - 2; i >= 0; i-- {
+		if tc.a[i] < tc.a[i+1] {
+			right[i] = right[i+1] + 1
+		} else {
+			right[i] = 1
+		}
+	}
+	ans := 1
+	for i := 0; i < n; i++ {
+		if left[i] > ans {
+			ans = left[i]
+		}
+	}
+	if n > 1 {
+		if right[1] > ans {
+			ans = right[1]
+		}
+		if left[n-2] > ans {
+			ans = left[n-2]
+		}
+	}
+	for i := 1; i+1 < n; i++ {
+		if tc.a[i+1] > tc.a[i-1] {
+			if left[i-1]+right[i+1] > ans {
+				ans = left[i-1] + right[i+1]
+			}
+		}
+	}
+	if ans > n {
+		ans = n
+	}
+	return ans
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsD()
+	for i, tc := range tests {
+		var input strings.Builder
+		fmt.Fprintf(&input, "%d\n", len(tc.a))
+		for j, v := range tc.a {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprintf(&input, "%d", v)
+		}
+		input.WriteByte('\n')
+		expected := fmt.Sprintf("%d", solveD(tc))
+		out, err := runBinary(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input.String(), expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1200-1299/1270-1279/1272/verifierE.go
+++ b/1000-1999/1200-1299/1270-1279/1272/verifierE.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type testE struct {
+	a []int
+}
+
+func genTestsE() []testE {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testE, 100)
+	for i := range tests {
+		n := r.Intn(100) + 1
+		arr := make([]int, n)
+		for j := range arr {
+			arr[j] = r.Intn(n) + 1
+		}
+		tests[i] = testE{a: arr}
+	}
+	return tests
+}
+
+func solveE(tc testE) []int {
+	n := len(tc.a)
+	adj := make([][]int, n)
+	for i := 0; i < n; i++ {
+		if i-tc.a[i] >= 0 {
+			adj[i-tc.a[i]] = append(adj[i-tc.a[i]], i)
+		}
+		if i+tc.a[i] < n {
+			adj[i+tc.a[i]] = append(adj[i+tc.a[i]], i)
+		}
+	}
+	dist := make([]int, n)
+	for i := range dist {
+		dist[i] = -1
+	}
+	queue := make([]int, 0)
+	for i := 0; i < n; i++ {
+		found := false
+		if i-tc.a[i] >= 0 && (tc.a[i-tc.a[i]]%2 != tc.a[i]%2) {
+			found = true
+		}
+		if !found && i+tc.a[i] < n && (tc.a[i+tc.a[i]]%2 != tc.a[i]%2) {
+			found = true
+		}
+		if found {
+			dist[i] = 1
+			queue = append(queue, i)
+		}
+	}
+	for head := 0; head < len(queue); head++ {
+		v := queue[head]
+		for _, to := range adj[v] {
+			if dist[to] == -1 {
+				dist[to] = dist[v] + 1
+				queue = append(queue, to)
+			}
+		}
+	}
+	return dist
+}
+
+func runBinary(bin, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", bin)
+	} else {
+		cmd = exec.CommandContext(ctx, bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := genTestsE()
+	for i, tc := range tests {
+		var input strings.Builder
+		fmt.Fprintf(&input, "%d\n", len(tc.a))
+		for j, v := range tc.a {
+			if j > 0 {
+				input.WriteByte(' ')
+			}
+			fmt.Fprintf(&input, "%d", v)
+		}
+		input.WriteByte('\n')
+		expectedSlice := solveE(tc)
+		var expBuilder strings.Builder
+		for j, v := range expectedSlice {
+			if j > 0 {
+				expBuilder.WriteByte(' ')
+			}
+			expBuilder.WriteString(strconv.Itoa(v))
+		}
+		expected := expBuilder.String()
+		out, err := runBinary(bin, input.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != expected {
+			fmt.Fprintf(os.Stderr, "case %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input.String(), expected, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}

--- a/1000-1999/1200-1299/1270-1279/1272/verifierF.go
+++ b/1000-1999/1200-1299/1270-1279/1272/verifierF.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type testF struct {
+	a string
+	b string
+}
+
+func genTestsF() []testF {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tests := make([]testF, 100)
+	for i := range tests {
+		la := r.Intn(10) + 1
+		lb := r.Intn(10) + 1
+		var sb strings.Builder
+		for j := 0; j < la; j++ {
+			if r.Intn(2) == 0 {
+				sb.WriteByte('(')
+			} else {
+				sb.WriteByte(')')
+			}
+		}
+		a := sb.String()
+		sb.Reset()
+		for j := 0; j < lb; j++ {
+			if r.Intn(2) == 0 {
+				sb.WriteByte('(')
+			} else {
+				sb.WriteByte(')')
+			}
+		}
+		b := sb.String()
+		tests[i] = testF{a: a, b: b}
+	}
+	return tests
+}
+
+func buildOracle() (string, error) {
+	exe := filepath.Join(os.TempDir(), "oracle1272F.bin")
+	cmd := exec.Command("go", "build", "-o", exe, "1272F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return exe, nil
+}
+
+func runBinary(path, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.CommandContext(ctx, "go", "run", path)
+	} else {
+		cmd = exec.CommandContext(ctx, path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	tests := genTestsF()
+	for i, tc := range tests {
+		input := tc.a + "\n" + tc.b + "\n"
+		expected, err := runBinary(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		if got != expected {
+			fmt.Fprintf(os.Stderr, "test %d failed\ninput:\n%sexpected:%s\ngot:%s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Accepted")
+}


### PR DESCRIPTION
## Summary
- implement Go verifiers for problems A–F of contest 1272
- each verifier generates 100 random test cases and runs the candidate binary
- verifiers compute expected results (or use the official solution as oracle for F)

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884dc3f091c83249dee2f5e33125213