### PR TITLE
Add Go verifiers for contest 1271

### DIFF
--- a/1000-1999/1200-1299/1270-1279/1271/verifierA.go
+++ b/1000-1999/1200-1299/1270-1279/1271/verifierA.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func expected(a, b, c, d, e, f int) string {
+	res := 0
+	if e > f {
+		t1 := min(a, d)
+		res += t1 * e
+		d -= t1
+		t2 := min(min(b, c), d)
+		res += t2 * f
+	} else {
+		t2 := min(min(b, c), d)
+		res += t2 * f
+		d -= t2
+		t1 := min(a, d)
+		res += t1 * e
+	}
+	return fmt.Sprintf("%d", res)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	a := rng.Intn(100000) + 1
+	b := rng.Intn(100000) + 1
+	c := rng.Intn(100000) + 1
+	d := rng.Intn(100000) + 1
+	e := rng.Intn(1000) + 1
+	f := rng.Intn(1000) + 1
+	input := fmt.Sprintf("%d\n%d\n%d\n%d\n%d\n%d\n", a, b, c, d, e, f)
+	return input, expected(a, b, c, d, e, f)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(exe, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1270-1279/1271/verifierB.go
+++ b/1000-1999/1200-1299/1270-1279/1271/verifierB.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func tryOps(orig []byte, target byte) ([]int, bool) {
+	n := len(orig)
+	a := make([]byte, n)
+	copy(a, orig)
+	ops := make([]int, 0, n)
+	for i := 0; i < n-1; i++ {
+		if a[i] != target {
+			ops = append(ops, i+1)
+			a[i] = target
+			if a[i+1] == 'W' {
+				a[i+1] = 'B'
+			} else {
+				a[i+1] = 'W'
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != target {
+			return nil, false
+		}
+	}
+	return ops, true
+}
+
+func expected(n int, s string) string {
+	orig := []byte(s)
+	if ops, ok := tryOps(orig, 'W'); ok {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", len(ops))
+		for i, v := range ops {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		if len(ops) > 0 {
+			sb.WriteByte('\n')
+		} else {
+			sb.WriteByte('\n')
+		}
+		return strings.TrimRight(sb.String(), "\n")
+	}
+	if ops, ok := tryOps(orig, 'B'); ok {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", len(ops))
+		for i, v := range ops {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		if len(ops) > 0 {
+			sb.WriteByte('\n')
+		} else {
+			sb.WriteByte('\n')
+		}
+		return strings.TrimRight(sb.String(), "\n")
+	}
+	return "-1"
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(199) + 2 // 2..200
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = 'W'
+		} else {
+			b[i] = 'B'
+		}
+	}
+	s := string(b)
+	input := fmt.Sprintf("%d\n%s\n", n, s)
+	return input, expected(n, s)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected = strings.TrimSpace(expected)
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(exe, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1270-1279/1271/verifierC.go
+++ b/1000-1999/1200-1299/1270-1279/1271/verifierC.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func expected(n, sx, sy int, pts [][2]int) string {
+	x1, x2, y1, y2 := 0, 0, 0, 0
+	for _, p := range pts {
+		x := p[0]
+		y := p[1]
+		if x < sx {
+			x1++
+		}
+		if x > sx {
+			x2++
+		}
+		if y < sy {
+			y1++
+		}
+		if y > sy {
+			y2++
+		}
+	}
+	ans := x1
+	ansx, ansy := sx, sy
+	if x2 > ans {
+		ans = x2
+	}
+	if y1 > ans {
+		ans = y1
+	}
+	if y2 > ans {
+		ans = y2
+	}
+	if ans == x1 {
+		ansx = sx - 1
+		ansy = sy
+	} else if ans == x2 {
+		ansx = sx + 1
+		ansy = sy
+	} else if ans == y1 {
+		ansx = sx
+		ansy = sy - 1
+	} else if ans == y2 {
+		ansx = sx
+		ansy = sy + 1
+	}
+	return fmt.Sprintf("%d\n%d %d", ans, ansx, ansy)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(1000) + 1
+	sx := rng.Intn(1000)
+	sy := rng.Intn(1000)
+	pts := make([][2]int, n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, sx, sy)
+	for i := 0; i < n; i++ {
+		x := rng.Intn(1000)
+		y := rng.Intn(1000)
+		if x == sx && y == sy {
+			if x > 0 {
+				x--
+			} else {
+				x++
+			}
+		}
+		pts[i] = [2]int{x, y}
+		fmt.Fprintf(&sb, "%d %d\n", x, y)
+	}
+	return sb.String(), expected(n, sx, sy, pts)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected = strings.TrimSpace(expected)
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(exe, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1270-1279/1271/verifierD.go
+++ b/1000-1999/1200-1299/1270-1279/1271/verifierD.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type IntHeap []int
+
+func (h IntHeap) Len() int            { return len(h) }
+func (h IntHeap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h IntHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *IntHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h *IntHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func expected(n, m, k int, a, b, c []int, edges [][2]int) string {
+	last := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		last[i] = i
+	}
+	for _, e := range edges {
+		u := e[0]
+		v := e[1]
+		if u > v {
+			if u > last[v] {
+				last[v] = u
+			}
+		}
+	}
+	base := make([]int, n+1)
+	base[0] = k
+	for i := 1; i <= n; i++ {
+		if base[i-1] < a[i] {
+			return "-1"
+		}
+		base[i] = base[i-1] + b[i]
+	}
+	cap := make([]int, n+1)
+	cap[n] = base[n]
+	for i := 1; i < n; i++ {
+		cap[i] = base[i] - a[i+1]
+		if cap[i] < 0 {
+			return "-1"
+		}
+	}
+	buckets := make([][]int, n+1)
+	for i := 1; i <= n; i++ {
+		d := last[i]
+		buckets[d] = append(buckets[d], c[i])
+	}
+	h := &IntHeap{}
+	heap.Init(h)
+	total := 0
+	size := 0
+	for t := 1; t <= n; t++ {
+		for _, val := range buckets[t] {
+			heap.Push(h, val)
+			total += val
+			size++
+		}
+		for size > cap[t] {
+			removed := heap.Pop(h).(int)
+			total -= removed
+			size--
+		}
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(10) + 1
+	maxM := n * (n - 1) / 2
+	m := rng.Intn(maxM + 1)
+	k := rng.Intn(20)
+	a := make([]int, n+1)
+	b := make([]int, n+1)
+	c := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		a[i] = rng.Intn(10)
+		b[i] = rng.Intn(10)
+		c[i] = rng.Intn(10)
+	}
+	edges := make([][2]int, m)
+	seen := map[[2]int]bool{}
+	for i := 0; i < m; {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(u-1) + 1
+		e := [2]int{u, v}
+		if !seen[e] {
+			seen[e] = true
+			edges[i] = e
+			i++
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&sb, "%d %d %d\n", a[i], b[i], c[i])
+	}
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	exp := expected(n, m, k, a, b, c, edges)
+	return sb.String(), exp
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	expected = strings.TrimSpace(expected)
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(exe, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1270-1279/1271/verifierE.go
+++ b/1000-1999/1200-1299/1270-1279/1271/verifierE.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func count(n, y int64) int64 {
+	length := int64(1)
+	if y%2 == 0 {
+		length = 2
+	}
+	var res int64
+	cur := y
+	l := length
+	for cur <= n {
+		end := cur + l - 1
+		if end > n {
+			res += n - cur + 1
+		} else {
+			res += l
+		}
+		if cur > n/2 {
+			break
+		}
+		cur <<= 1
+		l <<= 1
+	}
+	return res
+}
+
+func maxY(n, k, parity int64) int64 {
+	var low int64
+	if parity == 1 {
+		low = 1
+	} else {
+		low = 2
+	}
+	high := n
+	if high%2 != parity {
+		high--
+	}
+	var ans int64
+	for low <= high {
+		mid := (low + high) / 2
+		if mid%2 != parity {
+			mid++
+			if mid > high {
+				break
+			}
+		}
+		if count(n, mid) >= k {
+			if mid > ans {
+				ans = mid
+			}
+			low = mid + 2
+		} else {
+			high = mid - 2
+		}
+	}
+	return ans
+}
+
+func expected(n, k int64) string {
+	odd := maxY(n, k, 1)
+	even := maxY(n, k, 0)
+	if odd > even {
+		return fmt.Sprintf("%d", odd)
+	}
+	return fmt.Sprintf("%d", even)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000_000_000) + 1
+	k := rng.Int63n(n) + 1
+	input := fmt.Sprintf("%d %d\n", n, k)
+	return input, expected(n, k)
+}
+
+func runCase(exe, input, expected string) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	got := strings.TrimSpace(out.String())
+	if got != expected {
+		return fmt.Errorf("expected %q got %q", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input, expect := generateCase(rng)
+		if err := runCase(exe, input, expect); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1270-1279/1271/verifierF.go
+++ b/1000-1999/1200-1299/1270-1279/1271/verifierF.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, _ := os.Getwd()
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1271F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, string(out))
+	}
+	return oracle, nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		a1 := rng.Intn(10) + 1
+		b1 := rng.Intn(10) + 1
+		c1 := rng.Intn(10) + 1
+		a2 := rng.Intn(10) + 1
+		b2 := rng.Intn(10) + 1
+		c2 := rng.Intn(10) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", a1, b1, c1)
+		fmt.Fprintf(&sb, "%d %d %d\n", a2, b2, c2)
+		for j := 0; j < 7; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			d := rng.Intn(5)
+			fmt.Fprintf(&sb, "%d", d)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func run(exe, input string) (string, error) {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := run(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on test %d: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected:\n%s\n\ngot:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement Go-based verifiers for problems A-F of Codeforces contest 1271
- verifiers generate 100 random tests each and compare against expected output
- problem F verifier builds the provided reference solution as an oracle

## Testing
- `go vet 1000-1999/1200-1299/1270-1279/1271/verifierA.go`
- `go vet 1000-1999/1200-1299/1270-1279/1271/verifierB.go`
- `go vet 1000-1999/1200-1299/1270-1279/1271/verifierC.go`
- `go vet 1000-1999/1200-1299/1270-1279/1271/verifierD.go`
- `go vet 1000-1999/1200-1299/1270-1279/1271/verifierE.go`
- `go vet 1000-1999/1200-1299/1270-1279/1271/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884dbb2f6648324be8879858067b368