### PR TITLE
Add Go solution for 1828B

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1828/1828B.go
+++ b/1000-1999/1800-1899/1820-1829/1828/1828B.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+		}
+		g := 0
+		for i := 0; i < n; i++ {
+			diff := arr[i] - (i + 1)
+			if diff < 0 {
+				diff = -diff
+			}
+			g = gcd(g, diff)
+		}
+		fmt.Fprintln(out, g)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for contest 1828 problem B

## Testing
- `go build ./1000-1999/1800-1899/1820-1829/1828/1828B.go`


------
https://chatgpt.com/codex/tasks/task_e_68851e74b1648324a4f6ce21269cc749