### PR TITLE
Add Go verifiers for Round 1290

### DIFF
--- a/1000-1999/1200-1299/1290-1299/1290/verifierA.go
+++ b/1000-1999/1200-1299/1290-1299/1290/verifierA.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func expectedA(n, m, k int, a []int) int {
+	if k > m-1 {
+		k = m - 1
+	}
+	uncontrolled := m - 1 - k
+	finalLen := n - m + 1
+	ans := 0
+	for takeFront := 0; takeFront <= k; takeFront++ {
+		best := int(^uint(0) >> 1)
+		for skipFront := 0; skipFront <= uncontrolled; skipFront++ {
+			l := takeFront + skipFront
+			r := l + finalLen - 1
+			cand := a[l]
+			if a[r] > cand {
+				cand = a[r]
+			}
+			if cand < best {
+				best = cand
+			}
+		}
+		if best > ans {
+			ans = best
+		}
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		n := rng.Intn(8) + 1
+		m := rng.Intn(n) + 1
+		k := rng.Intn(n)
+		if k > n-1 {
+			k = n - 1
+		}
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			a[i] = rng.Intn(10)
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "1\n%d %d %d\n", n, m, k)
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", a[i]))
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		want := expectedA(n, m, k, a)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, input)
+			os.Exit(1)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(out))
+		if err != nil || got != want {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d got %s\ninput:\n%s", t, want, strings.TrimSpace(out), input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1290/verifierB.go
+++ b/1000-1999/1200-1299/1290-1299/1290/verifierB.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveQuery(s string, l, r int, prefix [][26]int) string {
+	if l == r {
+		return "Yes"
+	}
+	if s[l-1] != s[r-1] {
+		return "Yes"
+	}
+	distinct := 0
+	for c := 0; c < 26; c++ {
+		if prefix[r][c]-prefix[l-1][c] > 0 {
+			distinct++
+		}
+	}
+	if distinct >= 3 {
+		return "Yes"
+	}
+	return "No"
+}
+
+func expectedB(s string, queries [][2]int) []string {
+	n := len(s)
+	prefix := make([][26]int, n+1)
+	for i := 0; i < n; i++ {
+		prefix[i+1] = prefix[i]
+		prefix[i+1][s[i]-'a']++
+	}
+	res := make([]string, len(queries))
+	for i, q := range queries {
+		res[i] = solveQuery(s, q[0], q[1], prefix)
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		n := rng.Intn(20) + 1
+		var sb strings.Builder
+		sbytes := make([]byte, n)
+		for i := 0; i < n; i++ {
+			sbytes[i] = byte('a' + rng.Intn(26))
+		}
+		s := string(sbytes)
+		q := rng.Intn(20) + 1
+		queries := make([][2]int, q)
+		fmt.Fprintf(&sb, "%s\n%d\n", s, q)
+		for i := 0; i < q; i++ {
+			l := rng.Intn(n) + 1
+			r := rng.Intn(n-l+1) + l
+			queries[i] = [2]int{l, r}
+			fmt.Fprintf(&sb, "%d %d\n", l, r)
+		}
+		input := sb.String()
+		expected := expectedB(s, queries)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, input)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) != q {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", t, q, len(lines), input)
+			os.Exit(1)
+		}
+		for i := 0; i < q; i++ {
+			if strings.TrimSpace(lines[i]) != expected[i] {
+				fmt.Fprintf(os.Stderr, "case %d failed on query %d: expected %s got %s\ninput:\n%s", t, i+1, expected[i], lines[i], input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1290/verifierC.go
+++ b/1000-1999/1200-1299/1290-1299/1290/verifierC.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	parent []int
+	parity []int
+	size   []int
+	cnt    [][2]int
+	forced []int
+}
+
+func NewDSU(n int) *DSU {
+	d := &DSU{
+		parent: make([]int, n),
+		parity: make([]int, n),
+		size:   make([]int, n),
+		cnt:    make([][2]int, n),
+		forced: make([]int, n),
+	}
+	for i := 0; i < n; i++ {
+		d.parent[i] = i
+		d.size[i] = 1
+		d.forced[i] = -1
+	}
+	d.forced[0] = 0
+	for i := 1; i < n; i++ {
+		d.cnt[i][0] = 1
+	}
+	return d
+}
+
+func (d *DSU) find(x int) int {
+	if d.parent[x] != x {
+		px := d.parent[x]
+		d.parent[x] = d.find(px)
+		d.parity[x] ^= d.parity[px]
+	}
+	return d.parent[x]
+}
+
+func (d *DSU) cost(x int) int {
+	if d.forced[x] == -1 {
+		if d.cnt[x][0] < d.cnt[x][1] {
+			return d.cnt[x][0]
+		}
+		return d.cnt[x][1]
+	}
+	if d.forced[x] == 0 {
+		return d.cnt[x][1]
+	}
+	return d.cnt[x][0]
+}
+
+func (d *DSU) unite(a, b, w int, ans *int) {
+	ra := d.find(a)
+	rb := d.find(b)
+	w ^= d.parity[a] ^ d.parity[b]
+	if ra == rb {
+		return
+	}
+	if d.size[ra] > d.size[rb] {
+		ra, rb = rb, ra
+	}
+	*ans -= d.cost(ra)
+	*ans -= d.cost(rb)
+	d.parent[ra] = rb
+	d.parity[ra] = w
+	d.size[rb] += d.size[ra]
+	c0 := d.cnt[ra][0]
+	c1 := d.cnt[ra][1]
+	if w == 1 {
+		c0, c1 = c1, c0
+	}
+	d.cnt[rb][0] += c0
+	d.cnt[rb][1] += c1
+	if d.forced[ra] != -1 {
+		val := d.forced[ra] ^ w
+		if d.forced[rb] == -1 {
+			d.forced[rb] = val
+		}
+	}
+	*ans += d.cost(rb)
+}
+
+func solveC(n, k int, s string, pos [][]int) []int {
+	dsu := NewDSU(k + 1)
+	res := make([]int, n)
+	cur := 0
+	for i := 0; i < n; i++ {
+		v := int('1' - s[i])
+		if len(pos[i]) == 1 {
+			dsu.unite(pos[i][0], 0, v, &cur)
+		} else if len(pos[i]) == 2 {
+			dsu.unite(pos[i][0], pos[i][1], v, &cur)
+		}
+		res[i] = cur
+	}
+	return res
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		n := rng.Intn(8) + 1
+		k := rng.Intn(4) + 1
+		var sb strings.Builder
+		sbytes := make([]byte, n)
+		for i := 0; i < n; i++ {
+			if rng.Intn(2) == 0 {
+				sbytes[i] = '0'
+			} else {
+				sbytes[i] = '1'
+			}
+		}
+		s := string(sbytes)
+		pos := make([][]int, n)
+		sets := make([][]int, k+1)
+		for i := 0; i < n; i++ {
+			tcnt := rng.Intn(3)
+			used := map[int]bool{}
+			for j := 0; j < tcnt; j++ {
+				idx := rng.Intn(k) + 1
+				if used[idx] {
+					continue
+				}
+				used[idx] = true
+				pos[i] = append(pos[i], idx)
+				sets[idx] = append(sets[idx], i+1)
+			}
+		}
+		fmt.Fprintf(&sb, "%d %d\n%s\n", n, k, s)
+		for i := 1; i <= k; i++ {
+			if len(sets[i]) == 0 {
+				sets[i] = append(sets[i], rng.Intn(n)+1)
+			}
+			fmt.Fprintf(&sb, "%d\n", len(sets[i]))
+			for j, v := range sets[i] {
+				if j > 0 {
+					sb.WriteByte(' ')
+				}
+				fmt.Fprintf(&sb, "%d", v)
+			}
+			sb.WriteByte('\n')
+		}
+		input := sb.String()
+		expected := solveC(n, k, s, pos)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, input)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) != n {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", t, n, len(lines), input)
+			os.Exit(1)
+		}
+		for i := 0; i < n; i++ {
+			got := strings.TrimSpace(lines[i])
+			want := fmt.Sprintf("%d", expected[i])
+			if got != want {
+				fmt.Fprintf(os.Stderr, "case %d line %d: expected %s got %s\ninput:\n%s", t, i+1, want, got, input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1290/verifierD.go
+++ b/1000-1999/1200-1299/1290-1299/1290/verifierD.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem D is interactive and cannot be automatically verified.")
+}

--- a/1000-1999/1200-1299/1290-1299/1290/verifierE.go
+++ b/1000-1999/1200-1299/1290-1299/1290/verifierE.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Node struct {
+	key   int
+	left  *Node
+	right *Node
+	size  int
+	sum   int64
+}
+
+func update(t *Node) {
+	if t == nil {
+		return
+	}
+	ls, lsum := 0, int64(0)
+	if t.left != nil {
+		ls = t.left.size
+		lsum = t.left.sum
+	}
+	rs, rsum := 0, int64(0)
+	if t.right != nil {
+		rs = t.right.size
+		rsum = t.right.sum
+	}
+	t.size = ls + rs + 1
+	t.sum = int64(t.size) + lsum + rsum
+}
+
+func split(t *Node, key int) (*Node, *Node) {
+	if t == nil {
+		return nil, nil
+	}
+	if t.key <= key {
+		var r *Node
+		t.right, r = split(t.right, key)
+		update(t)
+		return t, r
+	}
+	var l *Node
+	l, t.left = split(t.left, key)
+	update(t)
+	return l, t
+}
+
+func newNode(key int) *Node {
+	return &Node{key: key, size: 1, sum: 1}
+}
+
+func solveE(a []int) []int64 {
+	n := len(a)
+	pos := make([]int, n+1)
+	for i, v := range a {
+		pos[v] = i
+	}
+	var root *Node
+	ans := make([]int64, n)
+	for i := 1; i <= n; i++ {
+		p := pos[i]
+		left, right := split(root, p-1)
+		node := newNode(p)
+		node.left = left
+		node.right = right
+		update(node)
+		root = node
+		ans[i-1] = root.sum
+	}
+	return ans
+}
+
+func run(bin, input string) (string, error) {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for t := 1; t <= 100; t++ {
+		n := rng.Intn(20) + 1
+		perm := rand.Perm(n)
+		for i := range perm {
+			perm[i]++
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d\n", n)
+		for i, v := range perm {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", v)
+		}
+		sb.WriteByte('\n')
+		input := sb.String()
+		expected := solveE(perm)
+		out, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", t, err, input)
+			os.Exit(1)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(lines) != n {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %d lines got %d\ninput:\n%s", t, n, len(lines), input)
+			os.Exit(1)
+		}
+		for i := 0; i < n; i++ {
+			want := fmt.Sprintf("%d", expected[i])
+			if strings.TrimSpace(lines[i]) != want {
+				fmt.Fprintf(os.Stderr, "case %d line %d: expected %s got %s\ninput:\n%s", t, i+1, want, lines[i], input)
+				os.Exit(1)
+			}
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1290/verifierF.go
+++ b/1000-1999/1200-1299/1290-1299/1290/verifierF.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Problem F is not implemented and cannot be automatically verified.")
+}


### PR DESCRIPTION
## Summary
- add verifierA.go to test problem A solutions
- add verifierB.go for problem B
- add verifierC.go implementing DSU based checks for problem C
- add stub for interactive problem D
- add verifierE.go based on the Cartesian tree solution
- add stub for problem F

## Testing
- `go run 1000-1999/1200-1299/1290-1299/1290/verifierA.go /tmp/1290A.bin`

------
https://chatgpt.com/codex/tasks/task_e_6884e6187f108324b81b66d33acad977