### PR TITLE
Add Go solution for 1878A

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1878/1878A.go
+++ b/1000-1999/1800-1899/1870-1879/1878/1878A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		found := false
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			if x == k {
+				found = true
+			}
+		}
+		if found {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem A in contest 1878

## Testing
- `go run 1878A.go <<EOF ... EOF`

------
https://chatgpt.com/codex/tasks/task_e_6884ffd03f348324ba909d85d13efa18