### PR TITLE
Add Go solution for CF 1326C

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1326/1326C.go
+++ b/1000-1999/1300-1399/1320-1329/1326/1326C.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 998244353
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, k int
+	if _, err := fmt.Fscan(reader, &n, &k); err != nil {
+		return
+	}
+	pos := make([]int, 0, k)
+	var sum int64
+	for i := 1; i <= n; i++ {
+		var x int
+		fmt.Fscan(reader, &x)
+		if x > n-k {
+			sum += int64(x)
+			pos = append(pos, i)
+		}
+	}
+
+	var ways int64 = 1
+	for i := 1; i < len(pos); i++ {
+		diff := int64(pos[i] - pos[i-1])
+		ways = (ways * diff) % mod
+	}
+
+	fmt.Fprintf(writer, "%d %d\n", sum, ways)
+}


### PR DESCRIPTION
## Summary
- add solution in Go for problem C of contest 1326

## Testing
- `gofmt -w 1000-1999/1300-1399/1320-1329/1326/1326C.go`
- `go build 1000-1999/1300-1399/1320-1329/1326/1326C.go`

------
https://chatgpt.com/codex/tasks/task_e_6885873ed5c483249963fff4ff738094