### PR TITLE
Add Go solution for 1366B

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1366/1366B.go
+++ b/1000-1999/1300-1399/1360-1369/1366/1366B.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var t int
+	if _, err := fmt.Fscan(reader, &t); err != nil {
+		return
+	}
+	for ; t > 0; t-- {
+		var n, x, m int
+		fmt.Fscan(reader, &n, &x, &m)
+		l, r := x, x
+		for i := 0; i < m; i++ {
+			var li, ri int
+			fmt.Fscan(reader, &li, &ri)
+			if li <= r && ri >= l {
+				if li < l {
+					l = li
+				}
+				if ri > r {
+					r = ri
+				}
+			}
+		}
+		fmt.Fprintln(writer, r-l+1)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for problem B in contest 1366

## Testing
- `gofmt -w 1000-1999/1300-1399/1360-1369/1366/1366B.go`


------
https://chatgpt.com/codex/tasks/task_e_6885a4858128832481293cfc124424c0