### PR TITLE
Add Go solution for 1324A

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1324/1324A.go
+++ b/1000-1999/1300-1399/1320-1329/1324/1324A.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	fmt.Fscan(reader, &t)
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		parity := arr[0] % 2
+		ok := true
+		for i := 1; i < n; i++ {
+			if arr[i]%2 != parity {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			fmt.Fprintln(writer, "YES")
+		} else {
+			fmt.Fprintln(writer, "NO")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add solution for the Tetris field parity check problem

## Testing
- `go build 1000-1999/1300-1399/1320-1329/1324/1324A.go`


------
https://chatgpt.com/codex/tasks/task_e_68858d89b95483248688abdf21402707