### PR TITLE
Add Go solution for problem 1805B

### DIFF
--- a/1000-1999/1800-1899/1800-1809/1805/1805B.go
+++ b/1000-1999/1800-1899/1800-1809/1805/1805B.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var s string
+		fmt.Fscan(reader, &s)
+
+		minChar := byte('z' + 1)
+		for i := 0; i < len(s); i++ {
+			if s[i] < minChar {
+				minChar = s[i]
+			}
+		}
+		idx := -1
+		for i := len(s) - 1; i >= 0; i-- {
+			if s[i] == minChar {
+				idx = i
+				break
+			}
+		}
+		result := make([]byte, 0, len(s))
+		result = append(result, minChar)
+		result = append(result, s[:idx]...)
+		if idx+1 < len(s) {
+			result = append(result, s[idx+1:]...)
+		}
+		fmt.Fprintln(writer, string(result))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem B 1805

## Testing
- `go build 1000-1999/1800-1899/1800-1809/1805/1805B.go`
- `echo -e "3\n6\nabaacd\n3\nabc\n6\nbanana\n" | go run 1000-1999/1800-1899/1800-1809/1805/1805B.go`

------
https://chatgpt.com/codex/tasks/task_e_688517119e248324badb2d42c7fd44d4