### PR TITLE
Add Go solution for 1843C

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1843/1843C.go
+++ b/1000-1999/1800-1899/1840-1849/1843/1843C.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		var sum int64
+		for n > 0 {
+			sum += n
+			n /= 2
+		}
+		fmt.Fprintln(writer, sum)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem C in contest 1843

## Testing
- `go build 1000-1999/1800-1899/1840-1849/1843/1843C.go`


------
https://chatgpt.com/codex/tasks/task_e_6884ec1dc454832480359777eeda9267