### PR TITLE
Add Go solution for 1347D

### DIFF
--- a/1000-1999/1300-1399/1340-1349/1347/1347D.go
+++ b/1000-1999/1300-1399/1340-1349/1347/1347D.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(in, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+		}
+		l, r := 0, n-1
+		moves := 0
+		aliceTotal, bobTotal := 0, 0
+		prev := 0
+		aliceTurn := true
+		for l <= r {
+			cur := 0
+			if aliceTurn {
+				for l <= r && cur <= prev {
+					cur += arr[l]
+					l++
+				}
+				aliceTotal += cur
+			} else {
+				for l <= r && cur <= prev {
+					cur += arr[r]
+					r--
+				}
+				bobTotal += cur
+			}
+			prev = cur
+			moves++
+			aliceTurn = !aliceTurn
+		}
+		fmt.Fprintf(out, "%d %d %d\n", moves, aliceTotal, bobTotal)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1347D

## Testing
- `go run 1000-1999/1300-1399/1340-1349/1347/1347D.go < /tmp/input.txt`

------
https://chatgpt.com/codex/tasks/task_e_68856c6e2dc4832480339e722abc7db5