### PR TITLE
Add Go solution for 1876G

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1876/1876G.go
+++ b/1000-1999/1800-1899/1870-1879/1876/1876G.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	a := make([]int64, n+1)
+	for i := 1; i <= n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+
+	var q int
+	fmt.Fscan(in, &q)
+	for ; q > 0; q-- {
+		var l, r int
+		var x int64
+		fmt.Fscan(in, &l, &r, &x)
+		prefix := int64(0)
+		cost := int64(0)
+		for i := r; i >= l; i-- {
+			need := x - a[i] - prefix
+			if need > 0 {
+				t := (need + 1) / 2
+				prefix += t
+				cost += int64(i) * t
+			}
+		}
+		fmt.Fprintln(out, cost)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem G in contest 1876

## Testing
- `go vet 1000-1999/1800-1899/1870-1879/1876/1876G.go`
- `go build 1000-1999/1800-1899/1870-1879/1876/1876G.go`


------
https://chatgpt.com/codex/tasks/task_e_6884fd9ff340832484458fcf084dd357