### PR TITLE
Add Go solution for 1329B

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1329/1329B.go
+++ b/1000-1999/1300-1399/1320-1329/1329/1329B.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var T int
+	fmt.Fscan(reader, &T)
+	for ; T > 0; T-- {
+		var d, m int64
+		fmt.Fscan(reader, &d, &m)
+		ans := int64(1)
+		for bit := 0; (int64(1) << bit) <= d; bit++ {
+			L := int64(1) << bit
+			R := (int64(1) << (bit + 1)) - 1
+			if R > d {
+				R = d
+			}
+			cnt := R - L + 1
+			ans = ans * (cnt + 1) % m
+		}
+		ans = (ans - 1 + m) % m
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for Dreamoon sequence counting problem

## Testing
- `go build 1000-1999/1300-1399/1320-1329/1329/1329B.go`

------
https://chatgpt.com/codex/tasks/task_e_688589fba06c832488406dde6dd81622