### PR TITLE
Add Go solution for CF 1368E

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1368/1368E.go
+++ b/1000-1999/1300-1399/1360-1369/1368/1368E.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var T int
+	fmt.Fscan(in, &T)
+	for ; T > 0; T-- {
+		var n, m int
+		fmt.Fscan(in, &n, &m)
+		g := make([][]int, n)
+		for i := 0; i < m; i++ {
+			var x, y int
+			fmt.Fscan(in, &x, &y)
+			x--
+			y--
+			g[x] = append(g[x], y)
+		}
+
+		dp := make([]int, n)
+		removed := make([]bool, n)
+		ans := make([]int, 0)
+		for i := 0; i < n; i++ {
+			if dp[i] >= 2 {
+				removed[i] = true
+				ans = append(ans, i+1)
+			} else {
+				for _, v := range g[i] {
+					if dp[i]+1 > dp[v] {
+						dp[v] = dp[i] + 1
+					}
+				}
+			}
+		}
+		fmt.Fprintln(out, len(ans))
+		for i, v := range ans {
+			if i > 0 {
+				fmt.Fprint(out, " ")
+			}
+			fmt.Fprint(out, v)
+		}
+		if len(ans) > 0 {
+			fmt.Fprintln(out)
+		} else {
+			fmt.Fprintln(out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement Go solution for problem 1368E using greedy removal strategy

## Testing
- `go build /tmp/zz.go`
- `echo -e "1\n3 2\n1 2\n2 3\n" | go run 1000-1999/1300-1399/1360-1369/1368/1368E.go`
- `echo -e "1\n7 8\n1 2\n1 3\n2 4\n3 4\n4 5\n5 6\n5 7\n6 7\n" | go run 1000-1999/1300-1399/1360-1369/1368/1368E.go`


------
https://chatgpt.com/codex/tasks/task_e_6885a5114de48324b8722f6521be5713