### PR TITLE
Add Go solution for 1866A

### DIFF
--- a/1000-1999/1800-1899/1860-1869/1866/1866A.go
+++ b/1000-1999/1800-1899/1860-1869/1866/1866A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	ans := int(^uint(0) >> 1) // max int
+	for i := 0; i < n; i++ {
+		var a int
+		fmt.Fscan(reader, &a)
+		v := abs(a)
+		if v < ans {
+			ans = v
+		}
+	}
+	fmt.Fprintln(writer, ans)
+}


### PR DESCRIPTION
## Summary
- add solution 1866A.go implementing minimal moves to set product to zero

## Testing
- `go build 1000-1999/1800-1899/1860-1869/1866/1866A.go`
- ran the program with sample-like inputs

------
https://chatgpt.com/codex/tasks/task_e_688540a7e1a483248ab6e2fd5c0040d7