### PR TITLE
Add Go solution for 1874B

### DIFF
--- a/1000-1999/1800-1899/1870-1879/1874/1874B.go
+++ b/1000-1999/1800-1899/1870-1879/1874/1874B.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type state struct{ x, y uint32 }
+
+type queue struct{ data []state }
+
+func (q *queue) push(s state) { q.data = append(q.data, s) }
+func (q *queue) pop() state   { v := q.data[0]; q.data = q.data[1:]; return v }
+
+func solve(a, b, c, d, m uint32) int {
+	start := state{a, b}
+	target := state{c, d}
+	if start == target {
+		return 0
+	}
+	q := queue{data: []state{start}}
+	dist := map[state]int{start: 0}
+	for len(q.data) > 0 {
+		cur := q.pop()
+		step := dist[cur]
+		if cur == target {
+			return step
+		}
+		x, y := cur.x, cur.y
+		next := [4]state{
+			{x & y, y},
+			{x | y, y},
+			{x, x ^ y},
+			{x, y ^ m},
+		}
+		for _, v := range next {
+			if _, ok := dist[v]; !ok {
+				dist[v] = step + 1
+				if v == target {
+					return step + 1
+				}
+				q.push(v)
+			}
+		}
+	}
+	return -1
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var a, b, c, d, m uint32
+		fmt.Fscan(reader, &a, &b, &c, &d, &m)
+		fmt.Fprintln(writer, solve(a, b, c, d, m))
+	}
+}


### PR DESCRIPTION
## Summary
- implement BFS-based solution for problem B in 1874 set

## Testing
- `go vet 1000-1999/1800-1899/1870-1879/1874/1874B.go`
- `go build 1000-1999/1800-1899/1870-1879/1874/1874B.go`


------
https://chatgpt.com/codex/tasks/task_e_6885077981cc832480f718d7f057373f