### PR TITLE
Add Go solution for 1350A

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1350/1350A.go
+++ b/1000-1999/1300-1399/1350-1359/1350/1350A.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func smallestDivisor(n int64) int64 {
+	if n%2 == 0 {
+		return 2
+	}
+	for i := int64(3); i*i <= n; i += 2 {
+		if n%i == 0 {
+			return i
+		}
+	}
+	return n
+}
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, k int64
+		fmt.Fscan(reader, &n, &k)
+		if n%2 == 0 {
+			n += 2 * k
+		} else {
+			d := smallestDivisor(n)
+			n += d
+			k--
+			n += 2 * k
+		}
+		fmt.Fprintln(writer, n)
+	}
+}


### PR DESCRIPTION
## Summary
- implement 1350A in Go

## Testing
- `go build 1000-1999/1300-1399/1350-1359/1350/1350A.go`


------
https://chatgpt.com/codex/tasks/task_e_6885941aae348324b4f43d85449a1979