### PR TITLE
Add Go solution for 1821A

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1821/1821A.go
+++ b/1000-1999/1800-1899/1820-1829/1821/1821A.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		if s[0] == '0' {
+			fmt.Fprintln(writer, 0)
+			continue
+		}
+		ans := 1
+		if s[0] == '?' {
+			ans *= 9
+		}
+		for i := 1; i < len(s); i++ {
+			if s[i] == '?' {
+				ans *= 10
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for 1821A

## Testing
- `go build 1821A.go`
- `./1821A << EOF
1
?
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6885205ef678832485a18e533f73f400