### PR TITLE
Add Go solution for Codeforces 1870D

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1870/1870D.go
+++ b/1000-1999/1800-1899/1870-1879/1870/1870D.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		c := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &c[i])
+		}
+		var k int64
+		fmt.Fscan(reader, &k)
+
+		a := make([]int64, n)
+		const INF int64 = 1 << 60
+		mn := INF
+		prefix := int64(0)
+		for i := n - 1; i >= 0; i-- {
+			if c[i] < mn {
+				mn = c[i]
+			}
+			times := k / mn
+			prefix += times
+			k -= times * mn
+			a[i] = prefix
+		}
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				fmt.Fprint(writer, " ")
+			}
+			fmt.Fprint(writer, a[i])
+		}
+		fmt.Fprintln(writer)
+	}
+}


### PR DESCRIPTION
## Summary
- add a new Go solution for problem 1870D

## Testing
- `gofmt -w 1000-1999/1800-1899/1870-1879/1870/1870D.go`
- `go vet ./...` *(fails: pattern ./...: directory prefix . does not contain main module)*
- `go build ./...` *(fails: pattern ./...: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_688502468ef08324b633e286c2daf933