### PR TITLE
Add Go solution for 1857B

### DIFF
--- a/1000-1999/1800-1899/1850-1859/1857/1857B.go
+++ b/1000-1999/1800-1899/1850-1859/1857/1857B.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		n := len(s)
+		digits := make([]int, n+1)
+		for i := 0; i < n; i++ {
+			digits[i+1] = int(s[i] - '0')
+		}
+		for i := n; i > 0; i-- {
+			if digits[i] >= 5 {
+				digits[i] = 0
+				// propagate carry to the left
+				j := i - 1
+				digits[j]++
+				for j > 0 && digits[j] == 10 {
+					digits[j] = 0
+					j--
+					digits[j]++
+				}
+				for k := i + 1; k <= n; k++ {
+					digits[k] = 0
+				}
+			}
+		}
+		start := 0
+		if digits[0] == 0 {
+			start = 1
+		}
+		var b strings.Builder
+		for i := start; i <= n; i++ {
+			b.WriteByte(byte(digits[i]) + '0')
+		}
+		fmt.Fprintln(writer, b.String())
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problemB in contest 1857

## Testing
- `go run 1000-1999/1800-1899/1850-1859/1857/1857B.go <<EOF
3
3451
585
44444
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6885319bc0108324a6ba408b1de4726e