### PR TITLE
Add Go solution for 1844F2

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1844/1844F2.go
+++ b/1000-1999/1800-1899/1840-1849/1844/1844F2.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		var c int
+		fmt.Fscan(in, &n, &c)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+		}
+		if c >= 0 {
+			sort.Ints(arr)
+		} else {
+			sort.Slice(arr, func(i, j int) bool { return arr[i] > arr[j] })
+		}
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				fmt.Fprint(out, " ")
+			}
+			fmt.Fprint(out, arr[i])
+		}
+		fmt.Fprintln(out)
+	}
+}


### PR DESCRIPTION
## Summary
- implement minimalistic Go solver for 1844F2

## Testing
- `go vet 1000-1999/1800-1899/1840-1849/1844/1844F2.go`
- `go build 1000-1999/1800-1899/1840-1849/1844/1844F2.go`


------
https://chatgpt.com/codex/tasks/task_e_6884ecefe5b083248b0511a4aadc13f5