### PR TITLE
Add Go solution for 1821C

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1821/1821C.go
+++ b/1000-1999/1800-1899/1820-1829/1821/1821C.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(in, &s)
+		n := len(s)
+		best := int(1<<31 - 1)
+		for ch := byte('a'); ch <= 'z'; ch++ {
+			prev := -1
+			maxSeg := 0
+			for i := 0; i < n; i++ {
+				if s[i] == ch {
+					seg := i - prev - 1
+					if seg > maxSeg {
+						maxSeg = seg
+					}
+					prev = i
+				}
+			}
+			seg := n - prev - 1
+			if seg > maxSeg {
+				maxSeg = seg
+			}
+			ops := 0
+			for v := maxSeg; v > 0; v >>= 1 {
+				ops++
+			}
+			if ops < best {
+				best = ops
+			}
+		}
+		fmt.Fprintln(out, best)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem C of contest 1821

## Testing
- `go build 1000-1999/1800-1899/1820-1829/1821/1821C.go`

------
https://chatgpt.com/codex/tasks/task_e_68851fd2ed5c832491cce4b6d58d4f31