### PR TITLE
Add Go solution for 1365C

### DIFF
--- a/1000-1999/1300-1399/1360-1369/1365/1365C.go
+++ b/1000-1999/1300-1399/1360-1369/1365/1365C.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	var n int
+	fmt.Fscan(in, &n)
+	a := make([]int, n)
+	b := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &a[i])
+	}
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &b[i])
+	}
+
+	pos := make([]int, n+1)
+	for i := 0; i < n; i++ {
+		pos[a[i]] = i
+	}
+
+	cnt := make(map[int]int)
+	best := 0
+	for i := 0; i < n; i++ {
+		shift := (i - pos[b[i]] + n) % n
+		cnt[shift]++
+		if cnt[shift] > best {
+			best = cnt[shift]
+		}
+	}
+
+	fmt.Fprintln(out, best)
+}


### PR DESCRIPTION
## Summary
- add Go solution for the rotation matching problem (1365C)

## Testing
- `go run 1000-1999/1300-1399/1360-1369/1365/1365C.go << EOF
5
1 2 3 4 5
5 1 2 3 4
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6885aa8a0e708324b49fbfd6beefafe7