### PR TITLE
Add Go solution for 1331D

### DIFF
--- a/1000-1999/1300-1399/1330-1339/1331/1331D.go
+++ b/1000-1999/1300-1399/1330-1339/1331/1331D.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	var hex string
+	fmt.Fscan(reader, &hex)
+	var value uint64
+	fmt.Sscanf(hex, "%x", &value)
+	fmt.Println(value)
+}


### PR DESCRIPTION
## Summary
- implement Go solution for the hex conversion problem 1331D

## Testing
- `go build 1000-1999/1300-1399/1330-1339/1331/1331D.go`
- `echo A1B2C3 | go run 1000-1999/1300-1399/1330-1339/1331/1331D.go`

------
https://chatgpt.com/codex/tasks/task_e_688563f3430c83249a9ed59a61e88dce