### PR TITLE
Add Go solution for 1375C

### DIFF
--- a/1000-1999/1300-1399/1370-1379/1375/1375C.go
+++ b/1000-1999/1300-1399/1370-1379/1375/1375C.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		if arr[0] < arr[n-1] {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1375C.go` with simple check based on first and last array elements

## Testing
- `go run 1000-1999/1300-1399/1370-1379/1375/1375C.go <<EOF
1
3
1 2 3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68857aa86c1483249f35279b3e468d66