### PR TITLE
Add naive Go solution for 1326F2

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1326/1326F2.go
+++ b/1000-1999/1300-1399/1320-1329/1326/1326F2.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	g := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		var s string
+		fmt.Fscan(in, &s)
+		g[i] = []byte(s)
+	}
+
+	total := 1 << (n - 1)
+	cnt := make([]int64, total)
+
+	perm := make([]int, n)
+	used := make([]bool, n)
+
+	var dfs func(int)
+	dfs = func(pos int) {
+		if pos == n {
+			var mask int
+			for i := 0; i < n-1; i++ {
+				if g[perm[i]][perm[i+1]] == '1' {
+					mask |= 1 << i
+				}
+			}
+			cnt[mask]++
+			return
+		}
+		for i := 0; i < n; i++ {
+			if !used[i] {
+				used[i] = true
+				perm[pos] = i
+				dfs(pos + 1)
+				used[i] = false
+			}
+		}
+	}
+
+	dfs(0)
+
+	for i := 0; i < total; i++ {
+		if i > 0 {
+			fmt.Fprint(out, " ")
+		}
+		fmt.Fprint(out, cnt[i])
+	}
+	fmt.Fprintln(out)
+}


### PR DESCRIPTION
## Summary
- add a simple brute force enumerator for problem F2 of contest 1326

## Testing
- `gofmt -w 1000-1999/1300-1399/1320-1329/1326/1326F2.go`

------
https://chatgpt.com/codex/tasks/task_e_688586269e308324a95a17506d2ec70e