### PR TITLE
Add Go solution for 1873E

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1873/1873E.go
+++ b/1000-1999/1800-1899/1870-1879/1873/1873E.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var x int64
+		fmt.Fscan(reader, &n, &x)
+		a := make([]int64, n)
+		var maxA int64
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+			if a[i] > maxA {
+				maxA = a[i]
+			}
+		}
+		lo := int64(1)
+		hi := maxA + x + 1 // exclusive upper bound
+		for lo+1 < hi {
+			mid := (lo + hi) / 2
+			var need int64
+			for _, v := range a {
+				if mid > v {
+					need += mid - v
+					if need > x {
+						break
+					}
+				}
+			}
+			if need <= x {
+				lo = mid
+			} else {
+				hi = mid
+			}
+		}
+		fmt.Fprintln(writer, lo)
+	}
+}


### PR DESCRIPTION
## Summary
- implement binary search solution for aquarium height problem

## Testing
- `go build 1000-1999/1800-1899/1870-1879/1873/1873E.go`
- `echo '1
3 5
1 2 3
' | go run 1000-1999/1800-1899/1870-1879/1873/1873E.go`

------
https://chatgpt.com/codex/tasks/task_e_6885084c12208324ad7d84c36f4ada4e