### PR TITLE
Add Go solution for 1327A

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1327/1327A.go
+++ b/1000-1999/1300-1399/1320-1329/1327/1327A.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(reader, &n, &k)
+		if n >= k*k && n%2 == k%2 {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go solution for 1327A

## Testing
- `go run 1000-1999/1300-1399/1320-1329/1327/1327A.go` with sample values

------
https://chatgpt.com/codex/tasks/task_e_6885896f06c0832484ab7c16deaf6f0f