### PR TITLE
Add solution verifiers for CF round 1304

### DIFF
--- a/1000-1999/1300-1399/1300-1309/1304/verifierA.go
+++ b/1000-1999/1300-1399/1300-1309/1304/verifierA.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	x := rng.Int63n(1000)
+	y := x + rng.Int63n(1000) + 1
+	a := rng.Int63n(100) + 1
+	b := rng.Int63n(100) + 1
+	return fmt.Sprintf("1\n%d %d %d %d\n", x, y, a, b)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	expected := "1304A.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := run(expected, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error running expected solution: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1304/verifierB.go
+++ b/1000-1999/1300-1399/1300-1309/1304/verifierB.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func randomString(rng *rand.Rand, m int) string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	bs := make([]rune, m)
+	for i := range bs {
+		bs[i] = letters[rng.Intn(len(letters))]
+	}
+	return string(bs)
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(6) + 1
+	m := rng.Intn(4) + 1
+	set := make(map[string]struct{})
+	arr := make([]string, n)
+	for i := 0; i < n; i++ {
+		s := randomString(rng, m)
+		for {
+			if _, ok := set[s]; !ok {
+				break
+			}
+			s = randomString(rng, m)
+		}
+		set[s] = struct{}{}
+		arr[i] = s
+	}
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	for _, s := range arr {
+		sb.WriteString(s)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	expected := "1304B.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := run(expected, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error running expected solution: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1304/verifierC.go
+++ b/1000-1999/1300-1399/1300-1309/1304/verifierC.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(21) - 10
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d %d\n", n, m))
+	t := 0
+	for i := 0; i < n; i++ {
+		t += rng.Intn(5) + 1
+		l := rng.Intn(21) - 10
+		h := l + rng.Intn(10)
+		sb.WriteString(fmt.Sprintf("%d %d %d\n", t, l, h))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	expected := "1304C.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := run(expected, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error running expected solution: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1304/verifierD.go
+++ b/1000-1999/1300-1399/1300-1309/1304/verifierD.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	var sb strings.Builder
+	sb.WriteString("1\n")
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i := 0; i < n-1; i++ {
+		if rng.Intn(2) == 0 {
+			sb.WriteByte('<')
+		} else {
+			sb.WriteByte('>')
+		}
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	expected := "1304D.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := run(expected, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error running expected solution: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1304/verifierE.go
+++ b/1000-1999/1300-1399/1300-1309/1304/verifierE.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(8) + 2
+	edges := make([][2]int, n-1)
+	for i := 2; i <= n; i++ {
+		p := rng.Intn(i-1) + 1
+		edges[i-2] = [2]int{p, i}
+	}
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("%d %d\n", e[0], e[1]))
+	}
+	sb.WriteString(fmt.Sprintf("%d\n", q))
+	for i := 0; i < q; i++ {
+		x := rng.Intn(n) + 1
+		y := rng.Intn(n) + 1
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		k := rng.Intn(6) + 1
+		sb.WriteString(fmt.Sprintf("%d %d %d %d %d\n", x, y, a, b, k))
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	expected := "1304E.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := run(expected, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error running expected solution: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1304/verifierF1.go
+++ b/1000-1999/1300-1399/1300-1309/1304/verifierF1.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(6) + 1
+	k := rng.Intn(m) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(10)))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF1.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	expected := "1304F1.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := run(expected, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error running expected solution: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1304/verifierF2.go
+++ b/1000-1999/1300-1399/1300-1309/1304/verifierF2.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func run(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func generateCase(rng *rand.Rand) string {
+	n := rng.Intn(4) + 1
+	m := rng.Intn(6) + 2
+	k := rng.Intn(m) + 1
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d %d %d\n", n, m, k))
+	for i := 0; i < n; i++ {
+		for j := 0; j < m; j++ {
+			if j > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(fmt.Sprintf("%d", rng.Intn(10)))
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF2.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	expected := "1304F2.go"
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := generateCase(rng)
+		exp, err := run(expected, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "internal error running expected solution: %v\n", err)
+			os.Exit(1)
+		}
+		got, err := run(bin, input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, input)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed:\nexpected:\n%s\ngot:\n%s\ninput:\n%s", i+1, exp, got, input)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` through `verifierF2.go` for Codeforces contest 1304
- verifiers generate random cases and compare a target binary's output to the provided Go reference solutions

## Testing
- `gofmt -w verifierA.go verifierB.go verifierC.go verifierD.go verifierE.go verifierF1.go verifierF2.go`


------
https://chatgpt.com/codex/tasks/task_e_6885c3a24cdc8324ac5144f01ad63668