### PR TITLE
Add Go solution for 1862C

### DIFF
--- a/1000-1999/1800-1899/1860-1869/1862/1862C.go
+++ b/1000-1999/1800-1899/1860-1869/1862/1862C.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func isSymmetric(a []int) bool {
+	n := len(a)
+	if a[0] != n {
+		return false
+	}
+	j := n - 1
+	for i := 1; i <= n; i++ {
+		for j >= 0 && a[j] < i {
+			j--
+		}
+		if j+1 != a[i-1] {
+			return false
+		}
+	}
+	return true
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		if isSymmetric(a) {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go solution for problem C in contest 1862

## Testing
- `go vet 1000-1999/1800-1899/1860-1869/1862/1862C.go`
- `go build 1000-1999/1800-1899/1860-1869/1862/1862C.go`


------
https://chatgpt.com/codex/tasks/task_e_6885398af0b48324887fc93786155edf