### PR TITLE
Add placeholder solution for 1357A4

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1357/1357A4.go
+++ b/1000-1999/1300-1399/1350-1359/1357/1357A4.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+// This program is a placeholder solution for problem A4 which asks to
+// distinguish between the quantum gates Rz and R1 by using the provided
+// operation once. Since Go cannot manipulate qubits directly, we simply
+// output 0 as a dummy result.
+func main() {
+	fmt.Println(0)
+}


### PR DESCRIPTION
## Summary
- add Go stub for problem A4 distinguishing Rz vs R1 gate

## Testing
- `go build 1000-1999/1300-1399/1350-1359/1357/1357A4.go`
- `go vet 1000-1999/1300-1399/1350-1359/1357/1357A4.go`


------
https://chatgpt.com/codex/tasks/task_e_68859578e3d8832491cdb7974652cfaf