### PR TITLE
Add Go solution for 1326B

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1326/1326B.go
+++ b/1000-1999/1300-1399/1320-1329/1326/1326B.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n int
+	if _, err := fmt.Fscan(reader, &n); err != nil {
+		return
+	}
+	b := make([]int64, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &b[i])
+	}
+	a := make([]int64, n)
+	var prefixMax int64
+	for i := 0; i < n; i++ {
+		a[i] = b[i] + prefixMax
+		if a[i] > prefixMax {
+			prefixMax = a[i]
+		}
+	}
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			writer.WriteByte(' ')
+		}
+		fmt.Fprint(writer, a[i])
+	}
+	writer.WriteByte('\n')
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1326B (restoring array `a` from `b`)

## Testing
- `go build 1000-1999/1300-1399/1320-1329/1326/1326B.go`


------
https://chatgpt.com/codex/tasks/task_e_68858785e1388324b059ba194575b002