### PR TITLE
Add Go solution for 1840A

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1840/1840A.go
+++ b/1000-1999/1800-1899/1840-1849/1840/1840A.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(in, &n, &s)
+		res := make([]byte, 0, n)
+		for i := 0; i < n; {
+			c := s[i]
+			res = append(res, c)
+			i++
+			for i < n && s[i] != c {
+				i++
+			}
+			if i < n {
+				i++
+			}
+		}
+		fmt.Fprintln(out, string(res))
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for `problemA.txt` of round 1840

## Testing
- `go build 1000-1999/1800-1899/1840-1849/1840/1840A.go`


------
https://chatgpt.com/codex/tasks/task_e_6884dfcd91c08324969a300272917871