### PR TITLE
Add stub for 1356A3

### DIFF
--- a/1000-1999/1300-1399/1350-1359/1356/1356A3.go
+++ b/1000-1999/1300-1399/1350-1359/1356/1356A3.go
@@ -1,0 +1,16 @@
+package main
+
+// 1356A3: Distinguish between the Z gate and the S gate using two applications of
+// an unknown single-qubit operation. In a quantum environment one would:
+//  1. Prepare a qubit in the |+> state using a Hadamard.
+//  2. Apply the given operation twice.
+//  3. Apply a Hadamard and measure in the computational basis.
+//
+// A result of 0 (state |+>) indicates the operation was Z; a result of 1 (state
+// |->) indicates the operation was S.
+//
+// Quantum operations are not available in this Go repository. Therefore this file
+// only documents the intended algorithm and leaves main empty.
+func main() {
+	// Implementation would require quantum gate primitives.
+}


### PR DESCRIPTION
## Summary
- add Go placeholder for problem 1356A3 with algorithm outline

## Testing
- `gofmt -w 1000-1999/1300-1399/1350-1359/1356/1356A3.go`
- `go vet ./...` *(fails: directory prefix does not contain main module)*
- `go build ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68858e15cf8c8324be9df748818ed9a2