### PR TITLE
Add Go solution for 1342A

### DIFF
--- a/1000-1999/1300-1399/1340-1349/1342/1342A.go
+++ b/1000-1999/1300-1399/1340-1349/1342/1342A.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var x, y, a, b int64
+		fmt.Fscan(reader, &x, &y)
+		fmt.Fscan(reader, &a, &b)
+
+		if x < y {
+			x, y = y, x
+		}
+		diff := x - y
+		pairCost := b
+		if pairCost > 2*a {
+			pairCost = 2 * a
+		}
+		cost := diff*a + y*pairCost
+		fmt.Fprintln(writer, cost)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1342A.go` using direct formula to minimize cost

## Testing
- `go run 1000-1999/1300-1399/1340-1349/1342/1342A.go <<EOF
1
1 3
391 555
EOF`
- `go run 1000-1999/1300-1399/1340-1349/1342/1342A.go <<EOF
1
0 0
1 2
EOF`
- `go run 1000-1999/1300-1399/1340-1349/1342/1342A.go <<EOF
1
1 0
3 5
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68856853daac8324945267977684e43e