### PR TITLE
Add 1854D Go interactive solution

### DIFF
--- a/1000-1999/1800-1899/1850-1859/1854/1854D.go
+++ b/1000-1999/1800-1899/1850-1859/1854/1854D.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+
+	ask := func(u, k int, s []int) int {
+		fmt.Fprintf(writer, "? %d %d %d", u, k, len(s))
+		for _, v := range s {
+			fmt.Fprintf(writer, " %d", v)
+		}
+		fmt.Fprintln(writer)
+		writer.Flush()
+		var resp int
+		if _, err := fmt.Fscan(reader, &resp); err != nil {
+			os.Exit(0)
+		}
+		return resp
+	}
+
+	reachable := make([]int, 0, n)
+	for i := 1; i <= n; i++ {
+		if ask(i, n, []int{1}) == 1 {
+			reachable = append(reachable, i)
+		}
+	}
+
+	fmt.Fprintf(writer, "! %d", len(reachable))
+	for _, v := range reachable {
+		fmt.Fprintf(writer, " %d", v)
+	}
+	fmt.Fprintln(writer)
+}


### PR DESCRIPTION
## Summary
- add Go solution `1854D.go` for the interactive teleporter problem

## Testing
- `go build 1000-1999/1800-1899/1850-1859/1854/1854D.go`

------
https://chatgpt.com/codex/tasks/task_e_688529664f0c8324a89480481a19e943