### PR TITLE
Add Go solution for 1389B

### DIFF
--- a/1000-1999/1300-1399/1380-1389/1389/1389B.go
+++ b/1000-1999/1300-1399/1380-1389/1389/1389B.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k, z int
+		fmt.Fscan(reader, &n, &k, &z)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &a[i])
+		}
+		sum := 0
+		bestPair := 0
+		ans := 0
+		for i := 0; i <= k; i++ {
+			sum += a[i]
+			if i < n-1 {
+				if v := a[i] + a[i+1]; v > bestPair {
+					bestPair = v
+				}
+			}
+			remaining := k - i
+			left := z
+			if remaining/2 < left {
+				left = remaining / 2
+			}
+			candidate := sum + bestPair*left
+			if candidate > ans {
+				ans = candidate
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem B in contest 1389

## Testing
- `go build 1000-1999/1300-1399/1380-1389/1389/1389B.go`


------
https://chatgpt.com/codex/tasks/task_e_688574a37e9083249ce56c107b675dee