### PR TITLE
Add Go solution for problem 1881B

### DIFF
--- a/1000-1999/1800-1899/1880-1889/1881/1881B.go
+++ b/1000-1999/1800-1899/1880-1889/1881/1881B.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// Solution for Codeforces problem 1881B - Three Threadlets.
+// We try all possible final counts of threadlets (3 to 6).
+// For each count k dividing the total length, every initial
+// thread length must also be divisible by the target piece length.
+// Since k <= 6, the required number of cuts k-3 never exceeds 3.
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var a, b, c int64
+		fmt.Fscan(in, &a, &b, &c)
+		sum := a + b + c
+		ok := false
+		for k := int64(3); k <= 6; k++ {
+			if sum%k != 0 {
+				continue
+			}
+			l := sum / k
+			if a%l == 0 && b%l == 0 && c%l == 0 {
+				ok = true
+				break
+			}
+		}
+		if ok {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for contest 1881 problem B "Three Threadlets"

## Testing
- `gofmt -w 1000-1999/1800-1899/1880-1889/1881/1881B.go`

------
https://chatgpt.com/codex/tasks/task_e_6884f9cb70248324a7d1e31f55ea2f6c