### PR TITLE
Add Go solution for 1867E2

### DIFF
--- a/1000-1999/1800-1899/1860-1869/1867/1867E2.go
+++ b/1000-1999/1800-1899/1860-1869/1867/1867E2.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var (
+	in  = bufio.NewReader(os.Stdin)
+	out = bufio.NewWriter(os.Stdout)
+)
+
+func main() {
+	defer out.Flush()
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(in, &n, &k)
+		xor := 0
+		for i := 0; i < n; i++ {
+			var x int
+			fmt.Fscan(in, &x)
+			xor ^= x
+		}
+		fmt.Fprintln(out, xor)
+	}
+}


### PR DESCRIPTION
## Summary
- add `1867E2.go` implementing XOR computation for array

## Testing
- `go build ./1000-1999/1800-1899/1860-1869/1867/1867E2.go`

------
https://chatgpt.com/codex/tasks/task_e_68853d19482c83248e1ea31841901bd0