### PR TITLE
Add placeholder solution for 1357E2

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1357/1357E2.go
+++ b/1000-1999/1300-1399/1350-1359/1357/1357E2.go
@@ -1,0 +1,18 @@
+package main
+
+// 1357E2: Fractional Quantum Fourier Transform.
+//
+// The original problem asks to implement an operation equivalent to
+// QFT^(1/P) on a LittleEndian qubit register. After applying this
+// operation P times, the effect should match a full QFT up to global
+// phase. Such functionality requires quantum gates and phase rotations,
+// which are not available in pure Go.
+//
+// This file provides a stub implementation. In a real quantum language
+// (e.g. Q#), one would decompose the QFT into rotations and controlled
+// operations and then take their P-th roots. The resulting circuit would
+// implement the desired unitary transformation.
+
+func main() {
+	// No classical I/O. Quantum circuit construction would go here.
+}


### PR DESCRIPTION
## Summary
- add a stub Go file for problem E2 in contest 1357

## Testing
- `gofmt -w 1000-1999/1300-1399/1350-1359/1357/1357E2.go`


------
https://chatgpt.com/codex/tasks/task_e_688597a947cc832487d5b7a2ea58e141