### PR TITLE
Add admin key for problem creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ directly from your browser. Launch it from the repository root:
 go run webserver.go
 ```
 
+If you set the `ADMIN_KEY` environment variable, the "Add Problem" form requires
+the same key before a problem is created. This helps prevent unauthorized
+modifications when running a public server.
+
 Open <http://localhost:8081> to see the list of contests. Each problem page
 allows you to paste code or upload a file in C, C++, Go, Rust, Java or Python.
 If a verifier is present in the contest directory it will run automatically

--- a/webserver.go
+++ b/webserver.go
@@ -54,6 +54,7 @@ var contestTmpl = template.Must(template.New("contest").Parse(`
 <form action="/addproblem" method="post">
 <input type="hidden" name="contest" value="{{.ID}}">
 Letter: <input name="letter"><br>
+Admin Key: <input type="password" name="adminkey"><br>
 <textarea name="statement" rows="10" cols="80"></textarea><br>
 <input type="submit" value="Add Problem">
 </form>
@@ -66,6 +67,7 @@ var addProblemTmpl = template.Must(template.New("addproblem").Parse(`
 <form action="/addproblem" method="post">
 Contest ID: <input name="contest" value="{{.Contest}}"><br>
 Letter: <input name="letter" value="{{.Letter}}"><br>
+Admin Key: <input type="password" name="adminkey"><br>
 <textarea name="statement" rows="10" cols="80">{{.Statement}}</textarea><br>
 <input type="submit" value="Add Problem">
 </form>
@@ -446,6 +448,11 @@ func addProblemHandler(w http.ResponseWriter, r *http.Request) {
 		contestID := r.FormValue("contest")
 		letter := strings.ToUpper(r.FormValue("letter"))
 		statement := r.FormValue("statement")
+		adminkey := r.FormValue("adminkey")
+		if adminkey != os.Getenv("ADMIN_KEY") {
+			http.Error(w, "admin key mismatch", http.StatusForbidden)
+			return
+		}
 		if contestID == "" || letter == "" {
 			http.Error(w, "missing parameters", http.StatusBadRequest)
 			return


### PR DESCRIPTION
## Summary
- secure problem creation with ADMIN_KEY check
- document ADMIN_KEY in README

## Testing
- `go build webserver.go` *(fails: go module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884e1c28ec88324b7c34a849fa888b4