### PR TITLE
Add go solution for CF 1829G

### DIFF
--- a/1000-1999/1800-1899/1820-1829/1829/1829G.go
+++ b/1000-1999/1800-1899/1820-1829/1829/1829G.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const maxN = 1000000
+
+var prefix [maxN + 1]int64
+var tri [2024]int
+
+func init() {
+	for i := 1; i <= maxN; i++ {
+		prefix[i] = prefix[i-1] + int64(i*i)
+	}
+	for i := 1; i < len(tri); i++ {
+		tri[i] = tri[i-1] + i
+	}
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		r := 1
+		for tri[r] < n {
+			r++
+		}
+		c := n - tri[r-1]
+		var ans int64
+		for i := 1; i <= r; i++ {
+			j1 := c - (r - i)
+			if j1 < 1 {
+				j1 = 1
+			}
+			if j1 > i {
+				continue
+			}
+			j2 := c
+			if j2 > i {
+				j2 = i
+			}
+			start := tri[i-1] + j1
+			end := tri[i-1] + j2
+			ans += prefix[end] - prefix[start-1]
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add `1829G.go` implementing solution for the pyramid of cans problem

## Testing
- `go vet ./1000-1999/1800-1899/1820-1829/1829/1829G.go`
- `go build ./1000-1999/1800-1899/1820-1829/1829/1829G.go`
- `go run ./1000-1999/1800-1899/1820-1829/1829/1829G.go <<EOF
5
9
1
2
3
4
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688525d7cb948324b6d9e97cdace242a