### PR TITLE
Add Go solution for 1850C

### DIFF
--- a/1000-1999/1800-1899/1850-1859/1850/1850C.go
+++ b/1000-1999/1800-1899/1850-1859/1850/1850C.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		grid := make([]string, 8)
+		for i := 0; i < 8; i++ {
+			fmt.Fscan(in, &grid[i])
+		}
+		var ans []byte
+		for i := 0; i < 8; i++ {
+			for j := 0; j < 8; j++ {
+				ch := grid[i][j]
+				if ch != '.' {
+					ans = append(ans, ch)
+				}
+			}
+		}
+		fmt.Fprintln(out, string(ans))
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1850C.go` with scanning the 8x8 grid and collecting non-dot characters

## Testing
- `go build 1000-1999/1800-1899/1850-1859/1850/1850C.go`


------
https://chatgpt.com/codex/tasks/task_e_68853386166483248bc3fef8cc567ef1