### PR TITLE
Add Go solution for 1337B

### DIFF
--- a/1000-1999/1300-1399/1330-1339/1337/1337B.go
+++ b/1000-1999/1300-1399/1330-1339/1337/1337B.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var x, n, m int
+		fmt.Fscan(reader, &x, &n, &m)
+		for n > 0 && x > 20 {
+			x = x/2 + 10
+			n--
+		}
+		if x-10*m <= 0 {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem 1337B

## Testing
- `go vet 1000-1999/1300-1399/1330-1339/1337/1337B.go` *(fails: package path not in std)


------
https://chatgpt.com/codex/tasks/task_e_68855f926d808324aee551e60c6da5ba