### PR TITLE
Add Go solution for 1389E

### DIFF
--- a/1000-1999/1300-1399/1380-1389/1389/1389E.go
+++ b/1000-1999/1300-1399/1380-1389/1389/1389E.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var m, d, w int64
+		fmt.Fscan(reader, &m, &d, &w)
+
+		if d == 1 {
+			fmt.Fprintln(writer, 0)
+			continue
+		}
+
+		if m > d {
+			m = d
+		}
+		g := gcd(w, d-1)
+		q := w / g
+		a := m / q
+		b := m % q
+		ans := b*(a+1)*a/2 + (q-b)*a*(a-1)/2
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement algorithm for problem E of round 1389
- use gcd reduction and combinatorial counting

## Testing
- `go build 1000-1999/1300-1399/1380-1389/1389/1389E.go`

------
https://chatgpt.com/codex/tasks/task_e_688573458b888324a2318396997ba7f3