### PR TITLE
Add Go solution for CF 1872D

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1872/1872D.go
+++ b/1000-1999/1800-1899/1870-1879/1872/1872D.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, x, y int64
+		fmt.Fscan(reader, &n, &x, &y)
+
+		if x == y {
+			fmt.Fprintln(writer, 0)
+			continue
+		}
+
+		g := gcd(x, y)
+		lcm := x / g * y
+
+		cntX := n/x - n/lcm
+		cntY := n/y - n/lcm
+
+		sumX := cntX * (2*n - cntX + 1) / 2
+		sumY := cntY * (cntY + 1) / 2
+
+		fmt.Fprintln(writer, sumX-sumY)
+	}
+}


### PR DESCRIPTION
## Summary
- add `1872D.go` implementing a greedy formula-based solution

## Testing
- `go build 1000-1999/1800-1899/1870-1879/1872/1872D.go`


------
https://chatgpt.com/codex/tasks/task_e_688504bcdf0483248d69732c4e392920