### PR TITLE
Add Go solution for 1873D

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1873/1873D.go
+++ b/1000-1999/1800-1899/1870-1879/1873/1873D.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		var s string
+		fmt.Fscan(reader, &s)
+		ops := 0
+		i := 0
+		for i < n {
+			if s[i] == 'B' {
+				ops++
+				i += k
+			} else {
+				i++
+			}
+		}
+		fmt.Fprintln(writer, ops)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1873D.go` solution for problem D in contest 1873

## Testing
- `go build 1000-1999/1800-1899/1870-1879/1873/1873D.go`
- `go build -o /tmp/1873D 1000-1999/1800-1899/1870-1879/1873/1873D.go`
- `/tmp/1873D < /tmp/test.in`

------
https://chatgpt.com/codex/tasks/task_e_68850891d24483249a9905f2c70a55bb