### PR TITLE
Add Go solution for 1328B

### DIFF
--- a/1000-1999/1300-1399/1320-1329/1328/1328B.go
+++ b/1000-1999/1300-1399/1320-1329/1328/1328B.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, k int
+		fmt.Fscan(in, &n, &k)
+		s := make([]byte, n)
+		for i := 0; i < n; i++ {
+			s[i] = 'a'
+		}
+		for i := n - 2; i >= 0; i-- {
+			cnt := n - i - 1
+			if k > cnt {
+				k -= cnt
+			} else {
+				s[i] = 'b'
+				s[n-k] = 'b'
+				break
+			}
+		}
+		fmt.Fprintln(out, string(s))
+	}
+}


### PR DESCRIPTION
## Summary
- implement `1328B.go` with lexicographic computation of two 'b' positions

## Testing
- `gofmt -w 1000-1999/1300-1399/1320-1329/1328/1328B.go`


------
https://chatgpt.com/codex/tasks/task_e_6885859a7b608324bf789283c9e0828c