### PR TITLE
Add Go solution for 1883E

### DIFF
--- a/1000-1999/1800-1899/1880-1889/1883/1883E.go
+++ b/1000-1999/1800-1899/1880-1889/1883/1883E.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+		}
+		var ops int
+		prev := arr[0]
+		for i := 1; i < n; i++ {
+			cur := arr[i]
+			for cur < prev {
+				cur <<= 1
+				ops++
+			}
+			prev = cur
+		}
+		fmt.Fprintln(out, ops)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem 1883E

## Testing
- `go build 1000-1999/1800-1899/1880-1889/1883/1883E.go`
- `go vet 1000-1999/1800-1899/1880-1889/1883/1883E.go`

------
https://chatgpt.com/codex/tasks/task_e_6884f5b16c688324b588995dc1497d43