### PR TITLE
Add Go verifiers for new contest 1306

### DIFF
--- a/1000-1999/1300-1399/1300-1309/1306/1306A.go
+++ b/1000-1999/1300-1399/1300-1309/1306/1306A.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	panic("runtime error")
+}

--- a/1000-1999/1300-1399/1300-1309/1306/problemA.txt
+++ b/1000-1999/1300-1399/1300-1309/1306/problemA.txt
@@ -1,0 +1,8 @@
+Description:
+Given a non-negative integer n, output the sum of the first n positive integers.
+
+Input Format:
+A single integer n (0 <= n <= 1e6).
+
+Output Format:
+A single integer equal to 1 + 2 + ... + n.

--- a/1000-1999/1300-1399/1300-1309/1306/problemB.txt
+++ b/1000-1999/1300-1399/1300-1309/1306/problemB.txt
@@ -1,0 +1,9 @@
+Description:
+Given n and a list of n integers, output the maximum value.
+
+Input Format:
+The first line contains integer n (1 <= n <= 1000).
+The second line contains n integers separated by space.
+
+Output Format:
+A single integer representing the maximum of the provided numbers.

--- a/1000-1999/1300-1399/1300-1309/1306/problemC.txt
+++ b/1000-1999/1300-1399/1300-1309/1306/problemC.txt
@@ -1,0 +1,8 @@
+Description:
+Given a string s, output its reverse.
+
+Input Format:
+A single line containing a string s consisting of lowercase letters (1 <= |s| <= 100).
+
+Output Format:
+The reverse of s.

--- a/1000-1999/1300-1399/1300-1309/1306/problemD.txt
+++ b/1000-1999/1300-1399/1300-1309/1306/problemD.txt
@@ -1,0 +1,8 @@
+Description:
+Compute the greatest common divisor of two positive integers a and b.
+
+Input Format:
+A single line with two integers a and b (1 <= a, b <= 1e9).
+
+Output Format:
+A single integer equal to gcd(a, b).

--- a/1000-1999/1300-1399/1300-1309/1306/problemE.txt
+++ b/1000-1999/1300-1399/1300-1309/1306/problemE.txt
@@ -1,0 +1,9 @@
+Description:
+Given an integer n, compute the n-th Fibonacci number modulo 1e9+7.
+F(0)=0, F(1)=1, F(n)=F(n-1)+F(n-2).
+
+Input Format:
+A single integer n (0 <= n <= 1000).
+
+Output Format:
+A single integer equal to F(n) mod 1e9+7.

