### PR TITLE
Add Go solution verifiers for contest 1296

### DIFF
--- a/1000-1999/1200-1299/1290-1299/1296/verifierA.go
+++ b/1000-1999/1200-1299/1290-1299/1296/verifierA.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expect(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	readInt := func() int {
+		in.Scan()
+		val := 0
+		fmt.Sscan(in.Text(), &val)
+		return val
+	}
+	t := readInt()
+	var sb strings.Builder
+	for i := 0; i < t; i++ {
+		n := readInt()
+		sum := 0
+		odd, even := 0, 0
+		for j := 0; j < n; j++ {
+			x := readInt()
+			sum += x
+			if x%2 == 0 {
+				even++
+			} else {
+				odd++
+			}
+		}
+		ans := "NO"
+		if sum%2 == 1 || (odd > 0 && even > 0) {
+			ans = "YES"
+		}
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(ans)
+	}
+	return sb.String()
+}
+
+type testCase struct{ input string }
+
+var tests = []testCase{
+	{"1\n1\n1\n"},
+	{"1\n1\n2\n"},
+	{"1\n2\n1 3\n"},
+	{"1\n2\n2 2\n"},
+	{"1\n2\n1 2\n"},
+	{"1\n3\n2 2 1\n"},
+	{"1\n4\n1 1 1 1\n"},
+	{"1\n4\n2 2 2 2\n"},
+	{"1\n2\n3 3\n"},
+	{"1\n3\n3 2 5\n"},
+	{"1\n4\n2 2 2 1\n"},
+	{"1\n5\n2 4 6 1 1\n"},
+	{"1\n1\n999\n"},
+	{"1\n1\n1000\n"},
+	{"3\n2\n1 2\n3\n1 1 1\n2\n2 4\n"},
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, tc := range tests {
+		exp := expect(tc.input)
+		got, err := runProg(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1296/verifierB.go
+++ b/1000-1999/1200-1299/1290-1299/1296/verifierB.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expect(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	readInt := func() int64 {
+		in.Scan()
+		var v int64
+		fmt.Sscan(in.Text(), &v)
+		return v
+	}
+	t := readInt()
+	var sb strings.Builder
+	for i := int64(0); i < t; i++ {
+		s := readInt()
+		spent := int64(0)
+		for s >= 10 {
+			spent += (s / 10) * 10
+			s = s/10 + s%10
+		}
+		spent += s
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(fmt.Sprintf("%d", spent))
+	}
+	return sb.String()
+}
+
+type testCase struct{ input string }
+
+var tests = []testCase{
+	{"1\n1\n"},
+	{"1\n9\n"},
+	{"1\n10\n"},
+	{"1\n19\n"},
+	{"1\n99\n"},
+	{"1\n100\n"},
+	{"1\n873\n"},
+	{"1\n123456\n"},
+	{"1\n1000000000\n"},
+	{"1\n15\n"},
+	{"1\n10000\n"},
+	{"1\n999999\n"},
+	{"1\n42\n"},
+	{"1\n500000000\n"},
+	{"1\n987654321\n"},
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, tc := range tests {
+		exp := expect(tc.input)
+		got, err := runProg(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\ngot:%s\ninput:%s", i+1, exp, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1296/verifierC.go
+++ b/1000-1999/1200-1299/1290-1299/1296/verifierC.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expect(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	readInt := func() int {
+		in.Scan()
+		v := 0
+		fmt.Sscan(in.Text(), &v)
+		return v
+	}
+	t := readInt()
+	var sb strings.Builder
+	for caseIdx := 0; caseIdx < t; caseIdx++ {
+		n := readInt()
+		in.Scan()
+		s := in.Text()
+		type pair struct{ x, y int }
+		pos := pair{0, 0}
+		last := map[pair]int{pos: 0}
+		bestLen := n + 1
+		bestL, bestR := -1, -1
+		for i := 1; i <= n; i++ {
+			switch s[i-1] {
+			case 'L':
+				pos.x--
+			case 'R':
+				pos.x++
+			case 'U':
+				pos.y++
+			case 'D':
+				pos.y--
+			}
+			if prev, ok := last[pos]; ok {
+				if i-prev < bestLen {
+					bestLen = i - prev
+					bestL = prev + 1
+					bestR = i
+				}
+			}
+			last[pos] = i
+		}
+		if caseIdx > 0 {
+			sb.WriteByte('\n')
+		}
+		if bestLen == n+1 {
+			sb.WriteString("-1")
+		} else {
+			sb.WriteString(fmt.Sprintf("%d %d", bestL, bestR))
+		}
+	}
+	return sb.String()
+}
+
+type testCase struct{ input string }
+
+var tests = []testCase{
+	{"1\n2\nLR\n"},
+	{"1\n2\nRL\n"},
+	{"1\n4\nLRUD\n"},
+	{"1\n2\nUD\n"},
+	{"1\n1\nL\n"},
+	{"1\n4\nLLLL\n"},
+	{"1\n4\nLRLR\n"},
+	{"1\n5\nLLRRR\n"},
+	{"1\n6\nLRLRUD\n"},
+	{"1\n3\nUDU\n"},
+	{"1\n5\nURDLU\n"},
+	{"1\n10\nRRRRLLLLUD\n"},
+	{"1\n8\nUDUDUDUD\n"},
+	{"1\n4\nLURD\n"},
+	{"1\n6\nLRRLLR\n"},
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, tc := range tests {
+		exp := expect(tc.input)
+		got, err := runProg(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1296/verifierD.go
+++ b/1000-1999/1200-1299/1290-1299/1296/verifierD.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expect(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	readInt := func() int {
+		in.Scan()
+		v := 0
+		fmt.Sscan(in.Text(), &v)
+		return v
+	}
+	n := readInt()
+	a := readInt()
+	b := readInt()
+	k := readInt()
+	h := make([]int, n)
+	for i := 0; i < n; i++ {
+		h[i] = readInt()
+	}
+	cycle := a + b
+	need := make([]int, n)
+	for i, hp := range h {
+		r := hp % cycle
+		if r == 0 {
+			r = cycle
+		}
+		need[i] = (r - 1) / a
+	}
+	sort.Ints(need)
+	points := 0
+	for _, v := range need {
+		if k < v {
+			break
+		}
+		k -= v
+		points++
+	}
+	return fmt.Sprintf("%d", points)
+}
+
+type testCase struct{ input string }
+
+var tests = []testCase{
+	{"3 1 2 1\n1 2 3\n"},
+	{"3 1 2 3\n3 3 3\n"},
+	{"5 2 3 2\n6 6 6 6 6\n"},
+	{"4 2 1 3\n5 8 3 4\n"},
+	{"1 2 2 1\n5\n"},
+	{"5 5 3 4\n9 11 8 7 20\n"},
+	{"5 1 5 3\n6 6 6 6 6\n"},
+	{"3 10 10 1\n21 31 41\n"},
+	{"2 7 3 2\n17 20\n"},
+	{"4 3 4 2\n8 12 18 22\n"},
+	{"3 2 2 3\n9 5 7\n"},
+	{"4 2 5 2\n10 9 8 7\n"},
+	{"5 2 3 1\n1 2 3 4 5\n"},
+	{"2 4 3 5\n8 7\n"},
+	{"2 2 1 1\n2 3\n"},
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, tc := range tests {
+		exp := expect(tc.input)
+		got, err := runProg(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:%s\ngot:%s\ninput:\n%s", i+1, exp, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1296/verifierE1.go
+++ b/1000-1999/1200-1299/1290-1299/1296/verifierE1.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expect(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	readInt := func() int {
+		in.Scan()
+		v := 0
+		fmt.Sscan(in.Text(), &v)
+		return v
+	}
+	n := readInt()
+	in.Scan()
+	s := in.Text()
+	colors := make([]byte, n)
+	last := [2]byte{'a' - 1, 'a' - 1}
+	for i := 0; i < n; i++ {
+		c := s[i]
+		if c >= last[0] {
+			colors[i] = '0'
+			last[0] = c
+		} else if c >= last[1] {
+			colors[i] = '1'
+			last[1] = c
+		} else {
+			return "NO"
+		}
+	}
+	return fmt.Sprintf("YES\n%s", string(colors))
+}
+
+type testCase struct{ input string }
+
+var tests = []testCase{
+	{"1\na\n"},
+	{"2\nba\n"},
+	{"3\nabc\n"},
+	{"3\ncba\n"},
+	{"4\nabac\n"},
+	{"4\naaaa\n"},
+	{"4\nabcd\n"},
+	{"4\ndcba\n"},
+	{"3\nbca\n"},
+	{"6\nacdbbd\n"},
+	{"3\nzyx\n"},
+	{"3\naaz\n"},
+	{"6\nabcabc\n"},
+	{"6\nbacdef\n"},
+	{"4\ncbba\n"},
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, tc := range tests {
+		exp := expect(tc.input)
+		got, err := runProg(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\ngot:\n%s\ninput:%s", i+1, exp, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1296/verifierE2.go
+++ b/1000-1999/1200-1299/1290-1299/1296/verifierE2.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expect(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	readInt := func() int {
+		in.Scan()
+		v := 0
+		fmt.Sscan(in.Text(), &v)
+		return v
+	}
+	n := readInt()
+	in.Scan()
+	s := in.Text()
+	dp := make([]int, 26)
+	colors := make([]int, n)
+	maxColor := 0
+	for i := 0; i < n; i++ {
+		ch := int(s[i] - 'a')
+		best := 0
+		for j := ch + 1; j < 26; j++ {
+			if dp[j] > best {
+				best = dp[j]
+			}
+		}
+		col := best + 1
+		colors[i] = col
+		if dp[ch] < col {
+			dp[ch] = col
+		}
+		if col > maxColor {
+			maxColor = col
+		}
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", maxColor))
+	for i, c := range colors {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", c))
+	}
+	return sb.String()
+}
+
+type testCase struct{ input string }
+
+var tests = []testCase{
+	{"1\na\n"},
+	{"3\nabc\n"},
+	{"3\ncba\n"},
+	{"4\nabac\n"},
+	{"1\nz\n"},
+	{"3\nzyx\n"},
+	{"8\nabcdabcd\n"},
+	{"3\nzxy\n"},
+	{"5\naaaaa\n"},
+	{"6\nbacdef\n"},
+	{"5\ncbacd\n"},
+	{"6\nazbycx\n"},
+	{"26\nzyxwvutsrqponmlkjihgfedcba\n"},
+	{"6\nabcdef\n"},
+	{"6\nfedcba\n"},
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, tc := range tests {
+		exp := expect(tc.input)
+		got, err := runProg(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\ngot:\n%s\ninput:%s", i+1, exp, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1200-1299/1290-1299/1296/verifierF.go
+++ b/1000-1999/1200-1299/1290-1299/1296/verifierF.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runProg(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expect(input string) string {
+	in := bufio.NewScanner(strings.NewReader(input))
+	in.Split(bufio.ScanWords)
+	readInt := func() int {
+		in.Scan()
+		v := 0
+		fmt.Sscan(in.Text(), &v)
+		return v
+	}
+	n := readInt()
+	type edge struct{ u, v int }
+	edges := make([]edge, n-1)
+	adj := make([][]int, n)
+	for i := 0; i < n-1; i++ {
+		u := readInt() - 1
+		v := readInt() - 1
+		edges[i] = edge{u, v}
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	parent := make([]int, n)
+	depth := make([]int, n)
+	parent[0] = -1
+	queue := []int{0}
+	for idx := 0; idx < len(queue); idx++ {
+		u := queue[idx]
+		for _, v := range adj[u] {
+			if v == parent[u] {
+				continue
+			}
+			parent[v] = u
+			depth[v] = depth[u] + 1
+			queue = append(queue, v)
+		}
+	}
+	value := make([]int, n)
+	for i := range value {
+		value[i] = 1
+	}
+	m := readInt()
+	type cons struct{ u, v, w int }
+	consList := make([]cons, m)
+	for i := 0; i < m; i++ {
+		u := readInt() - 1
+		v := readInt() - 1
+		w := readInt()
+		consList[i] = cons{u, v, w}
+		uu, vv := u, v
+		if depth[uu] < depth[vv] {
+			uu, vv = vv, uu
+		}
+		for depth[uu] > depth[vv] {
+			if value[uu] < w {
+				value[uu] = w
+			}
+			uu = parent[uu]
+		}
+		for uu != vv {
+			if value[uu] < w {
+				value[uu] = w
+			}
+			if value[vv] < w {
+				value[vv] = w
+			}
+			uu = parent[uu]
+			vv = parent[vv]
+		}
+	}
+	ok := true
+	for _, c := range consList {
+		u, v, w := c.u, c.v, c.w
+		uu, vv := u, v
+		if depth[uu] < depth[vv] {
+			uu, vv = vv, uu
+		}
+		found := false
+		for depth[uu] > depth[vv] {
+			if value[uu] == w {
+				found = true
+				break
+			}
+			uu = parent[uu]
+		}
+		for !found && uu != vv {
+			if value[uu] == w || value[vv] == w {
+				found = true
+				break
+			}
+			uu = parent[uu]
+			vv = parent[vv]
+		}
+		if !found {
+			ok = false
+			break
+		}
+	}
+	if !ok {
+		return "-1"
+	}
+	ans := make([]int, n-1)
+	for i, e := range edges {
+		if parent[e.u] == e.v {
+			ans[i] = value[e.u]
+		} else {
+			ans[i] = value[e.v]
+		}
+	}
+	var sb strings.Builder
+	for i, w := range ans {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", w))
+	}
+	return sb.String()
+}
+
+type testCase struct{ input string }
+
+var tests = []testCase{
+	{"2\n1 2\n0\n"},
+	{"2\n1 2\n1\n1 2 2\n"},
+	{"3\n1 2\n2 3\n1\n1 3 3\n"},
+	{"3\n1 2\n2 3\n2\n1 3 3\n1 2 2\n"},
+	{"5\n1 2\n2 3\n3 4\n4 5\n3\n1 3 2\n2 4 3\n5 3 1\n"},
+	{"4\n1 2\n2 3\n2 4\n1\n3 4 2\n"},
+	{"4\n1 2\n1 3\n3 4\n1\n2 4 2\n"},
+	{"4\n1 2\n2 3\n1 4\n1\n1 3 2\n"},
+	{"3\n1 2\n1 3\n2\n1 2 2\n2 3 2\n"},
+	{"3\n1 2\n2 3\n3\n2 3 2\n1 3 2\n1 3 1\n"},
+	{"5\n1 2\n1 3\n1 4\n1 5\n2\n2 3 2\n4 5 3\n"},
+	{"3\n1 2\n1 3\n0\n"},
+	{"2\n1 2\n0\n"},
+	{"2\n1 2\n1\n1 2 3\n"},
+	{"4\n1 2\n1 3\n1 4\n2\n2 3 1\n3 4 2\n"},
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	for i, tc := range tests {
+		exp := expect(tc.input)
+		got, err := runProg(bin, tc.input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d: %v\ninput:\n%s", i+1, err, tc.input)
+			os.Exit(1)
+		}
+		if got != exp {
+			fmt.Fprintf(os.Stderr, "case %d mismatch\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, tc.input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- implement verifiers for all problems of contest 1296
- each verifier runs a candidate binary (or Go file) against a suite of tests
- more than 100 tests across A–F

## Testing
- `go run 1000-1999/1200-1299/1290-1299/1296/verifierA.go /tmp/a.bin`
- `go run 1000-1999/1200-1299/1290-1299/1296/verifierB.go /tmp/b.bin`
- `go build 1000-1999/1200-1299/1290-1299/1296/verifierC.go`
- `go build 1000-1999/1200-1299/1290-1299/1296/verifierD.go`
- `go build 1000-1999/1200-1299/1290-1299/1296/verifierE1.go`
- `go build 1000-1999/1200-1299/1290-1299/1296/verifierE2.go`
- `go build 1000-1999/1200-1299/1290-1299/1296/verifierF.go`


------
https://chatgpt.com/codex/tasks/task_e_6884e96105a88324b39d8dc3dedb4146