### PR TITLE
Add Go solution for 1343A

### DIFF
--- a/1000-1999/1300-1399/1340-1349/1343/1343A.go
+++ b/1000-1999/1300-1399/1340-1349/1343/1343A.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		for k := int64(2); ; k++ {
+			denom := (int64(1) << k) - 1
+			if n%denom == 0 {
+				fmt.Fprintln(writer, n/denom)
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for contest 1343 problem A

## Testing
- `gofmt -w 1000-1999/1300-1399/1340-1349/1343/1343A.go`


------
https://chatgpt.com/codex/tasks/task_e_68856781aba0832492fa17be352ed870