### PR TITLE
Add Go solution for 1810F

### DIFF
--- a/1000-1999/1800-1899/1810-1819/1810/1810F.go
+++ b/1000-1999/1800-1899/1810-1819/1810/1810F.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func computeDepths(n, m int) []int {
+	q := []int{0}
+	for len(q) < n {
+		d := q[0]
+		q = q[1:]
+		for i := 0; i < m; i++ {
+			q = append(q, d+1)
+		}
+	}
+	return q[:n]
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, m, q int
+		fmt.Fscan(reader, &n, &m, &q)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		depth := computeDepths(n, m)
+		for ; q > 0; q-- {
+			var x, y int
+			fmt.Fscan(reader, &x, &y)
+			x--
+			a[x] = y
+			b := make([]int, n)
+			copy(b, a)
+			sort.Slice(b, func(i, j int) bool { return b[i] > b[j] })
+			res := 0
+			for i := 0; i < n; i++ {
+				v := b[i] + depth[i]
+				if v > res {
+					res = v
+				}
+			}
+			fmt.Fprint(writer, res)
+			if q > 0 {
+				fmt.Fprint(writer, " ")
+			}
+		}
+		fmt.Fprintln(writer)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solver for problem F of contest 1810 in Go
- uses BFS to compute depths and sorts values after each query

## Testing
- `go build 1000-1999/1800-1899/1810-1819/1810/1810F.go`

------
https://chatgpt.com/codex/tasks/task_e_688549231d3083248d419b5b0a40112f