### PR TITLE
Add Go solution for CF 1882B

### DIFF
--- a/1000-1999/1800-1899/1880-1889/1882/1882B.go
+++ b/1000-1999/1800-1899/1880-1889/1882/1882B.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+   "bufio"
+   "fmt"
+   "math/bits"
+   "os"
+)
+
+func main() {
+   reader := bufio.NewReader(os.Stdin)
+   writer := bufio.NewWriter(os.Stdout)
+   defer writer.Flush()
+
+   var t int
+   if _, err := fmt.Fscan(reader, &t); err != nil {
+      return
+   }
+   for ; t > 0; t-- {
+      var n int
+      fmt.Fscan(reader, &n)
+      sets := make([]uint64, n)
+      var all uint64
+      for i := 0; i < n; i++ {
+         var k int
+         fmt.Fscan(reader, &k)
+         var mask uint64
+         for j := 0; j < k; j++ {
+            var x int
+            fmt.Fscan(reader, &x)
+            mask |= 1 << uint(x-1)
+         }
+         sets[i] = mask
+         all |= mask
+      }
+      ans := 0
+      for e := 0; e < 50; e++ {
+         if all&(1<<uint(e)) == 0 {
+            continue
+         }
+         var u uint64
+         for i := 0; i < n; i++ {
+            if sets[i]&(1<<uint(e)) == 0 {
+               u |= sets[i]
+            }
+         }
+         cnt := bits.OnesCount64(u)
+         if cnt > ans {
+            ans = cnt
+         }
+      }
+      fmt.Fprintln(writer, ans)
+   }
+}


### PR DESCRIPTION
## Summary
- add solution `1882B.go` for problem B in contest 1882

## Testing
- `go build 1000-1999/1800-1899/1880-1889/1882/1882B.go`

------
https://chatgpt.com/codex/tasks/task_e_6884f2f4ab1883248ae082a6ec8ae0dc