### PR TITLE
Add naive Go solution for 1842E

### DIFF
--- a/1000-1999/1800-1899/1840-1849/1842/1842E.go
+++ b/1000-1999/1800-1899/1840-1849/1842/1842E.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, k, A int
+	if _, err := fmt.Fscan(in, &n, &k, &A); err != nil {
+		return
+	}
+
+	total := 0
+	for i := 0; i < n; i++ {
+		var x, y, c int
+		fmt.Fscan(in, &x, &y, &c)
+		triCost := A * (k - x - y)
+		if triCost < c {
+			total += triCost
+		} else {
+			total += c
+		}
+	}
+
+	if A*k < total {
+		fmt.Fprintln(out, A*k)
+	} else {
+		fmt.Fprintln(out, total)
+	}
+}


### PR DESCRIPTION
## Summary
- add initial Go implementation for Tenzing and Triangle

## Testing
- `gofmt -w 1000-1999/1800-1899/1840-1849/1842/1842E.go`
- `go vet 1000-1999/1800-1899/1840-1849/1842/1842E.go`
- `go build 1000-1999/1800-1899/1840-1849/1842/1842E.go`

------
https://chatgpt.com/codex/tasks/task_e_6884f0c4aeb08324b5641600302932dc