### PR TITLE
Add Go solution for 1380C

### DIFF
--- a/1000-1999/1300-1399/1380-1389/1380/1380C.go
+++ b/1000-1999/1300-1399/1380-1389/1380/1380C.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	if _, err := fmt.Fscan(in, &T); err != nil {
+		return
+	}
+	for ; T > 0; T-- {
+		var n int
+		var x int
+		fmt.Fscan(in, &n, &x)
+		a := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &a[i])
+		}
+		sort.Slice(a, func(i, j int) bool { return a[i] > a[j] })
+		teams := 0
+		size := 0
+		for _, v := range a {
+			size++
+			if size*v >= x {
+				teams++
+				size = 0
+			}
+		}
+		fmt.Fprintln(out, teams)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem C in contest 1380

## Testing
- `go build 1000-1999/1300-1399/1380-1389/1380/1380C.go`

------
https://chatgpt.com/codex/tasks/task_e_68857647bd308324aefa5bd822cfa821