### PR TITLE
Add Go solution verifiers for contest 1281

### DIFF
--- a/1000-1999/1200-1299/1280-1289/1281/verifierA.go
+++ b/1000-1999/1200-1299/1280-1289/1281/verifierA.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef(src string) (string, error) {
+	tmp, err := os.CreateTemp("", "refA-")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randWord(rng *rand.Rand, length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func genTest(rng *rand.Rand) string {
+	t := rng.Intn(20) + 1
+	var sb strings.Builder
+	fmt.Fprintln(&sb, t)
+	suffixes := []string{"po", "desu", "masu", "mnida"}
+	for i := 0; i < t; i++ {
+		suf := suffixes[rng.Intn(len(suffixes))]
+		l := rng.Intn(20)
+		sb.WriteString(randWord(rng, l))
+		sb.WriteString(suf)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate, _ := filepath.Abs(os.Args[1])
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	refBin, err := compileRef("1281A.go")
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < 100; i++ {
+		input := genTest(rng)
+		expectOut, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		expected := strings.TrimSpace(expectOut)
+		gotOut, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(gotOut)
+		if got != expected {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}

--- a/1000-1999/1200-1299/1280-1289/1281/verifierB.go
+++ b/1000-1999/1200-1299/1280-1289/1281/verifierB.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func compileRef(src string) (string, error) {
+	tmp, err := os.CreateTemp("", "refB-")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), src)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
+func runBinary(path, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(path, ".go") {
+		cmd = exec.Command("go", "run", path)
+	} else {
+		cmd = exec.Command(path)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func randWord(rng *rand.Rand, length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = byte('A' + rng.Intn(26))
+	}
+	return string(b)
+}
+
+func genTest(rng *rand.Rand) string {
+	t := rng.Intn(10) + 1
+	var sb strings.Builder
+	fmt.Fprintln(&sb, t)
+	for i := 0; i < t; i++ {
+		sLen := rng.Intn(6) + 2
+		cLen := rng.Intn(6) + 1
+		fmt.Fprintf(&sb, "%s %s\n", randWord(rng, sLen), randWord(rng, cLen))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	candidate, _ := filepath.Abs(os.Args[1])
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	refBin, err := compileRef("1281B.go")
+	if err != nil {
+		fmt.Println("failed to compile reference:", err)
+		os.Exit(1)
+	}
+	defer os.Remove(refBin)
+
+	for i := 0; i < 100; i++ {
+		input := genTest(rng)
+		expOut, err := runBinary(refBin, input)
+		if err != nil {
+			fmt.Println("reference failed:", err)
+			os.Exit(1)
+		}
+		expected := strings.TrimSpace(expOut)
+		gotOut, err := runBinary(candidate, input)
+		if err != nil {
+			fmt.Printf("test %d: runtime error: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got := strings.TrimSpace(gotOut)
+		if got != expected {
+			fmt.Printf("test %d failed:\ninput:\n%s\nexpected:%s\ngot:%s\n", i+1, input, expected, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed.")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go and verifierB.go for contest 1281
- verifiers compile the reference Go solutions and compare outputs of 100 random tests
- each verifier accepts candidate binaries or Go programs

## Testing
- `go build 1000-1999/1200-1299/1280-1289/1281/verifierA.go`
- `go build 1000-1999/1200-1299/1280-1289/1281/verifierB.go`


------
https://chatgpt.com/codex/tasks/task_e_6884e12bc0908324976d72a1e35908d5