### PR TITLE
Add Go verifiers for contest 1300

### DIFF
--- a/1000-1999/1300-1399/1300-1309/1300/verifierA.go
+++ b/1000-1999/1300-1399/1300-1309/1300/verifierA.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(100) + 1 // 1..100
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = rng.Intn(201) - 100 // -100..100
+	}
+
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+
+	sum := 0
+	zeros := 0
+	for _, x := range arr {
+		sum += x
+		if x == 0 {
+			zeros++
+		}
+	}
+	sum += zeros
+	ans := zeros
+	if sum == 0 {
+		ans++
+	}
+
+	return sb.String(), ans
+}
+
+func runCase(exe string, input string, expected int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(outStr)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1300/verifierB.go
+++ b/1000-1999/1300-1399/1300-1309/1300/verifierB.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func generateCase(rng *rand.Rand) (string, int) {
+	n := rng.Intn(20) + 1 // 1..20
+	total := 2 * n
+	arr := make([]int, total)
+	for i := 0; i < total; i++ {
+		arr[i] = rng.Intn(1000) + 1 // 1..1000
+	}
+
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(strconv.Itoa(n))
+	sb.WriteByte('\n')
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	sb.WriteByte('\n')
+
+	sorted := append([]int(nil), arr...)
+	sort.Ints(sorted)
+	diff := sorted[n] - sorted[n-1]
+
+	return sb.String(), diff
+}
+
+func runCase(exe string, input string, expected int) error {
+	cmd := exec.Command(exe)
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, out.String())
+	}
+	outStr := strings.TrimSpace(out.String())
+	got, err := strconv.Atoi(outStr)
+	if err != nil {
+		return fmt.Errorf("bad output: %v", err)
+	}
+	if got != expected {
+		return fmt.Errorf("expected %d got %d", expected, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	exe := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		if err := runCase(exe, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` for problem A
- add `verifierB.go` for problem B

## Testing
- `go build verifierA.go`
- `go build verifierB.go`


------
https://chatgpt.com/codex/tasks/task_e_6884eb922edc8324b15f505a07d682a5