### PR TITLE
Add Go solution for problem 1870B

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1870/1870B.go
+++ b/1000-1999/1800-1899/1870-1879/1870/1870B.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(in, &n, &m)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		orB := 0
+		for i := 0; i < m; i++ {
+			var b int
+			fmt.Fscan(in, &b)
+			orB |= b
+		}
+		xorA := 0
+		for i := 0; i < n; i++ {
+			xorA ^= a[i]
+		}
+		xorOR := 0
+		for i := 0; i < n; i++ {
+			xorOR ^= (a[i] | orB)
+		}
+		if n%2 == 1 {
+			fmt.Fprintln(out, xorA, xorOR)
+		} else {
+			fmt.Fprintln(out, xorOR, xorA)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1870B

## Testing
- `go build 1000-1999/1800-1899/1870-1879/1870/1870B.go`
- `./1870B <<EOF
1
2 1
0 1
1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6885035ebadc8324bce5182042626568