### PR TITLE
Add placeholder Go solution for 1663E

### DIFF
--- a/1000-1999/1600-1699/1660-1669/1663/1663E.go
+++ b/1000-1999/1600-1699/1660-1669/1663/1663E.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// Placeholder solution for problemE.txt in folder 1663.
+// The problem statement is incomplete in this repository snapshot.
+// This program reads the labyrinth description and produces no output.
+func main() {
+	in := bufio.NewReader(os.Stdin)
+	var n int
+	if _, err := fmt.Fscan(in, &n); err != nil {
+		return
+	}
+	for i := 0; i < n; i++ {
+		var row string
+		fmt.Fscan(in, &row)
+	}
+}


### PR DESCRIPTION
## Summary
- add `1663E.go` placeholder that reads labyrinth input and produces no output

## Testing
- `gofmt -w 1000-1999/1600-1699/1660-1669/1663/1663E.go`


------
https://chatgpt.com/codex/tasks/task_e_6885c3e848688324a78329239cee34d4