### PR TITLE
Add Go solution for 1808D

### DIFF
--- a/1000-1999/1800-1899/1800-1809/1808/1808D.go
+++ b/1000-1999/1800-1899/1800-1809/1808/1808D.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, k int
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &arr[i])
+	}
+
+	half := k / 2
+	total := 0
+	for l := 0; l <= n-k; l++ {
+		mism := 0
+		for d := 0; d < half; d++ {
+			if arr[l+d] != arr[l+k-1-d] {
+				mism++
+			}
+		}
+		total += mism
+	}
+	fmt.Fprintln(out, total)
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem D in contest 1808

## Testing
- `go build 1000-1999/1800-1899/1800-1809/1808/1808D.go`


------
https://chatgpt.com/codex/tasks/task_e_68850a36026083248d80a70795952ce2