### PR TITLE
Add Go solution for problem 1861E

### DIFF
--- a/1000-1999/1800-1899/1860-1869/1861/1861E.go
+++ b/1000-1999/1800-1899/1860-1869/1861/1861E.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 998244353
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, k int
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+
+	dp := make([]int64, k)
+	sum := make([]int64, k)
+	dp[0] = 1
+
+	prefixDp := make([]int64, k+1)
+	prefixSum := make([]int64, k+1)
+	nextDp := make([]int64, k)
+	nextSum := make([]int64, k)
+
+	for step := 0; step < n; step++ {
+		// compute prefix sums for repetition transitions
+		prefixDp[k] = 0
+		prefixSum[k] = 0
+		for i := k - 1; i >= 0; i-- {
+			prefixDp[i] = prefixDp[i+1] + dp[i]
+			if prefixDp[i] >= mod {
+				prefixDp[i] %= mod
+			}
+			prefixSum[i] = prefixSum[i+1] + sum[i]
+			if prefixSum[i] >= mod {
+				prefixSum[i] %= mod
+			}
+		}
+
+		for i := 0; i < k; i++ {
+			nextDp[i] = 0
+			nextSum[i] = 0
+		}
+
+		// contributions from repeating digits
+		for r := 1; r < k; r++ {
+			nextDp[r] = prefixDp[r]
+			nextSum[r] = prefixSum[r]
+		}
+
+		// contributions from new distinct digits
+		for m := 0; m < k; m++ {
+			if dp[m] == 0 && sum[m] == 0 {
+				continue
+			}
+			newChoices := int64(k - m)
+			if m+1 == k {
+				nextDp[0] = (nextDp[0] + dp[m]*newChoices) % mod
+				inc := (sum[m] + dp[m]) % mod
+				nextSum[0] = (nextSum[0] + inc*newChoices) % mod
+			} else {
+				nextDp[m+1] = (nextDp[m+1] + dp[m]*newChoices) % mod
+				nextSum[m+1] = (nextSum[m+1] + sum[m]*newChoices) % mod
+			}
+		}
+
+		dp, nextDp = nextDp, dp
+		sum, nextSum = nextSum, sum
+	}
+
+	var ans int64
+	for i := 0; i < k; i++ {
+		ans = (ans + sum[i]) % mod
+	}
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- implement solver for `problemE.txt`
- dynamic programming counts all arrays and accumulated cost

## Testing
- `go build 1000-1999/1800-1899/1860-1869/1861/1861E.go`
- `echo '3 2' | ./1861E_test` *(output: 6)*
- `echo '4 2' | ./1861E_test` *(output: 18)*

------
https://chatgpt.com/codex/tasks/task_e_688540edf5c08324b50d11617d83cbf0