### PR TITLE
Add Go solution for problem 1840D

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1840/1840D.go
+++ b/1000-1999/1800-1899/1840-1849/1840/1840D.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func canCover(a []int64, d int64) bool {
+	n := len(a)
+	i := 0
+	for k := 0; k < 3 && i < n; k++ {
+		limit := a[i] + 2*d
+		i++
+		for i < n && a[i] <= limit {
+			i++
+		}
+	}
+	return i == n
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
+		low, high := int64(0), int64(1_000_000_000)
+		for low < high {
+			mid := (low + high) / 2
+			if canCover(arr, mid) {
+				high = mid
+			} else {
+				low = mid + 1
+			}
+		}
+		fmt.Fprintln(writer, low)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for Wooden Toy Festival (1840D)

## Testing
- `go build ./1000-1999/1800-1899/1840-1849/1840/1840D.go`


------
https://chatgpt.com/codex/tasks/task_e_6884dd9d42f48324a51912baea162bb0