### PR TITLE
Add Go solution for 1369B AccurateLee

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1369/1369B.go
+++ b/1000-1999/1300-1399/1360-1369/1369/1369B.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		var s string
+		fmt.Fscan(reader, &n)
+		fmt.Fscan(reader, &s)
+		prefix := 0
+		for prefix < n && s[prefix] == '0' {
+			prefix++
+		}
+		suffix := n - 1
+		for suffix >= 0 && s[suffix] == '1' {
+			suffix--
+		}
+		if prefix > suffix {
+			fmt.Fprintln(writer, s)
+		} else {
+			result := s[:prefix] + "0" + s[suffix+1:]
+			fmt.Fprintln(writer, result)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1369B

## Testing
- `go build 1000-1999/1300-1399/1360-1369/1369/1369B.go`
- `echo -e "3\n1\n0\n2\n10\n8\n11001101" | go run 1000-1999/1300-1399/1360-1369/1369/1369B.go`

------
https://chatgpt.com/codex/tasks/task_e_68859df42fbc832485d3be8b69eb935e