### PR TITLE
Add stub for 1357A3

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1357/1357A3.go
+++ b/1000-1999/1300-1399/1350-1359/1357/1357A3.go
@@ -1,0 +1,21 @@
+package main
+
+// 1357A3: Distinguish between H and X gate using at most two applications of the unknown operation.
+// The task provides a single-qubit unitary U which is either the Hadamard (H) gate
+// or the Pauli-X (X) gate. U also has Adjoint and Controlled variants defined.
+// We need to return 0 if U is H and 1 if U is X. Go does not support quantum
+// operations natively, so below we outline the intended quantum procedure.
+//
+// Pseudocode:
+//
+//	// Allocate two qubits q0 and q1 initialized to |0>.
+//	// Apply Controlled-U with q0 as control and q1 as target.
+//	// Apply U on q0.
+//	// Measure both qubits in the computational basis.
+//	// If the result is |1,1> return 1 (U was X), otherwise return 0 (U was H).
+//
+// The real quantum implementation would use U and Controlled-U once each,
+// complying with the limit of two calls to the provided operation.
+func main() {
+	// No classical I/O. Quantum circuit construction would go here if supported.
+}


### PR DESCRIPTION
## Summary
- add a Go stub for quantum problem A3 in contest 1357

## Testing
- `gofmt -w 1000-1999/1300-1399/1350-1359/1357/1357A3.go`

------
https://chatgpt.com/codex/tasks/task_e_68859460a57c8324af47a73c0f2a225d