### PR TITLE
Add Go solution for 1357 C2

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1357/1357C2.go
+++ b/1000-1999/1300-1399/1350-1359/1357/1357C2.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"math/bits"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, parity int
+	if _, err := fmt.Fscan(reader, &n, &parity); err != nil {
+		return
+	}
+	if parity != 0 {
+		parity = 1
+	}
+
+	count := 0
+	for mask := 0; mask < 1<<uint(n); mask++ {
+		if bits.OnesCount(uint(mask))%2 == parity {
+			count++
+		}
+	}
+	amplitude := 1.0 / math.Sqrt(float64(count))
+	fmt.Fprintf(writer, "Amplitude per state: %.6f\n", amplitude)
+	for mask := 0; mask < 1<<uint(n); mask++ {
+		if bits.OnesCount(uint(mask))%2 == parity {
+			fmt.Fprintf(writer, "%0*b\n", n, mask)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for problem C2 in contest 1357

## Testing
- `go run 1000-1999/1300-1399/1350-1359/1357/1357C2.go <<EOF
2 0
EOF`
- `go run 1000-1999/1300-1399/1350-1359/1357/1357C2.go <<EOF
3 1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6885964b381083248f137c9e8681649f