### PR TITLE
Add Go solution for 1856A

### DIFF
--- a/1000-1999/1800-1899/1850-1859/1856/1856A.go
+++ b/1000-1999/1800-1899/1850-1859/1856/1856A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var t int
+	fmt.Fscan(in, &t)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		maxPrefix := a[0]
+		var ans int64
+		for i := 1; i < n; i++ {
+			if a[i] < maxPrefix {
+				if maxPrefix > ans {
+					ans = maxPrefix
+				}
+			} else {
+				maxPrefix = a[i]
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem A in contest 1856

## Testing
- `go build 1000-1999/1800-1899/1850-1859/1856/1856A.go`

------
https://chatgpt.com/codex/tasks/task_e_68852cf4ce688324bb309d6b93690210