### PR TITLE
Add Go solution for 1811A

### DIFF
--- a/1000-1999/1800-1899/1810-1819/1811/1811A.go
+++ b/1000-1999/1800-1899/1810-1819/1811/1811A.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		var d int
+		fmt.Fscan(reader, &n, &d)
+		var s string
+		fmt.Fscan(reader, &s)
+		inserted := false
+		for i := 0; i < n; i++ {
+			if !inserted && int(s[i]-'0') < d {
+				writer.WriteByte(byte('0' + d))
+				inserted = true
+			}
+			writer.WriteByte(s[i])
+		}
+		if !inserted {
+			writer.WriteByte(byte('0' + d))
+		}
+		writer.WriteByte('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problemA in contest 1811

## Testing
- `go build 1000-1999/1800-1899/1810-1819/1811/1811A.go`
- `echo -e "3\n5 4\n76543\n1 0\n7\n1 9\n9\n" | ./1811A`

------
https://chatgpt.com/codex/tasks/task_e_68854f6ddadc8324b5be83040a47eb1f