### PR TITLE
Add Go solution for 1353C

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1353/1353C.go
+++ b/1000-1999/1300-1399/1350-1359/1353/1353C.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int64
+		fmt.Fscan(reader, &n)
+		ans := n * (n*n - 1) / 3
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement solution for `1353C` (Board Moves) using closed form formula

## Testing
- `go build ./1000-1999/1300-1399/1350-1359/1353/1353C.go`
- `echo '4
1
3
5
7
' | go run ./1000-1999/1300-1399/1350-1359/1353/1353C.go`

------
https://chatgpt.com/codex/tasks/task_e_68859c4ffd5883248cb724fccbbda94b