### PR TITLE
Add 1881D Go solution

### DIFF
--- a/1000-1999/1800-1899/1880-1889/1881/1881D.go
+++ b/1000-1999/1800-1899/1880-1889/1881/1881D.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		counts := make(map[int]int)
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			v := x
+			for p := 2; p*p <= v; p++ {
+				for v%p == 0 {
+					counts[p]++
+					v /= p
+				}
+			}
+			if v > 1 {
+				counts[v]++
+			}
+		}
+		ok := true
+		for _, c := range counts {
+			if c%n != 0 {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go solution for problem D of contest 1881

## Testing
- `go build 1000-1999/1800-1899/1880-1889/1881/1881D.go`


------
https://chatgpt.com/codex/tasks/task_e_6884f8b343a483248d078a1209f271d6