### PR TITLE
Add Go solution for 1873F

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1873/1873F.go
+++ b/1000-1999/1800-1899/1870-1879/1873/1873F.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		var k int64
+		fmt.Fscan(in, &n, &k)
+		a := make([]int64, n)
+		h := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &h[i])
+		}
+
+		ans := 0
+		l := 0
+		var sum int64
+		for r := 0; r < n; r++ {
+			if r > 0 && h[r-1]%h[r] != 0 {
+				l = r
+				sum = 0
+			}
+			sum += a[r]
+			for sum > k {
+				sum -= a[l]
+				l++
+			}
+			if r-l+1 > ans {
+				ans = r - l + 1
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem 1873F

## Testing
- `go run 1000-1999/1800-1899/1870-1879/1873/1873F.go < /tmp/test.in`


------
https://chatgpt.com/codex/tasks/task_e_688508d7ff408324ae5f3affc6b2e63c