### PR TITLE
Add Go verifiers for Codeforces 1284

### DIFF
--- a/1000-1999/1200-1299/1280-1289/1284/verifierA.go
+++ b/1000-1999/1200-1299/1280-1289/1284/verifierA.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1284A.go")
+	tmpDir, err := os.MkdirTemp("", "ref1284A")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randWord(r *rand.Rand) string {
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	l := r.Intn(10) + 1
+	var sb strings.Builder
+	for i := 0; i < l; i++ {
+		sb.WriteByte(letters[r.Intn(len(letters))])
+	}
+	return sb.String()
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 1
+	m := r.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(randWord(r))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < m; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(randWord(r))
+	}
+	sb.WriteByte('\n')
+	q := r.Intn(10) + 1
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		y := r.Intn(1_000_000_000) + 1
+		sb.WriteString(fmt.Sprintf("%d\n", y))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1280-1289/1284/verifierB.go
+++ b/1000-1999/1200-1299/1280-1289/1284/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1284B.go")
+	tmpDir, err := os.MkdirTemp("", "ref1284B")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(20) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		l := r.Intn(10) + 1
+		sb.WriteString(fmt.Sprintf("%d ", l))
+		for j := 0; j < l; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", r.Intn(100)))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1280-1289/1284/verifierC.go
+++ b/1000-1999/1200-1299/1280-1289/1284/verifierC.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1284C.go")
+	tmpDir, err := os.MkdirTemp("", "ref1284C")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(20) + 1
+	mod := 1000000007
+	return fmt.Sprintf("%d %d\n", n, mod)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1280-1289/1284/verifierD.go
+++ b/1000-1999/1200-1299/1280-1289/1284/verifierD.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1284D.go")
+	tmpDir, err := os.MkdirTemp("", "ref1284D")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(10) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sa := r.Intn(90) + 1
+		ea := sa + r.Intn(10)
+		sbVal := r.Intn(90) + 1
+		eb := sbVal + r.Intn(10)
+		sb.WriteString(fmt.Sprintf("%d %d %d %d\n", sa, ea, sbVal, eb))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1280-1289/1284/verifierE.go
+++ b/1000-1999/1200-1299/1280-1289/1284/verifierE.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1284E.go")
+	tmpDir, err := os.MkdirTemp("", "ref1284E")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func collinear(x1, y1, x2, y2, x3, y3 int) bool {
+	return (x2-x1)*(y3-y1)-(y2-y1)*(x3-x1) == 0
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(8) + 5
+	type pt struct{ x, y int }
+	pts := make([]pt, 0, n)
+	for len(pts) < n {
+		x := r.Intn(200) - 100
+		y := r.Intn(200) - 100
+		ok := true
+		for j := 0; j < len(pts); j++ {
+			if pts[j].x == x && pts[j].y == y {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+		col := false
+		for j := 0; j < len(pts) && !col; j++ {
+			for k := j + 1; k < len(pts); k++ {
+				if collinear(pts[j].x, pts[j].y, pts[k].x, pts[k].y, x, y) {
+					col = true
+					break
+				}
+			}
+		}
+		if col {
+			continue
+		}
+		pts = append(pts, pt{x, y})
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, p := range pts {
+		sb.WriteString(fmt.Sprintf("%d %d\n", p.x, p.y))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1280-1289/1284/verifierF.go
+++ b/1000-1999/1200-1299/1280-1289/1284/verifierF.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "1284F.go")
+	tmpDir, err := os.MkdirTemp("", "ref1284F")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randTree(r *rand.Rand, n int) [][2]int {
+	edges := make([][2]int, 0, n-1)
+	for i := 2; i <= n; i++ {
+		p := r.Intn(i-1) + 1
+		edges = append(edges, [2]int{i, p})
+	}
+	return edges
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(5) + 2
+	t1 := randTree(r, n)
+	t2 := randTree(r, n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range t1 {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	for _, e := range t2 {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1280-1289/1284/verifierG.go
+++ b/1000-1999/1200-1299/1280-1289/1284/verifierG.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func buildRef() (string, func(), error) {
+	_, cur, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(cur)
+	src := filepath.Join(dir, "solG.cpp")
+	tmpDir, err := os.MkdirTemp("", "ref1284G")
+	if err != nil {
+		return "", nil, err
+	}
+	bin := filepath.Join(tmpDir, "refbin")
+	cmd := exec.Command("g++", "-std=c++17", "-O2", "-pipe", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", nil, fmt.Errorf("failed to build reference: %v\n%s", err, string(out))
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	return bin, cleanup, nil
+}
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(r *rand.Rand) string {
+	n := r.Intn(4) + 2
+	m := r.Intn(4) + 2
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			sb.WriteByte('O')
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		return
+	}
+	candidate := os.Args[1]
+	ref, cleanup, err := buildRef()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer cleanup()
+	r := rand.New(rand.NewSource(1))
+	for tc := 1; tc <= 100; tc++ {
+		in := genCase(r)
+		want, err := run(ref, in)
+		if err != nil {
+			fmt.Printf("reference failed on case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		got, err := run(candidate, in)
+		if err != nil {
+			fmt.Printf("case %d: %v\n", tc, err)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %q\ngot: %q\n", tc, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}


### PR DESCRIPTION
## Summary
- add automated solution verifiers for Codeforces Round 1284 problems A–G
- each verifier builds the reference solution and runs 100 random tests against a candidate binary
- reference for problem G is compiled from `solG.cpp` using g++

## Testing
- `go run verifierA.go ../../../../1284A`
- `go run verifierB.go ../../../../1284B`
- `go run verifierC.go ../../../../1284C`
- `go run verifierD.go ../../../../1284D`
- `go run verifierE.go ../../../../1284E`
- `go run verifierF.go ../../../../1284F`


------
https://chatgpt.com/codex/tasks/task_e_6884e2d0566c8324bde2544b411609b2