### PR TITLE
Add Go solution for 1873C

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1873/1873C.go
+++ b/1000-1999/1800-1899/1870-1879/1873/1873C.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		score := 0
+		for i := 0; i < 10; i++ {
+			var row string
+			fmt.Fscan(in, &row)
+			for j := 0; j < 10 && j < len(row); j++ {
+				if row[j] == 'X' {
+					val := min(min(i, 9-i), min(j, 9-j)) + 1
+					score += val
+				}
+			}
+		}
+		fmt.Fprintln(out, score)
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1873C

## Testing
- `go build ./1000-1999/1800-1899/1870-1879/1873/1873C.go`
- `go run ./1000-1999/1800-1899/1870-1879/1873/1873C.go` with sample input

------
https://chatgpt.com/codex/tasks/task_e_688509644d4c832499a2ce0dff0bd2c2