### PR TITLE
Add stub solution for 1356A1

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1356/1356A1.go
+++ b/1000-1999/1300-1399/1350-1359/1356/1356A1.go
@@ -1,0 +1,21 @@
+package main
+
+// This stub outlines a classical approach to distinguish between the
+// identity gate and the X gate using a single invocation of the
+// provided quantum operation. Go doesn't support quantum operations,
+// so the exact circuit is described in comments only.
+//
+// Algorithm (pseudocode):
+//  1. Prepare a qubit in the |1> state.
+//  2. Apply the provided operation once to this qubit.
+//  3. Measure the qubit in the computational (Z) basis.
+//  4. If the measurement result is 1, the operation was the identity;
+//     output 0. If the result is 0, the operation was X; output 1.
+//
+// The real implementation would use quantum gates and measurement
+// instructions. Here we only provide a placeholder so the file
+// compiles.
+func main() {
+	// No classical I/O is performed. In a real quantum environment,
+	// the above procedure would return 0 for identity and 1 for X.
+}


### PR DESCRIPTION
## Summary
- provide Go stub for problem 1356A1 detailing how to distinguish the identity gate from the X gate

## Testing
- `go build 1000-1999/1300-1399/1350-1359/1356/1356A1.go`

------
https://chatgpt.com/codex/tasks/task_e_68858ea1e6e883249f868742a027a6dd