### PR TITLE
Add Go solution for 1891C

### DIFF
--- a/1000-1999/1800-1899/1890-1899/1891/1891C.go
+++ b/1000-1999/1800-1899/1890-1899/1891/1891C.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int64, n)
+		var sum int64
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+			sum += arr[i]
+		}
+		limit := sum / 2
+		if limit == 0 {
+			fmt.Fprintln(out, sum)
+			continue
+		}
+		sort.Slice(arr, func(i, j int) bool { return arr[i] > arr[j] })
+		var pref int64
+		var r int64
+		for _, v := range arr {
+			pref += v
+			r++
+			if pref >= limit {
+				break
+			}
+		}
+		ans := sum - limit + r
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement algorithm for problem 1891C in Go

## Testing
- `go vet 1000-1999/1800-1899/1890-1899/1891/1891C.go`

------
https://chatgpt.com/codex/tasks/task_e_6885552cb8f88324b20d63287c7b745c