### PR TITLE
Add Go solution for 1809A

### DIFF
--- a/1000-1999/1800-1899/1800-1809/1809/1809A.go
+++ b/1000-1999/1800-1899/1800-1809/1809/1809A.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		count := make(map[rune]int)
+		for _, ch := range s {
+			count[ch]++
+		}
+		if len(count) == 1 {
+			fmt.Fprintln(writer, -1)
+			continue
+		}
+		ans := 4
+		for _, c := range count {
+			if c == 3 {
+				ans = 6
+				break
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution in Go for problem 1809A

## Testing
- `go vet 1000-1999/1800-1899/1800-1809/1809/1809A.go`
- `go run 1000-1999/1800-1899/1800-1809/1809/1809A.go < /tmp/input.txt`

------
https://chatgpt.com/codex/tasks/task_e_688514e156c48324a744b5cceea5f0eb