### PR TITLE
Add Go solution for 1857A

### DIFF
--- a/1000-1999/1800-1899/1850-1859/1857/1857A.go
+++ b/1000-1999/1800-1899/1850-1859/1857/1857A.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		sum := 0
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(in, &x)
+			sum += x
+		}
+		if sum%2 == 0 {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement 1857A solution in Go

## Testing
- `gofmt -w 1000-1999/1800-1899/1850-1859/1857/1857A.go`
- `go build 1000-1999/1800-1899/1850-1859/1857/1857A.go`
- `go vet 1000-1999/1800-1899/1850-1859/1857/1857A.go`


------
https://chatgpt.com/codex/tasks/task_e_688531e1c280832485c65d8ae284a801