### PR TITLE
Add Go solution for 1366C

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1366/1366C.go
+++ b/1000-1999/1300-1399/1360-1369/1366/1366C.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var t int
+	fmt.Fscan(in, &t)
+	for ; t > 0; t-- {
+		var n, m int
+		fmt.Fscan(in, &n, &m)
+		zeros := make([]int, n+m-1)
+		ones := make([]int, n+m-1)
+		for i := 0; i < n; i++ {
+			for j := 0; j < m; j++ {
+				var x int
+				fmt.Fscan(in, &x)
+				if x == 0 {
+					zeros[i+j]++
+				} else {
+					ones[i+j]++
+				}
+			}
+		}
+		total := n + m - 2
+		ans := 0
+		for l, r := 0, total; l < r; l, r = l+1, r-1 {
+			ans += min(zeros[l]+zeros[r], ones[l]+ones[r])
+		}
+		fmt.Fprintln(out, ans)
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem C in 1366

## Testing
- `go build 1000-1999/1300-1399/1360-1369/1366/1366C.go`
- `go vet 1000-1999/1300-1399/1360-1369/1366/1366C.go`

------
https://chatgpt.com/codex/tasks/task_e_6885a43f191c83248f2c7d4957067b3e