### PR TITLE
Add Go solution for 1370D

### DIFF
--- a/1000-1999/1300-1399/1370-1379/1370/1370D.go
+++ b/1000-1999/1300-1399/1370-1379/1370/1370D.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, k int
+	fmt.Fscan(reader, &n, &k)
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &arr[i])
+	}
+
+	low, high := 1, int(1e9)
+	answer := high
+
+	check := func(x int) bool {
+		// pattern 1: positions 1,3,... must be <= x
+		cnt := 0
+		for _, v := range arr {
+			if cnt%2 == 0 { // expecting constrained position
+				if v <= x {
+					cnt++
+				}
+			} else {
+				cnt++
+			}
+			if cnt >= k {
+				return true
+			}
+		}
+		// pattern 2: positions 2,4,... must be <= x
+		cnt = 0
+		for _, v := range arr {
+			if cnt%2 == 1 { // even position requires <= x
+				if v <= x {
+					cnt++
+				}
+			} else {
+				cnt++
+			}
+			if cnt >= k {
+				return true
+			}
+		}
+		return false
+	}
+
+	for low <= high {
+		mid := (low + high) / 2
+		if check(mid) {
+			answer = mid
+			high = mid - 1
+		} else {
+			low = mid + 1
+		}
+	}
+
+	fmt.Fprintln(writer, answer)
+}


### PR DESCRIPTION
## Summary
- implement solution for problem 1370D using binary search and greedy check

## Testing
- `go run 1000-1999/1300-1399/1370-1379/1370/1370D.go <<EOF
4 2
1 3 2 4
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68858369c5f08324bb56ce6a25f71314