### PR TITLE
Add Go solution for 1366E

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1366/1366E.go
+++ b/1000-1999/1300-1399/1360-1369/1366/1366E.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+const mod int64 = 998244353
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	defer writer.Flush()
+
+	var n, m int
+	if _, err := fmt.Fscan(reader, &n, &m); err != nil {
+		return
+	}
+	a := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(reader, &a[i])
+	}
+	b := make([]int, m)
+	for i := 0; i < m; i++ {
+		fmt.Fscan(reader, &b[i])
+	}
+
+	idx := n - 1
+	ans := int64(1)
+	for i := m - 1; i >= 0; i-- {
+		last := -1
+		for idx >= 0 && a[idx] >= b[i] {
+			if a[idx] == b[i] && last == -1 {
+				last = idx
+			}
+			idx--
+		}
+		if last == -1 {
+			fmt.Fprintln(writer, 0)
+			return
+		}
+		if i == 0 {
+			if idx != -1 {
+				fmt.Fprintln(writer, 0)
+				return
+			}
+		} else {
+			ans = ans * int64(last-idx) % mod
+		}
+	}
+	fmt.Fprintln(writer, ans%mod)
+}


### PR DESCRIPTION
## Summary
- implement solution for problemE in contest 1366

## Testing
- `go build 1000-1999/1300-1399/1360-1369/1366/1366E.go`
- `go run 1000-1999/1300-1399/1360-1369/1366/1366E.go << EOF
6 3
12 10 20 20 25 30
10 20 30
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6885a36d17a883248c27d816b2b5f81b