### PR TITLE
Add Go solution for 1821D

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1821/1821D.go
+++ b/1000-1999/1800-1899/1820-1829/1821/1821D.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		var k int64
+		fmt.Fscan(in, &n, &k)
+		l := make([]int64, n)
+		r := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &l[i])
+		}
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &r[i])
+		}
+		var pref int64
+		ans := int64(-1)
+		for i := 0; i < n; i++ {
+			seg := r[i] - l[i] + 1
+			if pref+seg >= k {
+				q := l[i] + (k - pref) - 1
+				ans = q + 2
+				break
+			}
+			pref += seg
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem D in contest 1821

## Testing
- `go build ./1000-1999/1800-1899/1820-1829/1821/1821D.go`


------
https://chatgpt.com/codex/tasks/task_e_68851f46ea6c83249b3d42e600b391ca