### PR TITLE
Add Go solution for 1862D

### DIFF
--- a/1000-1999/1800-1899/1860-1869/1862/1862D.go
+++ b/1000-1999/1800-1899/1860-1869/1862/1862D.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+   "bufio"
+   "fmt"
+   "math"
+   "os"
+)
+
+func isqrt(x int64) int64 {
+   r := int64(math.Sqrt(float64(x)))
+   for (r+1)*(r+1) <= x {
+      r++
+   }
+   for r*r > x {
+      r--
+   }
+   return r
+}
+
+func main() {
+   reader := bufio.NewReader(os.Stdin)
+   writer := bufio.NewWriter(os.Stdout)
+   defer writer.Flush()
+
+   var t int
+   fmt.Fscan(reader, &t)
+   for t > 0 {
+      t--
+      var n int64
+      fmt.Fscan(reader, &n)
+      x := (1 + isqrt(1+8*n)) / 2
+      for x*(x-1)/2 > n {
+         x--
+      }
+      tri := x * (x - 1) / 2
+      res := x + (n - tri)
+      fmt.Fprintln(writer, res)
+   }
+}


### PR DESCRIPTION
## Summary
- implement `1862D.go` with integer math and helper isqrt

## Testing
- `go build 1000-1999/1800-1899/1860-1869/1862/1862D.go`


------
https://chatgpt.com/codex/tasks/task_e_688538b8b38c83248cbd79fb13783422