### PR TITLE
Add Go solution for 1360B

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1360/1360B.go
+++ b/1000-1999/1300-1399/1360-1369/1360/1360B.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n int
+		fmt.Fscan(reader, &n)
+		arr := make([]int, n)
+		for i := 0; i < n; i++ {
+			fmt.Fscan(reader, &arr[i])
+		}
+		sort.Ints(arr)
+		ans := 10000
+		for i := 1; i < n; i++ {
+			diff := arr[i] - arr[i-1]
+			if diff < ans {
+				ans = diff
+			}
+		}
+		fmt.Fprintln(writer, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for problem 1360B

## Testing
- `go build 1000-1999/1300-1399/1360-1369/1360/1360B.go`
- `go run 1000-1999/1300-1399/1360-1369/1360/1360B.go` with sample input

------
https://chatgpt.com/codex/tasks/task_e_6885a1c8ceb0832483efe1b339436d37