### PR TITLE
Add Go solution for 1840B

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1840/1840B.go
+++ b/1000-1999/1800-1899/1840-1849/1840/1840B.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k int64
+		fmt.Fscan(in, &n, &k)
+		var ans int64
+		if k >= 31 {
+			ans = n + 1
+		} else {
+			pow := int64(1) << k
+			if n+1 < pow {
+				ans = n + 1
+			} else {
+				ans = pow
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 1840B Binary Cafe

## Testing
- `go build 1000-1999/1800-1899/1840-1849/1840/1840B.go`
- `echo -e "4\n1 1\n1 2\n2 2\n3 3\n" | go run 1000-1999/1800-1899/1840-1849/1840/1840B.go`

------
https://chatgpt.com/codex/tasks/task_e_6884df418374832497b965b899a4836e