### PR TITLE
Add Go solution for 1861D

### DIFF
--- a/1000-1999/1800-1899/1860-1869/1861/1861D.go
+++ b/1000-1999/1800-1899/1860-1869/1861/1861D.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func lisLength(arr []int) int {
+	dp := make([]int, 0)
+	for _, v := range arr {
+		l, r := 0, len(dp)
+		for l < r {
+			m := (l + r) / 2
+			if dp[m] < v {
+				l = m + 1
+			} else {
+				r = m
+			}
+		}
+		if l == len(dp) {
+			dp = append(dp, v)
+		} else {
+			dp[l] = v
+		}
+	}
+	return len(dp)
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+		}
+		l := lisLength(arr)
+		fmt.Fprintln(out, n-l)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem D in contest 1861

## Testing
- `go build 1000-1999/1800-1899/1860-1869/1861/1861D.go`


------
https://chatgpt.com/codex/tasks/task_e_68854133e0988324917f9e2d17b4c518