### PR TITLE
Add Go solution for 1822A

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1822/1822A.go
+++ b/1000-1999/1800-1899/1820-1829/1822/1822A.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var q int
+	fmt.Fscan(reader, &q)
+	for q > 0 {
+		q--
+		var n, t int
+		fmt.Fscan(reader, &n, &t)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		b := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &b[i])
+		}
+		bestIdx := -1
+		bestVal := -1
+		for i := 0; i < n; i++ {
+			if a[i]+i <= t && b[i] > bestVal {
+				bestVal = b[i]
+				bestIdx = i + 1
+			}
+		}
+		fmt.Fprintln(writer, bestIdx)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for 1822A (TubeTube Feed)

## Testing
- `go run 1000-1999/1800-1899/1820-1829/1822/1822A.go <<'EOF'
1
3 7
1 3 2
2 1 3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68851b724768832485af2b8374b58e50