### PR TITLE
Add Go solution for 1898B

### DIFF
--- a/1000-1999/1800-1899/1890-1899/1898/1898B.go
+++ b/1000-1999/1800-1899/1890-1899/1898/1898B.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		a := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		var ops int64
+		cur := a[n-1]
+		for i := n - 2; i >= 0; i-- {
+			if a[i] <= cur {
+				cur = a[i]
+			} else {
+				k := (a[i] + cur - 1) / cur
+				ops += k - 1
+				cur = a[i] / k
+			}
+		}
+		fmt.Fprintln(writer, ops)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for `1898B`

## Testing
- `go build 1000-1999/1800-1899/1890-1899/1898/1898B.go`


------
https://chatgpt.com/codex/tasks/task_e_688556d0ed388324894a2cd96e42ca3a