### PR TITLE
Add Go solution for 1352C

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1352/1352C.go
+++ b/1000-1999/1300-1399/1350-1359/1352/1352C.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+    "bufio"
+    "fmt"
+    "os"
+)
+
+func main() {
+    reader := bufio.NewReader(os.Stdin)
+    writer := bufio.NewWriter(os.Stdout)
+    defer writer.Flush()
+
+    var t int
+    fmt.Fscan(reader, &t)
+    for ; t > 0; t-- {
+        var n, k int64
+        fmt.Fscan(reader, &n, &k)
+        div := n - 1
+        q := k / div
+        r := k % div
+        var ans int64
+        if r == 0 {
+            ans = q*n - 1
+        } else {
+            ans = q*n + r
+        }
+        fmt.Fprintln(writer, ans)
+    }
+}


### PR DESCRIPTION
## Summary
- add solution `1352C.go` implementing the k-th number not divisible by `n`

## Testing
- `go build 1000-1999/1300-1399/1350-1359/1352/1352C.go`


------
https://chatgpt.com/codex/tasks/task_e_688598c157cc8324821fab1e603d5eb0