### PR TITLE
Add Go verifiers for contest 1278

### DIFF
--- a/1000-1999/1200-1299/1270-1279/1278/verifierA.go
+++ b/1000-1999/1200-1299/1270-1279/1278/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveA(p, h string) string {
+	if len(p) > len(h) {
+		return "NO"
+	}
+	var fp [26]int
+	for i := 0; i < len(p); i++ {
+		fp[p[i]-'a']++
+	}
+	var fh [26]int
+	l := len(p)
+	for i := 0; i < l; i++ {
+		fh[h[i]-'a']++
+	}
+	equal := func() bool {
+		for i := 0; i < 26; i++ {
+			if fp[i] != fh[i] {
+				return false
+			}
+		}
+		return true
+	}
+	if equal() {
+		return "YES"
+	}
+	for i := l; i < len(h); i++ {
+		fh[h[i]-'a']++
+		fh[h[i-l]-'a']--
+		if equal() {
+			return "YES"
+		}
+	}
+	return "NO"
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	pLen := r.Intn(100) + 1
+	hLen := r.Intn(100) + 1
+	b := make([]byte, pLen)
+	for i := 0; i < pLen; i++ {
+		b[i] = byte('a' + r.Intn(26))
+	}
+	p := string(b)
+	b = make([]byte, hLen)
+	for i := 0; i < hLen; i++ {
+		b[i] = byte('a' + r.Intn(26))
+	}
+	h := string(b)
+	expect := solveA(p, h)
+	input := fmt.Sprintf("1\n%s\n%s\n", p, h)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1270-1279/1278/verifierB.go
+++ b/1000-1999/1200-1299/1270-1279/1278/verifierB.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveB(a, b int64) int64 {
+	if a < b {
+		a, b = b, a
+	}
+	diff := a - b
+	if diff == 0 {
+		return 0
+	}
+	var k int64
+	for {
+		k++
+		sum := k * (k + 1) / 2
+		if sum >= diff && (sum-diff)%2 == 0 {
+			return k
+		}
+	}
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	a := r.Int63n(1_000_000_000) + 1
+	b := r.Int63n(1_000_000_000) + 1
+	expect := fmt.Sprintf("%d", solveB(a, b))
+	input := fmt.Sprintf("1\n%d %d\n", a, b)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if val, err := strconv.ParseInt(out, 10, 64); err != nil || fmt.Sprintf("%d", val) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1270-1279/1278/verifierC.go
+++ b/1000-1999/1200-1299/1270-1279/1278/verifierC.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solveC(arr []int) int {
+	n := len(arr) / 2
+	for i := range arr {
+		if arr[i] == 2 {
+			arr[i] = -1
+		} else {
+			arr[i] = 1
+		}
+	}
+	total := 0
+	for _, v := range arr {
+		total += v
+	}
+	right := map[int]int{0: 0}
+	diff := 0
+	for i := 0; i < n; i++ {
+		diff += arr[n+i]
+		if _, ok := right[diff]; !ok {
+			right[diff] = i + 1
+		}
+	}
+	ans := 2 * n
+	if val, ok := right[total]; ok && val < ans {
+		ans = val
+	}
+	diffLeft := 0
+	for j := 1; j <= n; j++ {
+		diffLeft += arr[n-j]
+		need := total - diffLeft
+		if k, ok := right[need]; ok {
+			if j+k < ans {
+				ans = j + k
+			}
+		}
+	}
+	return ans
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(50) + 1
+	arr := make([]int, 2*n)
+	for i := range arr {
+		if r.Intn(2) == 0 {
+			arr[i] = 1
+		} else {
+			arr[i] = 2
+		}
+	}
+	expect := fmt.Sprintf("%d", solveC(append([]int(nil), arr...)))
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteString("\n")
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1270-1279/1278/verifierD.go
+++ b/1000-1999/1200-1299/1270-1279/1278/verifierD.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	parent []int
+	size   []int
+}
+
+func NewDSU(n int) *DSU {
+	d := &DSU{parent: make([]int, n), size: make([]int, n)}
+	for i := 0; i < n; i++ {
+		d.parent[i] = i
+		d.size[i] = 1
+	}
+	return d
+}
+
+func (d *DSU) find(x int) int {
+	if d.parent[x] != x {
+		d.parent[x] = d.find(d.parent[x])
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) union(x, y int) {
+	fx := d.find(x)
+	fy := d.find(y)
+	if fx == fy {
+		return
+	}
+	if d.size[fx] < d.size[fy] {
+		fx, fy = fy, fx
+	}
+	d.parent[fy] = fx
+	d.size[fx] += d.size[fy]
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type event struct {
+	id   int
+	left bool
+}
+
+func solveD(n int, segs [][2]int) string {
+	events := make([]event, 2*n+2)
+	for i := 0; i < n; i++ {
+		l := segs[i][0]
+		r := segs[i][1]
+		events[l] = event{id: i + 1, left: true}
+		events[r] = event{id: i + 1, left: false}
+	}
+	dsu := NewDSU(n)
+	stack := []int{}
+	edges := 0
+	for pos := 1; pos <= 2*n; pos++ {
+		e := events[pos]
+		if e.id == 0 {
+			continue
+		}
+		id := e.id - 1
+		if e.left {
+			stack = append(stack, id)
+		} else {
+			temp := []int{}
+			for len(stack) > 0 && stack[len(stack)-1] != id {
+				top := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				dsu.union(id, top)
+				edges++
+				temp = append(temp, top)
+				if edges >= n {
+					return "NO"
+				}
+			}
+			if len(stack) == 0 {
+				return "NO"
+			}
+			stack = stack[:len(stack)-1]
+			for i := len(temp) - 1; i >= 0; i-- {
+				stack = append(stack, temp[i])
+			}
+		}
+	}
+	if edges != n-1 {
+		return "NO"
+	}
+	root := dsu.find(0)
+	for i := 1; i < n; i++ {
+		if dsu.find(i) != root {
+			return "NO"
+		}
+	}
+	return "YES"
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := r.Intn(7) + 1
+	perm := r.Perm(2 * n)
+	segs := make([][2]int, n)
+	for i := 0; i < n; i++ {
+		a := perm[2*i] + 1
+		b := perm[2*i+1] + 1
+		if a > b {
+			a, b = b, a
+		}
+		segs[i] = [2]int{a, b}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		sb.WriteString(fmt.Sprintf("%d %d\n", segs[i][0], segs[i][1]))
+	}
+	expect := solveD(n, segs)
+	return sb.String(), expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1270-1279/1278/verifierE.go
+++ b/1000-1999/1200-1299/1270-1279/1278/verifierE.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return out.String(), nil
+}
+
+func checkOutput(n int, edges [][2]int, out string) error {
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	scanner.Split(bufio.ScanWords)
+	vals := make([]int, 0, 2*n)
+	for scanner.Scan() {
+		v, err := strconv.Atoi(scanner.Text())
+		if err != nil {
+			return fmt.Errorf("invalid integer")
+		}
+		vals = append(vals, v)
+	}
+	if len(vals) != 2*n {
+		return fmt.Errorf("expected %d integers, got %d", 2*n, len(vals))
+	}
+	used := make([]bool, 2*n+1)
+	L := make([]int, n)
+	R := make([]int, n)
+	for i := 0; i < n; i++ {
+		l := vals[2*i]
+		r := vals[2*i+1]
+		if l < 1 || l > 2*n || r < 1 || r > 2*n || l >= r {
+			return fmt.Errorf("bad segment")
+		}
+		if used[l] || used[r] {
+			return fmt.Errorf("duplicate endpoint")
+		}
+		used[l] = true
+		used[r] = true
+		L[i] = l
+		R[i] = r
+	}
+	for v := 1; v <= 2*n; v++ {
+		if !used[v] {
+			return fmt.Errorf("missing endpoint %d", v)
+		}
+	}
+	adj := make(map[[2]int]bool)
+	for _, e := range edges {
+		if e[0] > e[1] {
+			e[0], e[1] = e[1], e[0]
+		}
+		adj[[2]int{e[0] - 1, e[1] - 1}] = true
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			inter := L[i] < R[j] && L[j] < R[i]
+			contain := (L[i] < L[j] && R[j] < R[i]) || (L[j] < L[i] && R[i] < R[j])
+			cross := inter && !contain
+			key := [2]int{i, j}
+			hasEdge := adj[key]
+			if cross != hasEdge {
+				return fmt.Errorf("pair %d %d mismatch", i+1, j+1)
+			}
+		}
+	}
+	return nil
+}
+
+func generateCase(r *rand.Rand) (string, [][2]int) {
+	n := r.Intn(6) + 1
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := r.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	return sb.String(), edges
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, edges := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if err := checkOutput(len(edges)+1, edges, out); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%soutput:\n%s", i+1, err, in, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1270-1279/1278/verifierF.go
+++ b/1000-1999/1200-1299/1270-1279/1278/verifierF.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const mod int64 = 998244353
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return out.String() + errBuf.String(), fmt.Errorf("runtime error: %v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func modPow(a, b int64) int64 {
+	res := int64(1)
+	a %= mod
+	for b > 0 {
+		if b&1 == 1 {
+			res = res * a % mod
+		}
+		a = a * a % mod
+		b >>= 1
+	}
+	return res
+}
+
+func solveF(n, m int64, k int) int64 {
+	limit := k
+	if n < int64(limit) {
+		limit = int(n)
+	}
+	invM := modPow(m%mod, mod-2)
+	powM := make([]int64, limit+1)
+	powM[0] = 1
+	for i := 1; i <= limit; i++ {
+		powM[i] = powM[i-1] * invM % mod
+	}
+	fall := make([]int64, limit+1)
+	fall[0] = 1
+	for i := 1; i <= limit; i++ {
+		fall[i] = fall[i-1] * ((n - int64(i) + 1) % mod) % mod
+	}
+	S := make([]int64, limit+1)
+	S[0] = 1
+	for i := 1; i <= k; i++ {
+		upper := i
+		if upper > limit {
+			upper = limit
+		}
+		for j := upper; j >= 1; j-- {
+			S[j] = (S[j-1] + S[j]*int64(j)) % mod
+		}
+		S[0] = 0
+	}
+	var ans int64
+	for j := 0; j <= limit; j++ {
+		ans = (ans + S[j]*fall[j]%mod*powM[j]) % mod
+	}
+	return ans
+}
+
+func generateCase(r *rand.Rand) (string, string) {
+	n := int64(r.Intn(200) + 1)
+	m := int64(r.Intn(200) + 1)
+	k := r.Intn(10) + 1
+	expect := fmt.Sprintf("%d", solveF(n, m, k))
+	input := fmt.Sprintf("%d %d %d\n", n, m, k)
+	return input, expect
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		out, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		out = strings.TrimSpace(out)
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go for Shuffle Hashing
- add verifierB.go for Controversial Operations
- add verifierC.go for Berry Jam
- add verifierD.go for segment tree check
- add verifierE.go for tree segments problem
- add verifierF.go for expected value of jokers

## Testing
- `go build 1000-1999/1200-1299/1270-1279/1278/verifierA.go`
- `go build 1000-1999/1200-1299/1270-1279/1278/verifierB.go`
- `go build 1000-1999/1200-1299/1270-1279/1278/verifierC.go`
- `go build 1000-1999/1200-1299/1270-1279/1278/verifierD.go`
- `go build 1000-1999/1200-1299/1270-1279/1278/verifierE.go`
- `go build 1000-1999/1200-1299/1270-1279/1278/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884df878a0c832482d9254c8823f940