### PR TITLE
Add Go solution for 1884D

### DIFF
--- a/1000-1999/1800-1899/1880-1889/1884/1884D.go
+++ b/1000-1999/1800-1899/1880-1889/1884/1884D.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int, n)
+		maxVal := n
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+		}
+
+		freq := make([]int, maxVal+1)
+		for _, v := range arr {
+			freq[v]++
+		}
+
+		cntMult := make([]int, maxVal+1)
+		hasDiv := make([]bool, maxVal+1)
+		// accumulate multiples and divisors presence
+		for v := 1; v <= maxVal; v++ {
+			if freq[v] > 0 {
+				for m := v; m <= maxVal; m += v {
+					cntMult[m] += freq[v]
+					hasDiv[m] = true
+				}
+			}
+		}
+
+		gcdCnt := make([]int64, maxVal+1)
+		// compute number of pairs with gcd exactly g
+		for g := maxVal; g >= 1; g-- {
+			c := cntMult[g]
+			if c >= 2 {
+				total := int64(c) * int64(c-1) / 2
+				for m := g * 2; m <= maxVal; m += g {
+					total -= gcdCnt[m]
+				}
+				gcdCnt[g] = total
+			}
+		}
+
+		var ans int64
+		for g := 1; g <= maxVal; g++ {
+			if !hasDiv[g] {
+				ans += gcdCnt[g]
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem D of contest 1884

## Testing
- `go build 1000-1999/1800-1899/1880-1889/1884/1884D.go`


------
https://chatgpt.com/codex/tasks/task_e_6884f40d05d08324ad7ea949928210c9