### PR TITLE
Add Go solution for 1851A

### DIFF
--- a/1000-1999/1800-1899/1850-1859/1851/1851A.go
+++ b/1000-1999/1800-1899/1850-1859/1851/1851A.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m int
+		var k, H int
+		fmt.Fscan(reader, &n, &m, &k, &H)
+		count := 0
+		for i := 0; i < n; i++ {
+			var h int
+			fmt.Fscan(reader, &h)
+			diff := int(math.Abs(float64(h - H)))
+			if diff%k == 0 {
+				d := diff / k
+				if d >= 1 && d <= m-1 {
+					count++
+				}
+			}
+		}
+		fmt.Fprintln(writer, count)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem A in contest 1851

## Testing
- `go build -o /tmp/1851A_bin 1000-1999/1800-1899/1850-1859/1851/1851A.go`
- `echo '1
5 3 3 11
5 4 14 18 2
' | go run 1000-1999/1800-1899/1850-1859/1851/1851A.go`

------
https://chatgpt.com/codex/tasks/task_e_68852bdca6388324afaa747446e04a4a