### PR TITLE
Add Go solution for 1826A

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1826/1826A.go
+++ b/1000-1999/1800-1899/1820-1829/1826/1826A.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		res := -1
+		for x := 0; x <= n; x++ {
+			cnt := 0
+			for _, v := range arr {
+				if v > x {
+					cnt++
+				}
+			}
+			if cnt == x {
+				res = x
+				break
+			}
+		}
+		fmt.Fprintln(writer, res)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem A in contest 1826

## Testing
- `go build 1000-1999/1800-1899/1820-1829/1826/1826A.go`


------
https://chatgpt.com/codex/tasks/task_e_688522042b588324bf9886e2bb381930