### PR TITLE
Add verifiers for contest 1295

### DIFF
--- a/1000-1999/1200-1299/1290-1299/1295/verifierA.go
+++ b/1000-1999/1200-1299/1290-1299/1295/verifierA.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleA")
+	cmd := exec.Command("go", "build", "-o", oracle, "1295A.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(100000-2+1) + 2
+	return fmt.Sprintf("1\n%d\n", n)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1295/verifierB.go
+++ b/1000-1999/1200-1299/1290-1299/1295/verifierB.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleB")
+	cmd := exec.Command("go", "build", "-o", oracle, "1295B.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	x := rng.Intn(31) - 15
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, x))
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1295/verifierC.go
+++ b/1000-1999/1200-1299/1290-1299/1295/verifierC.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleC")
+	cmd := exec.Command("go", "build", "-o", oracle, "1295C.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randString(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(3))
+	}
+	return string(b)
+}
+
+func genCase(rng *rand.Rand) string {
+	sLen := rng.Intn(6) + 1
+	tLen := rng.Intn(10) + 1
+	s := randString(rng, sLen)
+	t := randString(rng, tLen)
+	return fmt.Sprintf("1\n%s\n%s\n", s, t)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1295/verifierD.go
+++ b/1000-1999/1200-1299/1290-1299/1295/verifierD.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleD")
+	cmd := exec.Command("go", "build", "-o", oracle, "1295D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	a := rng.Int63n(1_000_000) + 1
+	m := rng.Int63n(1_000_000) + 1
+	return fmt.Sprintf("1\n%d %d\n", a, m)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1295/verifierE.go
+++ b/1000-1999/1200-1299/1290-1299/1295/verifierE.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleE")
+	cmd := exec.Command("go", "build", "-o", oracle, "1295E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	perm := rng.Perm(n)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range perm {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v+1))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", rng.Intn(100)+1))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1295/verifierF.go
+++ b/1000-1999/1200-1299/1290-1299/1295/verifierF.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	oracle := filepath.Join(dir, "oracleF")
+	cmd := exec.Command("go", "build", "-o", oracle, "1295F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("build oracle failed: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errb.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n; i++ {
+		l := rng.Int63n(10)
+		r := l + rng.Int63n(10)
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		want, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle error on case %d: %v\n", i+1, err)
+			os.Exit(1)
+		}
+		got, err := runProg(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Printf("case %d failed\ninput:\n%sexpected:\n%s\ngot:\n%s\n", i+1, input, want, got)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All 100 tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for problems A–F in contest 1295
- each verifier compiles an oracle solution and runs 100 random tests

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884e8d508308324b37e4db8552d1de4