### PR TITLE
Add naive 1866L solution

### DIFF
--- a/1000-1999/1800-1899/1860-1869/1866/1866L.go
+++ b/1000-1999/1800-1899/1860-1869/1866/1866L.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var N, M int
+	if _, err := fmt.Fscan(in, &N, &M); err != nil {
+		return
+	}
+	bestK := 1
+	bestTotal := -1
+	for K := 1; K <= M; K++ {
+		boxes := make(map[int]bool)
+		total := 0
+		for j := 1; j <= N; j++ {
+			boxes[j] = true
+			y := (j*K-1)%N + 1
+			if !boxes[y] {
+				total += y
+				boxes[y] = true
+			}
+		}
+		if total > bestTotal {
+			bestTotal = total
+			bestK = K
+		}
+	}
+	fmt.Println(bestK)
+}


### PR DESCRIPTION
## Summary
- add a naive Go solver for problem 1866L

## Testing
- `gofmt -w 1000-1999/1800-1899/1860-1869/1866/1866L.go`


------
https://chatgpt.com/codex/tasks/task_e_68853d5f564c8324a51f98ee11c7efe8