### PR TITLE
Add Go solution for 1853A

### DIFF
--- a/1000-1999/1800-1899/1850-1859/1853/1853A.go
+++ b/1000-1999/1800-1899/1850-1859/1853/1853A.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		// Check if already not sorted
+		notSorted := false
+		for i := 0; i < n-1; i++ {
+			if a[i] > a[i+1] {
+				notSorted = true
+				break
+			}
+		}
+		if notSorted {
+			fmt.Fprintln(writer, 0)
+			continue
+		}
+		// Array is non-decreasing
+		minDelta := int(1<<31 - 1)
+		for i := 0; i < n-1; i++ {
+			delta := a[i+1] - a[i]
+			if delta < minDelta {
+				minDelta = delta
+			}
+		}
+		operations := minDelta/2 + 1
+		fmt.Fprintln(writer, operations)
+	}
+}


### PR DESCRIPTION
## Summary
- implement problemA solution for contest 1853 in Go

## Testing
- `go run 1000-1999/1800-1899/1850-1859/1853/1853A.go < /tmp/test.in`

------
https://chatgpt.com/codex/tasks/task_e_688528da3a708324bc049bbeee0d4cd7