### PR TITLE
Add Go solution for 1338A

### DIFF
--- a/1000-1999/1300-1399/1330-1339/1338/1338A.go
+++ b/1000-1999/1300-1399/1330-1339/1338/1338A.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int64, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+		}
+
+		maxPrefix := arr[0]
+		var maxDiff int64
+		for i := 1; i < n; i++ {
+			if arr[i] < maxPrefix {
+				diff := maxPrefix - arr[i]
+				if diff > maxDiff {
+					maxDiff = diff
+				}
+			} else {
+				maxPrefix = arr[i]
+			}
+		}
+
+		ans := 0
+		for maxDiff > 0 {
+			ans++
+			maxDiff >>= 1
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement problem 1338A solution in Go

## Testing
- `gofmt -w 1000-1999/1300-1399/1330-1339/1338/1338A.go`


------
https://chatgpt.com/codex/tasks/task_e_68856136f9f083248391ff426f1ee250