### PR TITLE
Add Go solution for 1819D

### DIFF
--- a/1000-1999/1800-1899/1810-1819/1819/1819D.go
+++ b/1000-1999/1800-1899/1810-1819/1819/1819D.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var n, m int
+		fmt.Fscan(in, &n, &m)
+		shops := make([][]int, n)
+		unknown := make([]bool, n)
+		for i := 0; i < n; i++ {
+			var k int
+			fmt.Fscan(in, &k)
+			if k == 0 {
+				unknown[i] = true
+			} else {
+				arr := make([]int, k)
+				for j := 0; j < k; j++ {
+					fmt.Fscan(in, &arr[j])
+				}
+				shops[i] = arr
+			}
+		}
+
+		seen := make([]bool, m+1)
+		unionCnt := 0
+		unknownExist := false
+		for i := n - 1; i >= 0; i-- {
+			if unknown[i] {
+				unknownExist = true
+				continue
+			}
+			arr := shops[i]
+			conflict := false
+			for _, v := range arr {
+				if seen[v] {
+					conflict = true
+					break
+				}
+			}
+			if conflict {
+				break
+			}
+			for _, v := range arr {
+				if !seen[v] {
+					seen[v] = true
+					unionCnt++
+				}
+			}
+		}
+
+		if unknownExist {
+			fmt.Fprintln(out, m)
+		} else {
+			fmt.Fprintln(out, unionCnt)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem 1819D

## Testing
- `go build 1000-1999/1800-1899/1810-1819/1819/1819D.go`
- `go run 1000-1999/1800-1899/1810-1819/1819/1819D.go < /tmp/test.in` (custom test)
- `go run 1000-1999/1800-1899/1810-1819/1819/1819D.go < /tmp/test2.in` (custom test)
- `go run 1000-1999/1800-1899/1810-1819/1819/1819D.go < /tmp/test3.in` (custom test)


------
https://chatgpt.com/codex/tasks/task_e_68854c25bdc48324afef8e3e030a556b