### PR TITLE
Fix precision formatting in contest 93B solution

### DIFF
--- a/0-999/0-99/90-99/93/93B.go
+++ b/0-999/0-99/90-99/93/93B.go
@@ -6,6 +6,8 @@ import (
    "os"
 )
 
+const outFmt = "%.16f"
+
 func main() {
    r := bufio.NewReader(os.Stdin)
    w := bufio.NewWriter(os.Stdout)
@@ -32,7 +34,7 @@ func main() {
                fmt.Fprint(w, " ")
            }
            length := float64(cnt)/float64(m) * float64(W)
-           fmt.Fprintf(w, "%d %.16f", cur, length)
+           fmt.Fprintf(w, "%d "+outFmt, cur, length)
            printed = true
            used += cnt
            sum += cnt


### PR DESCRIPTION
## Summary
- ensure problem 93B prints using a constant format with 16 decimal places

## Testing
- `go build 93B.go`
- `go run verifierB.go ./93B | head`


------
https://chatgpt.com/codex/tasks/task_e_6884fcb6c9a883248236f167262c0900