### PR TITLE
Add Go solution for 1347B

### DIFF
--- a/1000-1999/1300-1399/1340-1349/1347/1347B.go
+++ b/1000-1999/1300-1399/1340-1349/1347/1347B.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(in, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var a1, b1, a2, b2 int
+		fmt.Fscan(in, &a1, &b1)
+		fmt.Fscan(in, &a2, &b2)
+		ok := false
+		if a1 == a2 && b1+b2 == a1 {
+			ok = true
+		}
+		if a1 == b2 && b1+a2 == a1 {
+			ok = true
+		}
+		if b1 == a2 && a1+b2 == b1 {
+			ok = true
+		}
+		if b1 == b2 && a1+a2 == b1 {
+			ok = true
+		}
+		if ok {
+			fmt.Fprintln(out, "YES")
+		} else {
+			fmt.Fprintln(out, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement solver for problemB in contest 1347

## Testing
- `go vet 1000-1999/1300-1399/1340-1349/1347/1347B.go`
- `go run 1000-1999/1300-1399/1340-1349/1347/1347B.go <<EOF
1
1 2
2 1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68856cfa488c8324880385c1f18d69a8