### PR TITLE
Add Go solution for 1335E2

### DIFF
--- a/1000-1999/1300-1399/1330-1339/1335/1335E2.go
+++ b/1000-1999/1300-1399/1330-1339/1335/1335E2.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	if _, err := fmt.Fscan(in, &T); err != nil {
+		return
+	}
+	const V = 200
+	for ; T > 0; T-- {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int, n)
+		// positions for each value
+		pos := make([][]int, V+1)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+			v := arr[i]
+			pos[v] = append(pos[v], i+1) // 1-indexed
+		}
+		// prefix counts
+		pref := make([][]int, V+1)
+		for v := 1; v <= V; v++ {
+			pref[v] = make([]int, n+1)
+		}
+		for i := 1; i <= n; i++ {
+			val := arr[i-1]
+			for v := 1; v <= V; v++ {
+				pref[v][i] = pref[v][i-1]
+			}
+			pref[val][i]++
+		}
+		ans := 0
+		// case when l=0 -> just middle block
+		for v := 1; v <= V; v++ {
+			if len(pos[v]) > ans {
+				ans = len(pos[v])
+			}
+		}
+		// consider blocks with value x at the ends
+		for x := 1; x <= V; x++ {
+			px := pos[x]
+			m := len(px)
+			for l := 1; l*2 <= m; l++ {
+				left := px[l-1]
+				right := px[m-l]
+				maxMid := 0
+				for y := 1; y <= V; y++ {
+					cnt := pref[y][right-1] - pref[y][left]
+					if cnt > maxMid {
+						maxMid = cnt
+					}
+				}
+				tot := 2*l + maxMid
+				if tot > ans {
+					ans = tot
+				}
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for problem E2 in 1335

## Testing
- `go vet 1000-1999/1300-1399/1330-1339/1335/1335E2.go`


------
https://chatgpt.com/codex/tasks/task_e_68855f06633c8324b650256641f42e39