### PR TITLE
Add naive Go solution for 1340F

### DIFF
--- a/1000-1999/1300-1399/1340-1349/1340/1340F.go
+++ b/1000-1999/1300-1399/1340-1349/1340/1340F.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n, k int
+	if _, err := fmt.Fscan(in, &n, &k); err != nil {
+		return
+	}
+	s := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &s[i])
+	}
+	var q int
+	fmt.Fscan(in, &q)
+	for ; q > 0; q-- {
+		var typ int
+		fmt.Fscan(in, &typ)
+		if typ == 1 {
+			var i, t int
+			fmt.Fscan(in, &i, &t)
+			s[i-1] = t
+		} else if typ == 2 {
+			var l, r int
+			fmt.Fscan(in, &l, &r)
+			stack := make([]int, 0, r-l+1)
+			valid := true
+			for i := l - 1; i < r; i++ {
+				v := s[i]
+				if v > 0 {
+					stack = append(stack, v)
+				} else {
+					t := -v
+					if len(stack) == 0 || stack[len(stack)-1] != t {
+						valid = false
+						break
+					}
+					stack = stack[:len(stack)-1]
+				}
+			}
+			if valid && len(stack) == 0 {
+				fmt.Fprintln(out, "Yes")
+			} else {
+				fmt.Fprintln(out, "No")
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement a basic stack-based solution for problem F

## Testing
- `go build 1000-1999/1300-1399/1340-1349/1340/1340F.go`


------
https://chatgpt.com/codex/tasks/task_e_68856b1007dc83249ab71e734b0a9a7a