### PR TITLE
Add Go solution for CF 1856B

### DIFF
--- a/1000-1999/1800-1899/1850-1859/1856/1856B.go
+++ b/1000-1999/1800-1899/1850-1859/1856/1856B.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		sum := int64(0)
+		ones := 0
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			sum += int64(x)
+			if x == 1 {
+				ones++
+			}
+		}
+		if n == 1 || int64(ones) > sum-int64(n) {
+			fmt.Fprintln(writer, "NO")
+		} else {
+			fmt.Fprintln(writer, "YES")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problemB from contest 1856 in Go

## Testing
- `go vet 1000-1999/1800-1899/1850-1859/1856/1856B.go`
- `go run 1000-1999/1800-1899/1850-1859/1856/1856B.go << EOF
1
2
2 1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68852caec6608324b5b54a133ac7bd7f