### PR TITLE
Add Go solution for 1829D

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1829/1829D.go
+++ b/1000-1999/1800-1899/1820-1829/1829/1829D.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func canCreate(n, m int) bool {
+	if n == m {
+		return true
+	}
+	if n < m || n%3 != 0 {
+		return false
+	}
+	a := n / 3
+	return canCreate(a, m) || canCreate(n-a, m)
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(in, &n, &m)
+		if canCreate(n, m) {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for the "Gold Rush" problem 1829D

## Testing
- `go build ./1000-1999/1800-1899/1820-1829/1829/1829D.go`
- `go run ./1000-1999/1800-1899/1820-1829/1829/1829D.go < input.txt`

------
https://chatgpt.com/codex/tasks/task_e_6885254bbb108324b25ba90afcbccb8c