### PR TITLE
Add Go solution for 1844C

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1844/1844C.go
+++ b/1000-1999/1800-1899/1840-1849/1844/1844C.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		sumOdd, sumEven := int64(0), int64(0)
+		maxVal := int64(-1 << 63)
+		for i := 1; i <= n; i++ {
+			var x int64
+			fmt.Fscan(in, &x)
+			if x > maxVal {
+				maxVal = x
+			}
+			if i%2 == 1 {
+				if x > 0 {
+					sumOdd += x
+				}
+			} else {
+				if x > 0 {
+					sumEven += x
+				}
+			}
+		}
+		if sumOdd == 0 && sumEven == 0 {
+			fmt.Fprintln(out, maxVal)
+		} else if sumOdd > sumEven {
+			fmt.Fprintln(out, sumOdd)
+		} else {
+			fmt.Fprintln(out, sumEven)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem C in 1844
- compute sum of positive values separately for odd and even indices
- choose the larger positive sum or the maximum value when all numbers are non-positive

## Testing
- `gofmt -w 1000-1999/1800-1899/1840-1849/1844/1844C.go`
- `go build 1000-1999/1800-1899/1840-1849/1844/1844C.go`


------
https://chatgpt.com/codex/tasks/task_e_6884ee9428a88324ae1c6b8968c7debd