### PR TITLE
Add Go solution for puzzle pieces problem

### DIFF
--- a/1000-1999/1300-1399/1340-1349/1345/1345A.go
+++ b/1000-1999/1300-1399/1340-1349/1345/1345A.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(in, &n, &m)
+		if n == 1 || m == 1 || (n == 2 && m == 2) {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Puzzle Pieces solution in Go for problem 1345A

## Testing
- `go build 1000-1999/1300-1399/1340-1349/1345/1345A.go`
- `echo -e "4\n1 1\n1 5\n2 2\n3 3" | go run 1000-1999/1300-1399/1340-1349/1345/1345A.go`

------
https://chatgpt.com/codex/tasks/task_e_688568dfb2708324891d3c47a341364f