### PR TITLE
Add Go solution for 1870A

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1870/1870A.go
+++ b/1000-1999/1800-1899/1870-1879/1870/1870A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k, x int64
+		fmt.Fscan(in, &n, &k, &x)
+
+		if n < k || x < k-1 {
+			fmt.Fprintln(out, -1)
+			continue
+		}
+
+		base := k * (k - 1) / 2
+		val := x
+		if val == k {
+			val--
+		}
+		sum := base + (n-k)*val
+		fmt.Fprintln(out, sum)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solver for 1870A

## Testing
- `go build 1000-1999/1800-1899/1870-1879/1870/1870A.go`

------
https://chatgpt.com/codex/tasks/task_e_688503a4c3708324bd2adf21f454350b