### PR TITLE
Add solution for 1829F

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1829/1829F.go
+++ b/1000-1999/1800-1899/1820-1829/1829/1829F.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(in, &n, &m)
+		adj := make([][]int, n+1)
+		for i := 0; i < m; i++ {
+			var u, v int
+			fmt.Fscan(in, &u, &v)
+			adj[u] = append(adj[u], v)
+			adj[v] = append(adj[v], u)
+		}
+		deg := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			deg[i] = len(adj[i])
+		}
+		leafNeighbors := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			cnt := 0
+			for _, v := range adj[i] {
+				if deg[v] == 1 {
+					cnt++
+				}
+			}
+			leafNeighbors[i] = cnt
+		}
+		x := 0
+		y := 0
+		for i := 1; i <= n; i++ {
+			if leafNeighbors[i] > 0 {
+				x++
+				y = leafNeighbors[i]
+			}
+		}
+		fmt.Fprintf(out, "%d %d\n", x, y)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem F in round 1829

## Testing
- `go build ./1000-1999/1800-1899/1820-1829/1829/1829F.go`


------
https://chatgpt.com/codex/tasks/task_e_6885259208b08324a3a8680ec1ccd7c3