### PR TITLE
Add Go solution for 1881C

### DIFF
--- a/1000-1999/1800-1899/1880-1889/1881/1881C.go
+++ b/1000-1999/1800-1899/1880-1889/1881/1881C.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		matrix := make([][]byte, n)
+		for i := 0; i < n; i++ {
+			var s string
+			fmt.Fscan(in, &s)
+			matrix[i] = []byte(s)
+		}
+
+		operations := 0
+		for i := 0; i < n/2; i++ {
+			for j := 0; j < n/2; j++ {
+				a := matrix[i][j]
+				b := matrix[j][n-1-i]
+				c := matrix[n-1-i][n-1-j]
+				d := matrix[n-1-j][i]
+				maxChar := a
+				if b > maxChar {
+					maxChar = b
+				}
+				if c > maxChar {
+					maxChar = c
+				}
+				if d > maxChar {
+					maxChar = d
+				}
+				operations += int(maxChar-a) + int(maxChar-b) + int(maxChar-c) + int(maxChar-d)
+			}
+		}
+		fmt.Fprintln(out, operations)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem C from round 1881

## Testing
- `go build 1000-1999/1800-1899/1880-1889/1881/1881C.go`
- `go vet 1000-1999/1800-1899/1880-1889/1881/1881C.go`


------
https://chatgpt.com/codex/tasks/task_e_6884f9855e208324a59eb2066433ad15