### PR TITLE
Add Go verifiers for contest 1283

### DIFF
--- a/1000-1999/1200-1299/1280-1289/1283/verifierA.go
+++ b/1000-1999/1200-1299/1280-1289/1283/verifierA.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct{ h, m int }
+
+func generateTests() []testCase {
+	var tests []testCase
+	for h := 0; h < 24 && len(tests) < 100; h++ {
+		for m := 0; m < 60 && len(tests) < 100; m++ {
+			if h == 0 && m == 0 {
+				continue
+			}
+			tests = append(tests, testCase{h, m})
+		}
+	}
+	return tests
+}
+
+func expected(tc testCase) int {
+	return 24*60 - (tc.h*60 + tc.m)
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return out.String(), fmt.Errorf("exec error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	rand.Seed(1)
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d %d\n", tc.h, tc.m)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var got int
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Printf("test %d: failed to parse output '%s'\n", i+1, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+		exp := expected(tc)
+		if got != exp {
+			fmt.Printf("test %d: expected %d got %d\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1200-1299/1280-1289/1283/verifierB.go
+++ b/1000-1999/1200-1299/1280-1289/1283/verifierB.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct{ n, k int64 }
+
+func generateTests() []testCase {
+	rnd := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		tests[i].n = rnd.Int63n(1e9) + 1
+		tests[i].k = rnd.Int63n(1e9) + 1
+	}
+	return tests
+}
+
+func expected(tc testCase) int64 {
+	base := (tc.n / tc.k) * tc.k
+	rem := tc.n % tc.k
+	half := tc.k / 2
+	if rem > half {
+		rem = half
+	}
+	return base + rem
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return out.String(), fmt.Errorf("exec error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for i, tc := range tests {
+		input := fmt.Sprintf("1\n%d %d\n", tc.n, tc.k)
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		var got int64
+		if _, err := fmt.Sscan(out, &got); err != nil {
+			fmt.Printf("test %d: failed to parse output '%s'\n", i+1, strings.TrimSpace(out))
+			os.Exit(1)
+		}
+		exp := expected(tc)
+		if got != exp {
+			fmt.Printf("test %d: expected %d got %d\n", i+1, exp, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1200-1299/1280-1289/1283/verifierC.go
+++ b/1000-1999/1200-1299/1280-1289/1283/verifierC.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	v []int
+}
+
+func generateTests() []testCase {
+	rnd := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		n := rnd.Intn(50) + 2
+		p := rnd.Perm(n)
+		v := make([]int, n)
+		for j := 0; j < n; j++ {
+			v[j] = p[j] + 1
+		}
+		for j := 0; j < n; j++ {
+			if v[j] == j+1 {
+				if j+1 < n {
+					v[j], v[j+1] = v[j+1], v[j]
+				} else {
+					v[j], v[0] = v[0], v[j]
+				}
+			}
+		}
+		zeros := rnd.Intn(n-1) + 2
+		if zeros > n {
+			zeros = n
+		}
+		perm := rnd.Perm(n)
+		for k := 0; k < zeros; k++ {
+			v[perm[k]] = 0
+		}
+		tests[i] = testCase{n, v}
+	}
+	return tests
+}
+
+func solveExpected(tc testCase) []int {
+	n := tc.n
+	v := append([]int(nil), tc.v...)
+	used := make([]bool, n)
+	for i := 0; i < n; i++ {
+		if v[i] != 0 {
+			used[v[i]-1] = true
+		}
+	}
+	var givers, missing []int
+	for i := 0; i < n; i++ {
+		if v[i] == 0 {
+			givers = append(givers, i)
+		}
+		if !used[i] {
+			missing = append(missing, i)
+		}
+	}
+	k := len(givers)
+	for i := 0; i < k; i++ {
+		j := (i + 1) % k
+		v[givers[i]] = missing[j] + 1
+	}
+	return v
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return out.String(), fmt.Errorf("exec error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for idx, tc := range tests {
+		input := fmt.Sprintf("%d\n", tc.n)
+		for i, x := range tc.v {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", x)
+		}
+		input += "\n"
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		fields := strings.Fields(out)
+		if len(fields) != tc.n {
+			fmt.Printf("test %d: expected %d numbers got %d\n", idx+1, tc.n, len(fields))
+			os.Exit(1)
+		}
+		res := make([]int, tc.n)
+		for i, f := range fields {
+			if _, err := fmt.Sscan(f, &res[i]); err != nil {
+				fmt.Printf("test %d: invalid number %q\n", idx+1, f)
+				os.Exit(1)
+			}
+		}
+		expected := solveExpected(tc)
+		for i := 0; i < tc.n; i++ {
+			if res[i] < 1 || res[i] > tc.n {
+				fmt.Printf("test %d: value out of range\n", idx+1)
+				os.Exit(1)
+			}
+		}
+		// check permutation
+		seen := make(map[int]bool)
+		for i, v := range res {
+			if tc.v[i] != 0 && v != tc.v[i] {
+				fmt.Printf("test %d: value %d expected fixed %d\n", idx+1, v, tc.v[i])
+				os.Exit(1)
+			}
+			if v == i+1 {
+				fmt.Printf("test %d: self gift\n", idx+1)
+				os.Exit(1)
+			}
+			if seen[v] {
+				fmt.Printf("test %d: duplicate value %d\n", idx+1, v)
+				os.Exit(1)
+			}
+			seen[v] = true
+		}
+		// expected arrangement from algorithm
+		for i, v := range expected {
+			if res[i] != v {
+				fmt.Printf("test %d: expected %v got %v\n", idx+1, expected, res)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1200-1299/1280-1289/1283/verifierD.go
+++ b/1000-1999/1200-1299/1280-1289/1283/verifierD.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n, m int
+	xs   []int
+}
+
+func generateTests() []testCase {
+	rnd := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		n := rnd.Intn(5) + 1
+		m := rnd.Intn(5) + 1
+		xs := make([]int, n)
+		used := map[int]bool{}
+		for j := 0; j < n; j++ {
+			for {
+				v := rnd.Intn(51) - 25
+				if !used[v] {
+					used[v] = true
+					xs[j] = v
+					break
+				}
+			}
+		}
+		tests[i] = testCase{n, m, xs}
+	}
+	return tests
+}
+
+type node struct{ pos, dist int }
+
+func bfs(tc testCase) (int64, map[int]int) {
+	q := list.New()
+	dist := map[int]int{}
+	for _, x := range tc.xs {
+		dist[x] = 0
+		q.PushBack(node{x, 0})
+	}
+	ansDist := make(map[int]int)
+	var sum int64
+	for q.Len() > 0 && len(ansDist) < tc.m {
+		e := q.Front()
+		q.Remove(e)
+		cur := e.Value.(node)
+		for _, d := range []int{-1, 1} {
+			np := cur.pos + d
+			if _, ok := dist[np]; ok {
+				continue
+			}
+			dist[np] = cur.dist + 1
+			q.PushBack(node{np, cur.dist + 1})
+			if len(ansDist) < tc.m {
+				ansDist[np] = cur.dist + 1
+				sum += int64(cur.dist + 1)
+			}
+			if len(ansDist) == tc.m {
+				break
+			}
+		}
+	}
+	return sum, ansDist
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return out.String(), fmt.Errorf("exec error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for idx, tc := range tests {
+		input := fmt.Sprintf("%d %d\n", tc.n, tc.m)
+		for i, x := range tc.xs {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", x)
+		}
+		input += "\n"
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) < 2 {
+			fmt.Printf("test %d: insufficient output\n", idx+1)
+			os.Exit(1)
+		}
+		var gotSum int64
+		if _, err := fmt.Sscan(lines[0], &gotSum); err != nil {
+			fmt.Printf("test %d: cannot parse sum\n", idx+1)
+			os.Exit(1)
+		}
+		fields := strings.Fields(lines[1])
+		if len(fields) != tc.m {
+			fmt.Printf("test %d: expected %d positions got %d\n", idx+1, tc.m, len(fields))
+			os.Exit(1)
+		}
+		posOut := make([]int, tc.m)
+		seen := map[int]bool{}
+		for i, f := range fields {
+			if _, err := fmt.Sscan(f, &posOut[i]); err != nil {
+				fmt.Printf("test %d: invalid position\n", idx+1)
+				os.Exit(1)
+			}
+			if seen[posOut[i]] {
+				fmt.Printf("test %d: duplicate position\n", idx+1)
+				os.Exit(1)
+			}
+			seen[posOut[i]] = true
+			for _, t := range tc.xs {
+				if posOut[i] == t {
+					fmt.Printf("test %d: position overlaps tree\n", idx+1)
+					os.Exit(1)
+				}
+			}
+		}
+		expSum, distMap := bfs(tc)
+		if gotSum != expSum {
+			fmt.Printf("test %d: expected sum %d got %d\n", idx+1, expSum, gotSum)
+			os.Exit(1)
+		}
+		var calcSum int64
+		for _, p := range posOut {
+			d, ok := distMap[p]
+			if !ok {
+				d = bfsDistance(tc.xs, p)
+			}
+			calcSum += int64(d)
+		}
+		if calcSum != expSum {
+			fmt.Printf("test %d: positions produce sum %d expected %d\n", idx+1, calcSum, expSum)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}
+
+func bfsDistance(src []int, target int) int {
+	visited := map[int]bool{}
+	q := list.New()
+	for _, x := range src {
+		visited[x] = true
+		if x == target {
+			return 0
+		}
+		q.PushBack(node{x, 0})
+	}
+	for q.Len() > 0 {
+		e := q.Front()
+		q.Remove(e)
+		cur := e.Value.(node)
+		for _, d := range []int{-1, 1} {
+			np := cur.pos + d
+			if visited[np] {
+				continue
+			}
+			if np == target {
+				return cur.dist + 1
+			}
+			visited[np] = true
+			q.PushBack(node{np, cur.dist + 1})
+		}
+	}
+	return -1
+}

--- a/1000-1999/1200-1299/1280-1289/1283/verifierE.go
+++ b/1000-1999/1200-1299/1280-1289/1283/verifierE.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n  int
+	xs []int
+}
+
+func generateTests() []testCase {
+	rnd := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		n := rnd.Intn(20) + 1
+		xs := make([]int, n)
+		for j := 0; j < n; j++ {
+			xs[j] = rnd.Intn(101) - 50
+		}
+		tests[i] = testCase{n, xs}
+	}
+	return tests
+}
+
+func expected(tc testCase) (int, int) {
+	xs := append([]int(nil), tc.xs...)
+	sort.Ints(xs)
+	minAns := 0
+	for i := 0; i < len(xs); {
+		minAns++
+		limit := xs[i] + 2
+		for i < len(xs) && xs[i] <= limit {
+			i++
+		}
+	}
+	used := make(map[int]bool)
+	for _, x := range xs {
+		if !used[x-1] {
+			used[x-1] = true
+		} else if !used[x] {
+			used[x] = true
+		} else if !used[x+1] {
+			used[x+1] = true
+		}
+	}
+	maxAns := len(used)
+	return minAns, maxAns
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return out.String(), fmt.Errorf("exec error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for idx, tc := range tests {
+		input := fmt.Sprintf("%d\n", tc.n)
+		for i, x := range tc.xs {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", x)
+		}
+		input += "\n"
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		var gotMin, gotMax int
+		if _, err := fmt.Sscan(out, &gotMin, &gotMax); err != nil {
+			fmt.Printf("test %d: parse error\n", idx+1)
+			os.Exit(1)
+		}
+		expMin, expMax := expected(tc)
+		if gotMin != expMin || gotMax != expMax {
+			fmt.Printf("test %d: expected %d %d got %d %d\n", idx+1, expMin, expMax, gotMin, gotMax)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}

--- a/1000-1999/1200-1299/1280-1289/1283/verifierF.go
+++ b/1000-1999/1200-1299/1280-1289/1283/verifierF.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	n int
+	a []int
+}
+
+func generateTests() []testCase {
+	rnd := rand.New(rand.NewSource(1))
+	tests := make([]testCase, 100)
+	for i := range tests {
+		n := rnd.Intn(10) + 2
+		a := make([]int, n-1)
+		for j := range a {
+			a[j] = rnd.Intn(n) + 1
+		}
+		tests[i] = testCase{n, a}
+	}
+	return tests
+}
+
+// expected using algorithm from 1283F.go
+func expected(tc testCase) (int, [][2]int) {
+	n := tc.n
+	v := append([]int{0}, tc.a...)
+	root := v[1]
+	findPath := make([]bool, n+1)
+	findPath[root] = true
+	p := 2
+	last := n
+	ans := make([][2]int, 0, n-1)
+	for {
+		for last > 0 && findPath[last] {
+			last--
+		}
+		if last <= 0 {
+			break
+		}
+		findPath[last] = true
+		for p < n && !findPath[v[p]] {
+			ans = append(ans, [2]int{v[p-1], v[p]})
+			findPath[v[p]] = true
+			p++
+		}
+		ans = append(ans, [2]int{last, v[p-1]})
+		p++
+	}
+	return root, ans
+}
+
+func runBinary(bin string, input string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return out.String(), fmt.Errorf("timeout")
+	}
+	if err != nil {
+		return out.String(), fmt.Errorf("exec error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func parseEdges(lines []string) (int, [][2]int, error) {
+	var root int
+	if _, err := fmt.Sscan(lines[0], &root); err != nil {
+		return 0, nil, fmt.Errorf("invalid root")
+	}
+	edges := make([][2]int, len(lines)-1)
+	for i := 1; i < len(lines); i++ {
+		if _, err := fmt.Sscan(lines[i], &edges[i-1][0], &edges[i-1][1]); err != nil {
+			return 0, nil, fmt.Errorf("bad edge")
+		}
+	}
+	return root, edges, nil
+}
+
+func normalize(edges [][2]int) [][2]int {
+	out := make([][2]int, len(edges))
+	for i, e := range edges {
+		if e[0] > e[1] {
+			e[0], e[1] = e[1], e[0]
+		}
+		out[i] = e
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i][0] == out[j][0] {
+			return out[i][1] < out[j][1]
+		}
+		return out[i][0] < out[j][0]
+	})
+	return out
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	tests := generateTests()
+	for idx, tc := range tests {
+		input := fmt.Sprintf("%d\n", tc.n)
+		for i, x := range tc.a {
+			if i > 0 {
+				input += " "
+			}
+			input += fmt.Sprintf("%d", x)
+		}
+		input += "\n"
+		out, err := runBinary(bin, input)
+		if err != nil {
+			fmt.Printf("test %d: %v\n", idx+1, err)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		rootGot, edgesGot, err := parseEdges(lines)
+		if err != nil || len(edgesGot) != tc.n-1 {
+			fmt.Printf("test %d: parse fail\n", idx+1)
+			os.Exit(1)
+		}
+		rootExp, edgesExp := expected(tc)
+		if rootGot != rootExp {
+			fmt.Printf("test %d: expected root %d got %d\n", idx+1, rootExp, rootGot)
+			os.Exit(1)
+		}
+		ne := normalize(edgesExp)
+		ng := normalize(edgesGot)
+		if len(ne) != len(ng) {
+			fmt.Printf("test %d: edge count mismatch\n", idx+1)
+			os.Exit(1)
+		}
+		for i := 0; i < len(ne); i++ {
+			if ne[i] != ng[i] {
+				fmt.Printf("test %d: edges mismatch\n", idx+1)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add verifiers for CF contest 1283 problems A-F
- each verifier generates 100 deterministic tests
- executes given binary and checks results

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go run verifierA.go ./1283A`

------
https://chatgpt.com/codex/tasks/task_e_6884e243ebb483249f44b7c0ecdf2e13