### PR TITLE
Add solution for 1877A

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1877/1877A.go
+++ b/1000-1999/1800-1899/1870-1879/1877/1877A.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		sum := 0
+		for i := 0; i < n-1; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			sum += x
+		}
+		fmt.Fprintln(writer, -sum)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1877A.go` for contest 1877 problem A

## Testing
- `go build 1000-1999/1800-1899/1870-1879/1877/1877A.go`

------
https://chatgpt.com/codex/tasks/task_e_68850430d05083248cfa697224acb64c