### PR TITLE
Add Go solution for 1360D

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1360/1360D.go
+++ b/1000-1999/1300-1399/1360-1369/1360/1360D.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(in, &n, &k)
+		if k >= n {
+			fmt.Fprintln(out, 1)
+			continue
+		}
+		ans := n
+		for i := 1; i*i <= n; i++ {
+			if n%i == 0 {
+				d1 := i
+				d2 := n / i
+				if d1 <= k {
+					if n/d1 < ans {
+						ans = n / d1
+					}
+				}
+				if d2 <= k {
+					if n/d2 < ans {
+						ans = n / d2
+					}
+				}
+			}
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem D in the 1360 set

## Testing
- `go run 1000-1999/1300-1399/1360-1369/1360/1360D.go <<EOF
1
8 7
EOF`
- `echo -e '3\n8 7\n8 1\n6 6\n' | go run 1000-1999/1300-1399/1360-1369/1360/1360D.go`

------
https://chatgpt.com/codex/tasks/task_e_6885a0f6c2148324acb8fc92cc46816a