### PR TITLE
Add Go solution for 1810B

### DIFF
--- a/1000-1999/1800-1899/1810-1819/1810/1810B.go
+++ b/1000-1999/1800-1899/1810-1819/1810/1810B.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		if n%2 == 0 {
+			fmt.Fprintln(out, -1)
+			continue
+		}
+		ops := make([]int, 0)
+		for n > 1 {
+			if n%4 == 1 {
+				ops = append(ops, 1)
+				n = (n + 1) / 2
+			} else {
+				ops = append(ops, 2)
+				n = (n - 1) / 2
+			}
+		}
+		// reverse operations to get order from start to finish
+		for i, j := 0, len(ops)-1; i < j; i, j = i+1, j-1 {
+			ops[i], ops[j] = ops[j], ops[i]
+		}
+		fmt.Fprintln(out, len(ops))
+		for i, v := range ops {
+			if i > 0 {
+				fmt.Fprint(out, " ")
+			}
+			fmt.Fprint(out, v)
+		}
+		fmt.Fprintln(out)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem B in 1810 using greedy reverse halving

## Testing
- `go build 1000-1999/1800-1899/1810-1819/1810/1810B.go`
- manual run with sample inputs

------
https://chatgpt.com/codex/tasks/task_e_688549f538c08324894ebab795c82b40