### PR TITLE
Add Go solution for 1878C

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1878/1878C.go
+++ b/1000-1999/1800-1899/1870-1879/1878/1878C.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k, x int64
+		fmt.Fscan(reader, &n, &k, &x)
+		minSum := k * (k + 1) / 2
+		maxSum := k * (2*n - k + 1) / 2
+		if x >= minSum && x <= maxSum {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation solving problem C of contest 1878

## Testing
- `go vet 1000-1999/1800-1899/1870-1879/1878/1878C.go`
- `go build 1000-1999/1800-1899/1870-1879/1878/1878C.go`


------
https://chatgpt.com/codex/tasks/task_e_6884ff8a2fcc83248ad441c6706bb7b5