### PR TITLE
Add Go solution for 1815A

### DIFF
--- a/1000-1999/1800-1899/1810-1819/1815/1815A.go
+++ b/1000-1999/1800-1899/1810-1819/1815/1815A.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		var altSum int64
+		for i := 0; i < n; i++ {
+			var x int64
+			fmt.Fscan(reader, &x)
+			if i%2 == 0 {
+				altSum += x
+			} else {
+				altSum -= x
+			}
+		}
+		if n%2 == 1 || altSum <= 0 {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for 1815A in Go

## Testing
- `go build 1000-1999/1800-1899/1810-1819/1815/1815A.go`

------
https://chatgpt.com/codex/tasks/task_e_6885480aec8c8324a255fbd467365379