### PR TITLE
Add Go verifiers for contest 1307

### DIFF
--- a/1000-1999/1300-1399/1300-1309/1307/verifierA.go
+++ b/1000-1999/1300-1399/1300-1309/1307/verifierA.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := strings.NewReader(input)
+	var t int
+	fmt.Fscan(in, &t)
+	var out strings.Builder
+	for i := 0; i < t; i++ {
+		var n, d int
+		fmt.Fscan(in, &n, &d)
+		a := make([]int, n)
+		for j := 0; j < n; j++ {
+			fmt.Fscan(in, &a[j])
+		}
+		res := a[0]
+		days := d
+		for j := 1; j < n && days > 0; j++ {
+			cost := j
+			move := days / cost
+			if move > a[j] {
+				move = a[j]
+			}
+			res += move
+			days -= move * cost
+		}
+		fmt.Fprintf(&out, "%d", res)
+		if i+1 < t {
+			out.WriteByte('\n')
+		}
+	}
+	return out.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(5) + 1
+		d := rng.Intn(10)
+		fmt.Fprintf(&sb, "%d %d\n", n, d)
+		for j := 0; j < n; j++ {
+			val := rng.Intn(10)
+			if j+1 == n {
+				fmt.Fprintf(&sb, "%d\n", val)
+			} else {
+				fmt.Fprintf(&sb, "%d ", val)
+			}
+		}
+	}
+	input := sb.String()
+	return input, solve(input)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierA.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1307/verifierB.go
+++ b/1000-1999/1300-1399/1300-1309/1307/verifierB.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := strings.NewReader(input)
+	var t int
+	fmt.Fscan(in, &t)
+	var out strings.Builder
+	for casei := 0; casei < t; casei++ {
+		var n int
+		var x int64
+		fmt.Fscan(in, &n, &x)
+		arr := make([]int64, n)
+		var maxa int64
+		eq := false
+		for i := 0; i < n; i++ {
+			fmt.Fscan(in, &arr[i])
+			if arr[i] == x {
+				eq = true
+			}
+			if arr[i] > maxa {
+				maxa = arr[i]
+			}
+		}
+		var ans int64
+		if eq {
+			ans = 1
+		} else {
+			hops := (x + maxa - 1) / maxa
+			if hops < 2 {
+				hops = 2
+			}
+			ans = hops
+		}
+		fmt.Fprintf(&out, "%d", ans)
+		if casei+1 < t {
+			out.WriteByte('\n')
+		}
+	}
+	return out.String()
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	t := rng.Intn(3) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d\n", t)
+	for i := 0; i < t; i++ {
+		n := rng.Intn(5) + 1
+		x := int64(rng.Intn(20) + 1)
+		fmt.Fprintf(&sb, "%d %d\n", n, x)
+		for j := 0; j < n; j++ {
+			val := int64(rng.Intn(20) + 1)
+			if j+1 == n {
+				fmt.Fprintf(&sb, "%d\n", val)
+			} else {
+				fmt.Fprintf(&sb, "%d ", val)
+			}
+		}
+	}
+	in := sb.String()
+	return in, solve(in)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierB.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1307/verifierC.go
+++ b/1000-1999/1300-1399/1300-1309/1307/verifierC.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := strings.NewReader(input)
+	var s string
+	fmt.Fscan(in, &s)
+	cnt := make([]int64, 26)
+	pairs := make([][]int64, 26)
+	for i := 0; i < 26; i++ {
+		pairs[i] = make([]int64, 26)
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i] - 'a'
+		for j := 0; j < 26; j++ {
+			pairs[j][c] += cnt[j]
+		}
+		cnt[c]++
+	}
+	var ans int64
+	for i := 0; i < 26; i++ {
+		if cnt[i] > ans {
+			ans = cnt[i]
+		}
+	}
+	for i := 0; i < 26; i++ {
+		for j := 0; j < 26; j++ {
+			if pairs[i][j] > ans {
+				ans = pairs[i][j]
+			}
+		}
+	}
+	return fmt.Sprintf("%d", ans)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(20) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rng.Intn(5))
+	}
+	s := string(b)
+	return s + "\n", solve(s + "\n")
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierC.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1307/verifierD.go
+++ b/1000-1999/1300-1399/1300-1309/1307/verifierD.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func bfs(start, n int, adj [][]int) []int {
+	const INF = int(1e9)
+	dist := make([]int, n+1)
+	for i := 1; i <= n; i++ {
+		dist[i] = INF
+	}
+	q := make([]int, 0, n)
+	dist[start] = 0
+	q = append(q, start)
+	for i := 0; i < len(q); i++ {
+		u := q[i]
+		du := dist[u]
+		for _, v := range adj[u] {
+			if dist[v] > du+1 {
+				dist[v] = du + 1
+				q = append(q, v)
+			}
+		}
+	}
+	return dist
+}
+
+func solve(input string) string {
+	in := strings.NewReader(input)
+	var n, m, k int
+	fmt.Fscan(in, &n, &m, &k)
+	special := make([]int, k)
+	for i := 0; i < k; i++ {
+		fmt.Fscan(in, &special[i])
+	}
+	adj := make([][]int, n+1)
+	for i := 0; i < m; i++ {
+		var x, y int
+		fmt.Fscan(in, &x, &y)
+		adj[x] = append(adj[x], y)
+		adj[y] = append(adj[y], x)
+	}
+	d1 := bfs(1, n, adj)
+	d2 := bfs(n, n, adj)
+	L0 := d1[n]
+	sort.Slice(special, func(i, j int) bool {
+		return d1[special[i]]-d2[special[i]] < d1[special[j]]-d2[special[j]]
+	})
+	best := 0
+	mxD1 := -1000000000
+	for _, u := range special {
+		if mxD1 > -1000000000 {
+			cand := mxD1 + d2[u] + 1
+			if cand > best {
+				best = cand
+			}
+		}
+		if d1[u] > mxD1 {
+			mxD1 = d1[u]
+		}
+	}
+	if best > L0 {
+		best = L0
+	}
+	if best == 0 {
+		best = L0
+	}
+	return fmt.Sprintf("%d", best)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(6) + 2
+	m := n - 1 + rng.Intn(n)
+	k := rng.Intn(n-1) + 2
+	adjSet := make(map[[2]int]struct{})
+	edges := make([][2]int, 0, m)
+	// build tree
+	for i := 2; i <= n; i++ {
+		j := rng.Intn(i-1) + 1
+		edges = append(edges, [2]int{i, j})
+		adjSet[[2]int{i, j}] = struct{}{}
+		adjSet[[2]int{j, i}] = struct{}{}
+	}
+	// add extra edges
+	for len(edges) < m {
+		u := rng.Intn(n) + 1
+		v := rng.Intn(n) + 1
+		if u == v {
+			continue
+		}
+		if _, ok := adjSet[[2]int{u, v}]; ok {
+			continue
+		}
+		edges = append(edges, [2]int{u, v})
+		adjSet[[2]int{u, v}] = struct{}{}
+		adjSet[[2]int{v, u}] = struct{}{}
+	}
+	specials := rng.Perm(n)[:k]
+	for i := range specials {
+		specials[i]++
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, m, k)
+	for i, v := range specials {
+		if i+1 == k {
+			fmt.Fprintf(&sb, "%d\n", v)
+		} else {
+			fmt.Fprintf(&sb, "%d ", v)
+		}
+	}
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	in := sb.String()
+	return in, solve(in)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierD.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1307/verifierE.go
+++ b/1000-1999/1300-1399/1300-1309/1307/verifierE.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const MOD = 1000000007
+
+type Cow struct {
+	posL, posR int
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := strings.NewReader(input)
+	var n, m int
+	fmt.Fscan(in, &n, &m)
+	s := make([]int, n)
+	for i := 0; i < n; i++ {
+		fmt.Fscan(in, &s[i])
+	}
+	occ := make([][]int, n+1)
+	for i, v := range s {
+		occ[v] = append(occ[v], i+1)
+	}
+	cowsByF := make([][]Cow, n+1)
+	for i := 0; i < m; i++ {
+		var f, h int
+		fmt.Fscan(in, &f, &h)
+		list := occ[f]
+		sz := len(list)
+		var posL, posR int
+		if h <= sz {
+			posL = list[h-1]
+			posR = list[sz-h]
+		} else {
+			posL = -1
+			posR = -1
+		}
+		if posL < 0 && posR < 0 {
+			continue
+		}
+		cowsByF[f] = append(cowsByF[f], Cow{posL, posR})
+	}
+	pow2 := make([]int, m+1)
+	pow2[0] = 1
+	for i := 1; i <= m; i++ {
+		pow2[i] = pow2[i-1] * 2 % MOD
+	}
+	bestCnt := 0
+	bestWays := 0
+	for k := 0; k <= n; k++ {
+		total := 0
+		ways := 1
+		for f := 1; f <= n; f++ {
+			list := cowsByF[f]
+			if len(list) == 0 {
+				continue
+			}
+			ca, cb, inter := 0, 0, 0
+			for _, c := range list {
+				inA := c.posL > 0 && c.posL <= k
+				inB := c.posR > 0 && c.posR > k
+				if inA {
+					ca++
+				}
+				if inB {
+					cb++
+				}
+				if inA && inB {
+					inter++
+				}
+			}
+			uni := ca + cb - inter
+			if uni == 0 {
+				continue
+			}
+			total += uni
+			if inter > 0 {
+				ways = ways * pow2[inter] % MOD
+			}
+		}
+		if total > bestCnt {
+			bestCnt = total
+			bestWays = ways
+		} else if total == bestCnt {
+			bestWays = (bestWays + ways) % MOD
+		}
+	}
+	return fmt.Sprintf("%d %d", bestCnt, bestWays)
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 1
+	m := rng.Intn(5) + 1
+	s := make([]int, n)
+	for i := range s {
+		s[i] = rng.Intn(n) + 1
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for i, v := range s {
+		if i+1 == n {
+			fmt.Fprintf(&sb, "%d\n", v)
+		} else {
+			fmt.Fprintf(&sb, "%d ", v)
+		}
+	}
+	for i := 0; i < m; i++ {
+		f := rng.Intn(n) + 1
+		h := rng.Intn(n) + 1
+		fmt.Fprintf(&sb, "%d %d\n", f, h)
+	}
+	in := sb.String()
+	return in, solve(in)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierE.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1307/verifierF.go
+++ b/1000-1999/1300-1399/1300-1309/1307/verifierF.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DSU struct {
+	p []int
+}
+
+func NewDSU(n int) *DSU {
+	p := make([]int, n)
+	for i := range p {
+		p[i] = i
+	}
+	return &DSU{p}
+}
+
+func (d *DSU) Find(x int) int {
+	if d.p[x] != x {
+		d.p[x] = d.Find(d.p[x])
+	}
+	return d.p[x]
+}
+
+func (d *DSU) Union(x, y int) {
+	rx, ry := d.Find(x), d.Find(y)
+	if rx != ry {
+		d.p[ry] = rx
+	}
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := strings.NewReader(input)
+	var n, k, r int
+	fmt.Fscan(in, &n, &k, &r)
+	adj := make([][]int, n)
+	edges := make([][2]int, n-1)
+	for i := 0; i < n-1; i++ {
+		var u, v int
+		fmt.Fscan(in, &u, &v)
+		u--
+		v--
+		adj[u] = append(adj[u], v)
+		adj[v] = append(adj[v], u)
+		edges[i] = [2]int{u, v}
+	}
+	rest := make([]int, r)
+	for i := 0; i < r; i++ {
+		fmt.Fscan(in, &rest[i])
+		rest[i]--
+	}
+	dist := make([]int, n)
+	for i := range dist {
+		dist[i] = -1
+	}
+	q := make([]int, 0, n)
+	for _, u := range rest {
+		dist[u] = 0
+		q = append(q, u)
+	}
+	for qi := 0; qi < len(q); qi++ {
+		u := q[qi]
+		for _, v := range adj[u] {
+			if dist[v] == -1 {
+				dist[v] = dist[u] + 1
+				q = append(q, v)
+			}
+		}
+	}
+	dsu := NewDSU(n)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		if dist[u]+dist[v]+1 <= k {
+			dsu.Union(u, v)
+		}
+	}
+	compID := make([]int, n)
+	idMap := make(map[int]int, n)
+	cid := 0
+	for i := 0; i < n; i++ {
+		r := dsu.Find(i)
+		if _, ok := idMap[r]; !ok {
+			idMap[r] = cid
+			cid++
+		}
+		compID[i] = idMap[r]
+	}
+	C := cid
+	cadj := make([][]int, C)
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		cu, cv := compID[u], compID[v]
+		if cu != cv {
+			cadj[cu] = append(cadj[cu], cv)
+			cadj[cv] = append(cadj[cv], cu)
+		}
+	}
+	LOG := 1
+	for (1 << LOG) <= C {
+		LOG++
+	}
+	up := make([][]int, LOG)
+	depth := make([]int, C)
+	for i := range up {
+		up[i] = make([]int, C)
+		for j := range up[i] {
+			up[i][j] = -1
+		}
+	}
+	var dfs func(u, p int)
+	dfs = func(u, p int) {
+		up[0][u] = p
+		for _, v := range cadj[u] {
+			if v == p {
+				continue
+			}
+			depth[v] = depth[u] + 1
+			dfs(v, u)
+		}
+	}
+	for i := 0; i < C; i++ {
+		if up[0][i] == -1 {
+			dfs(i, -1)
+		}
+	}
+	for j := 1; j < LOG; j++ {
+		for i := 0; i < C; i++ {
+			if up[j-1][i] < 0 {
+				up[j][i] = -1
+			} else {
+				up[j][i] = up[j-1][up[j-1][i]]
+			}
+		}
+	}
+	lca := func(a, b int) int {
+		if depth[a] < depth[b] {
+			a, b = b, a
+		}
+		diff := depth[a] - depth[b]
+		for j := 0; j < LOG; j++ {
+			if diff>>j&1 == 1 {
+				a = up[j][a]
+			}
+		}
+		if a == b {
+			return a
+		}
+		for j := LOG - 1; j >= 0; j-- {
+			if up[j][a] != up[j][b] {
+				a = up[j][a]
+				b = up[j][b]
+			}
+		}
+		return up[0][a]
+	}
+	var vq int
+	fmt.Fscan(in, &vq)
+	var out strings.Builder
+	for i := 0; i < vq; i++ {
+		var a, b int
+		fmt.Fscan(in, &a, &b)
+		a--
+		b--
+		ca, cb := compID[a], compID[b]
+		w := lca(ca, cb)
+		distc := depth[ca] + depth[cb] - 2*depth[w]
+		if distc <= k {
+			out.WriteString("YES\n")
+		} else {
+			out.WriteString("NO\n")
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	k := rng.Intn(3) + 1
+	r := rng.Intn(n) + 1
+	edges := make([][2]int, n-1)
+	adj := make(map[[2]int]bool)
+	for i := 1; i < n; i++ {
+		p := rng.Intn(i) + 1
+		edges[i-1] = [2]int{i + 1, p}
+		adj[[2]int{i + 1, p}] = true
+		adj[[2]int{p, i + 1}] = true
+	}
+	rest := rng.Perm(n)[:r]
+	for i := range rest {
+		rest[i]++
+	}
+	vq := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d %d\n", n, k, r)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d\n", e[0], e[1])
+	}
+	for i, v := range rest {
+		if i+1 == r {
+			fmt.Fprintf(&sb, "%d\n", v)
+		} else {
+			fmt.Fprintf(&sb, "%d ", v)
+		}
+	}
+	fmt.Fprintf(&sb, "%d\n", vq)
+	for i := 0; i < vq; i++ {
+		a := rng.Intn(n) + 1
+		b := rng.Intn(n) + 1
+		for b == a {
+			b = rng.Intn(n) + 1
+		}
+		fmt.Fprintf(&sb, "%d %d\n", a, b)
+	}
+	in := sb.String()
+	return in, solve(in)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierF.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}

--- a/1000-1999/1300-1399/1300-1309/1307/verifierG.go
+++ b/1000-1999/1300-1399/1300-1309/1307/verifierG.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Edge struct {
+	to, rev, cap, cost int
+}
+
+func addEdge(g [][]Edge, u, v, cap, cost int) {
+	g[u] = append(g[u], Edge{to: v, rev: len(g[v]), cap: cap, cost: cost})
+	g[v] = append(g[v], Edge{to: u, rev: len(g[u]) - 1, cap: 0, cost: -cost})
+}
+
+func runCandidate(bin, input string) (string, error) {
+	var cmd *exec.Cmd
+	if strings.HasSuffix(bin, ".go") {
+		cmd = exec.Command("go", "run", bin)
+	} else {
+		cmd = exec.Command(bin)
+	}
+	cmd.Stdin = strings.NewReader(input)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("runtime error: %v\n%s", err, errBuf.String())
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func solve(input string) string {
+	in := strings.NewReader(input)
+	var n, m int
+	if _, err := fmt.Fscan(in, &n, &m); err != nil {
+		return ""
+	}
+	g := make([][]Edge, n)
+	for i := 0; i < m; i++ {
+		var u, v, c int
+		fmt.Fscan(in, &u, &v, &c)
+		addEdge(g, u-1, v-1, 1, c)
+	}
+	var q int
+	fmt.Fscan(in, &q)
+	x := make([]int64, q)
+	ans := make([]float64, q)
+	for i := 0; i < q; i++ {
+		var xi int64
+		fmt.Fscan(in, &xi)
+		x[i] = xi
+		ans[i] = 1e18
+	}
+	const INF int64 = 1 << 60
+	sumF := 0
+	var sumC int64
+	dist := make([]int64, n)
+	prevv := make([]int, n)
+	preve := make([]int, n)
+	inq := make([]bool, n)
+	qv := make([]int, n+5)
+	for {
+		for i := 0; i < n; i++ {
+			dist[i] = INF
+			inq[i] = false
+		}
+		dist[0] = 0
+		head, tail := 0, 0
+		qv[tail] = 0
+		tail++
+		inq[0] = true
+		for head < tail {
+			v := qv[head]
+			head++
+			inq[v] = false
+			for ei, e := range g[v] {
+				if e.cap > 0 && dist[e.to] > dist[v]+int64(e.cost) {
+					dist[e.to] = dist[v] + int64(e.cost)
+					prevv[e.to] = v
+					preve[e.to] = ei
+					if !inq[e.to] {
+						qv[tail] = e.to
+						tail++
+						inq[e.to] = true
+					}
+				}
+			}
+		}
+		if dist[n-1] == INF {
+			break
+		}
+		sumC += dist[n-1]
+		sumF++
+		v := n - 1
+		for v != 0 {
+			u := prevv[v]
+			ei := preve[v]
+			g[u][ei].cap--
+			rev := g[u][ei].rev
+			g[v][rev].cap++
+			v = u
+		}
+		for i := 0; i < q; i++ {
+			cur := float64(sumC+x[i]) / float64(sumF)
+			if cur < ans[i] {
+				ans[i] = cur
+			}
+		}
+	}
+	var sb strings.Builder
+	for i := 0; i < q; i++ {
+		sb.WriteString(fmt.Sprintf("%.12f\n", ans[i]))
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func generateCase(rng *rand.Rand) (string, string) {
+	n := rng.Intn(5) + 2
+	maxEdges := n * (n - 1)
+	m := rng.Intn(maxEdges-n+1) + n - 1
+	edges := make([][3]int, m)
+	used := make(map[[2]int]bool)
+	for i := range edges {
+		for {
+			u := rng.Intn(n) + 1
+			v := rng.Intn(n) + 1
+			if u == v {
+				continue
+			}
+			if used[[2]int{u, v}] {
+				continue
+			}
+			used[[2]int{u, v}] = true
+			edges[i][0] = u
+			edges[i][1] = v
+			edges[i][2] = rng.Intn(10) + 1
+			break
+		}
+	}
+	q := rng.Intn(5) + 1
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d %d\n", n, m)
+	for _, e := range edges {
+		fmt.Fprintf(&sb, "%d %d %d\n", e[0], e[1], e[2])
+	}
+	fmt.Fprintf(&sb, "%d\n", q)
+	for i := 0; i < q; i++ {
+		fmt.Fprintf(&sb, "%d\n", rng.Intn(20))
+	}
+	in := sb.String()
+	return in, solve(in)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go run verifierG.go /path/to/binary")
+		os.Exit(1)
+	}
+	bin := os.Args[1]
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		in, exp := generateCase(rng)
+		got, err := runCandidate(bin, in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "case %d failed: %v\ninput:\n%s", i+1, err, in)
+			os.Exit(1)
+		}
+		if strings.TrimSpace(got) != strings.TrimSpace(exp) {
+			fmt.Fprintf(os.Stderr, "case %d failed: expected %s got %s\ninput:\n%s", i+1, exp, got, in)
+			os.Exit(1)
+		}
+	}
+	fmt.Println("All tests passed")
+}


### PR DESCRIPTION
## Summary
- add `verifierA.go` through `verifierG.go` for the problems in contest 1307
- each verifier runs a candidate binary on 100 random test cases and checks the output using an internal reference solution

## Testing
- `go build verifierA.go`
- `./verifierA 1307A.go`
- `for f in verifier*.go; do echo compiling $f; go build $f; done`

------
https://chatgpt.com/codex/tasks/task_e_6885c5467f988324b056996996998a55