### PR TITLE
Add Go solution for problem 1876A

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1876/1876A.go
+++ b/1000-1999/1800-1899/1870-1879/1876/1876A.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bufio"
+	"container/heap"
+	"fmt"
+	"os"
+	"sort"
+)
+
+type node struct {
+	cost int
+	rem  int
+}
+
+type minHeap []node
+
+func (h minHeap) Len() int            { return len(h) }
+func (h minHeap) Less(i, j int) bool  { return h[i].cost < h[j].cost }
+func (h minHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *minHeap) Push(x interface{}) { *h = append(*h, x.(node)) }
+func (h *minHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, p int
+		fmt.Fscan(in, &n, &p)
+		a := make([]int, n)
+		b := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &b[i])
+		}
+		// sort residents by b ascending
+		type pair struct{ a, b int }
+		arr := make([]pair, n)
+		for i := 0; i < n; i++ {
+			arr[i] = pair{a: a[i], b: b[i]}
+		}
+		sort.Slice(arr, func(i, j int) bool { return arr[i].b < arr[j].b })
+
+		idx := 0
+		var total int64
+		pq := &minHeap{}
+		heap.Init(pq)
+		for informed := 0; informed < n; informed++ {
+			if pq.Len() > 0 && (*pq)[0].cost < p {
+				x := heap.Pop(pq).(node)
+				total += int64(x.cost)
+				if x.rem > 1 {
+					x.rem--
+					heap.Push(pq, x)
+				}
+				// inform next resident with smallest b
+				cur := arr[idx]
+				idx++
+				if cur.a > 0 {
+					heap.Push(pq, node{cost: cur.b, rem: cur.a})
+				}
+			} else {
+				total += int64(p)
+				cur := arr[idx]
+				idx++
+				if cur.a > 0 {
+					heap.Push(pq, node{cost: cur.b, rem: cur.a})
+				}
+			}
+		}
+		fmt.Fprintln(out, total)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1876A.go` using greedy approach with a priority queue
- choose cheapest available method (direct share cost `p` or using existing residents) to inform all residents

## Testing
- `go build 1000-1999/1800-1899/1870-1879/1876/1876A.go`
- manual run with sample-like input

------
https://chatgpt.com/codex/tasks/task_e_6884fe2c0228832496d4332b475c4434