### PR TITLE
Add Go solution for 1355C

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1355/1355C.go
+++ b/1000-1999/1300-1399/1350-1359/1355/1355C.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var A, B, C, D int
+	if _, err := fmt.Fscan(in, &A, &B, &C, &D); err != nil {
+		return
+	}
+
+	maxS := B + C
+	diff := make([]int64, maxS+2)
+
+	for x := A; x <= B; x++ {
+		start := x + B
+		end := x + C
+		diff[start]++
+		diff[end+1]--
+	}
+
+	var ans int64
+	var pairs int64
+	for s := A + B; s <= maxS; s++ {
+		pairs += diff[s]
+		t := s - 1
+		if t >= C {
+			zMax := t
+			if zMax > D {
+				zMax = D
+			}
+			if zMax >= C {
+				zCount := int64(zMax - C + 1)
+				ans += pairs * zCount
+			}
+		}
+	}
+
+	fmt.Fprintln(out, ans)
+}


### PR DESCRIPTION
## Summary
- add Go implementation for Problem C in contest 1355

## Testing
- `go build 1000-1999/1300-1399/1350-1359/1355/1355C.go`


------
https://chatgpt.com/codex/tasks/task_e_688599937f3c8324932243d6bc9fac9f