### PR TITLE
Add Go solution for 1846E1

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1846/1846E1.go
+++ b/1000-1999/1800-1899/1840-1849/1846/1846E1.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const MAXN = 1000000
+
+func precompute() []bool {
+	valid := make([]bool, MAXN+1)
+	for k := 2; k*k <= MAXN; k++ { // if k^2 > MAXN, sum already > MAXN
+		sum := 1 + k + k*k
+		power := k * k
+		for sum <= MAXN {
+			valid[sum] = true
+			power *= k
+			if power > MAXN { // avoid overflow but also ensures next iteration sum>MAXN
+				break
+			}
+			sum += power
+		}
+	}
+	return valid
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	valid := precompute()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		if n >= 0 && n <= MAXN && valid[n] {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1846E1.go` for contest 1846 problem E1
- precompute valid vertex counts up to 1e6 and answer queries

## Testing
- `go build 1000-1999/1800-1899/1840-1849/1846/1846E1.go`

------
https://chatgpt.com/codex/tasks/task_e_6884e5d28f30832484f958abd8de90d4