### PR TITLE
Add Go solution for 1369D

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1369/1369D.go
+++ b/1000-1999/1300-1399/1360-1369/1369/1369D.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const MOD int64 = 1000000007
+const MAXN = 2000000
+
+var ans [MAXN + 1]int64
+
+func init() {
+	ans[1] = 0
+	ans[2] = 0
+	ans[3] = 4
+	ans[4] = 4
+	for i := 5; i <= MAXN; i++ {
+		ans[i] = (2 * ans[i-1]) % MOD
+		switch i % 6 {
+		case 3, 5:
+			ans[i] = (ans[i] + 4) % MOD
+		case 4:
+			ans[i] = (ans[i] + MOD - 4) % MOD
+		}
+	}
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		fmt.Fprintln(writer, ans[n])
+	}
+}


### PR DESCRIPTION
## Summary
- add Go implementation for problem 1369D

## Testing
- `gofmt -w 1000-1999/1300-1399/1360-1369/1369/1369D.go`

------
https://chatgpt.com/codex/tasks/task_e_68859d2222a88324ac45c9cc4eb88702