### PR TITLE
Add Go solution for 1842B

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1842/1842B.go
+++ b/1000-1999/1800-1899/1840-1849/1842/1842B.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var x int
+		fmt.Fscan(reader, &n, &x)
+		stacks := make([][]int, 3)
+		for s := 0; s < 3; s++ {
+			stacks[s] = make([]int, n)
+			for i := 0; i < n; i++ {
+				fmt.Fscan(reader, &stacks[s][i])
+			}
+		}
+		cur := 0
+		for s := 0; s < 3 && cur != x; s++ {
+			for i := 0; i < n && cur != x; i++ {
+				v := stacks[s][i]
+				if v|x != x {
+					break
+				}
+				cur |= v
+			}
+		}
+		if cur == x {
+			fmt.Fprintln(writer, "Yes")
+		} else {
+			fmt.Fprintln(writer, "No")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for `1842B`

## Testing
- `go build 1000-1999/1800-1899/1840-1849/1842/1842B.go`


------
https://chatgpt.com/codex/tasks/task_e_6884f1dd43bc8324ad1ea04f7d88aa71