### PR TITLE
Add Go solution for CF 1806A

### DIFF
--- a/1000-1999/1800-1899/1800-1809/1806/1806A.go
+++ b/1000-1999/1800-1899/1800-1809/1806/1806A.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a, b, c, d int
+		fmt.Fscan(reader, &a, &b, &c, &d)
+
+		if d < b || c > a+d-b {
+			fmt.Fprintln(writer, -1)
+			continue
+		}
+		steps := (d - b) + (a + d - b - c)
+		fmt.Fprintln(writer, steps)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1806A.go` for problem A in contest 1806

## Testing
- `go build ./1000-1999/1800-1899/1800-1809/1806/1806A.go`


------
https://chatgpt.com/codex/tasks/task_e_68850d386af083248e525078df527615