### PR TITLE
Add Go solution for 1820A

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1820/1820A.go
+++ b/1000-1999/1800-1899/1820-1829/1820/1820A.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+
+		hasCaret := false
+		for i := 0; i < len(s); i++ {
+			if s[i] == '^' {
+				hasCaret = true
+				break
+			}
+		}
+
+		if !hasCaret {
+			fmt.Fprintln(writer, len(s)+1)
+			continue
+		}
+		if len(s) == 1 {
+			fmt.Fprintln(writer, 1)
+			continue
+		}
+		ans := 0
+		if s[0] == '_' {
+			ans++
+		}
+		if s[len(s)-1] == '_' {
+			ans++
+		}
+		for i := 1; i < len(s); i++ {
+			if s[i] == '_' && s[i-1] == '_' {
+				ans++
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add solution `1820A.go` implementing the minimal insertion logic

## Testing
- `go build 1000-1999/1800-1899/1820-1829/1820/1820A.go`
- ran sample-style cases via `./1820A`

------
https://chatgpt.com/codex/tasks/task_e_6885247992148324977b2bd9f0fb8b3a