### PR TITLE
Add Go solution for CF 1860C

### DIFF
--- a/1000-1999/1800-1899/1860-1869/1860/1860C.go
+++ b/1000-1999/1800-1899/1860-1869/1860/1860C.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		p := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &p[i])
+		}
+		minVal := int(1e9)
+		minFalse := int(1e9)
+		lucky := 0
+		for _, val := range p {
+			if minVal > val || minFalse < val {
+				// current player has winning move or no moves at all
+			} else {
+				// losing state for current player
+				lucky++
+				if val < minFalse {
+					minFalse = val
+				}
+			}
+			if val < minVal {
+				minVal = val
+			}
+		}
+		fmt.Fprintln(writer, lucky)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem C in 1860 folder

## Testing
- `go run 1000-1999/1800-1899/1860-1869/1860/1860C.go <<EOF
1
4
3 1 4 2
EOF`
- `go vet 1000-1999/1800-1899/1860-1869/1860/1860C.go`

------
https://chatgpt.com/codex/tasks/task_e_68853b2f1b988324a25a4862186bfd28