### PR TITLE
Add Go solution for 1826C

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1826/1826C.go
+++ b/1000-1999/1800-1899/1820-1829/1826/1826C.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const MAXN = 1000000
+
+var spf [MAXN + 1]int
+
+func init() {
+	for i := 2; i <= MAXN; i++ {
+		if spf[i] == 0 {
+			for j := i; j <= MAXN; j += i {
+				if spf[j] == 0 {
+					spf[j] = i
+				}
+			}
+		}
+	}
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(reader, &n, &m)
+		if n == 1 || m == 1 {
+			fmt.Fprintln(writer, "YES")
+			continue
+		}
+		d := spf[n]
+		if d == 0 { // n == 1, already handled
+			d = n
+		}
+		if m >= d {
+			fmt.Fprintln(writer, "NO")
+		} else {
+			fmt.Fprintln(writer, "YES")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add Go solution for problem 1826C

## Testing
- `go build 1000-1999/1800-1899/1820-1829/1826/1826C.go`


------
https://chatgpt.com/codex/tasks/task_e_68852177212c8324865915c11453af1b