### PR TITLE
Add Go solution for 1863B

### DIFF
--- a/1000-1999/1800-1899/1860-1869/1863/1863B.go
+++ b/1000-1999/1800-1899/1860-1869/1863/1863B.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		pos := make([]int, n+1)
+		for i := 1; i <= n; i++ {
+			var x int
+			fmt.Fscan(reader, &x)
+			pos[x] = i
+		}
+		segments := 1
+		for v := 2; v <= n; v++ {
+			if pos[v] < pos[v-1] {
+				segments++
+			}
+		}
+		fmt.Fprintln(writer, segments-1)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem B in 1863
- compute number of segments based on positions
- output minimal operations required

## Testing
- `go run 1000-1999/1800-1899/1860-1869/1863/1863B.go << EOF
3
1
1
2
2 1
6
6 4 3 5 2 1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688537e68a5c8324b31467fa0a028489