### PR TITLE
Add Go solution for 1389C

### DIFF
--- a/1000-1999/1300-1399/1380-1389/1389/1389C.go
+++ b/1000-1999/1300-1399/1380-1389/1389/1389C.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var s string
+		fmt.Fscan(reader, &s)
+		n := len(s)
+		best := 0
+		// single digit subsequences
+		freq := make([]int, 10)
+		for i := 0; i < n; i++ {
+			d := int(s[i] - '0')
+			freq[d]++
+		}
+		for i := 0; i < 10; i++ {
+			if freq[i] > best {
+				best = freq[i]
+			}
+		}
+		// alternating subsequences for every pair of digits
+		for i := 0; i < 10; i++ {
+			for j := 0; j < 10; j++ {
+				if i == j {
+					continue
+				}
+				expect := i
+				length := 0
+				for k := 0; k < n; k++ {
+					d := int(s[k] - '0')
+					if d == expect {
+						length++
+						if expect == i {
+							expect = j
+						} else {
+							expect = i
+						}
+					}
+				}
+				if length%2 == 1 {
+					length--
+				}
+				if length > best {
+					best = length
+				}
+			}
+		}
+		fmt.Fprintln(writer, n-best)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for problem C in contest 1389
- use subsequence counts to minimize deletions

## Testing
- `go build ./1000-1999/1300-1399/1380-1389/1389/1389C.go`

------
https://chatgpt.com/codex/tasks/task_e_6885745d6df4832498b4aa413b61372d