### PR TITLE
Add stub for quantum problem 1357C1

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1357/1357C1.go
+++ b/1000-1999/1300-1399/1350-1359/1357/1357C1.go
@@ -1,0 +1,18 @@
+package main
+
+// 1357C1: Prepare a superposition of all N-qubit basis states that contain
+// at least one zero. The original problem restricts operations to Pauli and
+// Hadamard gates (and their controlled versions) with optional measurements.
+// Implementing such a quantum circuit is outside the scope of this Go
+// repository, so this file only provides a compilable stub.
+//
+// In a quantum language one would:
+//   1. Start from |0...0⟩.
+//   2. Apply H to every qubit to create uniform superposition over all 2^N states.
+//   3. Use a multi-controlled operation to exclude the |11..1⟩ state
+//      (for example by phase-kickback and measurement-based uncomputation).
+//   4. The resulting state is uniform over all states containing at least one 0.
+
+func main() {
+    // No classical I/O. Quantum circuit construction would go here.
+}


### PR DESCRIPTION
## Summary
- add a placeholder Go file for problem C1 in contest 1357

## Testing
- `go vet` *(fails: no packages to vet)*

------
https://chatgpt.com/codex/tasks/task_e_688596912b4483248f3de47b573c81e3