### PR TITLE
Add Go solution for 1883F

### DIFF
--- a/1000-1999/1800-1899/1880-1889/1883/1883F.go
+++ b/1000-1999/1800-1899/1880-1889/1883/1883F.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+
+		first := make([]bool, n)
+		seen := make(map[int]struct{})
+		for i, v := range a {
+			if _, ok := seen[v]; !ok {
+				first[i] = true
+				seen[v] = struct{}{}
+			}
+		}
+
+		last := make([]bool, n)
+		seen = make(map[int]struct{})
+		for i := n - 1; i >= 0; i-- {
+			v := a[i]
+			if _, ok := seen[v]; !ok {
+				last[i] = true
+				seen[v] = struct{}{}
+			}
+		}
+
+		suf := make([]int, n+1)
+		for i := n - 1; i >= 0; i-- {
+			if last[i] {
+				suf[i] = suf[i+1] + 1
+			} else {
+				suf[i] = suf[i+1]
+			}
+		}
+
+		var ans int64
+		for i := 0; i < n; i++ {
+			if first[i] {
+				ans += int64(suf[i])
+			}
+		}
+
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem F in contest 1883

## Testing
- `go build 1000-1999/1800-1899/1880-1889/1883/1883F.go`
- ran the compiled binary on a sample input

------
https://chatgpt.com/codex/tasks/task_e_6884f63d2f508324ab286b7fae9763d8