### PR TITLE
Add Go verifiers for Codeforces contest 1303

### DIFF
--- a/1000-1999/1300-1399/1300-1309/1303/verifierA.go
+++ b/1000-1999/1300-1399/1300-1309/1303/verifierA.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type testCase struct {
+	s string
+}
+
+func solveCase(tc testCase) string {
+	s := tc.s
+	l, r := -1, -1
+	for i := 0; i < len(s); i++ {
+		if s[i] == '1' {
+			if l == -1 {
+				l = i
+			}
+			r = i
+		}
+	}
+	if l == -1 || l == r {
+		return "0\n"
+	}
+	cnt := 0
+	for i := l; i <= r; i++ {
+		if s[i] == '0' {
+			cnt++
+		}
+	}
+	return fmt.Sprintf("%d\n", cnt)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		if rng.Intn(2) == 0 {
+			b[i] = '0'
+		} else {
+			b[i] = '1'
+		}
+	}
+	s := string(b)
+	tc := testCase{s: s}
+	in := fmt.Sprintf("1\n%s\n", s)
+	out := solveCase(tc)
+	return in, out
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1303/verifierB.go
+++ b/1000-1999/1300-1399/1300-1309/1303/verifierB.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n, g, b int64) string {
+	need := (n + 1) / 2
+	periods := (need + g - 1) / g
+	full := periods - 1
+	rem := need - full*g
+	daysHigh := full*(g+b) + rem
+	ans := daysHigh
+	if n > ans {
+		ans = n
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(100) + 1
+	g := rng.Int63n(10) + 1
+	b := rng.Int63n(10) + 1
+	in := fmt.Sprintf("1\n%d %d %d\n", n, g, b)
+	out := solveCase(n, g, b)
+	return in, out
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1303/verifierC.go
+++ b/1000-1999/1300-1399/1300-1309/1303/verifierC.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(s string) string {
+	adj := make([][]bool, 26)
+	for i := range adj {
+		adj[i] = make([]bool, 26)
+	}
+	n := len(s)
+	for i := 0; i < n; i++ {
+		cur := s[i] - 'a'
+		if i > 0 {
+			prev := s[i-1] - 'a'
+			adj[cur][prev] = true
+			adj[prev][cur] = true
+		}
+		if i < n-1 {
+			next := s[i+1] - 'a'
+			adj[cur][next] = true
+			adj[next][cur] = true
+		}
+	}
+	visited := make([]bool, 26)
+	deg := make([]int, 26)
+	poss := true
+	for i := 0; i < 26; i++ {
+		cnt := 0
+		for j := 0; j < 26; j++ {
+			if adj[i][j] {
+				cnt++
+			}
+		}
+		if cnt > 2 {
+			poss = false
+		}
+		deg[i] = cnt
+	}
+	var ans []byte
+	for i := 0; i < 26; i++ {
+		if !visited[i] && deg[i] <= 1 {
+			stack := [][2]int{{i, -1}}
+			for len(stack) > 0 {
+				top := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				cur, parent := top[0], top[1]
+				if visited[cur] {
+					continue
+				}
+				visited[cur] = true
+				ans = append(ans, byte(cur)+'a')
+				for c := 0; c < 26; c++ {
+					if adj[cur][c] {
+						if c == parent {
+							continue
+						}
+						if visited[c] {
+							poss = false
+						} else {
+							stack = append(stack, [2]int{c, cur})
+						}
+					}
+				}
+			}
+		}
+	}
+	for i := 0; i < 26; i++ {
+		if !visited[i] {
+			ans = append(ans, byte(i)+'a')
+		}
+	}
+	if !poss {
+		return "NO\n"
+	}
+	return fmt.Sprintf("YES\n%s\n", string(ans))
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	// generate random string without adjacent equal letters
+	length := rng.Intn(20) + 1
+	b := make([]byte, length)
+	for i := 0; i < length; i++ {
+		for {
+			ch := byte(rng.Intn(26)) + 'a'
+			if i == 0 || ch != b[i-1] {
+				b[i] = ch
+				break
+			}
+		}
+	}
+	s := string(b)
+	in := fmt.Sprintf("1\n%s\n", s)
+	out := solveCase(s)
+	return in, out
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1303/verifierD.go
+++ b/1000-1999/1300-1399/1300-1309/1303/verifierD.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n int64, boxes []int64) string {
+	const maxb = 61
+	cnt := make([]int64, maxb)
+	var sum int64
+	for _, a := range boxes {
+		b := 0
+		for (1 << uint(b)) != a {
+			b++
+		}
+		cnt[b]++
+		sum += a
+	}
+	if sum < n {
+		return "-1\n"
+	}
+	var ans int64
+	var have int64
+	for i := 0; i < maxb; i++ {
+		have += cnt[i]
+		if (n>>uint(i))&1 == 1 {
+			if have > 0 {
+				have--
+			} else {
+				j := i + 1
+				for j < maxb && cnt[j] == 0 {
+					j++
+				}
+				for k := j; k > i; k-- {
+					cnt[k]--
+					cnt[k-1] += 2
+					ans++
+				}
+				have += cnt[i]
+				have--
+			}
+		}
+		have /= 2
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Int63n(1_000_000) + 1
+	m := rng.Intn(8) + 1
+	boxes := make([]int64, m)
+	for i := 0; i < m; i++ {
+		b := rng.Intn(20)
+		boxes[i] = 1 << uint(b)
+	}
+	inSb := strings.Builder{}
+	fmt.Fprintf(&inSb, "1\n%d %d\n", n, m)
+	for i, a := range boxes {
+		if i > 0 {
+			inSb.WriteByte(' ')
+		}
+		fmt.Fprintf(&inSb, "%d", a)
+	}
+	inSb.WriteByte('\n')
+	out := solveCase(n, boxes)
+	return inSb.String(), out
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1303/verifierE.go
+++ b/1000-1999/1300-1399/1300-1309/1303/verifierE.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(s, t string) string {
+	n := len(s)
+	m := len(t)
+	for i := 0; i <= m; i++ {
+		used := make([]bool, n)
+		p := 0
+		for j := 0; j < n && p < i; j++ {
+			if s[j] == t[p] {
+				used[j] = true
+				p++
+			}
+		}
+		if p < i {
+			continue
+		}
+		q := i
+		for j := 0; j < n && q < m; j++ {
+			if used[j] {
+				continue
+			}
+			if s[j] == t[q] {
+				q++
+			}
+		}
+		if q == m {
+			return "YES\n"
+		}
+	}
+	return "NO\n"
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(6) + 1
+	sb1 := make([]byte, n)
+	sb2 := make([]byte, m)
+	for i := range sb1 {
+		sb1[i] = byte(rng.Intn(26)) + 'a'
+	}
+	for i := range sb2 {
+		sb2[i] = byte(rng.Intn(26)) + 'a'
+	}
+	s := string(sb1)
+	t := string(sb2)
+	in := fmt.Sprintf("1\n%s\n%s\n", s, t)
+	out := solveCase(s, t)
+	return in, out
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1303/verifierF.go
+++ b/1000-1999/1300-1399/1300-1309/1303/verifierF.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func countComponents(grid [][]int) int {
+	n := len(grid)
+	m := len(grid[0])
+	visited := make([][]bool, n)
+	for i := range visited {
+		visited[i] = make([]bool, m)
+	}
+	dirs := [][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}}
+	comps := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if !visited[i][j] {
+				comps++
+				stack := [][2]int{{i, j}}
+				visited[i][j] = true
+				for len(stack) > 0 {
+					cur := stack[len(stack)-1]
+					stack = stack[:len(stack)-1]
+					x, y := cur[0], cur[1]
+					for _, d := range dirs {
+						nx, ny := x+d[0], y+d[1]
+						if nx >= 0 && nx < n && ny >= 0 && ny < m && !visited[nx][ny] && grid[nx][ny] == grid[x][y] {
+							visited[nx][ny] = true
+							stack = append(stack, [2]int{nx, ny})
+						}
+					}
+				}
+			}
+		}
+	}
+	return comps
+}
+
+func solveCase(n, m, q int, queries [][3]int) string {
+	grid := make([][]int, n)
+	for i := range grid {
+		grid[i] = make([]int, m)
+	}
+	var sb strings.Builder
+	for _, qu := range queries {
+		x, y, c := qu[0], qu[1], qu[2]
+		grid[x][y] = c
+		comps := countComponents(grid)
+		fmt.Fprintf(&sb, "%d\n", comps)
+	}
+	return sb.String()
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(3) + 1
+	m := rng.Intn(3) + 1
+	q := rng.Intn(5) + 1
+	queries := make([][3]int, q)
+	lastC := 0
+	for i := 0; i < q; i++ {
+		x := rng.Intn(n)
+		y := rng.Intn(m)
+		c := lastC + rng.Intn(3) + 1
+		lastC = c
+		queries[i] = [3]int{x, y, c}
+	}
+	sb := strings.Builder{}
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, q)
+	for _, qu := range queries {
+		fmt.Fprintf(&sb, "%d %d %d\n", qu[0]+1, qu[1]+1, qu[2])
+	}
+	out := solveCase(n, m, q, queries)
+	return sb.String(), out
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1303/verifierG.go
+++ b/1000-1999/1300-1399/1300-1309/1303/verifierG.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func solveCase(n int, edges [][2]int, a []int64) string {
+	adj := make([][]int, n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+	}
+	par := make([]int, n)
+	order := make([]int, 0, n)
+	stack := []int{0}
+	par[0] = -1
+	for i := 0; i < len(stack); i++ {
+		u := stack[i]
+		order = append(order, u)
+		for _, v := range adj[u] {
+			if v == par[u] {
+				continue
+			}
+			par[v] = u
+			stack = append(stack, v)
+		}
+	}
+	dp1 := make([]int64, n)
+	sumA1 := make([]int64, n)
+	for i := n - 1; i >= 0; i-- {
+		u := order[i]
+		dp1[u] = a[u]
+		sumA1[u] = a[u]
+		var bestDir, bestSum int64
+		for _, v := range adj[u] {
+			if v == par[u] {
+				continue
+			}
+			dir := dp1[v] + sumA1[v]
+			if dir > bestDir {
+				bestDir = dir
+				bestSum = sumA1[v]
+			}
+		}
+		if bestDir > 0 {
+			dp1[u] = a[u] + bestDir
+			sumA1[u] = a[u] + bestSum
+		}
+	}
+	dp2 := make([]int64, n)
+	sumA2 := make([]int64, n)
+	const inf = int64(4e18)
+	for _, u := range order {
+		var max1Val, max2Val int64 = -inf, -inf
+		var max1Sum, max2Sum int64
+		var max1Id int = -1
+		if par[u] != -1 {
+			d := dp2[u]
+			s := sumA2[u]
+			val := d + s
+			if val > max1Val {
+				max2Val, max2Sum = max1Val, max1Sum
+				max1Val, max1Sum, max1Id = val, s, par[u]
+			} else if val > max2Val {
+				max2Val, max2Sum = val, s
+			}
+		}
+		for _, v := range adj[u] {
+			if v == par[u] {
+				continue
+			}
+			s := sumA1[v]
+			d := dp1[v] + s
+			val := d + s
+			if val > max1Val {
+				max2Val, max2Sum = max1Val, max1Sum
+				max1Val, max1Sum, max1Id = val, s, v
+			} else if val > max2Val {
+				max2Val, max2Sum = val, s
+			}
+		}
+		for _, v := range adj[u] {
+			if v == par[u] {
+				continue
+			}
+			var bestVal, bestSum int64
+			if max1Id != v {
+				bestVal = max1Val
+				bestSum = max1Sum
+			} else {
+				bestVal = max2Val
+				bestSum = max2Sum
+			}
+			if bestVal > 0 {
+				dp2[v] = 2*a[u] + bestVal
+				sumA2[v] = a[u] + bestSum
+			} else {
+				dp2[v] = 0
+				sumA2[v] = 0
+			}
+		}
+	}
+	var ans int64
+	for i := 0; i < n; i++ {
+		f1 := dp1[i]
+		f2 := a[i] + dp2[i]
+		if f1 > ans {
+			ans = f1
+		}
+		if f2 > ans {
+			ans = f2
+		}
+	}
+	return fmt.Sprintf("%d\n", ans)
+}
+
+func genCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 2
+	edges := make([][2]int, n-1)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i)
+		edges[i-1] = [2]int{p, i}
+	}
+	a := make([]int64, n)
+	for i := range a {
+		a[i] = int64(rng.Intn(10) + 1)
+	}
+	sb := strings.Builder{}
+	fmt.Fprintf(&sb, "%d\n", n)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0]+1, e[1]+1)
+	}
+	for i, v := range a {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", v)
+	}
+	sb.WriteByte('\n')
+	out := solveCase(n, edges, a)
+	return sb.String(), out
+}
+
+func runCase(bin, in, exp string) error {
+	cmd := exec.Command(bin)
+	cmd.Stdin = strings.NewReader(in)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("runtime error: %v\n%s", err, buf.String())
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != strings.TrimSpace(exp) {
+		return fmt.Errorf("expected \n%s\ngot \n%s", exp, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := genCase(rng)
+		if err := runCase(bin, in, exp); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add solution verifiers for problems A–G of contest 1303
- each verifier generates 100 random tests and checks a supplied binary
- verifiers mirror the algorithms used in the existing reference solutions

## Testing
- `go build 1000-1999/1300-1399/1300-1309/1303/verifierA.go`
- `go build 1000-1999/1300-1399/1300-1309/1303/verifierB.go`
- `go build 1000-1999/1300-1399/1300-1309/1303/verifierC.go`
- `go build 1000-1999/1300-1399/1300-1309/1303/verifierD.go`
- `go build 1000-1999/1300-1399/1300-1309/1303/verifierE.go`
- `go build 1000-1999/1300-1399/1300-1309/1303/verifierF.go`
- `go build 1000-1999/1300-1399/1300-1309/1303/verifierG.go`
- `go run 1000-1999/1300-1399/1300-1309/1303/verifierA.go /tmp/1303A_bin`
- `go run 1000-1999/1300-1399/1300-1309/1303/verifierB.go /tmp/1303B_bin`

------
https://chatgpt.com/codex/tasks/task_e_6885c316348883248b85ca7f9299933f