### PR TITLE
Add Go solution for 1366A

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1366/1366A.go
+++ b/1000-1999/1300-1399/1360-1369/1366/1366A.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+   "bufio"
+   "fmt"
+   "os"
+)
+
+func main() {
+   reader := bufio.NewReader(os.Stdin)
+   writer := bufio.NewWriter(os.Stdout)
+   defer writer.Flush()
+
+   var t int
+   if _, err := fmt.Fscan(reader, &t); err != nil {
+      return
+   }
+   for ; t > 0; t-- {
+      var a, b int64
+      fmt.Fscan(reader, &a, &b)
+      r := (a + b) / 3
+      if a < b {
+         if r > a {
+            r = a
+         }
+      } else {
+         if r > b {
+            r = b
+         }
+      }
+      fmt.Fprintln(writer, r)
+   }
+}


### PR DESCRIPTION
## Summary
- add a Go implementation for contest 1366 problem A

## Testing
- `go vet` (not run: no instructions)


------
https://chatgpt.com/codex/tasks/task_e_6885a4cb4d548324942438a4d2948450