### PR TITLE
Add Go solution for 1811B

### DIFF
--- a/1000-1999/1800-1899/1810-1819/1811/1811B.go
+++ b/1000-1999/1800-1899/1810-1819/1811/1811B.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func ring(n, x, y int) int {
+	if x > n+1-x {
+		x = n + 1 - x
+	}
+	if y > n+1-y {
+		y = n + 1 - y
+	}
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, x1, y1, x2, y2 int
+		fmt.Fscan(in, &n, &x1, &y1, &x2, &y2)
+		r1 := ring(n, x1, y1)
+		r2 := ring(n, x2, y2)
+		fmt.Fprintln(out, abs(r1-r2))
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1811B "Conveyor Belts"

## Testing
- `go run 1000-1999/1800-1899/1810-1819/1811/1811B.go < /tmp/testinput.txt`

------
https://chatgpt.com/codex/tasks/task_e_68854f27bf708324ba2f00f2f3ffeb26