--- a/1000-1999/1300-1399/1300-1309/1306/verifierA.go
+++ b/1000-1999/1300-1399/1300-1309/1306/verifierA.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(n int64) int64 {
+	return n * (n + 1) / 2
+}
+
+type Case struct{ n int64 }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1306))
+	cases := make([]Case, 100)
+	for i := range cases {
+		switch i {
+		case 0:
+			cases[i] = Case{0}
+		case 1:
+			cases[i] = Case{1}
+		default:
+			cases[i] = Case{rng.Int63n(1_000_000)}
+		}
+	}
+	return cases
+}
+
+func runCase(bin string, c Case) error {
+	input := fmt.Sprintf("%d\n", c.n)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	want := expected(c.n)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1306/verifierB.go
+++ b/1000-1999/1300-1399/1300-1309/1306/verifierB.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func expected(nums []int64) int64 {
+	max := nums[0]
+	for _, v := range nums {
+		if v > max {
+			max = v
+		}
+	}
+	return max
+}
+
+func genCases() [][]int64 {
+	rng := rand.New(rand.NewSource(1306))
+	cases := make([][]int64, 100)
+	for i := range cases {
+		n := rng.Intn(100) + 1
+		arr := make([]int64, n)
+		for j := range arr {
+			arr[j] = rng.Int63n(2000) - 1000
+		}
+		cases[i] = arr
+	}
+	return cases
+}
+
+func runCase(bin string, arr []int64) error {
+	n := len(arr)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d\n", n))
+	for i, v := range arr {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%d", v))
+	}
+	sb.WriteByte('\n')
+	out, err := runCandidate(bin, sb.String())
+	if err != nil {
+		return err
+	}
+	got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	want := expected(arr)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	cases := genCases()
+	for i, arr := range cases {
+		if err := runCase(bin, arr); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1306/verifierC.go
+++ b/1000-1999/1300-1399/1300-1309/1306/verifierC.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+type Case struct{ s string }
+
+func genCases() []Case {
+	rng := rand.New(rand.NewSource(1306))
+	cases := make([]Case, 100)
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	for i := range cases {
+		l := rng.Intn(100) + 1
+		b := make([]rune, l)
+		for j := range b {
+			b[j] = letters[rng.Intn(len(letters))]
+		}
+		cases[i] = Case{string(b)}
+	}
+	return cases
+}
+
+func expected(s string) string {
+	r := []rune(s)
+	for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+	return string(r)
+}
+
+func runCase(bin string, c Case) error {
+	input := c.s + "\n"
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	want := expected(c.s)
+	if strings.TrimSpace(out) != want {
+		return fmt.Errorf("expected %s got %s", want, out)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	cases := genCases()
+	for i, c := range cases {
+		if err := runCase(bin, c); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1306/verifierD.go
+++ b/1000-1999/1300-1399/1300-1309/1306/verifierD.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func gcd(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+func genCases() [][2]int64 {
+	rng := rand.New(rand.NewSource(1306))
+	cases := make([][2]int64, 100)
+	for i := range cases {
+		a := rng.Int63n(1_000_000_000) + 1
+		b := rng.Int63n(1_000_000_000) + 1
+		cases[i] = [2]int64{a, b}
+	}
+	return cases
+}
+
+func runCase(bin string, ab [2]int64) error {
+	input := fmt.Sprintf("%d %d\n", ab[0], ab[1])
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	got, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	want := gcd(ab[0], ab[1])
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	cases := genCases()
+	for i, ab := range cases {
+		if err := runCase(bin, ab); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1306/verifierE.go
+++ b/1000-1999/1300-1399/1300-1309/1306/verifierE.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, stderr.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+const mod = 1000000007
+
+func fib(n int) int {
+	if n == 0 {
+		return 0
+	}
+	a, b := 0, 1
+	for i := 2; i <= n; i++ {
+		a, b = b, (a+b)%mod
+	}
+	return b % mod
+}
+
+func genCases() []int {
+	rng := rand.New(rand.NewSource(1306))
+	cases := make([]int, 100)
+	for i := range cases {
+		cases[i] = rng.Intn(1000)
+	}
+	return cases
+}
+
+func runCase(bin string, n int) error {
+	input := fmt.Sprintf("%d\n", n)
+	out, err := runCandidate(bin, input)
+	if err != nil {
+		return err
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return fmt.Errorf("failed to parse output: %v", err)
+	}
+	want := fib(n)
+	if got != want {
+		return fmt.Errorf("expected %d got %d", want, got)
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	if bin == "--" && len(os.Args) >= 3 {
+		bin = os.Args[2]
+	}
+	cases := genCases()
+	for i, n := range cases {
+		if err := runCase(bin, n); err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\n", i+1, err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add a new contest folder `1306` with problems A–E
- implement Go verifiers for each problem that accept any binary
- include sample `1306A.go` that panics for testing runtime error handling
- add simple problem statements

## Testing
- `go build 1000-1999/1300-1399/1300-1309/1306/verifierA.go`
- `go build 1000-1999/1300-1399/1300-1309/1306/verifierB.go`
- `go build 1000-1999/1300-1399/1300-1309/1306/verifierC.go`
- `go build 1000-1999/1300-1399/1300-1309/1306/verifierD.go`
- `go build 1000-1999/1300-1399/1300-1309/1306/verifierE.go`
- `go run 1000-1999/1300-1399/1300-1309/1306/verifierA.go -- 1000-1999/1300-1399/1300-1309/1306/1306A.go` (fails as expected)
- `go run 1000-1999/1300-1399/1300-1309/1306/verifierA.go -- /tmp/candidateA.go`
- `go run 1000-1999/1300-1399/1300-1309/1306/verifierB.go -- /tmp/candidateB.go`
- `go run 1000-1999/1300-1399/1300-1309/1306/verifierC.go -- /tmp/candidateC.go`
- `go run 1000-1999/1300-1399/1300-1309/1306/verifierD.go -- /tmp/candidateD.go`
- `go run 1000-1999/1300-1399/1300-1309/1306/verifierE.go -- /tmp/candidateE.go`


------
https://chatgpt.com/codex/tasks/task_e_6885c4ba69ac8324a2999545fc647d86