### PR TITLE
Add Go verifiers for contest 1302

### DIFF
--- a/1000-1999/1300-1399/1300-1309/1302/verifierA.go
+++ b/1000-1999/1300-1399/1300-1309/1302/verifierA.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 2
+	m := rng.Intn(4) + 2
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			fmt.Fprintf(&sb, "%d", rng.Intn(20)+1)
+		}
+		if i+1 < n {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		want, err := run("./1302A.go", tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1300-1399/1300-1309/1302/verifierB.go
+++ b/1000-1999/1300-1399/1300-1309/1302/verifierB.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges + 1)
+	edges := make(map[[2]int]struct{})
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	count := 0
+	for count < m {
+		u := rng.Intn(n)
+		v := rng.Intn(n)
+		if u >= v {
+			continue
+		}
+		key := [2]int{u + 1, v + 1}
+		if _, ok := edges[key]; ok {
+			continue
+		}
+		edges[key] = struct{}{}
+		fmt.Fprintf(&sb, "%d %d\n", key[0], key[1])
+		count++
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		want, err := run("./1302B.go", tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1300-1399/1300-1309/1302/verifierC.go
+++ b/1000-1999/1300-1399/1300-1309/1302/verifierC.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	T := 1
+	n := rng.Intn(5) + 1
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", T)
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i := 0; i < q; i++ {
+		typ := rng.Intn(2) + 1
+		if typ == 1 {
+			x := rng.Intn(n) + 1
+			y := rng.Intn(21) - 10
+			fmt.Fprintf(&sb, "1 %d %d\n", x, y)
+		} else {
+			l := rng.Intn(n) + 1
+			r := l + rng.Intn(n-l+1)
+			fmt.Fprintf(&sb, "2 %d %d\n", l, r)
+		}
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		want, err := run("./1302C.go", tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1300-1399/1300-1309/1302/verifierD.go
+++ b/1000-1999/1300-1399/1300-1309/1302/verifierD.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 2
+	maxEdges := n * (n - 1) / 2
+	m := rng.Intn(maxEdges) + 1
+	edges := make(map[[2]int]struct{})
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	count := 0
+	for count < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		key := [2]int{u, v}
+		if _, ok := edges[key]; ok {
+			continue
+		}
+		edges[key] = struct{}{}
+		w := rng.Intn(20) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", u, v, w)
+		count++
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		want, err := run("./1302D.go", tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1300-1399/1300-1309/1302/verifierE.go
+++ b/1000-1999/1300-1399/1300-1309/1302/verifierE.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(10) + 1
+	a := rng.Intn(10) + 1
+	b := a + rng.Intn(10) + 1
+	return fmt.Sprintf("%d %d %d\n", n, a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		want, err := run("./1302E.go", tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1300-1399/1300-1309/1302/verifierF.go
+++ b/1000-1999/1300-1399/1300-1309/1302/verifierF.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	var sb strings.Builder
+	for i := 0; i < 5; i++ {
+		sb.WriteByte(byte('0' + rng.Intn(10)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		want, err := run("./1302F.go", tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1300-1399/1300-1309/1302/verifierG.go
+++ b/1000-1999/1300-1399/1300-1309/1302/verifierG.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	var sb strings.Builder
+	for i := 0; i < 5; i++ {
+		sb.WriteByte(byte('0' + rng.Intn(10)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		want, err := run("./1302G.go", tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1300-1399/1300-1309/1302/verifierH.go
+++ b/1000-1999/1300-1399/1300-1309/1302/verifierH.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, q)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		fmt.Fprintf(&sb, "%d", rng.Intn(5))
+	}
+	sb.WriteByte('\n')
+	for i := 0; i < q; i++ {
+		length := rng.Intn(n) + 1
+		p := rng.Intn(n-length+1) + 1
+		qpos := rng.Intn(n-length+1) + 1
+		fmt.Fprintf(&sb, "%d %d %d\n", length, p, qpos)
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierH.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		want, err := run("./1302H.go", tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1300-1399/1300-1309/1302/verifierI.go
+++ b/1000-1999/1300-1399/1300-1309/1302/verifierI.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	n := rng.Intn(20) + 1
+	k := rng.Intn(n) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, k)
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('0' + rng.Intn(10)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierI.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		want, err := run("./1302I.go", tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}

--- a/1000-1999/1300-1399/1300-1309/1302/verifierJ.go
+++ b/1000-1999/1300-1399/1300-1309/1302/verifierJ.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func genCase(rng *rand.Rand) string {
+	var sb strings.Builder
+	for i := 0; i < 100; i++ {
+		sb.WriteByte(byte('0' + rng.Intn(10)))
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierJ.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		tc := genCase(rng)
+		want, err := run("./1302J.go", tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, tc)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, tc)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(want) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, want, got, tc)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("All %d tests passed\n", 100)
+}


### PR DESCRIPTION
## Summary
- add Go verifiers for contest 1302 problems A–J
- verifiers invoke the provided reference solution and run 100 random tests

## Testing
- `go build 1000-1999/1300-1399/1300-1309/1302/verifierA.go`
- `go build 1000-1999/1300-1399/1300-1309/1302/verifierB.go`
- `go build 1000-1999/1300-1399/1300-1309/1302/verifierC.go`
- `go build 1000-1999/1300-1399/1300-1309/1302/verifierD.go`
- `go build 1000-1999/1300-1399/1300-1309/1302/verifierE.go`
- `go build 1000-1999/1300-1399/1300-1309/1302/verifierF.go`
- `go build 1000-1999/1300-1399/1300-1309/1302/verifierG.go`
- `go build 1000-1999/1300-1399/1300-1309/1302/verifierH.go`
- `go build 1000-1999/1300-1399/1300-1309/1302/verifierI.go`
- `go build 1000-1999/1300-1399/1300-1309/1302/verifierJ.go`


------
https://chatgpt.com/codex/tasks/task_e_6885c28a24408324b9a6a75bffcc7b8d