### PR TITLE
Add Go solution for 1829B

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1829/1829B.go
+++ b/1000-1999/1800-1899/1820-1829/1829/1829B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		maxZero := 0
+		curZero := 0
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			if x == 0 {
+				curZero++
+			} else {
+				if curZero > maxZero {
+					maxZero = curZero
+				}
+				curZero = 0
+			}
+		}
+		if curZero > maxZero {
+			maxZero = curZero
+		}
+		fmt.Fprintln(writer, maxZero)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem B in contest 1829

## Testing
- `go build 1000-1999/1800-1899/1820-1829/1829/1829B.go`


------
https://chatgpt.com/codex/tasks/task_e_68852663d2b88324bc95a9b434faa0c7