### PR TITLE
Add Go solution for 1884B

### DIFF
--- a/1000-1999/1800-1899/1880-1889/1884/1884B.go
+++ b/1000-1999/1800-1899/1880-1889/1884/1884B.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var s string
+		fmt.Fscan(reader, &s)
+
+		zeros := make([]int, 0, n)
+		for i, ch := range s {
+			if ch == '0' {
+				zeros = append(zeros, i+1) // 1-indexed positions
+			}
+		}
+		k := len(zeros)
+		prefix := make([]int, k+1)
+		for i := 0; i < k; i++ {
+			prefix[i+1] = prefix[i] + zeros[i]
+		}
+
+		for i := 1; i <= n; i++ {
+			if i > k {
+				if i > 1 {
+					writer.WriteByte(' ')
+				}
+				fmt.Fprint(writer, -1)
+				continue
+			}
+			targetSum := (n-i+1)*i + i*(i-1)/2
+			sumZeros := prefix[k] - prefix[k-i]
+			cost := targetSum - sumZeros
+			if i > 1 {
+				writer.WriteByte(' ')
+			}
+			fmt.Fprint(writer, cost)
+		}
+		writer.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem B in contest 1884

## Testing
- `go vet 1000-1999/1800-1899/1880-1889/1884/1884B.go`
- `go build 1000-1999/1800-1899/1880-1889/1884/1884B.go`


------
https://chatgpt.com/codex/tasks/task_e_6884f498f3188324a0973bc50875e592