### PR TITLE
Add verifiers for contest 1287

### DIFF
--- a/1000-1999/1200-1299/1280-1289/1287/verifierA.go
+++ b/1000-1999/1200-1299/1280-1289/1287/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+func expected(n int, s string) int {
+	maxDelay := 0
+	cur := 0
+	seenA := false
+	for i := 0; i < len(s); i++ {
+		if s[i] == 'A' {
+			seenA = true
+			cur = 0
+		} else if seenA {
+			cur++
+			if cur > maxDelay {
+				maxDelay = cur
+			}
+		}
+	}
+	return maxDelay
+}
+
+func buildTests() []testCase {
+	r := rand.New(rand.NewSource(1))
+	var tests []testCase
+	// Add some fixed edge cases
+	edge := []string{"A", "P", "AA", "PP", "AP", "PA", "APA", "PAP", strings.Repeat("A", 100), strings.Repeat("P", 100)}
+	for _, s := range edge {
+		input := fmt.Sprintf("1\n%d %s\n", len(s), s)
+		output := fmt.Sprintf("%d\n", expected(len(s), s))
+		tests = append(tests, testCase{input, output})
+	}
+	for len(tests) < 100 {
+		n := r.Intn(100) + 1
+		b := make([]byte, n)
+		for i := 0; i < n; i++ {
+			if r.Intn(2) == 0 {
+				b[i] = 'A'
+			} else {
+				b[i] = 'P'
+			}
+		}
+		s := string(b)
+		input := fmt.Sprintf("1\n%d %s\n", n, s)
+		output := fmt.Sprintf("%d\n", expected(n, s))
+		tests = append(tests, testCase{input, output})
+	}
+	return tests
+}
+
+func run(binary string, in string) (string, string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(in)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	cmd.Env = os.Environ()
+	if err := cmd.Start(); err != nil {
+		return "", errBuf.String(), err
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		return outBuf.String(), errBuf.String(), err
+	case <-time.After(2 * time.Second):
+		cmd.Process.Kill()
+		return outBuf.String(), errBuf.String(), fmt.Errorf("timeout")
+	}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := buildTests()
+	for i, tc := range tests {
+		out, errStr, err := run(binary, tc.input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nstderr: %s\n", i+1, err, errStr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(tc.output) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, tc.output, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}

--- a/1000-1999/1200-1299/1280-1289/1287/verifierB.go
+++ b/1000-1999/1200-1299/1280-1289/1287/verifierB.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+func third(a, b byte) byte {
+	if a == b {
+		return a
+	}
+	if a != 'S' && b != 'S' {
+		return 'S'
+	}
+	if a != 'E' && b != 'E' {
+		return 'E'
+	}
+	return 'T'
+}
+
+func expected(n, k int, cards []string) int64 {
+	index := make(map[string]int, n)
+	for i, c := range cards {
+		index[c] = i
+	}
+	var count int64
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			b := make([]byte, k)
+			for t := 0; t < k; t++ {
+				b[t] = third(cards[i][t], cards[j][t])
+			}
+			if idx, ok := index[string(b)]; ok && idx > j {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func buildTests() []testCase {
+	r := rand.New(rand.NewSource(2))
+	var tests []testCase
+	// deterministic seed ensures stable tests
+	// edge cases
+	tests = append(tests, testCase{input: "1 1\nS\n", output: "0\n"})
+	cards2 := []string{"S", "E", "T"}
+	tests = append(tests, testCase{input: "3 1\nS\nE\nT\n", output: fmt.Sprintf("%d\n", expected(3, 1, cards2))})
+
+	for len(tests) < 100 {
+		n := r.Intn(6) + 3 // 3..8 to keep runtime small
+		k := r.Intn(4) + 1 // 1..4
+		cardSet := make(map[string]struct{}, n)
+		cards := make([]string, 0, n)
+		for len(cards) < n {
+			b := make([]byte, k)
+			for i := 0; i < k; i++ {
+				switch r.Intn(3) {
+				case 0:
+					b[i] = 'S'
+				case 1:
+					b[i] = 'E'
+				default:
+					b[i] = 'T'
+				}
+			}
+			s := string(b)
+			if _, ok := cardSet[s]; !ok {
+				cardSet[s] = struct{}{}
+				cards = append(cards, s)
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+		for _, c := range cards {
+			sb.WriteString(c)
+			sb.WriteByte('\n')
+		}
+		ans := expected(n, k, cards)
+		tests = append(tests, testCase{input: sb.String(), output: fmt.Sprintf("%d\n", ans)})
+	}
+	return tests
+}
+
+func run(binary string, in string) (string, string, error) {
+	cmd := exec.Command(binary)
+	cmd.Stdin = strings.NewReader(in)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	cmd.Env = os.Environ()
+	if err := cmd.Start(); err != nil {
+		return "", errBuf.String(), err
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		return outBuf.String(), errBuf.String(), err
+	case <-time.After(2 * time.Second):
+		cmd.Process.Kill()
+		return outBuf.String(), errBuf.String(), fmt.Errorf("timeout")
+	}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	binary := os.Args[1]
+	tests := buildTests()
+	for i, tc := range tests {
+		out, errStr, err := run(binary, tc.input)
+		if err != nil {
+			fmt.Printf("Test %d: runtime error: %v\nstderr: %s\n", i+1, err, errStr)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(out) != strings.TrimSpace(tc.output) {
+			fmt.Printf("Test %d failed\nInput:\n%sExpected:\n%sGot:\n%s\n", i+1, tc.input, tc.output, out)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed.\n", len(tests))
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A and B of contest 1287
- each verifier runs a binary over 100 deterministic tests

## Testing
- `go run 1000-1999/1200-1299/1280-1289/1287/verifierA.go 1000-1999/1200-1299/1280-1289/1287/1287A`


------
https://chatgpt.com/codex/tasks/task_e_6884e4746a788324888178bba89a0ae1