### PR TITLE
Add Go solution for CF 1375E

### DIFF
--- a/1000-1999/1300-1399/1370-1379/1375/1375E.go
+++ b/1000-1999/1300-1399/1370-1379/1375/1375E.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+type pair struct{ u, v int }
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	fmt.Fscan(in, &n)
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	ops := make([]pair, 0)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if a[i] > a[j] {
+				ops = append(ops, pair{i, j})
+			}
+		}
+	}
+	sort.Slice(ops, func(i, j int) bool {
+		ai, aj := a[ops[i].u], a[ops[j].u]
+		if ai != aj {
+			return ai < aj
+		}
+		return ops[i].v > ops[j].v
+	})
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	fmt.Fprintln(out, len(ops))
+	for _, p := range ops {
+		fmt.Fprintln(out, p.u+1, p.v+1)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1375E.go` with inversion swap sorting algorithm

## Testing
- `go run 1000-1999/1300-1399/1370-1379/1375/1375E.go <<EOF
3
3 1 2
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688579d6435c8324a0f0ecbd019a0af8