### PR TITLE
Add Go verifiers for contest 1297

### DIFF
--- a/1000-1999/1200-1299/1290-1299/1297/verifierA.go
+++ b/1000-1999/1200-1299/1290-1299/1297/verifierA.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int64) string {
+	switch {
+	case n < 1000:
+		return fmt.Sprintf("%d", n)
+	case n < 1_000_000:
+		k := (n + 500) / 1000
+		if k == 1000 {
+			return "1M"
+		}
+		return fmt.Sprintf("%dK", k)
+	default:
+		m := (n + 500_000) / 1_000_000
+		return fmt.Sprintf("%dM", m)
+	}
+}
+
+func runCase(bin string, n int64) error {
+	input := fmt.Sprintf("1\n%d\n", n)
+	want := expected(n)
+	out, err := runProg(bin, input)
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out)
+	}
+	if out != want {
+		return fmt.Errorf("expected %s got %s (n=%d)", want, out, n)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		n := rng.Int63n(2_000_000_001)
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1297/verifierB.go
+++ b/1000-1999/1200-1299/1290-1299/1297/verifierB.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+type interval struct{ a, b int64 }
+
+type event struct {
+	pos   int64
+	delta int
+}
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(intervals []interval) int64 {
+	events := make([]event, 0, len(intervals)*2)
+	for _, iv := range intervals {
+		events = append(events, event{iv.a, 1})
+		events = append(events, event{iv.b + 1, -1})
+	}
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].pos == events[j].pos {
+			return events[i].delta > events[j].delta
+		}
+		return events[i].pos < events[j].pos
+	})
+	var cnt int64
+	var prev int64
+	if len(events) > 0 {
+		prev = events[0].pos
+	}
+	for _, e := range events {
+		if cnt == 1 && e.pos > prev {
+			return prev
+		}
+		cnt += int64(e.delta)
+		prev = e.pos
+	}
+	return -1
+}
+
+func genCase(rng *rand.Rand) []interval {
+	n := rng.Intn(5) + 1
+	res := make([]interval, n)
+	for i := 0; i < n; i++ {
+		a := rng.Int63n(50) + 1
+		b := a + rng.Int63n(50)
+		res[i] = interval{a, b}
+	}
+	return res
+}
+
+func runCase(bin string, ivs []interval) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(ivs)))
+	for _, iv := range ivs {
+		sb.WriteString(fmt.Sprintf("%d %d\n", iv.a, iv.b))
+	}
+	want := fmt.Sprintf("%d", solve(ivs))
+	out, err := runProg(bin, sb.String())
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out)
+	}
+	if out != want {
+		return fmt.Errorf("expected %s got %s\ninput:\n%s", want, out, sb.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		ivs := genCase(rng)
+		if err := runCase(bin, ivs); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1297/verifierC.go
+++ b/1000-1999/1200-1299/1290-1299/1297/verifierC.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(a []int) (int, string) {
+	n := len(a)
+	sumPos := 0
+	minAbs := 10001
+	idx := -1
+	for i, v := range a {
+		if v > 0 {
+			sumPos += v
+		}
+		if v != 0 {
+			x := v
+			if x < 0 {
+				x = -x
+			}
+			if x < minAbs {
+				minAbs = x
+				idx = i
+			}
+		}
+	}
+	ans := make([]byte, n)
+	for i, v := range a {
+		if v > 0 {
+			ans[i] = '1'
+		} else {
+			ans[i] = '0'
+		}
+	}
+	if a[idx] > 0 {
+		ans[idx] = '0'
+		sumPos -= a[idx]
+	} else {
+		ans[idx] = '1'
+		sumPos += a[idx]
+	}
+	return sumPos, string(ans)
+}
+
+func genCase(rng *rand.Rand) []int {
+	n := rng.Intn(7) + 2
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(21) - 10
+	}
+	// ensure not all zero
+	allZero := true
+	for _, v := range arr {
+		if v != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		arr[0] = 1
+	}
+	return arr
+}
+
+func runCase(bin string, arr []int) error {
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", len(arr)))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	sum, pattern := solve(arr)
+	want := fmt.Sprintf("%d\n%s", sum, pattern)
+	out, err := runProg(bin, sb.String())
+	if err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out)
+	}
+	if strings.TrimSpace(out) != strings.TrimSpace(want) {
+		return fmt.Errorf("expected:\n%s\ngot:\n%s\ninput:\n%s", want, out, sb.String())
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		arr := genCase(rng)
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1297/verifierD.go
+++ b/1000-1999/1200-1299/1290-1299/1297/verifierD.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleD.bin"
+	cmd := exec.Command("go", "build", "-o", oracle, "1297D.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build oracle: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	k := rng.Int63n(100)
+	vals := make([]int64, 0, n)
+	used := make(map[int64]bool)
+	for len(vals) < n {
+		v := rng.Int63n(100) + 1
+		if !used[v] {
+			used[v] = true
+			vals = append(vals, v)
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i, v := range vals {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		out, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1297/verifierE.go
+++ b/1000-1999/1200-1299/1290-1299/1297/verifierE.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleE.bin"
+	cmd := exec.Command("go", "build", "-o", oracle, "1297E.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build oracle: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 2
+	k := rng.Intn(n) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, k))
+	for i := 2; i <= n; i++ {
+		parent := rng.Intn(i-1) + 1
+		sb.WriteString(fmt.Sprintf("%d %d\n", parent, i))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		out, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1297/verifierF.go
+++ b/1000-1999/1200-1299/1290-1299/1297/verifierF.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleF.bin"
+	cmd := exec.Command("go", "build", "-o", oracle, "1297F.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build oracle: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(3) + 1
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for i := 0; i < n; i++ {
+		a := rng.Int63n(50) + 1
+		b := a + rng.Int63n(50)
+		sb.WriteString(fmt.Sprintf("%d %d\n", a, b))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		out, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1297/verifierG.go
+++ b/1000-1999/1200-1299/1290-1299/1297/verifierG.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleG.bin"
+	cmd := exec.Command("go", "build", "-o", oracle, "1297G.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build oracle: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	// m must be product of 2,3,5,7 powers
+	exp2 := rng.Intn(4)
+	exp3 := rng.Intn(4)
+	exp5 := rng.Intn(4)
+	exp7 := rng.Intn(4)
+	m := int64(1)
+	for i := 0; i < exp2; i++ {
+		m *= 2
+	}
+	for i := 0; i < exp3; i++ {
+		m *= 3
+	}
+	for i := 0; i < exp5; i++ {
+		m *= 5
+	}
+	for i := 0; i < exp7; i++ {
+		m *= 7
+	}
+	if m == 0 {
+		m = 1
+	}
+	k := rng.Int63n(100) + 1
+	return fmt.Sprintf("%d %d\n", m, k)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		out, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1297/verifierH.go
+++ b/1000-1999/1200-1299/1290-1299/1297/verifierH.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleH.bin"
+	cmd := exec.Command("go", "build", "-o", oracle, "1297H.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build oracle: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(19) + 2
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	for i := 0; i < n; i++ {
+		ch := 'a' + rune(rng.Intn(26))
+		sb.WriteByte(byte(ch))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		out, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1297/verifierI.go
+++ b/1000-1999/1200-1299/1290-1299/1297/verifierI.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func buildOracle() (string, error) {
+	oracle := "oracleI.bin"
+	cmd := exec.Command("go", "build", "-o", oracle, "1297I.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to build oracle: %v\n%s", err, out)
+	}
+	return oracle, nil
+}
+
+func runProg(prog, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(prog, ".go") {
+		cmd = exec.Command("go", "run", prog)
+	} else {
+		cmd = exec.Command(prog)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("%v", err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	d := rng.Intn(50) + 10
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, d))
+	for i := 0; i < n; i++ {
+		l := rng.Intn(d) + 1
+		r := l + rng.Intn(d-l+1)
+		sb.WriteString(fmt.Sprintf("%d %d\n", l, r))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	cand := os.Args[1]
+	oracle, err := buildOracle()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.Remove(oracle)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := genCase(rng)
+		exp, err := runProg(oracle, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "oracle failed on case %d: %v\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		out, err := runProg(cand, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d runtime error: %v\n%s", i+1, err, out)
+			os.Exit(1)
+		}
+		if out != exp {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:%s", i+1, exp, out, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add Go solution verifiers for all problems in contest 1297
- each verifier runs 100 random tests
- complex problems use reference solutions as oracles

## Testing
- `go build verifierA.go`
- `go build verifierB.go`
- `go build verifierC.go`
- `go build verifierD.go`
- `go build verifierE.go`
- `go build verifierF.go`
- `go build verifierG.go`
- `go build verifierH.go`
- `go build verifierI.go`


------
https://chatgpt.com/codex/tasks/task_e_6884e9ed8af08324b484434b8953af92