### PR TITLE
Add Go verifiers for contest 1279

### DIFF
--- a/1000-1999/1200-1299/1270-1279/1279/verifierA.go
+++ b/1000-1999/1200-1299/1270-1279/1279/verifierA.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1279A.go")
+	bin := filepath.Join(os.TempDir(), "oracle1279A.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n3 3 3\n",
+		"1\n1 10 2\n",
+		"1\n1 1 1\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	r := rng.Int63n(1_000_000_000) + 1
+	g := rng.Int63n(1_000_000_000) + 1
+	b := rng.Int63n(1_000_000_000) + 1
+	return fmt.Sprintf("1\n%d %d %d\n", r, g, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1200-1299/1270-1279/1279/verifierB.go
+++ b/1000-1999/1200-1299/1270-1279/1279/verifierB.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1279B.go")
+	bin := filepath.Join(os.TempDir(), "oracle1279B.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n4 10\n100 9 1 1\n",
+		"1\n1 5\n3\n",
+		"1\n3 5\n1 1 1\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	s := rng.Int63n(int64(n)*20 + 1)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, s)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(100)+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1200-1299/1270-1279/1279/verifierC.go
+++ b/1000-1999/1200-1299/1270-1279/1279/verifierC.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1279C.go")
+	bin := filepath.Join(os.TempDir(), "oracle1279C.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n1 1\n1\n1\n",
+		"1\n3 2\n1 2 3\n1 3\n",
+		"1\n4 3\n4 3 2 1\n2 3 1\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	m := rng.Intn(n) + 1
+	perm := rng.Perm(n)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "1\n%d %d\n", n, m)
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v+1)
+	}
+	sb.WriteByte('\n')
+	idxs := rng.Perm(n)[:m]
+	for i, id := range idxs {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", perm[id]+1)
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1200-1299/1270-1279/1279/verifierD.go
+++ b/1000-1999/1200-1299/1270-1279/1279/verifierD.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1279D.go")
+	bin := filepath.Join(os.TempDir(), "oracle1279D.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n1 1\n1\n",
+		"2\n1 2\n2 1 2\n",
+	}
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", n)
+	used := make(map[int]bool)
+	for i := 0; i < n; i++ {
+		k := rng.Intn(3) + 1
+		fmt.Fprintf(&sb, "%d", k)
+		for j := 0; j < k; j++ {
+			x := rng.Intn(10) + 1
+			// ensure no duplicates in same list
+			for used[x] {
+				x = rng.Intn(10) + 1
+			}
+			used[x] = true
+			fmt.Fprintf(&sb, " %d", x)
+		}
+		sb.WriteByte('\n')
+		for k := range used {
+			delete(used, k)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1200-1299/1270-1279/1279/verifierE.go
+++ b/1000-1999/1200-1299/1270-1279/1279/verifierE.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1279E.go")
+	bin := filepath.Join(os.TempDir(), "oracle1279E.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1\n1 1\n",
+		"1\n2 2\n",
+		"1\n3 1\n",
+	}
+}
+
+func factorial(n int) int64 {
+	res := int64(1)
+	for i := 2; i <= n; i++ {
+		res *= int64(i)
+		if res > 1e12 {
+			return 1e12
+		}
+	}
+	return res
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(7) + 1
+	maxK := factorial(n)
+	k := rng.Int63n(maxK*2 + 1)
+	if k == 0 {
+		k = 1
+	}
+	return fmt.Sprintf("1\n%d %d\n", n, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}

--- a/1000-1999/1200-1299/1270-1279/1279/verifierF.go
+++ b/1000-1999/1200-1299/1270-1279/1279/verifierF.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	src := filepath.Join(dir, "1279F.go")
+	bin := filepath.Join(os.TempDir(), "oracle1279F.bin")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return bin, nil
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func deterministicCases() []string {
+	return []string{
+		"1 1 1\na\n",
+		"3 2 2\nAbC\n",
+		"5 3 1\nabcDE\n",
+	}
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = byte('a' + rng.Intn(26))
+		} else {
+			b[i] = byte('A' + rng.Intn(26))
+		}
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	k := rng.Intn(n) + 1
+	l := rng.Intn(n) + 1
+	s := randString(rng, n)
+	return fmt.Sprintf("%d %d %d\n%s\n", n, k, l, s)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	userBin := os.Args[1]
+
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	cases := deterministicCases()
+	for len(cases) < 100 {
+		cases = append(cases, genCase(rng))
+	}
+
+	for i, in := range cases {
+		want, err := run(oracle, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		got, err := run(userBin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if got != want {
+			fmt.Printf("case %d failed\ninput:\n%sexpected: %s\n got: %s\n", i+1, in, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", len(cases))
+}


### PR DESCRIPTION
## Summary
- add Go verifier programs for contest 1279 problems A–F
- each verifier builds the provided official Go solution and checks 100+ generated test cases

## Testing
- `go build 1000-1999/1200-1299/1270-1279/1279/verifierA.go`
- `go build 1000-1999/1200-1299/1270-1279/1279/verifierB.go`
- `go build 1000-1999/1200-1299/1270-1279/1279/verifierC.go`
- `go build 1000-1999/1200-1299/1270-1279/1279/verifierD.go`
- `go build 1000-1999/1200-1299/1270-1279/1279/verifierE.go`
- `go build 1000-1999/1200-1299/1270-1279/1279/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884e01396348324ba822d64bf16cdac