### PR TITLE
Add Go solution for 1810C

### DIFF
--- a/1000-1999/1800-1899/1810-1819/1810/1810C.go
+++ b/1000-1999/1800-1899/1810-1819/1810/1810C.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		var c, d int64
+		fmt.Fscan(reader, &n, &c, &d)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		sort.Ints(arr)
+		uniq := make([]int, 0, n)
+		last := -1
+		for _, v := range arr {
+			if v != last {
+				uniq = append(uniq, v)
+				last = v
+			}
+		}
+		k := len(uniq)
+
+		cost := func(m int) int64 {
+			p := sort.Search(len(uniq), func(i int) bool { return uniq[i] > m })
+			del := n - p
+			ins := m - p
+			return int64(del)*c + int64(ins)*d
+		}
+
+		best := cost(1)
+		for i := 0; i < k; i++ {
+			v := uniq[i]
+			cur := cost(v)
+			if cur < best {
+				best = cur
+			}
+		}
+		fmt.Fprintln(writer, best)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problemC in folder 1810

## Testing
- `go run 1000-1999/1800-1899/1810-1819/1810/1810C.go < /tmp/test.in`

------
https://chatgpt.com/codex/tasks/task_e_688549af4b7c8324827e1aea25b0988b